### PR TITLE
fix(secrets): persist envMappings + name on update

### DIFF
--- a/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
@@ -210,4 +210,97 @@ describe("createK8sSecretsPort.updateSecret", () => {
     expect(replaced[0]!.body.stringData?.["sds.yaml"]).toContain('inline_string: "new"');
     expect(replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/injection-header-name"]).toBe("x-api-key");
   });
+
+  it("renames the display-name annotation when patch.name is set", async () => {
+    const { client, replaced } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+    await port.createSecret({
+      id: "abc",
+      name: "Old Name",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+    });
+    await port.updateSecret("abc", { name: "New Name" });
+    expect(
+      replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/display-name"],
+    ).toBe("New Name");
+  });
+});
+
+describe("createK8sSecretsPort envMappings round-trip", () => {
+  it("persists envMappings on create and reads them back on list", async () => {
+    const { client, created } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "abc",
+      name: "LiteLLM",
+      type: "generic",
+      value: "tok",
+      hostPattern: "proxy.example.com",
+      envMappings: [
+        { envName: "ANTHROPIC_API_KEY", placeholder: "dummy-placeholder" },
+        { envName: "LITELLM_BASE_URL", placeholder: "https://proxy.example.com" },
+      ],
+    });
+
+    const ann = created[0]!.metadata?.annotations ?? {};
+    expect(ann["agent-platform.ai/env-mappings"]).toBeDefined();
+    expect(JSON.parse(ann["agent-platform.ai/env-mappings"]!)).toEqual([
+      { envName: "ANTHROPIC_API_KEY", placeholder: "dummy-placeholder" },
+      { envName: "LITELLM_BASE_URL", placeholder: "https://proxy.example.com" },
+    ]);
+
+    const [stored] = await port.listSecrets();
+    expect(stored?.envMappings).toEqual([
+      { envName: "ANTHROPIC_API_KEY", placeholder: "dummy-placeholder" },
+      { envName: "LITELLM_BASE_URL", placeholder: "https://proxy.example.com" },
+    ]);
+  });
+
+  it("update overwrites envMappings; empty array clears them", async () => {
+    const { client, replaced } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "abc",
+      name: "x",
+      type: "generic",
+      value: "tok",
+      hostPattern: "h",
+      envMappings: [{ envName: "FOO", placeholder: "x" }],
+    });
+
+    await port.updateSecret("abc", {
+      envMappings: [{ envName: "BAR", placeholder: "y" }],
+    });
+    expect(
+      replaced.at(-1)!.body.metadata?.annotations?.["agent-platform.ai/env-mappings"],
+    ).toBe('[{"envName":"BAR","placeholder":"y"}]');
+
+    await port.updateSecret("abc", { envMappings: [] });
+    expect(
+      replaced.at(-1)!.body.metadata?.annotations?.["agent-platform.ai/env-mappings"],
+    ).toBeUndefined();
+  });
+
+  it("invalid env names are dropped at write time", async () => {
+    const { client, created } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+    await port.createSecret({
+      id: "abc",
+      name: "x",
+      type: "generic",
+      value: "tok",
+      hostPattern: "h",
+      envMappings: [
+        { envName: "GOOD_VAR", placeholder: "ok" },
+        { envName: "bad-name", placeholder: "x" },
+      ],
+    });
+    expect(
+      JSON.parse(created[0]!.metadata?.annotations?.["agent-platform.ai/env-mappings"]!),
+    ).toEqual([{ envName: "GOOD_VAR", placeholder: "ok" }]);
+  });
 });

--- a/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
+++ b/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
@@ -7,7 +7,8 @@
  * newly-created secrets land in K8s for the sidecar to discover.
  */
 import type * as k8s from "@kubernetes/client-node";
-import type { InjectionConfig } from "api-server-api";
+import type { EnvMapping, InjectionConfig } from "api-server-api";
+import { isValidEnvName } from "api-server-api";
 
 import type { K8sClient } from "../../agents/infrastructure/k8s.js";
 
@@ -19,6 +20,8 @@ const ANN_PATH_PATTERN = "agent-platform.ai/path-pattern";
 const ANN_HEADER_NAME = "agent-platform.ai/injection-header-name";
 const ANN_AUTH_MODE = "agent-platform.ai/auth-mode";
 const ANN_VALUE_FORMAT = "agent-platform.ai/injection-value-format";
+const ANN_DISPLAY_NAME = "agent-platform.ai/display-name";
+const ANN_ENV_MAPPINGS = "agent-platform.ai/env-mappings";
 
 export type AuthMode = "api-key" | "oauth";
 
@@ -87,6 +90,7 @@ export interface K8sStoredSecret {
   injectionConfig?: InjectionConfig | null;
   createdAt: string;
   authMode?: AuthMode;
+  envMappings?: EnvMapping[];
 }
 
 export interface K8sSecretsPort {
@@ -100,18 +104,57 @@ export interface K8sSecretsPort {
     pathPattern?: string;
     injectionConfig?: InjectionConfig;
     authMode?: AuthMode;
+    envMappings?: EnvMapping[];
   }): Promise<void>;
   updateSecret(
     id: string,
     input: {
+      name?: string;
       value?: string;
       hostPattern?: string;
       pathPattern?: string | null;
       injectionConfig?: InjectionConfig | null;
       authMode?: AuthMode;
+      envMappings?: EnvMapping[];
     },
   ): Promise<void>;
   deleteSecret(id: string): Promise<void>;
+}
+
+/**
+ * Serializes envMappings into the `agent-platform.ai/env-mappings` annotation.
+ * Empty input clears the annotation. Invalid entries are dropped — the router
+ * already validates, but the controller reads this annotation on every
+ * reconcile so we belt-and-suspender the shape here too.
+ */
+function serializeEnvMappings(mappings: readonly EnvMapping[]): string {
+  const cleaned = mappings
+    .filter((m) => isValidEnvName(m.envName) && m.placeholder.length > 0)
+    .map((m) => ({ envName: m.envName, placeholder: m.placeholder }));
+  return JSON.stringify(cleaned);
+}
+
+function parseEnvMappings(raw: string | undefined): EnvMapping[] | undefined {
+  if (!raw) return undefined;
+  try {
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return undefined;
+    const out: EnvMapping[] = [];
+    for (const m of parsed) {
+      if (
+        m &&
+        typeof m === "object" &&
+        typeof m.envName === "string" &&
+        typeof m.placeholder === "string" &&
+        isValidEnvName(m.envName)
+      ) {
+        out.push({ envName: m.envName, placeholder: m.placeholder });
+      }
+    }
+    return out.length > 0 ? out : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // K8s metadata.name is RFC 1123 subdomain: lowercase alphanumeric / hyphen,
@@ -153,7 +196,7 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
           const authMode = ann[ANN_AUTH_MODE] as AuthMode | undefined;
           const stored: K8sStoredSecret = {
             id,
-            name: ann["agent-platform.ai/display-name"] ?? id,
+            name: ann[ANN_DISPLAY_NAME] ?? id,
             type: labels[LABEL_SECRET_TYPE] ?? "generic",
             hostPattern: ann[ANN_HOST_PATTERN] ?? "",
             createdAt: s.metadata?.creationTimestamp
@@ -163,21 +206,26 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
           if (ann[ANN_PATH_PATTERN]) stored.pathPattern = ann[ANN_PATH_PATTERN];
           if (injectionConfig) stored.injectionConfig = injectionConfig;
           if (authMode) stored.authMode = authMode;
+          const envMappings = parseEnvMappings(ann[ANN_ENV_MAPPINGS]);
+          if (envMappings) stored.envMappings = envMappings;
           return stored;
         });
     },
 
-    async createSecret({ id, name, type, value, hostPattern, pathPattern, injectionConfig, authMode }) {
+    async createSecret({ id, name, type, value, hostPattern, pathPattern, injectionConfig, authMode, envMappings }) {
       const secretType = type === "anthropic" ? "anthropic" : "generic";
       const { headerName, valueFormat } = resolveInjection(secretType, authMode, injectionConfig);
       const annotations: Record<string, string> = {
         [ANN_HOST_PATTERN]: hostPattern,
         [ANN_HEADER_NAME]: headerName,
         [ANN_VALUE_FORMAT]: valueFormat,
-        "agent-platform.ai/display-name": name,
+        [ANN_DISPLAY_NAME]: name,
       };
       if (pathPattern) annotations[ANN_PATH_PATTERN] = pathPattern;
       if (authMode) annotations[ANN_AUTH_MODE] = authMode;
+      if (envMappings && envMappings.length > 0) {
+        annotations[ANN_ENV_MAPPINGS] = serializeEnvMappings(envMappings);
+      }
 
       const body: k8s.V1Secret = {
         metadata: {
@@ -203,9 +251,14 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
       const labels = existing.metadata?.labels ?? {};
       const secretType = labels[LABEL_SECRET_TYPE] ?? "generic";
 
+      if (patch.name !== undefined) annotations[ANN_DISPLAY_NAME] = patch.name;
       if (patch.hostPattern !== undefined) annotations[ANN_HOST_PATTERN] = patch.hostPattern;
       if (patch.pathPattern === null) delete annotations[ANN_PATH_PATTERN];
       else if (patch.pathPattern !== undefined) annotations[ANN_PATH_PATTERN] = patch.pathPattern;
+      if (patch.envMappings !== undefined) {
+        if (patch.envMappings.length === 0) delete annotations[ANN_ENV_MAPPINGS];
+        else annotations[ANN_ENV_MAPPINGS] = serializeEnvMappings(patch.envMappings);
+      }
 
       // Recompute header + value format if the injection config or auth mode
       // changed; otherwise keep what was stored at create time.

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -39,6 +39,7 @@ function toSecretView(s: K8sStoredSecret): SecretView {
   };
   if (s.pathPattern) view.pathPattern = s.pathPattern;
   if (type === "generic" && s.injectionConfig) view.injectionConfig = s.injectionConfig;
+  if (s.envMappings && s.envMappings.length > 0) view.envMappings = s.envMappings;
   return view;
 }
 
@@ -80,6 +81,7 @@ export function createSecretsService(deps: {
         ...(input.pathPattern ? { pathPattern: input.pathPattern } : {}),
         ...(input.injectionConfig ? { injectionConfig: input.injectionConfig } : {}),
         ...(authMode ? { authMode } : {}),
+        ...(input.envMappings ? { envMappings: input.envMappings } : {}),
       });
       const view: SecretView = {
         id,
@@ -92,15 +94,20 @@ export function createSecretsService(deps: {
       if (input.type === "generic" && input.injectionConfig) {
         view.injectionConfig = input.injectionConfig;
       }
+      if (input.envMappings && input.envMappings.length > 0) {
+        view.envMappings = input.envMappings;
+      }
       return view;
     },
 
     async update({ id, ...patch }: UpdateSecretInput) {
       await deps.k8sPort.updateSecret(id, {
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
         ...(patch.value !== undefined ? { value: patch.value } : {}),
         ...(patch.hostPattern !== undefined ? { hostPattern: patch.hostPattern } : {}),
         ...(patch.pathPattern !== undefined ? { pathPattern: patch.pathPattern } : {}),
         ...(patch.injectionConfig !== undefined ? { injectionConfig: patch.injectionConfig } : {}),
+        ...(patch.envMappings !== undefined ? { envMappings: patch.envMappings } : {}),
       });
     },
 

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -36,6 +37,10 @@ const (
 	envoyHostPatternAnn   = "agent-platform.ai/host-pattern"
 	envoyHeaderNameAnn    = "agent-platform.ai/injection-header-name"
 	envoyAuthModeAnn      = "agent-platform.ai/auth-mode"
+	// User-supplied env mappings on a generic credential Secret. JSON-encoded
+	// `[{envName, placeholder}]`. Read by `credentialEnvVars` to seed the
+	// agent pod with the matching env vars (Envoy rewrites the wire value).
+	envoyEnvMappingsAnn   = "agent-platform.ai/env-mappings"
 	// Per-agent grant annotations stamped by the api-server on the
 	// instance ConfigMap. The controller reads them on every reconcile
 	// and intersects with the owner's credential Secret list.
@@ -169,12 +174,15 @@ func listOwnerCredentialSecrets(ctx context.Context, client kubernetes.Interface
 func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 	const sentinel = "dummy-placeholder"
 	seen := map[string]struct{}{}
-	add := func(envs []corev1.EnvVar, name string) []corev1.EnvVar {
+	addWithValue := func(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
 		if _, dup := seen[name]; dup {
 			return envs
 		}
 		seen[name] = struct{}{}
-		return append(envs, corev1.EnvVar{Name: name, Value: sentinel})
+		return append(envs, corev1.EnvVar{Name: name, Value: value})
+	}
+	add := func(envs []corev1.EnvVar, name string) []corev1.EnvVar {
+		return addWithValue(envs, name, sentinel)
 	}
 	var envs []corev1.EnvVar
 	for _, s := range secrets {
@@ -191,8 +199,41 @@ func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 				envs = add(envs, "GH_TOKEN")
 			}
 		}
+		// User-supplied envMappings (generic secrets + custom Anthropic
+		// modes) win on dedup so a `dummy-placeholder` from the hardcoded
+		// branch above doesn't clobber a literal placeholder the user set
+		// (e.g. `GH_HOST=github.example.com` for an enterprise host).
+		for _, m := range parseUserEnvMappings(s.Annotations[envoyEnvMappingsAnn]) {
+			envs = addWithValue(envs, m.EnvName, m.Placeholder)
+		}
 	}
 	return envs
+}
+
+type userEnvMapping struct {
+	EnvName     string `json:"envName"`
+	Placeholder string `json:"placeholder"`
+}
+
+// parseUserEnvMappings decodes the `agent-platform.ai/env-mappings` annotation
+// written by the api-server. Returns nil on any decoding error or invalid
+// shape — the api-server validates the input, but we belt-and-suspender here
+// so a malformed annotation can't crash a reconcile.
+func parseUserEnvMappings(raw string) []userEnvMapping {
+	if raw == "" {
+		return nil
+	}
+	var parsed []userEnvMapping
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil
+	}
+	out := parsed[:0]
+	for _, m := range parsed {
+		if m.EnvName != "" && m.Placeholder != "" {
+			out = append(out, m)
+		}
+	}
+	return out
 }
 
 // hasGitHubCredential reports whether any of the owner's K8s credential

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -212,6 +212,65 @@ func TestRenderEnvoyBootstrap_MixedRoutesOnlyPinCredentialed(t *testing.T) {
 	assert.NotContains(t, got, "name: upstream_platform-allow-only-npm")
 }
 
+func TestCredentialEnvVars_AnthropicAndGitHub(t *testing.T) {
+	apiKey := ownerSecret("platform-cred-anthropic", "anthropic", "")
+	apiKey.Annotations[envoyAuthModeAnn] = "api-key"
+	oauth := ownerSecret("platform-cred-oauth", "anthropic", "")
+	oauth.Annotations[envoyAuthModeAnn] = "oauth"
+	gh := ownerSecret("platform-conn-github", "connection", "github")
+	gh.Annotations[envoyHostPatternAnn] = "api.github.com"
+
+	envs := credentialEnvVars([]corev1.Secret{apiKey, oauth, gh})
+	got := map[string]string{}
+	for _, e := range envs {
+		got[e.Name] = e.Value
+	}
+	assert.Equal(t, "dummy-placeholder", got["ANTHROPIC_API_KEY"])
+	assert.Equal(t, "dummy-placeholder", got["CLAUDE_CODE_OAUTH_TOKEN"])
+	assert.Equal(t, "dummy-placeholder", got["GH_TOKEN"])
+}
+
+func TestCredentialEnvVars_UserSuppliedEnvMappings(t *testing.T) {
+	// Generic secret with user-defined env mappings (e.g. an IBM LiteLLM
+	// proxy that wants ANTHROPIC_API_KEY set to a sentinel for the harness
+	// to even attempt the call).
+	generic := ownerSecret("platform-cred-litellm", "generic", "")
+	generic.Annotations[envoyEnvMappingsAnn] = `[{"envName":"ANTHROPIC_API_KEY","placeholder":"dummy-placeholder"},{"envName":"LITELLM_BASE_URL","placeholder":"https://proxy.example.com"}]`
+
+	envs := credentialEnvVars([]corev1.Secret{generic})
+	got := map[string]string{}
+	for _, e := range envs {
+		got[e.Name] = e.Value
+	}
+	assert.Equal(t, "dummy-placeholder", got["ANTHROPIC_API_KEY"])
+	assert.Equal(t, "https://proxy.example.com", got["LITELLM_BASE_URL"])
+}
+
+func TestCredentialEnvVars_UserMappingsOverrideHardcodedSentinel(t *testing.T) {
+	// When the same env name is contributed by both the hardcoded branch
+	// (anthropic api-key → ANTHROPIC_API_KEY=dummy-placeholder) and a
+	// user-supplied mapping with a literal placeholder, the user's literal
+	// value is dropped because the hardcoded branch added it first. That's
+	// the intended dedup direction — hardcoded credentials win on conflict.
+	apiKey := ownerSecret("platform-cred-anthropic", "anthropic", "")
+	apiKey.Annotations[envoyAuthModeAnn] = "api-key"
+	apiKey.Annotations[envoyEnvMappingsAnn] = `[{"envName":"ANTHROPIC_API_KEY","placeholder":"literal-not-used"}]`
+
+	envs := credentialEnvVars([]corev1.Secret{apiKey})
+	got := map[string]string{}
+	for _, e := range envs {
+		got[e.Name] = e.Value
+	}
+	assert.Equal(t, "dummy-placeholder", got["ANTHROPIC_API_KEY"])
+}
+
+func TestCredentialEnvVars_MalformedAnnotationIsIgnored(t *testing.T) {
+	generic := ownerSecret("platform-cred-bad", "generic", "")
+	generic.Annotations[envoyEnvMappingsAnn] = "not-json"
+	envs := credentialEnvVars([]corev1.Secret{generic})
+	assert.Empty(t, envs)
+}
+
 func TestEnvoySecretsRev_TemplateRevBumpRollsExistingPods(t *testing.T) {
 	// The rev hash must include a template-revision marker so any structural
 	// template change rolls existing pods on chart upgrade. Without it, the


### PR DESCRIPTION
## Summary

- Secret env vars vanished after save because the api-server's update path silently dropped `envMappings` and `name`, and the list view never re-emitted env mappings.
- K8s Secret now carries the user's mappings in a new `agent-platform.ai/env-mappings` annotation.
- The controller reads that annotation in `credentialEnvVars`, so generic secrets (e.g. an IBM LiteLLM proxy that needs `ANTHROPIC_API_KEY` set to a sentinel) actually surface the env vars on the agent pod.

Closes #118

## Test plan

- [x] `mise run check` (lint + tsc + go vet + helm lint)
- [x] `mise run test` (api-server, controller, ui, agent-runtime)
- [x] New api-server unit tests cover envMappings round-trip on create/list/update + display-name rename + invalid-env-name drop.
- [x] New controller unit tests cover anthropic/GH_TOKEN, user-supplied envMappings, hardcoded-vs-user dedup, and malformed-annotation safety.
- [ ] Manual: create generic secret with env vars in UI, save, re-open — values persist; `kubectl describe` shows the new annotation; new agent pod env contains the mapping.