### PR TITLE
fix(controller): pin credentialed Envoy chains to per-credential static clusters

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-04
+Last verified: 2026-05-05
 
 ## Motivated by
 
@@ -138,7 +138,14 @@ On the wire:
    stream into an internal listener that reads SNI.
 3. Per-host filter chains terminate TLS with the leaf cert, run the
    credential injector to add the configured `Authorization` header, then
-   re-originate upstream TLS via the dynamic forward proxy.
+   forward to a per-credential `STRICT_DNS` cluster pinned to the
+   credential's host (explicit upstream SNI + SAN-bound TLS validation).
+   The agent's inner `Host` header has no influence on the upstream
+   destination — the route-confusion exfiltration path from
+   [ADR-033 §Threat Model](../adrs/033-envoy-credential-gateway.md#threat-model)
+   is structurally closed. Allow-only chains (path-rule promoted, no
+   credential) keep using the dynamic forward proxy — they have no
+   credential to misroute.
 4. The default chain (SNI miss) does TCP passthrough — the request reaches
    the upstream unchanged.
 

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -245,13 +245,22 @@ func routesFromSecrets(secrets []corev1.Secret) []envoyRoute {
 //   3. The INTERNAL listener uses tls_inspector to read SNI. One filter chain
 //      per known host terminates TLS with that host's leaf cert; default
 //      filter chain (SNI miss) does TCP passthrough via sni_dynamic_forward_proxy.
-//   4. Inside a TLS-terminating chain, an HCM runs credential_injector + the
-//      HTTP dynamic_forward_proxy, which re-originates upstream TLS to the
-//      real host using the inner request's Host header.
+//   4. Inside a TLS-terminating chain, an HCM runs credential_injector and
+//      forwards to a per-credential STRICT_DNS cluster pinned to the
+//      credential's host. The agent's inner Host header has no influence on
+//      routing — Envoy's destination is fixed in config — so the
+//      route-confusion exfiltration path called out in ADR-033 §Threat Model
+//      is structurally closed. Allow-only chains (path-rule promoted, no
+//      credential) keep using dynamic_forward_proxy_https; they have no
+//      credential to misroute.
 //
 // Notes:
 //   - credential_injector lives at the HCM level (not per-route) because each
 //      filter chain's HCM is already host-specific. No composite filter needed.
+//   - Each credentialed cluster sets explicit upstream SNI and SAN-pinned
+//      validation against the credential's host, so a poisoned-DNS or
+//      misconfigured cluster fails the upstream TLS handshake before any
+//      credentialed body reaches the wire.
 //   - Upstream TLS validation uses Envoy's default system trust bundle; the
 //      sidecar image must ship one (envoy-distroless does).
 //   - Admin interface intentionally omitted (ADR-033 threat model: the agent
@@ -408,7 +417,22 @@ static_resources:
                       routes:
                         - match: { prefix: "/" }
                           route:
+{{- if .Credentialed }}
+                            # Pinned to a per-credential static cluster
+                            # (clusters list below). The agent's Host header
+                            # cannot steer this request to a different
+                            # upstream; the cluster's destination is fixed in
+                            # config. host_rewrite_literal additionally
+                            # canonicalises the upstream Host so honest
+                            # backends never see an agent-manipulated value.
+                            cluster: upstream_{{ .SecretName }}
+                            host_rewrite_literal: "{{ .Host }}"
+{{- else }}
+                            # Allow-only (path-rule promoted, no credential
+                            # injection). Forward via dynamic_forward_proxy;
+                            # no credential to misroute.
                             cluster: dynamic_forward_proxy_https
+{{- end }}
                             timeout: 0s
 {{- end }}
         # SNI miss: every other host hits the L4 ext_authz catch-all, which
@@ -509,6 +533,45 @@ static_resources:
           dns_cache_config:
             name: dns_cache
             dns_lookup_family: V4_PREFERRED
+
+{{- range .Routes }}
+{{- if .Credentialed }}
+
+    # Pinned upstream for the credentialed chain matching SNI={{ .Host }}.
+    # STRICT_DNS resolves {{ .Host }}:443 directly; the agent's Host header
+    # plays no role in destination selection. Upstream TLS hard-binds SNI
+    # and validates the upstream cert's SAN against {{ .Host }}, so even a
+    # poisoned cache or misrouted endpoint fails the handshake before any
+    # credentialed body is on the wire.
+    - name: upstream_{{ .SecretName }}
+      connect_timeout: 5s
+      type: STRICT_DNS
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: upstream_{{ .SecretName }}
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: {{ .Host }}
+                      port_value: 443
+      transport_socket:
+        name: envoy.transport_sockets.tls
+        typed_config:
+          "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.UpstreamTlsContext
+          sni: {{ .Host }}
+          auto_host_sni: false
+          common_tls_context:
+            validation_context:
+              trusted_ca:
+                filename: /etc/ssl/certs/ca-certificates.crt
+              match_typed_subject_alt_names:
+                - san_type: DNS
+                  matcher:
+                    exact: {{ .Host }}
+{{- end }}
+{{- end }}
 
     # Single gRPC ext_authz cluster: both Envoy filters (HTTP on
     # TLS-terminated chains, network on the catch-all) call the same
@@ -643,16 +706,23 @@ func envoySidecarVolumes(instanceName string, secrets []corev1.Secret) []corev1.
 
 func ptrBool(b bool) *bool { return &b }
 
+// envoyBootstrapTemplateRev is folded into envoySecretsRev so that
+// structural changes to the bootstrap template (new clusters, route shape
+// changes, etc.) force existing pods to roll on chart upgrade — without it,
+// the rendered ConfigMap diverges but the pod template stays identical and
+// kubelet keeps the old bootstrap mounted.
+//
+// Bump on any template change that affects pod-visible behavior.
+const envoyBootstrapTemplateRev = "v2-pinned-upstreams"
+
 // envoySecretsRev is a stable digest of the Secret set that drives Envoy's
-// chain rendering: secret name + host + secret-type label + headerName.
-// Stamped on the pod template so the StatefulSet rolls when any of those
-// change (new credentialed connection, allow-only Secret added, host
-// retargeted). Sort first so reconcile order doesn't churn the hash.
+// chain rendering: secret name + host + secret-type label + headerName,
+// plus a template-revision marker. Stamped on the pod template so the
+// StatefulSet rolls when any of those change (new credentialed connection,
+// allow-only Secret added, host retargeted, template format bumped). Sort
+// first so reconcile order doesn't churn the hash.
 func envoySecretsRev(secrets []corev1.Secret) string {
-	if len(secrets) == 0 {
-		return "empty"
-	}
-	parts := make([]string, 0, len(secrets))
+	parts := []string{"tmpl=" + envoyBootstrapTemplateRev}
 	for _, s := range secrets {
 		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s",
 			s.Name,
@@ -661,7 +731,9 @@ func envoySecretsRev(secrets []corev1.Secret) string {
 			s.Annotations[envoyHeaderNameAnn],
 		))
 	}
-	sort.Strings(parts)
+	// Keep the template marker first; sort the rest so reconcile order
+	// doesn't churn the hash.
+	sort.Strings(parts[1:])
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return hex.EncodeToString(sum[:8])
 }

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -1,11 +1,15 @@
 package reconciler
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
 
 func ownerSecret(name, secretType, connection string) corev1.Secret {
@@ -106,4 +110,120 @@ func TestFilterByGrants_SecretAndConnectionAxesAreIndependent(t *testing.T) {
 		grantConnectionIdsAnn: "slack",
 	})
 	assert.ElementsMatch(t, []string{"platform-cred-aaa", "platform-conn-slack"}, names(got))
+}
+
+// --- Bootstrap render tests ---
+//
+// These cover the security-critical shape of the rendered Envoy config:
+// credentialed chains forward to a per-credential static cluster pinned to
+// the credential's host with SAN-bound upstream TLS validation; the agent's
+// inner Host header has no influence on routing. The route-confusion
+// exfiltration path called out in ADR-033 §Threat Model is structurally
+// closed by these properties — the assertions below are the regression spec.
+
+var bootstrapTestCfg = &config.Config{
+	Namespace:           "agents",
+	EnvoyPort:           10000,
+	ExtAuthzHost:        "platform-apiserver.platform.svc",
+	ExtAuthzPort:        50051,
+	ExtAuthzHoldSeconds: 30,
+}
+
+func credentialedRoute(secretName, host string) envoyRoute {
+	return envoyRoute{
+		SecretName:   secretName,
+		Host:         host,
+		HeaderName:   "Authorization",
+		VolumeName:   "cred-" + secretName,
+		Credentialed: true,
+	}
+}
+
+func allowOnlyRoute(secretName, host string) envoyRoute {
+	return envoyRoute{
+		SecretName:   secretName,
+		Host:         host,
+		VolumeName:   "cred-" + secretName,
+		Credentialed: false,
+	}
+}
+
+func TestRenderEnvoyBootstrap_CredentialedRoutePinnedToStaticCluster(t *testing.T) {
+	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyRoute{
+		credentialedRoute("platform-conn-github", "api.github.com"),
+	})
+	require.NoError(t, err)
+
+	// Per-credential cluster exists, with the credential's host as its only
+	// endpoint. STRICT_DNS so Envoy resolves at refresh cadence; no
+	// dynamic_forward_proxy means the agent's Host header cannot redirect
+	// the request elsewhere.
+	assert.Contains(t, got, "name: upstream_platform-conn-github")
+	assert.Contains(t, got, "type: STRICT_DNS")
+	assert.Contains(t, got, "address: api.github.com")
+	assert.Contains(t, got, "port_value: 443")
+
+	// Upstream TLS hard-binds SNI to the credential's host and SAN-validates
+	// the upstream cert against it. Even a poisoned DNS cache or misrouted
+	// cluster fails the upstream handshake before the credentialed body
+	// reaches the wire.
+	assert.Contains(t, got, "sni: api.github.com")
+	assert.Contains(t, got, "match_typed_subject_alt_names")
+	assert.Regexp(t, `match_typed_subject_alt_names:\s*\n\s*-\s*san_type:\s*DNS\s*\n\s*matcher:\s*\n\s*exact:\s*api\.github\.com`, got)
+
+	// The credentialed chain forwards to that cluster — not to
+	// dynamic_forward_proxy_https (which uses agent-controlled Host).
+	assert.Contains(t, got, "cluster: upstream_platform-conn-github")
+	assert.Contains(t, got, `host_rewrite_literal: "api.github.com"`)
+}
+
+func TestRenderEnvoyBootstrap_NoCredentialedRouteForwardsViaDynamicForwardProxy(t *testing.T) {
+	// With no credentialed routes there should be no per-credential cluster
+	// and no host_rewrite_literal — the catch-all/L4 paths still use
+	// dynamic_forward_proxy clusters but those are non-credentialed.
+	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyRoute{
+		allowOnlyRoute("platform-allow-only-npm", "registry.npmjs.org"),
+	})
+	require.NoError(t, err)
+
+	// Allow-only chain still uses dynamic_forward_proxy_https — there's no
+	// credential to misroute, so the simpler shape is fine.
+	assert.NotContains(t, got, "upstream_platform-allow-only-npm")
+	assert.NotContains(t, got, "host_rewrite_literal")
+	assert.Contains(t, got, "cluster: dynamic_forward_proxy_https")
+}
+
+func TestRenderEnvoyBootstrap_MixedRoutesOnlyPinCredentialed(t *testing.T) {
+	// Credentialed and allow-only side-by-side: only the credentialed one
+	// gets a pinned cluster. The two chains are visually adjacent in the
+	// output, so we anchor each assertion on its specific cluster name.
+	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyRoute{
+		credentialedRoute("platform-conn-github", "api.github.com"),
+		allowOnlyRoute("platform-allow-only-npm", "registry.npmjs.org"),
+	})
+	require.NoError(t, err)
+
+	// `- name: upstream_…` is the cluster definition (list-entry dash);
+	// `cluster_name: upstream_…` inside each definition is a field, not a
+	// new cluster, so count only the definitions.
+	pinnedCount := strings.Count(got, "- name: upstream_")
+	assert.Equal(t, 1, pinnedCount, "exactly one pinned upstream cluster should be rendered (credentialed routes only)")
+	assert.Contains(t, got, "name: upstream_platform-conn-github")
+	assert.NotContains(t, got, "name: upstream_platform-allow-only-npm")
+}
+
+func TestEnvoySecretsRev_TemplateRevBumpRollsExistingPods(t *testing.T) {
+	// The rev hash must include a template-revision marker so any structural
+	// template change rolls existing pods on chart upgrade. Without it, the
+	// rendered ConfigMap diverges but the pod template stays identical and
+	// kubelet keeps the old bootstrap mounted.
+	rev := envoySecretsRev(nil)
+	assert.NotEqual(t, "empty", rev, "secrets-rev must not be a stable sentinel for empty Secret sets — bumping the template rev must change the hash")
+	assert.NotEmpty(t, rev)
+
+	// Different Secret sets produce different hashes (regression sanity check
+	// — the template marker shouldn't dominate the hash).
+	one := envoySecretsRev([]corev1.Secret{ownerSecret("platform-conn-github", "connection", "github")})
+	two := envoySecretsRev([]corev1.Secret{ownerSecret("platform-conn-slack", "connection", "slack")})
+	assert.NotEqual(t, one, two)
 }


### PR DESCRIPTION
## Summary

Fix the L7 route-confusion exfiltration path called out in ADR-033 §Threat Model and tracked as #92.

Each credentialed chain now forwards to its own per-credential `STRICT_DNS` Envoy cluster, pinned to the credential's host, with explicit upstream SNI and SAN-bound TLS validation. The agent's inner `Host` header no longer steers the upstream destination — it's discarded by `host_rewrite_literal` so honest backends see a clean request — and Envoy resolves and connects only to the host the credential belongs to. A poisoned-DNS or misrouted-cluster failure mode terminates at the upstream TLS handshake before any credentialed body reaches the wire.

Allow-only chains (path-rule promoted, no credential injection) keep using `dynamic_forward_proxy_https` — they have no credential to misroute, so the simpler shape is fine.

The bootstrap template-revision marker is folded into the existing `agent-platform.ai/envoy-secrets-rev` pod-template annotation so existing instances roll on chart upgrade and pick up the new cluster shape. Without that, the rendered ConfigMap would diverge but the pod template would stay identical and kubelet would keep the old bootstrap mounted.

Closes #92.

## Test plan

- [x] `mise run test` (controller + api-server + ui)
- [x] `mise run check` (lint + tsc + go vet + helm lint + kubeconform)
- [x] New `envoy_test.go` cases covering the regression spec:
  - Credentialed route forwards to the per-credential pinned cluster, with SNI + SAN matcher pinned to the credential's host and `host_rewrite_literal` set.
  - Allow-only routes keep using `dynamic_forward_proxy_https` and produce no `upstream_*` cluster.
  - Mixed sets render exactly one pinned cluster per credentialed route, none for allow-only routes.
  - `envoySecretsRev` no longer collapses empty Secret sets to a stable sentinel — bumping the template marker changes the hash so existing pods roll.
- [ ] Live cluster check after merge: confirm pods roll on upgrade and a forged-Host request from inside an agent pod ends up either at the credential's host or fails the upstream handshake — never at the forged host. Black-box egress test with an attacker server is filed separately.

## Out of scope

Wildcard `hostPattern` validation at the API Server's secret-create / connection-create input (single-FQDN only) and a black-box egress regression test against a real attacker server are tracked as follow-ups.