### PR TITLE
fix(controller): restore per-pair agent egress NetworkPolicy

### DIFF
--- a/deploy/helm/platform/templates/controller/rbac.yaml
+++ b/deploy/helm/platform/templates/controller/rbac.yaml
@@ -47,6 +47,12 @@ rules:
   - apiGroups: ["security.istio.io"]
     resources: ["authorizationpolicies"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Per-pair agent egress NetworkPolicy. Mesh AuthorizationPolicy gates
+  # ingress to the gateway pod; this NP closes the symmetric egress hole
+  # at the kernel layer so the agent process cannot bypass HTTPS_PROXY.
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["networkpolicies"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-07
+Last verified: 2026-05-11
 
 ## Motivated by
 
@@ -74,7 +74,7 @@ flowchart LR
 
   api-server -->|write K8s Secrets<br/>platform.ai/owner=sub| gatewaypod
   controller -->|render bootstrap + leaf cert<br/>list owner Secrets| gatewaypod
-  controller -->|render agent + paired gateway<br/>+ role-scoped NetworkPolicies| agentpod
+  controller -->|render agent + paired gateway<br/>+ AuthorizationPolicies<br/>+ per-pair agent egress NetworkPolicy| agentpod
 
   agent-runtime -->|HTTPS_PROXY=&lt;instance&gt;-gateway| envoy
   envoy -->|ext_authz Check| api-server
@@ -83,7 +83,21 @@ flowchart LR
 
 The credential boundary is the pod: K8s Secrets are mounted into the
 gateway pod only, and the agent pod has no admitted route to TCP 80/443
-other than its paired gateway. The agent pod has no service account token
+other than its paired gateway. Enforcement is layered:
+
+- **Mesh AuthorizationPolicy** (ADR-041) gates *ingress* on the gateway
+  pod by SA principal, so another instance's agent cannot reach this
+  gateway even if the pod IP is known.
+- **Per-pair agent egress NetworkPolicy** (controller-rendered,
+  `<id>-agent-egress`) restricts the agent pod's *egress* at the kernel
+  layer to DNS, its paired gateway pod, and the ambient HBONE port.
+  Without this, an agent process can ignore `HTTPS_PROXY` and dial
+  external hosts directly, escaping Envoy's MITM, credential
+  injection, and ext-authz HITL gates. The NetworkPolicy selects on
+  `pair=<id>, role=agent`, so the gateway pod's own egress (which
+  legitimately dials credentialed upstreams) stays unrestricted.
+
+The agent pod has no service account token
 (`automountServiceAccountToken: false`), and there is no co-located
 sidecar to share a network or PID namespace with. See
 [ADR-033 §Threat Model](../adrs/033-envoy-credential-gateway.md#threat-model)
@@ -246,7 +260,14 @@ caller identification all flow through the same SPIFFE primitive:
   per-instance SA from the agent namespace (ext-authz), closing the
   direct pod-IP bypass.
 
-NetworkPolicy retracts to coarse perimeter only — namespace-level
-egress allowlists and cluster-edge ingress where identity-blind kernel
-enforcement is still load-bearing. The fine-grained pair-key policies
-from ADR-038 are gone.
+NetworkPolicy retracts to coarse perimeter only — cluster-edge ingress
+and a per-pair *agent egress* policy (`<id>-agent-egress`, controller-
+rendered alongside the gateway-admission AuthorizationPolicy) that
+locks the agent pod's L3/L4 egress to its paired gateway plus DNS and
+ambient HBONE. The pair-pinning here is structural defence-in-depth on
+top of mesh AuthorizationPolicy: the AuthorizationPolicy on each
+gateway pod still cryptographically denies traffic from a non-matching
+SA, but the NetworkPolicy is what keeps the agent process from
+side-stepping `HTTPS_PROXY` and reaching external hosts that the mesh
+doesn't see. The fine-grained pair-key *ingress* policies from
+ADR-038 are gone — Istio AuthorizationPolicy owns that boundary now.

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -139,6 +139,13 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying fork ext-authz authz policy: %v", err))
 	}
 
+	// ADR-041: per-pair agent egress NetworkPolicy (same rationale as the
+	// long-lived shape — kernel-level perimeter so the agent process
+	// cannot bypass HTTPS_PROXY).
+	if err := r.applyAgentEgressNetworkPolicy(ctx, BuildAgentEgressNetworkPolicy(forkName, r.config, cm)); err != nil {
+		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, err.Error())
+	}
+
 	// ADR-038: paired gateway pod for the fork. Render the gateway-side
 	// resources first so HTTPS_PROXY's target exists by the time the
 	// agent Job's pod starts dialing it. ADR-041: pair-key NetworkPolicy

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -121,6 +121,14 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		return r.setError(ctx, name, fmt.Sprintf("applying ext-authz authz policy: %v", err))
 	}
 
+	// ADR-041: per-pair agent egress NetworkPolicy. AuthorizationPolicy on
+	// the gateway only gates ingress; without an egress NP the agent
+	// process can bypass HTTPS_PROXY and dial external hosts directly,
+	// escaping Envoy's credential and HITL gates.
+	if err := r.applyAgentEgressNetworkPolicy(ctx, BuildAgentEgressNetworkPolicy(name, r.config, cm)); err != nil {
+		return r.setError(ctx, name, err.Error())
+	}
+
 	hibernated := instanceSpec.DesiredState == "hibernated"
 
 	// ADR-038: paired pods, rendered as a unit. Render the gateway first

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -131,6 +131,14 @@ func TestReconcile_CreateResources(t *testing.T) {
 	_, err = client.CoreV1().Services("default").Get(ctx, "platform-extauthz-my-instance", metav1.GetOptions{})
 	require.NoError(t, err, "per-instance ext-authz Service must be created")
 
+	// ADR-041: per-pair agent egress NetworkPolicy. AuthorizationPolicy
+	// only gates ingress; this closes the symmetric egress hole at the
+	// kernel layer so an agent can't bypass HTTPS_PROXY.
+	np, err := client.NetworkingV1().NetworkPolicies("test-agents").Get(ctx, "my-instance-agent-egress", metav1.GetOptions{})
+	require.NoError(t, err, "per-pair agent egress NetworkPolicy must be created")
+	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels["agent-platform.ai/pair"])
+	assert.Equal(t, "agent", np.Spec.PodSelector.MatchLabels["agent-platform.ai/role"])
+
 	// Pod specs use the per-instance SA (ADR-041)
 	assert.Equal(t, "my-instance", ss.Spec.Template.Spec.ServiceAccountName,
 		"agent pod must run as the per-instance SA so SPIFFE peer principal == URL :id")

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -1,0 +1,197 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/util/retry"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+)
+
+// Per-pair agent egress NetworkPolicy (ADR-041 "namespace-level egress
+// allowlist" specialised to a single pair).
+//
+// AuthorizationPolicy on the gateway side already pins ingress to the
+// matching SA principal cryptographically — but it is a destination-side
+// gate. Without an egress restriction on the agent pod, the agent process
+// can bypass HTTPS_PROXY and dial external services directly, escaping
+// the Envoy MITM, credential-injection, and ext-authz HITL gates.
+// `kernel-level NetworkPolicy` is what closes that loop: it is identity-
+// blind but enforces at the L3/L4 perimeter regardless of what the agent
+// process does at L7.
+//
+// Allowed egress:
+//   - DNS to kube-system (TCP/UDP 53) — needed for resolving the gateway
+//     Service hostname.
+//   - The paired gateway pod (`pair=<id>, role=gateway`) on the Envoy
+//     proxy port and HBONE 15008. Per-pair selector pins reachability
+//     to *this* agent's gateway; mesh AuthorizationPolicy still enforces
+//     it cryptographically.
+//   - istio-system on HBONE 15008 — covers ambient-mesh routing where
+//     istio-cni redirects pod egress to ztunnel before NetworkPolicy
+//     enforcement. Without this, in-mesh traffic appears blocked even
+//     though the destination is admitted at the AuthorizationPolicy
+//     layer. (Mirror of the rationale in `migrate-stale-netpols.yaml`.)
+//
+// Everything else (external internet, other in-cluster Services) is
+// denied at the kernel layer.
+
+// BuildAgentEgressNetworkPolicy renders the per-pair egress NetworkPolicy
+// for the agent pod of `pairKey`. Long-lived pairs use the instance name
+// as `pairKey`; forks use the fork name. The selector pins to the pair's
+// agent pod specifically — the paired gateway pod's egress stays
+// unrestricted (it dials external upstreams for credential injection).
+func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
+	envoyPort := intstr.FromInt(cfg.EnvoyPort)
+	hbonePort := intstr.FromInt(15008)
+	dnsPort := intstr.FromInt(53)
+	tcp := corev1.ProtocolTCP
+	udp := corev1.ProtocolUDP
+
+	return &networkingv1.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      pairKey + "-agent-egress",
+			Namespace: cfg.Namespace,
+			Labels: map[string]string{
+				LabelInstance:                  pairKey,
+				LabelPair:                      pairKey,
+				LabelRole:                      RoleAgent,
+				"agent-platform.ai/managed-by": "platform-controller",
+			},
+			OwnerReferences: []metav1.OwnerReference{
+				*metav1.NewControllerRef(ownerCM, corev1.SchemeGroupVersion.WithKind("ConfigMap")),
+			},
+		},
+		Spec: networkingv1.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					LabelPair: pairKey,
+					LabelRole: RoleAgent,
+				},
+			},
+			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
+			Egress: []networkingv1.NetworkPolicyEgressRule{
+				{
+					To: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &udp, Port: &dnsPort},
+						{Protocol: &tcp, Port: &dnsPort},
+					},
+				},
+				{
+					To: []networkingv1.NetworkPolicyPeer{{
+						PodSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{
+								LabelPair: pairKey,
+								LabelRole: RoleGateway,
+							},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &envoyPort},
+						{Protocol: &tcp, Port: &hbonePort},
+					},
+				},
+				{
+					To: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "istio-system"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &tcp, Port: &hbonePort},
+					},
+				},
+			},
+		},
+	}
+}
+
+// applyNetworkPolicy creates or updates a NetworkPolicy. Mirrors
+// applyAuthorizationPolicy / applyServiceAccount shape.
+func applyNetworkPolicy(ctx context.Context, client networkPolicyClient, desired *networkingv1.NetworkPolicy) error {
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		existing, err := client.Get(ctx, desired.Name, desired.Namespace)
+		if errors.IsNotFound(err) {
+			return client.Create(ctx, desired)
+		}
+		if err != nil {
+			return err
+		}
+		desired.ResourceVersion = existing.ResourceVersion
+		return client.Update(ctx, desired)
+	})
+}
+
+// networkPolicyClient narrows the K8s networking client surface to the
+// three verbs applyNetworkPolicy needs, so unit tests can wire a fake
+// without dragging in the full kubernetes.Interface.
+type networkPolicyClient interface {
+	Get(ctx context.Context, name, namespace string) (*networkingv1.NetworkPolicy, error)
+	Create(ctx context.Context, np *networkingv1.NetworkPolicy) error
+	Update(ctx context.Context, np *networkingv1.NetworkPolicy) error
+}
+
+// k8sNetworkPolicyClient adapts kubernetes.Interface to networkPolicyClient.
+type k8sNetworkPolicyClient struct {
+	r *InstanceReconciler
+}
+
+func (c k8sNetworkPolicyClient) Get(ctx context.Context, name, namespace string) (*networkingv1.NetworkPolicy, error) {
+	return c.r.client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c k8sNetworkPolicyClient) Create(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Create(ctx, np, metav1.CreateOptions{})
+	return err
+}
+
+func (c k8sNetworkPolicyClient) Update(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Update(ctx, np, metav1.UpdateOptions{})
+	return err
+}
+
+// applyAgentEgressNetworkPolicy is the InstanceReconciler entry point.
+func (r *InstanceReconciler) applyAgentEgressNetworkPolicy(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	if err := applyNetworkPolicy(ctx, k8sNetworkPolicyClient{r: r}, np); err != nil {
+		return fmt.Errorf("applying agent egress NetworkPolicy: %w", err)
+	}
+	return nil
+}
+
+// forkNetworkPolicyClient adapts the ForkReconciler's kubernetes.Interface
+// to networkPolicyClient — same shape as k8sNetworkPolicyClient.
+type forkNetworkPolicyClient struct {
+	r *ForkReconciler
+}
+
+func (c forkNetworkPolicyClient) Get(ctx context.Context, name, namespace string) (*networkingv1.NetworkPolicy, error) {
+	return c.r.client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func (c forkNetworkPolicyClient) Create(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Create(ctx, np, metav1.CreateOptions{})
+	return err
+}
+
+func (c forkNetworkPolicyClient) Update(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Update(ctx, np, metav1.UpdateOptions{})
+	return err
+}
+
+func (r *ForkReconciler) applyAgentEgressNetworkPolicy(ctx context.Context, np *networkingv1.NetworkPolicy) error {
+	if err := applyNetworkPolicy(ctx, forkNetworkPolicyClient{r: r}, np); err != nil {
+		return fmt.Errorf("applying fork agent egress NetworkPolicy: %w", err)
+	}
+	return nil
+}

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -9,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/kagenti/platform/packages/controller/pkg/config"
@@ -89,6 +90,12 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 					},
 				},
 				{
+					// Bare PodSelector with no NamespaceSelector implicitly
+					// scopes to the policy's own namespace — correct today
+					// since agent + gateway pods of a pair share
+					// `cfg.Namespace`. If pods ever split across namespaces
+					// this peer must grow a NamespaceSelector or the rule
+					// silently denies the legitimate egress path.
 					To: []networkingv1.NetworkPolicyPeer{{
 						PodSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
@@ -119,78 +126,32 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 
 // applyNetworkPolicy creates or updates a NetworkPolicy. Mirrors
 // applyAuthorizationPolicy / applyServiceAccount shape.
-func applyNetworkPolicy(ctx context.Context, client networkPolicyClient, desired *networkingv1.NetworkPolicy) error {
+func applyNetworkPolicy(ctx context.Context, client kubernetes.Interface, desired *networkingv1.NetworkPolicy) error {
+	cli := client.NetworkingV1().NetworkPolicies(desired.Namespace)
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		existing, err := client.Get(ctx, desired.Name, desired.Namespace)
+		existing, err := cli.Get(ctx, desired.Name, metav1.GetOptions{})
 		if errors.IsNotFound(err) {
-			return client.Create(ctx, desired)
+			_, err = cli.Create(ctx, desired, metav1.CreateOptions{})
+			return err
 		}
 		if err != nil {
 			return err
 		}
 		desired.ResourceVersion = existing.ResourceVersion
-		return client.Update(ctx, desired)
+		_, err = cli.Update(ctx, desired, metav1.UpdateOptions{})
+		return err
 	})
 }
 
-// networkPolicyClient narrows the K8s networking client surface to the
-// three verbs applyNetworkPolicy needs, so unit tests can wire a fake
-// without dragging in the full kubernetes.Interface.
-type networkPolicyClient interface {
-	Get(ctx context.Context, name, namespace string) (*networkingv1.NetworkPolicy, error)
-	Create(ctx context.Context, np *networkingv1.NetworkPolicy) error
-	Update(ctx context.Context, np *networkingv1.NetworkPolicy) error
-}
-
-// k8sNetworkPolicyClient adapts kubernetes.Interface to networkPolicyClient.
-type k8sNetworkPolicyClient struct {
-	r *InstanceReconciler
-}
-
-func (c k8sNetworkPolicyClient) Get(ctx context.Context, name, namespace string) (*networkingv1.NetworkPolicy, error) {
-	return c.r.client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
-}
-
-func (c k8sNetworkPolicyClient) Create(ctx context.Context, np *networkingv1.NetworkPolicy) error {
-	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Create(ctx, np, metav1.CreateOptions{})
-	return err
-}
-
-func (c k8sNetworkPolicyClient) Update(ctx context.Context, np *networkingv1.NetworkPolicy) error {
-	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Update(ctx, np, metav1.UpdateOptions{})
-	return err
-}
-
-// applyAgentEgressNetworkPolicy is the InstanceReconciler entry point.
 func (r *InstanceReconciler) applyAgentEgressNetworkPolicy(ctx context.Context, np *networkingv1.NetworkPolicy) error {
-	if err := applyNetworkPolicy(ctx, k8sNetworkPolicyClient{r: r}, np); err != nil {
+	if err := applyNetworkPolicy(ctx, r.client, np); err != nil {
 		return fmt.Errorf("applying agent egress NetworkPolicy: %w", err)
 	}
 	return nil
 }
 
-// forkNetworkPolicyClient adapts the ForkReconciler's kubernetes.Interface
-// to networkPolicyClient — same shape as k8sNetworkPolicyClient.
-type forkNetworkPolicyClient struct {
-	r *ForkReconciler
-}
-
-func (c forkNetworkPolicyClient) Get(ctx context.Context, name, namespace string) (*networkingv1.NetworkPolicy, error) {
-	return c.r.client.NetworkingV1().NetworkPolicies(namespace).Get(ctx, name, metav1.GetOptions{})
-}
-
-func (c forkNetworkPolicyClient) Create(ctx context.Context, np *networkingv1.NetworkPolicy) error {
-	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Create(ctx, np, metav1.CreateOptions{})
-	return err
-}
-
-func (c forkNetworkPolicyClient) Update(ctx context.Context, np *networkingv1.NetworkPolicy) error {
-	_, err := c.r.client.NetworkingV1().NetworkPolicies(np.Namespace).Update(ctx, np, metav1.UpdateOptions{})
-	return err
-}
-
 func (r *ForkReconciler) applyAgentEgressNetworkPolicy(ctx context.Context, np *networkingv1.NetworkPolicy) error {
-	if err := applyNetworkPolicy(ctx, forkNetworkPolicyClient{r: r}, np); err != nil {
+	if err := applyNetworkPolicy(ctx, r.client, np); err != nil {
 		return fmt.Errorf("applying fork agent egress NetworkPolicy: %w", err)
 	}
 	return nil

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -1,0 +1,103 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+)
+
+// ADR-041: per-pair agent egress NetworkPolicy closes the kernel-level
+// perimeter that mesh AuthorizationPolicy can't (AuthorizationPolicy is
+// destination-side ingress; without an egress NP the agent process can
+// bypass HTTPS_PROXY and dial external hosts directly).
+func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
+	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
+
+	assert.Equal(t, "my-instance-agent-egress", np.Name)
+	assert.Equal(t, testConfig.Namespace, np.Namespace)
+	require.Len(t, np.OwnerReferences, 1)
+	assert.Equal(t, "my-instance", np.OwnerReferences[0].Name)
+
+	// Selector pins to THIS pair's agent pod — the gateway pod's egress
+	// stays unrestricted (it dials external upstreams for credential
+	// injection).
+	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels[LabelPair])
+	assert.Equal(t, RoleAgent, np.Spec.PodSelector.MatchLabels[LabelRole])
+
+	// Egress only — ingress is governed by mesh AuthorizationPolicy on
+	// other workloads.
+	require.Len(t, np.Spec.PolicyTypes, 1)
+	assert.Equal(t, networkingv1.PolicyTypeEgress, np.Spec.PolicyTypes[0])
+
+	require.Len(t, np.Spec.Egress, 3, "DNS + paired gateway + istio-system HBONE")
+
+	// DNS to kube-system (resolving the gateway Service hostname).
+	dnsRule := np.Spec.Egress[0]
+	require.Len(t, dnsRule.To, 1)
+	require.NotNil(t, dnsRule.To[0].NamespaceSelector)
+	assert.Equal(t, "kube-system", dnsRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	assert.Len(t, dnsRule.Ports, 2, "both UDP/53 and TCP/53 — modern resolvers fall through to TCP")
+	protocols := map[corev1.Protocol]bool{}
+	for _, p := range dnsRule.Ports {
+		protocols[*p.Protocol] = true
+		assert.Equal(t, int32(53), p.Port.IntVal)
+	}
+	assert.True(t, protocols[corev1.ProtocolUDP] && protocols[corev1.ProtocolTCP])
+
+	// Paired gateway pod — per-pair selector pins reachability; mesh
+	// AuthorizationPolicy on the gateway side cryptographically enforces
+	// the same boundary on top.
+	gwRule := np.Spec.Egress[1]
+	require.Len(t, gwRule.To, 1)
+	require.NotNil(t, gwRule.To[0].PodSelector)
+	assert.Equal(t, "my-instance", gwRule.To[0].PodSelector.MatchLabels[LabelPair])
+	assert.Equal(t, RoleGateway, gwRule.To[0].PodSelector.MatchLabels[LabelRole])
+	// Envoy proxy port + HBONE 15008 (ambient redirect lands here when
+	// istio-cni rewrites the destination port).
+	ports := map[int32]bool{}
+	for _, p := range gwRule.Ports {
+		ports[p.Port.IntVal] = true
+	}
+	assert.True(t, ports[int32(testConfig.EnvoyPort)], "must allow Envoy proxy port")
+	assert.True(t, ports[15008], "must allow HBONE — see migrate-stale-netpols.yaml for the prior incident this guards against")
+
+	// istio-system HBONE — covers the path where istio-cni redirects
+	// outbound to ztunnel before NetworkPolicy filter sees it.
+	hboneRule := np.Spec.Egress[2]
+	require.Len(t, hboneRule.To, 1)
+	require.NotNil(t, hboneRule.To[0].NamespaceSelector)
+	assert.Equal(t, "istio-system", hboneRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	require.Len(t, hboneRule.Ports, 1)
+	assert.Equal(t, int32(15008), hboneRule.Ports[0].Port.IntVal)
+}
+
+// Fork pair: same shape, keyed on the fork name. ADR-027's fork-pair
+// isolation property only holds because the agent NP scopes the agent's
+// egress to its OWN gateway — without this, a compromised fork agent
+// could dial the parent's gateway directly.
+func TestBuildAgentEgressNetworkPolicy_Fork(t *testing.T) {
+	np := BuildAgentEgressNetworkPolicy("fork-abc", testConfig, testForkOwnerCM)
+
+	assert.Equal(t, "fork-abc-agent-egress", np.Name)
+	assert.Equal(t, "fork-abc", np.Spec.PodSelector.MatchLabels[LabelPair])
+	assert.Equal(t, RoleAgent, np.Spec.PodSelector.MatchLabels[LabelRole])
+
+	// The gateway-pod egress rule must reference the FORK's gateway, not
+	// the parent's — otherwise the fork agent could reach the parent's
+	// gateway and inject under the parent owner's credentials.
+	gwRule := np.Spec.Egress[1]
+	require.NotNil(t, gwRule.To[0].PodSelector)
+	assert.Equal(t, "fork-abc", gwRule.To[0].PodSelector.MatchLabels[LabelPair],
+		"fork agent NP must scope to the FORK's gateway, not the parent's")
+}
+
+// Label-managed-by lets operators bulk-list controller-managed NPs and
+// distinguishes them from any chart-rendered namespace-level perimeter.
+func TestBuildAgentEgressNetworkPolicy_ManagedByLabel(t *testing.T) {
+	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
+	assert.Equal(t, "platform-controller", np.Labels["agent-platform.ai/managed-by"])
+	assert.Equal(t, "my-instance", np.Labels[LabelInstance])
+}


### PR DESCRIPTION
## Summary

- ADR-041 retired ADR-038's pair-key NetworkPolicy and replaced it with mesh AuthorizationPolicy on the gateway pod — but that only gates *ingress*. With no egress restriction on the agent pod, an agent process can bypass `HTTPS_PROXY` and dial external hosts directly, escaping the Envoy MITM, credential injection, and ext-authz HITL gates. ADR-041 mentioned "namespace-level egress allowlists" as the fallback but none was ever rendered.
- Controller now renders a per-pair `<id>-agent-egress` NetworkPolicy alongside the three AuthorizationPolicies. Selector pins to `pair=<id>, role=agent`; egress allowed to DNS (kube-system), the paired gateway pod on the Envoy port + HBONE 15008, and istio-system on HBONE (covers ambient redirect). The gateway pod's own egress stays unrestricted — it legitimately dials credentialed upstreams.
- Forks render the same shape keyed on the fork name, preserving ADR-027's fork-pair isolation at the kernel layer.

## Test plan

- [x] `mise run check` clean (build, vet, helm lint, kubeconform, tsc)
- [x] `mise run test` — all packages green, including new `network_policy_test.go` + the extended `TestReconcile_CreateResources` assertion
- [ ] Smoke on a live cluster: install, create an instance, `kubectl exec` into the agent pod and confirm `curl https://example.com` fails while `curl https://example.com` via the gateway works
- [ ] Same for a fork pair — fork agent can reach its own gateway, not the parent's