### PR TITLE
feat(controller): honor probes.enabled for agent and fork pods

### DIFF
--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -88,6 +88,8 @@ spec:
             # render time as `<release>-extauthz-<id>.<release-ns>.svc.cluster.local`
             # from PLATFORM_RELEASE_NAME + PLATFORM_RELEASE_NAMESPACE; no
             # static EXT_AUTHZ_HOST is needed.
+            - name: AGENT_PROBES_ENABLED
+              value: {{ .Values.probes.enabled | quote }}
             - name: EXT_AUTHZ_PORT
               value: {{ .Values.apiServer.extAuthzPort | quote }}
             - name: EXT_AUTHZ_HOLD_SECONDS

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -67,9 +67,11 @@ urls:
 imagePullSecrets: []
 
 # -- Kubelet probes for chart-managed pods (api-server, ui, keycloak,
-# postgres, redis). Set `enabled: false` to drop all readiness and liveness
-# probes — escape hatch for production clusters where the kubelet's probe
-# behavior is causing churn (false-positive restarts, slow rollouts).
+# postgres, redis) AND controller-managed agent / fork pods. Set
+# `enabled: false` to drop all readiness/liveness/startup probes — escape
+# hatch for clusters where the kubelet's probe behavior is causing churn
+# (false-positive restarts, slow rollouts). Plumbed into the controller via
+# `AGENT_PROBES_ENABLED` so newly reconciled pods follow the same setting.
 probes:
   enabled: true
 

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	AgentImagePullPolicy      string            // ImagePullPolicy for agent pods (default: IfNotPresent)
 	AgentImagePullSecrets     []string          // Pull secret names for agent pods (comma-separated via env)
 	AgentPodAnnotations       map[string]string // Extra annotations stamped on every agent pod (e.g. admission webhook break-glass)
+	AgentProbesEnabled        bool              // Render startup/readiness/liveness probes on agent pods (default: true; matches the chart's probes.enabled)
 	AgentStorageClass         string
 	AgentAccessMode           string // PVC access mode: ReadWriteMany (default) or ReadWriteOnce
 	AgentStorageSize          string // PVC size for persistent agent mounts (default: 10Gi)
@@ -81,6 +82,7 @@ func LoadFromEnv() (*Config, error) {
 	cfg.HarnessServerURL = os.Getenv("PLATFORM_HARNESS_SERVER_URL")
 	cfg.HarnessServerPort = envOrDefaultInt("PLATFORM_HARNESS_SERVER_PORT", 4001)
 	cfg.AgentImagePullPolicy = envOrDefault("AGENT_IMAGE_PULL_POLICY", "IfNotPresent")
+	cfg.AgentProbesEnabled = envOrDefaultBool("AGENT_PROBES_ENABLED", true)
 	if v := os.Getenv("AGENT_IMAGE_PULL_SECRETS"); v != "" {
 		for _, s := range strings.Split(v, ",") {
 			if name := strings.TrimSpace(s); name != "" {
@@ -166,6 +168,15 @@ func envOrDefaultInt(key string, def int) int {
 	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
+		}
+	}
+	return def
+}
+
+func envOrDefaultBool(key string, def bool) bool {
+	if v := os.Getenv(key); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			return b
 		}
 	}
 	return def

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -187,6 +187,19 @@ func BuildForkAgentJob(
 	}
 	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})
 
+	var readinessProbe, livenessProbe *corev1.Probe
+	if cfg.AgentProbesEnabled {
+		readinessProbe = &corev1.Probe{
+			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			PeriodSeconds: 1,
+		}
+		livenessProbe = &corev1.Probe{
+			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			InitialDelaySeconds: 10,
+			PeriodSeconds:       10,
+		}
+	}
+
 	containers := []corev1.Container{{
 		Name:            "agent",
 		Image:           agentSpec.Image,
@@ -194,17 +207,10 @@ func BuildForkAgentJob(
 		Ports: []corev1.ContainerPort{{
 			Name: "acp", ContainerPort: 8080,
 		}},
-		Env:     env,
-		EnvFrom: envFrom,
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-			PeriodSeconds: 1,
-		},
-		LivenessProbe: &corev1.Probe{
-			ProbeHandler:        corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-			InitialDelaySeconds: 10,
-			PeriodSeconds:       10,
-		},
+		Env:            env,
+		EnvFrom:        envFrom,
+		ReadinessProbe: readinessProbe,
+		LivenessProbe:  livenessProbe,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -53,6 +53,17 @@ func TestBuildForkAgentJob_BasicShape(t *testing.T) {
 	assert.True(t, *job.OwnerReferences[0].Controller)
 }
 
+func TestBuildForkAgentJob_ProbesDisabled(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentProbesEnabled = false
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, &cfg, testForkOwnerCM, nil)
+
+	c := job.Spec.Template.Spec.Containers[0]
+	assert.Nil(t, c.StartupProbe)
+	assert.Nil(t, c.ReadinessProbe)
+	assert.Nil(t, c.LivenessProbe)
+}
+
 func TestBuildForkAgentJob_LifecycleGuarantees(t *testing.T) {
 	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
 

--- a/packages/controller/pkg/reconciler/fork_test.go
+++ b/packages/controller/pkg/reconciler/fork_test.go
@@ -24,14 +24,15 @@ func setupForkReconciler(t *testing.T, agents map[string]*corev1.ConfigMap, obje
 	t.Helper()
 	client := fake.NewSimpleClientset(objects...)
 	cfg := &config.Config{
-		Namespace:         "test-agents",
-		ReleaseNamespace:  "default",
-		ReleaseName:       "platform",
-		HarnessServerPort: 4001,
-		EnvoyImage:        "envoyproxy/envoy:distroless-v1.37.2",
-		EnvoyPort:         10000,
-		IstioTrustDomain:  "cluster.local",
-		IstioWaypointName: "apiserver-waypoint",
+		Namespace:          "test-agents",
+		ReleaseNamespace:   "default",
+		ReleaseName:        "platform",
+		HarnessServerPort:  4001,
+		EnvoyImage:         "envoyproxy/envoy:distroless-v1.37.2",
+		EnvoyPort:          10000,
+		IstioTrustDomain:   "cluster.local",
+		IstioWaypointName:  "apiserver-waypoint",
+		AgentProbesEnabled: true,
 	}
 	getter := &fakeGetter{cms: agents}
 	// ADR-041: ForkReconciler writes per-fork AuthorizationPolicies via

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -247,6 +247,27 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	}
 	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})
 
+	// Fast (1s) during startup so wake-up is detected quickly, slow
+	// (10s) afterwards so we're not probing every agent pod every
+	// second forever. FailureThreshold=120 → ~2 min of startup
+	// runway, enough for a cold pull of a large agent image.
+	var startupProbe, readinessProbe, livenessProbe *corev1.Probe
+	if cfg.AgentProbesEnabled {
+		startupProbe = &corev1.Probe{
+			ProbeHandler:     corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			PeriodSeconds:    1,
+			FailureThreshold: 120,
+		}
+		readinessProbe = &corev1.Probe{
+			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			PeriodSeconds: 10,
+		}
+		livenessProbe = &corev1.Probe{
+			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
+			PeriodSeconds: 10,
+		}
+	}
+
 	containers := []corev1.Container{{
 		Name:            "agent",
 		Image:           agentSpec.Image,
@@ -254,25 +275,11 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 		Ports: []corev1.ContainerPort{{
 			Name: "acp", ContainerPort: 8080,
 		}},
-		Env:     env,
-		EnvFrom: envFrom,
-		// Fast (1s) during startup so wake-up is detected quickly, slow
-		// (10s) afterwards so we're not probing every agent pod every
-		// second forever. FailureThreshold=120 → ~2 min of startup
-		// runway, enough for a cold pull of a large agent image.
-		StartupProbe: &corev1.Probe{
-			ProbeHandler:     corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-			PeriodSeconds:    1,
-			FailureThreshold: 120,
-		},
-		ReadinessProbe: &corev1.Probe{
-			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-			PeriodSeconds: 10,
-		},
-		LivenessProbe: &corev1.Probe{
-			ProbeHandler:  corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
-			PeriodSeconds: 10,
-		},
+		Env:            env,
+		EnvFrom:        envFrom,
+		StartupProbe:   startupProbe,
+		ReadinessProbe: readinessProbe,
+		LivenessProbe:  livenessProbe,
 		SecurityContext: &corev1.SecurityContext{
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -14,16 +14,17 @@ import (
 )
 
 var testConfig = &config.Config{
-	Namespace:         "test-agents",
-	ReleaseNamespace:  "default",
-	ReleaseName:       "platform",
-	HarnessServerPort: 4001,
-	ExtAuthzPort:      4002,
-	AgentHome:         "/home/agent",
-	EnvoyImage:        "envoyproxy/envoy:distroless-v1.37.2",
-	EnvoyPort:         10000,
-	IstioTrustDomain:  "cluster.local",
-	IstioWaypointName: "apiserver-waypoint",
+	Namespace:          "test-agents",
+	ReleaseNamespace:   "default",
+	ReleaseName:        "platform",
+	HarnessServerPort:  4001,
+	ExtAuthzPort:       4002,
+	AgentHome:          "/home/agent",
+	EnvoyImage:         "envoyproxy/envoy:distroless-v1.37.2",
+	EnvoyPort:          10000,
+	IstioTrustDomain:   "cluster.local",
+	IstioWaypointName:  "apiserver-waypoint",
+	AgentProbesEnabled: true,
 }
 
 var testAgent = &types.AgentSpec{
@@ -119,6 +120,18 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	assert.Equal(t, resource.MustParse("2Gi"), *c.Resources.Limits.Memory())
 
 	assert.True(t, *ss.Spec.Template.Spec.SecurityContext.RunAsNonRoot)
+}
+
+func TestBuildAgentStatefulSet_ProbesDisabled(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentProbesEnabled = false
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
+
+	c := ss.Spec.Template.Spec.Containers[0]
+	assert.Nil(t, c.StartupProbe)
+	assert.Nil(t, c.ReadinessProbe)
+	assert.Nil(t, c.LivenessProbe)
 }
 
 func TestBuildAgentStatefulSet_Hibernated(t *testing.T) {


### PR DESCRIPTION
## Summary
Extend the `probes.enabled` flag (#153) to cover controller-managed agent StatefulSets and fork Jobs. Until now, the flag only suppressed probes on chart-managed Deployments (api-server, ui, keycloak, postgres, redis); newly reconciled agent / fork pods kept their startup/readiness/liveness probes regardless of the chart setting.

- New `AGENT_PROBES_ENABLED` env on the controller, plumbed from `.Values.probes.enabled`.
- `Config.AgentProbesEnabled` (default `true`) — preserves current behavior when env unset.
- `BuildAgentStatefulSet` and `BuildForkAgentJob` skip startup/readiness/liveness probes when false.

## Test plan
- [x] `mise run check`
- [x] `mise run test` (controller + UI + api-server)
- [x] New tests `TestBuildAgentStatefulSet_ProbesDisabled` and `TestBuildForkAgentJob_ProbesDisabled` assert all three probes are nil with the flag off.
- [x] `helm template . --set probes.enabled=false | grep AGENT_PROBES_ENABLED` → `value: "false"` on the controller Deployment.