### PR TITLE
fix(controller): pin credentialed upstream cluster to V4_PREFERRED

### DIFF
--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -569,9 +569,16 @@ static_resources:
     # and validates the upstream cert's SAN against {{ .Host }}, so even a
     # poisoned cache or misrouted endpoint fails the handshake before any
     # credentialed body is on the wire.
+    #
+    # dns_lookup_family is set explicitly because STRICT_DNS defaults to
+    # AUTO (IPv6-first); clusters whose pods lack IPv6 egress would fail
+    # with "Network is unreachable" before the credentialed body lands on
+    # the wire. Mirrors the V4_PREFERRED choice used by every other DNS
+    # cluster in this bootstrap.
     - name: upstream_{{ .SecretName }}
       connect_timeout: 5s
       type: STRICT_DNS
+      dns_lookup_family: V4_PREFERRED
       lb_policy: ROUND_ROBIN
       load_assignment:
         cluster_name: upstream_{{ .SecretName }}
@@ -754,7 +761,7 @@ func ptrBool(b bool) *bool { return &b }
 // kubelet keeps the old bootstrap mounted.
 //
 // Bump on any template change that affects pod-visible behavior.
-const envoyBootstrapTemplateRev = "v4-harness-trusted-header"
+const envoyBootstrapTemplateRev = "v5-upstream-v4-preferred"
 
 // envoySecretsRev is a stable digest of the Secret set that drives Envoy's
 // chain rendering: secret name + host + secret-type label + headerName,

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -153,6 +153,12 @@ func TestRenderEnvoyBootstrap_CredentialedRoutePinnedToStaticCluster(t *testing.
 	assert.Contains(t, got, "address: api.github.com")
 	assert.Contains(t, got, "port_value: 443")
 
+	// STRICT_DNS defaults to AUTO (IPv6-first); pods on IPv4-only egress
+	// would otherwise see "Network is unreachable" against the resolved
+	// AAAA. Match the explicit V4_PREFERRED used by every other DNS
+	// cluster in the bootstrap.
+	assert.Contains(t, got, "dns_lookup_family: V4_PREFERRED")
+
 	// Upstream TLS hard-binds SNI to the credential's host and SAN-validates
 	// the upstream cert against it. Even a poisoned DNS cache or misrouted
 	// cluster fails the upstream handshake before the credentialed body


### PR DESCRIPTION
## Summary

- Per-credential STRICT_DNS cluster (`upstream_<secret>`) had no `dns_lookup_family` set, so Envoy used the default `AUTO` (IPv6-first). Pods on IPv4-only egress saw "Network is unreachable" against the resolved AAAA — surfacing as a 503 from the gateway *after* a successful CONNECT + MITM TLS handshake (e.g. `api.anthropic.com → [2607:6bc0::10]:443`).
- Set `dns_lookup_family: V4_PREFERRED` on the pinned cluster to match every other DNS cluster in the bootstrap.
- Bumped `envoyBootstrapTemplateRev` so existing instance pods roll on chart upgrade. Added a regression assertion in `envoy_test.go`.

## Test plan

- [x] `mise run check` passes
- [x] `mise run test` passes (controller suite includes the new assertion)
- [ ] Verify on a v6-less cluster: deploy, exercise an Anthropic-credentialed instance end-to-end, confirm the agent reaches `api.anthropic.com` without the 503