### PR TITLE
feat: paired agent + gateway pods — cluster-enforced credential boundary

### DIFF
--- a/docs/adrs/038-paired-gateway-pod.md
+++ b/docs/adrs/038-paired-gateway-pod.md
@@ -1,0 +1,125 @@
+# ADR-038: Paired agent and gateway pods — cluster-enforced credential boundary
+
+**Date:** 2026-05-06
+**Status:** Accepted
+**Owner:** @pilartomas
+
+## Context
+
+[ADR-033](033-envoy-credential-gateway.md) runs Envoy as a sidecar in the
+agent pod. Agent and sidecar share a network namespace, so the pod's
+NetworkPolicy must admit egress on TCP 80/443 for Envoy to reach upstreams
+([resources.go:325-329](../../packages/controller/pkg/reconciler/resources.go#L325-L329)).
+The same rule admits direct egress from the agent process. `HTTPS_PROXY=127.0.0.1:<port>`
+is just an env var; an agent that ignores it bypasses Envoy entirely —
+no credential injection, no HITL, no audit. The boundary is cooperative,
+not enforced.
+
+ADR-033 rejected a namespace-shared Envoy because it would put a pod-IP
+resolver on the request path with an IP-reuse race. That argument is
+specific to a *shared* Envoy. A per-instance Envoy in its own paired pod
+preserves the 1:1 identity ADR-033 valued.
+
+## Decision
+
+Run **two paired pods per instance**, agent and gateway, with NetworkPolicies
+the cluster enforces:
+
+- **Agent pod** egress: paired gateway pod only, plus api-server harness
+  port and DNS. No path to TCP 80/443.
+- **Gateway pod** ingress: paired agent pod only. Egress: TCP 80/443
+  anywhere, ext_authz to api-server, DNS.
+
+Pairing is keyed on `agent-platform.ai/instance` plus a new
+`agent-platform.ai/role` ∈ `{agent, gateway}` label. The controller renders
+the pair as a unit from the existing `agent-instance` ConfigMap; no new
+resource type ([ADR-006](006-configmaps-over-crds.md) preserved).
+
+The agent reaches the gateway through a per-instance headless Service,
+`<instance>-gateway`. `HTTPS_PROXY` becomes the Service DNS name —
+stable across gateway pod restarts, no controller re-render on IP change.
+Envoy's listener moves from `127.0.0.1` to `0.0.0.0`; reach is gated by
+NetworkPolicy, not bind address.
+
+Credential Secrets, the leaf TLS Secret, and the Envoy bootstrap ConfigMap
+move to the gateway pod. The agent pod keeps only the CA bundle.
+`automountServiceAccountToken: false` stays on both.
+
+ADR-035's pod-IP resolver ([pod-ip-resolver.ts](../../packages/api-server/src/modules/instances/infrastructure/pod-ip-resolver.ts))
+narrows its filter to `role=gateway`. The IP source moves from agent pod
+to gateway pod; the protocol, rule model, and `x-platform-instance`
+header check are unchanged.
+
+**Fork Jobs** ([ADR-027](027-slack-user-impersonation.md)) inherit the
+shape: each fork spawns a paired gateway Job and gains a per-fork
+NetworkPolicy pair (forks have no NetworkPolicy today, so this closes the
+bypass for forks at the same time).
+
+This ADR supersedes the sidecar topology in ADR-033 and the parts of its
+threat model that depend on the shared network namespace
+(`HTTPS_PROXY` honoring, Envoy admin reachability, shared PID, in-pod
+escape to a co-located sidecar's volumes). ADR-005's pattern and the
+rest of ADR-033 (Envoy filters, credential injection, refresh loops,
+`(owner, connection)` Secret model) are unchanged. ADR-035 is unchanged.
+
+## Alternatives Considered
+
+**In-pod iptables/eBPF redirect to `127.0.0.1`.** Rejected: anything inside
+the pod is on the untrusted side of the boundary. The rule table is in
+the agent's namespace; an attacker with `CAP_NET_ADMIN` rewrites it, and
+even without that capability can connect out unredirected on a different
+local port. Behavioral mitigation, not structural.
+
+**Namespace-shared Envoy.** Rejected by ADR-033 already. A shared gateway
+puts a pod-IP-to-instance resolver on the request path with an IP-reuse
+race; this ADR keeps the per-instance Envoy precisely to avoid that.
+
+**mTLS-only between agent and a shared gateway pool.** Rejected: requires
+a per-instance identity issuer, certificate distribution the agent
+container cannot read directly, and Envoy config branched on client
+identity. Higher operational and verification cost than two pods plus
+two NetworkPolicies. mTLS as defense-in-depth on top of the paired-pod
+split is a clean v1.5 follow-on.
+
+**Per-instance pod-DNS or downward-API IP injection.** Rejected: pod
+ordinals and pod IPs are not stable across restarts; the agent's env
+goes stale. A Service is the indirection that solves this.
+
+## Consequences
+
+- **Bypass closes structurally.** The agent's NetworkPolicy admits no path
+  to TCP 80/443 other than its paired gateway. Boundary stops depending
+  on the agent honoring an env var.
+- **Resource doubling per instance.** Two pods, two NetworkPolicies, one
+  extra Service per instance and per fork. Idle Envoy is ~30–50 MB RSS,
+  small relative to the agent process.
+- **Controller render split.** [`BuildStatefulSet`](../../packages/controller/pkg/reconciler/resources.go),
+  [`BuildNetworkPolicy`](../../packages/controller/pkg/reconciler/resources.go),
+  and [`BuildForkJob`](../../packages/controller/pkg/reconciler/fork_resources.go)
+  become role-aware. Envoy bootstrap and credential volumes
+  ([envoy.go:670-759](../../packages/controller/pkg/reconciler/envoy.go#L670-L759))
+  attach to the gateway only.
+- **Forks gain a NetworkPolicy.** Today fork pods have none.
+- **`HTTPS_PROXY` becomes a Service DNS name.** Harness images need no
+  changes; they already honor the env var.
+- **Architecture pages update on acceptance.** [`security-and-credentials.md`](../architecture/security-and-credentials.md)
+  and [`platform-topology.md`](../architecture/platform-topology.md) gain
+  the gateway pod and lose the "sidecar inside the agent pod" framing.
+- **Container escape from the agent.** No longer reaches the gateway's
+  Secret volumes (different pod UID directory). Host-root escape still
+  reaches everything; gVisor / Kata at the pod level remains load-bearing.
+- **Gateway ingress on `0.0.0.0`.** The NetworkPolicy ingress selector
+  must exact-match on `instance=<name>`; a wildcard would let one
+  instance's agent dial another's gateway.
+- **mTLS as defense-in-depth deferred to v1.5.** Catches NetworkPolicy
+  misconfiguration without changing this ADR's shape.
+
+## Related ADRs
+
+- [ADR-005](005-credential-gateway.md) — pattern preserved.
+- [ADR-033](033-envoy-credential-gateway.md) — topology and shared-NS
+  threat-model items superseded.
+- [ADR-035](035-unified-hitl-ux.md) — rule model unchanged; resolver IP
+  source moves to gateway pod.
+- [ADR-027](027-slack-user-impersonation.md) — fork Jobs gain a paired
+  gateway Job and per-fork NetworkPolicy pair.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -42,6 +42,7 @@ This directory contains ADRs for the Platform project.
 | [035](035-unified-hitl-ux.md)                 | Unified HITL UX — verdict authority outside the agent pod | @jezekra1 |
 | [036](036-redis-platform-primitive.md)        | Redis as a platform primitive — pub/sub, queues, cache | @jezekra1 |
 | [037](037-remote-terminal.md)                 | Remote terminal — split "chat" and "terminal" session modes | @JanPokorny |
+| [038](038-paired-gateway-pod.md)               | Paired agent and gateway pods — cluster-enforced credential boundary | @pilartomas |
 
 ## Drafts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last verified: 2026-05-04
+Last verified: 2026-05-06
 
 ## System context
 
@@ -20,7 +20,9 @@ flowchart LR
     k8s-api[(K8s API)]
     subgraph agentpod[agent pod]
       agent-runtime
-      envoy[Envoy sidecar]
+    end
+    subgraph gatewaypod[gateway pod]
+      envoy[Envoy]
     end
   end
 
@@ -44,7 +46,7 @@ flowchart LR
   envoy -->|inject credentials| github
 ```
 
-The cluster boundary is the trust boundary. Browsers and Slack users reach Platform through the api-server; LLM and GitHub traffic from the agent always exits through the in-pod Envoy sidecar, which injects credentials from K8s Secrets mounted into the sidecar only. The agent container has no direct path to anything outside the cluster, no service-account credentials, and no upstream tokens of its own.
+The cluster boundary is the trust boundary. Browsers and Slack users reach Platform through the api-server; LLM and GitHub traffic from the agent always exits through the paired gateway pod ([ADR-038](adrs/038-paired-gateway-pod.md)), where Envoy injects credentials from K8s Secrets mounted on the gateway only. The agent pod's NetworkPolicy admits no path to TCP 80/443 other than the paired gateway, so credential injection is enforced by Kubernetes — not by the agent honoring `HTTPS_PROXY`. The agent pod has no service-account credentials and no upstream tokens of its own.
 
 ## Subsystems
 

--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-04-29
+Last verified: 2026-05-06
 
 ## Motivated by
 
@@ -66,7 +66,7 @@ sequenceDiagram
 
 ### Create
 
-The api-server writes a new `agent-instance` ConfigMap with `spec.yaml` carrying the template ref, env overrides, secret refs, and a `desiredState` of `running` or `hibernated`. The controller reconciles four owned resources: a StatefulSet (replicas tracking `desiredState`), a headless Service, a NetworkPolicy, and a per-instance Envoy bootstrap ConfigMap + leaf TLS Certificate ([ADR-033](../adrs/033-envoy-credential-gateway.md)).
+The api-server writes a new `agent-instance` ConfigMap with `spec.yaml` carrying the template ref, env overrides, secret refs, and a `desiredState` of `running` or `hibernated`. The controller reconciles a paired set of owned resources: two StatefulSets (the agent and its paired gateway, each tracking `desiredState`), two headless Services (the agent's ACP and the gateway's `<instance>-gateway` proxy DNS), two role-scoped NetworkPolicies, and a per-instance Envoy bootstrap ConfigMap + leaf TLS Certificate ([ADR-033](../adrs/033-envoy-credential-gateway.md), [ADR-038](../adrs/038-paired-gateway-pod.md)).
 
 The pod image is built from `platform-base` plus a harness-specific layer ([ADR-023](../adrs/023-harness-agnostic-base-image.md)). The single platform knob is `AGENT_COMMAND` — agent-runtime spawns it as the ACP subprocess for each session and otherwise treats the harness as opaque. The workspace PVC is provisioned on first wake and survives subsequent hibernations.
 

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-Last verified: 2026-04-27
+Last verified: 2026-05-06
 
 ## Motivated by
 
@@ -24,7 +24,7 @@ Inbound traffic and outbound traffic take different paths. Inbound is push from 
 
 Two cross-cutting concerns are owned elsewhere and only summarized here:
 
-- **Foreign replier fork.** Slack's two-tier access (channel membership + per-instance allowed users) admits multiple authorized users into one thread. Owner replies relay to the main pod; replies from any other authorized user fork into a per-turn Kubernetes Job whose Envoy sidecar mounts the replier's K8s credential Secrets ([ADR-027](../adrs/027-slack-user-impersonation.md)). The Job spec, the foreign-credential selection, and the shared-PVC mechanics are covered on [security-and-credentials](security-and-credentials.md). Channels just see "main pod or fork pod" at the relay step.
+- **Foreign replier fork.** Slack's two-tier access (channel membership + per-instance allowed users) admits multiple authorized users into one thread. Owner replies relay to the main pod; replies from any other authorized user fork into a per-turn paired pod set — a fork agent Job and a fork gateway Pod, each with its own NetworkPolicy — whose gateway mounts the replier's K8s credential Secrets ([ADR-027](../adrs/027-slack-user-impersonation.md), [ADR-038](../adrs/038-paired-gateway-pod.md)). The pair spec, the foreign-credential selection, and the shared-PVC mechanics are covered on [security-and-credentials](security-and-credentials.md). Channels just see "main pod or fork pod" at the relay step.
 - **Thread-session binding substrate.** The thread-to-session map lives in the sessions DB ([ADR-025](../adrs/025-thread-session.md)); see [persistence](persistence.md) for the storage shape.
 
 ## Topology

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -1,6 +1,6 @@
 # Persistence
 
-Last verified: 2026-04-29
+Last verified: 2026-05-06
 
 ## Motivated by
 
@@ -120,4 +120,4 @@ Schedules are independent ConfigMaps and survive instance deletion as orphans un
 
 The PVC is a **shared mutable surface across every session, trigger, fork, and channel-driven prompt that runs on the same instance.** Anything written into the workspace by one turn — model output saved to disk, tool output, files fetched from upstream — is plain context for the next turn. Treat workspace contents as adversarial input. A scheduled job can plant a file that prompt-injects a later user-driven session; a Slack-driven prompt can leak its instructions through residue left on disk.
 
-The platform does not sandbox writes within the workspace. Mitigations live elsewhere: NetworkPolicy restricts which upstreams the agent can reach, the Envoy sidecar gates credentialed egress, and forks let you run with a narrowed credential set without polluting the parent's workspace. The threat model and credential isolation are detailed on [security-and-credentials](security-and-credentials.md).
+The platform does not sandbox writes within the workspace. Mitigations live elsewhere: NetworkPolicy restricts which upstreams the agent can reach (the agent pod can only dial its paired gateway pod, never an upstream directly — [ADR-038](../adrs/038-paired-gateway-pod.md)), the gateway pod gates credentialed egress, and forks let you run with a narrowed credential set without polluting the parent's workspace. The threat model and credential isolation are detailed on [security-and-credentials](security-and-credentials.md).

--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -1,6 +1,6 @@
 # Platform topology
 
-Last verified: 2026-04-28
+Last verified: 2026-05-06
 
 ## Motivated by
 
@@ -12,11 +12,12 @@ Last verified: 2026-04-28
 - [ADR-012 — Runtime lifetime](../adrs/012-runtime-lifetime.md) — single-use spawn/hibernate model
 - [ADR-022 — Harness API server](../adrs/022-harness-api-server.md) — separate port with a restricted, internal-only surface
 - [ADR-023 — Harness-agnostic agent base image](../adrs/023-harness-agnostic-base-image.md) — `AGENT_COMMAND` contract
-- [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — per-pod Envoy sidecar that mounts owner-labelled K8s Secrets and injects credentials on the wire
+- [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy is the credential gateway; mounts owner-labelled K8s Secrets and injects credentials on the wire
+- [ADR-038 — Paired agent and gateway pods](../adrs/038-paired-gateway-pod.md) — agent and gateway run in two paired pods per instance, glued by NetworkPolicy
 
 ## Overview
 
-Platform runs as four long-lived subsystems on Kubernetes: a Go **controller** that reconciles ConfigMap-declared resources, a TypeScript **api-server** that brokers user requests and relays agent traffic, per-instance **agent-runtime** pods that host the agent process, and a React **ui** served by the api-server. The controller and api-server never talk to each other directly — they coordinate through the K8s API, using a `spec.yaml` / `status.yaml` split on each ConfigMap so that writes never contend.
+Platform runs as four long-lived subsystems on Kubernetes: a Go **controller** that reconciles ConfigMap-declared resources, a TypeScript **api-server** that brokers user requests and relays agent traffic, per-instance paired **agent-runtime** + **gateway** pods that host the agent process and its egress proxy, and a React **ui** served by the api-server. The controller and api-server never talk to each other directly — they coordinate through the K8s API, using a `spec.yaml` / `status.yaml` split on each ConfigMap so that writes never contend.
 
 ## Diagram
 
@@ -27,6 +28,7 @@ flowchart LR
   api-server[api-server]
   controller[controller]
   agent-runtime[agent-runtime pod]
+  gateway[gateway pod]
   k8s-api[(K8s API)]
 
   browser -->|HTTP + WS| ui
@@ -35,6 +37,8 @@ flowchart LR
   api-server -->|ACP relay / WS| agent-runtime
   api-server -->|tRPC proxy| agent-runtime
   agent-runtime -->|trigger POST / MCP| api-server
+  agent-runtime -->|HTTPS_PROXY| gateway
+  gateway -->|ext_authz Check| api-server
   api-server -->|REST| k8s-api
   controller -->|watch + status writes| k8s-api
   controller -.exec trigger.-> agent-runtime
@@ -64,7 +68,11 @@ The per-instance pod that runs the ACP WebSocket server and spawns the underlyin
 - Expose a scoped tRPC router (via the api-server's tRPC proxy) for in-pod file operations surfaced to the UI.
 - Hold an SSE connection to the api-server's pod-files endpoint and materialize declarative file state under the agent's HOME — currently `~/.config/gh/hosts.yml` for granted GitHub Enterprise app connections, more producers might come. Refuses paths outside HOME (defense-in-depth) and skips the loop when `PLATFORM_POD_FILES_EVENTS_URL` is unset (forks).
 
-See [`packages/agent-runtime/`](../../packages/agent-runtime/) and [`packages/agent-runtime-api/`](../../packages/agent-runtime-api/).
+The agent-runtime pod holds zero credential Secrets and has no admitted route to TCP 80/443 except its paired gateway pod ([ADR-038](../adrs/038-paired-gateway-pod.md)). Its `HTTPS_PROXY` value is the per-instance gateway Service DNS, but the value is decorative — Kubernetes admits no other route. See [`packages/agent-runtime/`](../../packages/agent-runtime/) and [`packages/agent-runtime-api/`](../../packages/agent-runtime-api/).
+
+### gateway
+
+A per-instance Envoy pod paired with the agent-runtime pod ([ADR-038](../adrs/038-paired-gateway-pod.md)). Mounts the owner's credential Secrets, the cert-manager-issued leaf TLS material, and the rendered Envoy bootstrap ConfigMap. Terminates the agent's egress TLS, injects credentials on the wire, and gates each credentialed request through the api-server's ext_authz handler. NetworkPolicy admits ingress only from the paired agent pod and egress only to upstream services, the api-server's ext_authz port, and DNS. See [security-and-credentials](security-and-credentials.md).
 
 ### ui
 
@@ -99,12 +107,12 @@ Platform models all of its domain state as ConfigMaps labelled `platform.ai/type
 | `agent-schedule` | Schedule: cron or RRULE, quiet hours, task payload, session mode |
 | `agent-fork` | Forked run: parent instance ref + overrides |
 
-For each `agent-instance`, the controller reconciles a StatefulSet (replicas 0 when hibernated, 1 when running), a headless Service, a NetworkPolicy, and a per-instance Envoy bootstrap ConfigMap + leaf-TLS Certificate ([ADR-033](../adrs/033-envoy-credential-gateway.md)). ConfigMaps are chosen over CRDs so Platform installs without cluster-admin. See [`deploy/helm/platform/templates/`](../../deploy/helm/platform/templates/) for the install layout.
+For each `agent-instance`, the controller reconciles **two paired StatefulSets** (agent + gateway, both at replicas 0 when hibernated and 1 when running), **two Services** (agent's ACP and the gateway's `<instance>-gateway` proxy DNS), **two NetworkPolicies** (one per role), and a per-instance Envoy bootstrap ConfigMap + leaf-TLS Certificate ([ADR-033](../adrs/033-envoy-credential-gateway.md), [ADR-038](../adrs/038-paired-gateway-pod.md)). ConfigMaps are chosen over CRDs so Platform installs without cluster-admin. See [`deploy/helm/platform/templates/`](../../deploy/helm/platform/templates/) for the install layout.
 
 ## Invariants
 
 - **Spec/status ownership.** Controller never writes `spec.yaml`; api-server never writes `status.yaml`. Write contention between the two is impossible by convention.
 - **Relay-only ACP.** All ACP traffic is proxied through the api-server. Agent pods do not accept ACP connections from outside the cluster and the UI never dials pods directly.
 - **Two-port api-server.** The public port is user-authenticated; the harness port is cluster-internal and has no user authentication. They do not share routes.
-- **Credential isolation.** Agent pods never hold real upstream credentials. An Envoy sidecar in the pod intercepts agent TLS using a per-instance leaf cert and injects the credential header from a K8s Secret mounted only into the sidecar — the agent container itself never sees the upstream credential ([ADR-033](../adrs/033-envoy-credential-gateway.md)). See [security-and-credentials](security-and-credentials.md).
+- **Credential isolation.** Agent pods never hold real upstream credentials. The paired gateway pod intercepts agent TLS using a per-instance leaf cert and injects the credential header from a K8s Secret mounted only on the gateway — the agent pod has no path to Secret material, and NetworkPolicy admits no egress to TCP 80/443 except through the paired gateway ([ADR-033](../adrs/033-envoy-credential-gateway.md), [ADR-038](../adrs/038-paired-gateway-pod.md)). See [security-and-credentials](security-and-credentials.md).
 - **Atomic triggers.** Trigger files are delivered via write-temp + rename so the agent's trigger watcher never reads a partial file.

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,15 +1,16 @@
 # Security and credentials
 
-Last verified: 2026-05-05
+Last verified: 2026-05-06
 
 ## Motivated by
 
 - [ADR-005 — Gateway pattern for credentials](../adrs/005-credential-gateway.md) — the agent never sees a real upstream token; a gateway injects them on the wire
 - [ADR-015 — Multi-user authentication via Keycloak](../adrs/015-multi-user-auth.md) — Keycloak is the IdP; resources are owner-labelled
 - [ADR-018 — Slack integration](../adrs/018-slack-integration.md) — identity linking and the per-instance `allowedUsers` gate that decides who can drive a thread
-- [ADR-027 — Slack per-turn user impersonation](../adrs/027-slack-user-impersonation.md) — foreign repliers fork the instance into a per-turn Job whose Envoy sidecar mounts the replier's K8s credential Secrets
-- [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy sidecar mints per-instance leaf certs, MITMs egress, and injects credential headers
+- [ADR-027 — Slack per-turn user impersonation](../adrs/027-slack-user-impersonation.md) — foreign repliers fork the instance into a per-turn paired pod whose gateway mounts the replier's K8s credential Secrets
+- [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy mints per-instance leaf certs, MITMs egress, and injects credential headers
 - [ADR-035 — HITL ext_authz](../adrs/035-hitl-ext-authz.md) — Envoy gates credentialed egress through an api-server ext_authz call
+- [ADR-038 — Paired agent and gateway pods](../adrs/038-paired-gateway-pod.md) — agent and gateway run in two paired pods, with NetworkPolicies the cluster enforces
 
 ## Overview
 
@@ -17,20 +18,24 @@ Three rules carry the security model:
 
 1. **Agents never hold upstream credentials.** Real upstream tokens (GitHub,
    Anthropic, Slack, internal gateways) live in K8s Secrets labelled with the
-   owner's `sub`. The Envoy sidecar in the agent pod injects them into
-   outbound traffic on the wire — the agent container never sees Secret
+   owner's `sub`. The Envoy proxy in the paired gateway pod injects them
+   into outbound traffic on the wire — the agent pod never mounts Secret
    bytes.
 2. **Identity flows from Keycloak.** Browser users authenticate against
    Keycloak; the api-server validates the JWT and stamps `platform.ai/owner` on
    every resource the user creates. Per-user credential isolation is the
    `platform.ai/owner` label on the K8s Secret — the controller's selector
-   refuses to mount any other owner's Secret into a given owner's pod.
-3. **The trust line is the agent pod's network egress.** Everything outside
-   the pod is the platform; everything inside the pod is least-privileged.
-   NetworkPolicy keeps the pod off the K8s API, off arbitrary in-cluster
-   peers, and forces all 80/443 egress through the Envoy sidecar on
-   `127.0.0.1`. Envoy then enforces what each grant actually permits on the
-   wire and gates each credentialed request through the ext_authz handler.
+   refuses to mount any other owner's Secret into a given owner's gateway pod.
+3. **The trust line is the agent pod's network egress, enforced by the
+   cluster.** Each instance runs as two paired pods (ADR-038): an `agent` pod
+   and a `gateway` pod, glued by role-scoped NetworkPolicies. The agent pod
+   has no admitted egress to TCP 80/443 anywhere except its paired gateway
+   pod's proxy port; the gateway pod accepts ingress only from its paired
+   agent. The agent's `HTTPS_PROXY` value points at the per-instance
+   gateway Service DNS, but obeying it is no longer a requirement —
+   Kubernetes admits no other route. Envoy in the gateway pod enforces what
+   each grant actually permits on the wire and gates each credentialed
+   request through the ext_authz handler.
 
 Workspace contents are explicitly outside the trust boundary — see the
 security note on [persistence](persistence.md).
@@ -49,7 +54,10 @@ flowchart LR
 
   subgraph agentpod[Agent pod]
     agent-runtime
-    envoy[Envoy sidecar]
+  end
+
+  subgraph gatewaypod[Gateway pod]
+    envoy[Envoy]
   end
 
   external[external services]
@@ -57,20 +65,22 @@ flowchart LR
   browser -->|user JWT| api-server
   api-server -->|JWKS validate| keycloak
 
-  api-server -->|write K8s Secrets<br/>platform.ai/owner=sub| agentpod
-  controller -->|render bootstrap + leaf cert<br/>list owner Secrets| agentpod
+  api-server -->|write K8s Secrets<br/>platform.ai/owner=sub| gatewaypod
+  controller -->|render bootstrap + leaf cert<br/>list owner Secrets| gatewaypod
+  controller -->|render agent + paired gateway<br/>+ role-scoped NetworkPolicies| agentpod
 
-  agent-runtime -->|HTTPS_PROXY=127.0.0.1| envoy
+  agent-runtime -->|HTTPS_PROXY=&lt;instance&gt;-gateway| envoy
   envoy -->|ext_authz Check| api-server
   envoy -->|inject credentials| external
 ```
 
-The credential boundary is the container: K8s Secrets are mounted into the
-Envoy sidecar only. The agent's process namespace is isolated from the
-sidecar's (`shareProcessNamespace: false`), and the agent has no service
-account token (`automountServiceAccountToken: false`) — Secret-read RBAC
-that would otherwise bypass the volume-mount scope is unavailable. See
-[ADR-033 §Threat Model](../adrs/033-envoy-credential-gateway.md#threat-model).
+The credential boundary is the pod: K8s Secrets are mounted into the
+gateway pod only, and the agent pod has no admitted route to TCP 80/443
+other than its paired gateway. The agent pod has no service account token
+(`automountServiceAccountToken: false`), and there is no co-located
+sidecar to share a network or PID namespace with. See
+[ADR-033 §Threat Model](../adrs/033-envoy-credential-gateway.md#threat-model)
+and [ADR-038 §Threat Model](../adrs/038-paired-gateway-pod.md#threat-model).
 
 ## Identity
 
@@ -100,7 +110,7 @@ namespace-per-user.
 
 The controller picks credentials per-instance by listing K8s Secrets
 labelled `platform.ai/owner=<sub>,platform.ai/managed-by=api-server` in the agent
-namespace, then mounting the matching set into the Envoy sidecar. Cross-
+namespace, then mounting the matching set into the paired gateway pod. Cross-
 owner leakage is structurally prevented by the label selector — a missing
 `platform.ai/owner` label is treated as no owner and never mounted.
 
@@ -116,26 +126,29 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
 - **User-supplied secrets** (Anthropic API keys, generic API tokens) —
   the secrets module writes them with the same labels and annotations.
 
-The Secret carries the SDS YAML the Envoy sidecar reads via its
-`path_config_source`. Only the Envoy sidecar mounts the Secret; the agent
-container does not. See [`packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts`](../../packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts) and
+The Secret carries the SDS YAML Envoy reads via its `path_config_source`.
+Only the gateway pod mounts the Secret; the agent pod does not. See
+[`packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts`](../../packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts) and
 [`packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts`](../../packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts).
 
 ## Envoy credential injection
 
 The controller renders a per-instance `Envoy bootstrap ConfigMap` and a
 cert-manager `Certificate` whose Secret holds the leaf TLS material the
-Envoy sidecar uses to terminate the agent's egress TLS. The leaf is
+gateway pod uses to terminate the agent's egress TLS. The leaf is
 issued by a chart-managed `platform-mitm-ca-issuer` ClusterIssuer; the CA
-cert is mounted into the agent at `/etc/platform/ca/ca.crt` so its TLS
-clients trust the sidecar.
+cert is mounted into the agent at `/etc/platform/ca/ca.crt` (single-key
+projection, `tls.key` stays in the gateway pod) so the agent's TLS
+clients trust Envoy's intercept cert.
 
 On the wire:
 
-1. Agent sets `HTTPS_PROXY=http://127.0.0.1:<envoyPort>`. Every egress
-   arrives as HTTP CONNECT.
-2. Envoy's outer listener terminates the CONNECT and routes the inner
-   stream into an internal listener that reads SNI.
+1. Agent sets `HTTPS_PROXY=http://<instance>-gateway:<envoyPort>`. The
+   per-instance gateway Service routes the connection to the paired
+   gateway pod; every egress arrives there as HTTP CONNECT.
+2. Envoy's outer listener (bound on `0.0.0.0`, reach gated by
+   NetworkPolicy) terminates the CONNECT and routes the inner stream
+   into an internal listener that reads SNI.
 3. Per-host filter chains terminate TLS with the leaf cert, run the
    credential injector to add the configured `Authorization` header, then
    forward to a per-credential `STRICT_DNS` cluster pinned to the
@@ -156,13 +169,15 @@ passthrough chains.
 ## HITL ext_authz
 
 Each credentialed request goes through an ext_authz Check call against
-the api-server. The handler resolves the source pod IP to an instance,
-looks up the matching egress rule, and either allows the request,
-denies it, or holds it open while the user makes a verdict in the inbox
-(ADR-035). `failure_mode_allow: false` — a blocked Check fails closed:
-agent gets 403, no inbox prompt.
+the api-server. The handler resolves the source pod IP — under the
+paired-pod model that's the gateway pod's IP, narrowed by the resolver
+filter `agent-platform.ai/instance, agent-platform.ai/role=gateway` — to
+an instance, looks up the matching egress rule, and either allows the
+request, denies it, or holds it open while the user makes a verdict in
+the inbox (ADR-035). `failure_mode_allow: false` — a blocked Check fails
+closed: agent gets 403, no inbox prompt.
 
-NetworkPolicy admits ext_authz traffic only from sidecar pods to the
+NetworkPolicy admits ext_authz traffic only from gateway pods to the
 api-server's gRPC listener. The HTTP filter on TLS-terminated chains
 sees method/path; the network filter on the catch-all chain sees SNI
 only.
@@ -171,23 +186,37 @@ only.
 
 When a user other than the instance owner replies in a Slack thread,
 the api-server emits a fork ConfigMap that the controller materialises
-into a per-turn Job. The fork pod's Envoy sidecar mounts the
-**replier's** K8s credential Secrets — selected by `platform.ai/owner=<replier-sub>`,
-not the instance owner's `sub`. The credential boundary is preserved:
-the fork pod runs the replier's credentials, never the parent instance
-owner's. See [ADR-027](../adrs/027-slack-user-impersonation.md).
+into a per-turn paired pod set: a fork agent Job and a fork gateway Pod
+(ADR-038). The fork's gateway pod mounts the **replier's** K8s credential
+Secrets — selected by `platform.ai/owner=<replier-sub>`, not the instance
+owner's `sub`. The credential boundary is preserved: the fork pair runs
+the replier's credentials, never the parent instance owner's. The fork
+agent's `agent-platform.ai/instance` label still points at the parent
+instance so traffic resolves under the parent's egress rules; the fork's
+own pair key (`agent-platform.ai/pair`) isolates it from the parent
+instance's pair. See [ADR-027](../adrs/027-slack-user-impersonation.md)
+and [ADR-038](../adrs/038-paired-gateway-pod.md).
 
 ## Network policy
 
-Each agent pod gets a NetworkPolicy that:
+Each instance and each fork get **two** NetworkPolicies, role-scoped on
+`agent-platform.ai/pair=<pair-key>`. The agent pod's policy:
 
-- Permits open egress on TCP 80/443 (the sidecar reaches arbitrary
-  upstreams; ADR-033 §Decision keeps the first-cut allowlist permissive).
-- Permits gRPC egress to the api-server's ext_authz port (the HITL gate).
-- Permits egress to the api-server's harness port (MCP, triggers).
-- Permits DNS.
+- Admits egress to the paired gateway pod's proxy port — exact-match on
+  `pair + role=gateway`.
+- Admits egress to the api-server's harness port (MCP, triggers).
+- Admits DNS.
+- **Does not** admit egress to TCP 80/443 anywhere — that's the bypass the
+  paired-pod split closes (ADR-038).
 - Admits ingress on the agent's ACP/tRPC port only from the api-server pod;
   the kernel-level peer match is the auth boundary on that hop.
 
-The credential gateway lives inside the agent pod (the Envoy sidecar);
-there is no cross-namespace gateway pod for the agent to reach.
+The gateway pod's policy:
+
+- Admits egress on TCP 80/443 anywhere (Envoy reaches arbitrary upstreams;
+  ADR-033 §Decision keeps the first-cut allowlist permissive).
+- Admits gRPC egress to the api-server's ext_authz port (the HITL gate).
+- Admits DNS.
+- Admits ingress on the proxy port only from the paired agent pod —
+  exact-match on `pair + role=agent`. Loosening to a wildcard would let
+  one pair's agent dial another's gateway.

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,14 +1,15 @@
 # Skills
 
-Last verified: 2026-04-29
+Last verified: 2026-05-06
 
 ## Motivated by
 
 - [ADR-030 — Skills: connectable sources and install](../adrs/030-skills-marketplace.md) — Platform owns skill *transport*, not skill format; sources are external git repos, not a Platform-hosted catalog
 - [ADR-023 — Harness-agnostic agent base image](../adrs/023-harness-agnostic-base-image.md) — `skillPaths` is a per-template knob; the controller stays harness-agnostic
-- [ADR-005 — Gateway pattern for credentials](../adrs/005-credential-gateway.md) — agent-runtime makes GitHub calls without holding credentials; the Envoy sidecar injects `Authorization` on the wire from the owner's K8s Secret
+- [ADR-005 — Gateway pattern for credentials](../adrs/005-credential-gateway.md) — agent-runtime makes GitHub calls without holding credentials; the gateway pod injects `Authorization` on the wire from the owner's K8s Secret
 - [ADR-024 — Connector-declared envs and per-agent overrides](../adrs/024-connector-declared-envs.md) — env composition rules for agent pods
-- [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — per-pod Envoy sidecar that performs the credential swap
+- [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy performs the credential swap
+- [ADR-038 — Paired agent and gateway pods](../adrs/038-paired-gateway-pod.md) — Envoy lives in a paired gateway pod, not a sidecar
 
 ## Overview
 
@@ -19,7 +20,7 @@ The subsystem splits cleanly across two bounded contexts ([`tseng/vocabulary.md`
 - **api-server side** — owns the catalog: which sources are connected, which skills are installed where, and what was published from which instance. All of it is api-server-only Application State and lives in Postgres or in api-server config. The api-server never touches a pod's filesystem directly.
 - **agent-runtime side** — owns the pod-local files: scanning a source, materializing a skill into the configured paths, walking the disk to enumerate local skills, and publishing a local skill upstream. It never reasons about catalogs, drift, or which user owns what.
 
-The two contexts share the agent-runtime as the only path that reaches a pod, and the Envoy sidecar as the only path that reaches GitHub with credentials. Everything else is a tRPC call between them.
+The two contexts share the agent-runtime as the only path that reaches a pod, and the paired gateway pod as the only path that reaches GitHub with credentials. Everything else is a tRPC call between them.
 
 ## Diagram
 
@@ -46,7 +47,9 @@ flowchart LR
     pvc[(per-instance PVC<br/>skillPaths)]
   end
 
-  envoy[Envoy sidecar]
+  subgraph gateway[gateway pod]
+    envoy[Envoy]
+  end
 
   user -->|tRPC| skills-svc
   user -->|tRPC| pub-svc
@@ -59,12 +62,12 @@ flowchart LR
   skills-svc -->|tRPC over harness port| rt-skills
   pub-svc -->|tRPC over harness port| rt-skills
 
-  rt-skills -->|HTTPS| envoy
+  rt-skills -->|HTTPS_PROXY| envoy
   envoy -->|inject user's OAuth token| github
   rt-skills <--> pvc
 ```
 
-The api-server scans **public** GitHub catalogs directly (no credentials needed) and falls back to agent-runtime for everything else. agent-runtime is the only component that talks to GitHub with credentials, and it does so without holding any: the request leaves the pod through the Envoy sidecar, which injects the owner's GitHub token from a K8s Secret on the wire ([security-and-credentials](security-and-credentials.md)).
+The api-server scans **public** GitHub catalogs directly (no credentials needed) and falls back to agent-runtime for everything else. agent-runtime is the only component that talks to GitHub with credentials, and it does so without holding any: the request leaves the agent pod through the paired gateway pod, where Envoy injects the owner's GitHub token from a K8s Secret on the wire ([security-and-credentials](security-and-credentials.md)).
 
 ## Concepts
 
@@ -106,7 +109,7 @@ Lives in [`packages/api-server/src/modules/skills/`](../../packages/api-server/s
 - The **Skill Source catalogue** — CRUD on user sources, merging in system seeds and template sources, dedupe and badge resolution.
 - The **scan cache** — per-`gitUrl`, 5-minute TTL, invalidated on `sources.refresh` or after a successful publish to that source.
 - **Public-archive scanning** — for `github.com` URLs, downloads `archive/HEAD.tar.gz` directly from GitHub, walks for `SKILL.md`, parses frontmatter, computes `contentHash`. No credentials required. This is the path that lets the catalog UI render even when no instance is running.
-- **Private / non-GitHub fallback** — falls through to the agent-runtime `skills.scan` over the harness port. Requires a running instance because the credential path needs the Envoy sidecar; the api-server has none.
+- **Private / non-GitHub fallback** — falls through to the agent-runtime `skills.scan` over the harness port. Requires a running instance because the credential path needs the paired gateway pod; the api-server has none.
 - **Install / uninstall orchestration** — calls agent-runtime over its harness-port tRPC and on success upserts the `instance_skills` row with the returned `contentHash`. The api-server is the only pod whose NetworkPolicy can reach the agent's tRPC listener; no Bearer token is sent.
 - **Publish orchestration** ([`publish-service`](../../packages/api-server/src/modules/skills/services/publish-service.ts)) — validates that the source is a GitHub URL (only host that supports publish), calls agent-runtime, and on success writes the `instance_skill_publishes` row and invalidates the scan cache for that source.
 - **Reconciled `state` view** — joins live `listLocal` from agent-runtime with the `instance_skills` rows, drops ghost rows whose directories were deleted out-of-band (and persists the cleanup), and folds in the `instance_skill_publishes` rows.
@@ -119,23 +122,23 @@ Lives in [`packages/agent-runtime/src/modules/skills/`](../../packages/agent-run
 
 Three responsibilities:
 
-- **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The Envoy sidecar injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the skill directory inside the fetch (`skills/<name>/` then top-level `<name>/`), copies it into every configured Skill Path, and returns the deterministic `contentHash`.
+- **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The paired gateway pod injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the skill directory inside the fetch (`skills/<name>/` then top-level `<name>/`), copies it into every configured Skill Path, and returns the deterministic `contentHash`.
 - **Scan** — same fetch path; walks for `SKILL.md`, parses frontmatter, and returns `(name, description, version, contentHash)` for each.
 - **Publish** — REST-only. Reads the local skill from disk (size-capped per file and per skill), creates blobs + tree + commit + branch + PR via the GitHub REST API, with author `Platform <platform-publish@users.noreply.github.com>`. Branch naming: `platform/publish-<name>-<timestamp>`. There is no `git push`.
 
-Boot-time wiring runs `gh auth setup-git` once before the tRPC server starts, so a private-repo `git clone` invoked from inside the pod also routes through `gh` (and therefore through the sidecar's credential injector) instead of stalling on a username prompt.
+Boot-time wiring runs `gh auth setup-git` once before the tRPC server starts, so a private-repo `git clone` invoked from inside the pod also routes through `gh` (and therefore through the gateway pod's credential injector) instead of stalling on a username prompt.
 
 ### Credential injection on the wire
 
-Agent-runtime never holds a real GitHub token. The Envoy sidecar performs the swap:
+Agent-runtime never holds a real GitHub token. The paired gateway pod performs the swap:
 
-1. The pod's `HTTPS_PROXY` is `http://127.0.0.1:<envoy-port>`, so every outbound request goes through the sidecar. `SSL_CERT_FILE` points at the cluster-issued MITM CA so TLS termination at the sidecar succeeds ([security-and-credentials](security-and-credentials.md)).
-2. The sidecar's host-specific filter chain for `api.github.com` injects `Authorization: Bearer <user's GitHub OAuth token>` from a K8s Secret labelled `platform.ai/owner=<sub>` and `platform.ai/connection=github` (or similar), then re-originates upstream TLS to the real host.
+1. The agent pod's `HTTPS_PROXY` is `http://<instance>-gateway:<envoy-port>` — the per-instance gateway Service DNS ([ADR-038](../adrs/038-paired-gateway-pod.md)). The agent pod's NetworkPolicy admits no other route to TCP 80/443, so credential injection is enforced by the cluster, not by the agent honoring an env var. `SSL_CERT_FILE` points at the cluster-issued MITM CA so TLS termination on the gateway succeeds ([security-and-credentials](security-and-credentials.md)).
+2. Envoy's host-specific filter chain for `api.github.com` injects `Authorization: Bearer <user's GitHub OAuth token>` from a K8s Secret mounted only on the gateway pod (labelled `platform.ai/owner=<sub>` and `platform.ai/connection=github` or similar), then re-originates upstream TLS to the real host.
 3. agent-runtime makes its API calls without authenticating — Envoy supplies the credential.
 
 If the user has not connected GitHub, no Secret exists and the request leaves authenticated only when the agent has supplied its own token. The agent runtime exposes `PLATFORM_GH_TOKEN_AVAILABLE=true|false` so wrapper scripts can short-circuit instead of making a 401-eliciting request first.
 
-The same path lets `git clone` of a private repo work without any credential being mounted into the agent container.
+The same path lets `git clone` of a private repo work without any credential being mounted into the agent pod.
 
 ## Flows
 
@@ -148,7 +151,7 @@ sequenceDiagram
   participant API as api-server<br/>skills-service
   participant DB as Postgres
   participant RT as agent-runtime<br/>skills
-  participant ENV as Envoy sidecar
+  participant ENV as gateway pod (Envoy)
   participant GH as GitHub
   participant PVC as PVC<br/>skillPaths
 
@@ -165,7 +168,7 @@ sequenceDiagram
   API-->>U: updated installed list
 ```
 
-Public-source installs work identically except the sidecar's filter chain has no credential to inject (no token swap, anonymous archive download).
+Public-source installs work identically except Envoy's filter chain has no credential to inject (no token swap, anonymous archive download).
 
 ### Publish
 
@@ -176,7 +179,7 @@ sequenceDiagram
   participant API as api-server<br/>publish-service
   participant DB as Postgres
   participant RT as agent-runtime<br/>skills
-  participant ENV as Envoy sidecar
+  participant ENV as gateway pod (Envoy)
   participant GH as GitHub
 
   U->>API: skills.publish(instanceId, sourceId, name)
@@ -234,6 +237,6 @@ The on-pod state lives on the per-instance PVC under the configured Skill Paths.
 
 - **Filesystem is authoritative for installed state.** `instance_skills` is a declarative record that self-heals on every `state` read. A skill removed via the Files panel disappears from the UI without any explicit uninstall.
 - **api-server never touches the pod filesystem.** Every disk-touching operation goes through agent-runtime over its tRPC port; the agent pod's NetworkPolicy admits ingress only from the api-server pod, so no in-process auth is needed on that hop.
-- **agent-runtime never holds a GitHub credential.** Every authenticated GitHub call leaves the agent unauthenticated; the Envoy sidecar injects `Authorization: Bearer <user OAuth token>` from the owner's K8s Secret on the wire. A compromised agent container cannot exfiltrate the user's GitHub token because the token is never mounted into the agent — only into the sidecar.
-- **Publish is REST-only.** No `git push` on the publish path. `git` is used only for cloning non-GitHub sources during install/scan, and that path also routes through the sidecar's credential injector via `gh auth setup-git`.
+- **agent-runtime never holds a GitHub credential.** Every authenticated GitHub call leaves the agent unauthenticated; Envoy in the paired gateway pod injects `Authorization: Bearer <user OAuth token>` from the owner's K8s Secret on the wire. A compromised agent pod cannot exfiltrate the user's GitHub token because the token is never mounted into the agent pod — only the gateway pod, and the agent pod's NetworkPolicy admits no route to GitHub other than through that gateway.
+- **Publish is REST-only.** No `git push` on the publish path. `git` is used only for cloning non-GitHub sources during install/scan, and that path also routes through the gateway pod's credential injector via `gh auth setup-git`.
 - **MCP `instanceId` is server-bound.** The per-instance MCP endpoint authenticates the agent against the agent ConfigMap's `accessTokenHash` ([channels § Auth without an admin login](channels.md#auth-without-an-admin-login)) and pins the `instanceId` from the verified token, not from tool input.

--- a/packages/api-server/src/__tests__/unit/label-contract.test.ts
+++ b/packages/api-server/src/__tests__/unit/label-contract.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import {
+  LABEL_INSTANCE_REF,
+  LABEL_ROLE,
+  ROLE_AGENT,
+  ROLE_GATEWAY,
+} from "../../modules/agents/infrastructure/labels.js";
+
+// Pins the on-the-wire label keys and values the controller's NetworkPolicy
+// selectors and the api-server's pod-IP resolver both depend on. The Go
+// side has a mirror test in
+// `packages/controller/pkg/reconciler/gateway_test.go (TestLabelContract)`.
+// Drift between the two would silently break the credential boundary
+// (ADR-038 §Threat Model).
+describe("paired-pod label contract (ADR-038)", () => {
+  it("pins keys/values the controller's Go constants must equal", () => {
+    expect(LABEL_INSTANCE_REF).toBe("agent-platform.ai/instance");
+    expect(LABEL_ROLE).toBe("agent-platform.ai/role");
+    expect(ROLE_AGENT).toBe("agent");
+    expect(ROLE_GATEWAY).toBe("gateway");
+  });
+});

--- a/packages/api-server/src/modules/agents/infrastructure/labels.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/labels.ts
@@ -10,6 +10,12 @@ export const LABEL_CHANNEL_TYPE = "agent-platform.ai/channel-type";
 export const LABEL_SYSTEM = "agent-platform.ai/system";
 export const LABEL_CREATED_BY = "agent-platform.ai/created-by";
 
+// Per-pod role within an instance pair (ADR-038). Distinguishes the agent
+// pod from the paired gateway (Envoy) pod that mounts credentials.
+export const LABEL_ROLE = "agent-platform.ai/role";
+export const ROLE_AGENT = "agent";
+export const ROLE_GATEWAY = "gateway";
+
 // ---- Label values for LABEL_TYPE ----
 export const TYPE_TEMPLATE = "agent-template";
 export const TYPE_AGENT = "agent";

--- a/packages/api-server/src/modules/instances/infrastructure/instances-repository.ts
+++ b/packages/api-server/src/modules/instances/infrastructure/instances-repository.ts
@@ -2,6 +2,7 @@ import { is409, type K8sClient } from "../../agents/infrastructure/k8s.js";
 import { retry } from "../../agents/infrastructure/retry.js";
 import {
   LABEL_TYPE, TYPE_INSTANCE, LABEL_OWNER, LABEL_INSTANCE_REF, LABEL_AGENT_REF, LAST_ACTIVITY_KEY,
+  LABEL_ROLE, ROLE_AGENT,
 } from "../../agents/infrastructure/labels.js";
 import {
   isOwnedBy, hasType, patchSpecField, setDesiredState, isPodReady,
@@ -79,7 +80,10 @@ export function createInstancesRepository(k8s: K8sClient): InstancesRepository {
       const ownerSelector = owner ? `,${LABEL_OWNER}=${owner}` : "";
       const [configMaps, pods] = await Promise.all([
         k8s.listConfigMaps(`${LABEL_TYPE}=${TYPE_INSTANCE}${ownerSelector}`),
-        k8s.listPods(LABEL_INSTANCE_REF),
+        // ADR-038: agent and gateway pods share the instance label;
+        // narrow to role=agent so status (Ready, podIP) reflects the
+        // agent half of the pair, which is what callers expect.
+        k8s.listPods(`${LABEL_INSTANCE_REF},${LABEL_ROLE}=${ROLE_AGENT}`),
       ]);
       const podMap = new Map<string, (typeof pods)[number]>();
       for (const pod of pods) {

--- a/packages/api-server/src/modules/instances/infrastructure/pod-ip-resolver.ts
+++ b/packages/api-server/src/modules/instances/infrastructure/pod-ip-resolver.ts
@@ -9,11 +9,14 @@
  * never use it for agents). The CNI rewrites/drops any non-pod source IP
  * at egress.
  *
- * This cache resolves an inbound peer IP to the `agent-platform.ai/instance` label
- * carried on the pod, which the gate then runs through the existing
- * `identityResolver` to get `(ownerSub, agentId)`. Both StatefulSet agent
- * pods and fork Jobs carry the label (`ForkLabelInstanceRef` reuses it),
- * so this single cache covers both shapes.
+ * Under ADR-038's paired-pod split the calling pod is the gateway, not the
+ * agent — both pods of the pair carry the same `agent-platform.ai/instance`
+ * label, so we narrow the LIST filter to `role=gateway` to disambiguate.
+ * The cache resolves an inbound peer IP to that pod's instance label,
+ * which the gate then runs through the existing `identityResolver` to
+ * get `(ownerSub, agentId)`. Both StatefulSet gateway pods and fork
+ * gateway Pods carry the same labels, so this single cache covers both
+ * shapes.
  *
  * Refresh strategy: a periodic re-list (cheap, single Pod LIST per tick).
  * Pods are added/removed at human cadence, so a few seconds of staleness
@@ -22,7 +25,11 @@
  * cold-start path without making it the steady state.
  */
 import type { K8sClient } from "../../agents/infrastructure/k8s.js";
-import { LABEL_INSTANCE_REF } from "../../agents/infrastructure/labels.js";
+import {
+  LABEL_INSTANCE_REF,
+  LABEL_ROLE,
+  ROLE_GATEWAY,
+} from "../../agents/infrastructure/labels.js";
 
 export interface PodIpResolver {
   start(): Promise<void>;
@@ -67,8 +74,14 @@ export function createPodIpResolver(deps: CreatePodIpResolverDeps): PodIpResolve
     if (refreshing) return refreshing;
     refreshing = (async () => {
       try {
-        // labelSelector with just the key name = "key exists" in K8s.
-        const pods = await deps.k8s.listPods(LABEL_INSTANCE_REF);
+        // ADR-038: ext_authz Check calls originate from the paired gateway
+        // pod, not the agent. Both pods carry the instance label; narrow
+        // to role=gateway so a misdirected agent-pod IP can't satisfy the
+        // resolver (it never should — agent pods have no admitted egress
+        // to the api-server's ext_authz port — but the explicit filter
+        // makes the contract obvious).
+        const selector = `${LABEL_INSTANCE_REF},${LABEL_ROLE}=${ROLE_GATEWAY}`;
+        const pods = await deps.k8s.listPods(selector);
         const next = new Map<string, string>();
         for (const pod of pods) {
           const ip = pod.status?.podIP;

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -236,9 +236,10 @@ func routesFromSecrets(secrets []corev1.Secret) []envoyRoute {
 
 // Bootstrap template — TLS-intercepting CONNECT proxy.
 //
-// Topology:
-//   1. The agent points HTTP(S)_PROXY at 127.0.0.1:<port>. All egress arrives
-//      as HTTP CONNECT.
+// Topology (ADR-038):
+//   1. The agent points HTTP(S)_PROXY at the paired gateway pod's Service DNS
+//      (e.g. `<instance>-gateway:<port>`). The listener binds 0.0.0.0 inside
+//      the gateway pod; reach is gated by NetworkPolicy, not bind address.
 //   2. The OUTER listener on that port is an HCM that terminates the agent's
 //      CONNECT and routes the inner stream into the INTERNAL listener (Envoy's
 //      "internal listener" feature, addressed via envoy_internal_address).
@@ -262,9 +263,9 @@ func routesFromSecrets(secrets []corev1.Secret) []envoyRoute {
 //      misconfigured cluster fails the upstream TLS handshake before any
 //      credentialed body reaches the wire.
 //   - Upstream TLS validation uses Envoy's default system trust bundle; the
-//      sidecar image must ship one (envoy-distroless does).
-//   - Admin interface intentionally omitted (ADR-033 threat model: the agent
-//      shares the network namespace).
+//      gateway image must ship one (envoy-distroless does).
+//   - Admin interface intentionally omitted; the gateway pod's NetworkPolicy
+//      additionally admits ingress only from its paired agent pod.
 
 const envoyBootstrapTmpl = `node:
   id: platform-credential-injector
@@ -277,7 +278,7 @@ static_resources:
   listeners:
     - name: agent_egress
       address:
-        socket_address: { address: 127.0.0.1, port_value: {{ .Port }} }
+        socket_address: { address: {{ .ListenAddress }}, port_value: {{ .Port }} }
       filter_chains:
         - filters:
             - name: envoy.filters.network.http_connection_manager
@@ -597,7 +598,13 @@ static_resources:
                       port_value: {{ $.ExtAuthzPort }}
 `
 
-// renderEnvoyBootstrap returns the Envoy bootstrap YAML for an instance.
+// envoyListenAddress is the bind address for the gateway pod's outer listener.
+// 0.0.0.0 — reach is gated by the gateway pod's NetworkPolicy (ingress admitted
+// only from the paired agent pod), not the bind address. ADR-038.
+const envoyListenAddress = "0.0.0.0"
+
+// renderEnvoyBootstrap returns the Envoy bootstrap YAML for an instance's
+// paired gateway pod.
 func renderEnvoyBootstrap(instanceName string, cfg *config.Config, routes []envoyRoute) (string, error) {
 	tmpl, err := template.New("envoy").Parse(envoyBootstrapTmpl)
 	if err != nil {
@@ -608,6 +615,7 @@ func renderEnvoyBootstrap(instanceName string, cfg *config.Config, routes []envo
 	extAuthzTimeoutSeconds := cfg.ExtAuthzHoldSeconds + 60
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, struct {
+		ListenAddress          string
 		Port                   int
 		Routes                 []envoyRoute
 		CredentialsRoot        string
@@ -620,6 +628,7 @@ func renderEnvoyBootstrap(instanceName string, cfg *config.Config, routes []envo
 		ExtAuthzHoldSeconds    int
 		ExtAuthzTimeoutSeconds int
 	}{
+		ListenAddress:          envoyListenAddress,
 		Port:                   cfg.EnvoyPort,
 		Routes:                 routes,
 		CredentialsRoot:        envoyCredentialsRoot,
@@ -658,12 +667,12 @@ func BuildEnvoyBootstrapConfigMap(instanceName string, cfg *config.Config, owner
 	}, nil
 }
 
-// envoySidecarVolumes returns the pod-level volumes that back the sidecar's
+// envoyVolumes returns the pod-level volumes that back the gateway pod's
 // bootstrap ConfigMap, per-Secret credential files, and the cert-manager-issued
 // TLS leaf used to terminate the agent's intercepted TLS. None of these are
-// referenced from the agent container — the credential boundary lives at the
-// container, not the pod.
-func envoySidecarVolumes(instanceName string, secrets []corev1.Secret) []corev1.Volume {
+// referenced from the agent pod — the credential boundary lives at the pod
+// boundary (ADR-038).
+func envoyVolumes(instanceName string, secrets []corev1.Secret) []corev1.Volume {
 	volumes := []corev1.Volume{{
 		Name: envoyBootstrapVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -713,7 +722,7 @@ func ptrBool(b bool) *bool { return &b }
 // kubelet keeps the old bootstrap mounted.
 //
 // Bump on any template change that affects pod-visible behavior.
-const envoyBootstrapTemplateRev = "v2-pinned-upstreams"
+const envoyBootstrapTemplateRev = "v3-paired-gateway"
 
 // envoySecretsRev is a stable digest of the Secret set that drives Envoy's
 // chain rendering: secret name + host + secret-type label + headerName,
@@ -738,10 +747,11 @@ func envoySecretsRev(secrets []corev1.Secret) string {
 	return hex.EncodeToString(sum[:8])
 }
 
-// envoySidecarContainer returns the Envoy sidecar spec. Drops all caps,
+// envoyContainer returns the gateway pod's Envoy container spec. Drops all caps,
 // ReadOnlyRootFilesystem; mounts only the bootstrap CM and the owner's
-// credential Secrets.
-func envoySidecarContainer(cfg *config.Config, secrets []corev1.Secret) corev1.Container {
+// credential Secrets. Used as the sole non-init container of the paired
+// gateway pod (ADR-038).
+func envoyContainer(cfg *config.Config, secrets []corev1.Secret) corev1.Container {
 	mounts := []corev1.VolumeMount{{
 		Name:      envoyBootstrapVolume,
 		MountPath: envoyBootstrapMount,

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -9,6 +9,7 @@ import (
 	cmv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -111,7 +112,28 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 		}
 	}
 
-	desired := BuildForkJob(forkName, forkSpec, instanceSpec, agentSpec, r.config, cm, credentialSecrets)
+	// ADR-038: paired gateway pod for the fork. Render the gateway-side
+	// resources first so HTTPS_PROXY's target exists by the time the
+	// agent Job's pod starts dialing it.
+	gatewayPod := BuildForkGatewayPod(forkName, forkSpec.Instance, r.config, cm, credentialSecrets)
+	gatewaySvc := BuildForkGatewayService(forkName, r.config, cm)
+	gatewayNP := BuildForkGatewayNetworkPolicy(forkName, r.config, cm)
+	agentNP := BuildForkAgentNetworkPolicy(forkName, r.config, cm)
+
+	if err := r.applyPod(ctx, gatewayPod); err != nil {
+		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying gateway pod: %v", err))
+	}
+	if err := r.applyService(ctx, gatewaySvc); err != nil {
+		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying gateway service: %v", err))
+	}
+	if err := r.applyNetworkPolicy(ctx, gatewayNP); err != nil {
+		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying gateway networkpolicy: %v", err))
+	}
+	if err := r.applyNetworkPolicy(ctx, agentNP); err != nil {
+		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying agent networkpolicy: %v", err))
+	}
+
+	desired := BuildForkAgentJob(forkName, forkSpec, instanceSpec, agentSpec, r.config, cm, credentialSecrets)
 
 	if err := r.applyForkJob(ctx, desired); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying job: %v", err))
@@ -163,6 +185,48 @@ func (r *ForkReconciler) applyForkJob(ctx context.Context, desired *batchv1.Job)
 			_, err = r.client.BatchV1().Jobs(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
 			return err
 		}
+		return err
+	})
+}
+
+// applyPod creates the fork's gateway Pod if missing. Bare Pods are immutable
+// in their key fields (image, args, volumes), so we treat existing Pods as
+// authoritative — a re-render with the same fork name keeps the running pod.
+// Owner references on the Pod GC it when the fork CM is deleted.
+func (r *ForkReconciler) applyPod(ctx context.Context, desired *corev1.Pod) error {
+	_, err := r.client.CoreV1().Pods(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = r.client.CoreV1().Pods(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+		return err
+	}
+	return err
+}
+
+// applyService mirrors `InstanceReconciler.applyService` for fork-scoped
+// gateway Services.
+func (r *ForkReconciler) applyService(ctx context.Context, desired *corev1.Service) error {
+	_, err := r.client.CoreV1().Services(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+	if errors.IsNotFound(err) {
+		_, err = r.client.CoreV1().Services(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+		return err
+	}
+	return err
+}
+
+// applyNetworkPolicy mirrors `InstanceReconciler.applyNetworkPolicy` for
+// fork-scoped policies (per-fork agent and gateway pair).
+func (r *ForkReconciler) applyNetworkPolicy(ctx context.Context, desired *networkingv1.NetworkPolicy) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Get(ctx, desired.Name, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			_, err = r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Create(ctx, desired, metav1.CreateOptions{})
+			return err
+		}
+		if err != nil {
+			return err
+		}
+		existing.Spec = desired.Spec
+		_, err = r.client.NetworkingV1().NetworkPolicies(desired.Namespace).Update(ctx, existing, metav1.UpdateOptions{})
 		return err
 	})
 }

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -19,25 +19,20 @@ const (
 	ForkLabelType        = "agent-platform.ai/type"
 )
 
-// BuildForkJob constructs the per-turn foreign-user fork pod.
+// BuildForkAgentJob constructs the agent half of the per-turn paired pod
+// pair (ADR-038). The fork agent runs the harness; egress credential
+// injection happens in the paired fork gateway pod, reached via HTTPS_PROXY.
 //
 // `credentialSecrets` are the replier's `(owner=foreignSub, connection=*)`
-// K8s Secrets — the instance owner's Secrets must NOT appear here; the
-// credential boundary is the container and the agent never sees Secret
-// bytes. `HTTPS_PROXY` points at the colocated `envoy` sidecar on
-// `127.0.0.1`; SA-token automount and process-namespace sharing are
-// disabled.
+// K8s Secrets — the instance owner's Secrets must NOT appear here. They mount
+// only on the paired gateway pod (ADR-027 + ADR-038). The agent container
+// itself sees no Secret bytes.
 //
 // Forks deliberately do NOT receive `PLATFORM_POD_FILES_EVENTS_URL`, so the
 // agent-runtime running in the fork pod skips the pod-files SSE loop
 // entirely. Forks are short-lived ACP-relay jobs spawned per turn; the
-// SSE overhead per pod isn't justified for that lifecycle, and most
-// pod-files state (config, allowlists, host entries for connection-
-// aware CLIs) is irrelevant to the relay flow. If a future fork-
-// relevant feature ever needs files materialized in fork pods, set
-// `PLATFORM_POD_FILES_EVENTS_URL` on the fork's env here — until then,
-// pod-files state inside fork pods is unsupported on purpose.
-func BuildForkJob(
+// SSE overhead per pod isn't justified for that lifecycle.
+func BuildForkAgentJob(
 	forkName string,
 	forkSpec *types.ForkSpec,
 	instanceSpec *types.InstanceSpec,
@@ -47,38 +42,48 @@ func BuildForkJob(
 	credentialSecrets []corev1.Secret,
 ) *batchv1.Job {
 	labels := map[string]string{
-		ForkLabelType:        ForkJobLabelType,
-		ForkLabelForkID:      forkName,
+		ForkLabelType:   ForkJobLabelType,
+		ForkLabelForkID: forkName,
+		// `agent-platform.ai/instance` references the *parent* instance for
+		// fork pods — the pod-IP resolver and ext_authz identity flow
+		// through that label, so traffic from the fork resolves under the
+		// parent's egress rules (ADR-027).
 		ForkLabelInstanceRef: forkSpec.Instance,
+		// Pair key + role for ADR-038 NetworkPolicy / Service scoping.
+		// Using the fork name as the pair key isolates the fork from the
+		// parent instance pair: fork agent only reaches fork gateway,
+		// never the parent's gateway.
+		LabelPair: forkName,
+		LabelRole: RoleAgent,
 	}
 
 	caCertPath := "/etc/platform/ca/ca.crt"
 
-	proxyAddr := fmt.Sprintf("http://127.0.0.1:%d", cfg.EnvoyPort)
+	// Paired gateway Service DNS — stable across the fork lifetime.
+	proxyAddr := fmt.Sprintf("http://%s:%d", GatewayName(forkName), cfg.EnvoyPort)
 
-	env := []corev1.EnvVar{}
-	env = append(env,
-		corev1.EnvVar{Name: "HTTPS_PROXY", Value: proxyAddr},
-		corev1.EnvVar{Name: "HTTP_PROXY", Value: proxyAddr},
-		corev1.EnvVar{Name: "https_proxy", Value: proxyAddr},
-		corev1.EnvVar{Name: "http_proxy", Value: proxyAddr},
-		corev1.EnvVar{Name: "NO_PROXY", Value: cfg.APIServerHost},
-		corev1.EnvVar{Name: "no_proxy", Value: cfg.APIServerHost},
-		corev1.EnvVar{Name: "SSL_CERT_FILE", Value: caCertPath},
-		corev1.EnvVar{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
-		corev1.EnvVar{Name: "GIT_SSL_CAINFO", Value: caCertPath},
-		corev1.EnvVar{Name: "NODE_USE_ENV_PROXY", Value: "1"},
-		corev1.EnvVar{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
-		corev1.EnvVar{Name: "ADK_INSTANCE_ID", Value: forkSpec.Instance},
-		corev1.EnvVar{Name: "API_SERVER_URL", Value: cfg.APIServerURL()},
-		corev1.EnvVar{Name: "HOME", Value: cfg.AgentHome},
-		corev1.EnvVar{Name: "PLATFORM_MCP_URL", Value: fmt.Sprintf("%s/api/instances/%s/mcp", cfg.HarnessServerURL, forkSpec.Instance)},
-		corev1.EnvVar{Name: "PLATFORM_FORK_ID", Value: forkName},
-		corev1.EnvVar{Name: "PLATFORM_FOREIGN_SUB", Value: forkSpec.ForeignSub},
-	)
+	env := []corev1.EnvVar{
+		{Name: "HTTPS_PROXY", Value: proxyAddr},
+		{Name: "HTTP_PROXY", Value: proxyAddr},
+		{Name: "https_proxy", Value: proxyAddr},
+		{Name: "http_proxy", Value: proxyAddr},
+		{Name: "NO_PROXY", Value: cfg.APIServerHost},
+		{Name: "no_proxy", Value: cfg.APIServerHost},
+		{Name: "SSL_CERT_FILE", Value: caCertPath},
+		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
+		{Name: "GIT_SSL_CAINFO", Value: caCertPath},
+		{Name: "NODE_USE_ENV_PROXY", Value: "1"},
+		{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
+		{Name: "ADK_INSTANCE_ID", Value: forkSpec.Instance},
+		{Name: "API_SERVER_URL", Value: cfg.APIServerURL()},
+		{Name: "HOME", Value: cfg.AgentHome},
+		{Name: "PLATFORM_MCP_URL", Value: fmt.Sprintf("%s/api/instances/%s/mcp", cfg.HarnessServerURL, forkSpec.Instance)},
+		{Name: "PLATFORM_FORK_ID", Value: forkName},
+		{Name: "PLATFORM_FOREIGN_SUB", Value: forkSpec.ForeignSub},
+	}
 	// Placeholder credential envs from the replier's K8s Secrets — same
-	// purpose as the long-lived StatefulSet shape: satisfy the harness's
-	// is-env-set check; Envoy overrides the header on the wire.
+	// purpose as the long-lived shape: satisfy the harness's is-env-set
+	// check; the gateway's Envoy overwrites the header on the wire.
 	env = append(env, credentialEnvVars(credentialSecrets)...)
 	for _, e := range agentSpec.Env {
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
@@ -123,14 +128,15 @@ func BuildForkJob(
 	}
 
 	// CA cert volume — projected from the per-fork cert-manager-issued leaf
-	// Secret. Mirrors `BuildStatefulSet`.
+	// Secret (single-key projection). The leaf private key (tls.key) lives
+	// only on the paired gateway pod (ADR-038).
 	if len(credentialSecrets) > 0 {
 		volumes = append(volumes, corev1.Volume{
 			Name: "ca-cert",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
 					SecretName: EnvoyLeafSecretName(forkName),
-					Items: []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
+					Items:      []corev1.KeyToPath{{Key: "ca.crt", Path: "ca.crt"}},
 				},
 			},
 		})
@@ -152,8 +158,7 @@ func BuildForkJob(
 		resourceReqs.Limits = toResourceList(agentSpec.Resources.Limits)
 	}
 
-	// Init containers: optional user-defined init only. The CA cert is
-	// projected from the per-fork leaf Secret, so no fetch step is needed.
+	// Init containers: optional user-defined init only.
 	var initContainers []corev1.Container
 	if agentSpec.Init != "" {
 		initContainers = append(initContainers, corev1.Container{
@@ -176,6 +181,13 @@ func BuildForkJob(
 			RunAsNonRoot: agentSpec.SecurityContext.RunAsNonRoot,
 		}
 	}
+
+	// GH_TOKEN signal — mirrors the long-lived shape.
+	ghAvail := "false"
+	if hasGitHubCredential(credentialSecrets) {
+		ghAvail = "true"
+	}
+	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})
 
 	containers := []corev1.Container{{
 		Name:            "agent",
@@ -204,27 +216,9 @@ func BuildForkJob(
 		VolumeMounts: volumeMounts,
 	}}
 
-	// Sidecar only — agent container never sees credential mounts.
-	volumes = append(volumes, envoySidecarVolumes(forkName, credentialSecrets)...)
-	containers = append(containers, envoySidecarContainer(cfg, credentialSecrets))
-	// ADR-033 Threat Model: agent must have no SA token (Secret-read RBAC
-	// would otherwise bypass volume-mount scoping) and process namespace
-	// must not be shared with the sidecar.
 	falseVal := false
 	automountSAToken := &falseVal
 	shareProcessNS := &falseVal
-
-	// GH_TOKEN signal — mirrors `BuildStatefulSet`. Surface whether a
-	// GitHub credential is wired up so tooling doesn't have to make a
-	// 401-eliciting request to find out.
-	ghAvail := "false"
-	if hasGitHubCredential(credentialSecrets) {
-		ghAvail = "true"
-	}
-	containers[0].Env = append(containers[0].Env, corev1.EnvVar{
-		Name:  "PLATFORM_GH_TOKEN_AVAILABLE",
-		Value: ghAvail,
-	})
 
 	ttl := int32(60)
 	backoff := int32(0)

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -33,23 +33,28 @@ var testForkInstance = &types.InstanceSpec{
 	Env:          []types.EnvVar{{Name: "GITHUB_ORG", Value: "alpha"}},
 }
 
-func TestBuildForkJob_BasicShape(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+func TestBuildForkAgentJob_BasicShape(t *testing.T) {
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
 
 	require.NotNil(t, job)
 	assert.Equal(t, "fork-abc", job.Name)
 	assert.Equal(t, "test-agents", job.Namespace)
 	assert.Equal(t, "agent-fork-job", job.Labels["agent-platform.ai/type"])
 	assert.Equal(t, "fork-abc", job.Labels["agent-platform.ai/fork-id"])
+	// `instance` label references the parent — for resolver / ext_authz
+	// identity. `pair` is the fork's own name — for ADR-038 NetworkPolicy
+	// scoping.
 	assert.Equal(t, "my-instance", job.Labels["agent-platform.ai/instance"])
+	assert.Equal(t, "fork-abc", job.Labels["agent-platform.ai/pair"])
+	assert.Equal(t, "agent", job.Labels["agent-platform.ai/role"])
 
 	require.Len(t, job.OwnerReferences, 1)
 	assert.Equal(t, "fork-uid-123", string(job.OwnerReferences[0].UID))
 	assert.True(t, *job.OwnerReferences[0].Controller)
 }
 
-func TestBuildForkJob_LifecycleGuarantees(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+func TestBuildForkAgentJob_LifecycleGuarantees(t *testing.T) {
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
 
 	require.NotNil(t, job.Spec.BackoffLimit)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
@@ -60,19 +65,20 @@ func TestBuildForkJob_LifecycleGuarantees(t *testing.T) {
 	assert.Equal(t, corev1.RestartPolicyNever, job.Spec.Template.Spec.RestartPolicy)
 }
 
-func TestBuildForkJob_ForkMetadataEnv(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+func TestBuildForkAgentJob_ForkMetadataEnv(t *testing.T) {
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
 	c := job.Spec.Template.Spec.Containers[0]
 
 	env := envMap(c.Env)
 	assert.Equal(t, "fork-abc", env["PLATFORM_FORK_ID"])
 	assert.Equal(t, "kc|user-42", env["PLATFORM_FOREIGN_SUB"])
 	assert.Equal(t, "my-instance", env["ADK_INSTANCE_ID"])
-	assert.Equal(t, "http://127.0.0.1:10000", env["HTTPS_PROXY"])
+	// HTTPS_PROXY targets the fork's OWN gateway — not the parent's.
+	assert.Equal(t, "http://fork-abc-gateway:10000", env["HTTPS_PROXY"])
 }
 
-func TestBuildForkJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+func TestBuildForkAgentJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
 
 	podSpec := job.Spec.Template.Spec
 
@@ -89,14 +95,14 @@ func TestBuildForkJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
 	assert.Nil(t, persistentVol.EmptyDir)
 }
 
-func TestBuildForkJob_InheritsInstanceEnvAndSecretRef(t *testing.T) {
+func TestBuildForkAgentJob_InheritsInstanceEnvAndSecretRef(t *testing.T) {
 	instance := &types.InstanceSpec{
 		Version:      types.SpecVersion,
 		DesiredState: "running",
 		Env:          []types.EnvVar{{Name: "FOO", Value: "bar"}},
 		SecretRef:    "my-extra-secret",
 	}
-	job := BuildForkJob("fork-abc", testForkSpec, instance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, instance, testAgent, testConfig, testForkOwnerCM, nil)
 	c := job.Spec.Template.Spec.Containers[0]
 
 	assert.Equal(t, "bar", envMap(c.Env)["FOO"])
@@ -113,20 +119,19 @@ func envMap(envs []corev1.EnvVar) map[string]string {
 	return m
 }
 
-func TestBuildForkJob_AddsEnvoySidecar(t *testing.T) {
+func TestBuildForkAgentJob_NoSidecar(t *testing.T) {
+	// ADR-038: agent and gateway are paired pods, not co-located. Fork
+	// agents have only one container.
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
 
-	require.Len(t, job.Spec.Template.Spec.Containers, 2, "agent + envoy sidecar")
+	require.Len(t, job.Spec.Template.Spec.Containers, 1, "fork agent has no sidecar")
 	agent := job.Spec.Template.Spec.Containers[0]
-	envoy := job.Spec.Template.Spec.Containers[1]
 	assert.Equal(t, "agent", agent.Name)
-	assert.Equal(t, "envoy", envoy.Name)
-	assert.Equal(t, "envoyproxy/envoy:distroless-v1.37.2", envoy.Image)
 
 	envM := envMap(agent.Env)
-	assert.Equal(t, "http://127.0.0.1:10000", envM["HTTP_PROXY"])
-	assert.Equal(t, "http://127.0.0.1:10000", envM["HTTPS_PROXY"])
+	assert.Equal(t, "http://fork-abc-gateway:10000", envM["HTTP_PROXY"])
+	assert.Equal(t, "http://fork-abc-gateway:10000", envM["HTTPS_PROXY"])
 
 	require.NotNil(t, job.Spec.Template.Spec.AutomountServiceAccountToken)
 	assert.False(t, *job.Spec.Template.Spec.AutomountServiceAccountToken)
@@ -134,28 +139,29 @@ func TestBuildForkJob_AddsEnvoySidecar(t *testing.T) {
 	assert.False(t, *job.Spec.Template.Spec.ShareProcessNamespace)
 }
 
-func TestBuildForkJob_ReplierSecretsMountedSidecarOnly(t *testing.T) {
+func TestBuildForkAgentJob_NoCredentialMountsOnAgent(t *testing.T) {
+	// Replier credentials live on the paired fork gateway pod only.
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
 
-	require.Len(t, job.Spec.Template.Spec.Containers, 2)
-	agent := job.Spec.Template.Spec.Containers[0]
-	envoy := job.Spec.Template.Spec.Containers[1]
-
-	envoyMounts := map[string]bool{}
-	for _, m := range envoy.VolumeMounts {
-		envoyMounts[m.Name] = true
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		assert.NotContains(t, v.Name, "cred-platform-cred-",
+			"fork agent pod must not mount credential Secrets (ADR-038)")
+		assert.NotEqual(t, "envoy-bootstrap", v.Name,
+			"fork agent must not mount the Envoy bootstrap CM")
+		assert.NotEqual(t, "envoy-tls", v.Name,
+			"fork agent must not mount the leaf TLS Secret with the private key")
 	}
-	require.True(t, envoyMounts["cred-platform-cred-replier-x"], "envoy must mount the replier credential secret")
 
-	for _, m := range agent.VolumeMounts {
-		assert.NotEqual(t, "cred-platform-cred-replier-x", m.Name, "credential boundary lives at the container — agent must not see Secret bytes")
+	for _, m := range job.Spec.Template.Spec.Containers[0].VolumeMounts {
+		assert.NotContains(t, m.Name, "cred-platform-cred-",
+			"credential boundary lives at the pod boundary — fork agent never sees Secret bytes")
 	}
 }
 
-func TestBuildForkJob_NoFetchCACertInit(t *testing.T) {
+func TestBuildForkAgentJob_NoFetchCACertInit(t *testing.T) {
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
 
 	for _, ic := range job.Spec.Template.Spec.InitContainers {
 		assert.NotEqual(t, "fetch-ca-cert", ic.Name, "no fetch-ca-cert init container")
@@ -171,9 +177,12 @@ func TestBuildForkJob_NoFetchCACertInit(t *testing.T) {
 	require.NotNil(t, caVol)
 	require.NotNil(t, caVol.Secret)
 	assert.Equal(t, EnvoyLeafSecretName("fork-abc"), caVol.Secret.SecretName)
+	require.Len(t, caVol.Secret.Items, 1)
+	assert.Equal(t, "ca.crt", caVol.Secret.Items[0].Key,
+		"fork agent must only see ca.crt — never tls.key")
 }
 
-func TestBuildForkJob_GHTokenSignal(t *testing.T) {
+func TestBuildForkAgentJob_GHTokenSignal(t *testing.T) {
 	cases := map[string]struct {
 		secrets []corev1.Secret
 		want    string
@@ -184,7 +193,7 @@ func TestBuildForkJob_GHTokenSignal(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			job := BuildForkJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, tc.secrets)
+			job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, tc.secrets)
 			env := envMap(job.Spec.Template.Spec.Containers[0].Env)
 			assert.Equal(t, tc.want, env["PLATFORM_GH_TOKEN_AVAILABLE"])
 		})

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -1,0 +1,283 @@
+package reconciler
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+)
+
+// Paired gateway pod (ADR-038). The gateway runs Envoy and is the only
+// pod the paired agent can reach for TCP 80/443. Credential Secrets, the
+// leaf TLS Secret, and the Envoy bootstrap ConfigMap mount here only —
+// the agent pod has no path to Secret material.
+
+// GatewayName returns the per-pair gateway pod / Service name.
+func GatewayName(pairKey string) string {
+	return pairKey + "-gateway"
+}
+
+// BuildGatewayStatefulSet renders the long-lived gateway StatefulSet paired
+// with the agent StatefulSet of the same instance. Replicas track the agent's
+// desired state (running → 1, hibernated → 0) so the pair scales as a unit.
+//
+// `instanceName` is both the pair key and the parent instance reference
+// (long-lived pairs collapse the two).
+func BuildGatewayStatefulSet(instanceName string, hibernated bool, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret) *appsv1.StatefulSet {
+	replicas := int32(1)
+	if hibernated {
+		replicas = 0
+	}
+
+	gatewayName := GatewayName(instanceName)
+	labels := map[string]string{
+		LabelInstance: instanceName,
+		LabelPair:     instanceName,
+		LabelRole:     RoleGateway,
+	}
+
+	volumes := envoyVolumes(instanceName, credentialSecrets)
+	containers := []corev1.Container{envoyContainer(cfg, credentialSecrets)}
+
+	falseVal := false
+
+	annotations := map[string]string{
+		// Roll trigger (ADR-035): hash of the Secret set driving the Envoy
+		// bootstrap. When the api-server adds an allow-only Secret to promote
+		// a host onto L7, the hash changes, the pod template diverges, and
+		// the gateway StatefulSet rolls so Envoy picks up the new chain set
+		// + leaf cert.
+		"agent-platform.ai/envoy-secrets-rev": envoySecretsRev(credentialSecrets),
+	}
+
+	return &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: cfg.Namespace,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+			},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas:    &replicas,
+			ServiceName: gatewayName,
+			Selector:    &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels:      labels,
+					Annotations: annotations,
+				},
+				Spec: corev1.PodSpec{
+					TerminationGracePeriodSeconds: &cfg.TerminationGracePeriod,
+					AutomountServiceAccountToken:  &falseVal,
+					Containers:                    containers,
+					Volumes:                       volumes,
+				},
+			},
+		},
+	}
+}
+
+// BuildGatewayService is the headless Service the agent reaches via
+// `HTTPS_PROXY`. Service-form is stable across gateway pod restarts; pod-DNS
+// would tie the agent's env to a StatefulSet ordinal (ADR-038).
+func BuildGatewayService(instanceName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
+	gatewayName := GatewayName(instanceName)
+	envoyPort := int32(cfg.EnvoyPort)
+	selector := map[string]string{LabelPair: instanceName, LabelRole: RoleGateway}
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: cfg.Namespace,
+			Labels:    map[string]string{LabelInstance: instanceName, LabelPair: instanceName, LabelRole: RoleGateway},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Selector:  selector,
+			Ports: []corev1.ServicePort{{
+				Name:       "proxy",
+				Port:       envoyPort,
+				TargetPort: intstr.FromInt32(envoyPort),
+			}},
+		},
+	}
+}
+
+// BuildGatewayNetworkPolicy admits ingress only from the paired agent pod
+// (exact-match on pair + role) and egress to upstream services + the
+// api-server's ext_authz endpoint + DNS.
+//
+// `pairKey` is the pair identifier — long-lived instances use the instance
+// name; forks use the fork name.
+func BuildGatewayNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+	envoyPort := intstr.FromInt32(int32(cfg.EnvoyPort))
+	extAuthzPort := intstr.FromInt32(int32(cfg.ExtAuthzPort))
+	httpsPort := intstr.FromInt32(443)
+	httpPort := intstr.FromInt32(80)
+	dnsPort := intstr.FromInt32(53)
+	dnsTargetPort := intstr.FromInt32(5353)
+
+	egress := []networkingv1.NetworkPolicyEgressRule{
+		{
+			// Envoy reaches arbitrary upstreams. ADR-033 §Decision keeps
+			// the first-cut allowlist permissive (no DNS allowlist in v1).
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &tcp, Port: &httpsPort},
+				{Protocol: &tcp, Port: &httpPort},
+			},
+		},
+		{
+			// HITL ext_authz gate (ADR-035). gRPC Check on every credentialed
+			// request and on the L4 catch-all chain. failure_mode_allow=false
+			// in Envoy means a blocked Check fails closed.
+			To: []networkingv1.NetworkPolicyPeer{{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app.kubernetes.io/component": "apiserver"},
+				},
+				NamespaceSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kubernetes.io/metadata.name": cfg.ReleaseNamespace},
+				},
+			}},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &tcp, Port: &extAuthzPort},
+			},
+		},
+		{
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &tcp, Port: &dnsPort},
+				{Protocol: &udp, Port: &dnsPort},
+				{Protocol: &tcp, Port: &dnsTargetPort},
+				{Protocol: &udp, Port: &dnsTargetPort},
+			},
+		},
+	}
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      GatewayName(pairKey) + "-egress",
+			Namespace: cfg.Namespace,
+			Labels:    map[string]string{LabelPair: pairKey, LabelRole: RoleGateway},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{LabelPair: pairKey, LabelRole: RoleGateway},
+			},
+			PolicyTypes: []networkingv1.PolicyType{
+				networkingv1.PolicyTypeEgress,
+				networkingv1.PolicyTypeIngress,
+			},
+			Egress: egress,
+			// Ingress only from the paired agent pod. Wildcard or
+			// instance-only selectors would let other pairs' agents dial
+			// in (ADR-038 §Threat Model).
+			Ingress: []networkingv1.NetworkPolicyIngressRule{{
+				From: []networkingv1.NetworkPolicyPeer{{
+					PodSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							LabelPair: pairKey,
+							LabelRole: RoleAgent,
+						},
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{{
+					Protocol: &tcp, Port: &envoyPort,
+				}},
+			}},
+		},
+	}
+}
+
+// BuildForkGatewayPod renders the gateway pod for a fork. Forks use a bare
+// Pod (not a StatefulSet) — there is exactly one fork pod ever, and the
+// owner reference on the fork ConfigMap GCs the Pod when the fork CM is
+// deleted (ADR-038).
+//
+// `parentInstanceID` flows into the `agent-platform.ai/instance` label so
+// ext_authz Check calls from this gateway resolve under the parent
+// instance's egress rules (ADR-027). The pair key is the fork's own name
+// so the fork pair is structurally isolated from the parent instance pair.
+func BuildForkGatewayPod(forkName, parentInstanceID string, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret) *corev1.Pod {
+	gatewayName := GatewayName(forkName)
+	labels := map[string]string{
+		LabelInstance: parentInstanceID,
+		LabelPair:     forkName,
+		LabelRole:     RoleGateway,
+		ForkLabelType: ForkJobLabelType,
+	}
+
+	volumes := envoyVolumes(forkName, credentialSecrets)
+	containers := []corev1.Container{envoyContainer(cfg, credentialSecrets)}
+
+	falseVal := false
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: cfg.Namespace,
+			Labels:    labels,
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+			},
+		},
+		Spec: corev1.PodSpec{
+			RestartPolicy:                 corev1.RestartPolicyAlways,
+			TerminationGracePeriodSeconds: &cfg.TerminationGracePeriod,
+			AutomountServiceAccountToken:  &falseVal,
+			Containers:                    containers,
+			Volumes:                       volumes,
+		},
+	}
+}
+
+// BuildForkGatewayService gives the fork's agent Job a stable DNS name to
+// point HTTPS_PROXY at, mirroring the long-lived shape.
+func BuildForkGatewayService(forkName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
+	gatewayName := GatewayName(forkName)
+	envoyPort := int32(cfg.EnvoyPort)
+	selector := map[string]string{LabelPair: forkName, LabelRole: RoleGateway}
+	return &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      gatewayName,
+			Namespace: cfg.Namespace,
+			Labels:    map[string]string{LabelPair: forkName, LabelRole: RoleGateway},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			ClusterIP: corev1.ClusterIPNone,
+			Selector:  selector,
+			Ports: []corev1.ServicePort{{
+				Name:       "proxy",
+				Port:       envoyPort,
+				TargetPort: intstr.FromInt32(envoyPort),
+			}},
+		},
+	}
+}
+
+// BuildForkAgentNetworkPolicy mirrors BuildAgentNetworkPolicy but scopes the
+// pair key to the fork's name (each fork has its own paired gateway). Today
+// fork pods get no NetworkPolicy at all — this closes the bypass for forks
+// alongside the long-lived case (ADR-038).
+func BuildForkAgentNetworkPolicy(forkName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
+	return BuildAgentNetworkPolicy(forkName, cfg, ownerCM)
+}
+
+// BuildForkGatewayNetworkPolicy mirrors BuildGatewayNetworkPolicy for the
+// fork's gateway pod.
+func BuildForkGatewayNetworkPolicy(forkName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
+	return BuildGatewayNetworkPolicy(forkName, cfg, ownerCM)
+}

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -87,7 +87,7 @@ func BuildGatewayStatefulSet(instanceName string, hibernated bool, cfg *config.C
 // would tie the agent's env to a StatefulSet ordinal (ADR-038).
 func BuildGatewayService(instanceName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
 	gatewayName := GatewayName(instanceName)
-	envoyPort := int32(cfg.EnvoyPort)
+	envoyPort := portInt32(cfg.EnvoyPort)
 	selector := map[string]string{LabelPair: instanceName, LabelRole: RoleGateway}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -119,8 +119,8 @@ func BuildGatewayService(instanceName string, cfg *config.Config, ownerCM *corev
 func BuildGatewayNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
-	envoyPort := intstr.FromInt32(int32(cfg.EnvoyPort))
-	extAuthzPort := intstr.FromInt32(int32(cfg.ExtAuthzPort))
+	envoyPort := intstr.FromInt32(portInt32(cfg.EnvoyPort))
+	extAuthzPort := intstr.FromInt32(portInt32(cfg.ExtAuthzPort))
 	httpsPort := intstr.FromInt32(443)
 	httpPort := intstr.FromInt32(80)
 	dnsPort := intstr.FromInt32(53)
@@ -245,7 +245,7 @@ func BuildForkGatewayPod(forkName, parentInstanceID string, cfg *config.Config, 
 // point HTTPS_PROXY at, mirroring the long-lived shape.
 func BuildForkGatewayService(forkName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
 	gatewayName := GatewayName(forkName)
-	envoyPort := int32(cfg.EnvoyPort)
+	envoyPort := portInt32(cfg.EnvoyPort)
 	selector := map[string]string{LabelPair: forkName, LabelRole: RoleGateway}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{

--- a/packages/controller/pkg/reconciler/gateway_test.go
+++ b/packages/controller/pkg/reconciler/gateway_test.go
@@ -161,3 +161,17 @@ func TestBuildForkGatewayService(t *testing.T) {
 	assert.Equal(t, "fork-abc", svc.Spec.Selector["agent-platform.ai/pair"])
 	assert.Equal(t, "gateway", svc.Spec.Selector["agent-platform.ai/role"])
 }
+
+// TestLabelContract pins the on-the-wire label keys and values that
+// NetworkPolicy selectors and the api-server's pod-IP resolver depend on.
+// The TS side has a mirror test in
+// `packages/api-server/src/__tests__/unit/label-contract.test.ts`. Drift
+// between the two would silently break the credential boundary
+// (ADR-038 §Threat Model).
+func TestLabelContract(t *testing.T) {
+	assert.Equal(t, "agent-platform.ai/instance", LabelInstance)
+	assert.Equal(t, "agent-platform.ai/pair", LabelPair)
+	assert.Equal(t, "agent-platform.ai/role", LabelRole)
+	assert.Equal(t, "agent", RoleAgent)
+	assert.Equal(t, "gateway", RoleGateway)
+}

--- a/packages/controller/pkg/reconciler/gateway_test.go
+++ b/packages/controller/pkg/reconciler/gateway_test.go
@@ -1,0 +1,163 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// --- Gateway StatefulSet ---
+
+func TestBuildGatewayStatefulSet_Shape(t *testing.T) {
+	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
+	ss := BuildGatewayStatefulSet("my-instance", false, testConfig, testOwnerCM, secrets)
+
+	require.NotNil(t, ss)
+	assert.Equal(t, "my-instance-gateway", ss.Name)
+	assert.Equal(t, "test-agents", ss.Namespace)
+	assert.Equal(t, int32(1), *ss.Spec.Replicas)
+
+	require.Len(t, ss.OwnerReferences, 1)
+	assert.Equal(t, "cm-uid-123", string(ss.OwnerReferences[0].UID))
+
+	labels := ss.Spec.Template.Labels
+	assert.Equal(t, "my-instance", labels["agent-platform.ai/instance"])
+	assert.Equal(t, "my-instance", labels["agent-platform.ai/pair"])
+	assert.Equal(t, "gateway", labels["agent-platform.ai/role"])
+
+	require.Len(t, ss.Spec.Template.Spec.Containers, 1, "gateway pod has exactly one Envoy container")
+	envoy := ss.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "envoy", envoy.Name)
+	assert.Equal(t, "envoyproxy/envoy:distroless-v1.37.2", envoy.Image)
+
+	mountPaths := map[string]string{}
+	for _, m := range envoy.VolumeMounts {
+		mountPaths[m.Name] = m.MountPath
+	}
+	assert.Equal(t, "/etc/envoy/credentials/cred-platform-cred-aaa", mountPaths["cred-platform-cred-aaa"])
+	assert.Equal(t, "/etc/envoy/tls", mountPaths["envoy-tls"])
+	assert.Equal(t, "/etc/envoy", mountPaths["envoy-bootstrap"])
+}
+
+func TestBuildGatewayStatefulSet_Hibernated(t *testing.T) {
+	ss := BuildGatewayStatefulSet("my-instance", true, testConfig, testOwnerCM, nil)
+	assert.Equal(t, int32(0), *ss.Spec.Replicas, "gateway scales with the agent")
+}
+
+func TestBuildGatewayStatefulSet_AutomountSAFalse(t *testing.T) {
+	ss := BuildGatewayStatefulSet("my-instance", false, testConfig, testOwnerCM, nil)
+	require.NotNil(t, ss.Spec.Template.Spec.AutomountServiceAccountToken)
+	assert.False(t, *ss.Spec.Template.Spec.AutomountServiceAccountToken,
+		"gateway pod must have no SA token — Secret-read RBAC would bypass volume-mount scoping")
+}
+
+func TestBuildGatewayStatefulSet_NoAgentVolumes(t *testing.T) {
+	// Workspace PVCs and CA-only mounts belong to the agent pod, not the
+	// gateway. The gateway only mounts the bootstrap CM, the leaf TLS
+	// Secret, and per-credential Secrets.
+	ss := BuildGatewayStatefulSet("my-instance", false, testConfig, testOwnerCM, nil)
+	for _, v := range ss.Spec.Template.Spec.Volumes {
+		assert.NotContains(t, v.Name, "home-agent",
+			"gateway must not mount the workspace PVC (ADR-038)")
+		assert.NotEqual(t, "ca-cert", v.Name,
+			"ca-cert is the agent-side projection; gateway holds the full leaf Secret")
+	}
+}
+
+// --- Gateway Service ---
+
+func TestBuildGatewayService(t *testing.T) {
+	svc := BuildGatewayService("my-instance", testConfig, testOwnerCM)
+	assert.Equal(t, "my-instance-gateway", svc.Name)
+	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
+	require.Len(t, svc.Spec.Ports, 1)
+	assert.Equal(t, "proxy", svc.Spec.Ports[0].Name)
+	assert.Equal(t, int32(10000), svc.Spec.Ports[0].Port)
+
+	// Selector pins to pair + role=gateway.
+	assert.Equal(t, "my-instance", svc.Spec.Selector["agent-platform.ai/pair"])
+	assert.Equal(t, "gateway", svc.Spec.Selector["agent-platform.ai/role"])
+}
+
+// --- Gateway NetworkPolicy ---
+
+func TestBuildGatewayNetworkPolicy(t *testing.T) {
+	np := BuildGatewayNetworkPolicy("my-instance", testConfig, testOwnerCM)
+	assert.Equal(t, "my-instance-gateway-egress", np.Name)
+	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels["agent-platform.ai/pair"])
+	assert.Equal(t, "gateway", np.Spec.PodSelector.MatchLabels["agent-platform.ai/role"])
+
+	// Egress: 80/443 anywhere, ext_authz to api-server, DNS.
+	require.Len(t, np.Spec.Egress, 3)
+
+	upstream := np.Spec.Egress[0]
+	assert.Empty(t, upstream.To, "upstream egress must not have a peer selector")
+	var saw80, saw443 bool
+	for _, p := range upstream.Ports {
+		if p.Port.IntVal == 80 {
+			saw80 = true
+		}
+		if p.Port.IntVal == 443 {
+			saw443 = true
+		}
+	}
+	assert.True(t, saw80, "gateway must permit egress on TCP 80")
+	assert.True(t, saw443, "gateway must permit egress on TCP 443")
+
+	extAuthz := np.Spec.Egress[1]
+	require.Len(t, extAuthz.To, 1)
+	assert.Equal(t, "apiserver", extAuthz.To[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
+	require.Len(t, extAuthz.Ports, 1)
+	assert.Equal(t, int32(4002), extAuthz.Ports[0].Port.IntVal)
+
+	// Ingress: paired agent pod only, exact pair-match.
+	require.Len(t, np.Spec.Ingress, 1)
+	require.Len(t, np.Spec.Ingress[0].From, 1)
+	from := np.Spec.Ingress[0].From[0]
+	require.NotNil(t, from.PodSelector)
+	assert.Equal(t, "my-instance", from.PodSelector.MatchLabels["agent-platform.ai/pair"])
+	assert.Equal(t, "agent", from.PodSelector.MatchLabels["agent-platform.ai/role"])
+	require.Len(t, np.Spec.Ingress[0].Ports, 1)
+	assert.Equal(t, int32(10000), np.Spec.Ingress[0].Ports[0].Port.IntVal)
+}
+
+// --- Fork gateway ---
+
+func TestBuildForkGatewayPod_Labels(t *testing.T) {
+	pod := BuildForkGatewayPod("fork-abc", "parent-instance", testConfig, testForkOwnerCM, nil)
+	assert.Equal(t, "fork-abc-gateway", pod.Name)
+	// Instance label points at the PARENT instance — ext_authz identity
+	// flows through this label, and forks inherit the parent's egress
+	// rules (ADR-027).
+	assert.Equal(t, "parent-instance", pod.Labels["agent-platform.ai/instance"])
+	// Pair key is the fork name — the fork pair is structurally isolated
+	// from the parent instance pair.
+	assert.Equal(t, "fork-abc", pod.Labels["agent-platform.ai/pair"])
+	assert.Equal(t, "gateway", pod.Labels["agent-platform.ai/role"])
+
+	require.Len(t, pod.OwnerReferences, 1)
+	assert.Equal(t, "fork-abc", pod.OwnerReferences[0].Name)
+
+	require.NotNil(t, pod.Spec.AutomountServiceAccountToken)
+	assert.False(t, *pod.Spec.AutomountServiceAccountToken)
+}
+
+func TestBuildForkAgentNetworkPolicy_PinsToForkGateway(t *testing.T) {
+	np := BuildForkAgentNetworkPolicy("fork-abc", testConfig, testForkOwnerCM)
+	// Egress to the gateway must use the fork's pair key, not the parent's.
+	require.NotEmpty(t, np.Spec.Egress)
+	gatewayEgress := np.Spec.Egress[0]
+	require.Len(t, gatewayEgress.To, 1)
+	assert.Equal(t, "fork-abc", gatewayEgress.To[0].PodSelector.MatchLabels["agent-platform.ai/pair"],
+		"fork agent must dial its OWN gateway, never the parent's (ADR-038)")
+	assert.Equal(t, "gateway", gatewayEgress.To[0].PodSelector.MatchLabels["agent-platform.ai/role"])
+}
+
+func TestBuildForkGatewayService(t *testing.T) {
+	svc := BuildForkGatewayService("fork-abc", testConfig, testOwnerCM)
+	assert.Equal(t, "fork-abc-gateway", svc.Name)
+	assert.Equal(t, "fork-abc", svc.Spec.Selector["agent-platform.ai/pair"])
+	assert.Equal(t, "gateway", svc.Spec.Selector["agent-platform.ai/role"])
+}

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -93,18 +93,36 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		}
 	}
 
-	ss := BuildStatefulSet(name, instanceSpec, agentSpec, r.config, cm, credentialSecrets)
-	svc := BuildService(name, r.config, cm)
-	np := BuildNetworkPolicy(name, r.config, cm)
+	hibernated := instanceSpec.DesiredState == "hibernated"
 
-	if err := r.applyStatefulSet(ctx, ss); err != nil {
-		return r.setError(ctx, name, fmt.Sprintf("applying statefulset: %v", err))
+	// ADR-038: paired pods, rendered as a unit. Render the gateway first
+	// so the agent's HTTPS_PROXY target exists by the time the agent pod
+	// starts dialing it.
+	gatewaySS := BuildGatewayStatefulSet(name, hibernated, r.config, cm, credentialSecrets)
+	gatewaySvc := BuildGatewayService(name, r.config, cm)
+	gatewayNP := BuildGatewayNetworkPolicy(name, r.config, cm)
+
+	agentSS := BuildAgentStatefulSet(name, instanceSpec, agentSpec, r.config, cm, credentialSecrets)
+	agentSvc := BuildAgentService(name, r.config, cm)
+	agentNP := BuildAgentNetworkPolicy(name, r.config, cm)
+
+	if err := r.applyStatefulSet(ctx, gatewaySS); err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("applying gateway statefulset: %v", err))
 	}
-	if err := r.applyService(ctx, svc); err != nil {
-		return r.setError(ctx, name, fmt.Sprintf("applying service: %v", err))
+	if err := r.applyService(ctx, gatewaySvc); err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("applying gateway service: %v", err))
 	}
-	if err := r.applyNetworkPolicy(ctx, np); err != nil {
-		return r.setError(ctx, name, fmt.Sprintf("applying networkpolicy: %v", err))
+	if err := r.applyNetworkPolicy(ctx, gatewayNP); err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("applying gateway networkpolicy: %v", err))
+	}
+	if err := r.applyStatefulSet(ctx, agentSS); err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("applying agent statefulset: %v", err))
+	}
+	if err := r.applyService(ctx, agentSvc); err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("applying agent service: %v", err))
+	}
+	if err := r.applyNetworkPolicy(ctx, agentNP); err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("applying agent networkpolicy: %v", err))
 	}
 
 	state := instanceSpec.DesiredState
@@ -148,11 +166,12 @@ func (r *InstanceReconciler) ensureAgentOwnerReference(ctx context.Context, inst
 }
 
 func (r *InstanceReconciler) Delete(ctx context.Context, name string) {
-	// Owner references handle cascade deletion of StatefulSet, Service,
-	// NetworkPolicy, and the agent-runtime token Secret.
+	// Owner references handle cascade deletion of both StatefulSets
+	// (agent + gateway), both Services, both NetworkPolicies, the Envoy
+	// bootstrap ConfigMap, and the cert-manager Certificate / leaf Secret.
 	//
-	// PVCs created via VolumeClaimTemplates are intentionally NOT deleted by
-	// Kubernetes when the StatefulSet is removed (to prevent data loss).
+	// PVCs created via VolumeClaimTemplates on the agent StatefulSet are
+	// intentionally NOT deleted by Kubernetes (to prevent data loss).
 	// We clean them up explicitly on instance removal.
 	r.deletePVCs(ctx, name)
 }

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -69,23 +69,35 @@ func TestReconcile_CreateResources(t *testing.T) {
 
 	ctx := context.Background()
 
-	// StatefulSet created with replicas=1
+	// Agent StatefulSet — replicas=1
 	ss, err := client.AppsV1().StatefulSets("test-agents").Get(ctx, "my-instance", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), *ss.Spec.Replicas)
 
-	// Proxy URL points at the colocated Envoy sidecar.
+	// Proxy URL targets the paired gateway Service (ADR-038).
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
-	assert.Equal(t, "http://127.0.0.1:10000", envMap["HTTPS_PROXY"])
+	assert.Equal(t, "http://my-instance-gateway:10000", envMap["HTTPS_PROXY"])
 
-	// Service created
+	// Gateway StatefulSet — also replicas=1
+	gws, err := client.AppsV1().StatefulSets("test-agents").Get(ctx, "my-instance-gateway", metav1.GetOptions{})
+	require.NoError(t, err, "gateway StatefulSet must be created alongside the agent")
+	assert.Equal(t, int32(1), *gws.Spec.Replicas)
+
+	// Agent Service
 	svc, err := client.CoreV1().Services("test-agents").Get(ctx, "my-instance", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 
-	// NetworkPolicy created
+	// Gateway Service
+	gwSvc, err := client.CoreV1().Services("test-agents").Get(ctx, "my-instance-gateway", metav1.GetOptions{})
+	require.NoError(t, err, "gateway Service must be created so HTTPS_PROXY DNS resolves")
+	assert.Equal(t, corev1.ClusterIPNone, gwSvc.Spec.ClusterIP)
+
+	// Both NetworkPolicies created
 	_, err = client.NetworkingV1().NetworkPolicies("test-agents").Get(ctx, "my-instance-egress", metav1.GetOptions{})
 	require.NoError(t, err)
+	_, err = client.NetworkingV1().NetworkPolicies("test-agents").Get(ctx, "my-instance-gateway-egress", metav1.GetOptions{})
+	require.NoError(t, err, "gateway NetworkPolicy must be created")
 
 	// Status written
 	updated, _ := client.CoreV1().ConfigMaps("test-agents").Get(ctx, "my-instance", metav1.GetOptions{})
@@ -104,6 +116,10 @@ func TestReconcile_Hibernate(t *testing.T) {
 
 	ss, _ := client.AppsV1().StatefulSets("test-agents").Get(context.Background(), "my-instance", metav1.GetOptions{})
 	assert.Equal(t, int32(0), *ss.Spec.Replicas)
+
+	// Gateway scales with the agent — both at 0 when hibernated.
+	gws, _ := client.AppsV1().StatefulSets("test-agents").Get(context.Background(), "my-instance-gateway", metav1.GetOptions{})
+	assert.Equal(t, int32(0), *gws.Spec.Replicas, "gateway must hibernate alongside the agent")
 
 	updated, _ := client.CoreV1().ConfigMaps("test-agents").Get(context.Background(), "my-instance", metav1.GetOptions{})
 	assert.Contains(t, updated.Data["status.yaml"], "currentState: hibernated")

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -14,21 +14,56 @@ import (
 	"github.com/kagenti/platform/packages/controller/pkg/types"
 )
 
-func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *types.AgentSpec, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret) *appsv1.StatefulSet {
+// ADR-038 paired-pod labels. `LabelPair` identifies the two pods of a single
+// agent/gateway pair; `LabelRole` distinguishes the roles inside the pair.
+//
+// Pair scope is *per orchestration unit*, not per instance: long-lived
+// instances use the instance name as the pair key, but forks use the fork
+// name (each fork has its own paired gateway, the parent's gateway is not
+// shared). The `LabelInstance` label still identifies the parent instance
+// for ext_authz / pod-IP resolver purposes — for long-lived pods it equals
+// the pair key, for fork pods it points at the parent instance so traffic
+// resolves under the parent's egress rules (ADR-027).
+const (
+	LabelInstance = "agent-platform.ai/instance"
+	LabelPair     = "agent-platform.ai/pair"
+	LabelRole     = "agent-platform.ai/role"
+	RoleAgent     = "agent"
+	RoleGateway   = "gateway"
+)
+
+// agentProxyAddr is the agent's HTTPS_PROXY value: the paired gateway pod's
+// Service DNS. Service-form is stable across gateway pod restarts (ADR-038).
+func agentProxyAddr(instanceName string, cfg *config.Config) string {
+	return fmt.Sprintf("http://%s:%d", GatewayName(instanceName), cfg.EnvoyPort)
+}
+
+// BuildAgentStatefulSet renders the agent half of the paired pod set
+// (ADR-038). The agent container holds zero credentials; egress credential
+// injection happens in the paired gateway pod, reached via HTTPS_PROXY.
+//
+// `credentialSecrets` is consulted only for the GH_TOKEN-availability signal
+// surfaced as an env var and pod annotation; no Secret material is mounted
+// into the agent pod.
+func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec *types.AgentSpec, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret) *appsv1.StatefulSet {
 	replicas := int32(1)
 	if instance.DesiredState == "hibernated" {
 		replicas = 0
 	}
 
-	labels := map[string]string{"agent-platform.ai/instance": name}
+	labels := map[string]string{
+		LabelInstance: name,
+		LabelPair:     name,
+		LabelRole:     RoleAgent,
+	}
 	caCertPath := "/etc/platform/ca/ca.crt"
 
-	proxyAddr := fmt.Sprintf("http://127.0.0.1:%d", cfg.EnvoyPort)
+	proxyAddr := agentProxyAddr(name, cfg)
 
 	// The agent container holds zero platform credentials. Inbound calls to
 	// agent-runtime's tRPC are gated at the kernel by the pod's
 	// NetworkPolicy (ingress admitted only from the api-server pod);
-	// outbound calls are credential-injected by the Envoy sidecar.
+	// outbound calls cross the paired gateway pod for credential injection.
 	env := []corev1.EnvVar{
 		{Name: "HTTPS_PROXY", Value: proxyAddr},
 		{Name: "HTTP_PROXY", Value: proxyAddr},
@@ -54,7 +89,8 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 	// Order matters: K8s resolves duplicate env names by keeping the last
 	// occurrence, so credential placeholders < template < instance — user
 	// overrides win. The placeholders only need to satisfy the harness's
-	// "is this env set?" check; Envoy overwrites the header on the wire.
+	// "is this env set?" check; Envoy in the paired gateway overwrites the
+	// header on the wire.
 	env = append(env, credentialEnvVars(credentialSecrets)...)
 	for _, e := range agentSpec.Env {
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
@@ -84,9 +120,6 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 			Name: volName, MountPath: m.Path,
 		})
 		if m.Persist {
-			// Per-mount `size:` (issue #244) wins over the cluster-wide
-			// AgentStorageSize default; both fall back to 10Gi.
-			// Validation happens in ParseAgentSpec, so MustParse here is safe.
 			storageSize := m.Size
 			if storageSize == "" {
 				storageSize = cfg.AgentStorageSize
@@ -109,7 +142,7 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 			pvcs = append(pvcs, corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   volName,
-					Labels: labels,
+					Labels: map[string]string{LabelInstance: name},
 				},
 				Spec: pvcSpec,
 			})
@@ -123,7 +156,8 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 
 	// CA cert volume — projected from the cert-manager-issued Envoy leaf
 	// Secret. We expose only the `ca.crt` key; the `tls.key` stays inside
-	// the Envoy sidecar's mount, never the agent's.
+	// the gateway pod's mount, never the agent's. This is the only
+	// platform-issued data the agent pod mounts (ADR-038).
 	if len(credentialSecrets) > 0 {
 		volumes = append(volumes, corev1.Volume{
 			Name: "ca-cert",
@@ -156,9 +190,7 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 		resourceReqs.Limits = toResourceList(agentSpec.Resources.Limits)
 	}
 
-	// Init containers: optional user-defined init only. The CA cert is
-	// projected from the cert-manager-issued leaf Secret, so no fetch step
-	// is needed.
+	// Init containers: optional user-defined init only.
 	var initContainers []corev1.Container
 	if agentSpec.Init != "" {
 		initContainers = append(initContainers, corev1.Container{
@@ -183,6 +215,15 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 			RunAsNonRoot: agentSpec.SecurityContext.RunAsNonRoot,
 		}
 	}
+
+	// GH_TOKEN signal. Surface whether a GitHub credential is wired up so
+	// wrapper scripts and operators can detect missing auth without making
+	// a 401-eliciting request first.
+	ghAvail := "false"
+	if hasGitHubCredential(credentialSecrets) {
+		ghAvail = "true"
+	}
+	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})
 
 	containers := []corev1.Container{{
 		Name:            "agent",
@@ -218,41 +259,21 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 		Resources:    resourceReqs,
 		VolumeMounts: volumeMounts,
 	}}
+
 	podAnnotations := map[string]string{}
 	for k, v := range cfg.AgentPodAnnotations {
 		podAnnotations[k] = v
 	}
+	podAnnotations["agent-platform.ai/gh-token-available"] = ghAvail
 
-	// Sidecar only — the agent container never sees credential mounts.
-	volumes = append(volumes, envoySidecarVolumes(name, credentialSecrets)...)
-	containers = append(containers, envoySidecarContainer(cfg, credentialSecrets))
 	// ADR-033 Threat Model: agent must have no SA token (Secret-read RBAC
-	// would otherwise bypass volume-mount scoping) and process namespace
-	// must not be shared with the sidecar.
+	// would otherwise bypass the per-pod credential boundary). With the
+	// paired-pod split (ADR-038) the agent and gateway are different pods
+	// so process-namespace sharing is structurally moot, but we keep
+	// `false` explicit for clarity.
 	falseVal := false
 	automountSAToken := &falseVal
 	shareProcessNS := &falseVal
-
-	// GH_TOKEN signal. Surface whether a GitHub credential is wired up so
-	// wrapper scripts and operators can detect missing auth without making
-	// a 401-eliciting request first.
-	ghAvail := "false"
-	if hasGitHubCredential(credentialSecrets) {
-		ghAvail = "true"
-	}
-	containers[0].Env = append(containers[0].Env, corev1.EnvVar{
-		Name:  "PLATFORM_GH_TOKEN_AVAILABLE",
-		Value: ghAvail,
-	})
-	podAnnotations["agent-platform.ai/gh-token-available"] = ghAvail
-
-	// Roll trigger (ADR-035 #10): hash of the Secret set driving the Envoy
-	// bootstrap. When the api-server adds an allow-only Secret to promote a
-	// host onto L7, the hash changes, the pod template diverges, and the
-	// StatefulSet rolls so Envoy picks up the new chain set + leaf cert.
-	// Without this, Secret list changes regenerate the bootstrap CM but
-	// don't restart the pod, and Envoy keeps serving the old config.
-	podAnnotations["agent-platform.ai/envoy-secrets-rev"] = envoySecretsRev(credentialSecrets)
 
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
@@ -288,19 +309,23 @@ func BuildStatefulSet(name string, instance *types.InstanceSpec, agentSpec *type
 	}
 }
 
-func BuildService(name string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
+// BuildAgentService is the headless Service the api-server uses to reach the
+// agent pod's ACP/tRPC port. Selector pins to the pair key + role=agent so
+// the gateway pod (which carries the same instance label) is excluded.
+func BuildAgentService(name string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
+	selector := map[string]string{LabelPair: name, LabelRole: RoleAgent}
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: cfg.Namespace,
-			Labels:    map[string]string{"agent-platform.ai/instance": name},
+			Labels:    map[string]string{LabelInstance: name, LabelPair: name, LabelRole: RoleAgent},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
 			},
 		},
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
-			Selector:  map[string]string{"agent-platform.ai/instance": name},
+			Selector:  selector,
 			Ports: []corev1.ServicePort{{
 				Name: "acp", Port: 8080, TargetPort: intstr.FromString("acp"),
 			}},
@@ -308,46 +333,44 @@ func BuildService(name string, cfg *config.Config, ownerCM *corev1.ConfigMap) *c
 	}
 }
 
-func BuildNetworkPolicy(name string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
+// BuildAgentNetworkPolicy is the cluster-enforced half of the credential
+// boundary on the agent side (ADR-038): no path to TCP 80/443 anywhere except
+// the paired gateway pod, plus the api-server harness port and DNS.
+//
+// `pairKey` is the pair identifier — the long-lived instance name for
+// long-lived agent pairs, the fork name for fork pairs. Both halves of the
+// pair carry `agent-platform.ai/pair=<pairKey>`.
+func BuildAgentNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
 	acpPort := intstr.FromInt32(8080)
 	harnessPort := intstr.FromInt32(int32(cfg.HarnessServerPort))
-	extAuthzPort := intstr.FromInt32(int32(cfg.ExtAuthzPort))
-	httpsPort := intstr.FromInt32(443)
-	httpPort := intstr.FromInt32(80)
+	envoyPort := intstr.FromInt32(int32(cfg.EnvoyPort))
 	dnsPort := intstr.FromInt32(53)
 	dnsTargetPort := intstr.FromInt32(5353)
 
-	// Sidecar reaches arbitrary upstreams. ADR-033 §Decision keeps the
-	// first-cut allowlist permissive (no DNS allowlist in v1) — refinement
-	// is a follow-up.
-	egress := []networkingv1.NetworkPolicyEgressRule{{
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &tcp, Port: &httpsPort},
-			{Protocol: &tcp, Port: &httpPort},
-		},
-	}, {
-		// HITL ext_authz gate (ADR-035). Envoy in this same pod calls the
-		// API server's ext_authz endpoint on every credentialed request.
-		// `failure_mode_allow: false` means a blocked call here fails
-		// closed — agent gets 403 with no inbox prompt.
-		To: []networkingv1.NetworkPolicyPeer{{
-			PodSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"app.kubernetes.io/component": "apiserver"},
+	egress := []networkingv1.NetworkPolicyEgressRule{
+		{
+			// Paired gateway pod only — exact-match on pair + role.
+			// Loosening to a wildcard would let one pair's agent dial
+			// another's gateway, defeating the boundary (ADR-038 §Threat Model).
+			To: []networkingv1.NetworkPolicyPeer{{
+				PodSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						LabelPair: pairKey,
+						LabelRole: RoleGateway,
+					},
+				},
+			}},
+			Ports: []networkingv1.NetworkPolicyPort{
+				{Protocol: &tcp, Port: &envoyPort},
 			},
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"kubernetes.io/metadata.name": cfg.ReleaseNamespace},
-			},
-		}},
-		Ports: []networkingv1.NetworkPolicyPort{
-			{Protocol: &tcp, Port: &extAuthzPort},
 		},
-	}}
-	egress = append(egress,
-		networkingv1.NetworkPolicyEgressRule{
+		{
 			// Harness API server: separate port exposing only the subset of
 			// API available to agent harnesses (triggers, MCP tools).
+			// Platform-internal control plane, not a credentialed external
+			// resource — no proxy hop needed.
 			To: []networkingv1.NetworkPolicyPeer{{
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"app.kubernetes.io/component": "apiserver"},
@@ -360,11 +383,8 @@ func BuildNetworkPolicy(name string, cfg *config.Config, ownerCM *corev1.ConfigM
 				{Protocol: &tcp, Port: &harnessPort},
 			},
 		},
-		networkingv1.NetworkPolicyEgressRule{
-			// DNS — allow both port 53 (service port) and 5353 (target port).
-			// OVN-Kubernetes evaluates egress policy after DNAT, so the policy
-			// sees the post-DNAT target port. OpenShift DNS pods run CoreDNS
-			// on 5353 behind a Service that maps 53→5353.
+		{
+			// DNS — service port (53) and CoreDNS-on-OpenShift target port (5353).
 			Ports: []networkingv1.NetworkPolicyPort{
 				{Protocol: &tcp, Port: &dnsPort},
 				{Protocol: &udp, Port: &dnsPort},
@@ -372,20 +392,20 @@ func BuildNetworkPolicy(name string, cfg *config.Config, ownerCM *corev1.ConfigM
 				{Protocol: &udp, Port: &dnsTargetPort},
 			},
 		},
-	)
+	}
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name + "-egress",
+			Name:      pairKey + "-egress",
 			Namespace: cfg.Namespace,
-			Labels:    map[string]string{"agent-platform.ai/instance": name},
+			Labels:    map[string]string{LabelPair: pairKey, LabelRole: RoleAgent},
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
 			},
 		},
 		Spec: networkingv1.NetworkPolicySpec{
 			PodSelector: metav1.LabelSelector{
-				MatchLabels: map[string]string{"agent-platform.ai/instance": name},
+				MatchLabels: map[string]string{LabelPair: pairKey, LabelRole: RoleAgent},
 			},
 			PolicyTypes: []networkingv1.PolicyType{
 				networkingv1.PolicyTypeEgress,

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -14,6 +14,19 @@ import (
 	"github.com/kagenti/platform/packages/controller/pkg/types"
 )
 
+// portInt32 narrows a config-supplied port (typed `int` because it comes
+// from `strconv.Atoi` on an env var) to int32 with an explicit upper-bound
+// check. Without the check, env-driven int → int32 conversion is flagged
+// by CodeQL (`go/incorrect-integer-conversion`) and could wrap on 32-bit
+// platforms; here it's a config-bootstrap invariant — port numbers are
+// uint16 — so a panic is the right shape if the operator misconfigures.
+func portInt32(p int) int32 {
+	if p < 0 || p > 65535 {
+		panic(fmt.Sprintf("port out of range: %d (must be 0..65535)", p))
+	}
+	return int32(p)
+}
+
 // ADR-038 paired-pod labels. `LabelPair` identifies the two pods of a single
 // agent/gateway pair; `LabelRole` distinguishes the roles inside the pair.
 //
@@ -344,8 +357,8 @@ func BuildAgentNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
 	acpPort := intstr.FromInt32(8080)
-	harnessPort := intstr.FromInt32(int32(cfg.HarnessServerPort))
-	envoyPort := intstr.FromInt32(int32(cfg.EnvoyPort))
+	harnessPort := intstr.FromInt32(portInt32(cfg.HarnessServerPort))
+	envoyPort := intstr.FromInt32(portInt32(cfg.EnvoyPort))
 	dnsPort := intstr.FromInt32(53)
 	dnsTargetPort := intstr.FromInt32(5353)
 

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -18,6 +18,7 @@ var testConfig = &config.Config{
 	ReleaseNamespace:  "default",
 	ReleaseName:       "platform",
 	HarnessServerPort: 4001,
+	ExtAuthzPort:      4002,
 	AgentHome:         "/home/agent",
 	EnvoyImage:        "envoyproxy/envoy:distroless-v1.37.2",
 	EnvoyPort:         10000,
@@ -62,15 +63,15 @@ func credSecret(name, host string) corev1.Secret {
 	}
 }
 
-// --- StatefulSet tests ---
+// --- Agent StatefulSet tests ---
 
-func TestBuildStatefulSet_Running(t *testing.T) {
+func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	instance := &types.InstanceSpec{
 		DesiredState: "running",
 		Env:          []types.EnvVar{{Name: "GITHUB_ORG", Value: "alpha"}},
 		SecretRef:    "my-secrets",
 	}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 
 	require.NotNil(t, ss)
 	assert.Equal(t, "my-instance", ss.Name)
@@ -81,9 +82,12 @@ func TestBuildStatefulSet_Running(t *testing.T) {
 	assert.Equal(t, "cm-uid-123", string(ss.OwnerReferences[0].UID))
 
 	assert.Equal(t, "my-instance", ss.Spec.Template.Labels["agent-platform.ai/instance"])
+	assert.Equal(t, "my-instance", ss.Spec.Template.Labels["agent-platform.ai/pair"])
+	assert.Equal(t, "agent", ss.Spec.Template.Labels["agent-platform.ai/role"])
 
-	require.Len(t, ss.Spec.Template.Spec.Containers, 2, "agent + envoy sidecar")
+	require.Len(t, ss.Spec.Template.Spec.Containers, 1, "agent only — gateway runs in its own paired pod (ADR-038)")
 	c := ss.Spec.Template.Spec.Containers[0]
+	assert.Equal(t, "agent", c.Name)
 	assert.Equal(t, "ghcr.io/myorg/agent:latest", c.Image)
 	assert.Equal(t, int32(8080), c.Ports[0].ContainerPort)
 	assert.Equal(t, "acp", c.Ports[0].Name)
@@ -93,11 +97,10 @@ func TestBuildStatefulSet_Running(t *testing.T) {
 	assert.Equal(t, int32(120), c.StartupProbe.FailureThreshold)
 
 	envMap := envToMap(c.Env)
-	assert.Equal(t, "http://127.0.0.1:10000", envMap["HTTPS_PROXY"])
-	assert.Equal(t, "http://127.0.0.1:10000", envMap["HTTP_PROXY"])
+	// HTTPS_PROXY now points at the paired gateway Service DNS, not loopback.
+	assert.Equal(t, "http://my-instance-gateway:10000", envMap["HTTPS_PROXY"])
+	assert.Equal(t, "http://my-instance-gateway:10000", envMap["HTTP_PROXY"])
 
-	// No platform-issued credential token in the agent container's env —
-	// the api-server → agent-runtime hop is gated by NetworkPolicy ingress.
 	for _, e := range c.Env {
 		assert.NotEqual(t, "AGENT_RUNTIME_TOKEN", e.Name)
 	}
@@ -116,15 +119,15 @@ func TestBuildStatefulSet_Running(t *testing.T) {
 	assert.True(t, *ss.Spec.Template.Spec.SecurityContext.RunAsNonRoot)
 }
 
-func TestBuildStatefulSet_Hibernated(t *testing.T) {
+func TestBuildAgentStatefulSet_Hibernated(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "hibernated"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 	assert.Equal(t, int32(0), *ss.Spec.Replicas)
 }
 
-func TestBuildStatefulSet_InitContainer(t *testing.T) {
+func TestBuildAgentStatefulSet_InitContainer(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 	require.Len(t, ss.Spec.Template.Spec.InitContainers, 1, "only the user-defined init runs")
 	ic := ss.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, "init", ic.Name)
@@ -132,17 +135,17 @@ func TestBuildStatefulSet_InitContainer(t *testing.T) {
 	assert.Equal(t, []string{"sh", "-c", testAgent.Init}, ic.Command)
 }
 
-func TestBuildStatefulSet_NoUserInitWhenEmpty(t *testing.T) {
+func TestBuildAgentStatefulSet_NoUserInitWhenEmpty(t *testing.T) {
 	agent := *testAgent
 	agent.Init = ""
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil)
 	assert.Empty(t, ss.Spec.Template.Spec.InitContainers)
 }
 
-func TestBuildStatefulSet_Volumes(t *testing.T) {
+func TestBuildAgentStatefulSet_Volumes(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 1)
 	pvc := ss.Spec.VolumeClaimTemplates[0]
@@ -168,7 +171,7 @@ func TestBuildStatefulSet_Volumes(t *testing.T) {
 	assert.Equal(t, "ca-cert", mountPaths["/etc/platform/ca"])
 }
 
-func TestBuildStatefulSet_PVCSize(t *testing.T) {
+func TestBuildAgentStatefulSet_PVCSize(t *testing.T) {
 	agent := types.AgentSpec{
 		Image: "platform-test:latest",
 		Mounts: []types.Mount{
@@ -177,7 +180,7 @@ func TestBuildStatefulSet_PVCSize(t *testing.T) {
 		},
 	}
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil)
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 2)
 	byName := map[string]corev1.PersistentVolumeClaim{}
@@ -190,11 +193,11 @@ func TestBuildStatefulSet_PVCSize(t *testing.T) {
 	assert.Equal(t, "10Gi", cache.String())
 }
 
-func TestBuildStatefulSet_AgentStorageClass(t *testing.T) {
+func TestBuildAgentStatefulSet_AgentStorageClass(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentStorageClass = "platform-rwx"
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 1)
 	pvc := ss.Spec.VolumeClaimTemplates[0]
@@ -202,11 +205,11 @@ func TestBuildStatefulSet_AgentStorageClass(t *testing.T) {
 	assert.Equal(t, "platform-rwx", *pvc.Spec.StorageClassName)
 }
 
-func TestBuildStatefulSet_PodFilesEventsURL(t *testing.T) {
+func TestBuildAgentStatefulSet_PodFilesEventsURL(t *testing.T) {
 	cfg := *testConfig
 	cfg.HarnessServerURL = "http://platform-apiserver.default.svc:4001"
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t,
@@ -214,67 +217,106 @@ func TestBuildStatefulSet_PodFilesEventsURL(t *testing.T) {
 		envMap["PLATFORM_POD_FILES_EVENTS_URL"])
 }
 
-func TestBuildStatefulSet_NoSecretRef(t *testing.T) {
+func TestBuildAgentStatefulSet_NoSecretRef(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 	assert.Empty(t, ss.Spec.Template.Spec.Containers[0].EnvFrom)
 }
 
-// --- Service tests ---
+func TestBuildAgentStatefulSet_NoCredentialMountsOnAgent(t *testing.T) {
+	// ADR-038: the agent pod's only platform-issued data is the CA cert
+	// (single-key projection of the leaf Secret). No credential Secrets,
+	// no Envoy bootstrap CM, no leaf private key.
+	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
 
-func TestBuildService(t *testing.T) {
-	svc := BuildService("my-instance", testConfig, testOwnerCM)
+	require.Len(t, ss.Spec.Template.Spec.Containers, 1, "no sidecar — gateway is its own pod")
+
+	for _, v := range ss.Spec.Template.Spec.Volumes {
+		assert.NotEqual(t, "envoy-bootstrap", v.Name, "agent pod must not mount the Envoy bootstrap CM")
+		assert.NotEqual(t, "envoy-tls", v.Name, "agent pod must not mount the leaf TLS Secret with the private key")
+		assert.NotContains(t, v.Name, "cred-platform-cred-", "agent pod must not mount any credential Secret")
+	}
+
+	// CA cert volume IS still on the agent — projected from the leaf Secret
+	// with single-key projection (ca.crt only).
+	var caCertVol *corev1.Volume
+	for i, v := range ss.Spec.Template.Spec.Volumes {
+		if v.Name == "ca-cert" {
+			caCertVol = &ss.Spec.Template.Spec.Volumes[i]
+			break
+		}
+	}
+	require.NotNil(t, caCertVol, "ca-cert volume must exist on the agent pod")
+	require.NotNil(t, caCertVol.Secret, "ca-cert volume must be sourced from the leaf Secret")
+	assert.Equal(t, "my-instance-envoy-tls", caCertVol.Secret.SecretName)
+	require.Len(t, caCertVol.Secret.Items, 1)
+	assert.Equal(t, "ca.crt", caCertVol.Secret.Items[0].Key, "agent must only see ca.crt — never tls.key")
+}
+
+// --- Agent Service tests ---
+
+func TestBuildAgentService(t *testing.T) {
+	svc := BuildAgentService("my-instance", testConfig, testOwnerCM)
 	assert.Equal(t, "my-instance", svc.Name)
 	assert.Equal(t, "test-agents", svc.Namespace)
 	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 	assert.Equal(t, int32(8080), svc.Spec.Ports[0].Port)
 	assert.Equal(t, "acp", svc.Spec.Ports[0].Name)
-	assert.Equal(t, "my-instance", svc.Spec.Selector["agent-platform.ai/instance"])
+	// Selector pins to pair + role=agent so the gateway pod (same instance
+	// label) is excluded.
+	assert.Equal(t, "my-instance", svc.Spec.Selector["agent-platform.ai/pair"])
+	assert.Equal(t, "agent", svc.Spec.Selector["agent-platform.ai/role"])
 	require.Len(t, svc.OwnerReferences, 1)
 }
 
-// --- NetworkPolicy tests ---
+// --- Agent NetworkPolicy tests ---
 
-func TestBuildNetworkPolicy(t *testing.T) {
-	np := BuildNetworkPolicy("my-instance", testConfig, testOwnerCM)
+func TestBuildAgentNetworkPolicy(t *testing.T) {
+	np := BuildAgentNetworkPolicy("my-instance", testConfig, testOwnerCM)
 	assert.Equal(t, "my-instance-egress", np.Name)
 	assert.Equal(t, "test-agents", np.Namespace)
-	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels["agent-platform.ai/instance"])
+	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels["agent-platform.ai/pair"])
+	assert.Equal(t, "agent", np.Spec.PodSelector.MatchLabels["agent-platform.ai/role"])
 	require.Len(t, np.OwnerReferences, 1)
 
-	// Sidecar permissive 80/443, ext_authz to api-server, harness to api-server, DNS.
-	require.Len(t, np.Spec.Egress, 4)
+	// ADR-038: egress is gateway pod + harness + DNS. Open 80/443 to the
+	// world is gone — that bypass is the whole point of the split.
+	require.Len(t, np.Spec.Egress, 3)
 
-	// 1: open egress for the sidecar
-	open := np.Spec.Egress[0]
-	assert.Empty(t, open.To, "open egress must not have a peer selector")
-	var sawHttps bool
-	for _, p := range open.Ports {
-		if p.Port != nil && p.Port.IntVal == 443 {
-			sawHttps = true
-		}
-	}
-	assert.True(t, sawHttps, "must permit egress on TCP 443")
+	// 1: paired gateway pod only
+	gatewayEgress := np.Spec.Egress[0]
+	require.Len(t, gatewayEgress.To, 1)
+	assert.Equal(t, "my-instance", gatewayEgress.To[0].PodSelector.MatchLabels["agent-platform.ai/pair"])
+	assert.Equal(t, "gateway", gatewayEgress.To[0].PodSelector.MatchLabels["agent-platform.ai/role"])
+	require.Len(t, gatewayEgress.Ports, 1)
+	assert.Equal(t, int32(10000), gatewayEgress.Ports[0].Port.IntVal)
 
-	// 2: ext_authz to api-server
-	extAuthz := np.Spec.Egress[1]
-	require.Len(t, extAuthz.To, 1)
-	assert.Equal(t, "apiserver", extAuthz.To[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
-
-	// 3: harness API server
-	harness := np.Spec.Egress[2]
+	// 2: harness API server
+	harness := np.Spec.Egress[1]
 	require.Len(t, harness.To, 1)
 	assert.Equal(t, "apiserver", harness.To[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
 	require.Len(t, harness.Ports, 1)
 	assert.Equal(t, int32(4001), harness.Ports[0].Port.IntVal)
 
-	// 4: DNS
-	dns := np.Spec.Egress[3]
+	// 3: DNS
+	dns := np.Spec.Egress[2]
 	assert.Empty(t, dns.To)
 
-	// Ingress: ACP port admitted only from the api-server pod. The
-	// kernel-level peer match is the only authentication boundary on this
-	// hop — there is no in-process auth check.
+	// Agent must NOT be allowed to dial 80/443 anywhere — that's the bypass.
+	for _, rule := range np.Spec.Egress {
+		if len(rule.To) == 0 {
+			for _, p := range rule.Ports {
+				assert.NotEqual(t, int32(443), p.Port.IntVal,
+					"agent NetworkPolicy must not admit open 443 egress (ADR-038)")
+				assert.NotEqual(t, int32(80), p.Port.IntVal,
+					"agent NetworkPolicy must not admit open 80 egress (ADR-038)")
+			}
+		}
+	}
+
+	// Ingress: ACP port admitted only from the api-server pod.
 	require.Len(t, np.Spec.Ingress, 1)
 	require.Len(t, np.Spec.Ingress[0].From, 1)
 	assert.Equal(t, "apiserver",
@@ -291,109 +333,37 @@ func envToMap(envs []corev1.EnvVar) map[string]string {
 	return m
 }
 
-// --- Envoy sidecar wiring ---
+// --- GH_TOKEN signal ---
 
-func TestBuildStatefulSet_AddsEnvoySidecar(t *testing.T) {
+func TestBuildAgentStatefulSet_GHTokenSignal_NoCredential(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
-
-	require.Len(t, ss.Spec.Template.Spec.Containers, 2, "agent + envoy sidecar")
-	agent := ss.Spec.Template.Spec.Containers[0]
-	envoy := ss.Spec.Template.Spec.Containers[1]
-	assert.Equal(t, "agent", agent.Name)
-	assert.Equal(t, "envoy", envoy.Name)
-	assert.Equal(t, "envoyproxy/envoy:distroless-v1.37.2", envoy.Image)
-
-	envMap := envToMap(agent.Env)
-	assert.Equal(t, "http://127.0.0.1:10000", envMap["HTTP_PROXY"])
-	assert.Equal(t, "http://127.0.0.1:10000", envMap["HTTPS_PROXY"])
-
-	volNames := map[string]bool{}
-	for _, v := range ss.Spec.Template.Spec.Volumes {
-		volNames[v.Name] = true
-	}
-	require.True(t, volNames["cred-platform-cred-aaa"], "credential volume must use cred-<secretName>")
-	require.True(t, volNames["envoy-tls"], "leaf-TLS volume must be present")
-
-	envoyMounts := map[string]string{}
-	for _, m := range envoy.VolumeMounts {
-		envoyMounts[m.Name] = m.MountPath
-	}
-	assert.Equal(t, "/etc/envoy/credentials/cred-platform-cred-aaa", envoyMounts["cred-platform-cred-aaa"])
-	assert.Equal(t, "/etc/envoy/tls", envoyMounts["envoy-tls"])
-}
-
-func TestBuildStatefulSet_GHTokenSignal_NoCredential(t *testing.T) {
-	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, "false", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
 	assert.Equal(t, "false", ss.Spec.Template.Annotations["agent-platform.ai/gh-token-available"])
 }
 
-func TestBuildStatefulSet_GHTokenSignal_WithCredential(t *testing.T) {
+func TestBuildAgentStatefulSet_GHTokenSignal_WithCredential(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	secrets := []corev1.Secret{credSecret("platform-cred-gh", "api.github.com")}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, "true", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
 	assert.Equal(t, "true", ss.Spec.Template.Annotations["agent-platform.ai/gh-token-available"])
 }
 
-func TestBuildStatefulSet_SecretMountsSidecarOnly(t *testing.T) {
-	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
+func TestBuildAgentStatefulSet_PodHardening(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
-
-	volNames := map[string]bool{}
-	for _, v := range ss.Spec.Template.Spec.Volumes {
-		volNames[v.Name] = true
-	}
-	assert.True(t, volNames["envoy-bootstrap"])
-	assert.True(t, volNames["cred-platform-cred-aaa"])
-
-	agentMounts := ss.Spec.Template.Spec.Containers[0].VolumeMounts
-	for _, m := range agentMounts {
-		assert.NotEqual(t, "cred-platform-cred-aaa", m.Name, "agent container must not mount credential secrets")
-		assert.NotEqual(t, "envoy-bootstrap", m.Name, "agent container must not mount the envoy bootstrap CM")
-	}
-
-	envoyMounts := map[string]bool{}
-	for _, m := range ss.Spec.Template.Spec.Containers[1].VolumeMounts {
-		envoyMounts[m.Name] = true
-	}
-	assert.True(t, envoyMounts["envoy-bootstrap"])
-	assert.True(t, envoyMounts["cred-platform-cred-aaa"])
-	assert.True(t, envoyMounts["envoy-tls"])
-
-	// Agent's ca-cert volume is now projected from the leaf Secret, exposing
-	// only ca.crt. The leaf private key (tls.key) must NOT be visible to the
-	// agent — it's the credential boundary between agent and sidecar.
-	var caCertVol *corev1.Volume
-	for i, v := range ss.Spec.Template.Spec.Volumes {
-		if v.Name == "ca-cert" {
-			caCertVol = &ss.Spec.Template.Spec.Volumes[i]
-			break
-		}
-	}
-	require.NotNil(t, caCertVol, "ca-cert volume must exist")
-	require.NotNil(t, caCertVol.Secret, "ca-cert volume must be sourced from the leaf Secret")
-	assert.Equal(t, "my-instance-envoy-tls", caCertVol.Secret.SecretName)
-	require.Len(t, caCertVol.Secret.Items, 1)
-	assert.Equal(t, "ca.crt", caCertVol.Secret.Items[0].Key, "agent must only see ca.crt — never tls.key")
-}
-
-func TestBuildStatefulSet_PodHardening(t *testing.T) {
-	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
 	require.NotNil(t, ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	assert.False(t, *ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	require.NotNil(t, ss.Spec.Template.Spec.ShareProcessNamespace)
 	assert.False(t, *ss.Spec.Template.Spec.ShareProcessNamespace)
 }
+
+// --- Envoy bootstrap rendering (still produces the same YAML, just bound on 0.0.0.0 now) ---
 
 func TestBuildEnvoyBootstrapConfigMap(t *testing.T) {
 	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
@@ -402,7 +372,9 @@ func TestBuildEnvoyBootstrapConfigMap(t *testing.T) {
 	assert.Equal(t, "my-instance-envoy-bootstrap", cm.Name)
 	assert.Equal(t, "test-agents", cm.Namespace)
 	yaml := cm.Data["envoy.yaml"]
-	assert.Contains(t, yaml, "127.0.0.1")
+	// ADR-038: gateway listener binds 0.0.0.0; reach is gated by NetworkPolicy.
+	assert.Contains(t, yaml, "0.0.0.0")
+	assert.NotContains(t, yaml, "127.0.0.1", "gateway listener must not bind loopback under the paired-pod model")
 	assert.Contains(t, yaml, "api.example.com", "filter chain must match by SNI on the host")
 	assert.Contains(t, yaml, "/etc/envoy/credentials/cred-platform-cred-aaa/sds.yaml")
 	assert.Contains(t, yaml, "internal_listener", "must declare an internal listener")


### PR DESCRIPTION
Closes #98. ADR-038.

## Summary

- Splits each instance (and each fork) into two paired pods: an `agent` pod and a `gateway` pod, glued by role-scoped NetworkPolicies. The agent pod has no admitted route to TCP 80/443 except its paired gateway pod's proxy port — the bypass that made the credential boundary cooperative is now structural.
- Credential Secrets, the leaf TLS Secret, and the Envoy bootstrap ConfigMap move to the gateway pod. The agent pod keeps only the CA bundle (single-key projection of the leaf Secret).
- `HTTPS_PROXY` becomes the per-instance gateway Service DNS (`<instance>-gateway:<port>`). Envoy listener binds `0.0.0.0`; reach is gated by NetworkPolicy.
- Forks gain per-fork NetworkPolicies (they had none) and their own paired gateway Pod + Service.
- New `agent-platform.ai/pair` label scopes NetworkPolicy/Service selectors to a pair. Forks use the fork name as the pair key so they stay structurally isolated from the parent instance pair, while keeping `agent-platform.ai/instance` pointed at the parent for ext_authz identity (ADR-027).
- api-server pod-IP resolver narrows to `role=gateway` (the IP source moves from agent pod to gateway pod). `instances-repository.list()` narrows to `role=agent` so status reads the agent half.
- Architecture pages updated for the paired-pod shape; `envoyBootstrapTemplateRev` bumped to `v3-paired-gateway` so live pods roll on chart upgrade.

## Test plan

- [x] `mise run check` (lint + tsc + helm lint/render)
- [x] `mise run test` (controller, agent-runtime, api-server, ui)
- [ ] `mise run cluster:install` and exercise an instance end-to-end (agent reaches an upstream through the paired gateway, ext_authz prompts surface in the inbox)
- [ ] Foreign-replier fork on Slack: confirm fork pair comes up, fork agent NetworkPolicy denies any direct egress, fork gateway gets the replier's Secrets only
- [ ] Confirm `kubectl exec` into the agent pod and a raw `curl https://api.github.com` fails (no admitted route)