### PR TITLE
feat(connections): GitHub App installation flow + admin-default override

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -164,6 +164,10 @@ spec:
             - name: PLATFORM_DEFAULT_GITHUB_CLIENT_SECRET
               value: {{ .clientSecret | quote }}
             {{- end }}
+            {{- if .appSlug }}
+            - name: PLATFORM_DEFAULT_GITHUB_APP_SLUG
+              value: {{ .appSlug | quote }}
+            {{- end }}
             {{- end }}
             {{- with .Values.apiServer.oauthAppDefaults.githubEnterprise }}
             {{- if .host }}
@@ -177,6 +181,10 @@ spec:
             {{- if .clientSecret }}
             - name: PLATFORM_DEFAULT_GHE_CLIENT_SECRET
               value: {{ .clientSecret | quote }}
+            {{- end }}
+            {{- if .appSlug }}
+            - name: PLATFORM_DEFAULT_GHE_APP_SLUG
+              value: {{ .appSlug | quote }}
             {{- end }}
             {{- end }}
             - name: REDIS_URL

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -348,17 +348,28 @@ apiServer:
     - cdn.mise.run
 
   # -- Optional platform-wide defaults for OAuth app credentials. When a field
-  # is set the connect form for the matching app drops the corresponding
-  # input — every user shares the admin-registered OAuth app. Leave empty
-  # to require each user to supply their own client id / secret.
+  # is set the connect form for the matching app collapses the corresponding
+  # input behind an "override" toggle — every user shares the admin-registered
+  # app by default, but can still substitute their own credentials when needed.
+  # Leave empty to require each user to supply their own client id / secret.
+  #
+  # `appSlug` is only relevant when the registered app is a GitHub App (not
+  # an OAuth App). The slug is the URL-friendly identifier from the app's
+  # GitHub URL (`https://github.com/apps/{slug}`). When set, the platform
+  # offers users a one-click installation step after authorizing the app —
+  # GitHub Apps see no private data without an installation, so without this
+  # the user would only have access to public repos. Leave empty for OAuth
+  # Apps.
   oauthAppDefaults:
     github:
       clientId: ""
       clientSecret: ""
+      appSlug: ""
     githubEnterprise:
       host: ""
       clientId: ""
       clientSecret: ""
+      appSlug: ""
 
   # -- Database connection (empty host = use shared local postgres)
   db:

--- a/packages/api-server/src/__tests__/unit/oauth-apps.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-apps.test.ts
@@ -74,11 +74,27 @@ describe("OAuth app registry — descriptors", () => {
   it("each descriptor surfaces input fields the UI needs to render the connect form", () => {
     const reg = createOAuthAppRegistry();
     const github = reg.get("github")!;
-    expect(github.inputs.map((i) => i.name)).toEqual(["clientId", "clientSecret"]);
+    expect(github.inputs.map((i) => i.name)).toEqual([
+      "clientId",
+      "clientSecret",
+      "appSlug",
+    ]);
     expect(github.inputs.find((i) => i.name === "clientSecret")?.secret).toBe(true);
+    // appSlug is intrinsically optional (OAuth Apps don't have one) — always
+    // visible in the form, not gated behind the override toggle that
+    // dynamic family-creds / admin-default coverage uses.
+    expect(github.inputs.find((i) => i.name === "appSlug")?.optional).toBe(true);
+    expect(github.inputs.find((i) => i.name === "appSlug")?.overridable).toBeUndefined();
 
     const ghe = reg.get("github-enterprise")!;
-    expect(ghe.inputs.map((i) => i.name)).toEqual(["host", "clientId", "clientSecret"]);
+    expect(ghe.inputs.map((i) => i.name)).toEqual([
+      "host",
+      "clientId",
+      "clientSecret",
+      "appSlug",
+    ]);
+    expect(ghe.inputs.find((i) => i.name === "appSlug")?.optional).toBe(true);
+    expect(ghe.inputs.find((i) => i.name === "appSlug")?.overridable).toBeUndefined();
   });
 
   it("descriptors carry a stable connectionKey separate from the id", () => {
@@ -285,19 +301,39 @@ describe("OAuth app registry — build()", () => {
 });
 
 describe("OAuth app registry — admin defaults", () => {
-  it("prunes inputs covered by GitHub admin defaults from the descriptor", () => {
+  it("marks inputs covered by GitHub admin defaults as overridable and flags the descriptor", () => {
     const reg = createOAuthAppRegistry({
       github: { clientId: "admin-id", clientSecret: "admin-secret" },
     });
-    expect(reg.get("github")!.inputs).toEqual([]);
+    const github = reg.get("github")!;
+    // All required fields are admin-defaulted, so the form has nothing to ask
+    // for on the happy path — but the inputs are still surfaced so the UI
+    // can offer an override toggle ("use a different app").
+    expect(github.defaultsApplied).toBe(true);
+    // Required = !overridable && !optional (appSlug is optional so it
+    // never appears in the required set regardless of admin coverage).
+    expect(
+      github.inputs.filter((i) => !i.overridable && !i.optional).map((i) => i.name),
+    ).toEqual([]);
+    expect(github.inputs.map((i) => i.name)).toEqual([
+      "clientId",
+      "clientSecret",
+      "appSlug",
+    ]);
   });
 
-  it("partial defaults prune only the matching field", () => {
+  it("partial defaults make only the matching field overridable", () => {
     const reg = createOAuthAppRegistry({
       github: { clientId: "admin-id" },
     });
-    const inputs = reg.get("github")!.inputs.map((i) => i.name);
-    expect(inputs).toEqual(["clientSecret"]);
+    const github = reg.get("github")!;
+    // Required (non-overridable, non-optional) inputs remain — the form
+    // still asks the user for clientSecret. The descriptor is *not* flagged
+    // as defaultsApplied because the form still requires user input.
+    expect(github.defaultsApplied).toBeUndefined();
+    expect(
+      github.inputs.filter((i) => !i.overridable && !i.optional).map((i) => i.name),
+    ).toEqual(["clientSecret"]);
   });
 
   it("uses GitHub defaults to fill missing fields when build() is called with empty input", () => {
@@ -320,7 +356,68 @@ describe("OAuth app registry — admin defaults", () => {
     expect(built.provider.clientId).toBe("user-override");
   });
 
-  it("GHE defaults: full config produces an empty form", () => {
+  it("admin-default appSlug surfaces on the descriptor and threads through the built flow", () => {
+    const reg = createOAuthAppRegistry({
+      github: {
+        clientId: "admin-id",
+        clientSecret: "admin-secret",
+        appSlug: "platform-app",
+      },
+    });
+    expect(reg.get("github")!.appSlug).toBe("platform-app");
+    expect(reg.get("github")!.defaultsApplied).toBe(true);
+    const built = reg.build("github", {});
+    expect(built.flow.appSlug).toBe("platform-app");
+  });
+
+  it("user-supplied appSlug overrides admin default when both are present", () => {
+    const reg = createOAuthAppRegistry({
+      github: {
+        clientId: "admin-id",
+        clientSecret: "admin-secret",
+        appSlug: "default-app",
+      },
+    });
+    const built = reg.build("github", { appSlug: "user-app" });
+    expect(built.flow.appSlug).toBe("user-app");
+  });
+
+  it("rejects appSlugs that violate GitHub's slug rules", () => {
+    const reg = createOAuthAppRegistry();
+    const baseInput = { clientId: "id", clientSecret: "sec" };
+    // Whitespace / uppercase — should never have been accepted.
+    expect(() => reg.build("github", { ...baseInput, appSlug: "Has Spaces" })).toThrow(/App slug/);
+    expect(() => reg.build("github", { ...baseInput, appSlug: "MyApp" })).toThrow(/App slug/);
+    // GitHub disallows leading, trailing, and consecutive hyphens — mirror that.
+    expect(() => reg.build("github", { ...baseInput, appSlug: "-leading" })).toThrow(/App slug/);
+    expect(() => reg.build("github", { ...baseInput, appSlug: "trailing-" })).toThrow(/App slug/);
+    expect(() => reg.build("github", { ...baseInput, appSlug: "double--hyphen" })).toThrow(/App slug/);
+    // 1–39 chars: 40 chars is one over the limit.
+    expect(() =>
+      reg.build("github", { ...baseInput, appSlug: "a".repeat(40) }),
+    ).toThrow(/App slug/);
+  });
+
+  it("accepts well-formed GitHub App slugs", () => {
+    const reg = createOAuthAppRegistry();
+    const baseInput = { clientId: "id", clientSecret: "sec" };
+    for (const slug of ["a", "dependabot", "github-actions", "my-app-1", "a".repeat(39)]) {
+      const built = reg.build("github", { ...baseInput, appSlug: slug });
+      expect(built.flow.appSlug).toBe(slug);
+    }
+  });
+
+  it("treats an empty-string appSlug input as 'not set' (no flow.appSlug)", () => {
+    const reg = createOAuthAppRegistry();
+    const built = reg.build("github", {
+      clientId: "id",
+      clientSecret: "sec",
+      appSlug: "",
+    });
+    expect(built.flow.appSlug).toBeUndefined();
+  });
+
+  it("GHE defaults: full config flags defaultsApplied and surfaces all inputs as overridable", () => {
     const reg = createOAuthAppRegistry({
       githubEnterprise: {
         host: "ghe.corp.example",
@@ -328,12 +425,30 @@ describe("OAuth app registry — admin defaults", () => {
         clientSecret: "sec",
       },
     });
-    expect(reg.get("github-enterprise")!.inputs).toEqual([]);
+    const ghe = reg.get("github-enterprise")!;
+    expect(ghe.defaultsApplied).toBe(true);
+    expect(
+      ghe.inputs.filter((i) => !i.overridable && !i.optional).map((i) => i.name),
+    ).toEqual([]);
     const built = reg.build("github-enterprise", {});
     expect(built.flow.hostPattern).toBe("ghe.corp.example");
     expect(built.provider.authorizationUrl).toBe(
       "https://ghe.corp.example/login/oauth/authorize",
     );
+  });
+
+  it("GHE admin-default appSlug threads through to the flow", () => {
+    const reg = createOAuthAppRegistry({
+      githubEnterprise: {
+        host: "ghe.corp.example",
+        clientId: "id",
+        clientSecret: "sec",
+        appSlug: "ghe-platform-app",
+      },
+    });
+    expect(reg.get("github-enterprise")!.appSlug).toBe("ghe-platform-app");
+    const built = reg.build("github-enterprise", {});
+    expect(built.flow.appSlug).toBe("ghe-platform-app");
   });
 
   it("Generic descriptor is unaffected by GitHub-only defaults", () => {
@@ -349,6 +464,7 @@ describe("OAuth app registry — admin defaults", () => {
       "clientId",
       "clientSecret",
     ]);
+    expect(reg.get("generic")!.defaultsApplied).toBeUndefined();
   });
 });
 

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -156,11 +156,13 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     github: {
       ...(config.defaultGithubClientId ? { clientId: config.defaultGithubClientId } : {}),
       ...(config.defaultGithubClientSecret ? { clientSecret: config.defaultGithubClientSecret } : {}),
+      ...(config.defaultGithubAppSlug ? { appSlug: config.defaultGithubAppSlug } : {}),
     },
     githubEnterprise: {
       ...(config.defaultGithubEnterpriseHost ? { host: config.defaultGithubEnterpriseHost } : {}),
       ...(config.defaultGithubEnterpriseClientId ? { clientId: config.defaultGithubEnterpriseClientId } : {}),
       ...(config.defaultGithubEnterpriseClientSecret ? { clientSecret: config.defaultGithubEnterpriseClientSecret } : {}),
+      ...(config.defaultGithubEnterpriseAppSlug ? { appSlug: config.defaultGithubEnterpriseAppSlug } : {}),
     },
   });
   app.route(

--- a/packages/api-server/src/apps/api-server/oauth.ts
+++ b/packages/api-server/src/apps/api-server/oauth.ts
@@ -95,11 +95,11 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
     // host-rewritten callback (see `localhostCallbackAlias`).
     //
     // Descriptors with `credentialFamily` set get their credential inputs
-    // marked `optional: true` when the user already has a sibling connection
-    // in the same family. The connect form hides those inputs behind an
-    // "override" toggle; on submit, empty fields fall through to the stored
-    // family creds (see the merge step in POST /api/oauth/apps/:id/connect),
-    // and filled fields override them.
+    // marked `overridable: true` when the user already has a sibling
+    // connection in the same family. The connect form hides those inputs
+    // behind an "override" toggle; on submit, empty fields fall through
+    // to the stored family creds (see the merge step in POST
+    // /api/oauth/apps/:id/connect), and filled fields override them.
     const user = c.get("user");
     const familyCreds = await readFamilyCreds(k8sConnectionsFor(user.sub));
     return c.json(
@@ -108,7 +108,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
         const inputs = inheritFamily
           ? d.inputs.map((i) =>
               i.name === "clientId" || i.name === "clientSecret"
-                ? { ...i, optional: true }
+                ? { ...i, overridable: true }
                 : i,
             )
           : d.inputs;
@@ -199,6 +199,10 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
             hostPattern: conn.hostPattern,
             connectedAt: conn.connectedAt ?? "",
             expired,
+            // Surfaces the GitHub App slug when the connection's credentials
+            // belong to a GitHub App — drives the "Install on GitHub" /
+            // "Manage installation" affordance in the UI.
+            ...(conn.appSlug ? { appSlug: conn.appSlug } : {}),
           };
         })
         .filter((x): x is NonNullable<typeof x> => x !== null);
@@ -428,6 +432,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
       ...(pending.provider.scopes && pending.provider.scopes.length > 0
         ? { scopes: pending.provider.scopes.join(" ") }
         : {}),
+      ...(pending.flow.appSlug ? { appSlug: pending.flow.appSlug } : {}),
     };
     try {
       await k8sConnectionsFor(pending.userSub).upsertConnection({
@@ -444,10 +449,18 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
       return c.redirect(`${uiBaseUrl}?oauth=error&message=${encodeURIComponent(msg)}`);
     }
 
-    const successQuery = isMcp
-      ? `oauth=success&host=${pending.flow.hostPattern}`
-      : `oauth=success&app=${encodeURIComponent(pending.flow.connectionKey)}`;
-    return c.redirect(`${uiBaseUrl}?${successQuery}`);
+    // Always return the user to the platform UI after OAuth, even for
+    // GitHub App connections that still need an install step. The UI then
+    // reads the just-stored connection (which carries `appSlug` for
+    // GitHub Apps) and surfaces an in-platform Install prompt — keeps the
+    // user in our context, avoids stranding them on GitHub's install page
+    // when the app is already installed, and removes the open-redirect
+    // surface the previous server-side install bounce required.
+    const successParams = new URLSearchParams();
+    successParams.set("oauth", "success");
+    if (isMcp) successParams.set("host", pending.flow.hostPattern);
+    else successParams.set("app", pending.flow.connectionKey);
+    return c.redirect(`${uiBaseUrl}?${successParams.toString()}`);
   });
 
   return oauth;

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -1,5 +1,25 @@
 import { z } from "zod/v4";
 import pkg from "../package.json" with { type: "json" };
+import { isValidAppSlug } from "./modules/connections/infrastructure/oauth-apps.js";
+
+// Admin-default GitHub App slugs come from Helm values
+// (`apiServer.oauthAppDefaults.{github,githubEnterprise}.appSlug`). Treat
+// empty string as unset so operators can leave the value blank in
+// values.yaml; reject anything else that GitHub itself wouldn't accept,
+// so a typo crashes the api-server pod at startup with a clear error
+// rather than surfacing as a 400 the next time someone tries to connect.
+const adminAppSlugSchema = z
+  .string()
+  .nullable()
+  .default(null)
+  .transform((v) => (v == null || v === "" ? null : v))
+  .refine(
+    (v) => v == null || isValidAppSlug(v),
+    {
+      message:
+        "Admin-default GitHub App slug must be 1–39 lowercase letters, digits, and single hyphens — no leading, trailing, or consecutive hyphens.",
+    },
+  );
 
 const configSchema = z.object({
   /** Build-time semver from this package's package.json — not env-driven.
@@ -47,9 +67,13 @@ const configSchema = z.object({
   // serve every user on a deployment.
   defaultGithubClientId: z.string().nullable().default(null),
   defaultGithubClientSecret: z.string().nullable().default(null),
+  // GitHub App slug — only set when the platform-default app is a GitHub
+  // App (not an OAuth App). Drives the post-authorization install prompt.
+  defaultGithubAppSlug: adminAppSlugSchema,
   defaultGithubEnterpriseHost: z.string().nullable().default(null),
   defaultGithubEnterpriseClientId: z.string().nullable().default(null),
   defaultGithubEnterpriseClientSecret: z.string().nullable().default(null),
+  defaultGithubEnterpriseAppSlug: adminAppSlugSchema,
   redisUrl: z.string().nullable().default(null),
   /** Optional Redis AUTH password. The chart provisions a generated
    *  per-release password and binds it via secretKeyRef; standalone dev
@@ -118,9 +142,11 @@ export function loadConfig(): Config {
     skillSourcesSeed: process.env.SKILL_SOURCES_SEED,
     defaultGithubClientId: process.env.PLATFORM_DEFAULT_GITHUB_CLIENT_ID,
     defaultGithubClientSecret: process.env.PLATFORM_DEFAULT_GITHUB_CLIENT_SECRET,
+    defaultGithubAppSlug: process.env.PLATFORM_DEFAULT_GITHUB_APP_SLUG,
     defaultGithubEnterpriseHost: process.env.PLATFORM_DEFAULT_GHE_HOST,
     defaultGithubEnterpriseClientId: process.env.PLATFORM_DEFAULT_GHE_CLIENT_ID,
     defaultGithubEnterpriseClientSecret: process.env.PLATFORM_DEFAULT_GHE_CLIENT_SECRET,
+    defaultGithubEnterpriseAppSlug: process.env.PLATFORM_DEFAULT_GHE_APP_SLUG,
     redisUrl: process.env.REDIS_URL,
     redisPassword: process.env.REDIS_PASSWORD,
     approvalHoldSeconds: process.env.APPROVAL_HOLD_SECONDS,

--- a/packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts
@@ -46,6 +46,7 @@ const ANN_CONNECTION_STATUS = "agent-platform.ai/connection-status";
 const ANN_CONNECTED_AT = "agent-platform.ai/connected-at";
 const ANN_DISPLAY_NAME = "agent-platform.ai/display-name";
 const ANN_SCOPES = "agent-platform.ai/scopes";
+const ANN_APP_SLUG = "agent-platform.ai/app-slug";
 
 const SECRET_TYPE_CONNECTION = "connection";
 const NAME_PREFIX = "platform-conn-";
@@ -80,6 +81,13 @@ export interface ConnectionMetadata {
   displayName?: string;
   /** Comma-separated scopes — surfaced for diagnostics. Optional. */
   scopes?: string;
+  /**
+   * GitHub App slug — set when the connection's credentials belong to a
+   * GitHub App. Surfaced on the connections list so the UI can offer an
+   * "Install" / "Manage installation" action linking to
+   * https://github.com/apps/{slug}/installations/new.
+   */
+  appSlug?: string;
 }
 
 export interface ConnectionSummary {
@@ -90,6 +98,9 @@ export interface ConnectionSummary {
   expiresAt?: number;
   connectedAt?: string;
   displayName?: string;
+  /** GitHub App slug — only set when the connection's credentials belong
+   *  to a GitHub App. See `ConnectionMetadata.appSlug`. */
+  appSlug?: string;
 }
 
 export interface ConnectionRecord {
@@ -150,6 +161,7 @@ function buildAnnotations(
   if (metadata.authorizationUrl) ann[ANN_AUTHORIZATION_URL] = metadata.authorizationUrl;
   if (metadata.displayName) ann[ANN_DISPLAY_NAME] = metadata.displayName;
   if (metadata.scopes) ann[ANN_SCOPES] = metadata.scopes;
+  if (metadata.appSlug) ann[ANN_APP_SLUG] = metadata.appSlug;
   if (tokens.expiresAt != null) ann[ANN_EXPIRES_AT] = String(tokens.expiresAt);
   return ann;
 }
@@ -191,6 +203,7 @@ function readSummary(secret: k8s.V1Secret): ConnectionSummary | null {
   }
   if (ann[ANN_CONNECTED_AT]) summary.connectedAt = ann[ANN_CONNECTED_AT];
   if (ann[ANN_DISPLAY_NAME]) summary.displayName = ann[ANN_DISPLAY_NAME];
+  if (ann[ANN_APP_SLUG]) summary.appSlug = ann[ANN_APP_SLUG];
   return summary;
 }
 
@@ -219,6 +232,7 @@ function readRecord(secret: k8s.V1Secret): ConnectionRecord | null {
   if (ann[ANN_AUTHORIZATION_URL]) metadata.authorizationUrl = ann[ANN_AUTHORIZATION_URL];
   if (ann[ANN_DISPLAY_NAME]) metadata.displayName = ann[ANN_DISPLAY_NAME];
   if (ann[ANN_SCOPES]) metadata.scopes = ann[ANN_SCOPES];
+  if (ann[ANN_APP_SLUG]) metadata.appSlug = ann[ANN_APP_SLUG];
   const clientSecret = decodeData(secret, "client_secret");
   if (clientSecret) metadata.clientSecret = clientSecret;
   return {

--- a/packages/api-server/src/modules/connections/infrastructure/oauth-apps.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/oauth-apps.ts
@@ -77,10 +77,25 @@ export interface OAuthAppInputField {
   /** Short hint shown beneath the field. */
   helper?: string;
   /**
-   * Empty value is acceptable. The form renders these collapsed behind an
-   * override toggle; the backend either merges in a stored value (e.g.
-   * family-credential prefill) or omits the field. Required fields default
-   * to `optional: false`.
+   * The field is currently covered by a stored value the backend will
+   * merge in at submit time (sibling family credentials, admin defaults).
+   * The form hides the input behind an "override" toggle ("Use a
+   * different app" / "Use different credentials") so the user doesn't
+   * have to re-enter what we already have; on submit, the field is
+   * dropped unless the override panel is open and the user typed
+   * something.
+   *
+   * Set dynamically — descriptors don't carry it. For inputs that are
+   * *intrinsically* optional (no stored fallback, the user may just
+   * leave them empty), use `optional` instead.
+   */
+  overridable?: boolean;
+  /**
+   * The field may be left empty by the user — there is no stored fallback,
+   * just nothing to fill in. The form keeps the input always visible and
+   * doesn't count it toward the "Connect" enable check; on submit, the
+   * field is dropped if empty and forwarded if filled. Used for the
+   * GitHub App `appSlug` input: OAuth Apps don't have one, GitHub Apps do.
    */
   optional?: boolean;
 }
@@ -106,6 +121,25 @@ export interface OAuthAppDescriptor {
    * their own OAuth app at the provider.
    */
   registrationUrl?: string;
+  /**
+   * GitHub App slug (URL-friendly identifier from the app's GitHub URL —
+   * `https://github.com/apps/{slug}`). Only meaningful for the github /
+   * github-enterprise descriptors when the credentials belong to a GitHub
+   * App (not an OAuth App). When set, the platform offers users an
+   * installation step after authorization, since GitHub Apps see no private
+   * data without an installation. Carried on the descriptor (admin default)
+   * and stored on the connection (so the UI can surface a "Manage
+   * installation" link later).
+   */
+  appSlug?: string;
+  /**
+   * True when an admin has pre-configured a platform-wide default for
+   * every required input on this descriptor. The connect form drops the
+   * "register your own OAuth app" guidance and the redirect-URI helper,
+   * and renders a one-click "Connect" plus an override toggle that
+   * unmasks the now-`overridable` inputs.
+   */
+  defaultsApplied?: boolean;
   /**
    * When set, the connect form runs RFC 8414 / OIDC issuer discovery against
    * the value of the named input field on blur, and auto-fills the
@@ -391,6 +425,14 @@ const DESCRIPTORS: Record<OAuthAppId, OAuthAppDescriptor> = {
         helper: "From the OAuth app you registered on github.com.",
       },
       { name: "clientSecret", label: "Client secret", secret: true },
+      {
+        name: "appSlug",
+        label: "GitHub App slug",
+        placeholder: "my-platform-app",
+        helper:
+          "Only for GitHub Apps (not OAuth Apps). The slug from https://github.com/apps/{slug}. When set, users are prompted to install the app after authorizing.",
+        optional: true,
+      },
     ],
     egressHosts: [{ host: "api.github.com" }, { host: "github.com" }],
   },
@@ -409,6 +451,14 @@ const DESCRIPTORS: Record<OAuthAppId, OAuthAppDescriptor> = {
       },
       { name: "clientId", label: "Client ID" },
       { name: "clientSecret", label: "Client secret", secret: true },
+      {
+        name: "appSlug",
+        label: "GitHub App slug",
+        placeholder: "my-platform-app",
+        helper:
+          "Only for GitHub Apps (not OAuth Apps). The slug from https://{host}/github-apps/{slug}. When set, users are prompted to install the app after authorizing.",
+        optional: true,
+      },
     ],
   },
   spotify: {
@@ -478,9 +528,41 @@ const DESCRIPTORS: Record<OAuthAppId, OAuthAppDescriptor> = {
   },
 };
 
+// `appSlug` (GitHub App URL slug) follows GitHub's slug rules:
+//   - lowercase letters, digits, hyphens
+//   - 1–39 characters
+//   - no leading or trailing hyphens
+//   - no consecutive hyphens
+// (Matches the rules GitHub itself enforces when registering an app or
+// renaming an account.) Empty string is treated as "not set" so admin
+// defaults can pass through `appSlug: ""` without forcing the field on.
+//
+// Exported so the api-server config can apply the same check to
+// admin-default slugs at startup — a misconfigured Helm value should
+// crash the pod, not surface as a confusing 400 to the next user who
+// tries to connect.
+export const APP_SLUG_MAX_LENGTH = 39;
+export const APP_SLUG_RE = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+export function isValidAppSlug(value: string): boolean {
+  return value.length <= APP_SLUG_MAX_LENGTH && APP_SLUG_RE.test(value);
+}
+
+const APP_SLUG_VALIDATION_MESSAGE =
+  "App slug must be 1–39 lowercase letters, digits, and single hyphens — no leading, trailing, or consecutive hyphens.";
+
+const appSlugSchema = z
+  .string()
+  .optional()
+  .transform((v) => (v && v.length > 0 ? v : undefined))
+  .refine(
+    (v) => v === undefined || isValidAppSlug(v),
+    APP_SLUG_VALIDATION_MESSAGE,
+  );
+
 const githubInputSchema = z.object({
   clientId: z.string().min(1, "Client ID is required"),
   clientSecret: z.string().min(1, "Client secret is required"),
+  appSlug: appSlugSchema,
 });
 
 const spotifyInputSchema = z.object({
@@ -530,6 +612,7 @@ const gheInputSchema = z.object({
     .regex(HOSTNAME_RE, "Host must be a valid DNS hostname (no scheme)."),
   clientId: z.string().min(1),
   clientSecret: z.string().min(1),
+  appSlug: appSlugSchema,
 });
 
 const httpsUrlSchema = z
@@ -558,18 +641,26 @@ export type GenericInput = z.infer<typeof genericInputSchema>;
 
 /**
  * Optional platform-wide defaults for OAuth app credentials. When a field
- * is set, the connect form's matching input disappears and `build()` uses
- * the default. Fields the admin doesn't set are required from the user.
+ * is set, the connect form's matching input is collapsed behind an
+ * "override" toggle and `build()` uses the default. Fields the admin
+ * doesn't set are still required from the user.
+ *
+ * `appSlug` is the GitHub App slug — when supplied alongside the OAuth
+ * client credentials, the connection flow recognises that the credentials
+ * belong to a GitHub App (not an OAuth App) and offers an installation
+ * step after authorization.
  */
 export interface OAuthAppDefaults {
   github?: {
     clientId?: string;
     clientSecret?: string;
+    appSlug?: string;
   };
   githubEnterprise?: {
     host?: string;
     clientId?: string;
     clientSecret?: string;
+    appSlug?: string;
   };
 }
 
@@ -641,6 +732,7 @@ function buildGithub(input: GithubInput): BuiltOAuthApp {
       hostPattern: "api.github.com",
       displayName: "GitHub",
       envMappings: [GH_TOKEN_ENV_MAPPING],
+      ...(input.appSlug ? { appSlug: input.appSlug } : {}),
     },
     connectionDisplayName: "GitHub",
   };
@@ -671,6 +763,7 @@ function buildGhe(input: GheInput): BuiltOAuthApp {
         GH_TOKEN_ENV_MAPPING,
         { envName: "GH_HOST", placeholder: host },
       ],
+      ...(input.appSlug ? { appSlug: input.appSlug } : {}),
     },
     connectionDisplayName: `GitHub Enterprise (${host})`,
   };
@@ -759,18 +852,40 @@ function buildGeneric(input: GenericInput): BuiltOAuthApp {
 
 /**
  * Returns a copy of the descriptor with inputs covered by `defaultsForApp`
- * pruned. Fields the admin pre-set never appear in the form; the user only
- * sees what they still need to supply.
+ * marked `overridable: true` (so the connect form collapses them behind
+ * an override toggle) and the descriptor flagged with `appSlug` /
+ * `defaultsApplied` when the admin has wired a platform-wide default app.
+ *
+ * We don't prune the inputs outright: the connect form needs to know which
+ * fields are *available* to override, even when none of them are required
+ * for the happy path.
  */
-function pruneDescriptorInputs(
+function decorateDescriptorWithDefaults(
   descriptor: OAuthAppDescriptor,
   defaultsForApp: Record<string, string | undefined>,
 ): OAuthAppDescriptor {
-  const filtered = descriptor.inputs.filter(
-    (input) => !defaultsForApp[input.name],
+  const hasAnyDefault = Object.values(defaultsForApp).some(
+    (v) => v !== undefined && v !== "",
   );
-  if (filtered.length === descriptor.inputs.length) return descriptor;
-  return { ...descriptor, inputs: filtered };
+  if (!hasAnyDefault) return descriptor;
+  const inputs = descriptor.inputs.map((input) =>
+    defaultsForApp[input.name]
+      ? { ...input, overridable: true as const }
+      : input,
+  );
+  // "All required inputs are admin-defaulted" — the form can render the
+  // connect button without asking the user for anything. `optional`
+  // inputs (e.g. appSlug) don't count: they're intrinsically optional, so
+  // the form is fully fillable whether or not the admin set them.
+  const requiredInputs = inputs.filter((i) => !i.overridable && !i.optional);
+  const defaultsApplied = requiredInputs.length === 0;
+  const defaultedAppSlug = defaultsForApp.appSlug;
+  return {
+    ...descriptor,
+    inputs,
+    ...(defaultsApplied ? { defaultsApplied: true as const } : {}),
+    ...(defaultedAppSlug ? { appSlug: defaultedAppSlug } : {}),
+  };
 }
 
 function defaultsObject(
@@ -781,6 +896,7 @@ function defaultsObject(
     return {
       clientId: defaults.github?.clientId,
       clientSecret: defaults.github?.clientSecret,
+      appSlug: defaults.github?.appSlug,
     };
   }
   if (descriptor.id === "github-enterprise") {
@@ -788,6 +904,7 @@ function defaultsObject(
       host: defaults.githubEnterprise?.host,
       clientId: defaults.githubEnterprise?.clientId,
       clientSecret: defaults.githubEnterprise?.clientSecret,
+      appSlug: defaults.githubEnterprise?.appSlug,
     };
   }
   return {};
@@ -797,7 +914,7 @@ export function createOAuthAppRegistry(
   defaults: OAuthAppDefaults = {},
 ): OAuthAppRegistry {
   const decorated: OAuthAppDescriptor[] = Object.values(DESCRIPTORS).map((d) =>
-    pruneDescriptorInputs(d, defaultsObject(d, defaults)),
+    decorateDescriptorWithDefaults(d, defaultsObject(d, defaults)),
   );
   const byId = new Map(decorated.map((d) => [d.id, d]));
 

--- a/packages/api-server/src/modules/connections/infrastructure/oauth-engine.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/oauth-engine.ts
@@ -57,6 +57,13 @@ export interface OAuthFlowMetadata {
    * tooling convention to enforce).
    */
   envMappings?: import("api-server-api").EnvMapping[];
+  /**
+   * GitHub App slug — set when the connection's credentials belong to a
+   * GitHub App (not an OAuth App). Threaded through the engine so the
+   * callback handler can persist it on the resulting K8s Secret without
+   * having to re-look-it-up via the registry.
+   */
+  appSlug?: string;
 }
 
 export interface PendingFlow {

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -8,6 +8,8 @@ import { Sidebar } from "./components/sidebar.js";
 import { ToastOverlay } from "./components/toast-overlay.js";
 import { ListView } from "./modules/agents/views/list-view.js";
 import { InboxView } from "./modules/approvals/views/inbox-view.js";
+import { fetchOAuthAppConnections } from "./modules/connections/api/fetchers.js";
+import { appInstallUrl } from "./modules/connections/lib/install-url.js";
 import { ConnectionsView } from "./modules/connections/views/connections-view.js";
 import { AgentEgressView } from "./modules/egress-rules/views/agent-egress-view.js";
 import { ChatView } from "./modules/sessions/views/chat-view.js";
@@ -36,12 +38,47 @@ export default function App() {
     const params = new URLSearchParams(window.location.search);
     const oauthResult = params.get("oauth");
     if (!oauthResult) return;
+    const connectedApp = params.get("app");
     window.history.replaceState({}, "", window.location.pathname);
     if (oauthResult === "error") {
       useStore.getState().showToast({
         kind: "error",
         message: `OAuth failed: ${params.get("message") ?? "Unknown error"}`,
       });
+      return;
+    }
+    // GitHub App install nudge: when the just-stored connection carries an
+    // `appSlug`, surface a sticky toast that lets the user install the app
+    // on their GitHub account in a new tab. GitHub Apps see no private data
+    // without an installation, so doing nothing leaves the user confused
+    // when subsequent agent calls 404. We don't force the install (already
+    // installed users would land on a dead-end management page with no
+    // way back); the toast's Cancel button just dismisses.
+    if (oauthResult === "success" && connectedApp) {
+      void (async () => {
+        try {
+          const connections = await fetchOAuthAppConnections();
+          const conn = connections.find((c) => c.connectionId === connectedApp);
+          if (!conn) return;
+          const installUrl = appInstallUrl(conn);
+          if (!installUrl) return;
+          useStore.getState().showToast({
+            kind: "info",
+            ttl: 0,
+            message: `${conn.displayName} connected. Install the GitHub App on your account to grant access to private repos.`,
+            action: {
+              label: "Install",
+              onClick: () => window.open(installUrl, "_blank", "noopener,noreferrer"),
+            },
+            secondaryAction: { label: "Cancel" },
+          });
+        } catch {
+          // Fetch failure is non-fatal — the connections view will refetch
+          // on its own and still surface the "Install to repository" link
+          // on the new connection row. The toast is a nudge, not the
+          // only path.
+        }
+      })();
     }
   }, []);
 

--- a/packages/ui/src/components/toast-overlay.tsx
+++ b/packages/ui/src/components/toast-overlay.tsx
@@ -57,13 +57,23 @@ function ToastRow({ toast, onDismiss }: { toast: Toast; onDismiss: () => void })
           {toast.action.label}
         </button>
       )}
-      <button
-        onClick={onDismiss}
-        className="shrink-0 h-5 w-5 rounded-md flex items-center justify-center text-text-muted hover:text-text transition-colors"
-        aria-label="Dismiss"
-      >
-        <X size={12} />
-      </button>
+      {toast.secondaryAction && (
+        <button
+          onClick={() => { toast.secondaryAction!.onClick?.(); onDismiss(); }}
+          className="shrink-0 text-[12px] font-semibold text-text-muted hover:text-text"
+        >
+          {toast.secondaryAction.label}
+        </button>
+      )}
+      {!toast.secondaryAction && (
+        <button
+          onClick={onDismiss}
+          className="shrink-0 h-5 w-5 rounded-md flex items-center justify-center text-text-muted hover:text-text transition-colors"
+          aria-label="Dismiss"
+        >
+          <X size={12} />
+        </button>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/lib/toast-sink.ts
+++ b/packages/ui/src/lib/toast-sink.ts
@@ -4,7 +4,13 @@ export interface Toast {
   id: string;
   kind: ToastKind;
   message: string;
+  /** Primary affirmative action — opens a flow, navigates, etc. Clicking
+   *  also dismisses the toast. */
   action?: { label: string; onClick: () => void };
+  /** Secondary action rendered alongside `action`, typically a Cancel-shaped
+   *  affordance. `onClick` is optional — by default the secondary just
+   *  dismisses the toast. When set, both buttons replace the floating X. */
+  secondaryAction?: { label: string; onClick?: () => void };
   /** ms until auto-dismiss. Omit/0 → sticky. */
   ttl?: number;
 }

--- a/packages/ui/src/modules/connections/api/fetchers.ts
+++ b/packages/ui/src/modules/connections/api/fetchers.ts
@@ -49,7 +49,12 @@ const oauthAppInputSchema = z.object({
   secret: z.boolean().optional(),
   placeholder: z.string().optional(),
   helper: z.string().optional(),
-  /** Empty value is acceptable; collapsed behind the override toggle. */
+  /** Covered by a stored fallback (family creds, admin default); collapsed
+   *  behind the override toggle ("Use a different app" / "Use different
+   *  credentials"). */
+  overridable: z.boolean().optional(),
+  /** Intrinsically optional — no fallback, the user may just leave it empty.
+   *  Always visible, dropped at submit if empty. */
   optional: z.boolean().optional(),
 });
 
@@ -74,6 +79,18 @@ const oauthAppDescriptorSchema = z.object({
    * Drives a "Using your stored credentials" hint in the connect form.
    */
   credentialsInherited: z.boolean().optional(),
+  /**
+   * GitHub App slug — only set for github / github-enterprise descriptors
+   * where the admin has wired a default GitHub App. UI uses this to offer
+   * a post-connect installation step.
+   */
+  appSlug: z.string().optional(),
+  /**
+   * True when the admin has pre-configured every required input. The
+   * connect form drops the registration / redirect-URI guidance and shows
+   * a one-click "Connect" plus an "Use a different app" override toggle.
+   */
+  defaultsApplied: z.boolean().optional(),
 });
 const oauthAppsSchema = z.array(oauthAppDescriptorSchema);
 export type OAuthAppDescriptor = z.infer<typeof oauthAppDescriptorSchema>;
@@ -87,6 +104,10 @@ const oauthAppConnectionSchema = z.object({
   hostPattern: z.string(),
   connectedAt: z.string(),
   expired: z.boolean(),
+  /** GitHub App slug — only set when the connection's credentials belong
+   *  to a GitHub App. Drives the "Install on GitHub" affordance on the
+   *  connection row. */
+  appSlug: z.string().optional(),
 });
 const oauthAppConnectionsSchema = z.array(oauthAppConnectionSchema);
 export type OAuthAppConnection = z.infer<typeof oauthAppConnectionSchema>;

--- a/packages/ui/src/modules/connections/components/oauth-app-row.tsx
+++ b/packages/ui/src/modules/connections/components/oauth-app-row.tsx
@@ -1,8 +1,9 @@
-import { Unplug } from "lucide-react";
+import { ExternalLink, Unplug } from "lucide-react";
 
 import { useStore } from "../../../store.js";
 import type { OAuthAppConnection, OAuthAppDescriptor } from "../api/fetchers.js";
 import { useDisconnectApp } from "../api/mutations.js";
+import { appInstallUrl } from "../lib/install-url.js";
 import { OAuthAppIcon } from "./oauth-app-icon.js";
 
 interface Props {
@@ -35,6 +36,8 @@ export function OAuthAppRow({ app, connection, animationDelayMs, onReconnect }: 
     ? "Expired — reconnect to refresh access"
     : `Connected ${new Date(connection.connectedAt).toLocaleDateString()} · ${connection.hostPattern}`;
 
+  const installUrl = appInstallUrl(connection);
+
   return (
     <div
       className="flex items-center gap-4 rounded-xl border-2 border-border bg-surface px-5 py-4 transition-shadow hover:shadow-[4px_4px_0_#292524] shadow-brutal anim-in"
@@ -63,6 +66,17 @@ export function OAuthAppRow({ app, connection, animationDelayMs, onReconnect }: 
         >
           Reconnect
         </button>
+      )}
+      {installUrl && (
+        <a
+          href={installUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="btn-brutal h-7 rounded-md border-2 border-border bg-surface px-3 text-[11px] font-bold text-text-secondary hover:text-accent hover:border-accent shadow-brutal-sm inline-flex items-center gap-1.5"
+          title="Install or manage which repositories this GitHub App can access"
+        >
+          Install to repository <ExternalLink size={11} />
+        </a>
       )}
       <button
         onClick={handleDisconnect}

--- a/packages/ui/src/modules/connections/forms/connect-app-form.tsx
+++ b/packages/ui/src/modules/connections/forms/connect-app-form.tsx
@@ -73,9 +73,9 @@ interface Props {
 
 export function ConnectAppForm({ app, onCancel }: Props) {
   const [values, setValues] = useState<Record<string, string>>({});
-  // Override toggle — when `credentialsInherited`, optional inputs (e.g.
-  // clientId/clientSecret for a sibling Google connection) stay hidden
-  // until the user explicitly opts in to provide alternates.
+  // Override toggle — when `credentialsInherited`, overridable inputs
+  // (e.g. clientId/clientSecret for a sibling Google connection) stay
+  // hidden until the user explicitly opts in to provide alternates.
   const [showOverride, setShowOverride] = useState(false);
   // Discovery state — `host` carries the value we last discovered against,
   // so re-blurring on the same host doesn't refetch. `error` is shown
@@ -89,12 +89,21 @@ export function ConnectAppForm({ app, onCancel }: Props) {
   const startAppOAuth = useStartAppOAuth();
   const lastDiscoveredHost = useRef<string | null>(null);
 
-  // Inputs the user actually sees and must fill: required ones plus any
-  // optional ones the override panel is showing.
-  const visibleInputs = app.inputs.filter((f) => !f.optional || showOverride);
+  // Inputs the user actually sees. `overridable` fields are covered by a
+  // stored fallback (family creds, admin defaults) and hide behind the
+  // override panel; `optional` fields have no fallback and stay visible
+  // always.
+  const visibleInputs = app.inputs.filter((f) => !f.overridable || showOverride);
   const allFilled = app.inputs
-    .filter((field) => !field.optional)
+    .filter((field) => !field.overridable && !field.optional)
     .every((field) => (values[field.name] ?? "").trim().length > 0);
+
+  // True when an admin has wired a platform-wide default for every required
+  // input (GitHub OAuth client + secret, optionally a GitHub App slug). We
+  // hide the "register your own OAuth app" guidance and the callback-URL
+  // copier in this case — the user just clicks Connect, unless they decide
+  // to substitute their own app via the override toggle.
+  const usingDefaultApp = app.defaultsApplied && !showOverride;
 
   const setField = (name: string, value: string) =>
     setValues((prev) => ({ ...prev, [name]: value }));
@@ -133,17 +142,28 @@ export function ConnectAppForm({ app, onCancel }: Props) {
 
   const submit = () => {
     if (!allFilled) return;
-    // Drop optional fields unless the override panel is open AND the user
-    // typed something into them. Without the `showOverride` gate, values
-    // typed into an override panel that the user later closed would
-    // silently leak through to the backend; gating ties "submit override"
-    // to "override is currently visible." Empty values fall through to
-    // the backend's family-credential merge, which fills them from a
-    // sibling connection.
+    // Drop:
+    //  - `overridable` fields unless the override panel is open AND the
+    //    user typed something — gating "submit override" to "override is
+    //    currently visible" prevents stale typed values from leaking after
+    //    the user closes the panel; the backend's family-creds /
+    //    admin-defaults merge fills the field from its fallback when we
+    //    don't send one.
+    //  - `optional` fields when empty — there's no fallback to merge, but
+    //    sending an empty string would override an admin default with ""
+    //    and silently disable the feature (e.g. an admin-configured
+    //    GitHub App slug stripped because the form submitted appSlug="").
+    //    Forwarded when non-empty so user input still wins over the
+    //    default.
     const input = Object.fromEntries(
       app.inputs
         .map((field) => [field.name, (values[field.name] ?? "").trim()] as const)
-        .filter(([, v], i) => !app.inputs[i]!.optional || (showOverride && v.length > 0)),
+        .filter(([, v], i) => {
+          const f = app.inputs[i]!;
+          if (f.optional) return v.length > 0;
+          if (f.overridable) return showOverride && v.length > 0;
+          return true;
+        }),
     );
     startAppOAuth.mutate(
       { appId: app.id, input },
@@ -173,7 +193,7 @@ export function ConnectAppForm({ app, onCancel }: Props) {
       <div className="min-h-0 flex-1 overflow-y-auto flex flex-col gap-5 p-5 md:p-7">
         <h2 className="text-[20px] font-bold text-text">Connect {app.displayName}</h2>
         <p className="text-[13px] text-text-secondary">{app.description}</p>
-        {app.registrationUrl && (
+        {app.registrationUrl && !usingDefaultApp && (
           <a
             href={app.registrationUrl}
             target="_blank"
@@ -183,8 +203,23 @@ export function ConnectAppForm({ app, onCancel }: Props) {
             Register an OAuth app first <ExternalLink size={13} />
           </a>
         )}
-        <CallbackUrlField url={app.callbackUrl} />
-        {app.credentialsInherited && (
+        {!usingDefaultApp && <CallbackUrlField url={app.callbackUrl} />}
+        {app.defaultsApplied && (
+          <div className="rounded-lg border-2 border-success/30 bg-success/5 px-4 py-3 text-[12px] text-text-secondary">
+            <div>
+              Connecting to the platform's pre-configured {app.displayName}{" "}
+              app — no setup required.
+            </div>
+            <button
+              type="button"
+              className="mt-1.5 text-[12px] font-semibold text-accent hover:underline"
+              onClick={() => setShowOverride((v) => !v)}
+            >
+              {showOverride ? "Use the platform's app instead" : "Use a different app"}
+            </button>
+          </div>
+        )}
+        {app.credentialsInherited && !app.defaultsApplied && (
           <div className="rounded-lg border-2 border-success/30 bg-success/5 px-4 py-3 text-[12px] text-text-secondary">
             <div>
               Reusing the Client ID and secret from another connected app in

--- a/packages/ui/src/modules/connections/lib/install-url.ts
+++ b/packages/ui/src/modules/connections/lib/install-url.ts
@@ -1,0 +1,16 @@
+import type { OAuthAppConnection } from "../api/fetchers.js";
+
+/**
+ * GitHub App install URL for a connection — `github.com/apps/{slug}/installations/new`
+ * for github.com, `{host}/github-apps/{slug}/installations/new` for GitHub
+ * Enterprise. Returns null for OAuth-App-shaped connections (no slug
+ * persisted on the K8s Secret). Both inputs are server-validated when the
+ * Secret is written, so the resulting URL is safe to feed to `window.open`.
+ */
+export function appInstallUrl(connection: OAuthAppConnection): string | null {
+  if (!connection.appSlug) return null;
+  if (connection.appId === "github-enterprise") {
+    return `https://${connection.hostPattern}/github-apps/${connection.appSlug}/installations/new`;
+  }
+  return `https://github.com/apps/${connection.appSlug}/installations/new`;
+}


### PR DESCRIPTION
## Summary

<img width="715" height="118" alt="image" src="https://github.com/user-attachments/assets/bc4f16eb-7109-4824-8a44-7b598eeca048" />

<img width="652" height="640" alt="image" src="https://github.com/user-attachments/assets/fe66d228-2bb9-42af-92ad-98594badbd38" />


GitHub OAuth Apps grant access to whatever the authorizing user can already see; GitHub Apps need a separate installation step on the user's account/org before they can read private repos. The connector previously only ran the OAuth dance, so admins who registered a GitHub App as the platform's connector ended up with credentials that only saw public repos.

This PR adds end-to-end support for the installation step:

- New optional `appSlug` input on the `github` / `github-enterprise` descriptors. When set, the OAuth callback redirects users to `https://github.com/apps/{slug}/installations/new` (or the GHE equivalent) immediately after token exchange, so they always go through the install flow.
- New Helm value `apiServer.oauthAppDefaults.{github,githubEnterprise}.appSlug` so a cluster-wide default can drive every user through the same flow without per-user configuration.
- Connection row surfaces an **Install to repository** link whenever the connection has a slug — for adding new accounts/orgs or changing repo selection after the fact.
- Connect form hides the "register an OAuth app first" link and callback-URL copier when admin defaults are present (since the platform-registered app is already configured), while preserving an **Use a different app** override toggle that reveals `clientId` / `clientSecret` / `appSlug` inputs for users who want to substitute their own.

The admin-defaults plumbing was switched from "prune covered inputs" to "mark optional + flag descriptor" so the override toggle has something to reveal.

## Test plan

- [x] `mise run check` (lint, tsc, helm lint, kubeconform)
- [x] `mise run test` (api-server, ui, controller, agent-runtime)
- [ ] Local cluster smoke test: register a GitHub App, set `appSlug` in Helm values, connect from the UI as a fresh user, confirm the post-OAuth redirect lands on `github.com/apps/{slug}/installations/new`
- [ ] Confirm an OAuth-App-shaped connection (no slug) still completes without the install redirect
- [ ] Verify the **Install to repository** button on the connection row routes to the correct install URL for both github.com and a GHE host
- [ ] Verify the **Use a different app** override toggle surfaces the Client ID / Client secret / App slug inputs and that user-supplied values win over the admin default