### PR TITLE
fix(api-server-api): keep updateSecretInputSchema out of @trpc/server's import path

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -70,7 +70,7 @@ export {
   ANTHROPIC_OAUTH_ENV_MAPPING,
   ANTHROPIC_API_KEY_ENV_MAPPING,
 } from "./modules/secrets/types.js";
-export { updateSecretInputSchema } from "./modules/secrets/router.js";
+export { updateSecretInputSchema } from "./modules/secrets/schemas.js";
 
 export type { ChannelsService } from "./modules/channels/types.js";
 

--- a/packages/api-server-api/src/modules/secrets/router.ts
+++ b/packages/api-server-api/src/modules/secrets/router.ts
@@ -1,50 +1,18 @@
 import { z } from "zod";
 import { t } from "../../trpc.js";
-import { ANTHROPIC_API_KEY_ENV_MAPPING, ENV_NAME_RE } from "./types.js";
+import { ANTHROPIC_API_KEY_ENV_MAPPING } from "./types.js";
+import {
+  envMappingsSchema,
+  injectionConfigSchema,
+  secretTypeSchema,
+  updateSecretInputSchema,
+} from "./schemas.js";
 
-const secretTypeSchema = z.enum(["anthropic", "generic"]);
-
-const envMappingSchema = z.object({
-  envName: z
-    .string()
-    .min(1)
-    .max(255)
-    .regex(ENV_NAME_RE, "envName must match [A-Z_][A-Z0-9_]*"),
-  placeholder: z.string().min(1).max(1000),
-});
-
-const envMappingsSchema = z.array(envMappingSchema).max(32);
-
-const injectionConfigSchema = z.object({
-  headerName: z.string().min(1).max(255),
-  valueFormat: z.string().max(1000).optional(),
-});
-
-export const updateSecretInputSchema = z
-  .object({
-    id: z.string().min(1),
-    name: z.string().min(1).max(100).optional(),
-    value: z.string().min(1).optional(),
-    hostPattern: z.string().min(1).max(253).optional(),
-    pathPattern: z.string().max(1000).nullable().optional(),
-    injectionConfig: injectionConfigSchema.nullable().optional(),
-    envMappings: envMappingsSchema.optional(),
-  })
-  .superRefine((d, ctx) => {
-    // The raw token is stored only inside the SDS file's `inline_string`
-    // pre-baked with the current `valueFormat`. Changing `injectionConfig`
-    // alone would leave that file out of sync with the new format, so we
-    // require callers to re-supply `value` and re-bake atomically. `null`
-    // (clear-to-defaults) counts as a change too — defaults aren't always
-    // identical to what was stored.
-    if (d.injectionConfig !== undefined && d.value === undefined) {
-      ctx.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "value is required when changing injectionConfig",
-        path: ["value"],
-      });
-    }
-  });
+// Re-export so existing barrel consumers (`api-server-api`'s index.ts +
+// the api-server's tests) keep working. UI code that imports
+// `updateSecretInputSchema` should prefer the schemas.ts path so the
+// UI bundle doesn't pull in @trpc/server through this file.
+export { updateSecretInputSchema };
 
 function messageForStatus(status: number): string {
   if (status === 401) return "Invalid credential.";

--- a/packages/api-server-api/src/modules/secrets/schemas.ts
+++ b/packages/api-server-api/src/modules/secrets/schemas.ts
@@ -1,0 +1,50 @@
+import { z } from "zod";
+import { ENV_NAME_RE } from "./types.js";
+
+// Browser-safe Zod schemas for the secrets module. Lives in its own
+// file so UI code can import these without dragging in @trpc/server
+// transitively via router.ts.
+
+export const secretTypeSchema = z.enum(["anthropic", "generic"]);
+
+export const envMappingSchema = z.object({
+  envName: z
+    .string()
+    .min(1)
+    .max(255)
+    .regex(ENV_NAME_RE, "envName must match [A-Z_][A-Z0-9_]*"),
+  placeholder: z.string().min(1).max(1000),
+});
+
+export const envMappingsSchema = z.array(envMappingSchema).max(32);
+
+export const injectionConfigSchema = z.object({
+  headerName: z.string().min(1).max(255),
+  valueFormat: z.string().max(1000).optional(),
+});
+
+export const updateSecretInputSchema = z
+  .object({
+    id: z.string().min(1),
+    name: z.string().min(1).max(100).optional(),
+    value: z.string().min(1).optional(),
+    hostPattern: z.string().min(1).max(253).optional(),
+    pathPattern: z.string().max(1000).nullable().optional(),
+    injectionConfig: injectionConfigSchema.nullable().optional(),
+    envMappings: envMappingsSchema.optional(),
+  })
+  .superRefine((d, ctx) => {
+    // The raw token is stored only inside the SDS file's `inline_string`
+    // pre-baked with the current `valueFormat`. Changing `injectionConfig`
+    // alone would leave that file out of sync with the new format, so we
+    // require callers to re-supply `value` and re-bake atomically. `null`
+    // (clear-to-defaults) counts as a change too — defaults aren't always
+    // identical to what was stored.
+    if (d.injectionConfig !== undefined && d.value === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "value is required when changing injectionConfig",
+        path: ["value"],
+      });
+    }
+  });


### PR DESCRIPTION
## Summary

After #132 (`feat: unified secret contributions`), the api-server-api barrel re-exports `updateSecretInputSchema` from `modules/secrets/router.ts`. That file imports `@trpc/server` at the top (`import { TRPCError } from "@trpc/server"`), so any UI module that imports the schema drags tRPC server runtime into the browser bundle. The Vite-bundled SPA hits its `Uncaught (in promise) Error: You're trying to use @trpc/server in a non-server environment` guard on first load.

## Fix

Move the Zod schemas (`envMappingSchema`, `envMappingsSchema`, `injectionConfigSchema`, `secretTypeSchema`, `updateSecretInputSchema`) into a new `modules/secrets/schemas.ts` that imports only Zod + the env-name regex from `types.ts`. `router.ts` re-exports `updateSecretInputSchema` for back-compat with existing api-server tests, and the `api-server-api` barrel sources it from `schemas.ts` instead. UI bundles that import the schema get only Zod; tree-shaking removes the rest.

## Test plan

- [x] `mise run check` — clean (helm + tsc + go vet).
- [x] `mise run test` — 247 tests pass.
- [x] Local k3s — UI loads cleanly, no tRPC server error in the bundle (`grep -c "trying to use @trpc/server" $entry-bundle.js` → 0).