### PR TITLE
fix(helm): render probes as explicit null when disabled

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -228,6 +228,12 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
+          {{- else }}
+          # Explicit null (not omission) so a `helm upgrade` from a release
+          # that previously had probes generates a delete patch; otherwise
+          # K8s rejects the upgrade with "must specify a handler type".
+          readinessProbe: null
+          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.apiServer.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -109,6 +109,9 @@ spec:
               port: 9000
             initialDelaySeconds: 60
             periodSeconds: 30
+          {{- else }}
+          readinessProbe: null
+          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.keycloak.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/postgres.yaml
+++ b/deploy/helm/platform/templates/postgres.yaml
@@ -101,6 +101,9 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 3
+          {{- else }}
+          readinessProbe: null
+          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/redis.yaml
+++ b/deploy/helm/platform/templates/redis.yaml
@@ -104,6 +104,9 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 3
+          {{- else }}
+          readinessProbe: null
+          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/ui/app.yaml
+++ b/deploy/helm/platform/templates/ui/app.yaml
@@ -112,6 +112,9 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 30
+          {{- else }}
+          readinessProbe: null
+          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}


### PR DESCRIPTION
## Summary
- `probes.enabled: false` now renders `readinessProbe: null` / `livenessProbe: null` in every chart Deployment instead of omitting the fields.
- Fixes `helm upgrade` failures from releases that previously had probes:
  ```
  Deployment.apps \"…-keycloak\" is invalid: [spec.template.spec.containers[0].livenessProbe: Required value: must specify a handler type, …]
  ```
  Helm's three-way merge was producing `livenessProbe: {}` in the patch instead of a delete; explicit `null` makes the deletion intent unambiguous so K8s removes the field cleanly.

## Test plan
- [x] `mise run helm:check:lint`
- [x] `mise run helm:check:render` (kubeconform clean)
- [x] `helm template . --set probes.enabled=false | grep -E 'readinessProbe|livenessProbe'` → 10 lines, all `…: null`
- [x] `helm template . | grep -cE 'readinessProbe|livenessProbe'` → 10 (full probe blocks)
- [ ] `helm upgrade` against the previously-failing prod release with `--set probes.enabled=false`