### PR TITLE
fix: secret environment variables vanish after save

### DIFF
--- a/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
@@ -190,6 +190,78 @@ describe("createK8sSecretsPort.createSecret", () => {
   });
 });
 
+describe("createK8sSecretsPort.createSecret — envMappings", () => {
+  it("stores envMappings as a JSON annotation", async () => {
+    const { client, created } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "env1",
+      name: "With Env",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+      envMappings: [{ envName: "MY_KEY", placeholder: "dummy-placeholder" }],
+    });
+
+    const ann = created[0]!.metadata?.annotations?.["agent-platform.ai/env-mappings"];
+    expect(ann).toBe(JSON.stringify([{ envName: "MY_KEY", placeholder: "dummy-placeholder" }]));
+  });
+
+  it("omits envMappings annotation when array is empty", async () => {
+    const { client, created } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "env2",
+      name: "No Env",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+      envMappings: [],
+    });
+
+    expect(created[0]!.metadata?.annotations?.["agent-platform.ai/env-mappings"]).toBeUndefined();
+  });
+});
+
+describe("createK8sSecretsPort.listSecrets — envMappings", () => {
+  it("returns envMappings from the annotation", async () => {
+    const { client } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "env3",
+      name: "Listed",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+      envMappings: [{ envName: "FOO", placeholder: "ph" }],
+    });
+
+    const secrets = await port.listSecrets();
+    const found = secrets.find((s) => s.id === "env3");
+    expect(found?.envMappings).toEqual([{ envName: "FOO", placeholder: "ph" }]);
+  });
+
+  it("returns no envMappings when annotation is absent", async () => {
+    const { client } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "env4",
+      name: "Plain",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+    });
+
+    const secrets = await port.listSecrets();
+    const found = secrets.find((s) => s.id === "env4");
+    expect(found?.envMappings).toBeUndefined();
+  });
+});
+
 describe("createK8sSecretsPort.updateSecret", () => {
   it("re-bakes the file content when value changes, preserving stored authMode", async () => {
     const { client, replaced } = fakeClient();
@@ -209,5 +281,60 @@ describe("createK8sSecretsPort.updateSecret", () => {
     expect(replaced).toHaveLength(1);
     expect(replaced[0]!.body.stringData?.["sds.yaml"]).toContain('inline_string: "new"');
     expect(replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/injection-header-name"]).toBe("x-api-key");
+  });
+
+  it("persists envMappings on update", async () => {
+    const { client, replaced } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "upd1",
+      name: "Secret",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+    });
+
+    await port.updateSecret("upd1", {
+      envMappings: [{ envName: "NEW_VAR", placeholder: "ph" }],
+    });
+
+    const ann = replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/env-mappings"];
+    expect(ann).toBe(JSON.stringify([{ envName: "NEW_VAR", placeholder: "ph" }]));
+  });
+
+  it("removes envMappings annotation when updated with empty array", async () => {
+    const { client, replaced } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "upd2",
+      name: "Secret",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+      envMappings: [{ envName: "OLD_VAR", placeholder: "ph" }],
+    });
+
+    await port.updateSecret("upd2", { envMappings: [] });
+
+    expect(replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/env-mappings"]).toBeUndefined();
+  });
+
+  it("updates display name", async () => {
+    const { client, replaced } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "upd3",
+      name: "Old Name",
+      type: "generic",
+      value: "tok",
+      hostPattern: "api.example.com",
+    });
+
+    await port.updateSecret("upd3", { name: "New Name" });
+
+    expect(replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/display-name"]).toBe("New Name");
   });
 });

--- a/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
+++ b/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
@@ -7,7 +7,7 @@
  * newly-created secrets land in K8s for the sidecar to discover.
  */
 import type * as k8s from "@kubernetes/client-node";
-import type { InjectionConfig } from "api-server-api";
+import type { EnvMapping, InjectionConfig } from "api-server-api";
 
 import type { K8sClient } from "../../agents/infrastructure/k8s.js";
 
@@ -19,6 +19,7 @@ const ANN_PATH_PATTERN = "agent-platform.ai/path-pattern";
 const ANN_HEADER_NAME = "agent-platform.ai/injection-header-name";
 const ANN_AUTH_MODE = "agent-platform.ai/auth-mode";
 const ANN_VALUE_FORMAT = "agent-platform.ai/injection-value-format";
+const ANN_ENV_MAPPINGS = "agent-platform.ai/env-mappings";
 
 export type AuthMode = "api-key" | "oauth";
 
@@ -87,6 +88,7 @@ export interface K8sStoredSecret {
   injectionConfig?: InjectionConfig | null;
   createdAt: string;
   authMode?: AuthMode;
+  envMappings?: EnvMapping[];
 }
 
 export interface K8sSecretsPort {
@@ -100,15 +102,18 @@ export interface K8sSecretsPort {
     pathPattern?: string;
     injectionConfig?: InjectionConfig;
     authMode?: AuthMode;
+    envMappings?: EnvMapping[];
   }): Promise<void>;
   updateSecret(
     id: string,
     input: {
+      name?: string;
       value?: string;
       hostPattern?: string;
       pathPattern?: string | null;
       injectionConfig?: InjectionConfig | null;
       authMode?: AuthMode;
+      envMappings?: EnvMapping[];
     },
   ): Promise<void>;
   deleteSecret(id: string): Promise<void>;
@@ -163,11 +168,14 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
           if (ann[ANN_PATH_PATTERN]) stored.pathPattern = ann[ANN_PATH_PATTERN];
           if (injectionConfig) stored.injectionConfig = injectionConfig;
           if (authMode) stored.authMode = authMode;
+          if (ann[ANN_ENV_MAPPINGS]) {
+            try { stored.envMappings = JSON.parse(ann[ANN_ENV_MAPPINGS]); } catch { /* ignore malformed */ }
+          }
           return stored;
         });
     },
 
-    async createSecret({ id, name, type, value, hostPattern, pathPattern, injectionConfig, authMode }) {
+    async createSecret({ id, name, type, value, hostPattern, pathPattern, injectionConfig, authMode, envMappings }) {
       const secretType = type === "anthropic" ? "anthropic" : "generic";
       const { headerName, valueFormat } = resolveInjection(secretType, authMode, injectionConfig);
       const annotations: Record<string, string> = {
@@ -178,6 +186,7 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
       };
       if (pathPattern) annotations[ANN_PATH_PATTERN] = pathPattern;
       if (authMode) annotations[ANN_AUTH_MODE] = authMode;
+      if (envMappings?.length) annotations[ANN_ENV_MAPPINGS] = JSON.stringify(envMappings);
 
       const body: k8s.V1Secret = {
         metadata: {
@@ -203,9 +212,14 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
       const labels = existing.metadata?.labels ?? {};
       const secretType = labels[LABEL_SECRET_TYPE] ?? "generic";
 
+      if (patch.name !== undefined) annotations["agent-platform.ai/display-name"] = patch.name;
       if (patch.hostPattern !== undefined) annotations[ANN_HOST_PATTERN] = patch.hostPattern;
       if (patch.pathPattern === null) delete annotations[ANN_PATH_PATTERN];
       else if (patch.pathPattern !== undefined) annotations[ANN_PATH_PATTERN] = patch.pathPattern;
+      if (patch.envMappings !== undefined) {
+        if (patch.envMappings.length > 0) annotations[ANN_ENV_MAPPINGS] = JSON.stringify(patch.envMappings);
+        else delete annotations[ANN_ENV_MAPPINGS];
+      }
 
       // Recompute header + value format if the injection config or auth mode
       // changed; otherwise keep what was stored at create time.

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -39,6 +39,7 @@ function toSecretView(s: K8sStoredSecret): SecretView {
   };
   if (s.pathPattern) view.pathPattern = s.pathPattern;
   if (type === "generic" && s.injectionConfig) view.injectionConfig = s.injectionConfig;
+  if (s.envMappings?.length) view.envMappings = s.envMappings;
   return view;
 }
 
@@ -80,6 +81,7 @@ export function createSecretsService(deps: {
         ...(input.pathPattern ? { pathPattern: input.pathPattern } : {}),
         ...(input.injectionConfig ? { injectionConfig: input.injectionConfig } : {}),
         ...(authMode ? { authMode } : {}),
+        ...(input.envMappings?.length ? { envMappings: input.envMappings } : {}),
       });
       const view: SecretView = {
         id,
@@ -92,15 +94,18 @@ export function createSecretsService(deps: {
       if (input.type === "generic" && input.injectionConfig) {
         view.injectionConfig = input.injectionConfig;
       }
+      if (input.envMappings?.length) view.envMappings = input.envMappings;
       return view;
     },
 
     async update({ id, ...patch }: UpdateSecretInput) {
       await deps.k8sPort.updateSecret(id, {
+        ...(patch.name !== undefined ? { name: patch.name } : {}),
         ...(patch.value !== undefined ? { value: patch.value } : {}),
         ...(patch.hostPattern !== undefined ? { hostPattern: patch.hostPattern } : {}),
         ...(patch.pathPattern !== undefined ? { pathPattern: patch.pathPattern } : {}),
         ...(patch.injectionConfig !== undefined ? { injectionConfig: patch.injectionConfig } : {}),
+        ...(patch.envMappings !== undefined ? { envMappings: patch.envMappings } : {}),
       });
     },
 


### PR DESCRIPTION
Contributes-to: #118 

This PR fixes the issue where secret environment variables are lost when configuring a secret i.e. pressing the save button causes the env vars to vanish even though the secret information is saved.

Tested as working.  However, running an agent configured using these secrets still fails with an Auth error so potentially more to do here or there's another bug.