### PR TITLE
revert(helm): drop explicit-null probe rendering (#154)

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -228,12 +228,6 @@ spec:
               port: http
             initialDelaySeconds: 10
             periodSeconds: 30
-          {{- else }}
-          # Explicit null (not omission) so a `helm upgrade` from a release
-          # that previously had probes generates a delete patch; otherwise
-          # K8s rejects the upgrade with "must specify a handler type".
-          readinessProbe: null
-          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.apiServer.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -109,9 +109,6 @@ spec:
               port: 9000
             initialDelaySeconds: 60
             periodSeconds: 30
-          {{- else }}
-          readinessProbe: null
-          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.keycloak.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/postgres.yaml
+++ b/deploy/helm/platform/templates/postgres.yaml
@@ -101,9 +101,6 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 3
-          {{- else }}
-          readinessProbe: null
-          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.postgres.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/redis.yaml
+++ b/deploy/helm/platform/templates/redis.yaml
@@ -104,9 +104,6 @@ spec:
             initialDelaySeconds: 15
             periodSeconds: 15
             timeoutSeconds: 3
-          {{- else }}
-          readinessProbe: null
-          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.redis.resources | nindent 12 }}

--- a/deploy/helm/platform/templates/ui/app.yaml
+++ b/deploy/helm/platform/templates/ui/app.yaml
@@ -112,9 +112,6 @@ spec:
               port: http
             initialDelaySeconds: 5
             periodSeconds: 30
-          {{- else }}
-          readinessProbe: null
-          livenessProbe: null
           {{- end }}
           resources:
             {{- toYaml .Values.ui.resources | nindent 12 }}


### PR DESCRIPTION
## Summary
Revert #154. Rendering `readinessProbe: null` / `livenessProbe: null` doesn't get translated by Helm's three-way merge into a field deletion — the patch reaches K8s as `livenessProbe: {}` and validation rejects it (`must specify a handler type`). Omitting the field entirely (the #153 behavior) does work.

## Repro
Minimal chart with a Deployment whose container has `livenessProbe` and `readinessProbe`. `helm install`, then upgrade to a chart that:

- renders `livenessProbe: null` → `UPGRADE FAILED: Deployment ... is invalid: ... must specify a handler type` (matches the prod symptom).
- omits the probe fields → upgrade succeeds, probes deleted from the deployment.

## If your cluster is already wedged
If a prior upgrade left the deployment with the empty-probe state, repair it manually before re-running helm:
```
kubectl patch deploy dam-platform-keycloak -n <ns> --type=strategic \
  -p '{"spec":{"template":{"spec":{"containers":[{"name":"keycloak","livenessProbe":null,"readinessProbe":null}]}}}}'
```

## Test plan
- [x] `mise run helm:check:lint`
- [x] `mise run helm:check:render` (kubeconform clean)
- [x] `helm template . --set probes.enabled=false | grep -cE 'readinessProbe|livenessProbe'` → 0
- [x] `helm template . | grep -cE 'readinessProbe|livenessProbe'` → 10
- [x] End-to-end repro against local k3s — `helm install` (probes) → `helm upgrade` (probe fields omitted) → succeeds, probes removed from the live deployment