### PR TITLE
feat(bob): add Bob Shell agent integration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,10 +184,41 @@ jobs:
           cache-from: type=gha,scope=pi-agent
           cache-to: type=gha,mode=max,scope=pi-agent
 
+  build-bob:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-images
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/bob
+          tags: type=sha,prefix=,format=long
+      - uses: docker/build-push-action@v6
+        with:
+          context: packages/agents/bob
+          file: packages/agents/bob/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ github.sha }}
+          cache-from: type=gha,scope=bob
+          cache-to: type=gha,mode=max,scope=bob
+
   helm-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-images, build-claude-code, build-google-workspace-agent, build-code-guardian, build-pi-agent]
+    needs: [build-images, build-claude-code, build-google-workspace-agent, build-code-guardian, build-pi-agent, build-bob]
     steps:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v4

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -206,10 +206,45 @@ jobs:
           cache-from: type=gha,scope=pi-agent
           cache-to: type=gha,mode=max,scope=pi-agent
 
+  build-bob:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-images
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/bob
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+      - uses: docker/build-push-action@v6
+        with:
+          context: packages/agents/bob
+          file: packages/agents/bob/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ steps.meta.outputs.version }}
+          cache-from: type=gha,scope=bob
+          cache-to: type=gha,mode=max,scope=bob
+
   helm-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-images, build-claude-code, build-google-workspace-agent, build-code-guardian, build-pi-agent]
+    needs: [build-images, build-claude-code, build-google-workspace-agent, build-code-guardian, build-pi-agent, build-bob]
     if: startsWith(github.ref, 'refs/tags/v')
     steps:
       - uses: actions/checkout@v4

--- a/deploy/helm/platform/templates/bob-agent-template.yaml
+++ b/deploy/helm/platform/templates/bob-agent-template.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.bobAgentTemplate.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.bobAgentTemplate.name }}
+  namespace: {{ .Values.agentNamespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    agent-platform.ai/type: agent-template
+data:
+  spec.yaml: |
+    version: agent-platform.ai/v1
+    image: "{{ .Values.bobAgentTemplate.image.repository }}:{{ .Values.bobAgentTemplate.image.tag | default .Chart.AppVersion }}"
+    description: {{ .Values.bobAgentTemplate.description | quote }}
+    mounts:
+      - path: /home/agent
+        persist: true
+      - path: /tmp
+        persist: false
+    init: |
+      #!/bin/bash
+      # Seed home from image on first boot
+      if [ ! -f /home/agent/.initialized ]; then
+        cp -rn /app/working-dir/. /home/agent/ 2>/dev/null || true
+        touch /home/agent/.initialized
+      fi
+      mkdir -p /home/agent/work
+      if [ -f /home/agent/work/requirements.txt ]; then
+        pip install -r /home/agent/work/requirements.txt
+      fi
+    env:
+      - name: PORT
+        value: "8080"
+      # Path (relative to the agent workdir, or absolute) where agent-runtime
+      # writes the platform-outbound MCP server config. Bob reads project-scope
+      # config from <workdir>/.bob/settings.json.
+      - name: MCP_CONFIG_PATH
+        value: {{ .Values.bobAgentTemplate.mcpConfigPath | quote }}
+    resources:
+      requests:
+        cpu: {{ .Values.bobAgentTemplate.resources.requests.cpu | quote }}
+        memory: {{ .Values.bobAgentTemplate.resources.requests.memory | quote }}
+      limits:
+        cpu: {{ .Values.bobAgentTemplate.resources.limits.cpu | quote }}
+        memory: {{ .Values.bobAgentTemplate.resources.limits.memory | quote }}
+    securityContext:
+      readOnlyRootFilesystem: false
+{{- end }}

--- a/deploy/helm/platform/templates/bob-agent-template.yaml
+++ b/deploy/helm/platform/templates/bob-agent-template.yaml
@@ -36,6 +36,19 @@ data:
       # config from <workdir>/.bob/settings.json.
       - name: MCP_CONFIG_PATH
         value: {{ .Values.bobAgentTemplate.mcpConfigPath | quote }}
+      # Placeholder so bobshell's harness check passes (it throws "API key
+      # required" if BOBSHELL_API_KEY is unset and falls back to OAuth BFF
+      # login flow). The `sk-` prefix is load-bearing: bobshell uses it to
+      # detect a legacy api-key and switch baseUrl to the old backend
+      # (prod.ibm-bob-staging.cloud.ibm.com) — see `rU()` in the bundle.
+      # Without the prefix, bobshell talks to api.us-east.bob.ibm.com
+      # (production) instead, which expects a JWT and rejects everything
+      # else with `API Key verification failed`.
+      # Envoy's credential_injector overwrites the wire-level Authorization
+      # header from the per-host Secret, so the placeholder never reaches
+      # the upstream.
+      - name: BOBSHELL_API_KEY
+        value: "sk-humr-sentinel"
     resources:
       requests:
         cpu: {{ .Values.bobAgentTemplate.resources.requests.cpu | quote }}

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -51,6 +51,13 @@ codeGuardianTemplate:
     tag: latest
     pullPolicy: Never
 
+bobAgentTemplate:
+  enabled: true
+  image:
+    repository: platform-bob
+    tag: latest
+    pullPolicy: Never
+
 # Local dev convenience: route requests with any Host header (including
 # IP literals like 127.0.0.1) to the app, so the cluster is reachable
 # however the developer happens to address it.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -583,6 +583,29 @@ codeGuardianTemplate:
       cpu: "1"
       memory: "2Gi"
 
+# -- Bob agent template
+bobAgentTemplate:
+  enabled: false
+  name: bob
+  image:
+    repository: ghcr.io/dam-agents/dam/bob
+    tag: ""
+    pullPolicy: IfNotPresent
+  description: "Bob agent"
+  # Path where agent-runtime writes the platform-outbound MCP config. Bob reads
+  # project-scope config from <workdir>/.bob/settings.json (lowercase `b`,
+  # `settings.json` — the official docs name `.Bob/mcp.json` is stale).
+  # Relative paths are resolved against the agent workdir (typically
+  # /home/agent/work).
+  mcpConfigPath: .bob/settings.json
+  resources:
+    requests:
+      cpu: "250m"
+      memory: "512Mi"
+    limits:
+      cpu: "1"
+      memory: "2Gi"
+
 # -- Platform-wide skill sources (shared catalog visible to all users).
 # Rendered into the api-server pod as SKILL_SOURCES_SEED (JSON array, one
 # entry per source) and parsed at startup. api-server merges these with

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -60,7 +60,7 @@ dir = "{{config_root}}"
 run = 'docker build -f packages/ui/Dockerfile -t platform-ui:latest .'
 
 ["image:agent"]
-description = "Build agent Docker images (platform-base + claude-code + google-workspace + pi-agent + code-guardian)"
+description = "Build agent Docker images (platform-base + claude-code + google-workspace + pi-agent + code-guardian + bob)"
 dir = "{{config_root}}"
 run = '''
 #!/usr/bin/env bash
@@ -70,6 +70,7 @@ docker build -t platform-claude-code:latest packages/agents/claude-code
 docker build -t platform-google-workspace-agent:latest packages/agents/google-workspace
 docker build -t platform-pi-agent:latest packages/agents/pi-agent
 docker build -t platform-code-guardian:latest packages/agents/code-guardian
+docker build -t platform-bob:latest packages/agents/bob
 '''
 
 # -- Cluster lifecycle (k3s via lima) --
@@ -251,7 +252,7 @@ kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mo
 # 3. Load images into k3s (built by depends: image:*)
 echo "Loading images into k3s..."
 tar="/tmp/platform-images.tar"
-docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-code-guardian:latest
+docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-code-guardian:latest platform-bob:latest
 if [ -n "${IS_SANDBOX:-}" ]; then
   docker image prune --all --force >/dev/null 2>&1 || true
   sudo k3s ctr images import "$tar"
@@ -413,7 +414,7 @@ set -eo pipefail
 
 echo "Loading into k3s..."
 tar="/tmp/platform-agent-images.tar"
-docker save platform-claude-code:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-code-guardian:latest -o "$tar"
+docker save platform-claude-code:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-code-guardian:latest platform-bob:latest -o "$tar"
 
 if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"

--- a/packages/agent-runtime/src/modules/config.ts
+++ b/packages/agent-runtime/src/modules/config.ts
@@ -11,6 +11,10 @@ const schema = z.object({
   TRIGGERS_DIR: z.string().default("/home/agent/.triggers"),
   API_SERVER_URL: z.string().default(""),
   PLATFORM_MCP_URL: z.string().optional(),
+  /** Path (relative to WORK_DIR, or absolute) where agent-runtime writes the
+   *  platform-outbound MCP server config on startup. Per-agent helm templates
+   *  override it. */
+  MCP_CONFIG_PATH: z.string().default(".mcp.json"),
   /** SSE endpoint for declarative pod-files materialization (built by the
    *  reconciler from the harness server URL + instance id). When unset the
    *  loop is skipped — used for forks and any pod that shouldn't receive

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -2,7 +2,8 @@ import http from "node:http";
 import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { isAbsolute } from "node:path";
 import headlessPkg from "@xterm/headless";
 const { Terminal: HeadlessTerminal } = headlessPkg;
 import serializePkg from "@xterm/addon-serialize";
@@ -236,7 +237,9 @@ server.on("upgrade", (req, socket, head) => {
 });
 
 if (config.PLATFORM_MCP_URL) {
-  const mcpPath = join(workDir, ".mcp.json");
+  const mcpPath = isAbsolute(config.MCP_CONFIG_PATH)
+    ? config.MCP_CONFIG_PATH
+    : join(workDir, config.MCP_CONFIG_PATH);
   let mcpConfig: Record<string, unknown> = {};
   if (existsSync(mcpPath)) {
     try { mcpConfig = JSON.parse(readFileSync(mcpPath, "utf8")); } catch {}
@@ -245,8 +248,17 @@ if (config.PLATFORM_MCP_URL) {
   // No Authorization header: the api-server's harness port identifies the
   // caller by source IP (NetworkPolicy admits only agent pods, podIpResolver
   // maps IP → instance label). See ADR-035.
-  mcpServers["platform-outbound"] = { type: "http", url: config.PLATFORM_MCP_URL };
+  // Shape superset: claude-code honours `type` + `url`, bob honours `httpUrl`
+  // + `trust`. Unknown fields are ignored by both, so one entry works for
+  // every agent.
+  mcpServers["platform-outbound"] = {
+    type: "http",
+    url: config.PLATFORM_MCP_URL,
+    httpUrl: config.PLATFORM_MCP_URL,
+    trust: true,
+  };
   mcpConfig.mcpServers = mcpServers;
+  mkdirSync(dirname(mcpPath), { recursive: true });
   writeFileSync(mcpPath, JSON.stringify(mcpConfig, null, 2));
   process.stderr.write(`[mcp] Wrote platform-outbound to ${mcpPath}\n`);
 }

--- a/packages/agents/bob/Dockerfile
+++ b/packages/agents/bob/Dockerfile
@@ -1,0 +1,10 @@
+ARG BASE_IMAGE=platform-base
+FROM ${BASE_IMAGE}
+
+
+RUN curl -s https://s3.us-south.cloud-object-storage.appdomain.cloud/bobshell/install-bobshell.sh | bash -s -- --pm npm
+
+COPY workspace/ /app/working-dir/
+COPY bob-acp-shim.mjs /app/bob-acp-shim.mjs
+
+ENV AGENT_COMMAND="node /app/bob-acp-shim.mjs"

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -90,7 +90,7 @@ let messageCarry = "";
 let outsideBuf = "";
 let lastSessionId = null;
 
-const bob = spawn("bob", ["--experimental-acp", "--yolo", ...process.argv.slice(2)], {
+const bob = spawn("bob", ["--experimental-acp", "--yolo", "--auth-method", "api-key", ...process.argv.slice(2)], {
   stdio: ["pipe", "pipe", "inherit"],
   cwd: process.cwd(),
   env: process.env,

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -1,0 +1,398 @@
+#!/usr/bin/env node
+// ACP translation shim for Bob Shell.
+//
+// Bob speaks ACP protocol-correctly but uses Cline/Roo conventions that don't
+// match platform UI expectations. This shim sits between agent-runtime and bob,
+// translating on the way out (bob→client) and handling a few agent→client
+// requests locally where the platform client has no useful implementation.
+//
+// ──────────────────────────────────────────────────────────────────────────
+// Translation table (bob → platform UI)
+//
+//   session/update
+//     agent_message_chunk              → processed by a <thinking>…</thinking>
+//                                         state machine. Bob emits reasoning
+//                                         (same content as agent_thought_chunk)
+//                                         wrapped in <thinking> tags, and the
+//                                         actual user-facing answer AFTER the
+//                                         closing </thinking>. Default state
+//                                         is *inside thinking* because bob
+//                                         skips the opening tag in some cases.
+//                                         "[using tool X: …]" meta hints are
+//                                         stripped. Text outside the thinking
+//                                         block is emitted as agent_message.
+//     agent_thought_chunk (cumulative) → re-emit as incremental delta. Bob
+//                                         re-sends the full thought on every
+//                                         token; platform UI appends, so without
+//                                         delta computation we'd duplicate.
+//     tool_call kind="think"           → DROP. Synthetic "attempt_completion"
+//                                         wrapper; the real text lives in its
+//                                         tool_call_update.content.
+//     tool_call_update on think id     → on status=completed, extract nested
+//                                         text and emit as final
+//                                         agent_message_chunk.
+//     all other session/update types   → passthrough (real tool_calls for
+//                                         shell exec, their updates, etc.).
+//
+//   agent→client JSON-RPC requests
+//     session/request_permission       → intercepted. Bob bundles the tool
+//                                         payload inside params.toolCall for
+//                                         permission-gated tools (e.g. file
+//                                         edits). We promote it to a
+//                                         session/update:tool_call (in_progress)
+//                                         so platform UI shows a chip, then auto-
+//                                         approve with the first allow-type
+//                                         option. Bob's own tool_call_update
+//                                         closes the chip later.
+//     fs/*                             → dispatched to local handlers below.
+//                                         platform UI has no-op stubs that would
+//                                         silently swallow writes; the shim
+//                                         runs in the same container as the
+//                                         agent workdir, so local I/O is the
+//                                         right target. Unknown fs/* methods
+//                                         are rejected with Method not found
+//                                         so bob can fall back.
+//     everything else                  → passthrough. If agent-runtime/UI
+//                                         can't handle it, the standard JSON-
+//                                         RPC "Method not found" will reach
+//                                         bob.
+//
+//   client→agent stdin (human → bob)   → piped through unchanged.
+//
+// Set BOB_SHIM_TRACE=1 to log every inbound and outbound frame to stderr.
+// ──────────────────────────────────────────────────────────────────────────
+import { spawn } from "node:child_process";
+import { promises as fsp } from "node:fs";
+import { dirname } from "node:path";
+
+const TRACE = process.env.BOB_SHIM_TRACE === "1";
+const thinkToolCallIds = new Set();
+let lastThoughtText = "";
+
+// agent_message_chunk state machine. Bob wraps reasoning in <thinking>…
+// </thinking>; the actual user-facing text is whatever lives outside the
+// block. Default state is "inside" because bob skips the opening tag for
+// direct-answer turns. messageCarry retains the tail that might contain a
+// partial THINK_OPEN/THINK_CLOSE tag split across token boundaries.
+//
+// outsideBuf accumulates out-of-thinking text for meta-hint filtering.
+// Bob peppers "[using tool X: …]" status lines into the message stream,
+// which spread over many tokens (e.g. the closing "]" arrives several
+// chunks later, with real answer text in between). We strip complete
+// "[using tool … ]" segments and keep the tail whenever a still-unclosed
+// "[using tool" start is present so we don't ship partial meta to the UI.
+const THINK_OPEN = "<thinking>";
+const THINK_CLOSE = "</thinking>";
+const META_COMPLETE = /\[using tool [^\]]*\]\n?/g;
+const META_UNCLOSED = /\[using tool [^\]]*$/;
+let messageState = "inside";
+let messageCarry = "";
+let outsideBuf = "";
+let lastSessionId = null;
+
+const bob = spawn("bob", ["--experimental-acp", "--yolo", ...process.argv.slice(2)], {
+  stdio: ["pipe", "pipe", "inherit"],
+  cwd: process.cwd(),
+  env: process.env,
+});
+
+process.stdin.pipe(bob.stdin);
+
+function sendToBob(frame) {
+  if (!bob.stdin.writable) return;
+  const line = JSON.stringify(frame);
+  if (TRACE) process.stderr.write(`[shim→bob] ${line}\n`);
+  bob.stdin.write(line + "\n");
+}
+
+function emitToClient(frame) {
+  const line = JSON.stringify(frame);
+  if (TRACE) process.stderr.write(`[shim→client] ${line}\n`);
+  process.stdout.write(line + "\n");
+}
+
+function passthrough(line) {
+  if (TRACE) process.stderr.write(`[bob→client] ${line}\n`);
+  process.stdout.write(line + "\n");
+}
+
+let buf = "";
+bob.stdout.on("data", (chunk) => {
+  buf += chunk.toString();
+  const lines = buf.split("\n");
+  buf = lines.pop();
+  for (const line of lines) if (line.trim()) handleLine(line);
+});
+
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+  process.on(sig, () => bob.kill(sig));
+}
+
+bob.on("exit", (code, signal) => {
+  if (signal) process.kill(process.pid, signal);
+  else process.exit(code ?? 0);
+});
+
+bob.on("error", (err) => {
+  process.stderr.write(`[bob-acp-shim] spawn error: ${err.message}\n`);
+  process.exit(1);
+});
+
+// ── emitters ──────────────────────────────────────────────────────────────
+
+function update(sessionId, update) {
+  emitToClient({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update } });
+}
+
+function emitAgentMessage(sessionId, text) {
+  update(sessionId, { sessionUpdate: "agent_message_chunk", content: { type: "text", text } });
+}
+
+function emitThoughtChunk(sessionId, text) {
+  update(sessionId, { sessionUpdate: "agent_thought_chunk", content: { type: "text", text } });
+}
+
+function emitToolCallOpen(sessionId, toolCall) {
+  if (!toolCall?.toolCallId) return;
+  update(sessionId, {
+    sessionUpdate: "tool_call",
+    toolCallId: toolCall.toolCallId,
+    status: toolCall.status ?? "in_progress",
+    title: toolCall.title,
+    content: toolCall.content ?? [],
+    locations: toolCall.locations ?? [],
+    kind: toolCall.kind,
+  });
+}
+
+// ── fs dispatcher ─────────────────────────────────────────────────────────
+// Add a new entry to extend support (e.g. fs/delete_file). Each handler
+// receives the JSON-RPC params and returns the `result` value to send back.
+
+const fsHandlers = {
+  async "fs/read_text_file"(params) {
+    const path = requireString(params, "path");
+    let content;
+    try {
+      content = await fsp.readFile(path, "utf8");
+    } catch (err) {
+      // Bob's create-new-file flow reads before writing; ENOENT → empty.
+      if (err?.code === "ENOENT") content = "";
+      else throw err;
+    }
+    const line = Number.isInteger(params?.line) ? params.line : null;
+    const limit = Number.isInteger(params?.limit) ? params.limit : null;
+    if (line !== null || limit !== null) {
+      const lines = content.split("\n");
+      const start = line !== null ? Math.max(0, line - 1) : 0;
+      const end = limit !== null ? start + limit : lines.length;
+      content = lines.slice(start, end).join("\n");
+    }
+    return { content };
+  },
+
+  async "fs/write_text_file"(params) {
+    const path = requireString(params, "path");
+    const content = typeof params?.content === "string" ? params.content : "";
+    await fsp.mkdir(dirname(path), { recursive: true });
+    await fsp.writeFile(path, content, "utf8");
+    return null;
+  },
+};
+
+function requireString(params, key) {
+  const v = params?.[key];
+  if (typeof v !== "string" || !v) {
+    const err = new Error(`${key} is required`);
+    err.jsonrpcCode = -32602;
+    throw err;
+  }
+  return v;
+}
+
+async function dispatchFsRequest(frame) {
+  const handler = fsHandlers[frame.method];
+  if (!handler) {
+    sendToBob({
+      jsonrpc: "2.0",
+      id: frame.id,
+      error: { code: -32601, message: `Method not found: ${frame.method}` },
+    });
+    return;
+  }
+  try {
+    const result = await handler(frame.params);
+    sendToBob({ jsonrpc: "2.0", id: frame.id, result });
+  } catch (err) {
+    sendToBob({
+      jsonrpc: "2.0",
+      id: frame.id,
+      error: { code: err?.jsonrpcCode ?? -32603, message: err?.message ?? String(err) },
+    });
+  }
+}
+
+function flushOutside(sessionId, finalize) {
+  if (!outsideBuf) return;
+  // Strip complete "[using tool ...]" segments.
+  outsideBuf = outsideBuf.replace(META_COMPLETE, "");
+  // If a still-unclosed "[using tool" start is present, hold everything from
+  // that point onward until the closer arrives (or until turn end, when we
+  // conservatively drop it).
+  const unclosedAt = outsideBuf.search(META_UNCLOSED);
+  if (unclosedAt !== -1 && !finalize) {
+    const emit = outsideBuf.slice(0, unclosedAt);
+    outsideBuf = outsideBuf.slice(unclosedAt);
+    if (emit) emitAgentMessage(sessionId, emit);
+    return;
+  }
+  if (finalize) outsideBuf = outsideBuf.replace(META_UNCLOSED, "");
+  if (outsideBuf) emitAgentMessage(sessionId, outsideBuf);
+  outsideBuf = "";
+}
+
+function processMessageChunk(sessionId, text) {
+  lastSessionId = sessionId;
+  let buf = messageCarry + text;
+  messageCarry = "";
+
+  while (buf.length > 0) {
+    if (messageState === "inside") {
+      const idx = buf.indexOf(THINK_CLOSE);
+      if (idx === -1) {
+        // Retain a short tail so a </thinking> split across chunks matches next time.
+        messageCarry = buf.slice(-(THINK_CLOSE.length - 1));
+        return;
+      }
+      messageState = "outside";
+      buf = buf.slice(idx + THINK_CLOSE.length);
+      continue;
+    }
+
+    const idx = buf.indexOf(THINK_OPEN);
+    const chunkEnd = idx === -1 ? buf.length : idx;
+    outsideBuf += buf.slice(0, chunkEnd);
+    flushOutside(sessionId, false);
+
+    if (idx === -1) {
+      const retain = THINK_OPEN.length - 1;
+      // Any remaining chars in outsideBuf came from flushOutside's unclosed-meta
+      // hold; don't touch that. Retain a tail from the raw stream to catch
+      // a <thinking> tag that arrives split across chunks.
+      // The chars we'd want to retain were already consumed into outsideBuf,
+      // so we only carry in messageCarry if buf had untouched suffix — which
+      // it doesn't here (chunkEnd = buf.length). Nothing to do.
+      return;
+    }
+    messageState = "inside";
+    buf = buf.slice(idx + THINK_OPEN.length);
+  }
+}
+
+function flushMessageStateAtTurnEnd() {
+  if (lastSessionId) flushOutside(lastSessionId, true);
+  messageState = "inside";
+  messageCarry = "";
+  outsideBuf = "";
+  lastThoughtText = "";
+}
+
+function pickAllowOption(options) {
+  if (!Array.isArray(options)) return null;
+  const allow =
+    options.find((o) => o?.kind === "allow_always") ??
+    options.find((o) => o?.kind === "allow_once");
+  return allow?.optionId ?? options[0]?.optionId ?? null;
+}
+
+// ── stdout handler ────────────────────────────────────────────────────────
+
+function handleLine(line) {
+  if (TRACE) process.stderr.write(`[bob→shim] ${line}\n`);
+  let f;
+  try {
+    f = JSON.parse(line);
+  } catch {
+    return passthrough(line);
+  }
+
+  // Agent→client RPC requests from bob: { id, method, params } with no result/error.
+  const isAgentRequest = f.id !== undefined && typeof f.method === "string";
+
+  if (isAgentRequest && f.method === "session/request_permission") {
+    const sid = f.params?.sessionId;
+    // Surface the embedded toolCall so platform UI shows a chip. Don't synthesize
+    // a completed update — bob emits its own tool_call_update once the op
+    // actually finishes, which keeps the chip honest on failures.
+    emitToolCallOpen(sid, f.params?.toolCall);
+    const optionId = pickAllowOption(f.params?.options);
+    sendToBob({
+      jsonrpc: "2.0",
+      id: f.id,
+      result: optionId
+        ? { outcome: { outcome: "selected", optionId } }
+        : { outcome: { outcome: "cancelled" } },
+    });
+    return;
+  }
+
+  if (isAgentRequest && f.method.startsWith("fs/")) {
+    dispatchFsRequest(f);
+    return;
+  }
+
+  // Reset streaming state at turn boundary (session/prompt reply).
+  if (f.id !== undefined && f.result?.stopReason) {
+    flushMessageStateAtTurnEnd();
+    return passthrough(line);
+  }
+
+  if (f.method !== "session/update" || !f.params?.update) return passthrough(line);
+
+  const { sessionId, update: u } = f.params;
+
+  switch (u.sessionUpdate) {
+    case "agent_message_chunk": {
+      const text = u.content?.text;
+      if (typeof text !== "string") return;
+      processMessageChunk(sessionId, text);
+      return;
+    }
+
+    case "agent_thought_chunk": {
+      const text = u.content?.text;
+      if (typeof text !== "string") return passthrough(line);
+      lastSessionId = sessionId;
+      const delta = text.startsWith(lastThoughtText)
+        ? text.slice(lastThoughtText.length)
+        : text;
+      lastThoughtText = text;
+      if (delta) emitThoughtChunk(sessionId, delta);
+      return;
+    }
+
+    case "tool_call": {
+      if (u.kind === "think") {
+        thinkToolCallIds.add(u.toolCallId);
+        return;
+      }
+      return passthrough(line);
+    }
+
+    case "tool_call_update": {
+      if (!thinkToolCallIds.has(u.toolCallId)) return passthrough(line);
+      if (u.status !== "completed") return;
+      for (const part of u.content ?? []) {
+        const inner = part?.content;
+        if (inner?.type === "text" && typeof inner.text === "string" && inner.text.length > 0) {
+          emitAgentMessage(sessionId, inner.text);
+        }
+      }
+      thinkToolCallIds.delete(u.toolCallId);
+      return;
+    }
+
+    default:
+      return passthrough(line);
+  }
+}


### PR DESCRIPTION
Introduces bobshell as a first-class humr agent: agent image, Helm template, CI build jobs, and an ACP translation shim that reconciles bob's Cline/Roo-style protocol conventions with humr UI expectations.

Shim handles:
- Reasoning normalisation — <thinking> state machine over agent_message chunks, incremental delta over cumulative agent_thought_chunk, drops meta "[using tool X]" lines.
- Synthetic attempt_completion unwrap — final text extracted from tool_call_update.content and re-emitted as agent_message_chunk.
- Local fs/read_text_file + fs/write_text_file (humr UI stubs these, so writes would otherwise silently disappear).
- session/request_permission interception — auto-approves and surfaces the embedded toolCall as a session/update tool_call chip.

Agent-runtime reads MCP_CONFIG_PATH to support per-agent config paths (bob -> .bob/settings.json, claude-code default .mcp.json). The entry shape is a superset (type/url/httpUrl/trust/headers) that both agents parse correctly while ignoring unknown fields.

Ref: #50 