### PR TITLE
fix(helm): point image repositories at dam-agents/dam registry path

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -222,7 +222,7 @@ ingress:
 # -- UI (nginx serving static SPA, reverse-proxies /api to API server)
 ui:
   image:
-    repository: ghcr.io/kagenti/platform/ui
+    repository: ghcr.io/dam-agents/dam/ui
     tag: "" # defaults to appVersion
     pullPolicy: IfNotPresent
   port: 8080
@@ -237,7 +237,7 @@ ui:
 # -- API Server
 apiServer:
   image:
-    repository: ghcr.io/kagenti/platform/api-server
+    repository: ghcr.io/dam-agents/dam/api-server
     tag: ""
     pullPolicy: IfNotPresent
   port: 4000
@@ -350,7 +350,7 @@ apiServer:
 # -- Controller (Go reconciler + scheduler)
 controller:
   image:
-    repository: ghcr.io/kagenti/platform/controller
+    repository: ghcr.io/dam-agents/dam/controller
     tag: ""
     pullPolicy: IfNotPresent
   agentImagePullPolicy: IfNotPresent
@@ -452,7 +452,7 @@ defaultTemplate:
   enabled: true
   name: claude-code
   image:
-    repository: ghcr.io/kagenti/platform/claude-code
+    repository: ghcr.io/dam-agents/dam/claude-code
     tag: ""
     pullPolicy: IfNotPresent
   description: "Default Claude Code agent"
@@ -473,7 +473,7 @@ googleWorkspaceTemplate:
   enabled: false
   name: google-workspace
   image:
-    repository: ghcr.io/kagenti/platform/google-workspace-agent
+    repository: ghcr.io/dam-agents/dam/google-workspace-agent
     tag: ""
     pullPolicy: IfNotPresent
   description: "Google Workspace agent with Drive and Gmail via gws CLI"
@@ -492,7 +492,7 @@ piAgentTemplate:
   enabled: false
   name: pi-agent
   image:
-    repository: ghcr.io/kagenti/platform/pi-agent
+    repository: ghcr.io/dam-agents/dam/pi-agent
     tag: ""
     pullPolicy: IfNotPresent
   description: "Pi coding agent with multi-LLM support"
@@ -511,7 +511,7 @@ codeGuardianTemplate:
   enabled: false
   name: code-guardian
   image:
-    repository: ghcr.io/kagenti/platform/code-guardian
+    repository: ghcr.io/dam-agents/dam/code-guardian
     tag: ""
     pullPolicy: IfNotPresent
   description: "PR code review agent (gh + Claude Code)"


### PR DESCRIPTION
## Summary
- Helm values still hardcoded `ghcr.io/kagenti/platform/<component>`, but CI publishes to `ghcr.io/${{ github.repository }}/<component>` which now resolves to `ghcr.io/dam-agents/dam/<component>`. The rebrand to the `dam-agents` org left this path stale.
- Updates all seven repos (ui, api-server, controller, claude-code, google-workspace-agent, pi-agent, code-guardian) to the correct prefix.

## Test plan
- [ ] `mise run helm:check:lint` passes
- [ ] `mise run helm:check:render` renders without error
- [ ] Fresh `mise run cluster:install` (with `values-local.yaml`) still works since local image refs are overridden there
- [ ] A PR run of the publish workflow produces images at `ghcr.io/dam-agents/dam/<component>` matching the values