### PR TITLE
docs(adr): switch CLI config from ~/.dam/ to XDG paths

### DIFF
--- a/docs/adrs/039-cli-foundation.md
+++ b/docs/adrs/039-cli-foundation.md
@@ -1,6 +1,6 @@
 # ADR-039: Platform CLI foundation — TypeScript on Node, npm distribution
 
-**Date:** 2026-05-05 (revised 2026-05-07 to switch from `~/.dam/` to XDG paths after review feedback in [#100](https://github.com/dam-agents/dam/pull/100))
+**Date:** 2026-05-05
 **Status:** Accepted
 **Owner:** @PetrBulanek
 
@@ -20,7 +20,7 @@ The load-bearing rules:
 
 - **One language stack.** TypeScript, the same stack as the API server and UI ([ADR-009](009-go-and-typescript.md)). The team writes TypeScript daily; the repo's only non-TS package is the controller. Adding a third language stack for one tool is ongoing tax. The CLI also consumes `api-server-api` directly today, getting tRPC types end-to-end without codegen — a current convenience that depends on how the API surface evolves.
 - **Ship as a Node script, not a native binary.** `npm install -g @dam-agents/cli` is the only install path. Users must have Node ≥ 20. npm is also the prevailing AI-CLI install path, so the audience already has the toolchain.
-- **Config lives at `$XDG_CONFIG_HOME/dam/config.toml`** (default `~/.config/dam/config.toml`). TOML for hand-edit ergonomics and comment support. State and credentials live separately under `$XDG_STATE_HOME/dam/` (default `~/.local/state/dam/`) — config is editable user intent; state is machine-managed. The CLI honors `XDG_CONFIG_HOME` and `XDG_STATE_HOME` overrides; on macOS the same defaults apply (we do not use `~/Library/Application Support`).
+- **Config lives at `$XDG_CONFIG_HOME/dam/config.toml`** (default `~/.config/dam/config.toml`). TOML for hand-edit ergonomics and comment support. State and credentials live separately under `$XDG_STATE_HOME/dam/` (default `~/.local/state/dam/`) — config is editable user intent; state is machine-managed. The CLI honors `XDG_CONFIG_HOME` and `XDG_STATE_HOME` overrides.
 - **Flat config schema; no profiles.** A single configured server, no `current-profile` indirection.
 - **Configuration precedence: flag > env > file > error.** No silent default for the server URL. The CLI errors with a setup hint when nothing is configured.
 - **Independent semver, server-advertised compatibility floor.** The CLI versions independently of the platform. The server exposes an unauthenticated version endpoint returning its own version and the minimum CLI version it accepts. The CLI hard-refuses to run if below the floor and soft-warns to stderr if behind current. The endpoint is plain HTTP, deliberately outside the tRPC surface so it can be called before any authentication or client setup.

--- a/docs/adrs/039-cli-foundation.md
+++ b/docs/adrs/039-cli-foundation.md
@@ -1,6 +1,6 @@
 # ADR-039: Platform CLI foundation — TypeScript on Node, npm distribution
 
-**Date:** 2026-05-05
+**Date:** 2026-05-05 (revised 2026-05-07 to switch from `~/.dam/` to XDG paths after review feedback in [#100](https://github.com/dam-agents/dam/pull/100))
 **Status:** Accepted
 **Owner:** @PetrBulanek
 
@@ -14,13 +14,13 @@ This ADR implements [#79](https://github.com/dam-agents/dam/issues/79). Subseque
 
 ## Decision
 
-**The CLI is a TypeScript Node package, distributed via npm, that shares the API server's tRPC contract directly.** It runs on the user's installed Node — no bundled runtime. Cross-platform reach is macOS + Linux + Windows-via-WSL2. Configuration follows the AI-CLI category convention (`~/.dam/`) rather than XDG.
+**The CLI is a TypeScript Node package, distributed via npm, that shares the API server's tRPC contract directly.** It runs on the user's installed Node — no bundled runtime. Cross-platform reach is macOS + Linux + Windows-via-WSL2. Configuration follows the [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) — config under `$XDG_CONFIG_HOME/dam/` (default `~/.config/dam/`), state and credentials under `$XDG_STATE_HOME/dam/` (default `~/.local/state/dam/`).
 
 The load-bearing rules:
 
 - **One language stack.** TypeScript, the same stack as the API server and UI ([ADR-009](009-go-and-typescript.md)). The team writes TypeScript daily; the repo's only non-TS package is the controller. Adding a third language stack for one tool is ongoing tax. The CLI also consumes `api-server-api` directly today, getting tRPC types end-to-end without codegen — a current convenience that depends on how the API surface evolves.
-- **Ship as a Node script, not a native binary.** `npm install -g @dam-agents/cli` is the only install path. Users must have Node ≥ 20.
-- **Config lives at `~/.dam/config.toml`.** The AI-CLI category convention is to put state in `~/.<vendor>/`; the audience expects that location. TOML for hand-edit ergonomics and comment support. Auth credentials and other state will share the `~/.dam/` tree but explicitly not this file.
+- **Ship as a Node script, not a native binary.** `npm install -g @dam-agents/cli` is the only install path. Users must have Node ≥ 20. npm is also the prevailing AI-CLI install path, so the audience already has the toolchain.
+- **Config lives at `$XDG_CONFIG_HOME/dam/config.toml`** (default `~/.config/dam/config.toml`). TOML for hand-edit ergonomics and comment support. State and credentials live separately under `$XDG_STATE_HOME/dam/` (default `~/.local/state/dam/`) — config is editable user intent; state is machine-managed. The CLI honors `XDG_CONFIG_HOME` and `XDG_STATE_HOME` overrides; on macOS the same defaults apply (we do not use `~/Library/Application Support`).
 - **Flat config schema; no profiles.** A single configured server, no `current-profile` indirection.
 - **Configuration precedence: flag > env > file > error.** No silent default for the server URL. The CLI errors with a setup hint when nothing is configured.
 - **Independent semver, server-advertised compatibility floor.** The CLI versions independently of the platform. The server exposes an unauthenticated version endpoint returning its own version and the minimum CLI version it accepts. The CLI hard-refuses to run if below the floor and soft-warns to stderr if behind current. The endpoint is plain HTTP, deliberately outside the tRPC surface so it can be called before any authentication or client setup.
@@ -30,7 +30,7 @@ The load-bearing rules:
 
 This ADR explicitly does *not* decide:
 
-- **Authentication.** Token format, storage, OIDC flow shape — all owned by [#80](https://github.com/dam-agents/dam/issues/80). Only commitment here: credentials live somewhere under `~/.dam/`, not inside `config.toml`.
+- **Authentication.** Token format, storage, OIDC flow shape — all owned by [#80](https://github.com/dam-agents/dam/issues/80). Only commitment here: credentials live under `$XDG_STATE_HOME/dam/` (default `~/.local/state/dam/`), not inside `config.toml`.
 - **Instance addressing.** Name resolution and how the CLI selects an instance belong to [#81](https://github.com/dam-agents/dam/issues/81).
 - **Streaming transport for `dam shell`.** [#86](https://github.com/dam-agents/dam/issues/86) extends the foundation with a WebSocket attach. tRPC supports WebSocket links, so the extension is bounded.
 - **Workspace import.** Owned by [#73](https://github.com/dam-agents/dam/issues/73).
@@ -42,7 +42,7 @@ This ADR explicitly does *not* decide:
 - **Native binary distribution (Bun-compile, brew, curl-pipe).** Polished install story, no Node prerequisite. Rejected on demo-deadline grounds: the engineering cost (CI matrix, code-signing, install-script hosting) buys polish the demo doesn't need, and the npm-script path does not block the migration.
 - **Go or Rust for the CLI binary.** Smaller binaries, no Node prerequisite. Rejected because TypeScript is the team's daily language and the repo's only non-TS package is the controller — adding a third stack for one tool is ongoing tax. Contract consumption is a secondary concern: the current TS-direct-import advantage is tied to today's tRPC API. Any evolution of that surface — replacement, wrapping, supplementation by a separate API — shifts how every client consumes the contract, regardless of language.
 - **Python.** Considered. Rejected on the same team-velocity and single-stack-consistency grounds, plus a weaker single-binary distribution story than TypeScript (PyInstaller/Nuitka are clunkier than Bun-compile if/when we go that direction).
-- **XDG-compliant config path.** Matches generic developer-tool precedent. Rejected because the AI-CLI audience expects `~/.<vendor>/`; matching the audience's muscle memory beats matching a different audience's precedent.
+- **`~/.<vendor>/` (AI-CLI category convention).** Matches the muscle memory of users coming from other AI CLIs that lump config, credentials, and ephemeral state in one home-relative directory. Rejected because XDG is the standard developer-tool convention on Linux, respects `XDG_*` overrides (containers, multi-user setups, dotfile managers), and cleanly separates editable config from machine-managed state — a separation the AI-CLI category conflates rather than upholds. The original ADR took the opposite position; reversed during review (see [#100](https://github.com/dam-agents/dam/pull/100)).
 - **Profiles from day one.** Rejected on YAGNI grounds; the migration path remains open as a non-breaking on-read rewrite.
 - **Native Windows support.** Rejected because native Windows pulls forward design work for [#86](https://github.com/dam-agents/dam/issues/86) (Windows PTY differs) and expands the test matrix during demo crunch. WSL2 is supported transparently — it is just Linux from the binary's perspective.
 - **REST + manual fetch instead of tRPC client.** Rejected because it discards direct type imports without offering anything in return. If the API surface evolves later, the CLI follows it through whatever client tooling matches the new surface — manual fetch is never that answer.

--- a/docs/plans/cli-foundation/README.md
+++ b/docs/plans/cli-foundation/README.md
@@ -16,7 +16,7 @@ The Platform CLI (`dam`) is a TypeScript Node command-line client that lets a us
   - Config is resolved by precedence: command-line flag → environment variable → config file → error. No silent default.
   - The config file is flat — top-level keys only, no profile indirection (no `[profiles.*]`, no `current-profile`).
   - Commands that need the server refuse to run when the CLI is below the server-advertised `minClientVersion`.
-  - `~/.dam/config.toml` is the only persistence location for configuration. Auth credentials ([#80](https://github.com/dam-agents/dam/issues/80)) live elsewhere under `~/.dam/`, never in this file.
+  - `$XDG_CONFIG_HOME/dam/config.toml` (default `~/.config/dam/config.toml`) is the only persistence location for configuration. Auth credentials and machine-managed state ([#80](https://github.com/dam-agents/dam/issues/80)) live under `$XDG_STATE_HOME/dam/` (default `~/.local/state/dam/`), never in the config file.
   - The package declares Node ≥ 20 as its engine and may rely on Node 20+ built-ins (native `fetch`, etc.).
   - The CLI's semver is independent of the Platform's; compatibility is negotiated at runtime, never assumed via version coupling.
 - **Layout:** module nested at `packages/cli/src/modules/cli/`, mirroring the architecture's standard `src/modules/<name>/` shape from day one. `bin.ts` lives at the package root as the entrypoint. When a second bounded context arrives ([#80](https://github.com/dam-agents/dam/issues/80)), it slots in as `src/modules/<name>/` next to this one.
@@ -77,7 +77,7 @@ Dropped from the server-style three-layer template:
 
 - **Single bounded context.** No inter-module coupling within the package.
 - **Outbound imports.** Only `api-server-api` (read-only consumer of contract types; no tRPC procedure called in v1). Never imports from `api-server`, `agent-runtime`, `controller`, or `ui`.
-- **File system.** Only `ConfigStore` reads/writes `~/.dam/config.toml`.
+- **File system.** Only `ConfigStore` reads/writes the config file under `$XDG_CONFIG_HOME/dam/` (default `~/.config/dam/`).
 - **Network.** Only `VersionProbe` performs network calls.
 - **Environment.** Only `EnvReader` reads `process.env`. Services depend on the port, never on the global directly.
 - **Coupling direction.** bootstrap → commands → services → domain ← infrastructure. Domain has zero outside imports. Infrastructure imports domain types only.
@@ -86,7 +86,7 @@ Risks and mitigations:
 
 - *Risk:* future verbs ([#80](https://github.com/dam-agents/dam/issues/80), [#86](https://github.com/dam-agents/dam/issues/86), [#73](https://github.com/dam-agents/dam/issues/73)) bypass services and import infrastructure directly. *Mitigation:* new commands go through application services; new ports follow `*Store` / `*Probe` / `*Reader` naming.
 - *Risk:* `api-server-api` types get re-declared inside the CLI. *Mitigation:* import directly, never duplicate. Enforced when tRPC is wired in [#80](https://github.com/dam-agents/dam/issues/80).
-- *Risk:* `~/.dam/` ownership contested when [#80](https://github.com/dam-agents/dam/issues/80) adds credentials. *Mitigation:* `ConfigStore` is scoped to `config.toml` only; [#80](https://github.com/dam-agents/dam/issues/80) introduces a separate adapter for credentials in the same directory.
+- *Risk:* directory ownership contested when [#80](https://github.com/dam-agents/dam/issues/80) adds credentials. *Mitigation:* the XDG split makes this a non-issue — `ConfigStore` owns `$XDG_CONFIG_HOME/dam/config.toml`; [#80](https://github.com/dam-agents/dam/issues/80) introduces a separate adapter rooted at `$XDG_STATE_HOME/dam/`.
 
 ## Project metadata updates
 


### PR DESCRIPTION
Post-merge revision to [#100](https://github.com/dam-agents/dam/pull/100), addressing @JanPokorny's review feedback that didn't make it in before merge.

- Config moves from `~/.dam/config.toml` to `$XDG_CONFIG_HOME/dam/config.toml`. State and credentials go under `$XDG_STATE_HOME/dam/`. Honors `XDG_*` overrides.
- "AI CLIs use npm" folded into the distribution rationale.
- Alternatives Considered inverted — `~/.<vendor>/` is now the rejected option.
- Spec updated to match.

Doc-only — `packages/cli/` is untracked, no code follows.