### PR TITLE
docs: rebrand README from Humr to DAM

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-# Humr
+# DAM
 
-<p align="center">
-  <img src="docs/assets/logo.svg" width="120" alt="Humr logo" />
-</p>
 <h3 align="center">
   Run your own background agents on Kubernetes.<br/>
   Isolated by default. Credentialed. Always-on.
 </h3>
 
-Keep your coding agents running when you close the lid. Ship them to your team. Sell them to your customers. Humr gives Claude Code, Codex, Gemini CLI, or pi.dev an isolated Kubernetes pod, a credential-injecting proxy, a scheduler, and a Slack channel.
+Keep your coding agents running when you close the lid. Ship them to your team. Sell them to your customers. DAM gives Claude Code, Codex, Gemini CLI, or pi.dev an isolated Kubernetes pod, a credential-injecting proxy, a scheduler, and a Slack channel.
 
 ## What you get
 
 - **Isolated by design** — Each agent runs in its own sandbox: separate pod, process, and filesystem. API keys live in a proxy; the agent never sees them. Network access is locked to destinations you've approved. That contains two of the three big agent-security risks structurally. [Security model →](docs/strategy/security-model.md)
 
-- **Built for team collaboration** — Until now, coding agents have been 1:1: you and your copilot. Humr unlocks N people collaborating with 1 or many agents, multi-player from the ground up. [Multiplayer →](docs/strategy/multi-player.md)
+- **Built for team collaboration** — Until now, coding agents have been 1:1: you and your copilot. DAM unlocks N people collaborating with 1 or many agents, multi-player from the ground up. [Multiplayer →](docs/strategy/multi-player.md)
 
 - **Always-on scheduling** — Cron lives on the platform, not your laptop. Scheduled tasks look identical to human messages from the agent's perspective. Workspace and conversation history persist across restarts.
 
@@ -22,18 +19,18 @@ Keep your coding agents running when you close the lid. Ship them to your team. 
 
 - **Bring your own agent** — Claude Code and [pi.dev](https://pi.dev) ship as built-in templates. Codex, Gemini CLI, or anything that speaks [ACP](https://agentclientprotocol.com/get-started/introduction) works too. No lock-in to one vendor's SDK or cloud.
 
-![Humr UI — agent chatting with Google Drive access](docs/assets/hero.png)
+![DAM UI — agent chatting with Google Drive access](docs/assets/hero.png)
 
 ## Guided Tour
 
 ```sh
-git clone https://github.com/kagenti/humr && cd humr
+git clone https://github.com/dam-agents/dam && cd dam
 ```
 
 Open your favorite AI coding agent in the repo and try:
 
 ```
-Walk me through how Humr works step by step. I want to do a demo for myself.
+Walk me through how DAM works step by step. I want to do a demo for myself.
 Explain how things work on the way. Help me connect a model provider, create
 an instance, add a connection to GitHub, and chat with an agent.
 ```
@@ -54,15 +51,15 @@ Prerequisites: [mise](https://mise.jdx.dev), a Docker-compatible runtime (Docker
 
 ```sh
 mise install                # install toolchain + deps
-mise run cluster:install    # create local k3s cluster + deploy Humr
+mise run cluster:install    # create local k3s cluster + deploy DAM
 ```
 
-Open [humr.localhost:4444](http://humr.localhost:4444) (login: `dev` / `dev`), create an instance from a template, and start chatting. See the [configuration guide](docs/configuration.md) for credential setup and Slack integration.
+Open [dam.localhost:4444](http://dam.localhost:4444) (login: `dev` / `dev`), create an instance from a template, and start chatting. See the [configuration guide](docs/configuration.md) for credential setup and Slack integration.
 
 ## Learn more
 
 - **[Configuration](docs/configuration.md)** — credential setup, Slack integration, development-mode toggle
 - **[Architecture](docs/architecture.md)** — system context, subsystem deep-dives, design decisions
-- **[Security model](docs/strategy/security-model.md)** — the three big risks when running AI agents, how Humr handles each, and what's still unsolved
-- **[Multiplayer](docs/strategy/multi-player.md)** — Humr's multi-user model: what's private to each player, what's shared when you collaborate, and what's install-wide plumbing
-- **[Why Humr exists](PITCH.md)** — the three problems every agent hits in production, how Humr solves each, and a 5-minute walkthrough
+- **[Security model](docs/strategy/security-model.md)** — the three big risks when running AI agents, how DAM handles each, and what's still unsolved
+- **[Multiplayer](docs/strategy/multi-player.md)** — DAM's multi-user model: what's private to each player, what's shared when you collaborate, and what's install-wide plumbing
+- **[Why DAM exists](PITCH.md)** — the three problems every agent hits in production, how DAM solves each, and a 5-minute walkthrough


### PR DESCRIPTION
## Summary
- Replace Humr branding with DAM throughout the README
- Drop the centered logo image
- Update clone URL to `dam-agents/dam` and local URL to `dam.localhost:4444`

## Test plan
- [ ] Verify rendered README on GitHub looks correct
- [ ] Note: `dam.localhost:4444` will resolve only after the cluster ingress is rebranded — separate change