### PR TITLE
docs: rebrand MOTIVATION and PITCH from Humr to DAM

### DIFF
--- a/MOTIVATION.md
+++ b/MOTIVATION.md
@@ -1,4 +1,4 @@
-# Why Humr
+# Why DAM
 
 ## What's an agent
 
@@ -18,17 +18,17 @@ All three hit the same wall when you try to run them in production: no open-sour
 
 ## The problem
 
-OpenClaw is wildly successful and keeps getting better. But it's a general-purpose platform that tries to serve every user and every scenario. Humr takes a different angle: narrower focus, zero-trust by default, building blocks instead of opinions.
+OpenClaw is wildly successful and keeps getting better. But it's a general-purpose platform that tries to serve every user and every scenario. DAM takes a different angle: narrower focus, zero-trust by default, building blocks instead of opinions.
 
 When an agent has bash access and can manipulate files, security can't be an afterthought. Credentials shouldn't be passed to the model. Network access shouldn't be open by default. Isolation shouldn't be optional. These aren't features. They're the foundation everything else is built on.
 
 And if you want to run agents on your own infrastructure without being tied to a specific vendor's harness, model, or cloud, that option doesn't exist today.
 
-## What Humr does
+## What DAM does
 
-Humr is a Kubernetes platform focused on running AI harnesses in production. It covers the second category (harnesses) and is building the foundation for the third (always-on personal assistants).
+DAM is a Kubernetes platform focused on running AI harnesses in production. It covers the second category (harnesses) and is building the foundation for the third (always-on personal assistants).
 
-**You bring the harness. Humr makes it production-ready.**
+**You bring the harness. DAM makes it production-ready.**
 
 Here's what that means:
 
@@ -42,7 +42,7 @@ Here's what that means:
 
 - **No vendor lock-in.** Model-agnostic. Harness-agnostic. Any harness that speaks ACP works. Today that's Claude Code, but the platform is designed for Codex, Gemini CLI, and whatever comes next.
 
-## What Humr believes
+## What DAM believes
 
 - **The harness is the unit of AI development.** The platform's job is to run it safely, not replace it.
 - **Security must be structural.** If it depends on the agent behaving correctly, it's not security.
@@ -51,4 +51,4 @@ Here's what that means:
 
 ## Where this is going
 
-Humr focuses on harnesses today and is preparing the building blocks for always-on personal assistants (scheduling, heartbeat, persistent workspace, channel integrations). A separate experiment will build an enterprise-grade OpenClaw alternative on top of these building blocks: an assistant that uses the harness to build software, create skills, and automate workflows, wrapped in an experience that's safe and manageable for enterprise use.
+DAM focuses on harnesses today and is preparing the building blocks for always-on personal assistants (scheduling, heartbeat, persistent workspace, channel integrations). A separate experiment will build an enterprise-grade OpenClaw alternative on top of these building blocks: an assistant that uses the harness to build software, create skills, and automate workflows, wrapped in an experience that's safe and manageable for enterprise use.

--- a/PITCH.md
+++ b/PITCH.md
@@ -1,9 +1,9 @@
-# Humr — Pitch
+# DAM — Pitch
 
 ## Contents
 
 - [So you want to run an agent in production](#so-you-want-to-run-an-agent-in-production)
-- [Meet Humr](#meet-humr)
+- [Meet DAM](#meet-dam)
 - [The mental model](#the-mental-model)
 - [The 5-minute tour](#the-5-minute-tour)
 - [Party tricks](#party-tricks)
@@ -32,11 +32,11 @@ And you have a list.
 
 None of this is the harness's fault. Harnesses are great at being harnesses. They're bad at being production systems because that was never their job.
 
-Humr signed up for that job.
+DAM signed up for that job.
 
-## Meet Humr
+## Meet DAM
 
-Humr is Kubernetes for agent harnesses. You bring the harness. Humr gives it an isolated pod, a credential gateway, a cron, a workspace that survives restarts, and a way to reach Slack.
+DAM is Kubernetes for agent harnesses. You bring the harness. DAM gives it an isolated pod, a credential gateway, a cron, a workspace that survives restarts, and a way to reach Slack.
 
 **Isolated** is doing real work in that sentence. Each agent gets its own Linux process, its own filesystem, its own network, its own credentials. Not N agents sharing one runtime. Not N threads in a long-running Python process. Not N tabs in one browser. A real OS-level boundary per agent, by default, because that's what Kubernetes gives you when you use it honestly.
 
@@ -44,35 +44,35 @@ The harness doesn't know any of that is happening. It runs the same way it ran o
 
 Here's the mapping to the three problems:
 
-| The problem | Humr's answer |
+| The problem | DAM's answer |
 |---|---|
 | Credentials and bash | Every pod routes outbound traffic through a MITM proxy (OneCLI). The agent's env has a placeholder token. Real creds get injected at the HTTP layer. Network policy drops everything else. If the agent is compromised, there's nothing to steal. |
 | Can't leave your laptop | Cron lives on the platform, not your laptop. Schedules fire as trigger files in `/workspace/.triggers/` — the harness can't tell a cron fire from a human message. Workspace persists on a PVC across hibernation; conversation history comes back on wake. Slack is a first-class channel. |
 | Can't become a product | Every instance is a ConfigMap. Multi-tenant by construction. Harness-agnostic and model-agnostic — anything that speaks ACP works. No CRDs, so no cluster-admin required. |
 
-**Humr has no opinions about your agent.** No memory format, no skill system, no prompt templates, no dashboards for tuning. Opinions belong in the product layer — that's where things like humr-claw live. Humr is the platform. humr-claw is one app that runs on it. This document is about the platform.
+**DAM has no opinions about your agent.** No memory format, no skill system, no prompt templates, no dashboards for tuning. Opinions belong in the product layer — that's where things like dam-claw live. DAM is the platform. dam-claw is one app that runs on it. This document is about the platform.
 
 ## The mental model
 
-Humr runs agents using three K8s primitives.
+DAM runs agents using three K8s primitives.
 
-**Template** — a blueprint for a kind of agent. A ConfigMap that says *"use this image, mount these paths, run this init script, allocate this much CPU/memory."* The template is the class. `claude-code` is the one Humr ships.
+**Template** — a blueprint for a kind of agent. A ConfigMap that says *"use this image, mount these paths, run this init script, allocate this much CPU/memory."* The template is the class. `claude-code` is the one DAM ships.
 
 **Instance** — a specific agent you've spun up from a template. Also a ConfigMap. Carries the instance name, the secret reference, any per-instance overrides. Template is the class; instance is the object. Ten users, ten instances, one template.
 
-**Pod** — what actually runs. Humr's controller turns each instance into a StatefulSet with `replicas: 1` and a PVC per persistent mount. StatefulSet means `demo-0` is *always* `demo-0` — same pod name, same PVC, same workspace, across restarts and hibernation. `replicas: 0` = hibernated, disk preserved. `replicas: 1` = running, disk remounted. That's the whole hibernate/wake story.
+**Pod** — what actually runs. DAM's controller turns each instance into a StatefulSet with `replicas: 1` and a PVC per persistent mount. StatefulSet means `demo-0` is *always* `demo-0` — same pod name, same PVC, same workspace, across restarts and hibernation. `replicas: 0` = hibernated, disk preserved. `replicas: 1` = running, disk remounted. That's the whole hibernate/wake story.
 
 **Pods are disposable; workspaces are not.** Anything outside `/workspace` and `/home/agent` is wiped on restart. That's a feature: bad state can't survive a reboot, and you can recover from almost any pod-level failure by killing it. The constraint: system-level changes (apt, `/etc` edits) don't stick. `$HOME`-scoped installs (`npm install -g`, `uv tool install`) do — that's what `/home/agent` persistence is for. Heavier stuff goes in the template image.
 
 **Each instance is its own.** Two instances in the same cluster can't see each other — no shared memory, no shared disk, no shared network namespace. One agent's crash doesn't touch others. One agent's compromise doesn't leak beyond its own pod. One agent's `rm -rf` hurts only itself.
 
-None of this uses CRDs. Every Humr resource is a plain ConfigMap with a `humr.ai/type` label:
+None of this uses CRDs. Every DAM resource is a plain ConfigMap with a `humr.ai/type` label:
 
 ```sh
 mise run cluster:kubectl -- get cm -l humr.ai/type -A
 ```
 
-So you can inspect, edit, diff, and back up Humr state with `kubectl` alone. No cluster-admin required to install. That's not a quirk — it's the entire reason Humr is namespace-scoped by design.
+So you can inspect, edit, diff, and back up DAM state with `kubectl` alone. No cluster-admin required to install. That's not a quirk — it's the entire reason DAM is namespace-scoped by design.
 
 ## The 5-minute tour
 
@@ -80,7 +80,7 @@ Prerequisites: [mise](https://mise.jdx.dev), Docker, Mac or Linux.
 
 ```sh
 mise install                # toolchain + deps + git hooks
-mise run cluster:install    # k3s in lima, deploys Humr
+mise run cluster:install    # k3s in lima, deploys DAM
 export KUBECONFIG="$(mise run cluster:kubeconfig)"
 ```
 
@@ -88,13 +88,13 @@ That booted a local k3s cluster and deployed the whole stack: OneCLI, Keycloak, 
 
 **Log in.** Everything uses `dev` / `dev` for local installs (seeded by `values-local.yaml`). Same login for both UIs.
 
-**Create an instance.** Open `http://humr.localhost:4444`, pick the `claude-code` template, give it a name (e.g. `demo`). In ~20 seconds the pod is ready.
+**Create an instance.** Open `http://dam.localhost:4444`, pick the `claude-code` template, give it a name (e.g. `demo`). In ~20 seconds the pod is ready.
 
 **Drop a credential into OneCLI.** Open `http://onecli.localhost:4444` → Connections → Secrets → Add Secret. Pick **Anthropic**, paste the output of `claude setup-token`. Save.
 
-**Grant the secret to the agent.** OneCLI lists your instance as an agent (Humr's controller provisioned it when you created the instance). Open it, choose **Selective** mode, grant the Anthropic secret, Create Agent.
+**Grant the secret to the agent.** OneCLI lists your instance as an agent (DAM's controller provisioned it when you created the instance). Open it, choose **Selective** mode, grant the Anthropic secret, Create Agent.
 
-**Chat.** Open the instance in Humr, type a message. You're done.
+**Chat.** Open the instance in DAM, type a message. You're done.
 
 ## Party tricks
 
@@ -155,10 +155,10 @@ mise run cluster:kubectl -- exec -n humr-agents <pod> -- \
 
 Four things that become possible once the floor is there.
 
-**1. Personal AI employees.** Non-technical users "hire" opinionated templates — a trip planner, a family assistant, a meal planner — the way you'd hire a human. Conversation happens wherever they already are — Telegram, Slack, whatever — not a dashboard. Each hire runs permanently, remembers you across sessions, and acts proactively on a schedule. This is what humr-claw is being built to do.
+**1. Personal AI employees.** Non-technical users "hire" opinionated templates — a trip planner, a family assistant, a meal planner — the way you'd hire a human. Conversation happens wherever they already are — Telegram, Slack, whatever — not a dashboard. Each hire runs permanently, remembers you across sessions, and acts proactively on a schedule. This is what dam-claw is being built to do.
 
 **2. The morning team brief.** A scheduled agent that scans Slack and GitHub every morning and sends a team lead their situational awareness DM: who's unblocked, who's stuck, what's at risk. Read-only. Replaces a workflow that experienced PMs do manually — except this one runs at 7am whether you're online or not.
 
-**3. The codebase guardian.** An agent that scans your repo on a schedule, detects drift in `README.md` / `CLAUDE.md` / architecture notes, posts proposed edits to your team channel. When a human responds, the agent opens a PR **under that person's GitHub identity** — not a shared bot account. Whoever approves authored it. Accountability is structural, same as Humr's credential story.
+**3. The codebase guardian.** An agent that scans your repo on a schedule, detects drift in `README.md` / `CLAUDE.md` / architecture notes, posts proposed edits to your team channel. When a human responds, the agent opens a PR **under that person's GitHub identity** — not a shared bot account. Whoever approves authored it. Accountability is structural, same as DAM's credential story.
 
 **4. The agent you sell.** You're shipping an agent as a product — a support triage bot, a release-notes writer, a translator that lives in somebody else's Jira. Every customer gets their own isolated pod, their own credentials, their own schedule. The SaaS plumbing from Section 1 is already in the box.


### PR DESCRIPTION
## Summary
- Replace `Humr` brand with `DAM` throughout MOTIVATION.md and PITCH.md
- Rename `humr-claw` → `dam-claw` (product name)
- Update guided-tour URL `humr.localhost:4444` → `dam.localhost:4444` (matches README)
- Fix broken `#meet-humr` anchor in PITCH ToC after heading rename

Left as-is (still real cluster identifiers, not branding):
- `humr-agents` namespace and `humr.ai/type` label in kubectl examples

## Test plan
- [ ] Visual review of rendered MOTIVATION.md and PITCH.md on GitHub
- [ ] Confirm PITCH ToC anchor `#meet-dam` resolves