### PR TITLE
fix(harness): trusted-header auth via paired gateway Envoy

### DIFF
--- a/deploy/helm/platform/templates/apiserver/networkpolicy.yaml
+++ b/deploy/helm/platform/templates/apiserver/networkpolicy.yaml
@@ -14,9 +14,12 @@
 
   Policy shape:
     - `http` is allowed from anywhere (UI, ingress controller, in-cluster).
-    - `harness` + `ext-authz` are allowed only from pods carrying
-      `agent-platform.ai/instance` (instance pods + fork pods both set it) in the
-      configured `agentNamespace`.
+    - `harness` + `ext-authz` are allowed only from gateway pods
+      (`agent-platform.ai/role=gateway`) in the configured `agentNamespace`.
+      The api-server identifies the calling instance from the trusted
+      `x-platform-instance` header that gateway-pod Envoy injects on harness
+      traffic; admitting only gateway pods (and not the agent half of the
+      pair) ensures the agent cannot bypass Envoy to forge that header.
 
   K8s NetworkPolicy semantics: each ingress rule is OR-ed. A rule with no
   `from` allows from anywhere; a rule with `from` restricts to that source.
@@ -46,18 +49,19 @@ spec:
         - protocol: TCP
           port: {{ .Values.apiServer.port }}
 
-    # harness + ext-authz: agent + fork pods only. The pod-selector key
-    # `agent-platform.ai/instance` is set by the controller on both StatefulSet pods
-    # and fork Jobs (`ForkLabelInstanceRef`); matching by Exists covers
-    # both without listing each fork-id.
+    # harness + ext-authz: gateway pods only. Both long-lived pair gateways
+    # and per-fork gateways carry `agent-platform.ai/role=gateway`; matching
+    # on the role label admits both shapes without enumerating fork-ids.
+    # The agent half of each pair is deliberately NOT admitted here — it
+    # must traverse its paired gateway's Envoy, which stamps the trusted
+    # `x-platform-instance` header.
     - from:
         - namespaceSelector:
             matchLabels:
               kubernetes.io/metadata.name: {{ .Values.agentNamespace | quote }}
           podSelector:
-            matchExpressions:
-              - key: agent-platform.ai/instance
-                operator: Exists
+            matchLabels:
+              agent-platform.ai/role: gateway
       ports:
         - protocol: TCP
           port: {{ .Values.apiServer.harnessServerPort }}

--- a/packages/agent-runtime/src/modules/pod-files/sse-client.ts
+++ b/packages/agent-runtime/src/modules/pod-files/sse-client.ts
@@ -1,88 +1,75 @@
-import { request as httpRequest, Agent as HttpAgent } from "node:http";
-import { request as httpsRequest, Agent as HttpsAgent } from "node:https";
-
-// Direct agents bypass HTTP_PROXY env vars — the api-server is reached
-// internally over the cluster network, not through the Envoy sidecar.
-const directAgent = new HttpAgent({ keepAlive: true });
-const directHttpsAgent = new HttpsAgent({ keepAlive: true });
-
 export interface StreamOptions {
   url: string;
   onDispatch: (event: string, data: string) => void;
+  signal?: AbortSignal;
 }
 
 /**
  * Open one SSE connection and dispatch frames until the server closes the
  * stream or the connection errors. Resolves on clean end; rejects on
- * status != 200 or transport error. The api-server's harness port admits
- * agent pods via NetworkPolicy and identifies the caller by source IP — no
- * Bearer header is sent.
+ * status != 200 or transport error. The connection goes through the
+ * paired gateway pod's Envoy (HTTP_PROXY honored via undici because
+ * NODE_USE_ENV_PROXY=1 is set on the agent pod), and Envoy stamps the
+ * trusted `x-platform-instance` header that the api-server identifies
+ * the caller from. No client-side auth header is sent.
  */
-export function streamOnce(opts: StreamOptions): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const url = new URL(opts.url);
-    const doRequest = url.protocol === "https:" ? httpsRequest : httpRequest;
-    const agent = url.protocol === "https:" ? directHttpsAgent : directAgent;
+export async function streamOnce(opts: StreamOptions): Promise<void> {
+  const res = await fetch(opts.url, {
+    method: "GET",
+    headers: {
+      Accept: "text/event-stream",
+      "Cache-Control": "no-cache",
+    },
+    signal: opts.signal,
+  });
+  if (res.status !== 200) {
+    // Drain so the connection can be reused.
+    await res.body?.cancel();
+    throw new Error(`unexpected status ${res.status}`);
+  }
+  if (!res.body) throw new Error("response had no body");
+  process.stderr.write(`[pod-files] connected ${opts.url}\n`);
 
-    const req = doRequest(
-      url,
-      {
-        method: "GET",
-        agent,
-        headers: {
-          Accept: "text/event-stream",
-          "Cache-Control": "no-cache",
-        },
-      },
-      (res) => {
-        if (res.statusCode !== 200) {
-          // Drain body so the socket can be reused.
-          res.resume();
-          reject(new Error(`unexpected status ${res.statusCode}`));
-          return;
-        }
-        process.stderr.write(`[pod-files] connected ${opts.url}\n`);
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder("utf-8");
+  let buffer = "";
+  let event = "";
+  let data = "";
 
-        let buffer = "";
-        let event = "";
-        let data = "";
+  try {
+    for (;;) {
+      const { value, done } = await reader.read();
+      if (done) return;
+      buffer += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = buffer.indexOf("\n")) >= 0) {
+        let line = buffer.slice(0, nl);
+        buffer = buffer.slice(nl + 1);
+        if (line.endsWith("\r")) line = line.slice(0, -1);
 
-        res.setEncoding("utf8");
-        res.on("data", (chunk: string) => {
-          buffer += chunk;
-          let nl: number;
-          while ((nl = buffer.indexOf("\n")) >= 0) {
-            let line = buffer.slice(0, nl);
-            buffer = buffer.slice(nl + 1);
-            if (line.endsWith("\r")) line = line.slice(0, -1);
-
-            if (line === "") {
-              if (event !== "" || data !== "") {
-                try {
-                  opts.onDispatch(event, data);
-                } catch (err) {
-                  process.stderr.write(`[pod-files] dispatch failed: ${err}\n`);
-                }
-              }
-              event = "";
-              data = "";
-              continue;
-            }
-            if (line.startsWith("event:")) {
-              event = line.slice("event:".length).trim();
-            } else if (line.startsWith("data:")) {
-              const piece = line.slice("data:".length).trim();
-              data = data === "" ? piece : data + "\n" + piece;
+        if (line === "") {
+          if (event !== "" || data !== "") {
+            try {
+              opts.onDispatch(event, data);
+            } catch (err) {
+              process.stderr.write(`[pod-files] dispatch failed: ${err}\n`);
             }
           }
-        });
-        res.on("end", resolve);
-        res.on("error", reject);
-      },
-    );
-    req.on("error", reject);
-    req.end();
-  });
+          event = "";
+          data = "";
+          continue;
+        }
+        if (line.startsWith("event:")) {
+          event = line.slice("event:".length).trim();
+        } else if (line.startsWith("data:")) {
+          const piece = line.slice("data:".length).trim();
+          data = data === "" ? piece : data + "\n" + piece;
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
 }
 
 export interface RunOptions extends StreamOptions {
@@ -97,7 +84,7 @@ export interface RunOptions extends StreamOptions {
 /**
  * Run the SSE loop forever, reconnecting with exponential backoff (jittered)
  * after each disconnect. Returns when never — pod lifetime is the loop's
- * lifetime. The Go sidecar's behaviour, ported.
+ * lifetime.
  */
 export async function runSseLoop(opts: RunOptions): Promise<never> {
   const minBackoff = opts.minBackoffMs ?? 1000;

--- a/packages/agent-runtime/src/trigger-watcher.ts
+++ b/packages/agent-runtime/src/trigger-watcher.ts
@@ -1,13 +1,5 @@
 import { watch, mkdirSync, readdirSync, readFileSync, unlinkSync, existsSync } from "node:fs";
 import { join } from "node:path";
-import { Agent, request } from "node:http";
-import { Agent as HttpsAgent, request as requestHttps } from "node:https";
-
-// Explicit agents bypass HTTP_PROXY env vars (agent pods route external
-// traffic through the Envoy sidecar, but internal cluster calls must go
-// direct).
-const directAgent = new Agent();
-const directHttpsAgent = new HttpsAgent();
 import { z } from "zod/v4";
 import { config } from "./modules/config.js";
 
@@ -107,8 +99,9 @@ async function processTrigger(
     }
     const mcpServers = [...trigger.mcpServers];
     if (config.PLATFORM_MCP_URL) {
-      // No Authorization header: the api-server's harness port admits agent
-      // pods via NetworkPolicy and identifies the caller by source IP.
+      // No Authorization header: harness traffic flows through the paired
+      // gateway pod's Envoy, which stamps the trusted `x-platform-instance`
+      // header the api-server identifies the caller from.
       mcpServers.push({ type: "http", name: "platform-outbound", url: config.PLATFORM_MCP_URL, headers: [] });
     }
 
@@ -128,41 +121,27 @@ async function processTrigger(
   }
 }
 
-/** POST to the API server's /internal/trigger endpoint using node:http (bypasses HTTP_PROXY). */
-function postTrigger(
+/** POST to the API server's /internal/trigger endpoint. fetch routes via
+ *  HTTP_PROXY because NODE_USE_ENV_PROXY=1 is set on agent pods, so the
+ *  request flows through the paired gateway pod's Envoy and picks up the
+ *  trusted `x-platform-instance` header on the way through. */
+async function postTrigger(
   apiServerUrl: string,
   body: object,
 ): Promise<{ sessionId: string; stopReason?: string }> {
-  return new Promise((resolve, reject) => {
-    const url = new URL("/internal/trigger", apiServerUrl);
-    const payload = JSON.stringify(body);
-    const doRequest = url.protocol === "https:" ? requestHttps : request;
-
-    const req = doRequest(url, {
-      method: "POST",
-      agent: url.protocol === "https:" ? directHttpsAgent : directAgent,
-      headers: {
-        "Content-Type": "application/json",
-        "Content-Length": Buffer.byteLength(payload),
-      },
-    }, (res) => {
-      let data = "";
-      res.on("data", (chunk) => { data += chunk; });
-      res.on("end", () => {
-        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
-          try {
-            resolve(JSON.parse(data));
-          } catch {
-            reject(new Error(`Invalid JSON response: ${data}`));
-          }
-        } else {
-          reject(new Error(`POST /internal/trigger failed: ${res.statusCode} ${data}`));
-        }
-      });
-    });
-
-    req.on("error", reject);
-    req.write(payload);
-    req.end();
+  const url = new URL("/internal/trigger", apiServerUrl);
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
   });
+  const data = await res.text();
+  if (!res.ok) {
+    throw new Error(`POST /internal/trigger failed: ${res.status} ${data}`);
+  }
+  try {
+    return JSON.parse(data);
+  } catch {
+    throw new Error(`Invalid JSON response: ${data}`);
+  }
 }

--- a/packages/api-server/src/apps/harness-api-server/harness-router.ts
+++ b/packages/api-server/src/apps/harness-api-server/harness-router.ts
@@ -5,6 +5,7 @@ import {
   mountPodFilesEventsRoute,
   type PodFilesEventsDeps,
 } from "./pod-files-events.js";
+import { verifyInstanceFromHeader } from "./instance-auth.js";
 import type { ChannelManager } from "./../../modules/channels/services/channel-manager.js";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
 
@@ -36,6 +37,14 @@ export function createHarnessRouter(deps: {
     const body = await c.req.json<TriggerRequest>();
     if (!body.instanceId || !body.schedule || !body.task) {
       return c.json({ error: "instanceId, schedule, task required" }, 400);
+    }
+    // The body's `instanceId` must match the trusted header that the
+    // gateway pod's Envoy stamps; without this an instance could fire
+    // triggers for someone else's instance even though it can only have
+    // the header for its own pair.
+    const verified = await verifyInstanceFromHeader(deps.k8s, c, body.instanceId);
+    if (!verified) {
+      return c.json({ error: "not found" }, 404);
     }
     const result = await deps.handleTrigger(body);
     return c.json(result);

--- a/packages/api-server/src/apps/harness-api-server/instance-auth.ts
+++ b/packages/api-server/src/apps/harness-api-server/instance-auth.ts
@@ -1,13 +1,24 @@
-import { createHash } from "node:crypto";
-import yaml from "js-yaml";
+import type { Context } from "hono";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
 import {
   LABEL_AGENT_REF,
   LABEL_OWNER,
-  STATUS_KEY,
 } from "../../modules/agents/infrastructure/labels.js";
 
-/** Resolved instance metadata derived from a successful Bearer-token check. */
+/** Header injected by the paired gateway pod's Envoy on harness-bound
+ *  traffic. The route that adds it strips any client-supplied value first
+ *  (`request_headers_to_remove` + `OVERWRITE_IF_EXISTS_OR_ADD`), so the
+ *  agent cannot forge identity even if it could route around `HTTP_PROXY`.
+ *  Trust here is topological: the api-server's harness-port ingress
+ *  NetworkPolicy admits only `role=gateway` pods, and the agent's egress
+ *  NetworkPolicy admits only the paired gateway — there is no path that
+ *  reaches this port without traversing an Envoy filter that owns this
+ *  header. */
+const INSTANCE_HEADER = "x-platform-instance";
+
+/** Resolved instance metadata. `instanceId` mirrors the URL parameter
+ *  after a successful header check; `agentId` and `owner` come from the
+ *  instance ConfigMap's labels. */
 export interface InstanceIdentity {
   instanceId: string;
   agentId: string;
@@ -15,36 +26,31 @@ export interface InstanceIdentity {
 }
 
 /**
- * Verify a per-instance Bearer token against the agent ConfigMap's
- * `accessTokenHash` and return the resolved (agent, owner) identity.
- * Returns null on any auth or lookup failure — callers map that to 401/404.
+ * Resolve the calling instance from the trusted `x-platform-instance`
+ * header injected by the paired gateway pod's Envoy. Returns null on any
+ * mismatch or lookup failure — callers map that to 404. Specifically:
+ *
+ *   - missing header → null (request did not traverse the gateway)
+ *   - header ≠ URL `:id` → null (caller addressing another instance)
+ *   - instance ConfigMap missing or unlabeled → null (drift)
+ *
+ * The header itself is not authenticated cryptographically; trust derives
+ * from the NetworkPolicy + Envoy topology described on `INSTANCE_HEADER`.
  */
-export async function verifyInstanceToken(
+export async function verifyInstanceFromHeader(
   k8s: K8sClient,
+  c: Context,
   instanceId: string,
-  token: string,
 ): Promise<InstanceIdentity | null> {
+  const claimed = c.req.header(INSTANCE_HEADER);
+  if (!claimed || claimed !== instanceId) return null;
+
   const instanceCm = await k8s.getConfigMap(instanceId);
   if (!instanceCm) return null;
 
   const agentId = instanceCm.metadata?.labels?.[LABEL_AGENT_REF];
   const owner = instanceCm.metadata?.labels?.[LABEL_OWNER];
   if (!agentId || !owner) return null;
-
-  const agentCm = await k8s.getConfigMap(agentId);
-  if (!agentCm) return null;
-  // Cross-check owner on both ConfigMaps so a relabeled instance (LABEL_AGENT_REF
-  // pointing at someone else's agent) can't authenticate against that agent's
-  // token hash.
-  if (agentCm.metadata?.labels?.[LABEL_OWNER] !== owner) return null;
-
-  const statusYaml = agentCm.data?.[STATUS_KEY];
-  if (!statusYaml) return null;
-  const status = yaml.load(statusYaml) as { accessTokenHash?: string };
-  if (!status?.accessTokenHash) return null;
-
-  const hash = createHash("sha256").update(token).digest("hex");
-  if (hash !== status.accessTokenHash) return null;
 
   return { instanceId, agentId, owner };
 }

--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -10,7 +10,7 @@ import { ChannelType, type SchedulesService, type SkillsService } from "api-serv
 import type { ChannelManager, ChannelAttachment } from "./../../modules/channels/services/channel-manager.js";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
 import { podBaseUrl } from "../../modules/agents/infrastructure/k8s.js";
-import { verifyInstanceToken } from "./instance-auth.js";
+import { verifyInstanceFromHeader } from "./instance-auth.js";
 
 const SESSION_TTL_MS = 30 * 60 * 1000;
 
@@ -355,14 +355,8 @@ export interface MountMcpDeps {
 
 export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
   app.all("/api/instances/:id/mcp", async (c) => {
-    const authHeader = c.req.header("authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return c.json({ error: "unauthorized" }, 401);
-    }
-    const token = authHeader.slice(7);
-
     const instanceId = c.req.param("id")!;
-    const verified = await verifyInstanceToken(deps.k8s, instanceId, token);
+    const verified = await verifyInstanceFromHeader(deps.k8s, c, instanceId);
     if (!verified) {
       return c.json({ error: "not found" }, 404);
     }

--- a/packages/api-server/src/apps/harness-api-server/pod-files-events.ts
+++ b/packages/api-server/src/apps/harness-api-server/pod-files-events.ts
@@ -3,7 +3,7 @@ import { streamSSE } from "hono/streaming";
 import type { PodFilesBus } from "../../modules/pod-files/bus.js";
 import type { FileSpec } from "../../modules/pod-files/types.js";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
-import { verifyInstanceToken } from "./instance-auth.js";
+import { verifyInstanceFromHeader } from "./instance-auth.js";
 
 export interface PodFilesEventsDeps {
   k8s: K8sClient;
@@ -14,19 +14,15 @@ export interface PodFilesEventsDeps {
 
 /**
  * Mount the SSE channel that the agent-pod sidecar holds open.
- * Auth: Bearer token (per-instance). Topics: keyed by agent name because
+ * Auth: trusted `x-platform-instance` header from the paired gateway's
+ * Envoy (see instance-auth.ts). Topics: keyed by agent name because
  * connection grants are agent-scoped — every running instance of the same
  * agent sees the same set of granted connections, so they share one topic.
  */
 export function mountPodFilesEventsRoute(app: Hono, deps: PodFilesEventsDeps) {
   app.get("/api/instances/:id/pod-files/events", async (c) => {
-    const authHeader = c.req.header("authorization");
-    if (!authHeader?.startsWith("Bearer ")) {
-      return c.json({ error: "unauthorized" }, 401);
-    }
-    const token = authHeader.slice(7);
     const instanceId = c.req.param("id")!;
-    const identity = await verifyInstanceToken(deps.k8s, instanceId, token);
+    const identity = await verifyInstanceFromHeader(deps.k8s, c, instanceId);
     if (!identity) return c.json({ error: "not found" }, 404);
 
     const { agentId, owner } = identity;

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -323,6 +323,37 @@ static_resources:
                             envoy.filters.http.ext_authz:
                               "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
                               disabled: true
+                        # Platform-internal harness traffic. Match by
+                        # :authority so this route only applies to
+                        # api-server-bound calls; everything else falls
+                        # through to the egress fallthrough below.
+                        # Strip any client-supplied x-platform-instance
+                        # first, then re-add the trusted value — the
+                        # api-server identifies the caller from this
+                        # header and the agent must not be able to
+                        # forge it. ext_authz is disabled here: this is
+                        # control-plane traffic to the api-server, not
+                        # user egress, so HITL rules do not apply.
+                        - match:
+                            prefix: "/"
+                            headers:
+                              - name: ":authority"
+                                string_match:
+                                  exact: "{{ $.HarnessAuthority }}"
+                          route:
+                            cluster: dynamic_forward_proxy_http
+                            timeout: 0s
+                          request_headers_to_remove:
+                            - x-platform-instance
+                          request_headers_to_add:
+                            - header:
+                                key: x-platform-instance
+                                value: "{{ $.InstanceID }}"
+                              append_action: OVERWRITE_IF_EXISTS_OR_ADD
+                          typed_per_filter_config:
+                            envoy.filters.http.ext_authz:
+                              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                              disabled: true
                         # Plain HTTP fallthrough. The outer HCM's
                         # ext_authz fires here (CONNECT disables it
                         # per-route above; plain HTTP does not), passing
@@ -607,6 +638,11 @@ func renderEnvoyBootstrap(instanceName string, cfg *config.Config, routes []envo
 	// Envoy's per-call timeout sits ahead of the application-level hold so a
 	// hold-window timeout fires from the api-server side, not from Envoy.
 	extAuthzTimeoutSeconds := cfg.ExtAuthzHoldSeconds + 60
+	// :authority value the api-server harness port is reached on. The agent
+	// builds harness URLs from cfg.HarnessServerURL, so the Host/:authority
+	// includes the port. We match on this exact string so the trusted-header
+	// route is scoped to api-server traffic only.
+	harnessAuthority := fmt.Sprintf("%s:%d", cfg.APIServerHost, cfg.HarnessServerPort)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, struct {
 		ListenAddress          string
@@ -617,6 +653,7 @@ func renderEnvoyBootstrap(instanceName string, cfg *config.Config, routes []envo
 		CredentialSDSName      string
 		LeafTLSDir             string
 		InstanceID             string
+		HarnessAuthority       string
 		ExtAuthzHost           string
 		ExtAuthzPort           int
 		ExtAuthzHoldSeconds    int
@@ -630,6 +667,7 @@ func renderEnvoyBootstrap(instanceName string, cfg *config.Config, routes []envo
 		CredentialSDSName:      envoyCredentialSDSName,
 		LeafTLSDir:             envoyLeafTLSMount,
 		InstanceID:             instanceName,
+		HarnessAuthority:       harnessAuthority,
 		ExtAuthzHost:           cfg.ExtAuthzHost,
 		ExtAuthzPort:           cfg.ExtAuthzPort,
 		ExtAuthzHoldSeconds:    cfg.ExtAuthzHoldSeconds,
@@ -716,7 +754,7 @@ func ptrBool(b bool) *bool { return &b }
 // kubelet keeps the old bootstrap mounted.
 //
 // Bump on any template change that affects pod-visible behavior.
-const envoyBootstrapTemplateRev = "v3-paired-gateway"
+const envoyBootstrapTemplateRev = "v4-harness-trusted-header"
 
 // envoySecretsRev is a stable digest of the Secret set that drives Envoy's
 // chain rendering: secret name + host + secret-type label + headerName,

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -67,8 +67,6 @@ func BuildForkAgentJob(
 		{Name: "HTTP_PROXY", Value: proxyAddr},
 		{Name: "https_proxy", Value: proxyAddr},
 		{Name: "http_proxy", Value: proxyAddr},
-		{Name: "NO_PROXY", Value: cfg.APIServerHost},
-		{Name: "no_proxy", Value: cfg.APIServerHost},
 		{Name: "SSL_CERT_FILE", Value: caCertPath},
 		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
 		{Name: "GIT_SSL_CAINFO", Value: caCertPath},

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -121,6 +121,7 @@ func BuildGatewayNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *core
 	udp := corev1.ProtocolUDP
 	envoyPort := intstr.FromInt32(portInt32(cfg.EnvoyPort))
 	extAuthzPort := intstr.FromInt32(portInt32(cfg.ExtAuthzPort))
+	harnessPort := intstr.FromInt32(portInt32(cfg.HarnessServerPort))
 	httpsPort := intstr.FromInt32(443)
 	httpPort := intstr.FromInt32(80)
 	dnsPort := intstr.FromInt32(53)
@@ -136,9 +137,11 @@ func BuildGatewayNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *core
 			},
 		},
 		{
-			// HITL ext_authz gate (ADR-035). gRPC Check on every credentialed
-			// request and on the L4 catch-all chain. failure_mode_allow=false
-			// in Envoy means a blocked Check fails closed.
+			// API server: HITL ext_authz gate (ADR-035) on the gRPC port and
+			// harness API (MCP, pod-files SSE, /internal/trigger) on the HTTP
+			// port. Both run on the apiserver pod; Envoy stamps a trusted
+			// `x-platform-instance` header on harness traffic and the
+			// agent has no path here that bypasses Envoy.
 			To: []networkingv1.NetworkPolicyPeer{{
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"app.kubernetes.io/component": "apiserver"},
@@ -149,6 +152,7 @@ func BuildGatewayNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *core
 			}},
 			Ports: []networkingv1.NetworkPolicyPort{
 				{Protocol: &tcp, Port: &extAuthzPort},
+				{Protocol: &tcp, Port: &harnessPort},
 			},
 		},
 		{

--- a/packages/controller/pkg/reconciler/gateway_test.go
+++ b/packages/controller/pkg/reconciler/gateway_test.go
@@ -106,11 +106,23 @@ func TestBuildGatewayNetworkPolicy(t *testing.T) {
 	assert.True(t, saw80, "gateway must permit egress on TCP 80")
 	assert.True(t, saw443, "gateway must permit egress on TCP 443")
 
-	extAuthz := np.Spec.Egress[1]
-	require.Len(t, extAuthz.To, 1)
-	assert.Equal(t, "apiserver", extAuthz.To[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
-	require.Len(t, extAuthz.Ports, 1)
-	assert.Equal(t, int32(4002), extAuthz.Ports[0].Port.IntVal)
+	apiserver := np.Spec.Egress[1]
+	require.Len(t, apiserver.To, 1)
+	assert.Equal(t, "apiserver", apiserver.To[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
+	// ext_authz (gRPC) + harness (HTTP). Both terminate at the apiserver pod;
+	// the same egress rule covers both ports.
+	require.Len(t, apiserver.Ports, 2)
+	var sawExtAuthz, sawHarness bool
+	for _, p := range apiserver.Ports {
+		if p.Port.IntVal == 4002 {
+			sawExtAuthz = true
+		}
+		if p.Port.IntVal == 4001 {
+			sawHarness = true
+		}
+	}
+	assert.True(t, sawExtAuthz, "gateway must permit egress to apiserver ext_authz port")
+	assert.True(t, sawHarness, "gateway must permit egress to apiserver harness port")
 
 	// Ingress: paired agent pod only, exact pair-match.
 	require.Len(t, np.Spec.Ingress, 1)

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -77,13 +77,17 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	// agent-runtime's tRPC are gated at the kernel by the pod's
 	// NetworkPolicy (ingress admitted only from the api-server pod);
 	// outbound calls cross the paired gateway pod for credential injection.
+	//
+	// Harness API traffic ALSO crosses the paired gateway: there is no
+	// NO_PROXY carve-out for the api-server. Envoy on the gateway pod
+	// injects an `x-platform-instance` header that the api-server trusts
+	// for caller identity (the agent pod has no direct egress path to the
+	// harness port, so it cannot forge the header by bypassing Envoy).
 	env := []corev1.EnvVar{
 		{Name: "HTTPS_PROXY", Value: proxyAddr},
 		{Name: "HTTP_PROXY", Value: proxyAddr},
 		{Name: "https_proxy", Value: proxyAddr},
 		{Name: "http_proxy", Value: proxyAddr},
-		{Name: "NO_PROXY", Value: cfg.APIServerHost},
-		{Name: "no_proxy", Value: cfg.APIServerHost},
 		{Name: "SSL_CERT_FILE", Value: caCertPath},
 		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
 		{Name: "GIT_SSL_CAINFO", Value: caCertPath},
@@ -357,7 +361,6 @@ func BuildAgentNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
 	acpPort := intstr.FromInt32(8080)
-	harnessPort := intstr.FromInt32(portInt32(cfg.HarnessServerPort))
 	envoyPort := intstr.FromInt32(portInt32(cfg.EnvoyPort))
 	dnsPort := intstr.FromInt32(53)
 	dnsTargetPort := intstr.FromInt32(5353)
@@ -367,6 +370,12 @@ func BuildAgentNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1
 			// Paired gateway pod only — exact-match on pair + role.
 			// Loosening to a wildcard would let one pair's agent dial
 			// another's gateway, defeating the boundary (ADR-038 §Threat Model).
+			//
+			// All TCP egress — including harness API calls to the api-server —
+			// flows through this single gateway hop. Envoy on the gateway pod
+			// stamps the trusted `x-platform-instance` header on harness
+			// traffic; without a direct path here the agent cannot bypass
+			// Envoy to forge identity.
 			To: []networkingv1.NetworkPolicyPeer{{
 				PodSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
@@ -377,23 +386,6 @@ func BuildAgentNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1
 			}},
 			Ports: []networkingv1.NetworkPolicyPort{
 				{Protocol: &tcp, Port: &envoyPort},
-			},
-		},
-		{
-			// Harness API server: separate port exposing only the subset of
-			// API available to agent harnesses (triggers, MCP tools).
-			// Platform-internal control plane, not a credentialed external
-			// resource — no proxy hop needed.
-			To: []networkingv1.NetworkPolicyPeer{{
-				PodSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"app.kubernetes.io/component": "apiserver"},
-				},
-				NamespaceSelector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{"kubernetes.io/metadata.name": cfg.ReleaseNamespace},
-				},
-			}},
-			Ports: []networkingv1.NetworkPolicyPort{
-				{Protocol: &tcp, Port: &harnessPort},
 			},
 		},
 		{

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -281,9 +281,12 @@ func TestBuildAgentNetworkPolicy(t *testing.T) {
 	assert.Equal(t, "agent", np.Spec.PodSelector.MatchLabels["agent-platform.ai/role"])
 	require.Len(t, np.OwnerReferences, 1)
 
-	// ADR-038: egress is gateway pod + harness + DNS. Open 80/443 to the
-	// world is gone — that bypass is the whole point of the split.
-	require.Len(t, np.Spec.Egress, 3)
+	// ADR-038: egress is paired gateway + DNS. The agent must have no path
+	// to 80/443 anywhere (that bypass is the point of the split) and no
+	// direct path to the harness port either — harness traffic must
+	// traverse the gateway's Envoy so the trusted x-platform-instance
+	// header is stamped on the way through.
+	require.Len(t, np.Spec.Egress, 2)
 
 	// 1: paired gateway pod only
 	gatewayEgress := np.Spec.Egress[0]
@@ -293,16 +296,18 @@ func TestBuildAgentNetworkPolicy(t *testing.T) {
 	require.Len(t, gatewayEgress.Ports, 1)
 	assert.Equal(t, int32(10000), gatewayEgress.Ports[0].Port.IntVal)
 
-	// 2: harness API server
-	harness := np.Spec.Egress[1]
-	require.Len(t, harness.To, 1)
-	assert.Equal(t, "apiserver", harness.To[0].PodSelector.MatchLabels["app.kubernetes.io/component"])
-	require.Len(t, harness.Ports, 1)
-	assert.Equal(t, int32(4001), harness.Ports[0].Port.IntVal)
-
-	// 3: DNS
-	dns := np.Spec.Egress[2]
+	// 2: DNS
+	dns := np.Spec.Egress[1]
 	assert.Empty(t, dns.To)
+
+	// No direct egress to the harness port: every harness call must go
+	// through the gateway's Envoy or the trusted-header trust model breaks.
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			assert.NotEqual(t, int32(testConfig.HarnessServerPort), p.Port.IntVal,
+				"agent NetworkPolicy must not admit direct egress to the harness port")
+		}
+	}
 
 	// Agent must NOT be allowed to dial 80/443 anywhere — that's the bypass.
 	for _, rule := range np.Spec.Egress {

--- a/packages/controller/pkg/reconciler/status.go
+++ b/packages/controller/pkg/reconciler/status.go
@@ -12,14 +12,6 @@ import (
 	"github.com/kagenti/platform/packages/controller/pkg/types"
 )
 
-type AgentStatus struct {
-	AccessTokenHash string `yaml:"accessTokenHash"`
-}
-
-func WriteAgentStatus(ctx context.Context, client kubernetes.Interface, namespace, name string, status *AgentStatus) error {
-	return writeStatus(ctx, client, namespace, name, status)
-}
-
 func WriteInstanceStatus(ctx context.Context, client kubernetes.Interface, namespace, name string, status *types.InstanceStatus) error {
 	return writeStatus(ctx, client, namespace, name, status)
 }


### PR DESCRIPTION
## Summary

- harness API was 401-looping for every agent: server required `Authorization: Bearer` validated against `accessTokenHash`, but the controller never wrote that hash and agent-runtime sent no Authorization header (half-finished migration). Pod-files SSE never delivered.
- closes the gap with topology-rooted trust: paired gateway pod's Envoy stamps `x-platform-instance` on harness-bound traffic (`request_headers_to_remove` + `OVERWRITE_IF_EXISTS_OR_ADD`); api-server identifies the caller from that header.
- agent has no direct egress to the harness port, and the api-server's harness-port ingress admits only `role=gateway` pods, so the agent cannot bypass Envoy to forge identity.

Stop-gap until Istio ambient / PeerAuthentication identity replaces it.

## Implementation

- `controller/envoy.go`: new route on the outer HCM matched by `:authority == <api-server-harness-host:port>` with `request_headers_to_remove: [x-platform-instance]` + `request_headers_to_add: x-platform-instance: <pair-key>` (OVERWRITE_IF_EXISTS_OR_ADD); ext_authz disabled per-route (control-plane traffic). Bootstrap rev bumped to `v4-harness-trusted-header` so live gateway pods roll on chart upgrade.
- `controller/resources.go` + `fork_resources.go`: dropped the `NO_PROXY` carve-out for the api-server and the agent NetworkPolicy egress rule that admitted direct harness reach. All harness traffic now flows through `HTTP_PROXY` → paired gateway Envoy.
- `controller/gateway.go`: gateway egress to the api-server now covers ext_authz (4002) and harness (4001). Tests updated.
- `helm/apiserver/networkpolicy.yaml`: harness + ext_authz ingress tightened to pods carrying `agent-platform.ai/role=gateway`.
- `api-server/instance-auth.ts`: `verifyInstanceToken` (Bearer + SHA256 compare) replaced by `verifyInstanceFromHeader`. Applied on `/api/instances/:id/pod-files/events`, `/api/instances/:id/mcp`, and `/internal/trigger`.
- `agent-runtime/sse-client.ts` + `trigger-watcher.ts`: dropped the explicit `directAgent` HTTP agents (which bypassed `HTTP_PROXY`); switched to `fetch`. undici routes through `HTTP_PROXY` because `NODE_USE_ENV_PROXY=1` is already set on agent pods.
- Dead controller `AgentStatus.AccessTokenHash` and `WriteAgentStatus` removed.

## Test plan

- [x] `mise run check` (lint + tsc + helm lint/render + go vet)
- [x] `mise run test` (controller, agent-runtime, ui, api-server)
- [ ] `mise run cluster:install` and exercise an instance: pod-files SSE no longer 401-loops, MCP tools work, scheduled trigger fires.
- [ ] Foreign-replier fork: confirm fork pair authenticates as the parent against api-server endpoints (forks reuse the parent instance label, header is stamped with the parent id).

## Follow-ups (out of scope here)

- Architecture docs (`docs/architecture/channels.md`, `platform-topology.md`, `skills.md`) still describe the old auth model (Bearer / source-IP). Worth a focused doc pass once this lands.
- The `[acp] closing idle session ... Session not found` log noise is unrelated and not addressed here — `maybeCloseIdleSession` deletes its bookkeeping before the agent's `session/close` reply lands. Cosmetic.