### PR TITLE
fix(helm): wildcard Keycloak redirect URIs for local dev

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -64,8 +64,6 @@ keycloak:
     username: dev
     password: dev
   extraRedirectUris:
-    - "http://127.0.0.1:4444/*"
-    - "http://localhost:4444/*"
+    - "*"
   extraWebOrigins:
-    - "http://127.0.0.1:4444"
-    - "http://localhost:4444"
+    - "*"


### PR DESCRIPTION
## Summary
- Set `extraRedirectUris` and `extraWebOrigins` to `"*"` in `values-local.yaml`, replacing the previous enumerated list of `localhost` and `127.0.0.1` entries.
- When `catchAllAppHost` is enabled, the ingress accepts any hostname — but Keycloak still needs matching redirect URIs. Subdomains like `dam.localhost:4444` would fail with "Invalid parameter: redirect_uri" because `http://dam.localhost:4444/*` wasn't in the allowed list, and Keycloak's wildcard matching (`*.localhost`) doesn't work on single-label domains.

## Test plan
- [x] `helm check:lint` and `helm check:render` pass
- [x] `http://localhost:4444` — login works
- [x] `http://127.0.0.1:4444` — login works
- [x] `http://dam.localhost:4444` — login works (previously failed)