### PR TITLE
feat(controller,api-server): ADR-027 fork pods on Envoy sidecar

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -231,6 +231,19 @@ Two boundaries are deliberately mismatched: the **data** boundary is permissive 
 
 The Foreign Registration cache is **process memory in the api-server, with no TTL** — eviction is manual and the cache is lost on api-server restart. The first fork request after a restart re-mints (idempotent — OneCLI returns the existing fork agent on `409`), so the worst case is a one-impersonation-exchange round-trip on cold path, not a correctness failure. Foreign-Registration tokens are opaque, identical in shape to the per-instance access token, and survive only as long as the agent-fork ConfigMap and its Job — both deleted at turn completion.
 
+### Forks on the experimental Envoy path
+
+When the parent instance has `experimentalCredentialInjector: true`, the fork follows the Envoy sidecar topology from ADR-033 instead of the OneCLI flow above:
+
+- The api-server **does not mint** a OneCLI fork-agent token. The `(instanceId, foreignSub) → accessToken` cache and the RFC 8693 impersonation hop in the Connections module are skipped entirely; `spec.yaml` carries `foreignSub` only — `accessToken` and `forkAgentIdentifier` are omitted.
+- The controller, on reconciling the fork ConfigMap, lists K8s credential `Secret`s labeled `humr.ai/owner=<foreignSub>` (the replier — *not* the parent owner) and renders them into a per-fork Envoy bootstrap ConfigMap and a per-fork cert-manager `Certificate` (leaf TLS for the SAN list of the replier's host patterns). Both resources are owned by the fork ConfigMap and GC'd with it on `ttlSecondsAfterFinished`.
+- The fork pod gets the same Envoy sidecar shape as a flag-on StatefulSet: `HTTPS_PROXY=http://127.0.0.1:<envoyPort>`; no `ONECLI_ACCESS_TOKEN`; agent container has no SA token (`automountServiceAccountToken: false`); pod has no shared process namespace; agent volume mounts do **not** include any credential `Secret` — the boundary lives at the container, not the pod.
+- The credential boundary that ADR-027 establishes is preserved: the fork can read the parent's PVC contents (data boundary, permissive — RWX cross-user mount) but its outbound calls go through Envoy injection driven exclusively by the **replier's** Secrets. The parent owner's Secrets do not appear in the fork's pod spec.
+- `HUMR_GH_TOKEN_AVAILABLE` is set on the fork's agent container based on whether any of the replier's Secrets target a GitHub host, mirroring the parent's flag-on signal so wrapper scripts can detect missing credentials without observing a 401 mid-request.
+- NetworkPolicy is shared with the parent via the `humr.ai/instance` label, so the parent's flag-on egress (TCP 443/80 to `0.0.0.0/0` plus DNS + harness API server) automatically applies to fork pods.
+
+The legacy OneCLI fork path remains the default for instances without the flag and is unaffected by this change. The OneCLI mint goes away entirely once the OneCLI dual-write is removed (issue #339).
+
 ## Threat model
 
 What the agent **cannot** do, structurally:

--- a/packages/api-server/src/__tests__/unit/forks-k8s-orchestrator.test.ts
+++ b/packages/api-server/src/__tests__/unit/forks-k8s-orchestrator.test.ts
@@ -52,6 +52,27 @@ describe("buildForkConfigMap", () => {
     const body = yaml.load(cm.data!["spec.yaml"]) as Record<string, unknown>;
     expect(body).not.toHaveProperty("sessionId");
   });
+
+  // Envoy path (ADR-033): the api-server skips the OneCLI mint, so the
+  // ConfigMap must omit `accessToken` and `forkAgentIdentifier`. The
+  // controller resolves credentials from foreignSub-labeled K8s Secrets at
+  // render time.
+  it("omits accessToken and forkAgentIdentifier on the Envoy path", () => {
+    const envoySpec: ForkSpec = {
+      instanceId: "inst-abc",
+      foreignSub: toForeignSub("kc|user-42"),
+      forkAgentIdentifier: "",
+    };
+    const cm = buildForkConfigMap({ forkId: "fork-1", spec: envoySpec });
+    const body = yaml.load(cm.data!["spec.yaml"]) as Record<string, unknown>;
+    expect(body).toEqual({
+      version: "humr.ai/v1",
+      instance: "inst-abc",
+      foreignSub: "kc|user-42",
+    });
+    expect(body).not.toHaveProperty("accessToken");
+    expect(body).not.toHaveProperty("forkAgentIdentifier");
+  });
 });
 
 describe("parseForkStatus", () => {

--- a/packages/api-server/src/__tests__/unit/forks-sagas.test.ts
+++ b/packages/api-server/src/__tests__/unit/forks-sagas.test.ts
@@ -32,10 +32,11 @@ async function drain(): Promise<void> {
 describe("on-foreign-reply saga", () => {
   let harness: ReturnType<typeof makeService>;
   let sub: { unsubscribe: () => void };
+  const flagOff = async () => false;
 
   beforeEach(() => {
     harness = makeService();
-    sub = startOnForeignReplySaga(harness.service);
+    sub = startOnForeignReplySaga(harness.service, flagOff);
   });
 
   it("calls openFork with correlation+identity fields from the event", async () => {
@@ -57,6 +58,7 @@ describe("on-foreign-reply saga", () => {
         foreignSub: "kc|user-42",
         replyId: "reply-1",
         sessionId: "sess-7",
+        experimentalCredentialInjector: false,
       },
     ]);
     sub.unsubscribe();
@@ -75,6 +77,28 @@ describe("on-foreign-reply saga", () => {
     await drain();
 
     expect(harness.openCalls[0]).not.toHaveProperty("sessionId");
+    sub.unsubscribe();
+  });
+
+  it("propagates experimentalCredentialInjector=true when the resolver says so", async () => {
+    sub.unsubscribe();
+    sub = startOnForeignReplySaga(harness.service, async () => true);
+
+    emit({
+      type: EventType.ForeignReplyReceived,
+      replyId: "reply-flag",
+      instanceId: "inst-flag",
+      foreignSub: "kc|user-42",
+      threadTs: "1700000000.000300",
+      prompt: "hi",
+      slackContext: { channelId: "C123", userSlackId: "U42" },
+    });
+    await drain();
+
+    expect(harness.openCalls[0]).toMatchObject({
+      instanceId: "inst-flag",
+      experimentalCredentialInjector: true,
+    });
     sub.unsubscribe();
   });
 
@@ -98,7 +122,7 @@ describe("on-foreign-reply saga", () => {
       },
       closeFork: async () => {},
     };
-    const s = startOnForeignReplySaga(failing);
+    const s = startOnForeignReplySaga(failing, flagOff);
 
     expect(() =>
       emit({

--- a/packages/api-server/src/__tests__/unit/forks-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/forks-service.test.ts
@@ -209,6 +209,74 @@ describe("ForksService.openFork", () => {
   });
 });
 
+describe("ForksService.openFork — Envoy path (experimentalCredentialInjector=true)", () => {
+  it("skips the foreign-credentials mint and creates the fork without an accessToken", async () => {
+    let mintCalls = 0;
+    const orchestratorCalls: Array<{ forkId: string; accessToken?: string; forkAgentIdentifier: string }> = [];
+    const h = makeHarness({
+      foreignCredentials: {
+        mintForeignToken: async () => {
+          mintCalls++;
+          return ok({ accessToken: "should-not-be-used", agentIdentifier: "should-not-be-used" });
+        },
+      },
+      orchestrator: {
+        createFork: async ({ forkId, spec, accessToken }) => {
+          orchestratorCalls.push({ forkId, accessToken, forkAgentIdentifier: spec.forkAgentIdentifier });
+          return ok(undefined);
+        },
+      },
+    });
+
+    await h.service.openFork({
+      instanceId: "inst-1",
+      foreignSub: "kc|user-42",
+      replyId: "reply-1",
+      experimentalCredentialInjector: true,
+    });
+    h.statusStream("fork-1", [{ phase: "Ready", podIP: "10.0.0.7" }]);
+    await h.streamDone();
+
+    expect(mintCalls).toBe(0);
+    expect(orchestratorCalls).toEqual([
+      { forkId: "fork-1", accessToken: undefined, forkAgentIdentifier: "" },
+    ]);
+    expect(h.events).toEqual([
+      {
+        type: EventType.ForkReady,
+        forkId: "fork-1",
+        replyId: "reply-1",
+        podIP: "10.0.0.7",
+      },
+    ]);
+  });
+
+  it("emits ForkFailed(OrchestrationFailed) when the controller can't write the ConfigMap", async () => {
+    const h = makeHarness({
+      orchestrator: {
+        createFork: async () => err({ kind: "WriteFailed", detail: "apiserver 503" }),
+      },
+    });
+
+    await h.service.openFork({
+      instanceId: "inst-1",
+      foreignSub: "kc|user-42",
+      replyId: "reply-1",
+      experimentalCredentialInjector: true,
+    });
+
+    expect(h.events).toEqual([
+      {
+        type: EventType.ForkFailed,
+        forkId: "fork-1",
+        replyId: "reply-1",
+        reason: "OrchestrationFailed",
+        detail: "apiserver 503",
+      },
+    ]);
+  });
+});
+
 describe("ForksService.closeFork", () => {
   it("deletes the K8s fork and emits ForkCompleted after a Ready fork", async () => {
     const h = makeHarness({});

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -78,7 +78,21 @@ const { forks } = composeForksModule({
   orchestrator: createK8sForkOrchestrator({ api, namespace: config.namespace }),
 });
 
-const onForeignReplySub = startOnForeignReplySaga(forks);
+// Resolves the parent instance's `experimentalCredentialInjector` flag at
+// fork time. Failure → false: we fall back to the legacy OneCLI path rather
+// than blocking the fork on a transient K8s read error. See ADR-033.
+const onForeignReplySub = startOnForeignReplySaga(
+  forks,
+  async (instanceId) => {
+    try {
+      const inst = await instancesRepo.get(instanceId);
+      return inst?.experimentalCredentialInjector ?? false;
+    } catch (err) {
+      process.stderr.write(`[forks/on-foreign-reply] flag-lookup ${instanceId}: ${err}\n`);
+      return false;
+    }
+  },
+);
 const onSlackTurnRelayedSub = startOnSlackTurnRelayedSaga(forks);
 
 const userDirectory = createKeycloakUserDirectory({

--- a/packages/api-server/src/modules/forks/domain/fork.ts
+++ b/packages/api-server/src/modules/forks/domain/fork.ts
@@ -12,6 +12,11 @@ export type ForkPhase = "Pending" | "Ready" | "Failed" | "Completed";
 export interface ForkSpec {
   readonly instanceId: string;
   readonly foreignSub: ForeignSub;
+  /**
+   * OneCLI fork-agent identifier minted by the api-server's
+   * foreign-credentials port. Empty on the Envoy path (ADR-033) where the
+   * controller resolves credentials from foreignSub-labeled K8s Secrets.
+   */
   readonly forkAgentIdentifier: string;
   readonly sessionId?: string;
 }

--- a/packages/api-server/src/modules/forks/infrastructure/configmap-mappers.ts
+++ b/packages/api-server/src/modules/forks/infrastructure/configmap-mappers.ts
@@ -16,9 +16,15 @@ interface ForkSpecYaml {
   version: string;
   instance: string;
   foreignSub: string;
-  forkAgentIdentifier: string;
+  /**
+   * Set on the legacy OneCLI path; omitted on the Envoy path (ADR-033)
+   * where the controller resolves credentials from foreignSub-labeled
+   * K8s Secrets at render time.
+   */
+  forkAgentIdentifier?: string;
   sessionId?: string;
-  accessToken: string;
+  /** Same gating as `forkAgentIdentifier`. */
+  accessToken?: string;
 }
 
 interface ForkStatusYaml {
@@ -32,15 +38,18 @@ interface ForkStatusYaml {
 export function buildForkConfigMap(args: {
   forkId: string;
   spec: ForkSpec;
-  accessToken: string;
+  /** Omitted on the Envoy path. */
+  accessToken?: string;
 }): k8s.V1ConfigMap {
   const body: ForkSpecYaml = {
     version: SPEC_VERSION,
     instance: args.spec.instanceId,
     foreignSub: args.spec.foreignSub,
-    forkAgentIdentifier: args.spec.forkAgentIdentifier,
-    accessToken: args.accessToken,
   };
+  if (args.spec.forkAgentIdentifier) {
+    body.forkAgentIdentifier = args.spec.forkAgentIdentifier;
+  }
+  if (args.accessToken !== undefined) body.accessToken = args.accessToken;
   if (args.spec.sessionId !== undefined) body.sessionId = args.spec.sessionId;
 
   return {

--- a/packages/api-server/src/modules/forks/infrastructure/ports.ts
+++ b/packages/api-server/src/modules/forks/infrastructure/ports.ts
@@ -23,10 +23,16 @@ export type OrchestratorCreateError =
   | { kind: "AlreadyExists" };
 
 export interface ForkOrchestratorPort {
+  /**
+   * Write the fork ConfigMap. `accessToken` is omitted on the Envoy path
+   * (ADR-033): the controller resolves the replier's K8s credential
+   * Secrets at render time using `spec.foreignSub`, so no minted OneCLI
+   * token is needed in `spec.yaml`.
+   */
   createFork(args: {
     forkId: string;
     spec: ForkSpec;
-    accessToken: string;
+    accessToken?: string;
   }): Promise<Result<void, OrchestratorCreateError>>;
 
   watchStatus(forkId: string): AsyncIterable<ForkStatus>;

--- a/packages/api-server/src/modules/forks/sagas/on-foreign-reply.ts
+++ b/packages/api-server/src/modules/forks/sagas/on-foreign-reply.ts
@@ -8,15 +8,26 @@ import {
 } from "../../../events.js";
 import type { ForksService } from "../services/forks-service.js";
 
-export function startOnForeignReplySaga(forks: ForksService): Subscription {
+/** Looks up the parent instance's `experimentalCredentialInjector` flag. The
+ *  saga consults this to choose between the OneCLI mint path and the Envoy
+ *  sidecar render path (ADR-033). Returns false on any read failure (we
+ *  fall back to the legacy path rather than blocking the fork). */
+export type ResolveExperimentalFlag = (instanceId: string) => Promise<boolean>;
+
+export function startOnForeignReplySaga(
+  forks: ForksService,
+  resolveExperimentalFlag: ResolveExperimentalFlag,
+): Subscription {
   return events$().pipe(
     ofType<ForeignReplyReceived>(EventType.ForeignReplyReceived),
     mergeMap(async (event) => {
       try {
+        const experimentalCredentialInjector = await resolveExperimentalFlag(event.instanceId);
         await forks.openFork({
           instanceId: event.instanceId,
           foreignSub: event.foreignSub,
           replyId: event.replyId,
+          experimentalCredentialInjector,
           ...(event.sessionId !== undefined ? { sessionId: event.sessionId } : {}),
         });
       } catch (err) {

--- a/packages/api-server/src/modules/forks/services/forks-service.ts
+++ b/packages/api-server/src/modules/forks/services/forks-service.ts
@@ -23,6 +23,13 @@ export interface OpenForkInput {
   foreignSub: string;
   replyId: string;
   sessionId?: string;
+  /**
+   * Parent instance's `experimentalCredentialInjector` flag. When `true`,
+   * the foreign-credentials mint (RFC 8693 token exchange + OneCLI
+   * fork-agent registration) is skipped — the controller resolves
+   * credentials from the replier's K8s Secrets at render time (ADR-033).
+   */
+  experimentalCredentialInjector?: boolean;
 }
 
 export interface ForksService {
@@ -84,6 +91,38 @@ export function createForksService(deps: {
     async openFork(input) {
       const forkId = generateForkId();
 
+      // Envoy path (ADR-033): no OneCLI fork-agent, no minted access
+      // token. The controller picks up the replier's K8s Secrets at render
+      // time via foreignSub-labelled selectors.
+      if (input.experimentalCredentialInjector) {
+        const fork = createFork({
+          forkId,
+          replyId: input.replyId,
+          spec: {
+            instanceId: input.instanceId,
+            foreignSub: toForeignSub(input.foreignSub),
+            forkAgentIdentifier: "",
+            ...(input.sessionId !== undefined ? { sessionId: input.sessionId } : {}),
+          },
+        });
+        open.set(forkId, fork);
+
+        const created = await deps.orchestrator.createFork({
+          forkId,
+          spec: fork.spec,
+        });
+        if (!created.ok) {
+          const detail =
+            created.error.kind === "WriteFailed" ? created.error.detail : created.error.kind;
+          emitFailed(fork, "OrchestrationFailed", detail);
+          return;
+        }
+
+        void consumeStatus(fork);
+        return;
+      }
+
+      // Legacy OneCLI path: mint foreign-user token, inline into ConfigMap.
       const minted = await deps.foreignCredentials.mintForeignToken({
         foreignSub: input.foreignSub,
         instanceId: input.instanceId,

--- a/packages/controller/main.go
+++ b/packages/controller/main.go
@@ -112,7 +112,7 @@ func run(ctx context.Context, client kubernetes.Interface, dynClient dynamic.Int
 	agentResolver := reconciler.NewAgentResolver(cmInformer.Lister().ConfigMaps(cfg.Namespace))
 	agentReconciler := reconciler.NewAgentReconciler(client, cfg, onecliFactory)
 	instanceReconciler := reconciler.NewInstanceReconciler(client, cfg, agentResolver, onecliFactory).WithDynamicClient(dynClient)
-	forkReconciler := reconciler.NewForkReconciler(client, cfg, agentResolver, onecliFactory)
+	forkReconciler := reconciler.NewForkReconciler(client, cfg, agentResolver, onecliFactory).WithDynamicClient(dynClient)
 
 	sched := scheduler.New(client, cfg).WithRESTConfig(restCfg)
 	sched.Start()

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -6,10 +6,14 @@ import (
 	"log/slog"
 	"time"
 
+	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 	"gopkg.in/yaml.v3"
@@ -23,6 +27,7 @@ const ForkPodReadyTimeout = 120 * time.Second
 
 type ForkReconciler struct {
 	client   kubernetes.Interface
+	dynamic  dynamic.Interface // optional; required only on the experimental Envoy path
 	config   *config.Config
 	resolver *AgentResolver
 	factory  onecli.Factory
@@ -31,6 +36,15 @@ type ForkReconciler struct {
 
 func NewForkReconciler(client kubernetes.Interface, cfg *config.Config, resolver *AgentResolver, factory onecli.Factory) *ForkReconciler {
 	return &ForkReconciler{client: client, config: cfg, resolver: resolver, factory: factory, now: time.Now}
+}
+
+// WithDynamicClient supplies a dynamic client used to apply the cert-manager
+// Certificate that backs the per-fork Envoy leaf TLS Secret. Must be set when
+// the controller will reconcile flag-on parents; the OneCLI path doesn't need
+// it. Mirrors `InstanceReconciler.WithDynamicClient`.
+func (r *ForkReconciler) WithDynamicClient(d dynamic.Interface) *ForkReconciler {
+	r.dynamic = d
+	return r
 }
 
 func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) error {
@@ -72,9 +86,51 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, err.Error())
 	}
 
-	connectorEnvs := r.collectForeignConnectorEnvs(ctx, forkSpec.ForkAgentIdentifier, forkSpec.ForeignSub)
+	// Connector envs come from OneCLI's per-agent grant list. On the legacy
+	// path the api-server has minted a fork-agent under foreignSub and the
+	// identifier is in the spec; on the Envoy path no fork-agent exists,
+	// so envMappings (e.g. GH_TOKEN=humr:sentinel) are not surfaced — Envoy
+	// handles the wire-level injection regardless. Once #339 removes
+	// OneCLI, env-var derivation will move to K8s Secret labels.
+	var connectorEnvs []corev1.EnvVar
+	if !instanceSpec.ExperimentalCredentialInjector {
+		connectorEnvs = r.collectForeignConnectorEnvs(ctx, forkSpec.ForkAgentIdentifier, forkSpec.ForeignSub)
+	}
 
-	desired := BuildForkJob(forkName, forkSpec, instanceSpec, agentSpec, r.config, cm, connectorEnvs)
+	// Envoy path: load the replier's K8s credential Secrets and render the
+	// per-fork bootstrap ConfigMap + leaf certificate. Crucially, secrets
+	// are scoped to `foreignSub` — the parent owner's secrets must NOT
+	// appear here (ADR-033 §"Fork-Job pods follow the replier"). The
+	// per-fork bootstrap/leaf names are derived from `forkName`, so the
+	// resources are owned by the fork ConfigMap and GC'd with it.
+	var credentialSecrets []corev1.Secret
+	if instanceSpec.ExperimentalCredentialInjector {
+		secrets, err := listOwnerCredentialSecrets(ctx, r.client, r.config.Namespace, forkSpec.ForeignSub)
+		if err != nil {
+			return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("listing replier credential secrets: %v", err))
+		}
+		credentialSecrets = secrets
+
+		if !hasGitHubCredential(credentialSecrets) {
+			slog.Warn("fork on Envoy path: replier has no GitHub credential Secret; gh/octokit calls will be unauthenticated",
+				"fork", forkName, "foreignSub", forkSpec.ForeignSub)
+		}
+
+		bootstrapCM, err := BuildEnvoyBootstrapConfigMap(forkName, r.config, cm, credentialSecrets)
+		if err != nil {
+			return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("rendering envoy bootstrap: %v", err))
+		}
+		if err := r.applyConfigMap(ctx, bootstrapCM); err != nil {
+			return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying envoy bootstrap: %v", err))
+		}
+		if cert := BuildEnvoyLeafCertificate(forkName, r.config, cm, credentialSecrets); cert != nil {
+			if err := r.applyCertificate(ctx, cert); err != nil {
+				return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying envoy leaf certificate: %v", err))
+			}
+		}
+	}
+
+	desired := BuildForkJob(forkName, forkSpec, instanceSpec, agentSpec, r.config, cm, connectorEnvs, credentialSecrets)
 
 	if err := r.applyForkJob(ctx, desired); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying job: %v", err))
@@ -203,4 +259,54 @@ func jobFailureReason(job *batchv1.Job) string {
 		}
 	}
 	return "job failed"
+}
+
+// applyConfigMap mirrors `InstanceReconciler.applyConfigMap` for fork-scoped
+// ConfigMaps (Envoy bootstrap). Owner references on `desired` cause the CM to
+// be GC'd when the fork CM is deleted.
+func (r *ForkReconciler) applyConfigMap(ctx context.Context, desired *corev1.ConfigMap) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := r.client.CoreV1().ConfigMaps(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			_, err = r.client.CoreV1().ConfigMaps(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		existing.Data = desired.Data
+		existing.OwnerReferences = desired.OwnerReferences
+		existing.Labels = desired.Labels
+		_, err = r.client.CoreV1().ConfigMaps(desired.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// applyCertificate mirrors `InstanceReconciler.applyCertificate` for fork-scoped
+// cert-manager Certificates (Envoy leaf TLS).
+func (r *ForkReconciler) applyCertificate(ctx context.Context, desired *cmv1.Certificate) error {
+	if r.dynamic == nil {
+		return fmt.Errorf("dynamic client not configured (cert-manager Certificate cannot be applied)")
+	}
+	raw, err := runtime.DefaultUnstructuredConverter.ToUnstructured(desired)
+	if err != nil {
+		return fmt.Errorf("encoding Certificate: %w", err)
+	}
+	desiredU := &unstructured.Unstructured{Object: raw}
+	desiredU.SetAPIVersion(cmv1.SchemeGroupVersion.String())
+	desiredU.SetKind("Certificate")
+	cli := r.dynamic.Resource(certificateGVR).Namespace(desired.Namespace)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := cli.Get(ctx, desired.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			_, err = cli.Create(ctx, desiredU, metav1.CreateOptions{})
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		desiredU.SetResourceVersion(existing.GetResourceVersion())
+		_, err = cli.Update(ctx, desiredU, metav1.UpdateOptions{})
+		return err
+	})
 }

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -21,6 +21,22 @@ const (
 
 // BuildForkJob constructs the per-turn foreign-user fork pod.
 //
+// Two paths share this renderer, switched by the parent instance's
+// `experimentalCredentialInjector` flag:
+//
+//   - **OneCLI path** (flag-off): `forkSpec.AccessToken` rides in
+//     `ONECLI_ACCESS_TOKEN`; `HTTPS_PROXY` points at the OneCLI gateway;
+//     credential injection happens in the cross-namespace MITM. Mirrors
+//     the long-lived StatefulSet's flag-off shape from `BuildStatefulSet`.
+//
+//   - **Envoy path** (flag-on, ADR-033): `credentialSecrets` are the
+//     replier's `(owner=foreignSub, connection=*)` K8s Secrets — the
+//     instance owner's Secrets must NOT appear here; the credential
+//     boundary is the container, and the agent never sees Secret bytes.
+//     `HTTPS_PROXY` points at the colocated `envoy` sidecar on
+//     `127.0.0.1`; `ONECLI_ACCESS_TOKEN` is dropped; SA-token automount
+//     and process-namespace sharing are disabled.
+//
 // Forks deliberately do NOT receive `HUMR_POD_FILES_EVENTS_URL`, so the
 // agent-runtime running in the fork pod skips the pod-files SSE loop
 // entirely. Forks are short-lived ACP-relay jobs spawned per turn; the
@@ -38,6 +54,7 @@ func BuildForkJob(
 	cfg *config.Config,
 	ownerCM *corev1.ConfigMap,
 	connectorEnvs []corev1.EnvVar,
+	credentialSecrets []corev1.Secret,
 ) *batchv1.Job {
 	labels := map[string]string{
 		ForkLabelType:        ForkJobLabelType,
@@ -45,29 +62,41 @@ func BuildForkJob(
 		ForkLabelInstanceRef: forkSpec.Instance,
 	}
 
-	proxyAddr := fmt.Sprintf("http://x:$(ONECLI_ACCESS_TOKEN)@%s:%d", cfg.GatewayFQDN(), cfg.GatewayPort)
 	caCertPath := "/etc/humr/ca/ca.crt"
 
-	env := []corev1.EnvVar{
-		{Name: "ONECLI_ACCESS_TOKEN", Value: forkSpec.AccessToken},
-		{Name: "HTTPS_PROXY", Value: proxyAddr},
-		{Name: "HTTP_PROXY", Value: proxyAddr},
-		{Name: "https_proxy", Value: proxyAddr},
-		{Name: "http_proxy", Value: proxyAddr},
-		{Name: "NO_PROXY", Value: cfg.APIServerHost},
-		{Name: "no_proxy", Value: cfg.APIServerHost},
-		{Name: "SSL_CERT_FILE", Value: caCertPath},
-		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
-		{Name: "GIT_SSL_CAINFO", Value: caCertPath},
-		{Name: "NODE_USE_ENV_PROXY", Value: "1"},
-		{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
-		{Name: "ADK_INSTANCE_ID", Value: forkSpec.Instance},
-		{Name: "API_SERVER_URL", Value: cfg.APIServerURL()},
-		{Name: "HOME", Value: cfg.AgentHome},
-		{Name: "HUMR_MCP_URL", Value: fmt.Sprintf("%s/api/instances/%s/mcp", cfg.HarnessServerURL, forkSpec.Instance)},
-		{Name: "HUMR_FORK_ID", Value: forkName},
-		{Name: "HUMR_FOREIGN_SUB", Value: forkSpec.ForeignSub},
+	var proxyAddr string
+	if instanceSpec.ExperimentalCredentialInjector {
+		proxyAddr = fmt.Sprintf("http://127.0.0.1:%d", cfg.EnvoyPort)
+	} else {
+		proxyAddr = fmt.Sprintf("http://x:$(ONECLI_ACCESS_TOKEN)@%s:%d", cfg.GatewayFQDN(), cfg.GatewayPort)
 	}
+
+	env := []corev1.EnvVar{}
+	if !instanceSpec.ExperimentalCredentialInjector {
+		// Inlined directly from the fork spec (minted by api-server). On the
+		// Envoy path the sidecar reads creds from disk; the agent has no
+		// proxy credential at all.
+		env = append(env, corev1.EnvVar{Name: "ONECLI_ACCESS_TOKEN", Value: forkSpec.AccessToken})
+	}
+	env = append(env,
+		corev1.EnvVar{Name: "HTTPS_PROXY", Value: proxyAddr},
+		corev1.EnvVar{Name: "HTTP_PROXY", Value: proxyAddr},
+		corev1.EnvVar{Name: "https_proxy", Value: proxyAddr},
+		corev1.EnvVar{Name: "http_proxy", Value: proxyAddr},
+		corev1.EnvVar{Name: "NO_PROXY", Value: cfg.APIServerHost},
+		corev1.EnvVar{Name: "no_proxy", Value: cfg.APIServerHost},
+		corev1.EnvVar{Name: "SSL_CERT_FILE", Value: caCertPath},
+		corev1.EnvVar{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
+		corev1.EnvVar{Name: "GIT_SSL_CAINFO", Value: caCertPath},
+		corev1.EnvVar{Name: "NODE_USE_ENV_PROXY", Value: "1"},
+		corev1.EnvVar{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
+		corev1.EnvVar{Name: "ADK_INSTANCE_ID", Value: forkSpec.Instance},
+		corev1.EnvVar{Name: "API_SERVER_URL", Value: cfg.APIServerURL()},
+		corev1.EnvVar{Name: "HOME", Value: cfg.AgentHome},
+		corev1.EnvVar{Name: "HUMR_MCP_URL", Value: fmt.Sprintf("%s/api/instances/%s/mcp", cfg.HarnessServerURL, forkSpec.Instance)},
+		corev1.EnvVar{Name: "HUMR_FORK_ID", Value: forkName},
+		corev1.EnvVar{Name: "HUMR_FOREIGN_SUB", Value: forkSpec.ForeignSub},
+	)
 	env = append(env, connectorEnvs...)
 	for _, e := range agentSpec.Env {
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
@@ -111,10 +140,25 @@ func BuildForkJob(
 		}
 	}
 
-	volumes = append(volumes, corev1.Volume{
-		Name:         "ca-cert",
-		VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-	})
+	// CA cert volume — mirrors `BuildStatefulSet`. On the Envoy path the
+	// `ca.crt` is projected from the per-fork leaf Secret; on the OneCLI
+	// path it's an emptyDir populated by the fetch-ca-cert init container.
+	if instanceSpec.ExperimentalCredentialInjector && len(credentialSecrets) > 0 {
+		volumes = append(volumes, corev1.Volume{
+			Name: "ca-cert",
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: EnvoyLeafSecretName(forkName),
+					Items: []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+				},
+			},
+		})
+	} else {
+		volumes = append(volumes, corev1.Volume{
+			Name:         "ca-cert",
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name: "ca-cert", MountPath: "/etc/humr/ca", ReadOnly: true,
 	})
@@ -127,19 +171,24 @@ func BuildForkJob(
 		resourceReqs.Limits = toResourceList(agentSpec.Resources.Limits)
 	}
 
-	caCertScript := fmt.Sprintf(
-		`until wget -qO /etc/humr/ca/ca.crt "%s/api/gateway/ca" 2>/dev/null; do sleep 2; done`,
-		cfg.WebURL())
-
-	initContainers := []corev1.Container{{
-		Name:            "fetch-ca-cert",
-		Image:           cfg.CACertInitImage,
-		ImagePullPolicy: corev1.PullIfNotPresent,
-		Command:         []string{"sh", "-c", caCertScript},
-		VolumeMounts: []corev1.VolumeMount{{
-			Name: "ca-cert", MountPath: "/etc/humr/ca",
-		}},
-	}}
+	// Init containers: fetch-ca-cert is OneCLI-only — Envoy-path forks get
+	// the CA from the projected leaf Secret. Optional user-defined init
+	// container runs on either path.
+	var initContainers []corev1.Container
+	if !instanceSpec.ExperimentalCredentialInjector {
+		caCertScript := fmt.Sprintf(
+			`until wget -qO /etc/humr/ca/ca.crt "%s/api/gateway/ca" 2>/dev/null; do sleep 2; done`,
+			cfg.WebURL())
+		initContainers = append(initContainers, corev1.Container{
+			Name:            "fetch-ca-cert",
+			Image:           cfg.CACertInitImage,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Command:         []string{"sh", "-c", caCertScript},
+			VolumeMounts: []corev1.VolumeMount{{
+				Name: "ca-cert", MountPath: "/etc/humr/ca",
+			}},
+		})
+	}
 	if agentSpec.Init != "" {
 		initContainers = append(initContainers, corev1.Container{
 			Name:            "init",
@@ -160,6 +209,60 @@ func BuildForkJob(
 		podSec = &corev1.PodSecurityContext{
 			RunAsNonRoot: agentSpec.SecurityContext.RunAsNonRoot,
 		}
+	}
+
+	containers := []corev1.Container{{
+		Name:            "agent",
+		Image:           agentSpec.Image,
+		ImagePullPolicy: corev1.PullPolicy(cfg.AgentImagePullPolicy),
+		Ports: []corev1.ContainerPort{{
+			Name: "acp", ContainerPort: 8080,
+		}},
+		Env:     env,
+		EnvFrom: envFrom,
+		ReadinessProbe: &corev1.Probe{
+			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			PeriodSeconds: 1,
+		},
+		LivenessProbe: &corev1.Probe{
+			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+		},
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
+		Resources:    resourceReqs,
+		VolumeMounts: volumeMounts,
+	}}
+
+	var automountSAToken *bool
+	var shareProcessNS *bool
+	if instanceSpec.ExperimentalCredentialInjector {
+		// Sidecar only — agent container never sees credential mounts.
+		volumes = append(volumes, envoySidecarVolumes(forkName, credentialSecrets)...)
+		containers = append(containers, envoySidecarContainer(cfg, credentialSecrets))
+		// ADR-033 Threat Model: agent must have no SA token (Secret-read
+		// RBAC would otherwise bypass volume-mount scoping) and process
+		// namespace must not be shared with the sidecar.
+		falseVal := false
+		automountSAToken = &falseVal
+		shareProcessNS = &falseVal
+
+		// GH_TOKEN signal — mirrors `BuildStatefulSet`. The OneCLI sentinel
+		// doesn't apply on the Envoy path, so tooling has no way to know
+		// whether GitHub auth is wired up other than to make a request and
+		// observe a 401. Surface the state explicitly.
+		ghAvail := "false"
+		if hasGitHubCredential(credentialSecrets) {
+			ghAvail = "true"
+		}
+		containers[0].Env = append(containers[0].Env, corev1.EnvVar{
+			Name:  "HUMR_GH_TOKEN_AVAILABLE",
+			Value: ghAvail,
+		})
 	}
 
 	ttl := int32(60)
@@ -185,33 +288,10 @@ func BuildForkJob(
 					ImagePullSecrets:              pullSecrets,
 					SecurityContext:               podSec,
 					InitContainers:                initContainers,
-					Containers: []corev1.Container{{
-						Name:            "agent",
-						Image:           agentSpec.Image,
-						ImagePullPolicy: corev1.PullPolicy(cfg.AgentImagePullPolicy),
-						Ports: []corev1.ContainerPort{{
-							Name: "acp", ContainerPort: 8080,
-						}},
-						Env:     env,
-						EnvFrom: envFrom,
-						ReadinessProbe: &corev1.Probe{
-							ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-							PeriodSeconds: 1,
-						},
-						LivenessProbe: &corev1.Probe{
-							ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-							InitialDelaySeconds: 10,
-							PeriodSeconds:       10,
-						},
-						SecurityContext: &corev1.SecurityContext{
-							Capabilities: &corev1.Capabilities{
-								Drop: []corev1.Capability{"ALL"},
-							},
-						},
-						Resources:    resourceReqs,
-						VolumeMounts: volumeMounts,
-					}},
-					Volumes: volumes,
+					AutomountServiceAccountToken:  automountSAToken,
+					ShareProcessNamespace:         shareProcessNS,
+					Containers:                    containers,
+					Volumes:                       volumes,
 				},
 			},
 		},

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -36,7 +36,7 @@ var testForkInstance = &types.InstanceSpec{
 }
 
 func TestBuildForkJob_BasicShape(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 
 	require.NotNil(t, job)
 	assert.Equal(t, "fork-abc", job.Name)
@@ -51,7 +51,7 @@ func TestBuildForkJob_BasicShape(t *testing.T) {
 }
 
 func TestBuildForkJob_LifecycleGuarantees(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 
 	require.NotNil(t, job.Spec.BackoffLimit)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
@@ -63,7 +63,7 @@ func TestBuildForkJob_LifecycleGuarantees(t *testing.T) {
 }
 
 func TestBuildForkJob_ForeignTokenInlined(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 
 	require.Len(t, job.Spec.Template.Spec.Containers, 1)
 	c := job.Spec.Template.Spec.Containers[0]
@@ -81,7 +81,7 @@ func TestBuildForkJob_ForeignTokenInlined(t *testing.T) {
 }
 
 func TestBuildForkJob_ForkMetadataEnv(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 	c := job.Spec.Template.Spec.Containers[0]
 
 	env := envMap(c.Env)
@@ -91,7 +91,7 @@ func TestBuildForkJob_ForkMetadataEnv(t *testing.T) {
 }
 
 func TestBuildForkJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 
 	podSpec := job.Spec.Template.Spec
 
@@ -109,7 +109,7 @@ func TestBuildForkJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
 }
 
 func TestBuildForkJob_CACertInitContainer(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 
 	initNames := make([]string, 0, len(job.Spec.Template.Spec.InitContainers))
 	for _, ic := range job.Spec.Template.Spec.InitContainers {
@@ -125,7 +125,7 @@ func TestBuildForkJob_InheritsInstanceEnvAndSecretRef(t *testing.T) {
 		Env:          []types.EnvVar{{Name: "FOO", Value: "bar"}},
 		SecretRef:    "my-extra-secret",
 	}
-	job := BuildForkJob("fork-abc", testForkSpec, instance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkJob("fork-abc", testForkSpec, instance, testAgent, testConfig, testForkOwnerCM, nil, nil)
 	c := job.Spec.Template.Spec.Containers[0]
 
 	assert.Equal(t, "bar", envMap(c.Env)["FOO"])
@@ -140,4 +140,127 @@ func envMap(envs []corev1.EnvVar) map[string]string {
 		m[e.Name] = e.Value
 	}
 	return m
+}
+
+// --- Experimental credential injector (Envoy sidecar) path ---
+
+// On the Envoy fork path the api-server skips the OneCLI mint, so the spec
+// arrives without `accessToken` / `forkAgentIdentifier`. The controller
+// resolves credentials from foreignSub-labelled K8s Secrets at render time.
+var testForkSpecEnvoy = &types.ForkSpec{
+	Version:    types.SpecVersion,
+	Instance:   "my-instance",
+	ForeignSub: "kc|user-42",
+	SessionID:  "sess-1",
+}
+
+var testForkInstanceFlagOn = &types.InstanceSpec{
+	Version:                        types.SpecVersion,
+	DesiredState:                   "running",
+	AgentName:                      "my-agent",
+	ExperimentalCredentialInjector: true,
+}
+
+func TestBuildForkJob_FlagOn_AddsEnvoySidecar(t *testing.T) {
+	secrets := []corev1.Secret{credSecret("humr-cred-replier-x", "api.example.com")}
+	job := BuildForkJob("fork-abc", testForkSpecEnvoy, testForkInstanceFlagOn, testAgent, testEnvoyConfig, testForkOwnerCM, nil, secrets)
+
+	require.Len(t, job.Spec.Template.Spec.Containers, 2, "agent + envoy sidecar")
+	agent := job.Spec.Template.Spec.Containers[0]
+	envoy := job.Spec.Template.Spec.Containers[1]
+	assert.Equal(t, "agent", agent.Name)
+	assert.Equal(t, "envoy", envoy.Name)
+	assert.Equal(t, "envoyproxy/envoy:distroless-v1.37.2", envoy.Image)
+
+	envM := envMap(agent.Env)
+	assert.Equal(t, "http://127.0.0.1:10000", envM["HTTP_PROXY"])
+	assert.Equal(t, "http://127.0.0.1:10000", envM["HTTPS_PROXY"])
+	assert.NotContains(t, envM, "ONECLI_ACCESS_TOKEN", "fork on Envoy path must not see the OneCLI sentinel")
+
+	// Pod-level threat-model wiring matches the parent's flag-on path.
+	require.NotNil(t, job.Spec.Template.Spec.AutomountServiceAccountToken)
+	assert.False(t, *job.Spec.Template.Spec.AutomountServiceAccountToken)
+	require.NotNil(t, job.Spec.Template.Spec.ShareProcessNamespace)
+	assert.False(t, *job.Spec.Template.Spec.ShareProcessNamespace)
+}
+
+func TestBuildForkJob_FlagOn_ReplierSecretsMountedSidecarOnly(t *testing.T) {
+	secrets := []corev1.Secret{credSecret("humr-cred-replier-x", "api.example.com")}
+	job := BuildForkJob("fork-abc", testForkSpecEnvoy, testForkInstanceFlagOn, testAgent, testEnvoyConfig, testForkOwnerCM, nil, secrets)
+
+	require.Len(t, job.Spec.Template.Spec.Containers, 2)
+	agent := job.Spec.Template.Spec.Containers[0]
+	envoy := job.Spec.Template.Spec.Containers[1]
+
+	// Sidecar gets the credential mount...
+	envoyMounts := map[string]bool{}
+	for _, m := range envoy.VolumeMounts {
+		envoyMounts[m.Name] = true
+	}
+	require.True(t, envoyMounts["cred-humr-cred-replier-x"], "envoy must mount the replier credential secret")
+
+	// ...and the agent absolutely does not.
+	for _, m := range agent.VolumeMounts {
+		assert.NotEqual(t, "cred-humr-cred-replier-x", m.Name, "credential boundary lives at the container — agent must not see Secret bytes")
+	}
+}
+
+func TestBuildForkJob_FlagOn_NoFetchCACertInit(t *testing.T) {
+	// On the Envoy path the CA comes from a projected leaf Secret; the OneCLI
+	// fetch-ca-cert init container is only relevant on the legacy path.
+	secrets := []corev1.Secret{credSecret("humr-cred-replier-x", "api.example.com")}
+	job := BuildForkJob("fork-abc", testForkSpecEnvoy, testForkInstanceFlagOn, testAgent, testEnvoyConfig, testForkOwnerCM, nil, secrets)
+
+	for _, ic := range job.Spec.Template.Spec.InitContainers {
+		assert.NotEqual(t, "fetch-ca-cert", ic.Name, "fetch-ca-cert is OneCLI-only — must not run on the Envoy path")
+	}
+
+	// CA volume is the projected per-fork leaf Secret.
+	var caVol *corev1.Volume
+	for i := range job.Spec.Template.Spec.Volumes {
+		if job.Spec.Template.Spec.Volumes[i].Name == "ca-cert" {
+			caVol = &job.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, caVol)
+	require.NotNil(t, caVol.Secret)
+	assert.Equal(t, EnvoyLeafSecretName("fork-abc"), caVol.Secret.SecretName)
+}
+
+func TestBuildForkJob_FlagOn_GHTokenSignal(t *testing.T) {
+	cases := map[string]struct {
+		secrets []corev1.Secret
+		want    string
+	}{
+		"with github cred":    {[]corev1.Secret{credSecret("humr-cred-gh", "api.github.com")}, "true"},
+		"without github cred": {[]corev1.Secret{credSecret("humr-cred-other", "api.example.com")}, "false"},
+		"no creds":            {nil, "false"},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			job := BuildForkJob("fork-abc", testForkSpecEnvoy, testForkInstanceFlagOn, testAgent, testEnvoyConfig, testForkOwnerCM, nil, tc.secrets)
+			env := envMap(job.Spec.Template.Spec.Containers[0].Env)
+			assert.Equal(t, tc.want, env["HUMR_GH_TOKEN_AVAILABLE"])
+		})
+	}
+}
+
+func TestBuildForkJob_FlagOff_KeepsOneCLIShape(t *testing.T) {
+	// Sanity check that the legacy path is untouched: single agent container,
+	// inlined ONECLI_ACCESS_TOKEN, fetch-ca-cert init container, no SA-token
+	// override. Mirrors the existing fork tests but contrasts with flag-on.
+	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, nil)
+
+	require.Len(t, job.Spec.Template.Spec.Containers, 1, "no sidecar on flag-off path")
+	env := envMap(job.Spec.Template.Spec.Containers[0].Env)
+	assert.Equal(t, "onecli-foreign-token", env["ONECLI_ACCESS_TOKEN"])
+	assert.Nil(t, job.Spec.Template.Spec.AutomountServiceAccountToken, "flag-off leaves SA-token automount at K8s default")
+	assert.Nil(t, job.Spec.Template.Spec.ShareProcessNamespace, "flag-off leaves share-pid at K8s default")
+
+	initNames := []string{}
+	for _, ic := range job.Spec.Template.Spec.InitContainers {
+		initNames = append(initNames, ic.Name)
+	}
+	assert.Contains(t, initNames, "fetch-ca-cert")
 }

--- a/packages/controller/pkg/types/types.go
+++ b/packages/controller/pkg/types/types.go
@@ -129,12 +129,20 @@ type ScheduleStatus struct {
 // --- Fork ---
 
 type ForkSpec struct {
-	Version             string `yaml:"version"`
-	Instance            string `yaml:"instance"`
-	ForeignSub          string `yaml:"foreignSub"`
-	ForkAgentIdentifier string `yaml:"forkAgentIdentifier"`
+	Version    string `yaml:"version"`
+	Instance   string `yaml:"instance"`
+	ForeignSub string `yaml:"foreignSub"`
+	// ForkAgentIdentifier and AccessToken are populated only when the parent
+	// instance does **not** have `experimentalCredentialInjector` set —
+	// they are the OneCLI fork-agent registration that the api-server mints
+	// per (instance, foreignSub) on the legacy ADR-027 path. On the Envoy
+	// sidecar path (ADR-033) the fork's outbound identity is derived
+	// entirely from `ForeignSub` at render time (the controller mounts the
+	// replier's K8s credential Secrets into the sidecar) and these fields
+	// are left empty. They go away with OneCLI itself (#339).
+	ForkAgentIdentifier string `yaml:"forkAgentIdentifier,omitempty"`
 	SessionID           string `yaml:"sessionId,omitempty"`
-	AccessToken         string `yaml:"accessToken"`
+	AccessToken         string `yaml:"accessToken,omitempty"`
 }
 
 type ForkError struct {
@@ -219,11 +227,13 @@ func ParseForkSpec(data string) (*ForkSpec, error) {
 	if spec.ForeignSub == "" {
 		return nil, fmt.Errorf("fork spec: foreignSub is required")
 	}
-	if spec.AccessToken == "" {
-		return nil, fmt.Errorf("fork spec: accessToken is required")
-	}
-	if spec.ForkAgentIdentifier == "" {
-		return nil, fmt.Errorf("fork spec: forkAgentIdentifier is required")
+	// AccessToken / ForkAgentIdentifier are optional — required together
+	// only on the legacy ADR-027 (OneCLI) path; the Envoy path (ADR-033)
+	// renders the fork without either. The controller branches at render
+	// time on the parent instance's `experimentalCredentialInjector` flag
+	// and validates accordingly.
+	if (spec.AccessToken == "") != (spec.ForkAgentIdentifier == "") {
+		return nil, fmt.Errorf("fork spec: accessToken and forkAgentIdentifier must be set together (or both omitted on the Envoy path)")
 	}
 	return &spec, nil
 }

--- a/packages/controller/pkg/types/types_test.go
+++ b/packages/controller/pkg/types/types_test.go
@@ -278,10 +278,14 @@ accessToken: onecli-xyz
 
 func TestParseForkSpec_MissingRequired(t *testing.T) {
 	cases := map[string]string{
-		"missing instance":            `version: humr.ai/v1` + "\n" + `foreignSub: kc|u` + "\n" + `forkAgentIdentifier: fork-x-y` + "\n" + `accessToken: t`,
-		"missing foreignSub":          `version: humr.ai/v1` + "\n" + `instance: inst-abc` + "\n" + `forkAgentIdentifier: fork-x-y` + "\n" + `accessToken: t`,
-		"missing accessToken":         `version: humr.ai/v1` + "\n" + `instance: inst-abc` + "\n" + `foreignSub: kc|u` + "\n" + `forkAgentIdentifier: fork-x-y`,
-		"missing forkAgentIdentifier": `version: humr.ai/v1` + "\n" + `instance: inst-abc` + "\n" + `foreignSub: kc|u` + "\n" + `accessToken: t`,
+		// instance / foreignSub are required on every path.
+		"missing instance":   `version: humr.ai/v1` + "\n" + `foreignSub: kc|u` + "\n" + `forkAgentIdentifier: fork-x-y` + "\n" + `accessToken: t`,
+		"missing foreignSub": `version: humr.ai/v1` + "\n" + `instance: inst-abc` + "\n" + `forkAgentIdentifier: fork-x-y` + "\n" + `accessToken: t`,
+		// accessToken / forkAgentIdentifier must be set together — partial
+		// is rejected so the legacy OneCLI path can't accidentally render
+		// without the OneCLI agent identifier (or vice versa).
+		"only accessToken":         `version: humr.ai/v1` + "\n" + `instance: inst-abc` + "\n" + `foreignSub: kc|u` + "\n" + `accessToken: t`,
+		"only forkAgentIdentifier": `version: humr.ai/v1` + "\n" + `instance: inst-abc` + "\n" + `foreignSub: kc|u` + "\n" + `forkAgentIdentifier: fork-x-y`,
 	}
 	for name, yaml := range cases {
 		t.Run(name, func(t *testing.T) {
@@ -289,6 +293,20 @@ func TestParseForkSpec_MissingRequired(t *testing.T) {
 			assert.Error(t, err)
 		})
 	}
+}
+
+// Envoy path: accessToken + forkAgentIdentifier may both be omitted; the
+// controller resolves credentials at render time via foreignSub.
+func TestParseForkSpec_EnvoyPathAllowsOmittedTokenAndAgentIdentifier(t *testing.T) {
+	spec, err := ParseForkSpec(`version: humr.ai/v1
+instance: inst-abc
+foreignSub: kc|user-42
+`)
+	require.NoError(t, err)
+	assert.Equal(t, "inst-abc", spec.Instance)
+	assert.Equal(t, "kc|user-42", spec.ForeignSub)
+	assert.Empty(t, spec.AccessToken)
+	assert.Empty(t, spec.ForkAgentIdentifier)
 }
 
 func TestNewForkStatus(t *testing.T) {


### PR DESCRIPTION
## Summary

- ADR-027 fork pods (Slack foreign-replier per-turn Jobs) now ride the Envoy sidecar shape from ADR-033 when the parent instance has `experimentalCredentialInjector: true`. Flag-off parents are unchanged.
- The api-server's RFC 8693 mint of a foreign-user OneCLI access token is **skipped on the Envoy path** — `spec.yaml` carries `foreignSub` only; the controller resolves the replier's `(owner=foreignSub, connection)` K8s Secrets at render time and mounts them into the sidecar container only.
- The credential boundary ADR-027 establishes is preserved: data boundary stays permissive (RWX cross-user PVC mount), credential boundary stays strict (replier's grants only, parent owner's Secrets never appear in the fork's pod spec).

This is the last hard prereq for OneCLI removal. The OneCLI mint and the `(instanceId, foreignSub) → accessToken` cache stay until OneCLI itself goes away — this PR only adds the gated branch.

## What's in the diff

### Controller
- `pkg/types/types.go` — `ForkSpec.AccessToken` + `ForkSpec.ForkAgentIdentifier` are optional and validated as a pair. `ParseForkSpec` accepts the Envoy shape (both omitted) and rejects partial.
- `pkg/reconciler/fork.go` — On flag-on parents lists K8s credential Secrets labeled `humr.ai/owner=<foreignSub>`, renders per-fork Envoy bootstrap ConfigMap + per-fork cert-manager `Certificate` (leaf TLS over the SAN list of the replier's host patterns). Both resources are owner-referenced to the fork ConfigMap and GC'd with it. New `WithDynamicClient` for the cert-manager apply.
- `pkg/reconciler/fork_resources.go` — `BuildForkJob` accepts `credentialSecrets`. On flag-on emits the same Envoy sidecar shape as the parent's flag-on `BuildStatefulSet` (no `ONECLI_ACCESS_TOKEN`, `HTTPS_PROXY → 127.0.0.1`, projected leaf Secret CA, no `fetch-ca-cert` init, `automountServiceAccountToken=false`, `shareProcessNamespace=false`, `HUMR_GH_TOKEN_AVAILABLE` signal). Replier secrets mount into the sidecar only.
- `main.go` — `forkReconciler.WithDynamicClient(dynClient)`.

### api-server
- `forks/services/forks-service.ts` — `OpenForkInput.experimentalCredentialInjector`; flag-on skips `mintForeignToken` and creates the fork without an access token / agent identifier.
- `forks/sagas/on-foreign-reply.ts` — `startOnForeignReplySaga` accepts a `ResolveExperimentalFlag` callback and threads the parent's flag into `openFork`.
- `forks/infrastructure/{configmap-mappers,ports}.ts` — `accessToken` / `forkAgentIdentifier` optional in YAML output and port signature.
- `index.ts` — wires the resolver via `instancesRepo.get(instanceId)`, falling back to flag-off on any K8s read error so a transient lookup failure doesn't block forking.

### NetworkPolicy
- No fork-specific NetworkPolicy needed: forks share the parent's `humr.ai/instance` label so the parent's flag-on egress rules (TCP 443/80 to `0.0.0.0/0` + DNS + harness API) apply automatically.

### Docs
- New "Forks on the experimental Envoy path" subsection in `docs/architecture/security-and-credentials.md`.

## Test plan

- [x] `mise run check` — go build, go vet, helm lint, kubeconform, ui+agent-runtime tsc all green.
- [x] `mise run test` — 254 api-server unit tests + controller suite pass.
- [x] Controller unit: flag-on shape (`TestBuildForkJob_FlagOn_AddsEnvoySidecar`), replier-only mounts (`TestBuildForkJob_FlagOn_ReplierSecretsMountedSidecarOnly` — agent container does NOT see Secret volumes), no fetch-ca-cert init (`TestBuildForkJob_FlagOn_NoFetchCACertInit`), GH_TOKEN signal across cred presence (`TestBuildForkJob_FlagOn_GHTokenSignal`), legacy shape preserved (`TestBuildForkJob_FlagOff_KeepsOneCLIShape`).
- [x] Controller unit: `ParseForkSpec` accepts the Envoy shape, rejects partial accessToken/forkAgentIdentifier.
- [x] api-server unit: saga propagates flag; service skips mint on flag-on; configmap mapper omits both fields on the Envoy path.
- [ ] Manual on `mise run cluster:install` with a flagged parent: bind a Slack thread, have a non-owner allowed user reply; confirm the fork Job spawns with the envoy sidecar, the replier's GitHub/Slack/Anthropic Secrets are mounted into the envoy container, the fork can call those upstreams, and the parent owner's Secrets are not visible in the fork's pod spec.
- [ ] Manual: same flow with a flag-off parent — confirm the existing OneCLI fork-token path still works unchanged.
- [ ] Manual: flagged parent without the replier having connected the relevant provider — fork fails closed with a clear error per ADR-027 (no `Authorization` injection on hosts the replier doesn't have, agent receives upstream 401).

## Out of scope

- Removing the foreign-credentials port and the cache outright. They stay until the OneCLI dual-write is removed; this issue only adds the gated branch.
- HITL on fork pods. Inherits automatically once the HITL ext_authz follow-up lands.
- gVisor / RuntimeClass enforcement on fork pods. Inherits from the platform-wide gVisor work.

## Follow-ups

- After OneCLI removal: delete `onecli-foreign-credentials-port.ts`, drop `AccessToken` from `ForkSpec` entirely, remove the in-memory cache and the saga's flag-off branch.