### PR TITLE
chore: drop hardcoded brand from CI + bare-host README links

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/dam-agents/dam
+  IMAGE_PREFIX: ghcr.io/${{ github.repository }}
 
 jobs:
   build-images:
@@ -196,8 +196,8 @@ jobs:
       - name: Package Helm chart (SHA-pinned)
         run: helm package deploy/helm/platform --version 0.0.0-${{ github.sha }} --app-version ${{ github.sha }}
       - name: Push SHA-pinned chart
-        run: helm push platform-0.0.0-${{ github.sha }}.tgz oci://ghcr.io/dam-agents/dam/charts
+        run: helm push platform-0.0.0-${{ github.sha }}.tgz oci://ghcr.io/${{ github.repository }}/charts
       - name: Package Helm chart (main floating tag)
         run: helm package deploy/helm/platform --version 0.0.0-main --app-version ${{ github.sha }}
       - name: Push main-floating chart
-        run: helm push platform-0.0.0-main.tgz oci://ghcr.io/dam-agents/dam/charts
+        run: helm push platform-0.0.0-main.tgz oci://ghcr.io/${{ github.repository }}/charts

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_PREFIX: ghcr.io/dam-agents/dam
+  IMAGE_PREFIX: ghcr.io/${{ github.repository }}
 
 jobs:
   build-images:
@@ -222,5 +222,5 @@ jobs:
       - name: Package Helm chart
         run: helm package deploy/helm/platform --version ${{ steps.version.outputs.version }} --app-version ${{ steps.version.outputs.version }}
       - name: Push to OCI registry
-        run: helm push platform-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/dam-agents/dam/charts
+        run: helm push platform-${{ steps.version.outputs.version }}.tgz oci://ghcr.io/${{ github.repository }}/charts
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DAM
 
 <p align="center">
-  <img src="docs/assets/icon.svg" width="120" alt="DAM icon" />
+  <img src="docs/assets/icon.svg" width="120" alt="icon" />
 </p>
 <h3 align="center">
   Run your own background agents on Kubernetes.<br/>
@@ -57,7 +57,7 @@ mise install                # install toolchain + deps
 mise run cluster:install    # create local k3s cluster + deploy DAM
 ```
 
-Open [dam.localhost:4444](http://dam.localhost:4444) (login: `dev` / `dev`), create an instance from a template, and start chatting. See the [configuration guide](docs/configuration.md) for credential setup and Slack integration.
+Open [localhost:4444](http://localhost:4444) (login: `dev` / `dev`), create an instance from a template, and start chatting. See the [configuration guide](docs/configuration.md) for credential setup and Slack integration.
 
 ## Learn more
 

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -89,7 +89,7 @@ export function createSlackWorker(
   getInstanceOwner: (instanceId: string) => Promise<string | null>,
   channelRegistry: ChannelRegistry,
   /** Lowercase brand identifier used as the Slack slash command name (e.g.
-   *  brandShort="dam" → /dam login). Sourced from BRAND_SHORT env var. */
+   *  brandShort="name" → /name login). Sourced from BRAND_SHORT env var. */
   brandShort: string,
   emit: (event: DomainEvent) => void = defaultEmit,
 ): SlackWorker {


### PR DESCRIPTION
## Summary
Tail end of the brand-templating PR (#89). Removes the last batch of hardcoded brand mentions where templating was straightforward — without going as far as a full markdown render pipeline.

- **CI workflows** (`.github/workflows/{main,publish}.yml`): replace hardcoded `ghcr.io/dam-agents/dam` image prefix with `ghcr.io/${{ github.repository }}`. Whatever org/repo the chart actually lives in is now the image namespace; renaming the GitHub repo or forking no longer needs a workflow edit.
- **README**: bare hostname for the local-dev URL (`localhost:4444`, matching the post-PR ingress that path-routes `/api` and `/` on the same host) and drop "DAM" from the icon `alt` text — the surrounding `<h1>DAM</h1>` already names the project.
- **slack.ts doc-comment**: rephrase the `brandShort` example so it doesn't bake `dam` into the comment as the canonical value.

Marketing markdown (README/PITCH/MOTIVATION) keeps "DAM" inline — GitHub markdown can't substitute text content (only URLs via reference-style links), and a build-time render pipeline (template files + render script + pre-commit drift check) felt heavier than the project-pitch text warrants. If we ever want it, the path is sketched in this branch's history.

## Test plan
- [x] `mise run check` passes (lint + tsc + helm lint + kubeconform render)
- [ ] Push a tag in CI and confirm images publish to `ghcr.io/dam-agents/dam/<component>` exactly as before (the `${{ github.repository }}` substitution evaluates to the same path on this repo)