### PR TITLE
fix(controller): select apiserver pods on ext-authz Service by .Release.Name

### DIFF
--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -30,6 +30,13 @@ spec:
           env:
             - name: PLATFORM_RELEASE_NAME
               value: {{ include "platform.fullname" . }}
+            # Value of `app.kubernetes.io/instance` on chart-rendered apiserver
+            # pods — i.e. the literal Helm `.Release.Name`. Used by the
+            # controller to populate the selector on per-instance ext-authz
+            # Services so they actually resolve to apiserver pods even when
+            # release name and `platform.fullname` diverge.
+            - name: PLATFORM_INSTANCE_LABEL
+              value: {{ .Release.Name | quote }}
             - name: PLATFORM_AGENT_NAMESPACE
               value: {{ .Values.agentNamespace }}
             - name: PLATFORM_RELEASE_NAMESPACE

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -12,7 +12,14 @@ import (
 type Config struct {
 	Namespace        string // Agent workload namespace
 	ReleaseNamespace string // Helm release namespace (where controller runs)
-	ReleaseName      string // Helm release name
+	ReleaseName      string // Helm release name — used as the prefix for controller-rendered object names (matches `platform.fullname` in the chart). May differ from APIServerInstanceLabel when the chart name isn't contained in the release name.
+	// APIServerInstanceLabel is the value of `app.kubernetes.io/instance` on
+	// chart-rendered apiserver pods — i.e. the literal Helm `.Release.Name`.
+	// Used to select apiserver pods from the per-instance ext-authz Service.
+	// Diverges from `ReleaseName` (= `platform.fullname`) whenever the chart
+	// name isn't a substring of the release name (e.g. release `dam`, chart
+	// `platform` → fullname `dam-platform`, instance label `dam`).
+	APIServerInstanceLabel string
 	LeaseName        string // Leader election lease name
 	PodName          string // This pod's name (from downward API)
 	AgentImagePullPolicy      string            // ImagePullPolicy for agent pods (default: IfNotPresent)
@@ -76,6 +83,10 @@ func LoadFromEnv() (*Config, error) {
 		Namespace:        envOrDefault("PLATFORM_AGENT_NAMESPACE", "platform-agents"),
 		ReleaseNamespace: envOrDefault("PLATFORM_RELEASE_NAMESPACE", "default"),
 		ReleaseName:      release,
+		// Defaults to ReleaseName so unit tests and older deployments that
+		// don't set the var continue to behave as before; the chart always
+		// sets it explicitly to `.Release.Name`.
+		APIServerInstanceLabel: envOrDefault("PLATFORM_INSTANCE_LABEL", release),
 		LeaseName:        envOrDefault("PLATFORM_LEASE_NAME", release+"-controller"),
 		PodName:          podName,
 	}

--- a/packages/controller/pkg/reconciler/extauthz_service.go
+++ b/packages/controller/pkg/reconciler/extauthz_service.go
@@ -48,9 +48,16 @@ func BuildExtAuthzService(instanceName string, cfg *config.Config, _ *corev1.Con
 		},
 		Spec: corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,
+			// Match the chart's selectorLabels (`app.kubernetes.io/instance` =
+			// `.Release.Name`). `cfg.ReleaseName` carries `platform.fullname`
+			// instead, which diverges from `.Release.Name` whenever the chart
+			// name isn't a substring of the release name — using it here would
+			// produce a selector that matches no pods, leaving the Service
+			// with zero endpoints and envoy ext-authz returning "no healthy
+			// upstream" (HTTP 403 with empty body).
 			Selector: map[string]string{
 				"app.kubernetes.io/component": "apiserver",
-				"app.kubernetes.io/instance":  cfg.ReleaseName,
+				"app.kubernetes.io/instance":  cfg.APIServerInstanceLabel,
 			},
 			Ports: []corev1.ServicePort{{
 				Name:        "ext-authz",

--- a/packages/controller/pkg/reconciler/extauthz_service_test.go
+++ b/packages/controller/pkg/reconciler/extauthz_service_test.go
@@ -1,0 +1,31 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+)
+
+// The per-instance ext-authz Service must select apiserver pods by the
+// chart's `app.kubernetes.io/instance` label, which carries the Helm
+// `.Release.Name`. Wiring the selector to `cfg.ReleaseName` (which is the
+// chart's `platform.fullname` — release+chart) silently produces a
+// selector that matches no pods whenever the chart name isn't a substring
+// of the release name (e.g. release `dam`, chart `platform`), and envoy
+// ext-authz then fails closed with "no healthy upstream".
+func TestBuildExtAuthzService_SelectorUsesInstanceLabel_NotFullname(t *testing.T) {
+	cfg := &config.Config{
+		ReleaseNamespace:       "default",
+		ReleaseName:            "dam-platform", // fullname
+		APIServerInstanceLabel: "dam",          // .Release.Name
+		ExtAuthzPort:           4002,
+	}
+	svc := BuildExtAuthzService("inst-1", cfg, nil)
+	assert.Equal(t, "dam", svc.Spec.Selector["app.kubernetes.io/instance"],
+		"selector must match the chart's .Release.Name-based instance label, not the fullname-based ReleaseName")
+	assert.Equal(t, "apiserver", svc.Spec.Selector["app.kubernetes.io/component"])
+	assert.Equal(t, "dam-platform-extauthz-inst-1", svc.Name,
+		"Service name continues to use fullname (ReleaseName)")
+}


### PR DESCRIPTION
## Summary
- Per-instance ext-authz Service selector used `cfg.ReleaseName` (= `platform.fullname`), but apiserver pods are labeled `app.kubernetes.io/instance: {{ .Release.Name }}`. When fullname ≠ release name (e.g. release `dam`, chart `platform` → fullname `dam-platform`, label `dam`) the Service ended up with zero endpoints and envoy ext-authz returned 403 with empty body — ztunnel logged "no healthy upstream" for `<release>-extauthz-inst-*:4002`.
- Added a separate `PLATFORM_INSTANCE_LABEL` env (= `.Release.Name`) and use it for the selector. `PLATFORM_RELEASE_NAME` keeps its `fullname` semantics so Service *names* and the ADR-041 hostname-parsing in api-server are unchanged.
- New test (`extauthz_service_test.go`) pins the selector to the `.Release.Name`-based label and asserts the Service name still uses fullname, so a future "simplify by using ReleaseName" regresses loudly.

## Test plan
- [x] `mise run test` — controller + api-server + ui + agent-runtime suites green
- [x] `mise run check` — lint + tsc + go vet/build clean
- [x] `mise run helm:check:lint` / `helm:check:render` — chart renders + kubeconform clean
- [x] `helm template dam` confirms controller pod gets `PLATFORM_RELEASE_NAME=dam-platform` and `PLATFORM_INSTANCE_LABEL="dam"`
- [ ] Roll controller on affected cluster, confirm `kubectl get endpoints -l agent-platform.ai/instance -n <release-ns>` now populates and envoy ext-authz stops returning 403