### PR TITLE
ci: point workflows at dam-agents/dam GHCR namespace

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/kagenti/humr
+  IMAGE_PREFIX: ghcr.io/dam-agents/dam
 
 jobs:
   build-images:
@@ -196,33 +196,8 @@ jobs:
       - name: Package Helm chart (SHA-pinned)
         run: helm package deploy/helm/humr --version 0.0.0-${{ github.sha }} --app-version ${{ github.sha }}
       - name: Push SHA-pinned chart
-        run: helm push humr-0.0.0-${{ github.sha }}.tgz oci://ghcr.io/kagenti/humr/charts
+        run: helm push humr-0.0.0-${{ github.sha }}.tgz oci://ghcr.io/dam-agents/dam/charts
       - name: Package Helm chart (main floating tag)
         run: helm package deploy/helm/humr --version 0.0.0-main --app-version ${{ github.sha }}
       - name: Push main-floating chart
-        run: helm push humr-0.0.0-main.tgz oci://ghcr.io/kagenti/humr/charts
-
-  deploy:
-    runs-on: arc-runner-set
-    timeout-minutes: 10
-    needs: helm-package
-    environment:
-      name: Development
-    env:
-      HOME: /tmp
-    steps:
-      - uses: actions/checkout@v4
-      - uses: azure/setup-helm@v4
-      - name: Deploy via Helm
-        run: |
-          helm upgrade ${{ vars.HELM_RELEASE }} \
-            oci://ghcr.io/kagenti/humr/charts/humr \
-            --version 0.0.0-${{ github.sha }} \
-            --namespace ${{ vars.HELM_NAMESPACE }} \
-            --reset-then-reuse-values \
-            --timeout 5m
-      - uses: azure/setup-kubectl@v4
-      - name: Wait for rollout
-        run: |
-          kubectl rollout status statefulset --namespace ${{ vars.HELM_NAMESPACE }} --timeout=5m
-          kubectl rollout status deployment --namespace ${{ vars.HELM_NAMESPACE }} --timeout=5m
+        run: helm push humr-0.0.0-main.tgz oci://ghcr.io/dam-agents/dam/charts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/kagenti/humr
+  IMAGE_PREFIX: ghcr.io/dam-agents/dam
 
 jobs:
   build-images:
@@ -222,5 +222,5 @@ jobs:
       - name: Package Helm chart
         run: helm package deploy/helm/humr --version ${{ steps.version.outputs.version }} --app-version ${{ steps.version.outputs.version }}
       - name: Push to OCI registry
-        run: helm push humr-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/kagenti/humr/charts
+        run: helm push humr-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/dam-agents/dam/charts
 


### PR DESCRIPTION
## Summary
- Update `IMAGE_PREFIX` from `ghcr.io/kagenti/humr` to `ghcr.io/dam-agents/dam` in both workflows
- Update Helm chart push targets to `oci://ghcr.io/dam-agents/dam/charts`
- Drop `deploy` job from CD — it ran on `arc-runner-set` and used the `Development` environment, neither of which exist in this repo

## Why
Continuous Deployment was failing on main with `denied: permission_denied` because the `GITHUB_TOKEN` from `dam-agents/dam` cannot push to `ghcr.io/kagenti/humr/*`.

Note: the helm chart at `deploy/helm/humr/values.yaml` still references `ghcr.io/kagenti/humr/*` for image repositories. CD will now produce a chart that points at images that don't exist in the new namespace until the chart values are also updated — separate change, since the immediate goal here is to make the workflow pass.

## Test plan
- [ ] Watch CI / CD on this PR; both should succeed
- [ ] Confirm images appear under packages on `dam-agents/dam` after merge to main