### PR TITLE
fix(uninstall): drain platform-agents before helm uninstall

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -495,9 +495,28 @@ if [ -n "${IS_SANDBOX:-}" ]; then
 else
   KUBECONFIG="$HOME/.lima/platform-k3s/copied-from-guest/kubeconfig.yaml"
 fi
+KCTL=(kubectl --kubeconfig="$KUBECONFIG")
+
+# Drain RWX-mounting workloads BEFORE helm uninstall. The chart ships the NFS
+# provisioner that backs `platform-rwx`; once helm uninstall removes it, any
+# pod still mounting one of its PVCs hangs in Terminating (kubelet can't
+# unmount from the dead NFS server) and blocks namespace deletion forever.
+if "${KCTL[@]}" get ns platform-agents >/dev/null 2>&1; then
+  echo "Draining platform-agents while NFS provisioner is still alive..."
+  "${KCTL[@]}" -n platform-agents delete sts --all --wait=true --timeout=60s 2>/dev/null || true
+  "${KCTL[@]}" -n platform-agents wait --for=delete pod --all --timeout=60s 2>/dev/null || true
+  "${KCTL[@]}" -n platform-agents delete pvc --all --wait=true --timeout=60s 2>/dev/null || true
+  "${KCTL[@]}" delete ns platform-agents --ignore-not-found --wait=true --timeout=60s 2>/dev/null || true
+fi
+
 helm --kubeconfig="$KUBECONFIG" uninstall platform || true
-kubectl --kubeconfig="$KUBECONFIG" delete pvc --all 2>/dev/null || true
-kubectl --kubeconfig="$KUBECONFIG" delete ns platform-agents --ignore-not-found 2>/dev/null || true
+
+# Clean up StatefulSet-managed PVCs in the release namespace (postgres, redis,
+# nfs-provisioner export). These aren't owned by the helm release, so helm
+# leaves them behind. Delete them AFTER helm uninstall — pods are gone now,
+# so pvc-protection finalizers clear immediately.
+"${KCTL[@]}" delete pvc --all --ignore-not-found 2>/dev/null || true
+
 echo "Platform uninstalled and cleaned up. Use 'mise run cluster:delete' to remove the entire cluster."
 '''
 


### PR DESCRIPTION
## Summary
- `cluster:uninstall` now drains the `platform-agents` namespace (StatefulSets, pods, PVCs, namespace) **before** `helm uninstall platform`, so RWX volumes can unmount while the chart-bundled NFS provisioner is still serving them.
- Release-namespace PVCs (postgres, redis, nfs export) are swept *after* helm uninstall — they're StatefulSet-created so helm doesn't own them, but their `pvc-protection` finalizer clears immediately once the pods are gone.

## Context
Previously the order was:
1. `helm uninstall platform` — removes the NFS provisioner that backs `platform-rwx`.
2. `kubectl delete ns platform-agents` — agent pods try to terminate, but kubelet can't unmount their RWX volumes from the now-dead NFS server.

Result: pods stuck in `Terminating` (containers got SIGKILL'd at the 5s grace period, but the pod object lingers on volume cleanup), namespace stuck in `Terminating` with `unexpected items still remain in namespace: platform-agents for gvr: /v1, Resource=pods`, and only `kubectl delete pod --force --grace-period=0` could break the deadlock.

## Test plan
- [x] Repro: `mise run cluster:install` → start an agent instance → `mise run cluster:uninstall` previously hung; with this change, drain phase clears `platform-agents` cleanly.
- [x] Verified `helm uninstall` runs after drain and release-namespace PVCs (postgres, redis, nfs export) clear immediately.
- [x] `mise run cluster:install` then immediate `mise run cluster:uninstall` (no agents) — the `if get ns platform-agents` guard skips drain, no regression.