### PR TITLE
fix(platform-base): install harness-chat / harness-terminal shims into the agent image

### DIFF
--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -37,6 +37,14 @@ RUN npm install --omit=dev
 
 COPY --from=builder /app/packages/agent-runtime/dist/ dist/
 
+# ADR-037: agent-runtime spawns `/usr/local/bin/harness-chat` for chat
+# sessions and `/usr/local/bin/harness-terminal` for terminal sessions.
+# The shell shims live in this package's source; install them as
+# executables on the PATH the runtime expects.
+COPY packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
+COPY packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
+RUN chmod +x /usr/local/bin/harness-chat /usr/local/bin/harness-terminal
+
 COPY packages/platform-base/skills/ /app/working-dir/.agents/skills/
 RUN mkdir -p /app/working-dir/.claude /app/working-dir/.pi/agent \
     && ln -s ../.agents/skills /app/working-dir/.claude/skills \


### PR DESCRIPTION
## Summary

agent-runtime spawns `/usr/local/bin/harness-chat` (chat sessions) and `/usr/local/bin/harness-terminal` (terminal sessions) per ADR-037. The shell shims live in `packages/platform-base/harness-chat.sh` and `harness-terminal.sh`, but the platform-base Dockerfile never \`COPY\`'d them into the runner stage. Agent pod startup hits \`spawn ENOENT\` on the first session/prompt:

\`\`\`
[agent-process] spawn error: spawn /usr/local/bin/harness-chat ENOENT
\`\`\`

…and the request hangs forever waiting on a process that never came up.

Pre-existing bug from #101 (\`feat: remote terminal\`) that shipped without the install step.

## Fix

Add \`COPY\` + \`chmod +x\` for both shims alongside the runner-stage layout in \`packages/platform-base/Dockerfile\`. No source changes anywhere else.

## Test plan

- [x] Local k3s — agent pod logs no longer show \`spawn ENOENT\`; \`session/prompt\` reaches the harness.