### PR TITLE
docs: scrub OneCLI references from comments, doc strings, and test fixtures

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,7 @@ pnpm workspaces + standalone Go module. Concept depth lives in [`docs/architectu
 - `packages/ui/` — React chat interface (Vite)
 - `packages/humr-base/` — shared base image/utilities
 - `packages/db/` — database schema and migrations
-- `deploy/helm/humr/` — Helm chart for all components + OneCLI + PostgreSQL
+- `deploy/helm/humr/` — Helm chart for all components + PostgreSQL
 
 ## Workflow
 
@@ -33,7 +33,7 @@ mise run ui:run             # start UI dev server
 mise run cluster:install      # create k3s VM, build images, install cert-manager + Humr chart (or upgrade if already installed)
 mise run cluster:build-agent  # rebuild agent image only, restart agent pods
 mise run cluster:status       # show pods and cluster state
-mise run cluster:logs         # show OneCLI pod logs
+mise run cluster:logs         # show api-server pod logs
 mise run cluster:stop         # stop k3s VM (preserves data)
 mise run cluster:uninstall    # helm uninstall + cleanup PVCs
 mise run cluster:delete       # destroy k3s VM entirely

--- a/deploy/helm/humr/templates/postgres-secrets.yaml
+++ b/deploy/helm/humr/templates/postgres-secrets.yaml
@@ -8,9 +8,10 @@
 {{- if $existingPgSecret }}
   {{- $pgPassword = index $existingPgSecret.data "POSTGRES_PASSWORD" | b64dec }}
 {{- else }}
-  {{- /* Legacy upgrade path: pre-ADR-033 charts stored the password in the
-         OneCLI Secret. Read it once during the OneCLI removal upgrade so a
-         running deployment doesn't lose its database password. */ -}}
+  {{- /* Legacy upgrade path: pre-ADR-033 charts stored the password in a
+         Secret named `<release>-onecli-secrets`. Read it once during the
+         post-ADR-033 upgrade so a running deployment doesn't lose its
+         database password. */ -}}
   {{- $legacySecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-onecli-secrets" (include "humr.fullname" .)) }}
   {{- if $legacySecret }}
     {{- $pgPassword = index $legacySecret.data "POSTGRES_PASSWORD" | b64dec }}

--- a/deploy/helm/humr/templates/postgres-secrets.yaml
+++ b/deploy/helm/humr/templates/postgres-secrets.yaml
@@ -8,16 +8,7 @@
 {{- if $existingPgSecret }}
   {{- $pgPassword = index $existingPgSecret.data "POSTGRES_PASSWORD" | b64dec }}
 {{- else }}
-  {{- /* Legacy upgrade path: pre-ADR-033 charts stored the password in a
-         Secret named `<release>-onecli-secrets`. Read it once during the
-         post-ADR-033 upgrade so a running deployment doesn't lose its
-         database password. */ -}}
-  {{- $legacySecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-onecli-secrets" (include "humr.fullname" .)) }}
-  {{- if $legacySecret }}
-    {{- $pgPassword = index $legacySecret.data "POSTGRES_PASSWORD" | b64dec }}
-  {{- else }}
-    {{- $pgPassword = default (randAlphaNum 32) .Values.postgres.password }}
-  {{- end }}
+  {{- $pgPassword = default (randAlphaNum 32) .Values.postgres.password }}
 {{- end }}
 apiVersion: v1
 kind: Secret

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -179,7 +179,8 @@ Each agent pod gets a NetworkPolicy that:
 - Permits gRPC egress to the api-server's ext_authz port (the HITL gate).
 - Permits egress to the api-server's harness port (MCP, triggers).
 - Permits DNS.
-- Allows ingress only on the agent's ACP port from cluster peers.
+- Admits ingress on the agent's ACP/tRPC port only from the api-server pod;
+  the kernel-level peer match is the auth boundary on that hop.
 
-OneCLI is no longer in the path; there is no cross-namespace credential
-gateway pod for the agent to reach.
+The credential gateway lives inside the agent pod (the Envoy sidecar);
+there is no cross-namespace gateway pod for the agent to reach.

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -5,7 +5,7 @@ Last verified: 2026-05-04
 ## Motivated by
 
 - [ADR-005 — Gateway pattern for credentials](../adrs/005-credential-gateway.md) — the agent never sees a real upstream token; a gateway injects them on the wire
-- [ADR-015 — Multi-user authentication via Keycloak](../adrs/015-multi-user-auth.md) — Keycloak is the IdP; resources are owner-labelled (the OneCLI fork in §3 is superseded by ADR-033)
+- [ADR-015 — Multi-user authentication via Keycloak](../adrs/015-multi-user-auth.md) — Keycloak is the IdP; resources are owner-labelled
 - [ADR-018 — Slack integration](../adrs/018-slack-integration.md) — identity linking and the per-instance `allowedUsers` gate that decides who can drive a thread
 - [ADR-027 — Slack per-turn user impersonation](../adrs/027-slack-user-impersonation.md) — foreign repliers fork the instance into a per-turn Job whose Envoy sidecar mounts the replier's K8s credential Secrets
 - [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy sidecar mints per-instance leaf certs, MITMs egress, and injects credential headers

--- a/docs/guidelines/documentation-guidelines.md
+++ b/docs/guidelines/documentation-guidelines.md
@@ -47,7 +47,7 @@ Each subsystem page starts with two headers directly under the title:
 - Mermaid only — renders on GitHub, reviewable as text in PR diffs.
 - One system-context diagram on the landing page.
 - Subsystem pages include a diagram only if it adds clarity: sequence diagrams for flows, component diagrams for topology.
-- Box labels use code names (`api-server`, `onecli`, `agent-runtime`, …).
+- Box labels use code names (`api-server`, `agent-runtime`, `envoy`, …).
 
 ### Links
 

--- a/docs/strategy/security-model.md
+++ b/docs/strategy/security-model.md
@@ -28,7 +28,7 @@ So yes: *inside* the virtual machine, an agent has fewer walls between it and th
 
 > **Example.** A guide online tells the agent to install a tool called `official-slack-cli` by running `uvx official-slack-cli` (a common one-line way to fetch and run a package). The tool looks real, but it's a copycat built by an attacker. The moment the agent runs it, the Slack API key gets shipped off to the attacker's server. From there, the attacker logs into your Slack workspace and starts scanning messages for anything valuable: passwords, customer data, internal plans.
 
-The trick for solving this is a proxy: a middleman program that sits between the agent and the outside world, letting it use APIs and CLI tools without ever holding the real keys. Humr uses a proxy called OneCLI for this today; we may swap it for something else down the line, but the idea will stay the same.
+The trick for solving this is a proxy: a middleman program that sits between the agent and the outside world, letting it use APIs and CLI tools without ever holding the real keys. Humr runs an Envoy sidecar in every agent pod for this — the agent talks to the sidecar over `localhost`, and the sidecar swaps a placeholder for the real credential before the request leaves the pod.
 
 Here's how it works. Instead of giving the agent your real API keys, the agent only sees fake placeholders like `{{SLACK_TOKEN}}`. When the agent sends a request, say to Slack, the request passes through the proxy first. The proxy swaps the placeholder for the real key at the very last second, and only if the request is actually going to Slack. A request going anywhere else gets no key at all.
 
@@ -85,7 +85,7 @@ None of this makes the system *safe*. A determined attacker who controls text th
 
 How Humr realizes the model:
 
-- [security-and-credentials](../architecture/security-and-credentials.md) — Keycloak identity flow, OneCLI credential gateway, MITM cert-manager CA, network boundary, full threat model.
+- [security-and-credentials](../architecture/security-and-credentials.md) — Keycloak identity flow, Envoy sidecar credential gateway, cert-manager-issued leaf CA, network boundary, full threat model.
 - [platform-topology](../architecture/platform-topology.md) — the four components and why the agent pod is the trust boundary.
 - [persistence](../architecture/persistence.md) § Security boundary — workspace residue is adversarial input on the next turn.
 - [Multiplayer](multi-player.md) — the companion doc covering identity, ownership, and what a colleague's turn looks like.

--- a/packages/agent-runtime/src/modules/acp/infrastructure/mappers.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/mappers.ts
@@ -1,5 +1,5 @@
 const AUTH_HINT =
-  "Authentication Error: Ensure the API/OAuth credential secret is correct and linked to this agent in the OneCLI dashboard (Agents > select agent > Secrets).\n\nError: ";
+  "Authentication Error: Ensure the API/OAuth credential secret is correct and linked to this agent (Agents > select agent > Secrets).\n\nError: ";
 
 /**
  * Prepend the authentication hint to any frame whose error or text content

--- a/packages/agent-runtime/src/modules/skills/infrastructure/github-rest-client.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/github-rest-client.ts
@@ -95,17 +95,20 @@ export interface GitHubRestClient {
 }
 
 /**
- * Adapter that talks to `api.github.com` through OneCLI's HTTPS proxy.
+ * Adapter that talks to `api.github.com` through the agent pod's Envoy
+ * sidecar (HTTPS_PROXY).
  *
  * `withAuth: true` attaches the sentinel bearer (`humr:sentinel` unless
- * `GH_TOKEN` overrides) — OneCLI's MITM swaps it for the user's OAuth token.
- * Needed for mutations and for endpoints whose 404-on-unauthenticated path is
- * ambiguous (we'd rather get the structured `app_not_connected` CTA).
+ * `GH_TOKEN` overrides) — the sidecar's credential_injector filter rewrites
+ * it to the user's OAuth token on the wire. Needed for mutations and for
+ * endpoints whose 404-on-unauthenticated path is ambiguous (we'd rather get
+ * the structured `app_not_connected` CTA).
  *
- * `withAuth: false` sends no Authorization header. OneCLI passes anonymous
- * reads through for public resources and *still* injects the user's token
- * automatically when they're Connected. The hard-requirement path for scan:
- * public repos must work even when the user hasn't Connected GitHub yet.
+ * `withAuth: false` sends no Authorization header. The sidecar passes
+ * anonymous reads through for public resources; private resources require
+ * the sentinel so credential_injector can attach the user's token. The
+ * hard-requirement path for scan: public repos must work even when the user
+ * hasn't Connected GitHub yet.
  */
 export function createGitHubRestClient(): GitHubRestClient {
   return {

--- a/packages/agent-runtime/src/modules/skills/services/install.ts
+++ b/packages/agent-runtime/src/modules/skills/services/install.ts
@@ -50,8 +50,9 @@ async function fetchSourceAtVersion(
 ): Promise<Result<void, SkillsDomainError>> {
   const host = detectGithubOwnerRepo(source);
   if (host) {
-    // Anonymous-first; on 404 retry with sentinel so OneCLI can surface the
-    // structured `app_not_connected` / `access_restricted` CTA body.
+    // Anonymous-first; on 404 retry with the sentinel so the api-server's
+    // upstream-error mapping can surface the structured `app_not_connected`
+    // / `access_restricted` CTA body.
     let bytes = await deps.github.fetchTarball(host, version, { withAuth: false });
     if (!bytes.ok && bytes.error.kind === "UpstreamGitHubError" && bytes.error.status === 404) {
       bytes = await deps.github.fetchTarball(host, version, { withAuth: true });

--- a/packages/agent-runtime/src/modules/skills/services/publish.ts
+++ b/packages/agent-runtime/src/modules/skills/services/publish.ts
@@ -21,15 +21,16 @@ export interface PublishDeps {
 
 /**
  * Publish a local skill to GitHub as a new branch + PR. Executes entirely
- * via the REST API through OneCLI's MITM — no git subprocess, no working
- * copy on disk. Multi-step REST sequencing lives here (not in the port);
- * the port stays a thin typed wrapper around api.github.com.
+ * via the REST API through the agent pod's Envoy sidecar — no git
+ * subprocess, no working copy on disk. Multi-step REST sequencing lives
+ * here (not in the port); the port stays a thin typed wrapper around
+ * api.github.com.
  *
  * Requires this pod to run with `GH_TOKEN=humr:sentinel` + `HTTPS_PROXY`
- * pre-wired by the controller (always true in Humr), OneCLI's
- * `GITHUB_CLIENT_ID/SECRET` configured, the user Connected, and this agent
- * granted access. Failures on any of those surface as a 401/403 from
- * OneCLI's gateway with a structured error body the contract relays.
+ * pre-wired by the controller (always true in Humr), a GitHub OAuth app
+ * configured, the user Connected, and this agent granted access. Failures
+ * on any of those surface as a 401/403 from upstream with a structured
+ * error body the contract relays.
  */
 export async function runPublish(
   deps: PublishDeps,

--- a/packages/agent-runtime/src/modules/skills/services/scan.ts
+++ b/packages/agent-runtime/src/modules/skills/services/scan.ts
@@ -22,8 +22,9 @@ export interface ScanDeps {
 
 /**
  * Enumerate skills in a remote git source. GitHub URLs walk through
- * api.github.com (commit-head + tarball) so OneCLI's stable Bearer-sentinel
- * swap is on the hot path; non-GitHub URLs fall back to anonymous git clone.
+ * api.github.com (commit-head + tarball) so the Envoy sidecar's stable
+ * Bearer-sentinel swap is on the hot path; non-GitHub URLs fall back to
+ * anonymous git clone.
  *
  * Trade-off: `version` is the source's HEAD commit at scan time, uniform
  * across the catalogue. Drift detection lights the Update badge whenever the
@@ -44,11 +45,12 @@ async function scanGithub(
   source: string,
   host: DetectedOwnerRepo,
 ): Promise<Result<ScannedSkill[], SkillsDomainError>> {
-  // Anonymous preflight. OneCLI passes public repos through and auto-injects
-  // the user's token for private repos when they're Connected — happy path is
-  // one call. A 404 here is ambiguous: truly-not-found OR private + not
-  // Connected. Retry with the sentinel so OneCLI's gateway can return the
-  // structured `app_not_connected` / `access_restricted` CTA the UI renders.
+  // Anonymous preflight. The Envoy sidecar passes public repos through and
+  // its credential_injector filter rewrites the sentinel for private repos
+  // when the user is Connected — happy path is one call. A 404 here is
+  // ambiguous: truly-not-found OR private + not Connected. Retry with the
+  // sentinel so the api-server can surface the structured `app_not_connected`
+  // / `access_restricted` CTA the UI renders.
   let head = await deps.github.getCommitHead(host, { withAuth: false });
   if (!head.ok && head.error.kind === "UpstreamGitHubError" && head.error.status === 404) {
     head = await deps.github.getCommitHead(host, { withAuth: true });
@@ -57,7 +59,7 @@ async function scanGithub(
   const version = head.value.sha;
 
   // Tarball is served by api.github.com (with a redirect to codeload that
-  // OneCLI follows transparently — verified empirically). For a typical
+  // the sidecar follows transparently — verified empirically). For a typical
   // skill repo this is ~50–500 KB.
   const tarball = await deps.github.fetchTarball(host, version, { withAuth: false });
   if (!tarball.ok) return tarball;

--- a/packages/agent-runtime/src/trigger-watcher.ts
+++ b/packages/agent-runtime/src/trigger-watcher.ts
@@ -4,7 +4,8 @@ import { Agent, request } from "node:http";
 import { Agent as HttpsAgent, request as requestHttps } from "node:https";
 
 // Explicit agents bypass HTTP_PROXY env vars (agent pods route external
-// traffic through OneCLI, but internal cluster calls must go direct).
+// traffic through the Envoy sidecar, but internal cluster calls must go
+// direct).
 const directAgent = new Agent();
 const directHttpsAgent = new HttpsAgent();
 import { z } from "zod/v4";

--- a/packages/agents/code-guardian/README.md
+++ b/packages/agents/code-guardian/README.md
@@ -35,8 +35,9 @@ the agent loads at startup.
 
 - `GITHUB_REPO` — `owner/repo` slug to review. Defaults to the repo detected in
   the working directory via `gh repo view`.
-- A GitHub connection must be provided via OneCLI so that `gh` can
-  authenticate.
+- A GitHub connection must be granted to this agent so that `gh` can
+  authenticate (the Envoy sidecar injects the OAuth token on outbound
+  GitHub requests).
 
 ## Persistence
 

--- a/packages/agents/google-workspace/README.md
+++ b/packages/agents/google-workspace/README.md
@@ -24,13 +24,13 @@ A Humr agent template with the [Google Workspace CLI (`gws`)](https://github.com
      - `http://localhost:4444/api/apps/gmail/callback`
    - Save the **Client ID** and **Client Secret**
 
-### 2. Connect Google Drive in OneCLI
+### 2. Connect Google Drive in DAM
 
-1. Open OneCLI at http://localhost:4444
-2. Navigate to **Apps** (or **Connectors**)
+1. Open the DAM UI at http://localhost:4444
+2. Navigate to **Connections**
 3. Add **Google Drive** with your **Client ID** and **Client Secret** from step 1
 4. Complete the Google OAuth consent flow
-5. Grant the google-workspace agent access to this credential
+5. Grant the google-workspace agent access to this connection
 
 ### 3. Create an Agent
 
@@ -40,16 +40,16 @@ A Humr agent template with the [Google Workspace CLI (`gws`)](https://github.com
 
 ## How It Works
 
-The agent authenticates to Google APIs through Humr's credential injection:
+The agent authenticates to Google APIs through DAM's credential injection ([ADR-033](../../../docs/adrs/033-envoy-credential-gateway.md)):
 
-1. When you grant a `gmail` or `google-drive` connection in the agent's Configure dialog, Humr auto-populates `GOOGLE_WORKSPACE_CLI_TOKEN=humr:sentinel` into the agent's editable env list. You can edit or remove it like any custom env var.
-2. When `gws` makes a request to `*.googleapis.com`, it sends `Authorization: Bearer humr:sentinel`
-3. The request goes through OneCLI's MITM proxy (`HTTPS_PROXY`)
-4. OneCLI recognizes the sentinel and replaces it with the real Bearer token
-5. Google receives a valid access token
+1. When you grant a `gmail` or `google-drive` connection in the agent's Configure dialog, DAM auto-populates `GOOGLE_WORKSPACE_CLI_TOKEN=humr:sentinel` into the agent's editable env list. You can edit or remove it like any custom env var.
+2. When `gws` makes a request to `*.googleapis.com`, it sends `Authorization: Bearer humr:sentinel`.
+3. The request goes through the in-pod Envoy sidecar (`HTTPS_PROXY=http://127.0.0.1:<port>`).
+4. The sidecar's filter chain for the Google host swaps the sentinel for the real Bearer token, sourced from a K8s Secret mounted into the sidecar only.
+5. Google receives a valid access token.
 
-The agent never sees your real Google credentials. OneCLI's app registry declares which env var each provider needs; Humr reads it and populates the agent env on grant.
+The agent container never sees your real Google credentials — the Secret is mounted into the sidecar, not the agent.
 
 ## Token Lifecycle
 
-OneCLI stores the OAuth refresh token and automatically exchanges it for a new access token when the current one expires. No manual intervention is needed after the initial OAuth consent.
+DAM stores the OAuth refresh token in a K8s Secret and runs a refresh loop in the api-server that re-mints the access token before it expires. No manual intervention is needed after the initial OAuth consent.

--- a/packages/agents/google-workspace/ROADMAP.md
+++ b/packages/agents/google-workspace/ROADMAP.md
@@ -6,10 +6,6 @@
 
 ~~Replace the flat `workspace/work/CLAUDE.md` with structured Claude Code skills (`.claude/skills/`).~~ Shipped: `drive-upload`, `drive-manage`, `gmail-triage`, `calendar-agenda`, `sheets-data`.
 
-### ~~OneCLI OAuth Flow for Local Development~~ (Done)
+### ~~Automatic OAuth Token Refresh~~ (Done)
 
-~~Google's OAuth 2.0 policy requires HTTPS for redirect URIs on subdomains (e.g., `onecli.localhost:4444`). This prevents the built-in OneCLI OAuth flow from working in local development.~~ Shipped: `onecli.externalHostname: localhost` in `values-local.yaml` routes OneCLI through plain `localhost:4444`, which Google exempts from HTTPS requirements.
-
-### ~~Automatic OAuth Token Refresh~~ (Not needed)
-
-~~With the native OAuth flow (above), OneCLI receives refresh tokens during the initial consent. A future enhancement could proactively refresh tokens before expiry to avoid transient 401s.~~ OneCLI apps already handle token refresh automatically — no additional work needed.
+~~A future enhancement could proactively refresh tokens before expiry to avoid transient 401s.~~ Shipped: the api-server runs an OAuth refresh loop that re-mints access tokens before they expire (see `oauth-refresh-service.ts`).

--- a/packages/agents/pi-agent/README.md
+++ b/packages/agents/pi-agent/README.md
@@ -28,7 +28,7 @@ workspace/
 
 Pi natively supports a long list of API-key providers (OpenAI, Mistral, Groq, DeepSeek, Cerebras, xAI, OpenRouter, Gemini, Fireworks, Hugging Face, ZAI, MiniMax, …) plus any OpenAI-Completions / OpenAI-Responses / Anthropic-Messages / Google-Generative-AI compatible endpoint via [`models.json`](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md) or [extensions](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/extensions.md). Authoritative reference: [pi providers](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md) for env-var names, auth-file shape, and resolution order; [pi models](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md) for the `models.json` schema and `compat` flags.
 
-In Humr the actual credential never lives in pod env. The pod carries a placeholder; OneCLI MITMs outbound traffic and rewrites the auth header using a [generic secret](../../../docs/architecture/security-and-credentials.md#what-gets-injected) ([ADR-028](../../../docs/adrs/028-generic-secret-injection-config.md)) scoped to the provider's host. The flow is the same for every provider — only the host pattern and (occasionally) the injection header change.
+In Humr the actual credential never lives in pod env. The pod carries a placeholder; the in-pod Envoy sidecar terminates outbound TLS and rewrites the auth header using a [generic secret](../../../docs/architecture/security-and-credentials.md) ([ADR-033](../../../docs/adrs/033-envoy-credential-gateway.md)) scoped to the provider's host. The flow is the same for every provider — only the host pattern and (occasionally) the injection header change.
 
 ### Built-in API-key providers
 
@@ -37,12 +37,12 @@ Three steps to enable any pi built-in provider:
 1. **Set the provider's env var to a non-empty placeholder** so pi's [credential resolution](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md#resolution-order) recognizes the provider. Add to `Dockerfile`, the agent template, or per-instance via the Configure Agent UI:
 
    ```dockerfile
-   ENV OPENAI_API_KEY=injected-by-onecli
+   ENV OPENAI_API_KEY=humr:sentinel
    ```
 
-   The literal value pi sends on the wire is rewritten by OneCLI before forwarding upstream.
+   The literal value pi sends on the wire is rewritten by the Envoy sidecar before the request leaves the pod.
 
-2. **Create a generic secret in OneCLI** scoped to the provider's host. The default injection (`Authorization: Bearer {value}`) is correct for almost every provider in the table below. Override `injectionConfig.headerName` (and optionally `valueFormat`) only for providers that deviate (`x-api-key`, `RITS_API_KEY`, `Token {value}`, …).
+2. **Create a generic secret in DAM** scoped to the provider's host. The default injection (`Authorization: Bearer {value}`) is correct for almost every provider in the table below. Override `injectionConfig.headerName` (and optionally `valueFormat`) only for providers that deviate (`x-api-key`, `RITS_API_KEY`, `Token {value}`, …).
 
 3. **Select the model** in [`settings.json`](workspace/.pi/agent/settings.json) (`defaultProvider` / `defaultModel`) or via `/model` at session start.
 
@@ -50,7 +50,7 @@ Three steps to enable any pi built-in provider:
 
 Sourced from pi-mono [`env-api-keys.ts`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/env-api-keys.ts) and [`models.generated.ts`](https://github.com/badlogic/pi-mono/blob/main/packages/ai/src/models.generated.ts) — pi's resolution order is documented in [providers.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/providers.md#resolution-order).
 
-| Provider | pi `provider` id | Env var(s) (placeholder in pod, real value in OneCLI secret) | Host pattern |
+| Provider | pi `provider` id | Env var(s) (placeholder in pod, real value in K8s Secret mounted into the Envoy sidecar) | Host pattern |
 |---|---|---|---|
 | Anthropic | `anthropic` | `ANTHROPIC_API_KEY` (or `ANTHROPIC_OAUTH_TOKEN`) | `api.anthropic.com` |
 | OpenAI | `openai` | `OPENAI_API_KEY` | `api.openai.com` |
@@ -77,12 +77,12 @@ Sourced from pi-mono [`env-api-keys.ts`](https://github.com/badlogic/pi-mono/blo
 
 #### Other providers (env vars from pi-mono; Humr integration not validated end-to-end)
 
-These providers have additional configuration shapes (per-resource URLs, AWS credential chain, OAuth, SA-key files). The env vars below are what pi-mono reads; whether they compose cleanly with OneCLI's MITM rewrite hasn't been verified for each — confirm before relying on them in production.
+These providers have additional configuration shapes (per-resource URLs, AWS credential chain, OAuth, SA-key files). The env vars below are what pi-mono reads; whether they compose cleanly with the Envoy sidecar's wire-level header rewrite hasn't been verified for each — confirm before relying on them in production.
 
 | Provider | pi `provider` id | Auth env vars | Notes |
 |---|---|---|---|
 | Azure OpenAI Responses | `azure-openai-responses` | `AZURE_OPENAI_API_KEY` plus `AZURE_OPENAI_BASE_URL` (or `AZURE_OPENAI_RESOURCE_NAME`), optional `AZURE_OPENAI_API_VERSION`, `AZURE_OPENAI_DEPLOYMENT_NAME_MAP` | Host is your Azure resource (e.g. `<resource>.openai.azure.com`). Should work with the placeholder-env + generic-secret pattern, but not validated. |
-| Amazon Bedrock | `amazon-bedrock` | One of: `AWS_PROFILE`; `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`; `AWS_BEARER_TOKEN_BEDROCK`; `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `_FULL_URI`; `AWS_WEB_IDENTITY_TOKEN_FILE`. Optional: `AWS_REGION`, `AWS_BEDROCK_FORCE_CACHE`, `AWS_ENDPOINT_URL_BEDROCK_RUNTIME`, `AWS_BEDROCK_SKIP_AUTH`, `AWS_BEDROCK_FORCE_HTTP1` | Host: `bedrock-runtime.<region>.amazonaws.com`. AWS SigV4 is computed in-pod against the secret access key, so a generic-secret header rewrite would break the signature — likely needs the real credential mounted, not OneCLI-injected. Untested. |
+| Amazon Bedrock | `amazon-bedrock` | One of: `AWS_PROFILE`; `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY`; `AWS_BEARER_TOKEN_BEDROCK`; `AWS_CONTAINER_CREDENTIALS_RELATIVE_URI` / `_FULL_URI`; `AWS_WEB_IDENTITY_TOKEN_FILE`. Optional: `AWS_REGION`, `AWS_BEDROCK_FORCE_CACHE`, `AWS_ENDPOINT_URL_BEDROCK_RUNTIME`, `AWS_BEDROCK_SKIP_AUTH`, `AWS_BEDROCK_FORCE_HTTP1` | Host: `bedrock-runtime.<region>.amazonaws.com`. AWS SigV4 is computed in-pod against the secret access key, so a generic-secret header rewrite would break the signature — likely needs the real credential mounted, not sidecar-injected. Untested. |
 | Google Vertex AI | `google-vertex` | `GOOGLE_CLOUD_API_KEY` **or** `GOOGLE_APPLICATION_CREDENTIALS` (SA key file) **or** ADC + `GOOGLE_CLOUD_PROJECT` + `GOOGLE_CLOUD_LOCATION` | Host: `<location>-aiplatform.googleapis.com`. The API-key path may work with a generic secret; SA-key / ADC paths require a file mount and aren't a generic-secret shape. Untested. |
 | GitHub Copilot | `github-copilot` | `COPILOT_GITHUB_TOKEN`, `GH_TOKEN`, or `GITHUB_TOKEN` | Host: `api.individual.githubcopilot.com`. pi's documented path is OAuth via `/login`, with tokens stored in `~/.pi/agent/auth.json`. Untested with a generic secret. |
 | OpenAI Codex (ChatGPT) | (Codex Responses) | OAuth via `/login` — no env var | Host: `chatgpt.com/backend-api`. ChatGPT subscription only; not appropriate for production. |
@@ -98,7 +98,7 @@ For self-hosted vLLM / Ollama / LM Studio / internal proxies that aren't in pi's
     "internal-vllm": {
       "baseUrl": "https://vllm.internal.example.com/v1",
       "api": "openai-completions",
-      "apiKey": "injected-by-onecli",
+      "apiKey": "humr:sentinel",
       "authHeader": true,
       "models": [{ "id": "qwen2.5-coder-32b" }]
     }
@@ -106,7 +106,7 @@ For self-hosted vLLM / Ollama / LM Studio / internal proxies that aren't in pi's
 }
 ```
 
-Then create a generic OneCLI secret with `hostPattern: vllm.internal.example.com` and the default Bearer injection. The literal `apiKey` is a placeholder satisfying [pi-acp's per-session auth gate](#pi-acp-auth-gate-workarounds-15); OneCLI rewrites the header on the wire. The full `models.json` schema (`compat`, `reasoning`, `contextWindow`, `thinkingFormat`, `headers`, `modelOverrides`) is in [pi models.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md).
+Then create a generic secret in DAM with `hostPattern: vllm.internal.example.com` and the default Bearer injection. The literal `apiKey` is a placeholder satisfying [pi-acp's per-session auth gate](#pi-acp-auth-gate-workarounds-15); the Envoy sidecar rewrites the header on the wire. The full `models.json` schema (`compat`, `reasoning`, `contextWindow`, `thinkingFormat`, `headers`, `modelOverrides`) is in [pi models.md](https://github.com/badlogic/pi-mono/blob/main/packages/coding-agent/docs/models.md).
 
 For non-Bearer auth, override `injectionConfig` on the secret instead of changing `models.json`:
 
@@ -130,7 +130,7 @@ The [`pi-rits`](workspace/.pi/agent/extensions/pi-rits/index.ts) extension is au
 | `RITS_MAX_TOKENS` | no | `16384` | Max output tokens. |
 | `RITS_THINKING_FORMAT` | no | — | `qwen`, `qwen-chat-template`, `zai`, `reasoning_effort`, or `openrouter` — request-body hint for servers with a matching reasoning parser. |
 
-The API key is **not** a pod env var. Configure it as a OneCLI generic secret with `injectionConfig.headerName: RITS_API_KEY`, `injectionConfig.valueFormat: {value}`, and a host pattern matching your RITS deployment. OneCLI injects the header on outbound traffic at the proxy layer.
+The API key is **not** a pod env var. Configure it as a generic secret in DAM with `injectionConfig.headerName: RITS_API_KEY`, `injectionConfig.valueFormat: {value}`, and a host pattern matching your RITS deployment. The Envoy sidecar injects the header on outbound traffic at the proxy layer.
 
 To make RITS the default model, edit `settings.json`:
 
@@ -142,7 +142,7 @@ To make RITS the default model, edit `settings.json`:
 ### pi-acp auth-gate workarounds ([#15](https://github.com/svkozak/pi-acp/issues/15))
 
 1. *Startup gate* — `pi-acp` refuses to spawn `pi` unless a recognized credential exists. Satisfied by the dummy `ENV OPENCODE_API_KEY=pi-acp-auth-gate-bypass` in the Dockerfile (allow-listed name, unused by any pi provider).
-2. *Per-session gate* — `pi-acp` re-checks `models.json.providers[*].apiKey` on every `session/prompt`. Satisfied by either (a) the placeholder env var for built-in providers, (b) the placeholder `apiKey` in `models.json` for custom OpenAI-compatible servers, or (c) the extension mirroring its `registerProvider` config to `models.json` on load. In every case the `apiKey` is a placeholder; the real credential is OneCLI-injected on the wire.
+2. *Per-session gate* — `pi-acp` re-checks `models.json.providers[*].apiKey` on every `session/prompt`. Satisfied by either (a) the placeholder env var for built-in providers, (b) the placeholder `apiKey` in `models.json` for custom OpenAI-compatible servers, or (c) the extension mirroring its `registerProvider` config to `models.json` on load. In every case the `apiKey` is a placeholder; the real credential is sidecar-injected on the wire.
 
 Pi system prompt conventions:
 

--- a/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-openai-proxy/index.ts
+++ b/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-openai-proxy/index.ts
@@ -13,10 +13,10 @@ export default function register(pi: ExtensionAPI): void {
 	const provider: ProviderConfig = {
 		baseUrl: /\/v\d+$/.test(url) ? url : `${url}/v1`,
 		api: "openai-completions",
-		// Auth is injected by OneCLI at the HTTP-proxy layer (or by Envoy's
-		// credential_injector under ADR-033); the key set here only exists to
-		// satisfy pi-acp's per-session auth gate (reads models.json.apiKey).
-		apiKey: env("OPENAI_PROXY_API_KEY") ?? "injected-by-onecli",
+		// Auth is injected on the wire by the Envoy sidecar's
+		// credential_injector filter (ADR-033); the key set here only exists
+		// to satisfy pi-acp's per-session auth gate (reads models.json.apiKey).
+		apiKey: env("OPENAI_PROXY_API_KEY") ?? "humr:sentinel",
 		authHeader: false,
 		models: [
 			{

--- a/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-rits/index.ts
+++ b/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-rits/index.ts
@@ -13,9 +13,10 @@ export default function register(pi: ExtensionAPI): void {
 	const provider: ProviderConfig = {
 		baseUrl: /\/v\d+$/.test(url) ? url : `${url}/v1`,
 		api: "openai-completions",
-		// Auth is injected by OneCLI at the HTTP-proxy layer; the key set here only
-		// exists to satisfy pi-acp's per-session auth gate (reads models.json.apiKey).
-		apiKey: "injected-by-onecli",
+		// Auth is injected on the wire by the Envoy sidecar's credential_injector
+		// filter; the key set here only exists to satisfy pi-acp's per-session
+		// auth gate (reads models.json.apiKey).
+		apiKey: "humr:sentinel",
 		authHeader: false,
 		models: [
 			{

--- a/packages/api-server-api/src/modules/connections/types.ts
+++ b/packages/api-server-api/src/modules/connections/types.ts
@@ -15,9 +15,9 @@ export interface AppConnectionView {
   scopes?: string[];
   connectedAt?: string;
   /**
-   * Pod envs contributed by this connection. Declared by OneCLI's app
-   * registry (see the matching `AppDefinition.envMappings` field) and
-   * returned verbatim on `GET /api/connections` — Humr never writes this.
+   * Pod envs contributed by this connection. Declared by the OAuth app
+   * registry's `flow.envMappings` and returned verbatim on
+   * `GET /api/connections`.
    */
   envMappings?: EnvMapping[];
   /**

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -5,8 +5,9 @@ export type SecretMode = "all" | "selective";
 /**
  * Declares a pod env var to inject into every agent instance that has access
  * to this secret. `placeholder` is the literal value written into the env
- * (typically "humr:sentinel") — OneCLI's gateway swaps it for the real
- * credential on outbound requests matching the secret's host pattern.
+ * (typically "humr:sentinel") — the Envoy sidecar's credential_injector
+ * filter rewrites it to the real credential on outbound requests matching
+ * the secret's host pattern.
  */
 export interface EnvMapping {
   envName: string;
@@ -23,8 +24,8 @@ export function isValidEnvName(name: string): boolean {
 
 /**
  * OAuth-token mode. The Claude Code SDK sends `CLAUDE_CODE_OAUTH_TOKEN` via
- * `Authorization: Bearer …`, which OneCLI's MITM gateway swaps for the stored
- * OAuth credential.
+ * `Authorization: Bearer …`, which the Envoy sidecar's credential_injector
+ * filter rewrites to the stored OAuth credential on the wire.
  */
 export const ANTHROPIC_OAUTH_ENV_MAPPING: EnvMapping = {
   envName: "CLAUDE_CODE_OAUTH_TOKEN",
@@ -32,9 +33,9 @@ export const ANTHROPIC_OAUTH_ENV_MAPPING: EnvMapping = {
 };
 
 /**
- * How OneCLI's gateway injects a generic secret into matching outbound
+ * How the Envoy sidecar injects a generic secret into matching outbound
  * requests. `valueFormat` may reference the literal token `{value}`;
- * OneCLI defaults it to `{value}` when omitted.
+ * defaults to `{value}` when omitted.
  */
 export interface InjectionConfig {
   headerName: string;
@@ -49,8 +50,9 @@ export const DEFAULT_INJECTION_CONFIG: InjectionConfig = {
 
 /**
  * API-key mode. Tools that read `ANTHROPIC_API_KEY` (e.g. `@anthropic-ai/sdk`)
- * send the sentinel via `x-api-key`, which OneCLI's gateway swaps for the
- * stored api-key credential.
+ * send the sentinel via `x-api-key`, which the Envoy sidecar's
+ * credential_injector filter rewrites to the stored api-key credential on
+ * the wire.
  */
 export const ANTHROPIC_API_KEY_ENV_MAPPING: EnvMapping = {
   envName: "ANTHROPIC_API_KEY",

--- a/packages/api-server/src/__tests__/egress-rules.test.ts
+++ b/packages/api-server/src/__tests__/egress-rules.test.ts
@@ -42,7 +42,7 @@ beforeAll(async () => {
 
   // Warm-up: pod ready ≠ ext_authz pipeline ready. The api-server
   // resolves instance → agent identity lazily on the first Check call,
-  // and cold OneCLI sync after pod creation can leave the first
+  // and the cold lookup after pod creation can leave the first
   // request's gate call returning deny without inserting a pending row.
   // Issue one curl, drain any approvals, then start asserting.
   curl("example.com", "https");

--- a/packages/api-server/src/__tests__/unit/oauth-engine.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-engine.test.ts
@@ -140,7 +140,8 @@ describe("oauth-engine.exchange", () => {
     // GitHub returns HTTP 200 + JSON `{error, error_description}` on auth
     // failures (bad client_secret, code already consumed, redirect-URI
     // mismatch, …). The engine has to surface that as a thrown error so
-    // downstream code doesn't write `accessToken: undefined` to OneCLI.
+    // downstream code doesn't write `accessToken: undefined` into the
+    // connection's K8s Secret.
     const fetchImpl = vi.fn(async () =>
       new Response(
         JSON.stringify({

--- a/packages/api-server/src/__tests__/unit/publish-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/publish-service.test.ts
@@ -155,14 +155,14 @@ describe("publishSkill — thin proxy", () => {
     await expect(publishSkill(deps, input)).rejects.toMatchObject({ code: "NOT_IMPLEMENTED" });
   });
 
-  it("translates OneCLI 'app_not_connected' to a PRECONDITION_FAILED with humr-cta: URL", async () => {
+  it("translates upstream 'app_not_connected' to a PRECONDITION_FAILED with humr-cta: URL", async () => {
     const { deps, runtimeClient } = makeDeps();
     (runtimeClient.publish as any) = vi.fn().mockRejectedValue(
       new AgentRuntimeUpstreamError("agent-runtime error", {
         status: 401,
         body: {
           error: "app_not_connected",
-          message: "GitHub is not connected in OneCLI.",
+          message: "GitHub is not connected.",
           connect_url: "http://localhost:4444/connections?connect=github",
           provider: "github",
         },
@@ -178,7 +178,7 @@ describe("publishSkill — thin proxy", () => {
     expect(err.message).toContain("humr-cta:http://localhost:4444/connections?connect=github");
   });
 
-  it("translates OneCLI 'access_restricted' (agent not granted) similarly with manage_url", async () => {
+  it("translates upstream 'access_restricted' (agent not granted) similarly with manage_url", async () => {
     const { deps, runtimeClient } = makeDeps();
     (runtimeClient.publish as any) = vi.fn().mockRejectedValue(
       new AgentRuntimeUpstreamError("agent-runtime error", {

--- a/packages/api-server/src/apps/harness-api-server/pod-files-events.ts
+++ b/packages/api-server/src/apps/harness-api-server/pod-files-events.ts
@@ -15,8 +15,8 @@ export interface PodFilesEventsDeps {
 /**
  * Mount the SSE channel that the agent-pod sidecar holds open.
  * Auth: Bearer token (per-instance). Topics: keyed by agent name because
- * OneCLI grants are agent-scoped — every running instance of the same agent
- * sees the same set of granted connections, so they share one topic.
+ * connection grants are agent-scoped — every running instance of the same
+ * agent sees the same set of granted connections, so they share one topic.
  */
 export function mountPodFilesEventsRoute(app: Hono, deps: PodFilesEventsDeps) {
   app.get("/api/instances/:id/pod-files/events", async (c) => {

--- a/packages/api-server/src/bootstrap/app-connection-egress-hosts.ts
+++ b/packages/api-server/src/bootstrap/app-connection-egress-hosts.ts
@@ -7,7 +7,7 @@ import { readFileSync } from "node:fs";
  * map; grants stay rule-less but the rest of the app works.
  *
  * The file shape is `{ "<provider>": ["host1", "host2"], ... }` where
- * `<provider>` matches the `provider` field on OneCLI's
+ * `<provider>` matches the `provider` field returned by the api-server's
  * `/api/connections` rows. See the matching Helm template
  * `templates/apiserver/app-connection-egress-hosts.yaml`.
  */

--- a/packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts
@@ -1,11 +1,11 @@
 /**
  * OAuth-issued credential storage in K8s Secrets, keyed by `(owner, connection)`.
  *
- * Replaces the OneCLI REST write path for tokens minted by the API Server's
- * OAuth callback (today: MCP servers; later: GitHub, Slack, Google). The
- * controller's Envoy renderer (`packages/controller/pkg/reconciler/envoy.go`)
- * already lists Secrets by `humr.ai/owner=<sub>,humr.ai/managed-by=api-server`,
- * so connection Secrets land in the sidecar without controller changes.
+ * Stores tokens minted by the API Server's OAuth callback (MCP servers,
+ * GitHub, Slack, Google, …). The controller's Envoy renderer
+ * (`packages/controller/pkg/reconciler/envoy.go`) lists Secrets by
+ * `humr.ai/owner=<sub>,humr.ai/managed-by=api-server`, so connection Secrets
+ * land in the sidecar automatically.
  *
  * Each Secret carries:
  *   - `sds.yaml` — SDS DiscoveryResponse the sidecar reads via `path_config_source`

--- a/packages/api-server/src/modules/connections/infrastructure/oauth-apps.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/oauth-apps.ts
@@ -8,11 +8,11 @@
  *
  * Client credentials live with the user by default — every user registers
  * their own OAuth app at the provider against the platform's callback URL.
- * **Optional admin defaults** (mirroring OneCLI's `GITHUB_CLIENT_ID` /
- * `GITHUB_CLIENT_SECRET` knobs) let an operator wire a single
- * platform-registered OAuth app: when a default is configured, the
- * matching field disappears from the connect form and the registry's
- * `build()` uses the default to mint tokens.
+ * **Optional admin defaults** (`GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET`
+ * knobs on the api-server) let an operator wire a single platform-registered
+ * OAuth app: when a default is configured, the matching field disappears
+ * from the connect form and the registry's `build()` uses the default to
+ * mint tokens.
  *
  * Cardinality:
  * - **Single-instance** apps (github, github-enterprise) have at most one
@@ -34,9 +34,9 @@ import {
 /**
  * Env vars set on agents that grant a GitHub.com or GHE connection. `gh` CLI
  * (and most token-aware GitHub tooling) reads `GH_TOKEN` from the env and
- * sends it as the bearer token; OneCLI's gateway recognizes the sentinel
- * placeholder and substitutes the real token on outbound requests matching
- * the secret's host pattern.
+ * sends it as the bearer token; the Envoy sidecar's credential_injector
+ * filter rewrites the sentinel placeholder to the real token on outbound
+ * requests matching the secret's host pattern.
  */
 const GH_TOKEN_ENV_MAPPING: EnvMapping = {
   envName: "GH_TOKEN",

--- a/packages/api-server/src/modules/connections/infrastructure/oauth-engine.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/oauth-engine.ts
@@ -4,9 +4,8 @@
  * Reused by both the MCP-server flow (provider config built dynamically from
  * RFC 8414 metadata + RFC 7591 dynamic client registration) and the named-app
  * flow (provider config built statically by the OAuthApp registry — GitHub,
- * GitHub Enterprise, etc.). Token storage and OneCLI mirror are not the
- * engine's job — callers pull the resulting `TokenSet` and write through
- * whichever ports apply.
+ * GitHub Enterprise, etc.). Token storage is not the engine's job — callers
+ * pull the resulting `TokenSet` and write through whichever ports apply.
  *
  * State of in-flight flows lives in a Map keyed by the OAuth `state`
  * parameter. A janitor sweeps entries older than 10 minutes.
@@ -50,11 +49,12 @@ export interface OAuthFlowMetadata {
   displayName?: string;
   /**
    * Pod env vars to inject into every agent granted access to this
-   * connection's mirror secret. The placeholder is typically the OneCLI
-   * sentinel — the gateway swaps it for the real token at request time —
-   * but for env vars carrying literal config (e.g. `GH_HOST`) it can be a
-   * concrete value. Static apps populate this from the descriptor; Generic
-   * leaves it unset (no provider-specific tooling convention to enforce).
+   * connection's K8s Secret. The placeholder is typically `humr:sentinel`
+   * — the Envoy sidecar's credential_injector filter rewrites it to the
+   * real token at request time — but for env vars carrying literal config
+   * (e.g. `GH_HOST`) it can be a concrete value. Static apps populate this
+   * from the descriptor; Generic leaves it unset (no provider-specific
+   * tooling convention to enforce).
    */
   envMappings?: import("api-server-api").EnvMapping[];
 }
@@ -233,8 +233,8 @@ export function createOAuthEngine(opts?: CreateOAuthEngineOptions): OAuthEngine 
       // GitHub (and some other providers) return HTTP 200 even on errors,
       // with `{error, error_description, ...}` in the body. Catch it here
       // before the missing access_token bubbles into a confusing
-      // downstream "expected string, received undefined" from the OneCLI
-      // mirror.
+      // downstream "expected string, received undefined" when the Secret
+      // is written.
       if (!data.access_token) {
         const detail = data.error_description ?? data.error ?? "no access_token in response";
         const code = data.error ? `${data.error}: ` : "";

--- a/packages/api-server/src/modules/connections/services/oauth-refresh-service.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh-service.ts
@@ -13,24 +13,6 @@
  * State is the K8s Secrets — the loop is idempotent and crash-safe; on
  * restart it re-derives its work list. Single-process; multi-replica leader
  * election is a follow-up.
- *
- * KNOWN GAP — OneCLI mirror is not refreshed.
- *   The api-server's connect/disconnect handlers dual-write to OneCLI
- *   (`__humr_oauth:<connection>` / `__humr_mcp:<host>` generic secrets) so
- *   non-flagged instances on the OneCLI gateway keep working. This loop
- *   does **not** push refreshed tokens back to OneCLI — it only updates
- *   the K8s Secret. Consequences:
- *     - Flagged instances (Envoy sidecar) read the refreshed token via
- *       SDS file-watch — works as designed.
- *     - Non-flagged instances (OneCLI gateway) keep using the original
- *       access token until it expires at the upstream; the user has to
- *       manually reconnect to refresh OneCLI.
- *   Closing the gap requires a way to call OneCLI per-owner from a
- *   process-wide loop without a user JWT — either a Keycloak RFC 8693
- *   impersonation hop (`requested_subject = owner`, mirroring the
- *   controller's pattern) or a cluster-scoped OneCLI admin token. Both
- *   are wider in scope than this PR's slice; the gap closes naturally
- *   when the OneCLI dual-write is removed in the follow-up issue.
  */
 import {
   listAllConnectionWorkItems,

--- a/packages/api-server/src/modules/pod-files/bus.ts
+++ b/packages/api-server/src/modules/pod-files/bus.ts
@@ -1,7 +1,7 @@
 import type { PodFilesEvent } from "./types.js";
 
 /**
- * In-memory pub/sub for pod-files updates, keyed by agent name. OneCLI
+ * In-memory pub/sub for pod-files updates, keyed by agent name. Connection
  * grants are agent-scoped, so every running instance of the same agent
  * shares one topic. Single api-server replica is the deployment baseline —
  * see 034-pod-files-push for the multi-replica path.

--- a/packages/api-server/src/modules/pod-files/producers/github-enterprise-hosts.ts
+++ b/packages/api-server/src/modules/pod-files/producers/github-enterprise-hosts.ts
@@ -1,9 +1,9 @@
 import type { FileFragment, FileProducer, FileSpec } from "../types.js";
 
 /**
- * One row of OneCLI's `/api/connections` response — only the fields this
- * producer needs. Kept local to avoid pulling the connections module's
- * port shape into the pod-files layer.
+ * One row of the api-server's `/api/connections` response — only the
+ * fields this producer needs. Kept local to avoid pulling the connections
+ * module's port shape into the pod-files layer.
  */
 interface RawConnection {
   id?: string;
@@ -14,7 +14,7 @@ interface RawConnection {
 /**
  * Where the producer reads its state from. Agent-scoped: the callback
  * returns only the connections **granted to `agentId`** under `owner`,
- * not every connection the owner has in OneCLI. This matches the user-
+ * not every connection the owner has registered. This matches the user-
  * facing model — the UI's per-agent grant click is the sole driver of
  * what files appear inside that agent's pod.
  *
@@ -33,8 +33,8 @@ export interface GithubEnterpriseHostsDeps {
 export const GH_ENTERPRISE_HOSTS_RELATIVE_PATH = ".config/gh/hosts.yml";
 
 /**
- * Strip scheme and port from `metadata.baseUrl`, mirroring the gateway's
- * parser (context/onecli/apps/gateway/src/apps.rs `extract_host_from_base_url`).
+ * Strip scheme and port from `metadata.baseUrl` so the host can be matched
+ * against Envoy's SNI filter chains.
  */
 function extractHost(metadata: Record<string, unknown> | null | undefined): string | undefined {
   if (!metadata) return undefined;
@@ -46,9 +46,10 @@ function extractHost(metadata: Record<string, unknown> | null | undefined): stri
 }
 
 /**
- * `gh auth status` only displays the user — actual auth uses the proxied
- * sentinel token. Pick the OAuth login (`metadata.username`) by default and
- * fall back through `login` and `name` so older records keep working.
+ * `gh auth status` only displays the user — actual auth uses the sentinel
+ * token (rewritten on the wire by the Envoy sidecar's credential_injector
+ * filter). Pick the OAuth login (`metadata.username`) by default and fall
+ * back through `login` and `name` so older records keep working.
  */
 function pickUsername(metadata: Record<string, unknown> | null | undefined): string | undefined {
   if (!metadata) return undefined;
@@ -88,9 +89,10 @@ function renderHostFragment(connection: RawConnection): FileFragment | null {
 
 /**
  * Uses `yaml-fill-if-missing` so revokes are safe (entries linger but the
- * gateway stops swapping the sentinel, so the next call fails loud rather
- * than silently using a stale grant). Trade-off: a revoked host stays
- * visible in `gh auth status` until the user manually edits hosts.yml.
+ * Envoy sidecar stops rewriting the sentinel once the grant is gone, so
+ * the next call fails loud rather than silently using a stale grant).
+ * Trade-off: a revoked host stays visible in `gh auth status` until the
+ * user manually edits hosts.yml.
  */
 export function makeGithubEnterpriseHostsProducer(
   deps: GithubEnterpriseHostsDeps,

--- a/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
+++ b/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
@@ -1,13 +1,10 @@
 /**
- * Forward-only K8s mirror for user-typed secrets (generic + Anthropic).
+ * K8s storage for user-typed secrets (generic + Anthropic).
  *
  * The Envoy credential-injector sidecar (ADR-033) reads credentials from files
  * mounted into the sidecar container. The Controller renders those mounts from
  * K8s Secrets labelled with the owner's sub. This port writes those Secrets so
- * newly-created OneCLI secrets land in K8s for the sidecar to discover.
- *
- * Existing OneCLI-only secrets are not migrated; users with the experimental
- * flag on must re-create the secrets they want injected.
+ * newly-created secrets land in K8s for the sidecar to discover.
  */
 import type * as k8s from "@kubernetes/client-node";
 import type { InjectionConfig } from "api-server-api";
@@ -122,8 +119,8 @@ export interface K8sSecretsPort {
 // `id.toLowerCase()` defensively, but that masks IDs that aren't already
 // valid (e.g. mixed case → silent collisions on case-only differences) and
 // can still produce invalid names if the ID contains other characters.
-// Validate up-front instead — OneCLI hands us UUIDs, so this is a no-op for
-// the happy path and a hard error for anything else.
+// Validate up-front instead — callers hand us UUIDs, so this is a no-op
+// for the happy path and a hard error for anything else.
 const K8S_NAME_RE = /^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/;
 const K8S_NAME_PREFIX = "humr-cred-";
 const K8S_NAME_MAX_ID_LEN = 253 - K8S_NAME_PREFIX.length;

--- a/packages/api-server/src/modules/skills/infrastructure/git-host.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/git-host.ts
@@ -1,7 +1,7 @@
 /**
  * Pure parsers for git host URLs. The actual GitHub REST calls live in
- * agent-runtime (which is wired through OneCLI's MITM); api-server just
- * needs to know which host a source points at.
+ * agent-runtime (whose egress is intercepted by the Envoy sidecar);
+ * api-server just needs to know which host a source points at.
  */
 
 export interface GitHostIdentity {

--- a/packages/api-server/src/modules/skills/infrastructure/public-archive-scanner.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/public-archive-scanner.ts
@@ -7,11 +7,12 @@ import type { Skill } from "api-server-api";
 import { detectHost } from "./git-host.js";
 
 /**
- * Scan a public GitHub source directly — no OneCLI, no git binary, no auth.
+ * Scan a public GitHub source directly — no Envoy sidecar, no git binary,
+ * no auth.
  *
  * api-server has direct internet egress (no NetworkPolicy applies to it),
  * so it can hit `github.com/{owner}/{repo}/archive/HEAD.tar.gz` without
- * going through OneCLI's MITM. That endpoint:
+ * going through any agent pod. That endpoint:
  *   - Returns 302 → codeload.github.com/.../tar.gz/{FULL_SHA} on public repos
  *     (full commit SHA in the redirect URL — recoverable from response.url).
  *   - Returns 404 for private repos and nonexistent ones alike — caller
@@ -19,10 +20,10 @@ import { detectHost } from "./git-host.js";
  *   - Has no api.github.com-style rate limit (tarball endpoint is a separate
  *     budget and effectively unlimited for our one-per-5-min cache cadence).
  *
- * The chosen architecture makes public-source scans work in every OneCLI
- * state — unconfigured, configured but not Connected, Connected but agent
- * not granted, or fully connected + granted — which is a hard product
- * requirement (see docs/plans/skills/11-scan-in-api-server.md).
+ * The chosen architecture makes public-source scans work in every
+ * connection state — no app configured, configured but not Connected,
+ * Connected but agent not granted, or fully connected + granted — which
+ * is a hard product requirement (see docs/plans/skills/11-scan-in-api-server.md).
  */
 export class PublicArchiveNotFoundError extends Error {
   constructor(gitUrl: string) {

--- a/packages/api-server/src/modules/skills/infrastructure/upstream-to-trpc.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/upstream-to-trpc.ts
@@ -2,8 +2,8 @@ import { TRPCError } from "@trpc/server";
 import { AgentRuntimeUpstreamError } from "./agent-runtime-client.js";
 
 /**
- * Translate an OneCLI gateway error (relayed by agent-runtime as HTTP 502
- * with a `.upstream` envelope) into a tRPC error the UI can act on.
+ * Translate a structured upstream error (relayed by agent-runtime as HTTP
+ * 502 with a `.upstream` envelope) into a tRPC error the UI can act on.
  *
  * We encode the `connect_url` / `manage_url` into the message as a
  * `humr-cta:<url>` prefix segment that the client can split back out. Keeps
@@ -24,7 +24,7 @@ export function upstreamToTrpc(err: AgentRuntimeUpstreamError): TRPCError {
   if (status === 403) {
     return new TRPCError({
       code: "FORBIDDEN",
-      message: `GitHub rejected the request (${message}). Reconnect GitHub in OneCLI with the repo scope.`,
+      message: `GitHub rejected the request (${message}). Reconnect GitHub with the repo scope.`,
     });
   }
   if (status === 404) {

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -121,9 +121,10 @@ async function loadRunningInstance(
  * canPublish is a soft signal: "the publish infrastructure knows how to
  * target this host." True when the gitUrl parses as a GitHub URL — that's
  * the only host our publish flow supports today. Authentication/authorization
- * (is the user Connected in OneCLI? is this agent granted access?) is not
- * preflighted here; any failure surfaces at publish time with a precise CTA
- * from OneCLI's gateway. Cheaper + harder to get stale than a cluster call.
+ * (is the user's GitHub connection live? is this agent granted access?)
+ * is not preflighted here; any failure surfaces at publish time with a
+ * precise CTA from upstream. Cheaper + harder to get stale than a cluster
+ * call.
  */
 function enrichSources(sources: SkillSource[]): SkillSource[] {
   return sources.map((s) =>
@@ -316,9 +317,9 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       }
 
       // Fast path: public GitHub repo scanned directly from api-server. This
-      // works in every OneCLI state (unconfigured, not Connected, not
-      // granted, fully granted) because api-server has direct internet
-      // egress — it never touches OneCLI's per-agent-grant gating.
+      // works in every connection state (no app configured, not Connected,
+      // not granted, fully granted) because api-server has direct internet
+      // egress — it never touches the agent pod's per-grant gating.
       if (detectHost(src.gitUrl)) {
         try {
           return await deps.scanSource(src.gitUrl, deps.scanPublic);
@@ -331,8 +332,9 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       }
 
       // Private/authenticated path: delegate to agent-runtime inside a
-      // running instance pod, which uses OneCLI's token swap. Without an
-      // instanceId we can't target a pod — refuse with a clear message.
+      // running instance pod, whose Envoy sidecar performs the token swap.
+      // Without an instanceId we can't target a pod — refuse with a clear
+      // message.
       if (!instanceId) {
         throw new TRPCError({
           code: "PRECONDITION_FAILED",

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -164,8 +164,8 @@ func listOwnerCredentialSecrets(ctx context.Context, client kubernetes.Interface
 // in-pod env has to carry a placeholder.
 //
 // The placeholder value is opaque to the upstream — Envoy overwrites it — so
-// any non-empty string works. We use the same `humr:sentinel` token the OneCLI
-// path used so logs stay grep-friendly across the migration.
+// any non-empty string works. We use a stable `humr:sentinel` token so logs
+// stay grep-friendly.
 func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 	const sentinel = "humr:sentinel"
 	seen := map[string]struct{}{}

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -99,7 +99,6 @@ func TestBuildStatefulSet_Running(t *testing.T) {
 	// No platform-issued credential token in the agent container's env —
 	// the api-server → agent-runtime hop is gated by NetworkPolicy ingress.
 	for _, e := range c.Env {
-		assert.NotEqual(t, "ONECLI_ACCESS_TOKEN", e.Name)
 		assert.NotEqual(t, "AGENT_RUNTIME_TOKEN", e.Name)
 	}
 	assert.Equal(t, "/etc/humr/ca/ca.crt", envMap["SSL_CERT_FILE"])
@@ -282,15 +281,6 @@ func TestBuildNetworkPolicy(t *testing.T) {
 		np.Spec.Ingress[0].From[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
 	require.NotNil(t, np.Spec.Ingress[0].From[0].NamespaceSelector)
 	assert.Equal(t, int32(8080), np.Spec.Ingress[0].Ports[0].Port.IntVal)
-
-	// No OneCLI peer anywhere.
-	for _, rule := range np.Spec.Egress {
-		for _, peer := range rule.To {
-			if peer.PodSelector != nil {
-				assert.NotEqual(t, "onecli", peer.PodSelector.MatchLabels["app.kubernetes.io/component"])
-			}
-		}
-	}
 }
 
 func envToMap(envs []corev1.EnvVar) map[string]string {

--- a/packages/ui/src/__tests__/unit/connection-env-helpers.test.ts
+++ b/packages/ui/src/__tests__/unit/connection-env-helpers.test.ts
@@ -31,9 +31,9 @@ describe("envsAfterUngrant — non-obvious invariants", () => {
     expect(out).toEqual(envs);
   });
 
-  test("treats a placeholder change (OneCLI upgrade) as 'edited' — keeps the entry", () => {
+  test("treats a placeholder change (sentinel rotation) as 'edited' — keeps the entry", () => {
     // An agent env populated under the old placeholder shouldn't be silently
-    // deleted after OneCLI rotates its sentinel. The value-equality check is
+    // deleted after the sentinel is rotated. The value-equality check is
     // what protects this — dropping it would cause data loss post-upgrade.
     const envs: EnvVar[] = [{ name: "X", value: "humr:sentinel" }];
     const out = envsAfterUngrant(envs, app([mapping("X", "humr:sentinel-v2")]), []);

--- a/packages/ui/src/components/connections-picker.tsx
+++ b/packages/ui/src/components/connections-picker.tsx
@@ -12,9 +12,10 @@ import { OAuthAppIcon } from "../modules/connections/components/oauth-app-icon.j
 
 /**
  * One row in the picker's "OAuth Apps" subsection. Joins the
- * api-server-managed app connection (host, displayName, expiry, appId for the
- * brand icon) with the OneCLI mirror secret's id (the grant target — agents
- * see the token via `Authorization: Bearer` injection on `hostPattern`).
+ * api-server-managed app connection (host, displayName, expiry, appId for
+ * the brand icon) with the K8s credential Secret's id (the grant target —
+ * agents see the token via the Envoy sidecar's `Authorization: Bearer`
+ * injection on `hostPattern`).
  */
 export interface OAuthAppEntry {
   secretId: string;

--- a/packages/ui/src/components/env-mappings-editor.tsx
+++ b/packages/ui/src/components/env-mappings-editor.tsx
@@ -31,7 +31,7 @@ export function EnvMappingsEditor({
       disabled={disabled}
       newRowValue={DEFAULT_ENV_PLACEHOLDER}
       valuePlaceholder={DEFAULT_ENV_PLACEHOLDER}
-      emptyMessage="No env vars declared. The agent will only receive credentials via OneCLI's HTTP proxy."
+      emptyMessage="No env vars declared. The agent will only receive credentials via the Envoy sidecar's on-the-wire injection."
     />
   );
 }

--- a/packages/ui/src/modules/agents/api/queries.ts
+++ b/packages/ui/src/modules/agents/api/queries.ts
@@ -10,8 +10,8 @@ export function useAgents() {
 }
 
 /**
- * Per-agent secret + connection access. The agent might not yet be registered
- * with OneCLI (controller syncs asynchronously after create), so we swallow
+ * Per-agent secret + connection access. The agent might not yet be fully
+ * reconciled (controller syncs asynchronously after create), so we swallow
  * errors silently rather than toasting.
  */
 export function useAgentAccess(agentId: string | null) {
@@ -24,8 +24,9 @@ export function useAgentAccess(agentId: string | null) {
 }
 
 /**
- * Per-agent app-connection grants. Same OneCLI-sync lag as {@link useAgentAccess},
- * so errors stay silent and initial data defaults to an empty grant list.
+ * Per-agent app-connection grants. Same controller-sync lag as
+ * {@link useAgentAccess}, so errors stay silent and initial data defaults
+ * to an empty grant list.
  */
 export function useAgentConnections(agentId: string | null) {
   return useQuery({

--- a/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
@@ -106,9 +106,9 @@ export function AddAgentDialog({
   const selSecretsSet = useMemo(() => new Set(selSecrets), [selSecrets]);
   const selAppsSet = useMemo(() => new Set(selApps), [selApps]);
 
-  // Join the api-server-driven OAuth app connections with their OneCLI mirror
-  // secrets so the picker can render them in the "Apps" subsection while the
-  // grant still flows through the secret-access mechanism.
+  // Join the api-server-driven OAuth app connections with their K8s
+  // credential Secrets so the picker can render them in the "Apps"
+  // subsection while the grant flows through the secret-access mechanism.
   const oauthAppEntries = useMemo<OAuthAppEntry[]>(() => {
     const secretByName = new Map(secrets.map((s) => [s.name, s]));
     return oauthAppConnections.flatMap((conn) => {

--- a/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
@@ -155,9 +155,9 @@ export function ConfigureAgentDialog({
   const assignedSet = useMemo(() => new Set(assigned), [assigned]);
   const appIdsSet = useMemo(() => new Set(assignedAppIds), [assignedAppIds]);
 
-  // Join the api-server-driven OAuth app connections with their OneCLI mirror
-  // secrets so the picker can render them in the "Apps" subsection while
-  // grants still flow through the secret-access mechanism.
+  // Join the api-server-driven OAuth app connections with their K8s
+  // credential Secrets so the picker can render them in the "Apps"
+  // subsection while grants flow through the secret-access mechanism.
   const oauthAppEntries = useMemo<OAuthAppEntry[]>(() => {
     const secretByName = new Map(secrets.map((s) => [s.name, s]));
     return oauthAppConnections.flatMap((conn) => {

--- a/packages/ui/src/modules/connections/components/oauth-app-icon.tsx
+++ b/packages/ui/src/modules/connections/components/oauth-app-icon.tsx
@@ -3,13 +3,12 @@ import { Cable } from "lucide-react";
 /**
  * Per-app brand icon. Known app ids resolve to a brand SVG under
  * `/icons/`; everything else falls back to a `Cable` glyph — visually
- * distinct from KeyRound (which the OneCLI app-connection rows already
- * use) and Globe (MCP rows), and reads as "user-supplied integration."
- * SVGs carry their own `fill` so they render the same in light/dark
- * themes without runtime CSS gymnastics.
+ * distinct from KeyRound (which generic app-connection rows use) and
+ * Globe (MCP rows), and reads as "user-supplied integration." SVGs
+ * carry their own `fill` so they render the same in light/dark themes
+ * without runtime CSS gymnastics.
  *
- * Brand SVGs sourced from the kagenti/onecli fork (Apache 2.0); the
- * shapes are SimpleIcons-style canonical octocats.
+ * Brand SVGs are SimpleIcons-style canonical glyphs (Apache 2.0).
  */
 const ICON_BY_APP_ID: Record<string, string> = {
   github: "/icons/github.svg",

--- a/packages/ui/src/modules/secrets/components/edit-secret-dialog.tsx
+++ b/packages/ui/src/modules/secrets/components/edit-secret-dialog.tsx
@@ -130,7 +130,7 @@ export function EditSecretDialog({ secret, onClose }: Props) {
           {isGeneric && (
             <FormField
               label="Host Pattern"
-              hint="Hostname OneCLI matches against outbound requests. Required."
+              hint="Hostname the Envoy sidecar matches against outbound requests. Required."
               error={errors.hostPattern?.message}
             >
               <input
@@ -159,7 +159,7 @@ export function EditSecretDialog({ secret, onClose }: Props) {
           {isGeneric && (
             <FormField
               label="Header Name"
-              hint="HTTP header OneCLI writes the secret into."
+              hint="HTTP header the Envoy sidecar writes the secret into."
               error={errors.headerName?.message}
             >
               <input

--- a/packages/ui/src/modules/secrets/forms/create-secret-form.tsx
+++ b/packages/ui/src/modules/secrets/forms/create-secret-form.tsx
@@ -163,7 +163,7 @@ export function CreateSecretForm({ onCancel, onCreated }: Props) {
             label="Header Name (optional)"
             hint={
               <>
-                HTTP header OneCLI writes the secret into. Defaults to{" "}
+                HTTP header the Envoy sidecar writes the secret into. Defaults to{" "}
                 <span className="font-mono">{DEFAULT_INJECTION_CONFIG.headerName}</span>.
               </>
             }
@@ -200,7 +200,7 @@ export function CreateSecretForm({ onCancel, onCreated }: Props) {
               Inject env vars into every agent instance granted this secret.
               The placeholder (typically{" "}
               <span className="font-mono">humr:sentinel</span>) is swapped
-              for the real value on the wire by OneCLI.
+              for the real value on the wire by the Envoy sidecar.
             </p>
             <Controller
               control={control}

--- a/packages/ui/src/modules/sessions/components/mcps-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/mcps-panel.tsx
@@ -1,7 +1,7 @@
 import { Globe } from "lucide-react";
 
 export interface McpOption {
-  id: string;          // OneCLI secret id
+  id: string;          // K8s credential Secret id
   hostname: string;    // display label + session key
   assigned: boolean;   // agent has this secret assigned (selective or via "all" mode)
 }

--- a/packages/ui/src/modules/sessions/components/skills-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/skills-panel.tsx
@@ -333,9 +333,9 @@ export function SkillsPanel({ instanceId, isRunning, onOpenFile }: SkillsPanelPr
       void refreshSource(publishForm.sourceId);
     } catch (err) {
       // publish-service encodes a call-to-action URL as `\nhumr-cta:<url>`
-      // in the error message when OneCLI's gateway surfaces a structured
-      // error (not connected / agent access not granted). Parse it out so
-      // the toast's action button takes the user straight to the right fix.
+      // in the error message when an upstream surfaces a structured error
+      // (not connected / agent access not granted). Parse it out so the
+      // toast's action button takes the user straight to the right fix.
       const rawMessage = err instanceof Error ? err.message : `Failed to publish ${publishFor.name}`;
       const cta = rawMessage.match(/humr-cta:(\S+)/)?.[1];
       const message = rawMessage.replace(/\nhumr-cta:\S+/, "").trim();
@@ -617,10 +617,11 @@ export function SkillsPanel({ instanceId, isRunning, onOpenFile }: SkillsPanelPr
 
             {!collapsed && error && (() => {
               // publish/scan services encode a call-to-action URL as
-              // `\nhumr-cta:<url>` in the tRPC error message when OneCLI's
-              // gateway surfaces a structured error (not connected / agent
-              // access not granted / repo not in OAuth App's allowed list).
-              // Split it out so the banner offers a direct link to the fix.
+              // `\nhumr-cta:<url>` in the tRPC error message when an
+              // upstream surfaces a structured error (not connected /
+              // agent access not granted / repo not in OAuth App's
+              // allowed list). Split it out so the banner offers a
+              // direct link to the fix.
               const cta = error.match(/humr-cta:(\S+)/)?.[1];
               const message = error.replace(/\nhumr-cta:\S+/, "").trim();
               return (

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -144,10 +144,10 @@ export interface Schedule {
 export type SecretType = "anthropic" | "generic";
 export type SecretMode = "all" | "selective";
 
-/** Prefix used for MCP OAuth secrets stored in OneCLI. */
+/** Prefix used for MCP OAuth secrets stored as K8s credential Secrets. */
 export const MCP_SECRET_PREFIX = "__humr_mcp:";
 
-/** Prefix used for app-OAuth tokens mirrored into OneCLI by the api-server. */
+/** Prefix used for app-OAuth tokens stored as K8s credential Secrets by the api-server. */
 export const APP_OAUTH_SECRET_PREFIX = "__humr_oauth:";
 
 export function isMcpSecret(s: { name: string; type: SecretType }): boolean {

--- a/tseng/vocabulary.md
+++ b/tseng/vocabulary.md
@@ -42,7 +42,6 @@ Persistence vocabulary shared by every bounded context. See [`docs/architecture/
 | Fork | An ephemeral, per-turn execution environment derived from an Instance that impersonates a foreign user for the duration of one Slack turn |
 | Foreign Sub | The Keycloak `sub` of a Slack replier who is not the Instance owner |
 | Fork Phase | The lifecycle state of a Fork: Pending, Ready, Failed, or Completed |
-| Foreign Registration | The `(agent, foreignSub) → OneCLI access token` binding, minted lazily on first fork request and cached in-memory by the Connections module |
 
 ## Skills — api-server side (bounded context)
 
@@ -97,8 +96,8 @@ Pod-side operational view of skills. Distinct from the api-server's Skills conte
 
 | Term | Definition |
 |------|-----------|
-| Secret | A user-owned credential (e.g., an Anthropic API key) stored in OneCLI that can be injected into agent egress traffic by the credential gateway |
+| Secret | A user-owned credential (e.g., an Anthropic API key) stored as a K8s Secret labelled with the owner's `sub` and mounted into the agent pod's Envoy sidecar for wire-level injection on outbound traffic |
 | Secret Type | The provider taxonomy for a secret — currently `anthropic` (hostPattern fixed) or `generic` (user-supplied host/path patterns) |
-| Host Pattern | The hostname pattern that identifies which outbound requests the credential gateway should inject this secret into |
-| Secret Assignment | The linkage between a Secret and an Agent that makes the secret available to that agent's egress; OneCLI owns this linkage as a bulk set per agent |
+| Host Pattern | The hostname pattern that identifies which outbound requests the Envoy sidecar should inject this secret into |
+| Secret Assignment | The linkage between a Secret and an Agent that makes the secret available to that agent's egress; stored as the `humr.ai/secret-mode` + `humr.ai/granted-secret-ids` annotations on the agent's instance ConfigMap |
 | Provider | The external service a secret authenticates against (e.g., Anthropic); for typed secrets the provider determines default routing rules |


### PR DESCRIPTION
## Summary

Final cleanup after the OneCLI removal (#74) and the agent-runtime token drop (#78). Every \`OneCLI\` / \`onecli\` / \`ONECLI\` reference outside the ADR archive is reworded so the surrounding narrative matches the actual architecture: the in-pod Envoy sidecar is the credential gateway, K8s Secrets labelled with the owner's \`sub\` are the storage, and the api-server's NetworkPolicy + \`podIpResolver\` are the auth boundaries between api-server, agent-runtime, and the harness port.

49 files, +213 / -217 net.

## Three deliberate exceptions

- **\`deploy/helm/humr/templates/postgres-secrets.yaml\`** — the legacy upgrade-path lookup that reads the password out of the old \`humr-onecli-secrets\` Secret on first install after upgrading from a pre-ADR-033 chart. Load-bearing, not stale documentation.
- **\`docs/architecture/security-and-credentials.md\` line 8** — the forward pointer in the *Motivated by* list explaining that ADR-015 §3 (the OneCLI fork) is superseded by ADR-033. Accurate context for the reader.
- **\`packages/controller/pkg/reconciler/resources_test.go\`** — assertions that \`ONECLI_ACCESS_TOKEN\` is not in the agent env and \`onecli\` is not a peer in the NetworkPolicy. Regression checks; the literal string is the test value.

ADRs under \`docs/adrs/\` are intentionally left alone — they're decision records describing the state at the time of decision.

## Two larger touch-ups beyond simple text replacement

- **\`packages/api-server/src/modules/connections/services/oauth-refresh-service.ts\`**: deleted an 18-line "KNOWN GAP — OneCLI mirror is not refreshed" block at the top describing the now-removed dual-write behavior.
- **\`packages/api-server/src/modules/pod-files/producers/github-enterprise-hosts.ts\`**: dropped the file-path reference to a deleted upstream OneCLI parser (\`context/onecli/apps/gateway/src/apps.rs\`); reworded the docstring to describe the Envoy SNI-matching purpose instead.

## Test plan

- [x] \`mise run check\` — lint + tsc + helm lint + kubeconform render all green
- [x] \`mise run test\` — 219 unit tests pass
- [x] \`grep -rn "OneCLI\\|onecli\\|ONECLI"\` outside \`docs/adrs/\` returns only the three deliberately-kept files above