### PR TITLE
[POC – DO NOT MERGE] humr CLI tmux shell relay (dam-wn6)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,7 +1,45 @@
 {
   "attribution": {
-    "commit": "Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>",
+    "commit": "Assisted-By: Claude (Anthropic AI) \u003cnoreply@anthropic.com\u003e",
     "pr": ""
+  },
+  "enabledPlugins": {
+    "claude-md-management@claude-plugins-official": true,
+    "frontend-design@claude-plugins-official": true,
+    "practical-skills@apoco-plugins": false
+  },
+  "extraKnownMarketplaces": {
+    "apoco-plugins": {
+      "autoUpdate": true,
+      "source": {
+        "repo": "apocohq/claude-plugins",
+        "source": "github"
+      }
+    }
+  },
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
   },
   "permissions": {
     "allow": [
@@ -39,19 +77,5 @@
       "Bash(gh run list*)",
       "Bash(gh run view*)"
     ]
-  },
-  "enabledPlugins": {
-    "claude-md-management@claude-plugins-official": true,
-    "frontend-design@claude-plugins-official": true,
-    "practical-skills@apoco-plugins": false
-  },
-  "extraKnownMarketplaces": {
-    "apoco-plugins": {
-      "source": {
-        "source": "github",
-        "repo": "apocohq/claude-plugins"
-      },
-      "autoUpdate": true
-    }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,8 @@ context/
 # Playwright
 .playwright-mcp
 
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,3 +95,51 @@ After setup, report: worktree path, test results, and readiness.
 ## TSEng
 
 This project follows the [TypeScript Engineering](tseng/index.md) architecture.
+
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/deploy/helm/humr/templates/apiserver/app.yaml
+++ b/deploy/helm/humr/templates/apiserver/app.yaml
@@ -72,6 +72,10 @@ spec:
               value: {{ .Values.apiServer.harnessServerPort | quote }}
             - name: UI_BASE_URL
               value: {{ include "humr.url.ui" . | quote }}
+            {{- if .Values.apiServer.shellSecret }}
+            - name: HUMR_SHELL_SECRET
+              value: {{ .Values.apiServer.shellSecret | quote }}
+            {{- end }}
             {{- if .Values.apiServer.slackBotToken }}
             - name: SLACK_BOT_TOKEN
               value: {{ .Values.apiServer.slackBotToken | quote }}

--- a/deploy/helm/humr/templates/apiserver/rbac.yaml
+++ b/deploy/helm/humr/templates/apiserver/rbac.yaml
@@ -63,6 +63,13 @@ rules:
     # recreate it with the current spec — functionally equivalent to a rolling
     # restart for replicas=1 without racing against the controller's reconcile.
     verbs: ["get", "list", "watch", "delete"]
+  # POC shell relay (dam-wn6) — `/api/instances/:id/shell` execs `tmux new -A
+  # -s humr claude` inside the agent pod and bridges the pod-exec WebSocket to
+  # the local CLI. Required even when shellSecret is empty so the helm chart
+  # stays consistent across enable/disable toggles.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/humr/templates/apiserver/rbac.yaml
+++ b/deploy/helm/humr/templates/apiserver/rbac.yaml
@@ -65,11 +65,11 @@ rules:
     verbs: ["get", "list", "watch", "delete"]
   # POC shell relay (dam-wn6) — `/api/instances/:id/shell` execs `tmux new -A
   # -s humr claude` inside the agent pod and bridges the pod-exec WebSocket to
-  # the local CLI. Required even when shellSecret is empty so the helm chart
-  # stays consistent across enable/disable toggles.
+  # the local CLI. WebSocket exec maps to verb `get` on the `pods/exec`
+  # subresource (SPDY exec maps to `create`); we grant both for compatibility.
   - apiGroups: [""]
     resources: ["pods/exec"]
-    verbs: ["create"]
+    verbs: ["get", "create"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/deploy/helm/humr/values-local.yaml
+++ b/deploy/helm/humr/values-local.yaml
@@ -17,6 +17,8 @@ apiServer:
     repository: humr-api-server
     tag: latest
     pullPolicy: Never
+  # POC shell relay shared secret (dam-wn6). Local dev only.
+  shellSecret: dev-shell-secret
 
 controller:
   image:

--- a/deploy/helm/humr/values.yaml
+++ b/deploy/helm/humr/values.yaml
@@ -278,6 +278,11 @@ apiServer:
     pullPolicy: IfNotPresent
   port: 4000
   harnessServerPort: 4001
+  # -- POC `humr` CLI shell relay (dam-wn6). When set, exposes
+  # `/api/instances/:id/shell` as a WS bridge into the agent pod's TUI
+  # via `tmux new -A -s humr claude`. Bearer-token auth only — every user
+  # who knows this secret can attach to any instance. Leave empty to disable.
+  shellSecret: ""
   # -- Slack bot token (xoxb-...) for the platform-wide Slack app. Leave empty to disable Slack integration.
   slackBotToken: ""
   # -- Slack app-level token (xapp-...) for Socket Mode. Required alongside slackBotToken.

--- a/mise.toml
+++ b/mise.toml
@@ -30,6 +30,7 @@ includes = [
     "packages/controller/tasks.toml",
     "packages/api-server/tasks.toml",
     "packages/agent-runtime/tasks.toml",
+    "packages/humr-cli/tasks.toml",
     "deploy/helm/tasks.toml",
     "deploy/tasks.toml",
 ]

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -1,6 +1,10 @@
 ARG BASE_IMAGE=humr-base
 FROM ${BASE_IMAGE}
 
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends tmux \
+    && rm -rf /var/lib/apt/lists/*
+
 # Claude Code harness
 RUN cd /app && npm install @agentclientprotocol/claude-agent-acp @anthropic-ai/claude-agent-sdk \
     && npm install -g @anthropic-ai/claude-code

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -3,7 +3,7 @@ import { serve } from "@hono/node-server";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import { appRouter } from "api-server-api/router";
 import type { ApiContext, UserIdentity } from "api-server-api";
-import type { CoreV1Api } from "@kubernetes/client-node";
+import type { CoreV1Api, KubeConfig } from "@kubernetes/client-node";
 import type { Db } from "db";
 import type { SkillSourceSeed } from "../../modules/skills/index.js";
 import {
@@ -21,6 +21,7 @@ import {
   isThreadAuthorized, authorizeThread, revokeThread, listAuthorizedThreads,
 } from "../../modules/channels/infrastructure/telegram-threads-repository.js";
 import { createAcpRelay } from "./acp-relay.js";
+import { createShellRelay } from "./shell-relay.js";
 import { createOAuthRoutes } from "./oauth.js";
 import { createOAuthAppRegistry } from "../../modules/connections/infrastructure/oauth-apps.js";
 import type { Config } from "../../config.js";
@@ -40,6 +41,7 @@ import type { PodFilesPublisher } from "../../modules/pod-files/publisher.js";
 export interface ApiServerAppDeps {
   config: Config;
   api: CoreV1Api;
+  kc: KubeConfig;
   db: Db;
   onecli: OnecliClient;
   channelManager: ChannelManager;
@@ -52,7 +54,7 @@ export interface ApiServerAppDeps {
 }
 
 export function startApiServerApp(deps: ApiServerAppDeps) {
-  const { config, api, db, onecli, channelManager, channelSecretStore, identityLinkService, pendingSlackOAuthFlows, pendingTelegramOAuthFlows, podFilesPublisher, seedSources } = deps;
+  const { config, api, kc, db, onecli, channelManager, channelSecretStore, identityLinkService, pendingSlackOAuthFlows, pendingTelegramOAuthFlows, podFilesPublisher, seedSources } = deps;
 
   const k8sClient = createK8sClient(api, config.namespace);
   const instancesRepo = createInstancesRepository(k8sClient);
@@ -218,6 +220,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   });
 
   const acpRelay = createAcpRelay(config.namespace, instancesRepo);
+  const shellRelay = config.shellSecret ? createShellRelay(config.namespace, kc) : null;
 
   const server = serve({ fetch: app.fetch, port: config.port }, () => {
     process.stderr.write(`api-server listening on http://localhost:${config.port}\n`);
@@ -225,6 +228,30 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
 
   server.on("upgrade", async (req, socket, head) => {
     const url = new URL(req.url!, `http://${req.headers.host}`);
+
+    // Shell relay (POC, dam-wn6) — Bearer-token auth via shared secret. Skips
+    // user JWT and instance-ownership checks by design; see ticket "Auth".
+    const shellMatch = url.pathname.match(/^\/api\/instances\/([^/]+)\/shell$/);
+    if (shellMatch) {
+      if (!shellRelay) {
+        socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+      const authHeader = req.headers["authorization"];
+      const provided = typeof authHeader === "string" && authHeader.startsWith("Bearer ")
+        ? authHeader.slice("Bearer ".length)
+        : null;
+      if (provided !== config.shellSecret) {
+        socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+      const instanceId = decodeURIComponent(shellMatch[1]);
+      shellRelay.handleUpgrade(req, socket, head, instanceId);
+      return;
+    }
+
     const match = url.pathname.match(/^\/api\/instances\/([^/]+)\/acp$/);
     if (!match) {
       socket.destroy();

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -220,7 +220,12 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   });
 
   const acpRelay = createAcpRelay(config.namespace, instancesRepo);
-  const shellRelay = config.shellSecret ? createShellRelay(config.namespace, kc) : null;
+  // tmux start-directory matches agent-runtime's WORK_DIR
+  // (`${HOME}/work`) so the CLI Claude session sees the same file tree as
+  // the UI session.
+  const shellRelay = config.shellSecret
+    ? createShellRelay(config.namespace, kc, `${config.agentHome}/work`)
+    : null;
 
   const server = serve({ fetch: app.fetch, port: config.port }, () => {
     process.stderr.write(`api-server listening on http://localhost:${config.port}\n`);

--- a/packages/api-server/src/apps/api-server/shell-relay.ts
+++ b/packages/api-server/src/apps/api-server/shell-relay.ts
@@ -66,7 +66,13 @@ export function createShellRelay(namespace: string, kc: KubeConfig) {
           },
         )) as unknown as WebSocket;
       } catch (err) {
-        process.stderr.write(`shell-relay: upstream connect failed for ${instanceId}: ${err}\n`);
+        // The K8s WS client surfaces upgrade failures as a generic event-shaped
+        // object (no .stack), so we pull `message` plus the resolved upstream
+        // URL out by hand to make the cause obvious in logs.
+        const e = err as { message?: string; target?: { url?: string } };
+        process.stderr.write(
+          `shell-relay: upstream connect failed for ${instanceId}: ${e.message ?? "(empty error)"} (${e.target?.url ?? ""})\n`,
+        );
         try { client.close(1011, "failed to attach to pod"); } catch { client.terminate(); }
         return;
       }

--- a/packages/api-server/src/apps/api-server/shell-relay.ts
+++ b/packages/api-server/src/apps/api-server/shell-relay.ts
@@ -1,0 +1,128 @@
+/**
+ * POC shell relay (dam-wn6) — `/api/instances/:id/shell`.
+ *
+ * Bridges a client WebSocket to a Kubernetes pod-exec WebSocket with a TTY,
+ * running `tmux new -A -s humr claude` inside the `agent` container. tmux's
+ * `-A` flag attaches to the named session if it exists, so reconnects land
+ * back in the same TUI for free.
+ *
+ * Frame protocol:
+ *   client → relay (binary)  → stdin bytes (channel 0) to pod
+ *   client → relay (text)    → JSON `{type:"resize", cols, rows}` → resize
+ *                              channel 4 with `{Height, Width}` payload
+ *   pod    → relay (channel 1, 2) → binary frame to client
+ */
+import type { KubeConfig } from "@kubernetes/client-node";
+// `WebSocketHandler` exists in the package but isn't re-exported from the
+// barrel — deep import lets us drive the K8s exec WS frame-protocol directly
+// (one byte channel prefix) without dragging Node streams into the bridge.
+import { WebSocketHandler } from "@kubernetes/client-node/dist/web-socket-handler.js";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import { WebSocketServer, WebSocket } from "ws";
+
+const TMUX_COMMAND = ["tmux", "new", "-A", "-s", "humr", "claude"];
+
+function buildExecPath(namespace: string, podName: string): string {
+  const params = new URLSearchParams();
+  params.set("stdin", "true");
+  params.set("stdout", "true");
+  params.set("stderr", "true");
+  params.set("tty", "true");
+  params.set("container", "agent");
+  for (const arg of TMUX_COMMAND) params.append("command", arg);
+  return `/api/v1/namespaces/${namespace}/pods/${podName}/exec?${params.toString()}`;
+}
+
+function podName(instanceId: string): string {
+  return `${instanceId}-0`;
+}
+
+export function createShellRelay(namespace: string, kc: KubeConfig) {
+  const wss = new WebSocketServer({ noServer: true });
+
+  function handleUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    instanceId: string,
+  ) {
+    wss.handleUpgrade(req, socket, head, async (client) => {
+      const handler = new WebSocketHandler(kc);
+      const path = buildExecPath(namespace, podName(instanceId));
+
+      let upstream: WebSocket | undefined;
+      try {
+        upstream = (await handler.connect(
+          path,
+          null,
+          (streamNum: number, buff: Buffer): boolean => {
+            // 1 = stdout, 2 = stderr — both go to the client as binary frames
+            if ((streamNum === 1 || streamNum === 2) && client.readyState === WebSocket.OPEN) {
+              client.send(buff, { binary: true });
+            }
+            // 3 = status, 255 = close — stop forwarding
+            return streamNum !== 3 && streamNum !== 255;
+          },
+        )) as unknown as WebSocket;
+      } catch (err) {
+        process.stderr.write(`shell-relay: upstream connect failed for ${instanceId}: ${err}\n`);
+        try { client.close(1011, "failed to attach to pod"); } catch { client.terminate(); }
+        return;
+      }
+
+      client.on("message", (data, isBinary) => {
+        if (!upstream || upstream.readyState !== WebSocket.OPEN) return;
+        if (isBinary) {
+          const buf = data instanceof Buffer
+            ? data
+            : Buffer.isBuffer(data)
+              ? data
+              : Array.isArray(data)
+                ? Buffer.concat(data)
+                : Buffer.from(data as ArrayBuffer);
+          const out = Buffer.alloc(buf.length + 1);
+          out.writeInt8(0, 0);
+          buf.copy(out, 1);
+          upstream.send(out);
+          return;
+        }
+        const text = data.toString();
+        try {
+          const msg = JSON.parse(text) as { type?: string; cols?: number; rows?: number };
+          if (msg.type === "resize" && typeof msg.cols === "number" && typeof msg.rows === "number") {
+            const payload = JSON.stringify({ Height: msg.rows, Width: msg.cols });
+            const body = Buffer.from(payload, "utf8");
+            const out = Buffer.alloc(body.length + 1);
+            out.writeInt8(4, 0);
+            body.copy(out, 1);
+            upstream.send(out);
+          }
+        } catch {
+          // Ignore malformed control frames in the POC
+        }
+      });
+
+      client.on("close", () => {
+        if (upstream && upstream.readyState === WebSocket.OPEN) {
+          try { upstream.close(); } catch { /* noop */ }
+        }
+      });
+
+      upstream.on("close", () => {
+        if (client.readyState === WebSocket.OPEN) {
+          try { client.close(1000, "session ended"); } catch { client.terminate(); }
+        }
+      });
+
+      upstream.on("error", (err) => {
+        process.stderr.write(`shell-relay: upstream error for ${instanceId}: ${err}\n`);
+        if (client.readyState === WebSocket.OPEN) {
+          try { client.close(1011, "upstream error"); } catch { client.terminate(); }
+        }
+      });
+    });
+  }
+
+  return { handleUpgrade };
+}

--- a/packages/api-server/src/apps/api-server/shell-relay.ts
+++ b/packages/api-server/src/apps/api-server/shell-relay.ts
@@ -21,16 +21,45 @@ import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
 import { WebSocketServer, WebSocket } from "ws";
 
-const TMUX_COMMAND = ["tmux", "new", "-A", "-s", "humr", "claude"];
+// `-c <dir>` makes the tmux session's start-directory match the cwd that
+// agent-runtime hands to ACP (`WORK_DIR`, default `${HOME}/work`). Without
+// this the exec lands in the container's `/app` WORKDIR and Claude sees
+// a different file tree than the UI session.
+//
+// We also ship a minimal tmux.conf so Claude renders correctly inside the
+// session: `focus-events` (Claude warns when off), 256/true-color terminal
+// (default `screen` strips color), and mouse for scrollback. Written to
+// `/tmp` per attach so we don't pollute the persistent HOME.
+const TMUX_CONF = [
+  "set -g focus-events on",
+  'set -g default-terminal "tmux-256color"',
+  'set -ga terminal-overrides ",*256col*:Tc"',
+  "set -g mouse on",
+].join("\n");
 
-function buildExecPath(namespace: string, podName: string): string {
+function tmuxCommand(workDir: string): string[] {
+  // LANG/LC_ALL are unset in the agent image; without them tmux uses ASCII
+  // width math and Claude's box-drawing/emoji glyphs misalign by a column on
+  // every line that contains a wide char. Forcing C.UTF-8 fixes it without
+  // pulling in a locale package.
+  const script = [
+    `export LANG=C.UTF-8 LC_ALL=C.UTF-8`,
+    `cat >/tmp/humr-tmux.conf <<'__HUMR_TMUX_CONF__'`,
+    TMUX_CONF,
+    `__HUMR_TMUX_CONF__`,
+    `exec tmux -u -f /tmp/humr-tmux.conf new -A -s humr -c ${JSON.stringify(workDir)} claude`,
+  ].join("\n");
+  return ["bash", "-c", script];
+}
+
+function buildExecPath(namespace: string, podName: string, workDir: string): string {
   const params = new URLSearchParams();
   params.set("stdin", "true");
   params.set("stdout", "true");
   params.set("stderr", "true");
   params.set("tty", "true");
   params.set("container", "agent");
-  for (const arg of TMUX_COMMAND) params.append("command", arg);
+  for (const arg of tmuxCommand(workDir)) params.append("command", arg);
   return `/api/v1/namespaces/${namespace}/pods/${podName}/exec?${params.toString()}`;
 }
 
@@ -38,7 +67,7 @@ function podName(instanceId: string): string {
   return `${instanceId}-0`;
 }
 
-export function createShellRelay(namespace: string, kc: KubeConfig) {
+export function createShellRelay(namespace: string, kc: KubeConfig, workDir: string) {
   const wss = new WebSocketServer({ noServer: true });
 
   function handleUpgrade(
@@ -49,7 +78,23 @@ export function createShellRelay(namespace: string, kc: KubeConfig) {
   ) {
     wss.handleUpgrade(req, socket, head, async (client) => {
       const handler = new WebSocketHandler(kc);
-      const path = buildExecPath(namespace, podName(instanceId));
+      const path = buildExecPath(namespace, podName(instanceId), workDir);
+
+      // The CLI sends an initial resize the moment the WS opens. Without
+      // queueing here, that frame fires before the post-`await` listener is
+      // attached and gets dropped — tmux then sticks at its default 80×24
+      // until the next SIGWINCH. Buffer everything the client sends until
+      // upstream is ready, then drain in order.
+      const pending: { data: Buffer; isBinary: boolean }[] = [];
+      const bufferOnly = (data: unknown, isBinary: boolean) => {
+        const buf = data instanceof Buffer
+          ? data
+          : Array.isArray(data)
+            ? Buffer.concat(data as Buffer[])
+            : Buffer.from(data as ArrayBuffer);
+        pending.push({ data: buf, isBinary });
+      };
+      client.on("message", bufferOnly);
 
       let upstream: WebSocket | undefined;
       try {
@@ -77,25 +122,17 @@ export function createShellRelay(namespace: string, kc: KubeConfig) {
         return;
       }
 
-      client.on("message", (data, isBinary) => {
+      const forward = (data: Buffer, isBinary: boolean) => {
         if (!upstream || upstream.readyState !== WebSocket.OPEN) return;
         if (isBinary) {
-          const buf = data instanceof Buffer
-            ? data
-            : Buffer.isBuffer(data)
-              ? data
-              : Array.isArray(data)
-                ? Buffer.concat(data)
-                : Buffer.from(data as ArrayBuffer);
-          const out = Buffer.alloc(buf.length + 1);
+          const out = Buffer.alloc(data.length + 1);
           out.writeInt8(0, 0);
-          buf.copy(out, 1);
+          data.copy(out, 1);
           upstream.send(out);
           return;
         }
-        const text = data.toString();
         try {
-          const msg = JSON.parse(text) as { type?: string; cols?: number; rows?: number };
+          const msg = JSON.parse(data.toString()) as { type?: string; cols?: number; rows?: number };
           if (msg.type === "resize" && typeof msg.cols === "number" && typeof msg.rows === "number") {
             const payload = JSON.stringify({ Height: msg.rows, Width: msg.cols });
             const body = Buffer.from(payload, "utf8");
@@ -107,6 +144,18 @@ export function createShellRelay(namespace: string, kc: KubeConfig) {
         } catch {
           // Ignore malformed control frames in the POC
         }
+      };
+
+      client.off("message", bufferOnly);
+      for (const m of pending) forward(m.data, m.isBinary);
+      pending.length = 0;
+      client.on("message", (data, isBinary) => {
+        const buf = data instanceof Buffer
+          ? data
+          : Array.isArray(data)
+            ? Buffer.concat(data as Buffer[])
+            : Buffer.from(data as ArrayBuffer);
+        forward(buf, isBinary);
       });
 
       client.on("close", () => {

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -38,6 +38,11 @@ const configSchema = z.object({
   defaultGithubEnterpriseHost: z.string().nullable().default(null),
   defaultGithubEnterpriseClientId: z.string().nullable().default(null),
   defaultGithubEnterpriseClientSecret: z.string().nullable().default(null),
+  // POC shell relay (dam-wn6). When set, exposes
+  // `/api/instances/:id/shell` — a WS bridge to a TTY-attached
+  // `tmux new -A -s humr claude` exec inside the agent pod. Bearer-token
+  // auth via this shared secret. Empty/null disables the endpoint.
+  shellSecret: z.string().nullable().default(null),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -72,5 +77,6 @@ export function loadConfig(): Config {
     defaultGithubEnterpriseHost: process.env.HUMR_DEFAULT_GHE_HOST,
     defaultGithubEnterpriseClientId: process.env.HUMR_DEFAULT_GHE_CLIENT_ID,
     defaultGithubEnterpriseClientSecret: process.env.HUMR_DEFAULT_GHE_CLIENT_SECRET,
+    shellSecret: process.env.HUMR_SHELL_SECRET,
   });
 }

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -51,7 +51,7 @@ const onecli = createOnecliClient({
   onecliBaseUrl: config.onecliBaseUrl,
 });
 
-const { api } = createApi(config.namespace);
+const { api, kc } = createApi(config.namespace);
 await runMigrations(config.databaseUrl, config.migrationsPath);
 const { db, sql } = createDb(config.databaseUrl);
 
@@ -241,7 +241,7 @@ const podFilesPublisher = createPodFilesPublisher({
 });
 
 const { server: apiServer } = startApiServerApp({
-  config, api, db, onecli, channelManager, channelSecretStore, identityLinkService,
+  config, api, kc, db, onecli, channelManager, channelSecretStore, identityLinkService,
   pendingSlackOAuthFlows, pendingTelegramOAuthFlows, podFilesPublisher, seedSources,
 });
 

--- a/packages/api-server/src/modules/agents/infrastructure/k8s.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/k8s.ts
@@ -162,5 +162,5 @@ export function podBaseUrl(instanceId: string, namespace: string): string {
 export function createApi(namespace: string) {
   const kc = new k8s.KubeConfig();
   kc.loadFromDefault();
-  return { api: kc.makeApiClient(k8s.CoreV1Api), namespace };
+  return { api: kc.makeApiClient(k8s.CoreV1Api), kc, namespace };
 }

--- a/packages/humr-cli/package.json
+++ b/packages/humr-cli/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "humr-cli",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "shell": "tsx src/shell.ts",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "ws": "^8.20.0"
+  },
+  "devDependencies": {
+    "@types/node": "^25.5.0",
+    "@types/ws": "^8.18.1",
+    "tsx": "^4.21.0",
+    "typescript": "^6.0.2"
+  }
+}

--- a/packages/humr-cli/src/shell.ts
+++ b/packages/humr-cli/src/shell.ts
@@ -1,0 +1,104 @@
+/**
+ * POC `humr` CLI shell (dam-wn6).
+ *
+ * Connects the local terminal to a Humr instance pod's TUI:
+ *   stdin → WS binary frame  → pod stdin via `tmux new -A -s humr claude`
+ *   pod stdout → WS binary frame → local stdout
+ *   SIGWINCH  → WS text frame `{type:"resize", cols, rows}`
+ *
+ * Usage:
+ *   HUMR_API_BASE=ws://humr-api.localhost:4444 \
+ *   HUMR_SHELL_SECRET=dev-shell-secret \
+ *   tsx src/shell.ts <instanceId>
+ *
+ * Reconnect: closing the local CLI does not kill tmux inside the pod.
+ * Re-running the same command lands in the same TUI.
+ */
+import WebSocket from "ws";
+
+const apiBase = process.env.HUMR_API_BASE ?? "ws://humr-api.localhost:4444";
+const secret = process.env.HUMR_SHELL_SECRET;
+const instanceId = process.argv[2];
+
+if (!instanceId) {
+  process.stderr.write("usage: humr-cli shell <instanceId>\n");
+  process.exit(2);
+}
+if (!secret) {
+  process.stderr.write("HUMR_SHELL_SECRET is not set\n");
+  process.exit(2);
+}
+
+const url = `${apiBase.replace(/\/$/, "")}/api/instances/${encodeURIComponent(instanceId)}/shell`;
+
+const stdin = process.stdin;
+const stdout = process.stdout;
+
+if (!stdin.isTTY || !stdout.isTTY) {
+  process.stderr.write("humr-cli shell requires a TTY\n");
+  process.exit(2);
+}
+
+const ws = new WebSocket(url, {
+  headers: { Authorization: `Bearer ${secret}` },
+});
+
+let restored = false;
+function restoreTty() {
+  if (restored) return;
+  restored = true;
+  try { stdin.setRawMode(false); } catch { /* noop */ }
+  stdin.pause();
+}
+
+function fail(reason: string, code = 1): never {
+  restoreTty();
+  process.stderr.write(`\nhumr-cli shell: ${reason}\n`);
+  process.exit(code);
+}
+
+ws.on("open", () => {
+  stdin.setRawMode(true);
+  stdin.resume();
+
+  sendResize();
+  process.on("SIGWINCH", sendResize);
+
+  stdin.on("data", (chunk: Buffer) => {
+    if (ws.readyState === WebSocket.OPEN) ws.send(chunk, { binary: true });
+  });
+});
+
+function sendResize() {
+  if (ws.readyState !== WebSocket.OPEN) return;
+  const cols = stdout.columns ?? 80;
+  const rows = stdout.rows ?? 24;
+  ws.send(JSON.stringify({ type: "resize", cols, rows }));
+}
+
+ws.on("message", (data, isBinary) => {
+  if (!isBinary) return;
+  const buf = data instanceof Buffer
+    ? data
+    : Array.isArray(data)
+      ? Buffer.concat(data)
+      : Buffer.from(data as ArrayBuffer);
+  stdout.write(buf);
+});
+
+ws.on("close", (code, reason) => {
+  restoreTty();
+  if (code === 1000) {
+    process.exit(0);
+  }
+  process.stderr.write(`\nshell closed (${code}) ${reason.toString()}\n`);
+  process.exit(code === 1006 ? 1 : 0);
+});
+
+ws.on("error", (err) => {
+  fail(`websocket error: ${err.message}`);
+});
+
+process.on("exit", restoreTty);
+process.on("SIGTERM", () => { restoreTty(); process.exit(0); });
+process.on("SIGHUP", () => { restoreTty(); process.exit(0); });

--- a/packages/humr-cli/tasks.toml
+++ b/packages/humr-cli/tasks.toml
@@ -1,0 +1,24 @@
+["cli:shell"]
+description = "Attach to the Claude Code TUI of a Humr instance pod (POC, dam-wn6). Usage: mise run cli:shell -- <instanceId>"
+dir = "{{config_root}}"
+raw = true
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+# Token discovery for the POC: read it from the running apiserver Deployment
+# when not set in the local env. Falls through silently when the cluster
+# isn't reachable so the CLI's own "secret missing" error wins.
+if [ -z "${HUMR_SHELL_SECRET:-}" ]; then
+  if KCFG="$(mise run cluster:kubeconfig 2>/dev/null)" && [ -n "$KCFG" ]; then
+    HUMR_SHELL_SECRET="$(kubectl --kubeconfig="$KCFG" get deploy humr-apiserver \
+      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="HUMR_SHELL_SECRET")].value}' 2>/dev/null || true)"
+    export HUMR_SHELL_SECRET
+  fi
+fi
+exec pnpm --filter humr-cli exec tsx src/shell.ts "$@"
+'''
+
+["humr-cli:check"]
+description = "Type-check humr-cli"
+dir = "{{config_root}}"
+run = "pnpm --filter humr-cli typecheck"

--- a/packages/humr-cli/tsconfig.json
+++ b/packages/humr-cli/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,25 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
 
+  packages/humr-cli:
+    dependencies:
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+      typescript:
+        specifier: ^6.0.2
+        version: 6.0.2
+
   packages/ui:
     dependencies:
       '@agentclientprotocol/sdk':
@@ -1684,89 +1703,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1885,30 +1920,35 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-arm64-musl@0.3.3':
     resolution: {integrity: sha512-o1paj2+zmAQ/LaPS85XJCxhNowNQpxYM2cGY6pWvB5Kqmz6hZjl6CzDg5tbf1hZkn/Em6jpOaE2UtMxKdELBDA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-linux-riscv64-gnu@0.3.3':
     resolution: {integrity: sha512-dkEhE4ekePJwMbBq9HP1//CFMNmDzA/iV9AXqBfvL5CWmmDIRXqh4A3YZt3tWO/HdMerX+xNCEiR7WiOsIG+UA==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-gnu@0.3.3':
     resolution: {integrity: sha512-lT2yANtTLlEtFBIH3uGoRa/CQas/eBoLNi3qr9axQFoRgF4RGPSJ66yHOSnMECBneTIb1Iqv3UxokTfX27CdoQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@mariozechner/clipboard-linux-x64-musl@0.3.3':
     resolution: {integrity: sha512-saq/MCB0QHK/7ZZLjAZ0QkbY944dyjOsur8gneGCfMitt+GOiE1CU4OUipHC4b6x8UDY9bRLsR4aBaxu22OFPA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@mariozechner/clipboard-win32-arm64-msvc@0.3.3':
     resolution: {integrity: sha512-cGuvSj0/2X2w983yEcKw+i+r1EBej6ZZIN+fXG3eY2G/HaIQpbXpLvMxKyZ9LKtbZx+Z6q/gELEoSBMLML6BaQ==}
@@ -2080,66 +2120,79 @@ packages:
     resolution: {integrity: sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.60.1':
     resolution: {integrity: sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.60.1':
     resolution: {integrity: sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.60.1':
     resolution: {integrity: sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.60.1':
     resolution: {integrity: sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.60.1':
     resolution: {integrity: sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.60.1':
     resolution: {integrity: sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.60.1':
     resolution: {integrity: sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.60.1':
     resolution: {integrity: sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.60.1':
     resolution: {integrity: sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.60.1':
     resolution: {integrity: sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.60.1':
     resolution: {integrity: sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.60.1':
     resolution: {integrity: sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.60.1':
     resolution: {integrity: sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==}
@@ -2435,24 +2488,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
     resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
     resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.2':
     resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.2':
     resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
@@ -4153,24 +4210,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -8457,7 +8518,7 @@ snapshots:
 
   '@types/yauzl@2.10.3':
     dependencies:
-      '@types/node': 22.19.17
+      '@types/node': 25.5.0
     optional: true
 
   '@typescript-eslint/eslint-plugin@8.58.2(@typescript-eslint/parser@8.58.2(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2))(eslint@10.2.0(jiti@2.6.1))(typescript@6.0.2)':
@@ -10845,7 +10906,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 22.19.17
+      '@types/node': 25.5.0
       long: 5.3.2
 
   proxy-addr@2.0.7:


### PR DESCRIPTION
## Summary
- POC for `mise run cli:shell -- <id>` — bridges a local TTY to a tmux/Claude Code session inside the agent pod via api-server WS relay.
- Bearer-secret auth (shared `HUMR_SHELL_SECRET`); endpoint 404s when unset.
- Adds tmux to claude-code image, `pods/exec` RBAC (verbs `get` for WS + `create` for SPDY), and a new `humr-cli` workspace.
- Aligns CLI session with UI session: cwd `${AGENT_HOME}/work`, UTF-8 locale, minimal tmux conf for focus-events/256-color/mouse.

## Status
**POC, not for merge.** Out of scope: real auth (OIDC + ownership checks), hibernate handling, concurrent attach guards, automated tests on the WS↔PTY bridge. See bd issue dam-wn6.

## Test plan
- [x] Auth: 401 on missing/wrong secret, upgrade succeeds with right secret
- [x] tmux + claude render correctly inside the relay (cwd, colors, alignment)
- [x] Reattach lands in same tmux session (state persists across CLI restarts)
- [ ] Real-auth path / PRD follow-up