### PR TITLE
docs: Platform CLI foundation — ADR-039 + spec

### DIFF
--- a/docs/adrs/039-cli-foundation.md
+++ b/docs/adrs/039-cli-foundation.md
@@ -1,0 +1,75 @@
+# ADR-039: Platform CLI foundation — Node-on-npm, tRPC contract reuse
+
+**Date:** 2026-05-05
+**Status:** Accepted
+**Owner:** @PetrBulanek
+
+## Context
+
+[ADR-037](037-remote-terminal.md) committed to a "terminal" session mode and anticipated a follow-up ADR designing the CLI counterpart to the web terminal view, "reusing the same communication interface." This is that ADR — but scoped narrower than the full CLI surface. We decide only the **foundation** here: how to build, ship, and configure a `dam` binary that future verbs plug into.
+
+The driver is the May 18 demo. The story is "I install the CLI, point it at a hosted Platform deployment, and start coding." There is no entry point today other than the web UI.
+
+This ADR implements [#79](https://github.com/dam-agents/dam/issues/79). Subsequent verbs — `dam login` ([#80](https://github.com/dam-agents/dam/issues/80)), instance addressing ([#81](https://github.com/dam-agents/dam/issues/81)), `dam shell` ([#86](https://github.com/dam-agents/dam/issues/86)), `dam import` ([#73](https://github.com/dam-agents/dam/issues/73)) — are out of scope and will land in their own ADRs or specs. The foundation must not foreclose any of them.
+
+## Decision
+
+**The CLI is a TypeScript Node package, distributed via npm, that shares the API server's tRPC contract directly.** It runs on the user's installed Node — no bundled runtime. Cross-platform reach is macOS + Linux + Windows-via-WSL2. Configuration follows the AI-CLI category convention (`~/.dam/`) rather than XDG.
+
+The load-bearing rules:
+
+- **One language stack.** TypeScript, the same stack as the API server and UI ([ADR-009](009-go-and-typescript.md)). The CLI imports `api-server-api` directly and consumes the tRPC contract end-to-end-typed; every server-side type change reaches the CLI without codegen or manual mirroring. This is the single biggest leverage point and the reason TypeScript wins over Go, Rust, or Python here.
+- **Ship as a Node script, not a native binary.** `npm install -g @dam-agents/cli` is the only install path. Users must have Node ≥ 20.
+- **Config lives at `~/.dam/config.toml`.** The AI-CLI category convention is to put state in `~/.<vendor>/`; the audience expects that location. TOML for hand-edit ergonomics and comment support. Auth credentials and other state will share the `~/.dam/` tree but explicitly not this file.
+- **Flat config schema; no profiles.** A single configured server, no `current-profile` indirection.
+- **Configuration precedence: flag > env > file > error.** No silent default for the server URL. The CLI errors with a setup hint when nothing is configured.
+- **Independent semver, server-advertised compatibility floor.** The CLI versions independently of the platform. The server exposes an unauthenticated version endpoint returning its own version and the minimum CLI version it accepts. The CLI hard-refuses to run if below the floor and soft-warns to stderr if behind current. The endpoint is plain HTTP, deliberately outside the tRPC surface so it can be called before any authentication or client setup.
+- **No telemetry.** The platform collects nothing today and the CLI does not break that posture.
+
+## Scope boundaries
+
+This ADR explicitly does *not* decide:
+
+- **Authentication.** Token format, storage, OIDC flow shape — all owned by [#80](https://github.com/dam-agents/dam/issues/80). Only commitment here: credentials live somewhere under `~/.dam/`, not inside `config.toml`.
+- **Instance addressing.** Name resolution and how the CLI selects an instance belong to [#81](https://github.com/dam-agents/dam/issues/81).
+- **Streaming transport for `dam shell`.** [#86](https://github.com/dam-agents/dam/issues/86) extends the foundation with a WebSocket attach. tRPC supports WebSocket links, so the extension is bounded.
+- **Workspace import.** Owned by [#73](https://github.com/dam-agents/dam/issues/73).
+- **The full CLI command tree.** Only the foundation verbs (version, help, server-config, connectivity check) are in scope. Every other verb in [Epic #71](https://github.com/dam-agents/dam/issues/71) lands in its own work item.
+- **Implementation specifics** — exact env var names, exit codes, command names, build tool, library choices. Those belong in a spec or the implementation PR.
+
+## Alternatives Considered
+
+- **Native binary distribution (Bun-compile, brew, curl-pipe).** Polished install story, no Node prerequisite. Rejected on demo-deadline grounds: the engineering cost (CI matrix, code-signing, install-script hosting) buys polish the demo doesn't need, and the npm-script path does not block the migration.
+- **Go or Rust for the CLI binary.** Smaller binaries, no Node prerequisite. Rejected because both throw away tRPC contract reuse — every API change becomes a two-place edit, forever — and add a third language stack to the repo.
+- **Python.** Considered. Rejected on three grounds: zero code reuse with the tRPC contract, weaker single-binary distribution story than TypeScript, and a third language stack to maintain.
+- **XDG-compliant config path.** Matches generic developer-tool precedent. Rejected because the AI-CLI audience expects `~/.<vendor>/`; matching the audience's muscle memory beats matching a different audience's precedent.
+- **Profiles from day one.** Rejected on YAGNI grounds; the migration path remains open as a non-breaking on-read rewrite.
+- **Native Windows support.** Rejected because native Windows pulls forward design work for [#86](https://github.com/dam-agents/dam/issues/86) (Windows PTY differs) and expands the test matrix during demo crunch. WSL2 is supported transparently — it is just Linux from the binary's perspective.
+- **REST + manual fetch instead of tRPC client.** Rejected because it discards the entire reason TypeScript was chosen over Go/Rust.
+- **`/version` inside the tRPC surface.** Rejected because the version check must run before authentication and before any client setup; a plain HTTP endpoint is simpler and useful for non-CLI consumers (uptime checks, ops tooling) too.
+- **Opt-out anonymous telemetry.** The standard pattern in many developer CLIs. Rejected because it would be inconsistent with the platform's broader posture; flipping just the CLI to phone-home would be a surprise.
+
+## Consequences
+
+- The CLI ships on a tighter timeline because npm-only distribution skips CI matrix, code-signing, and install-script hosting. Every future verb the team adds — login, instances, shell, import — inherits the foundation without re-litigating.
+- Every server-side tRPC contract change automatically reaches the CLI's type system. There is no contract-drift risk between UI and CLI; both consume the same package.
+- Users without Node ≥ 20 cannot install the CLI. Install docs must call this out.
+- Native Windows users must use WSL2.
+- The CLI has no ability to phone home, including for crash data. Bug reports rely on user-supplied output. Diagnostic ergonomics are a spec concern.
+- The configured server URL lives in plain text on disk. Auth tokens do not — that is [#80](https://github.com/dam-agents/dam/issues/80)'s problem; this ADR's `config.toml` pattern explicitly does not constrain credential storage.
+- The package publishes as `@dam-agents/cli` (matching the GitHub organization). The project-wide license decision is a prerequisite for first publication and is out of scope for this ADR.
+
+## Future considerations
+
+Items deliberately not committed by this ADR. Each is an explicit future decision, not a quiet drift:
+
+- **Native-binary distribution** — Bun-compiled binary, brew tap, curl-pipe install script, GitHub Releases binaries, or native-binary npm wrapping. The migration is non-breaking from the user's perspective: `npm install -g @dam-agents/cli` keeps working through any later switch.
+- **Profiles** — multi-server / multi-context support. Migration from the flat schema to a profile-shaped one is a non-breaking on-read rewrite.
+- **Native Windows support** — covered via WSL2 today. Native support reopens when [#86](https://github.com/dam-agents/dam/issues/86) ergonomics or audience demand warrant the PTY divergence cost.
+- **Telemetry and crash reporting** — explicitly out today. Revisitable when the command surface grows enough that "which commands fail" becomes a real product question.
+
+## Related ADRs
+
+- [ADR-037](037-remote-terminal.md) — predecessor; this ADR is the follow-up it explicitly anticipated.
+- [ADR-009](009-go-and-typescript.md) — language split that makes TypeScript the default outside the controller.
+- [ADR-022](022-harness-api-server.md) — separate-port API surface; the unauthenticated `/version` endpoint lives in this style.

--- a/docs/adrs/039-cli-foundation.md
+++ b/docs/adrs/039-cli-foundation.md
@@ -1,4 +1,4 @@
-# ADR-039: Platform CLI foundation — Node-on-npm, tRPC contract reuse
+# ADR-039: Platform CLI foundation — TypeScript on Node, npm distribution
 
 **Date:** 2026-05-05
 **Status:** Accepted
@@ -18,7 +18,7 @@ This ADR implements [#79](https://github.com/dam-agents/dam/issues/79). Subseque
 
 The load-bearing rules:
 
-- **One language stack.** TypeScript, the same stack as the API server and UI ([ADR-009](009-go-and-typescript.md)). The CLI imports `api-server-api` directly and consumes the tRPC contract end-to-end-typed; every server-side type change reaches the CLI without codegen or manual mirroring. This is the single biggest leverage point and the reason TypeScript wins over Go, Rust, or Python here.
+- **One language stack.** TypeScript, the same stack as the API server and UI ([ADR-009](009-go-and-typescript.md)). The team writes TypeScript daily; the repo's only non-TS package is the controller. Adding a third language stack for one tool is ongoing tax. The CLI also consumes `api-server-api` directly today, getting tRPC types end-to-end without codegen — a current convenience that depends on how the API surface evolves.
 - **Ship as a Node script, not a native binary.** `npm install -g @dam-agents/cli` is the only install path. Users must have Node ≥ 20.
 - **Config lives at `~/.dam/config.toml`.** The AI-CLI category convention is to put state in `~/.<vendor>/`; the audience expects that location. TOML for hand-edit ergonomics and comment support. Auth credentials and other state will share the `~/.dam/` tree but explicitly not this file.
 - **Flat config schema; no profiles.** A single configured server, no `current-profile` indirection.
@@ -40,19 +40,19 @@ This ADR explicitly does *not* decide:
 ## Alternatives Considered
 
 - **Native binary distribution (Bun-compile, brew, curl-pipe).** Polished install story, no Node prerequisite. Rejected on demo-deadline grounds: the engineering cost (CI matrix, code-signing, install-script hosting) buys polish the demo doesn't need, and the npm-script path does not block the migration.
-- **Go or Rust for the CLI binary.** Smaller binaries, no Node prerequisite. Rejected because both throw away tRPC contract reuse — every API change becomes a two-place edit, forever — and add a third language stack to the repo.
-- **Python.** Considered. Rejected on three grounds: zero code reuse with the tRPC contract, weaker single-binary distribution story than TypeScript, and a third language stack to maintain.
+- **Go or Rust for the CLI binary.** Smaller binaries, no Node prerequisite. Rejected because TypeScript is the team's daily language and the repo's only non-TS package is the controller — adding a third stack for one tool is ongoing tax. Contract consumption is a secondary concern: the current TS-direct-import advantage is tied to today's tRPC API. Any evolution of that surface — replacement, wrapping, supplementation by a separate API — shifts how every client consumes the contract, regardless of language.
+- **Python.** Considered. Rejected on the same team-velocity and single-stack-consistency grounds, plus a weaker single-binary distribution story than TypeScript (PyInstaller/Nuitka are clunkier than Bun-compile if/when we go that direction).
 - **XDG-compliant config path.** Matches generic developer-tool precedent. Rejected because the AI-CLI audience expects `~/.<vendor>/`; matching the audience's muscle memory beats matching a different audience's precedent.
 - **Profiles from day one.** Rejected on YAGNI grounds; the migration path remains open as a non-breaking on-read rewrite.
 - **Native Windows support.** Rejected because native Windows pulls forward design work for [#86](https://github.com/dam-agents/dam/issues/86) (Windows PTY differs) and expands the test matrix during demo crunch. WSL2 is supported transparently — it is just Linux from the binary's perspective.
-- **REST + manual fetch instead of tRPC client.** Rejected because it discards the entire reason TypeScript was chosen over Go/Rust.
+- **REST + manual fetch instead of tRPC client.** Rejected because it discards direct type imports without offering anything in return. If the API surface evolves later, the CLI follows it through whatever client tooling matches the new surface — manual fetch is never that answer.
 - **`/version` inside the tRPC surface.** Rejected because the version check must run before authentication and before any client setup; a plain HTTP endpoint is simpler and useful for non-CLI consumers (uptime checks, ops tooling) too.
 - **Opt-out anonymous telemetry.** The standard pattern in many developer CLIs. Rejected because it would be inconsistent with the platform's broader posture; flipping just the CLI to phone-home would be a surprise.
 
 ## Consequences
 
 - The CLI ships on a tighter timeline because npm-only distribution skips CI matrix, code-signing, and install-script hosting. Every future verb the team adds — login, instances, shell, import — inherits the foundation without re-litigating.
-- Every server-side tRPC contract change automatically reaches the CLI's type system. There is no contract-drift risk between UI and CLI; both consume the same package.
+- Every server-side tRPC contract change automatically reaches the CLI's type system today. There is no contract-drift risk between UI and CLI; both consume the same package. If the API surface evolves — whether by replacing tRPC, wrapping it, or adding a separate API for public consumption — the CLI's consumption mechanism evolves with it. The migration is bounded and falls equally on the UI and CLI; it is not a CLI-specific cost.
 - Users without Node ≥ 20 cannot install the CLI. Install docs must call this out.
 - Native Windows users must use WSL2.
 - The CLI has no ability to phone home, including for crash data. Bug reports rely on user-supplied output. Diagnostic ergonomics are a spec concern.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -43,6 +43,7 @@ This directory contains ADRs for the Platform project.
 | [036](036-redis-platform-primitive.md)        | Redis as a platform primitive — pub/sub, queues, cache | @jezekra1 |
 | [037](037-remote-terminal.md)                 | Remote terminal — split "chat" and "terminal" session modes | @JanPokorny |
 | [038](038-paired-gateway-pod.md)               | Paired agent and gateway pods — cluster-enforced credential boundary | @pilartomas |
+| [039](039-cli-foundation.md)                  | Platform CLI foundation — Node-on-npm, tRPC contract reuse | @PetrBulanek |
 
 ## Drafts
 

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -43,7 +43,7 @@ This directory contains ADRs for the Platform project.
 | [036](036-redis-platform-primitive.md)        | Redis as a platform primitive — pub/sub, queues, cache | @jezekra1 |
 | [037](037-remote-terminal.md)                 | Remote terminal — split "chat" and "terminal" session modes | @JanPokorny |
 | [038](038-paired-gateway-pod.md)               | Paired agent and gateway pods — cluster-enforced credential boundary | @pilartomas |
-| [039](039-cli-foundation.md)                  | Platform CLI foundation — Node-on-npm, tRPC contract reuse | @PetrBulanek |
+| [039](039-cli-foundation.md)                  | Platform CLI foundation — TypeScript on Node, npm distribution | @PetrBulanek |
 
 ## Drafts
 

--- a/docs/plans/cli-foundation/README.md
+++ b/docs/plans/cli-foundation/README.md
@@ -1,0 +1,115 @@
+# Spec: Platform CLI foundation
+
+> Implements [ADR-039](../../adrs/039-cli-foundation.md) and issue [#79](https://github.com/dam-agents/dam/issues/79). Foundation for [#80](https://github.com/dam-agents/dam/issues/80), [#81](https://github.com/dam-agents/dam/issues/81), [#86](https://github.com/dam-agents/dam/issues/86), [#73](https://github.com/dam-agents/dam/issues/73).
+
+## Feature Overview
+
+The Platform CLI (`dam`) is a TypeScript Node command-line client that lets a user point at a hosted Platform deployment and verify connectivity. It lives at `packages/cli/`, ships via npm as `@dam-agents/cli`, and uses commander.js for argument parsing and subcommand dispatch. The package is structured so wiring tRPC against `api-server-api` in [#80](https://github.com/dam-agents/dam/issues/80) is a mechanical extension, not an architectural change.
+
+## Affected Bounded Contexts
+
+**`platform-cli` — new bounded context, scoped to the package.**
+
+- **Responsibility:** own the user's local interaction with a configured Platform server — resolve Config, check Compat, expose foundation verbs.
+- **Domain concepts:** Config, Config Source, Server URL, Compat Verdict (see [vocabulary](../../../tseng/vocabulary.md)).
+- **Invariants:**
+  - Config is resolved by precedence: command-line flag → environment variable → config file → error. No silent default.
+  - The config file is flat — top-level keys only, no profile indirection (no `[profiles.*]`, no `current-profile`).
+  - Commands that need the server refuse to run when the CLI is below the server-advertised `minClientVersion`.
+  - `~/.dam/config.toml` is the only persistence location for configuration. Auth credentials ([#80](https://github.com/dam-agents/dam/issues/80)) live elsewhere under `~/.dam/`, never in this file.
+  - The package declares Node ≥ 20 as its engine and may rely on Node 20+ built-ins (native `fetch`, etc.).
+  - The CLI's semver is independent of the Platform's; compatibility is negotiated at runtime, never assumed via version coupling.
+- **Layout:** module nested at `packages/cli/src/modules/cli/`, mirroring the architecture's standard `src/modules/<name>/` shape from day one. `bin.ts` lives at the package root as the entrypoint. When a second bounded context arrives ([#80](https://github.com/dam-agents/dam/issues/80)), it slots in as `src/modules/<name>/` next to this one.
+
+**No other modules affected.** The api-server gains one endpoint (`GET /version`) outside the tRPC surface — owned by the api-server side, scoped here as a contract the CLI consumes.
+
+## Domain Events
+
+**None.** Single bounded context, request/response interactions only. Re-evaluate when a second bounded context arrives.
+
+## Application Services
+
+Two services in `packages/cli/src/modules/cli/services/`:
+
+- **Config service.** Resolves configuration from the three sources (file via `ConfigStore`, env via `EnvReader`, flag) and persists changes via `ConfigStore`. Uses the pure `resolveConfig` domain function. Translates infrastructure failures (file unreadable or malformed) into domain errors.
+- **Compat service.** Calls the version probe, compares the result against the local CLI semver via `compareVersions`, and produces a `Compat Verdict`. Depends on Config — the probe target comes from the resolved Server URL, so Config resolution always precedes Compat.
+
+Commands (`packages/cli/src/modules/cli/commands/`) are commander.js handlers that:
+
+1. Receive args parsed by commander.js.
+2. Ask the Config service for the resolved Config when needed.
+3. Invoke the Compat service as a gate (opt-in per command).
+4. Run the command's work.
+5. Translate the `Result` into exit code + stdout/stderr.
+
+**commander.js is the validation/dispatch layer for this package** — analogous to Zod + tRPC routers in the contract package. It owns argument parsing, type coercion, `--help` generation, and the local-only `--version`. No custom code lives at this layer.
+
+Per-command behavior:
+
+| Verb | Compat gate | Network |
+|---|---|---|
+| `--version`, `--help` | n/a (commander-owned) | none |
+| `dam version` | no | best-effort `/version` call |
+| `dam config set` | no | none |
+| `dam ping` | yes | `/version` call (the only v1 verb that opts in) |
+
+v1 command surface: `--version`, `--help`, `version`, `help`, `config set <key> <value>`, `ping`.
+
+## Layer Responsibilities
+
+| Layer | Lives at | Owns |
+|---|---|---|
+| **Bootstrap** | `packages/cli/src/bin.ts` | Runs the module's `compose.ts` once, configures the commander.js program with wired services, hands control to commander.js. **Wiring and process-handover only — no domain logic, no I/O beyond stdin/stdout/exit code.** |
+| **Validation / dispatch** | commander.js | Argument parsing, type coercion, subcommand routing, `--help`, `--version`. Configuration only — no custom code. |
+| **Commands** | `packages/cli/src/modules/cli/commands/` | One commander handler per verb; output formatting; `Result` → exit-code translation. **Only this layer translates `Result` into exit codes — services and domain never call `process.exit` or throw on domain errors. Commands never compose `Result` chains or implement multi-step logic — those belong in services.** |
+| **Application** | `packages/cli/src/modules/cli/services/` | `ConfigService`, `CompatService`. Orchestrate domain functions and infrastructure ports. |
+| **Domain** | `packages/cli/src/modules/cli/domain/` | `Config`, `ConfigKey`, `Compat Verdict`, `resolveConfig`, `compareVersions`, `Result<T, E>`, domain errors. Zero external imports. |
+| **Infrastructure** | `packages/cli/src/modules/cli/infrastructure/` | `ConfigStore` port + TOML adapter; `VersionProbe` port + plain HTTP adapter; `EnvReader` port + `process.env` adapter. **No infrastructure adapter performs outbound network I/O other than `VersionProbe`** — encodes the no-telemetry policy as a layer-level rule. |
+| **Composition** | `packages/cli/src/modules/cli/compose.ts` | Single wiring point — instantiates adapters, injects them into services. |
+
+Dropped from the server-style three-layer template:
+
+- `sagas/` — no internal events.
+- `events.ts` — no internal event bus.
+- module-level `index.ts` — no public API surface; reintroduce if the package ever exposes a programmatic API.
+
+## Coupling Analysis
+
+- **Single bounded context.** No inter-module coupling within the package.
+- **Outbound imports.** Only `api-server-api` (read-only consumer of contract types; no tRPC procedure called in v1). Never imports from `api-server`, `agent-runtime`, `controller`, or `ui`.
+- **File system.** Only `ConfigStore` reads/writes `~/.dam/config.toml`.
+- **Network.** Only `VersionProbe` performs network calls.
+- **Environment.** Only `EnvReader` reads `process.env`. Services depend on the port, never on the global directly.
+- **Coupling direction.** bootstrap → commands → services → domain ← infrastructure. Domain has zero outside imports. Infrastructure imports domain types only.
+
+Risks and mitigations:
+
+- *Risk:* future verbs ([#80](https://github.com/dam-agents/dam/issues/80), [#86](https://github.com/dam-agents/dam/issues/86), [#73](https://github.com/dam-agents/dam/issues/73)) bypass services and import infrastructure directly. *Mitigation:* new commands go through application services; new ports follow `*Store` / `*Probe` / `*Reader` naming.
+- *Risk:* `api-server-api` types get re-declared inside the CLI. *Mitigation:* import directly, never duplicate. Enforced when tRPC is wired in [#80](https://github.com/dam-agents/dam/issues/80).
+- *Risk:* `~/.dam/` ownership contested when [#80](https://github.com/dam-agents/dam/issues/80) adds credentials. *Mitigation:* `ConfigStore` is scoped to `config.toml` only; [#80](https://github.com/dam-agents/dam/issues/80) introduces a separate adapter for credentials in the same directory.
+
+## Project metadata updates
+
+Required as part of the implementation:
+
+- Add the CLI package entry to [`tseng/project-structure.md`](../../../tseng/project-structure.md) under the client role:
+  ```
+  <!-- package: cli | role: client | path: packages/cli | package_name: @dam-agents/cli -->
+  ```
+
+## What This Specification Does NOT Prescribe
+
+Implementation freedom retained:
+
+- Function signatures, class names, file names, exported identifiers.
+- TOML library, fetch wrapper, argument-parsing flag style (within commander.js).
+- commander.js program organization (single root file vs subcommand registration; inline vs imported handlers).
+- TOML schema beyond "flat, single key `server` for v1."
+- Shape of `Result<T, E>` (custom vs library; alignment with agent-runtime encouraged).
+- Error message wording, color/no-color handling.
+- Test framework specifics within repo conventions.
+- Build tool selection (`tsc` vs `esbuild`).
+- Exit-code numeric assignments (the ADR proposed a scheme).
+- Identifiers for `VersionProbe`, `ConfigStore`, and `EnvReader` ports — naming is guidance, not contract.
+- Adapter parameterization (URL at construction, per-call, or via a service handle).
+- File-write atomicity, parent-directory creation, concurrent-writer handling.

--- a/tseng/vocabulary.md
+++ b/tseng/vocabulary.md
@@ -101,3 +101,13 @@ Pod-side operational view of skills. Distinct from the api-server's Skills conte
 | Host Pattern | The hostname pattern that identifies which outbound requests the Envoy sidecar should inject this secret into |
 | Secret Assignment | The linkage between a Secret and an Agent that makes the secret available to that agent's egress; stored as the `agent-platform.ai/secret-mode` + `agent-platform.ai/granted-secret-ids` annotations on the agent's instance ConfigMap |
 | Provider | The external service a secret authenticates against (e.g., Anthropic); for typed secrets the provider determines default routing rules |
+
+## Platform CLI (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Platform CLI | The `dam` command-line client that talks to a hosted Platform deployment from the user's terminal; package at `packages/cli/` |
+| Config | The CLI's resolved settings for the current invocation — currently only the target Server URL |
+| Config Source | One of the three inputs the Config is resolved from: command-line flag, environment variable, or config file |
+| Server URL | The Platform deployment the CLI is configured to talk to |
+| Compat Verdict | The result of comparing the local CLI's version against the server's reported `minClientVersion` and current version: `Ok`, `BehindMinClient` (hard-refuse), or `BehindCurrent` (soft-warn) |


### PR DESCRIPTION
## Summary

Two documents anchoring the `dam` CLI before any code lands:

- [**ADR-039**](docs/adrs/039-cli-foundation.md) — load-bearing decisions: TypeScript Node package, npm-only distribution as `@dam-agents/cli`, config at `~/.dam/config.toml` (flat schema), independent semver with server-advertised compatibility floor via plain HTTP `/version`, no telemetry, macOS + Linux + Windows-via-WSL2.
- [**Spec**](docs/plans/cli-foundation/README.md) — translates the ADR into module shape, layer responsibilities, and coupling rules. Single bounded context (`platform-cli`) under `packages/cli/src/modules/cli/`, server-style three-layer scaled down (no sagas, no event bus, no module-level `index.ts`), commander.js as the validation/dispatch layer, ports for `ConfigStore` / `VersionProbe` / `EnvReader`. Reviewed against the architecture rules; remaining hand-waves removed.

Also adds the Platform CLI bounded context to [`tseng/vocabulary.md`](tseng/vocabulary.md).

Out of scope (each lands in its own ADR/spec): authentication (#80), instance addressing (#81), `dam shell` (#86), workspace import (#73), and the wider command tree from epic #71.

Implements #79.