### PR TITLE
fix(controller): emit env vars from Secret env-mappings annotation

### DIFF
--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -36,6 +37,7 @@ const (
 	envoyHostPatternAnn   = "agent-platform.ai/host-pattern"
 	envoyHeaderNameAnn    = "agent-platform.ai/injection-header-name"
 	envoyAuthModeAnn      = "agent-platform.ai/auth-mode"
+	envoyEnvMappingsAnn   = "agent-platform.ai/env-mappings"
 	// Per-agent grant annotations stamped by the api-server on the
 	// instance ConfigMap. The controller reads them on every reconcile
 	// and intersects with the owner's credential Secret list. Both lists
@@ -163,26 +165,49 @@ func listOwnerCredentialSecrets(ctx context.Context, client kubernetes.Interface
 func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 	const sentinel = "dummy-placeholder"
 	seen := map[string]struct{}{}
-	add := func(envs []corev1.EnvVar, name string) []corev1.EnvVar {
+	add := func(envs []corev1.EnvVar, name, value string) []corev1.EnvVar {
+		if name == "" {
+			return envs
+		}
 		if _, dup := seen[name]; dup {
 			return envs
 		}
+		if value == "" {
+			value = sentinel
+		}
 		seen[name] = struct{}{}
-		return append(envs, corev1.EnvVar{Name: name, Value: sentinel})
+		return append(envs, corev1.EnvVar{Name: name, Value: value})
 	}
 	var envs []corev1.EnvVar
 	for _, s := range secrets {
+		// User-defined env mappings (api-server stamps this on every Secret).
+		// Any envName the user requested lands in the agent pod with its
+		// declared placeholder; Envoy overwrites the header on the wire.
+		if raw := s.Annotations[envoyEnvMappingsAnn]; raw != "" {
+			var mappings []struct {
+				EnvName     string `json:"envName"`
+				Placeholder string `json:"placeholder"`
+			}
+			if err := json.Unmarshal([]byte(raw), &mappings); err == nil {
+				for _, m := range mappings {
+					envs = add(envs, m.EnvName, m.Placeholder)
+				}
+			}
+		}
+		// Per-type fallbacks for legacy Secrets that predate the
+		// env-mappings annotation. Dedup keeps these no-ops when the
+		// annotation already contributed the same name.
 		switch s.Labels[envoySecretTypeLabel] {
 		case "anthropic":
 			if s.Annotations[envoyAuthModeAnn] == "api-key" {
-				envs = add(envs, "ANTHROPIC_API_KEY")
+				envs = add(envs, "ANTHROPIC_API_KEY", sentinel)
 			} else {
-				envs = add(envs, "CLAUDE_CODE_OAUTH_TOKEN")
+				envs = add(envs, "CLAUDE_CODE_OAUTH_TOKEN", sentinel)
 			}
 		case "connection":
 			host := s.Annotations[envoyHostPatternAnn]
 			if host == "github.com" || host == "api.github.com" {
-				envs = add(envs, "GH_TOKEN")
+				envs = add(envs, "GH_TOKEN", sentinel)
 			}
 		}
 	}

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sort"
 	"strings"
 	"text/template"
@@ -188,7 +189,13 @@ func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 				EnvName     string `json:"envName"`
 				Placeholder string `json:"placeholder"`
 			}
-			if err := json.Unmarshal([]byte(raw), &mappings); err == nil {
+			if err := json.Unmarshal([]byte(raw), &mappings); err != nil {
+				// Bad annotation shouldn't crash the reconcile loop, but
+				// silently dropping it produces a pod missing env vars with
+				// no operator visibility — log it so the cause is findable.
+				slog.Warn("invalid env-mappings annotation; skipping",
+					"namespace", s.Namespace, "secret", s.Name, "error", err)
+			} else {
 				for _, m := range mappings {
 					envs = add(envs, m.EnvName, m.Placeholder)
 				}

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -223,3 +223,52 @@ func TestEnvoySecretsRev_TemplateRevBumpRollsExistingPods(t *testing.T) {
 	two := envoySecretsRev([]corev1.Secret{ownerSecret("platform-conn-slack", "connection", "slack")})
 	assert.NotEqual(t, one, two)
 }
+
+func TestCredentialEnvVars_RespectsEnvMappingsAnnotation(t *testing.T) {
+	// User-defined mappings on a generic Secret must land on the agent pod —
+	// without this, `env: GH_TOKEN=...` configured for a generic GitHub PAT
+	// is silently dropped because only anthropic / connection secret types
+	// were hardcoded to emit env vars.
+	s := ownerSecret("platform-cred-x", "generic", "")
+	s.Annotations[envoyEnvMappingsAnn] = `[{"envName":"GH_TOKEN","placeholder":"dummy-placeholder"},{"envName":"OTHER","placeholder":"ph"}]`
+
+	envs := credentialEnvVars([]corev1.Secret{s})
+
+	got := map[string]string{}
+	for _, e := range envs {
+		got[e.Name] = e.Value
+	}
+	assert.Equal(t, "dummy-placeholder", got["GH_TOKEN"])
+	assert.Equal(t, "ph", got["OTHER"])
+}
+
+func TestCredentialEnvVars_DedupesAcrossAnnotationAndHardcoded(t *testing.T) {
+	// The anthropic hardcoded path and the env-mappings annotation can
+	// agree on the same envName. Dedup must keep a single entry.
+	s := ownerSecret("platform-cred-anth", "anthropic", "")
+	s.Annotations[envoyAuthModeAnn] = "oauth"
+	s.Annotations[envoyEnvMappingsAnn] = `[{"envName":"CLAUDE_CODE_OAUTH_TOKEN","placeholder":"dummy-placeholder"}]`
+
+	envs := credentialEnvVars([]corev1.Secret{s})
+
+	count := 0
+	for _, e := range envs {
+		if e.Name == "CLAUDE_CODE_OAUTH_TOKEN" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
+}
+
+func TestCredentialEnvVars_MalformedAnnotationFallsBackCleanly(t *testing.T) {
+	// A malformed env-mappings JSON must not skip the per-type fallback or
+	// take down the reconcile loop.
+	s := ownerSecret("platform-cred-broken", "anthropic", "")
+	s.Annotations[envoyAuthModeAnn] = "api-key"
+	s.Annotations[envoyEnvMappingsAnn] = "not json"
+
+	envs := credentialEnvVars([]corev1.Secret{s})
+
+	require.Len(t, envs, 1)
+	assert.Equal(t, "ANTHROPIC_API_KEY", envs[0].Name)
+}


### PR DESCRIPTION
## Summary

The controller's `credentialEnvVars` only hardcoded env vars for two cases — `secret-type=anthropic` and `secret-type=connection` with a GitHub host. Every other Secret carrying an `agent-platform.ai/env-mappings` annotation (e.g. a generic GitHub PAT mapped to `GH_TOKEN`) had its mapping silently dropped, so the agent pod never saw the env var. Harnesses that gate on env presence then refused to dispatch.

- Parse `agent-platform.ai/env-mappings` on every Secret and emit each `(envName, placeholder)` pair as a pod env var.
- Per-type fallbacks (anthropic → `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`; connection + github host → `GH_TOKEN`) remain for legacy Secrets without the annotation; a `seen` set dedupes overlap.
- Malformed annotation JSON is logged via `slog.Warn` instead of swallowed, so a bad annotation is findable in controller logs instead of silently producing a pod missing env vars.
- `fork_resources.go` inherits the fix transparently (same `credentialEnvVars` function).

## Test plan

- [x] `go test ./pkg/reconciler/ -run TestCredentialEnvVars` — three new tests cover the happy path, dedup across annotation + per-type hardcoded path, and malformed-JSON fallback
- [x] `mise run check` — lint, vet, build, helm, kubeconform all clean
- [ ] Manual: rebuild controller image (`mise run cluster:install`), grant a generic GitHub PAT Secret with `envMappings: [{envName: "GH_TOKEN", ...}]` to an instance, restart the agent pod, confirm `env | grep GH_TOKEN` shows `dummy-placeholder` and `git clone` of a private repo through the gateway succeeds