### PR TITLE
fix(cluster): drop redundant non-portable timeout in install

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -137,6 +137,9 @@ else
   echo "Waiting for k3s to be ready..."
   for _ in $(seq 1 60); do kubectl --kubeconfig="$KUBECONFIG" get nodes -o name 2>/dev/null | grep -q . && break; sleep 2; done
 fi
+# k3s writes kubeconfig before the node registers; the for-loop above
+# ensures ≥1 node exists, otherwise `kubectl wait --all` would error
+# immediately with "no matching resources found".
 kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Ready node --all --timeout=120s
 
 # 1b. Ensure k3s container-log rotation is configured (issue #244 upgrade

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -137,15 +137,6 @@ else
   echo "Waiting for k3s to be ready..."
   for _ in $(seq 1 60); do kubectl --kubeconfig="$KUBECONFIG" get nodes -o name 2>/dev/null | grep -q . && break; sleep 2; done
 fi
-# k3s writes the kubeconfig file before the node has registered with the
-# API server, so `kubectl wait --all` against an empty resource set
-# returns "no matching resources found" immediately. Poll until at least
-# one node exists, then wait for Ready.
-timeout 120 bash -c '
-  while ! kubectl --kubeconfig="'"$KUBECONFIG"'" get nodes -o name 2>/dev/null | grep -q .; do
-    sleep 2
-  done
-'
 kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Ready node --all --timeout=120s
 
 # 1b. Ensure k3s container-log rotation is configured (issue #244 upgrade


### PR DESCRIPTION
## Summary

`mise run cluster:install` fails on macOS with `timeout: command not found`. Root cause is a `timeout 120 bash -c '...'` block in `deploy/tasks.toml` that:

1. Relies on GNU coreutils' `timeout`, which isn't on darwin by default.
2. Duplicates a portable for-loop that already runs in both branches of the preceding if/else (lines 125 and 138, introduced in [#9](https://github.com/dam-agents/dam/pull/9)).

This block was added in [#4](https://github.com/dam-agents/dam/pull/4) (8f8fe8d), most likely a rebase artifact — it re-introduced the pattern that #9 had just removed.

Removing the block restores the post-#9 / pre-#4 working state.

## Why this is safe

The `kubectl wait --for=condition=Ready node --all --timeout=120s` immediately after the deleted block is the real safety boundary:

- If the for-loops above succeeded, `kubectl wait` waits up to 120s for the node to reach `Ready`.
- If the for-loops fell through with no node, `kubectl wait --all` errors with `no matching resources found` (exit 1) and `set -e` aborts the script.

So a never-ready cluster still fails the script — just with a slightly different error message than the `timeout` block produced. This is the same failure mode the project ran with for the three days between #9 (May 1) and #4 (May 4).

## Test plan

- [ ] `mise run cluster:install` succeeds on macOS without GNU coreutils on PATH
- [ ] `mise run cluster:install` succeeds on Linux (sandbox + lima paths unchanged)
- [ ] CI's e2e job (sandbox path) still passes