### PR TITLE
fix(ui): prevent dialog dismiss on backdrop click or Escape

### DIFF
--- a/packages/ui/src/components/dialog-overlay.tsx
+++ b/packages/ui/src/components/dialog-overlay.tsx
@@ -14,7 +14,6 @@ export function DialogOverlay() {
   useEffect(() => {
     if (!dialog) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") closeDialog(false);
       if (e.key === "Enter") closeDialog(true);
     };
     window.addEventListener("keydown", onKey);
@@ -24,11 +23,10 @@ export function DialogOverlay() {
   if (!dialog) return null;
 
   return (
-    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-[4px] anim-in" onClick={() => closeDialog(false)}>
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/50 backdrop-blur-[4px] anim-in">
       <div
         className="w-[400px] max-w-[calc(100vw-2rem)] rounded-xl border-2 border-border bg-surface p-5 md:p-6 flex flex-col gap-4 anim-scale-in"
         style={{ boxShadow: "var(--shadow-brutal)" }}
-        onClick={e => e.stopPropagation()}
       >
         <div className="flex items-start gap-3">
           <div className="h-8 w-8 rounded-lg bg-accent-light flex items-center justify-center shrink-0 mt-0.5">

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -1,41 +1,24 @@
-import { useEffect, type ReactNode } from "react";
+import { type ReactNode } from "react";
 
 interface ModalProps {
-  onClose: () => void;
   widthClass?: string;
   children: ReactNode;
-  /** When true, clicking the backdrop does not close the modal. Default: false. */
-  disableBackdropClose?: boolean;
 }
 
 /**
- * Centered overlay modal with brutal styling. Escape key + backdrop click
- * close it; clicks inside the modal body don't bubble out. Children lay out
- * the modal content (header / body / footer) themselves.
+ * Centered overlay modal with brutal styling. Closes only via explicit
+ * actions in the modal body — backdrop clicks and Escape are ignored so
+ * users can't lose in-progress form state by accident.
  */
 export function Modal({
-  onClose,
   widthClass = "w-[560px]",
   children,
-  disableBackdropClose,
 }: ModalProps) {
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") onClose();
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [onClose]);
-
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[4px] anim-in"
-      onClick={disableBackdropClose ? undefined : onClose}
-    >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[4px] anim-in">
       <div
         className={`${widthClass} max-h-[85vh] overflow-hidden rounded-xl border-2 border-border bg-surface flex flex-col anim-scale-in`}
         style={{ boxShadow: "var(--shadow-brutal)" }}
-        onClick={(e) => e.stopPropagation()}
       >
         {children}
       </div>

--- a/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
@@ -141,14 +141,8 @@ export function AddAgentDialog({
   const anthropicSecrets = secrets.filter((s) => s.type === "anthropic");
 
   return (
-    <div
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[4px] anim-in"
-      onClick={onCancel}
-    >
-      <div
-        className="w-[520px] max-w-[calc(100vw-2rem)] max-h-[85vh] overflow-y-auto rounded-xl border-2 border-border bg-surface p-5 md:p-7 flex flex-col gap-5 anim-scale-in shadow-brutal"
-        onClick={(e) => e.stopPropagation()}
-      >
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-[4px] anim-in">
+      <div className="w-[520px] max-w-[calc(100vw-2rem)] max-h-[85vh] overflow-y-auto rounded-xl border-2 border-border bg-surface p-5 md:p-7 flex flex-col gap-5 anim-scale-in shadow-brutal">
         {step === "pick" ? (
           <>
             <h2 className="text-[20px] font-bold text-text">Add Agent</h2>

--- a/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
@@ -187,7 +187,7 @@ export function ConfigureAgentDialog({
   const isSubmitDisabled = saving || !ready || !isDirty; 
 
   return (
-    <Modal onClose={onClose} widthClass="w-[640px]">
+    <Modal widthClass="w-[640px]">
       <form onSubmit={onSubmit} className="contents">
         <div className="px-7 pt-7 pb-4 border-b-2 border-border-light flex flex-col gap-3">
           <div>

--- a/packages/ui/src/modules/connections/forms/add-mcp-form.tsx
+++ b/packages/ui/src/modules/connections/forms/add-mcp-form.tsx
@@ -35,7 +35,7 @@ export function AddMcpForm({ initialUrl = "", onCancel }: Props) {
   };
 
   return (
-    <Modal onClose={onCancel} widthClass="w-[480px]">
+    <Modal widthClass="w-[480px]">
       <div className="flex flex-col gap-5 p-5 md:p-7">
         <h2 className="text-[20px] font-bold text-text">Connect MCP Server</h2>
         <p className="text-[13px] text-text-secondary">

--- a/packages/ui/src/modules/instances/dialogs/instance-settings-dialog.tsx
+++ b/packages/ui/src/modules/instances/dialogs/instance-settings-dialog.tsx
@@ -35,7 +35,7 @@ export function InstanceSettingsDialog({
   const removeUser = (email: string) => setUsers(users.filter(u => u !== email));
 
   return (
-    <Modal onClose={onCancel} widthClass="w-[460px]">
+    <Modal widthClass="w-[460px]">
       <div className="flex-1 overflow-y-auto p-5 md:p-7 flex flex-col gap-5">
         <div>
           <h2 className="text-[20px] font-bold text-text">Instance Settings</h2>

--- a/packages/ui/src/modules/secrets/components/edit-secret-dialog.tsx
+++ b/packages/ui/src/modules/secrets/components/edit-secret-dialog.tsx
@@ -110,7 +110,7 @@ export function EditSecretDialog({ secret, onClose }: Props) {
   });
 
   return (
-    <Modal onClose={onClose} widthClass="w-[540px]">
+    <Modal widthClass="w-[540px]">
       <form onSubmit={onSubmit} className="contents">
         <div className="px-7 pt-7 pb-4 border-b-2 border-border-light">
           <h2 className="text-[20px] font-bold text-text">Edit Secret</h2>

--- a/packages/ui/src/modules/secrets/forms/create-secret-form.tsx
+++ b/packages/ui/src/modules/secrets/forms/create-secret-form.tsx
@@ -88,7 +88,7 @@ export function CreateSecretForm({ onCancel, onCreated }: Props) {
   });
 
   return (
-    <Modal onClose={onCancel} widthClass="w-[480px]">
+    <Modal widthClass="w-[480px]">
       <form onSubmit={onSubmit} className="contents">
         <div className="px-7 pt-7 pb-4 border-b-2 border-border-light">
           <h2 className="text-[20px] font-bold text-text">Add Secret</h2>


### PR DESCRIPTION
## Summary
Cherry-picked from kagenti/humr#378.

Modals and confirm dialogs no longer close from accidental backdrop clicks or Escape presses — only explicit Cancel/Confirm/Save buttons close them, so users can't lose in-progress form state by mistake.

## Test plan
- [ ] Open a modal with form input, click on the backdrop — dialog stays open
- [ ] Open a modal, press Escape — dialog stays open
- [ ] Click explicit Cancel/Save/Confirm buttons — dialog closes as expected