### PR TITLE
fix(secrets): require new value when changing injection format

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -70,6 +70,7 @@ export {
   ANTHROPIC_OAUTH_ENV_MAPPING,
   ANTHROPIC_API_KEY_ENV_MAPPING,
 } from "./modules/secrets/types.js";
+export { updateSecretInputSchema } from "./modules/secrets/router.js";
 
 export type { ChannelsService } from "./modules/channels/types.js";
 

--- a/packages/api-server-api/src/modules/secrets/router.ts
+++ b/packages/api-server-api/src/modules/secrets/router.ts
@@ -20,6 +20,32 @@ const injectionConfigSchema = z.object({
   valueFormat: z.string().max(1000).optional(),
 });
 
+export const updateSecretInputSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1).max(100).optional(),
+    value: z.string().min(1).optional(),
+    hostPattern: z.string().min(1).max(253).optional(),
+    pathPattern: z.string().max(1000).nullable().optional(),
+    injectionConfig: injectionConfigSchema.nullable().optional(),
+    envMappings: envMappingsSchema.optional(),
+  })
+  .superRefine((d, ctx) => {
+    // The raw token is stored only inside the SDS file's `inline_string`
+    // pre-baked with the current `valueFormat`. Changing `injectionConfig`
+    // alone would leave that file out of sync with the new format, so we
+    // require callers to re-supply `value` and re-bake atomically. `null`
+    // (clear-to-defaults) counts as a change too — defaults aren't always
+    // identical to what was stored.
+    if (d.injectionConfig !== undefined && d.value === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "value is required when changing injectionConfig",
+        path: ["value"],
+      });
+    }
+  });
+
 function messageForStatus(status: number): string {
   if (status === 401) return "Invalid credential.";
   if (status === 403) return "Credential lacks required permissions.";
@@ -65,20 +91,7 @@ export const secretsRouter = t.router({
     )
     .mutation(({ ctx, input }) => ctx.secrets.create(input)),
 
-  update: t.procedure
-    .input(
-      z
-        .object({
-          id: z.string().min(1),
-          name: z.string().min(1).max(100).optional(),
-          value: z.string().min(1).optional(),
-          hostPattern: z.string().min(1).max(253).optional(),
-          pathPattern: z.string().max(1000).nullable().optional(),
-          injectionConfig: injectionConfigSchema.nullable().optional(),
-          envMappings: envMappingsSchema.optional(),
-        }),
-    )
-    .mutation(({ ctx, input }) => ctx.secrets.update(input)),
+  update: t.procedure.input(updateSecretInputSchema).mutation(({ ctx, input }) => ctx.secrets.update(input)),
 
   delete: t.procedure
     .input(z.object({ id: z.string().min(1) }))

--- a/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type * as k8s from "@kubernetes/client-node";
+import { updateSecretInputSchema } from "api-server-api";
 
 import {
   createK8sSecretsPort,
@@ -336,5 +337,64 @@ describe("createK8sSecretsPort.updateSecret", () => {
     await port.updateSecret("upd3", { name: "New Name" });
 
     expect(replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/display-name"]).toBe("New Name");
+  });
+
+  it("re-bakes the SDS file with the new format when value+injectionConfig are patched together", async () => {
+    const { client, replaced } = fakeClient();
+    const port = createK8sSecretsPort(client, "owner-1");
+
+    await port.createSecret({
+      id: "rebake",
+      name: "GitHub PAT",
+      type: "generic",
+      value: "old-pat",
+      hostPattern: "github.com",
+      injectionConfig: { headerName: "Authorization", valueFormat: "Bearer {value}" },
+    });
+
+    await port.updateSecret("rebake", {
+      value: "new-pat",
+      injectionConfig: { headerName: "Authorization", valueFormat: "Basic {value}" },
+    });
+
+    expect(replaced[0]!.body.stringData?.["sds.yaml"]).toContain('inline_string: "Basic new-pat"');
+    expect(replaced[0]!.body.metadata?.annotations?.["agent-platform.ai/injection-value-format"]).toBe(
+      "Basic {value}",
+    );
+  });
+});
+
+describe("updateSecretInputSchema", () => {
+  it("accepts a value-only patch", () => {
+    expect(updateSecretInputSchema.safeParse({ id: "abc", value: "tok" }).success).toBe(true);
+  });
+
+  it("accepts injectionConfig + value together", () => {
+    const r = updateSecretInputSchema.safeParse({
+      id: "abc",
+      value: "tok",
+      injectionConfig: { headerName: "Authorization", valueFormat: "Basic {value}" },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects an injectionConfig change without value", () => {
+    const r = updateSecretInputSchema.safeParse({
+      id: "abc",
+      injectionConfig: { headerName: "Authorization", valueFormat: "Basic {value}" },
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.path).toEqual(["value"]);
+      expect(r.error.issues[0]!.message).toMatch(/value is required/);
+    }
+  });
+
+  it("rejects a clear-injectionConfig (null) without value", () => {
+    const r = updateSecretInputSchema.safeParse({ id: "abc", injectionConfig: null });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.path).toEqual(["value"]);
+    }
   });
 });

--- a/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
+++ b/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
@@ -222,7 +222,10 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
       }
 
       // Recompute header + value format if the injection config or auth mode
-      // changed; otherwise keep what was stored at create time.
+      // changed; otherwise keep what was stored at create time. The router
+      // enforces that any `injectionConfig` change is paired with a new
+      // `value`, so we re-bake the SDS file in that branch below — there is
+      // no need to recover the prior value from the existing inline_string.
       const newAuthMode: AuthMode | undefined = patch.authMode ?? (annotations[ANN_AUTH_MODE] as AuthMode | undefined);
       const newInjection: InjectionConfig | undefined =
         patch.injectionConfig === null ? undefined :

--- a/packages/ui/src/modules/secrets/components/edit-secret-dialog.tsx
+++ b/packages/ui/src/modules/secrets/components/edit-secret-dialog.tsx
@@ -25,6 +25,10 @@ const envMappingSchema = z.object({
 
 const baseShape = {
   name: z.string().trim().min(1, "Required"),
+  // The token (`value`) is NOT round-tripped from the api-server — it lives
+  // only inside the SDS file inside the K8s Secret. The field stays blank on
+  // open and is only sent on save when the user types into it.
+  value: z.string(),
   hostPattern: z.string().trim(),
   pathPattern: z.string().trim(),
   headerName: z.string().trim(),
@@ -52,6 +56,7 @@ const MONO_INPUT_CLASS = `${INPUT_CLASS} font-mono`;
 interface UpdateSecretPatch {
   id: string;
   name?: string;
+  value?: string;
   hostPattern?: string;
   pathPattern?: string | null;
   injectionConfig?: InjectionConfig | null;
@@ -68,11 +73,12 @@ export function EditSecretDialog({ secret, onClose }: Props) {
   const updateSecret = useUpdateSecret();
   const saving = updateSecret.isPending;
 
-  const { register, handleSubmit, control, formState } = useForm<EditSecretValues>({
+  const { register, handleSubmit, control, formState, setError } = useForm<EditSecretValues>({
     resolver: zodResolver(isGeneric ? genericSchema : anthropicSchema),
     mode: "onChange",
     defaultValues: {
       name: secret.name,
+      value: "",
       hostPattern: secret.hostPattern,
       pathPattern: secret.pathPattern ?? "",
       headerName: secret.injectionConfig?.headerName ?? "",
@@ -88,6 +94,7 @@ export function EditSecretDialog({ secret, onClose }: Props) {
   const onSubmit = handleSubmit((values) => {
     const patch: UpdateSecretPatch = { id: secret.id };
     if (dirtyFields.name) patch.name = values.name.trim();
+    if (dirtyFields.value && values.value.length > 0) patch.value = values.value;
     if (isGeneric) {
       if (dirtyFields.hostPattern) patch.hostPattern = values.hostPattern.trim();
       if (dirtyFields.pathPattern) {
@@ -95,7 +102,17 @@ export function EditSecretDialog({ secret, onClose }: Props) {
         patch.pathPattern = trimmed === "" ? null : trimmed;
       }
       if (dirtyFields.headerName || dirtyFields.valueFormat) {
-        const header = values.headerName.trim();
+        if (patch.value === undefined) {
+          // The api-server rejects this combination because the SDS file is
+          // pre-baked with the previous format and would drift. Surface it
+          // inline instead of round-tripping for the error.
+          setError("value", {
+            type: "manual",
+            message: "Re-enter the token when changing the header or value format.",
+          });
+          return;
+        }
+        const header = values.headerName.trim() || DEFAULT_INJECTION_CONFIG.headerName;
         const format = values.valueFormat.trim();
         patch.injectionConfig = {
           headerName: header,
@@ -125,6 +142,21 @@ export function EditSecretDialog({ secret, onClose }: Props) {
         <div className="flex-1 overflow-y-auto px-7 py-5 flex flex-col gap-5">
           <FormField label="Name" error={errors.name?.message}>
             <input className={INPUT_CLASS} autoFocus {...register("name")} />
+          </FormField>
+
+          <FormField
+            label="Token"
+            hint="Leave blank to keep the current token. Type a new value to rotate it."
+            error={errors.value?.message}
+          >
+            <input
+              className={INPUT_CLASS}
+              type="password"
+              placeholder="••••••••"
+              autoComplete="new-password"
+              disabled={saving}
+              {...register("value")}
+            />
           </FormField>
 
           {isGeneric && (

--- a/packages/ui/src/modules/secrets/forms/create-secret-form.tsx
+++ b/packages/ui/src/modules/secrets/forms/create-secret-form.tsx
@@ -68,6 +68,10 @@ export function CreateSecretForm({ onCancel, onCreated }: Props) {
     const headerName = values.headerName.trim();
     const valueFormat = values.valueFormat.trim();
     const mappings = sanitizeEnvMappings(values.envMappings);
+    // Send injectionConfig if EITHER field was filled. When only the value
+    // format is customised (e.g. `Basic {value}`), default the header to
+    // `Authorization` so the user's chosen format isn't silently discarded.
+    const hasInjectionInput = headerName.length > 0 || valueFormat.length > 0;
     createSecret.mutate(
       {
         type: "generic",
@@ -75,9 +79,9 @@ export function CreateSecretForm({ onCancel, onCreated }: Props) {
         value: values.value.trim(),
         hostPattern: values.hostPattern.trim(),
         ...(pathPattern.length > 0 && { pathPattern }),
-        ...(headerName.length > 0 && {
+        ...(hasInjectionInput && {
           injectionConfig: {
-            headerName,
+            headerName: headerName || DEFAULT_INJECTION_CONFIG.headerName,
             ...(valueFormat.length > 0 && { valueFormat }),
           },
         }),


### PR DESCRIPTION
## Summary

The raw token is stored only inside the K8s Secret's SDS file (`data["sds.yaml"]`), pre-baked with the current `valueFormat`. Updating `injectionConfig` alone updated the annotation but left the file out of sync — Envoy kept injecting the previous prefix (e.g. `Bearer …` while the annotation said `Basic {value}`), so GitHub returned 401 and `git clone` failed inside the agent.

- **Router rule** — `update` rejects `injectionConfig` patches without a paired `value`. The edit form mirrors this client-side and surfaces it as an inline error on the Token field.
- **Edit-secret dialog** — adds a Token input so users can rotate the credential through the UI (previously impossible). Blank by default; only sent when typed.
- **Create-secret form** — no longer drops `valueFormat` when only that field is filled. Defaults `headerName` to `Authorization`.

Follow-up issue for the analogous Anthropic `authMode` drift on value rotation: #136.

## Test plan

- [x] `mise run check` (lint + typecheck + helm + go vet) — clean
- [x] `mise run test` — 239/239 passing, including new schema tests:
  - rejects `injectionConfig` change without `value`
  - rejects `injectionConfig: null` (clear) without `value`
  - accepts the `value` + `injectionConfig` pair
- [ ] Manual: edit an existing GitHub PAT secret, change format from `Bearer {value}` to `Basic {value}`, leave Token blank → see inline error
- [ ] Manual: same flow with the Token re-entered → save succeeds, Envoy hot-reloads, `git clone` from agent works
- [ ] Manual: create a new secret entering only `valueFormat` (no `headerName`) → `headerName` defaults to `Authorization` and the value format is honoured