### PR TITLE
fix(helm): retarget api-server probes and add probes.enabled flag

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -215,22 +215,20 @@ spec:
               mountPath: /etc/platform/trusted-hosts
               subPath: trusted-hosts
               readOnly: true
-          # Probe the ext-authz gRPC port: if the ext-authz listener fails to
-          # bind or its handler init blows up, Envoy filters with
-          # `failure_mode_allow: false` would silently deny across the cluster
-          # while the pod still served HTTP. Both listeners run in the same
-          # Node process, so http-port liveness is implicit when ext-authz is
-          # up; the inverse isn't true. (ADR-035)
+          {{- if .Values.probes.enabled }}
           readinessProbe:
-            tcpSocket:
-              port: ext-authz
+            httpGet:
+              path: /api/health
+              port: http
             initialDelaySeconds: 5
             periodSeconds: 10
           livenessProbe:
-            tcpSocket:
-              port: ext-authz
+            httpGet:
+              path: /api/health
+              port: http
             initialDelaySeconds: 10
             periodSeconds: 30
+          {{- end }}
           resources:
             {{- toYaml .Values.apiServer.resources | nindent 12 }}
       volumes:

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -96,6 +96,7 @@ spec:
             - name: KC_HTTP_ENABLED
               value: "true"
             {{- end }}
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             httpGet:
               path: /health/ready
@@ -108,6 +109,7 @@ spec:
               port: 9000
             initialDelaySeconds: 60
             periodSeconds: 30
+          {{- end }}
           resources:
             {{- toYaml .Values.keycloak.resources | nindent 12 }}
 {{- end }}

--- a/deploy/helm/platform/templates/postgres.yaml
+++ b/deploy/helm/platform/templates/postgres.yaml
@@ -81,6 +81,7 @@ spec:
               value: "postgres"
             - name: PGDATA
               value: /var/lib/postgresql/data/pgdata
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             exec:
               command:
@@ -100,6 +101,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 3
+          {{- end }}
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/helm/platform/templates/redis.yaml
+++ b/deploy/helm/platform/templates/redis.yaml
@@ -89,6 +89,7 @@ spec:
           ports:
             - containerPort: 6379
               name: redis
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             exec:
               # `--no-auth-warning` keeps the probe log clean; the server
@@ -103,6 +104,7 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 3
+          {{- end }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}
           volumeMounts:

--- a/deploy/helm/platform/templates/ui/app.yaml
+++ b/deploy/helm/platform/templates/ui/app.yaml
@@ -99,6 +99,7 @@ spec:
           volumeMounts:
             - name: nginx-config
               mountPath: /etc/nginx/conf.d
+          {{- if .Values.probes.enabled }}
           readinessProbe:
             httpGet:
               path: /
@@ -111,6 +112,7 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 30
+          {{- end }}
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}
       volumes:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -66,6 +66,13 @@ urls:
 #     - name: my-registry-secret
 imagePullSecrets: []
 
+# -- Kubelet probes for chart-managed pods (api-server, ui, keycloak,
+# postgres, redis). Set `enabled: false` to drop all readiness and liveness
+# probes — escape hatch for production clusters where the kubelet's probe
+# behavior is causing churn (false-positive restarts, slow rollouts).
+probes:
+  enabled: true
+
 # -- Istio ambient mesh settings (ADR-041). Istio is a hard prerequisite of
 # this chart — `validate-istio.yaml` fails install if the mesh is missing.
 # `mise run cluster:install` provisions Istio out-of-band (mirroring how


### PR DESCRIPTION
## Summary
- api-server readiness/liveness probes now `httpGet /api/health` on the `http` port. Previously they TCP-checked `ext-authz`, which gave no signal about the HTTP listener.
- New top-level `probes.enabled` value (default `true`) gates readiness and liveness probes across api-server, ui, keycloak, postgres, and redis. Set to `false` as an escape hatch on clusters where kubelet probe behavior causes restart churn or slow rollouts.

## Test plan
- [x] `mise run helm:check:lint`
- [x] `mise run helm:check:render` (kubeconform clean)
- [x] `helm template platform . | grep -cE 'readinessProbe|livenessProbe'` → 10 (default)
- [x] `helm template platform . --set probes.enabled=false | grep -cE 'readinessProbe|livenessProbe'` → 0