### PR TITLE
fix(connections): restore app connections in the agent picker dialog

### DIFF
--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -260,7 +260,6 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       podFiles: podFilesPublisher,
       egressHostsByProvider: appConnectionEgressHosts,
       connectionRules: createConnectionRulesSyncAdapter(db),
-      apps: oauthApps,
     });
     const isAgentOwnedBy = async (agentId: string, ownerSub: string) =>
       (await agents.get(agentId)) !== null && ownerSub === user.sub;

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -7,10 +7,6 @@ import type {
 import type { K8sConnectionsPort } from "../infrastructure/k8s-connections-port.js";
 import type { AgentGrantsPort } from "../../agents/infrastructure/agent-grants-port.js";
 import type { PodFilesPublisher } from "../../pod-files/publisher.js";
-import {
-  matchesAppConnection,
-  type OAuthAppRegistry,
-} from "../infrastructure/oauth-apps.js";
 
 /** Minimal port consumed by `setAgentConnections` to insert / revoke
  *  `connection:<id>` egress rules when grants change. */
@@ -53,21 +49,11 @@ export function createConnectionsService(deps: {
   egressHostsByProvider?: ReadonlyMap<string, readonly string[]>;
   /** Egress-rules adapter the composition root supplies. */
   connectionRules?: ConnectionRulesSyncPort;
-  /**
-   * OAuth app registry. When set, `list()` skips connections whose key
-   * matches a registered app descriptor — those are surfaced separately
-   * via `/api/oauth/apps/connections` and would otherwise show up twice
-   * in the UI (once under "Apps", once under "Other connections").
-   */
-  apps?: OAuthAppRegistry;
 }): ConnectionsService {
   return {
     async list() {
       const connections = await deps.port.listConnections();
-      const appList = deps.apps?.list() ?? [];
-      return connections
-        .filter((c) => !appList.some((a) => matchesAppConnection(a, c.connection)))
-        .map<AppConnectionView>((c) => {
+      return connections.map<AppConnectionView>((c) => {
         // Provider is the connection key (host or named-app id) in the K8s
         // model. Without per-provider host metadata the egressHosts join is
         // best-effort — present only when the connection key matches a


### PR DESCRIPTION
## Summary

Regression from #99: the previous service-level filter on `ConnectionsService.list()` meant to dedup the connections page also stripped OAuth apps out of the agent picker dialog, where there is no other source for them.

## Why it broke

The dialog has two render paths for app rows:
- `apps.map(...)` — backed by `ConnectionsService.list()`
- `oauthAppEntries.map(...)` — backed by `/api/oauth/apps/connections` joined against mirror Secrets prefixed `__oauth:`

Nothing in the codebase actually creates `__oauth:` Secrets — the prefix is referenced by the UI types and dialogs but has no server-side writer. So `oauthAppEntries` is always empty, and the only path that surfaces app connections in the dialog is `apps`. Once the filter excluded app-matched keys from that list, Spotify and GitHub silently disappeared from the dialog with no way to grant them.

## Fix

Revert the service-level filter and the `apps: oauthApps` wiring in `app.ts`. The connections page no longer renders the duplicate either way — that's solved at the UI layer by removing the "Other connections" subsection (already in #99).

## Follow-up (not in this PR)

The mirror-secret model the dialog already imagines is the right shape. Wiring the OAuth callback handler to write a `__oauth:<connectionId>` Secret alongside each app connection (or having the service synthesize one) would let the dialog use `oauthAppEntries` and let us re-introduce the filter cleanly. Left for a separate change since the immediate breakage is the priority.

## Test plan

- [x] `mise run check` and `mise run test` (225 passing)
- [x] Rebuilt api-server, verified the dialog shows Spotify again under "Apps"
- [x] Confirmed no regression on the connections page (no duplicate row reappears — UI subsection removal is doing the work)