### PR TITLE
docs: add security overview strategy page

### DIFF
--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -5,16 +5,17 @@ from the credentials they use to reach external services.
 
 ## Layers of defence
 
-Each layer does one job; you'd have to break all four to compromise
-an instance.
+Four independent controls. They don't stack on top of each other —
+each one tackles a different concern, and an attacker would need to
+break all four to compromise an instance.
 
 ```mermaid
-flowchart TB
+flowchart LR
   L1["<b>Identity</b><br/>every workload has a cryptographic name"]
   L2["<b>Boundary</b><br/>the agent runs alone in its own pod"]
   L3["<b>Network</b><br/>the kernel decides what an agent can reach"]
   L4["<b>Credentials</b><br/>real tokens never reach the agent"]
-  L1 --> L2 --> L3 --> L4
+  L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
 **Identity.** Every workload runs as a per-instance ServiceAccount,

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -5,13 +5,6 @@ from the credentials they use to reach external services.
 
 ## Layers of defence
 
-Four controls, layered for defence in depth. They overlap and
-reinforce each other rather than working in isolation — identity
-underpins authorization, the pod boundary contains a credential leak,
-kernel-level network policy forces traffic through the proxy
-regardless of process intent, and credential isolation means there's
-nothing real for the agent to expose in the first place.
-
 ```mermaid
 flowchart LR
   L1["<b>Identity</b><br/>per-instance ServiceAccount<br/>+ SPIFFE cert via Istio mesh"]

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -50,6 +50,29 @@ where a credential is configured, the sibling pod adds the credential
 header on the wire after the ext-authz Check has authorized the
 request — for everything else, traffic passes through unchanged.
 
+## Security boundary
+
+The pod is the security boundary. Everything inside it — the agent
+process, any tools it spawns, any content it reads — is treated as
+untrusted. The controls above all live outside the pod (in the mesh,
+in the kernel's network stack, in a sibling pod that holds the
+credentials), so that a compromised agent cannot reach beyond what
+its network and identity allow.
+
+By default, pods run on the cluster's container runtime — typically
+runc — which shares a kernel with the node. The four controls above
+stand regardless, but a kernel-level escape from the agent's
+container reaches the node directly, and from there anything
+co-located on it.
+
+For deployments where that risk matters, the cluster operator should
+run Platform's pods under a stronger runtime — [gVisor](https://gvisor.dev/)
+or [Kata Containers](https://katacontainers.io/) — via a Kubernetes
+RuntimeClass. Platform itself does not pin a RuntimeClass; the
+choice of substrate sits with whoever operates the cluster. See
+[security-model § Execution](security-model.md#execution) for the
+longer framing.
+
 ## Authorization flow
 
 Every internal hop carries a SPIFFE identity stamped by istiod, and

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -32,16 +32,16 @@ issues the workload cert independently.
 - **Network.** Multiple layers restrict where the agent can talk. At
 the kernel, a Kubernetes NetworkPolicy locks the agent pod's L3/L4
 egress to a narrow allow-list — DNS, the Istio ambient data path, and
-the single sibling pod it is paired with. At the mesh, Istio
+the single sibling gateway pod it is paired with. At the mesh, Istio
 AuthorizationPolicies key on the per-instance ServiceAccount: peer-pod
 admission is gated at L4, and the harness path on the api-server is
 gated at L7. And every egress request through the sibling pod runs
-through an ext-authz Check at the api-server before being forwarded.
+through an ext-authz check at the api-server before being forwarded.
 
 - **Credentials.** Real upstream tokens never reach the agent. They
-live in Kubernetes Secrets mounted into a sibling pod. For hosts
+live in Kubernetes Secrets mounted into a sibling gateway pod. For hosts
 where a credential is configured, the sibling pod adds the credential
-header on the wire after the ext-authz Check has authorized the
+header on the wire after the ext-authz check has authorized the
 request — for everything else, traffic passes through unchanged.
 
 ## Security boundary

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -1,8 +1,8 @@
 # Security overview
 
-A single-page synthesis of where Platform sits on the security spectrum
-today: what isolation each layer provides, what it does *not* provide,
-and where the architecture would progress to get stronger guarantees.
+A single-page synthesis of Platform's security posture today: what
+isolation each layer provides, what it does *not* provide, and where
+the architecture would progress to get stronger guarantees.
 
 This page is forward-looking and crosses subsystems. The companion
 [security-model](security-model.md) frames the *why* (execution,
@@ -36,9 +36,7 @@ flowchart TB
 
 Green bands are mechanisms Platform owns end-to-end. Blue is cluster-
 operator responsibility Platform documents and assumes but cannot
-enforce. Red bands mark gaps the architecture acknowledges today —
-progression along the spectrum (below) means moving these one step
-right.
+enforce. Red bands mark gaps the architecture acknowledges today.
 
 ## Trust boundary and data flow
 
@@ -80,48 +78,6 @@ NetworkPolicy on agent egress is structural defence-in-depth: it stops
 a misbehaving agent from side-stepping `HTTPS_PROXY` at the kernel
 layer, independent of mesh AuthZ.
 
-## Isolation spectrum
-
-Two axes describe the posture: how strongly the runtime contains
-broken-out code, and how tightly the network constrains where the
-agent can reach.
-
-**Execution sandboxing** — what stands between a compromised process
-and the host kernel:
-
-```mermaid
-flowchart LR
-  nothing[nothing<br/>default runc] --> bwrap[bwrap]
-  bwrap --> nono[nono]
-  nono --> gvisor[gVisor]
-  gvisor --> kata[Kata]
-  kata --> vm[full VM]
-
-  marker(["▲ Platform today"]) -.-> nothing
-```
-
-Platform itself sets no RuntimeClass and applies no in-process
-sandbox. Stronger runtimes (gVisor, Kata) are a cluster-operator
-decision Platform documents and assumes but cannot enforce — see
-[security-model § Execution](security-model.md#execution).
-
-**Network isolation** — what constrains where an agent's traffic can
-go:
-
-```mermaid
-flowchart LR
-  flat[flat namespace<br/>no policy] --> netpol[NetworkPolicy]
-  netpol --> mtls[mesh mTLS]
-  mtls --> wlid[workload-identity authz]
-
-  marker(["▲ Platform today<br/>Istio ambient + per-instance AuthZ<br/>+ per-pair agent egress NetworkPolicy"]) -.-> wlid
-```
-
-The execution and network axes move independently. Platform's
-posture is asymmetric by design: weak on execution sandboxing
-(deferred to the cluster), strong on network and identity (owned by
-the chart).
-
 ## Threats today
 
 Every row traces to an accepted ADR or to the architecture page; no
@@ -142,11 +98,11 @@ novel claims are introduced here.
 
 ## Staged progression
 
-The position on the spectrum is intentionally uneven: the identity
-and credential layers are strong because Platform owns them
-end-to-end; the runtime sandboxing layer is weak because Platform
-runs on whatever the cluster provides and cannot enforce a stronger
-runtime from inside the chart.
+The posture is intentionally uneven: the identity and credential
+layers are strong because Platform owns them end-to-end; the runtime
+sandboxing layer is weak because Platform runs on whatever the
+cluster provides and cannot enforce a stronger runtime from inside
+the chart.
 
 **Where Platform sits today**
 
@@ -178,9 +134,8 @@ runtime from inside the chart.
   exfiltration along legitimate egress paths beyond shrinking the
   outbound surface.
 
-Progression along the spectrum means moving each of these gaps one
-step right on the diagrams above. The order is a future decision,
-not a commitment of this document.
+Closing any of these gaps is a future decision, not a commitment of
+this document.
 
 ## References
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -18,39 +18,27 @@ What enforces isolation at each level of the stack:
 
 ```mermaid
 flowchart TB
-  subgraph cluster[Cluster]
-    direction TB
-    note_cluster["RuntimeClass (gVisor/Kata)<br/><i>cluster-operator responsibility — Platform does not set</i>"]
+  L1["<b>Cluster</b><br/>RuntimeClass — gVisor / Kata<br/><i>cluster-operator responsibility; Platform sets none</i>"]
+  L2["<b>Namespace</b><br/>Istio ambient label · coarse-perimeter NetworkPolicy<br/>per-instance AuthorizationPolicies · pod-level DENY on api-server"]
+  L3["<b>Pod</b><br/>Paired agent + gateway · per-instance SA → SPIFFE<br/>per-pair agent-egress NetworkPolicy · no SA-token mount"]
+  L4["<b>Container</b><br/><i>no seccomp / AppArmor / dropped capabilities today</i>"]
+  L5["<b>Process</b><br/><i>no in-process sandbox (no bwrap)</i>"]
 
-    subgraph release_ns[release namespace]
-      direction TB
-      note_relns["istio.io/dataplane-mode=ambient<br/>coarse-perimeter NetworkPolicy<br/>pod-level DENY AuthorizationPolicy on api-server"]
-      apiserver_pod[api-server pod]
-      waypoint_pod[harness waypoint pod]
-    end
+  L1 --> L2 --> L3 --> L4 --> L5
 
-    subgraph agent_ns[agent namespace]
-      direction TB
-      note_agentns["istio.io/dataplane-mode=ambient<br/>per-instance AuthorizationPolicies<br/>per-pair agent-egress NetworkPolicy"]
-
-      subgraph pair[Instance pair — per-instance ServiceAccount → SPIFFE]
-        direction LR
-        subgraph agent_pod[agent pod]
-          note_agentpod["automountServiceAccountToken: false<br/><i>no seccomp / AppArmor / dropped caps today</i>"]
-          agent_proc["agent process<br/><i>no in-process sandbox (no bwrap)</i>"]
-        end
-        subgraph gw_pod[gateway pod]
-          note_gwpod["mounts owner-scoped K8s Secrets<br/>Envoy SDS, ext-authz HITL"]
-          envoy_proc[Envoy]
-        end
-      end
-    end
-  end
+  classDef owned fill:#dff5e1,stroke:#2a7a3a,color:#0b3d18
+  classDef external fill:#e5edf7,stroke:#3a5a8a,color:#0b1f3d
+  classDef gap fill:#fbe5e5,stroke:#8a2a2a,color:#3d0b0b
+  class L1 external
+  class L2,L3 owned
+  class L4,L5 gap
 ```
 
-The labels on each box are the mechanisms Platform owns. Italicised
-text marks responsibility that lives *below* Platform (cluster
-operator) or gaps the architecture acknowledges today.
+Green bands are mechanisms Platform owns end-to-end. Blue is cluster-
+operator responsibility Platform documents and assumes but cannot
+enforce. Red bands mark gaps the architecture acknowledges today —
+progression along the spectrum (below) means moving these one step
+right.
 
 ## Trust boundary and data flow
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -37,7 +37,7 @@ flowchart TB
         direction LR
         subgraph agent_pod[agent pod]
           note_agentpod["automountServiceAccountToken: false<br/><i>no seccomp / AppArmor / dropped caps today</i>"]
-          agent_proc[agent process<br/><i>no in-process sandbox (no bwrap)</i>]
+          agent_proc["agent process<br/><i>no in-process sandbox (no bwrap)</i>"]
         end
         subgraph gw_pod[gateway pod]
           note_gwpod["mounts owner-scoped K8s Secrets<br/>Envoy SDS, ext-authz HITL"]
@@ -70,11 +70,11 @@ flowchart LR
   end
 
   subgraph waypoint[harness waypoint]
-    wp[/AuthZ: SA → /api/instances/&lt;id&gt;/*/]
+    wp["AuthZ: SA → /api/instances/&lt;id&gt;/*"]
   end
 
   subgraph extauthz[per-instance ext-authz Service]
-    ea[/AuthZ: SA only/]
+    ea["AuthZ: SA only"]
   end
 
   user -->|OIDC| api

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -39,25 +39,35 @@ flowchart LR
 
   subgraph pair[Instance pair]
     agent[agent pod]
-    gw["gateway pod<br/>Envoy + ext-authz"]
+    gw["gateway pod<br/>Envoy"]
   end
 
   user -->|OIDC JWT| api
   agent -->|HTTPS_PROXY| gw
   gw -->|harness call| api
-  gw -->|inject credential| ext
+  gw -->|ext-authz Check<br/>per credentialed request| api
+  api -->|"allow · deny · hold for HITL"| gw
+  user -.->|verdict from inbox| api
+  gw -->|inject credential on allow| ext
 ```
 
 Three AuthorizationPolicies per instance form the cryptographic
-boundary. The gateway pod admits only its own pair's
-ServiceAccount — agents in other instances can resolve the gateway's
-address but the call is denied at the mesh. The api-server's harness
-path admits the per-instance ServiceAccount only to its own
-`/api/instances/<id>/*` prefix. And the per-instance ext-authz Service
-admits only the matching ServiceAccount, so by the time a HITL check
-arrives the calling instance is already proven cryptographically. Fork
-pairs (per-turn Slack threads) get their own ServiceAccount and a
-narrower set of policies on top.
+boundary: gateway admission, the harness path on the api-server, and
+the per-instance ext-authz Service. Each is keyed on the per-instance
+ServiceAccount, so peer instances are denied at the mesh — they can
+resolve the address but the call never lands.
+
+On top of that boundary, every credentialed request runs through a
+second gate. An Envoy filter on the gateway makes a gRPC ext-authz
+Check to the api-server before injecting a credential, with the
+calling instance proven cryptographically by the ServiceAccount on
+the connection. The api-server matches the request against the
+instance's egress rules and answers allow, deny, or hold-open. A
+held-open Check waits while the owner approves or denies the egress
+from the inbox in the UI; if the verdict is deny — or none arrives —
+the Check fails closed and the agent gets a 403 with no credential
+ever injected. Fork pairs (per-turn Slack threads) get their own
+ServiceAccount and narrower policies on top.
 
 ## Threats and mitigations
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -1,145 +1,77 @@
 # Security overview
 
-A single-page synthesis of Platform's security posture today: what
-isolation each layer provides, what it does *not* provide, and where
-the architecture would progress to get stronger guarantees.
+How Platform isolates agents from each other, from the cluster, and
+from the credentials they use to reach external services.
 
-This page is forward-looking and crosses subsystems. The companion
-[security-model](security-model.md) frames the *why* (execution,
-credentials, confidentiality) for product and security readers; this
-page maps the *what* of today's stack and the gaps it acknowledges.
-The current-state authority is
-[`docs/architecture/security-and-credentials.md`](../architecture/security-and-credentials.md)
-— this page links there rather than restating it.
+## Layers of defence
 
-## Isolation levels
-
-What enforces isolation at each level of the stack:
+Isolation is layered, with each layer doing one job:
 
 ```mermaid
 flowchart TB
-  L1["<b>Cluster</b><br/>RuntimeClass — gVisor / Kata<br/><i>cluster-operator responsibility; Platform sets none</i>"]
-  L2["<b>Namespace</b><br/>Istio ambient label · coarse-perimeter NetworkPolicy<br/>per-instance AuthorizationPolicies · pod-level DENY on api-server"]
-  L3["<b>Pod</b><br/>Paired agent + gateway · per-instance SA → SPIFFE<br/>per-pair agent-egress NetworkPolicy · no SA-token mount"]
-  L4["<b>Container</b><br/><i>no seccomp / AppArmor / dropped capabilities today</i>"]
-  L5["<b>Process</b><br/><i>no in-process sandbox (no bwrap)</i>"]
-
-  L1 --> L2 --> L3 --> L4 --> L5
-
-  classDef owned fill:#dff5e1,stroke:#2a7a3a,color:#0b3d18
-  classDef external fill:#e5edf7,stroke:#3a5a8a,color:#0b1f3d
-  classDef gap fill:#fbe5e5,stroke:#8a2a2a,color:#3d0b0b
-  class L1 external
-  class L2,L3 owned
-  class L4,L5 gap
+  L1["<b>Namespace</b><br/>Istio ambient mesh on every internal hop · NetworkPolicy at the perimeter"]
+  L2["<b>Pod pair</b><br/>agent and gateway run as two separate pods<br/>per-instance ServiceAccount stamped with a SPIFFE workload identity"]
+  L3["<b>Network</b><br/>per-pair agent-egress NetworkPolicy at L3/L4<br/>per-instance AuthorizationPolicies on every internal call"]
+  L4["<b>Credentials</b><br/>K8s Secrets mounted into the gateway pod only<br/>Envoy injects on the wire; ext-authz gates each credentialed call"]
+  L1 --> L2 --> L3 --> L4
 ```
 
-Green bands are mechanisms Platform owns end-to-end. Blue is cluster-
-operator responsibility Platform documents and assumes but cannot
-enforce. Red bands mark gaps the architecture acknowledges today.
+The mesh layer gives every workload a cryptographic name, so admission
+decisions are made on identity rather than IP or port. The pod-pair
+layer puts the credential boundary at a real Linux boundary — the
+agent process and the gateway process are in different pods, with
+different kernels' view of the world. The network layer is structural
+defence in depth: even if the agent process tried to ignore
+`HTTPS_PROXY` and dial out directly, the kernel refuses. And the
+credential layer means the agent never holds a real upstream token in
+the first place — Envoy holds them, and only on the wire.
 
-## Trust boundary and data flow
+## Trust boundary
 
-Every internal hop carries a SPIFFE identity stamped by istiod; every
-admission is gated by an AuthorizationPolicy keyed on that identity.
+Every internal hop carries a SPIFFE identity stamped by istiod, and
+every admission is gated on it.
 
 ```mermaid
 flowchart LR
-  user[browser<br/>Keycloak JWT]
+  user[browser]
   api[api-server]
-  ext[external services<br/>GitHub, Slack, MCP, …]
+  ext[external services]
 
-  subgraph pair[Instance pair — SA principal: per-instance]
-    direction LR
+  subgraph pair[Instance pair]
     agent[agent pod]
-    gw["gateway pod<br/>Envoy + SDS<br/>(mounts owner Secrets)"]
+    gw["gateway pod<br/>Envoy + ext-authz"]
   end
 
-  subgraph waypoint[harness waypoint]
-    wp["AuthZ: SA → /api/instances/&lt;id&gt;/*"]
-  end
-
-  subgraph extauthz[per-instance ext-authz Service]
-    ea["AuthZ: SA only"]
-  end
-
-  user -->|OIDC| api
-  agent -->|HTTPS_PROXY<br/>AuthZ: pair self-talk| gw
-  gw -->|harness path<br/>via waypoint| wp --> api
-  gw -->|ext-authz Check<br/>per-instance Service| ea --> api
-  gw -->|inject credential<br/>SAN-pinned upstream TLS| ext
+  user -->|OIDC JWT| api
+  agent -->|HTTPS_PROXY| gw
+  gw -->|harness call| api
+  gw -->|inject credential| ext
 ```
 
 Three AuthorizationPolicies per instance form the cryptographic
-boundary: gateway admission, harness path-prefix at the waypoint, and
-the per-instance ext-authz Service. Fork pairs (ADR-027) get their own
-SA and narrower per-fork policies layered on top. The per-pair
-NetworkPolicy on agent egress is structural defence-in-depth: it stops
-a misbehaving agent from side-stepping `HTTPS_PROXY` at the kernel
-layer, independent of mesh AuthZ.
+boundary. The gateway pod admits only its own pair's
+ServiceAccount — agents in other instances can resolve the gateway's
+address but the call is denied at the mesh. The api-server's harness
+path admits the per-instance ServiceAccount only to its own
+`/api/instances/<id>/*` prefix. And the per-instance ext-authz Service
+admits only the matching ServiceAccount, so by the time a HITL check
+arrives the calling instance is already proven cryptographically. Fork
+pairs (per-turn Slack threads) get their own ServiceAccount and a
+narrower set of policies on top.
 
-## Threats today
+## Threats and mitigations
 
-Every row traces to an accepted ADR or to the architecture page; no
-novel claims are introduced here.
+| Threat | Mitigation |
+|---|---|
+| Agent steals an upstream token | Credentials live only in the gateway pod; Envoy injects them on the wire and the agent sees no real token |
+| Agent escalates via its ServiceAccount token | `automountServiceAccountToken: false` on both pods — istiod issues the workload cert without a mounted SA-token |
+| Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy denies traffic from any non-matching ServiceAccount |
+| Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy restricts L3/L4 egress to DNS, the paired gateway, and the ambient mesh |
+| Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |
+| Cross-tenant fork access to parent surface | Per-fork ServiceAccount; fork policies admit only the parent's MCP path |
+| Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (ext-authz) |
 
-| Threat | Current mitigation | Residual risk | Where it would be addressed |
-|---|---|---|---|
-| Agent steals upstream token | Credential boundary at the pod: Secrets mounted into gateway pod only; Envoy injects on the wire ([ADR-005](../adrs/005-credential-gateway.md), [ADR-033](../adrs/033-envoy-credential-gateway.md)) | Gateway-pod compromise yields credentials in memory | Cluster-level kernel isolation (gVisor/Kata); Envoy CVE cadence |
-| Agent escalates via SA token | `automountServiceAccountToken: false` on both pods of the pair; istiod issues workload cert independently | None material at K8s API surface | — |
-| Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy on gateway admission, keyed on SA principal ([ADR-041](../adrs/041-istio-ambient-mesh.md)) | ztunnel / istiod bugs | Mesh CVE tracking |
-| Agent bypasses `HTTPS_PROXY` to dial external hosts directly | Per-pair agent-egress NetworkPolicy (`<id>-agent-egress`) restricts L3/L4 egress to DNS, paired gateway, and ambient HBONE | DNS tunnelling; abuse of the paired gateway itself | ext-authz HITL on credentialed egress ([ADR-035](../adrs/035-unified-hitl-ux.md)); allow-listing |
-| Route-confusion exfil through the gateway | Per-host filter chains pinned to credential host; SAN-bound upstream TLS validation ([ADR-033 §Threat Model](../adrs/033-envoy-credential-gateway.md#threat-model)) | None structural | — |
-| Cross-tenant fork access to parent surface | Per-fork SA; per-fork AuthorizationPolicies admit fork SA only to `/api/instances/<parent>/mcp` and the parent's ext-authz Service ([ADR-041](../adrs/041-istio-ambient-mesh.md)) | None material | — |
-| Direct pod-IP bypass of the waypoint | Pod-level DENY AuthorizationPolicy on api-server: only the waypoint's SA (harness) or a per-instance SA from agent ns (ext-authz) is admitted | None material | — |
-| Container escape to the node | *No Platform mitigation* — default runc | Full node compromise if a kernel CVE is exploitable | Cluster-level RuntimeClass (gVisor/Kata) provisioned by the operator |
-| Envoy data-path CVE | Upstream Envoy patch cadence (managed by Istio releases) | Window between disclosure and patch | Sandboxed runtime as defence in depth, if the cluster provides one |
-| Confidentiality / prompt-injection exfil | Outbound surface narrowing via ext-authz HITL on credentialed egress; egress NetworkPolicy on non-credentialed traffic | No reliable mitigation industry-wide (see [security-model § Confidentiality](security-model.md#confidentiality)) | Open research problem (CaMeL-style dirty-data tracking, Rule of Two) |
+## See also
 
-## Staged progression
-
-The posture is intentionally uneven: the identity and credential
-layers are strong because Platform owns them end-to-end; the runtime
-sandboxing layer is weak because Platform runs on whatever the
-cluster provides and cannot enforce a stronger runtime from inside
-the chart.
-
-**Where Platform sits today**
-
-- Strong workload identity on every internal hop (SPIFFE via Istio
-  ambient, [ADR-041](../adrs/041-istio-ambient-mesh.md)).
-- Strong credential boundary at the pod (paired-pod topology with
-  Envoy SDS, [ADR-005](../adrs/005-credential-gateway.md),
-  [ADR-033](../adrs/033-envoy-credential-gateway.md),
-  [ADR-038](../adrs/038-paired-gateway-pod.md)).
-- Coarse but correct network controls (per-pair egress NetworkPolicy,
-  three per-instance AuthorizationPolicies, pod-level DENY on the
-  api-server).
-- Confidentiality controls limited to outbound-surface narrowing via
-  HITL ([ADR-035](../adrs/035-unified-hitl-ux.md)).
-
-**Named gaps the architecture acknowledges**
-
-- *Kernel isolation.* Platform assumes the cluster operator provides
-  gVisor or Kata via RuntimeClass; the chart sets no RuntimeClass and
-  the docs are explicit that without one, a kernel-CVE breakout
-  reaches the node.
-- *Container-level hardening.* The agent and gateway pods carry no
-  seccomp profile, no AppArmor profile, and no dropped capabilities
-  today. `readOnlyRootFilesystem` is also off on agent containers.
-- *Process-level sandboxing.* No bwrap or equivalent inside the
-  agent container — every tool the agent invokes runs with the same
-  privileges as the agent process.
-- *Confidentiality.* No general defence against prompt-injection
-  exfiltration along legitimate egress paths beyond shrinking the
-  outbound surface.
-
-Closing any of these gaps is a future decision, not a commitment of
-this document.
-
-## References
-
-- [`docs/architecture/security-and-credentials.md`](../architecture/security-and-credentials.md) — current-state architecture, authoritative for *how*
-- [security-model](security-model.md) — narrative framing of the three risks (execution, credentials, confidentiality)
-- [multi-player](multi-player.md) — identity, ownership, per-user credential isolation
-- ADRs: [005](../adrs/005-credential-gateway.md), [033](../adrs/033-envoy-credential-gateway.md), [035](../adrs/035-unified-hitl-ux.md), [038](../adrs/038-paired-gateway-pod.md), [041](../adrs/041-istio-ambient-mesh.md)
+- [security-and-credentials](../architecture/security-and-credentials.md) — current-state architecture details
+- [security-model](security-model.md) — narrative framing of the three risks: execution, credentials, confidentiality

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -11,33 +11,33 @@ an instance.
 ```mermaid
 flowchart TB
   L1["<b>Identity</b><br/>every workload has a cryptographic name"]
-  L2["<b>Boundary</b><br/>agent and gateway run in separate pods"]
+  L2["<b>Boundary</b><br/>the agent runs alone in its own pod"]
   L3["<b>Network</b><br/>the kernel decides what an agent can reach"]
-  L4["<b>Credentials</b><br/>real tokens never leave the gateway"]
+  L4["<b>Credentials</b><br/>real tokens never reach the agent"]
   L1 --> L2 --> L3 --> L4
 ```
 
 **Identity.** Every workload runs as a per-instance ServiceAccount,
 and istiod stamps that SA into a SPIFFE workload certificate. Mesh
 admission decisions are made on the certificate, not on IP or port —
-a peer instance can resolve the gateway's address but its call is
-denied before it lands.
+a peer instance can resolve the address but its call is denied before
+it lands.
 
-**Boundary.** Agent and gateway run as two separate pods, not as
-sidecars in one pod. The credential boundary is a pod boundary, with
-its own kernel view and no shared address space. The agent has no
-service-account token mounted and no co-located sidecar to share a
-namespace with.
+**Boundary.** Each agent runs alone in its own pod, with its own
+kernel view, its own filesystem, and no shared address space. The
+agent has no service-account token mounted and no co-located sidecar
+to share a namespace with.
 
 **Network.** Even if the agent process ignored `HTTPS_PROXY` and tried
 to dial external hosts directly, the kernel refuses. A per-pair
-agent-egress NetworkPolicy restricts L3/L4 egress to DNS, the paired
-gateway, and the mesh — so Envoy stays on the only path out.
+NetworkPolicy restricts the agent's L3/L4 egress to a narrow, fixed
+allow-list — DNS, the mesh, and the single outbound path it is
+permitted to use.
 
-**Credentials.** Real upstream tokens never leave the gateway pod.
-Envoy reads them via SDS and adds the credential header on the wire,
-just before the request exits. The agent process never sees a real
-token to leak in the first place.
+**Credentials.** Real upstream tokens never reach the agent. A
+separate process holds them and adds the credential header on the
+wire, just before the request leaves the cluster. The agent process
+never sees a real token to leak in the first place.
 
 ## Trust boundary
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -64,8 +64,7 @@ instance's egress rules and answers allow, deny, or hold-open. A
 held-open Check waits while the owner approves or denies the egress
 from the inbox in the UI; if the verdict is deny — or none arrives —
 the Check fails closed and the agent gets a 403 with no credential
-ever injected. Fork pairs (per-turn Slack threads) get their own
-ServiceAccount and narrower policies on top.
+ever injected.
 
 ## Threats and mitigations
 
@@ -76,7 +75,6 @@ ServiceAccount and narrower policies on top.
 | Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy denies traffic from any non-matching ServiceAccount |
 | Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy restricts L3/L4 egress to DNS, the paired gateway, and the ambient mesh |
 | Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |
-| Cross-tenant fork access to parent surface | Per-fork ServiceAccount; fork policies admit only the parent's MCP path |
 | Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (ext-authz) |
 
 ## See also

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -5,26 +5,39 @@ from the credentials they use to reach external services.
 
 ## Layers of defence
 
-Isolation is layered, with each layer doing one job:
+Each layer does one job; you'd have to break all four to compromise
+an instance.
 
 ```mermaid
 flowchart TB
-  L1["<b>Namespace</b><br/>Istio ambient mesh on every internal hop · NetworkPolicy at the perimeter"]
-  L2["<b>Pod pair</b><br/>agent and gateway run as two separate pods<br/>per-instance ServiceAccount stamped with a SPIFFE workload identity"]
-  L3["<b>Network</b><br/>per-pair agent-egress NetworkPolicy at L3/L4<br/>per-instance AuthorizationPolicies on every internal call"]
-  L4["<b>Credentials</b><br/>K8s Secrets mounted into the gateway pod only<br/>Envoy injects on the wire; ext-authz gates each credentialed call"]
+  L1["<b>Identity</b><br/>every workload has a cryptographic name"]
+  L2["<b>Boundary</b><br/>agent and gateway run in separate pods"]
+  L3["<b>Network</b><br/>the kernel decides what an agent can reach"]
+  L4["<b>Credentials</b><br/>real tokens never leave the gateway"]
   L1 --> L2 --> L3 --> L4
 ```
 
-The mesh layer gives every workload a cryptographic name, so admission
-decisions are made on identity rather than IP or port. The pod-pair
-layer puts the credential boundary at a real Linux boundary — the
-agent process and the gateway process are in different pods, with
-different kernels' view of the world. The network layer is structural
-defence in depth: even if the agent process tried to ignore
-`HTTPS_PROXY` and dial out directly, the kernel refuses. And the
-credential layer means the agent never holds a real upstream token in
-the first place — Envoy holds them, and only on the wire.
+**Identity.** Every workload runs as a per-instance ServiceAccount,
+and istiod stamps that SA into a SPIFFE workload certificate. Mesh
+admission decisions are made on the certificate, not on IP or port —
+a peer instance can resolve the gateway's address but its call is
+denied before it lands.
+
+**Boundary.** Agent and gateway run as two separate pods, not as
+sidecars in one pod. The credential boundary is a pod boundary, with
+its own kernel view and no shared address space. The agent has no
+service-account token mounted and no co-located sidecar to share a
+namespace with.
+
+**Network.** Even if the agent process ignored `HTTPS_PROXY` and tried
+to dial external hosts directly, the kernel refuses. A per-pair
+agent-egress NetworkPolicy restricts L3/L4 egress to DNS, the paired
+gateway, and the mesh — so Envoy stays on the only path out.
+
+**Credentials.** Real upstream tokens never leave the gateway pod.
+Envoy reads them via SDS and adds the credential header on the wire,
+just before the request exits. The agent process never sees a real
+token to leak in the first place.
 
 ## Trust boundary
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -7,10 +7,10 @@ from the credentials they use to reach external services.
 
 ```mermaid
 flowchart LR
-  L1["<b>Identity</b><br/>per-instance ServiceAccount<br/>+ SPIFFE cert via Istio mesh"]
-  L2["<b>Boundary</b><br/>agent isolated in its own container,<br/>no SA-token mounted on the pod"]
-  L3["<b>Network</b><br/>NetworkPolicy + AuthorizationPolicy<br/>at L3, L4, and L7"]
-  L4["<b>Credentials</b><br/>K8s Secrets stay outside the agent,<br/>injected on the wire after authz"]
+  L1["<b>Identity</b><br/>SPIFFE cert via Istio mesh"]
+  L2["<b>Boundary</b><br/>Agent isolated in its own container"]
+  L3["<b>Network</b><br/>NetworkPolicy + AuthorizationPolicy"]
+  L4["<b>Credentials</b><br/>Injected on egress"]
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -5,9 +5,12 @@ from the credentials they use to reach external services.
 
 ## Layers of defence
 
-Four independent controls. They don't stack on top of each other —
-each one tackles a different concern, and an attacker would need to
-break all four to compromise an instance.
+Four controls, layered for defence in depth. They overlap and
+reinforce each other rather than working in isolation — identity
+underpins authorization, the pod boundary contains a credential leak,
+kernel-level network policy forces traffic through the proxy
+regardless of process intent, and credential isolation means there's
+nothing real for the agent to expose in the first place.
 
 ```mermaid
 flowchart LR

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -16,8 +16,8 @@ nothing real for the agent to expose in the first place.
 flowchart LR
   L1["<b>Identity</b><br/>per-instance ServiceAccount<br/>+ SPIFFE cert via Istio mesh"]
   L2["<b>Boundary</b><br/>agent isolated in its own pod,<br/>no ServiceAccount token mounted"]
-  L3["<b>Network</b><br/>NetworkPolicy restricts the agent's<br/>L3/L4 egress to a narrow allow-list"]
-  L4["<b>Credentials</b><br/>K8s Secrets stay outside the agent,<br/>injected on the wire under ext-authz"]
+  L3["<b>Network</b><br/>NetworkPolicy at L3/L4,<br/>ext-authz on every egress request"]
+  L4["<b>Credentials</b><br/>K8s Secrets stay outside the agent,<br/>injected on the wire after authz"]
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
@@ -39,13 +39,16 @@ share a namespace with.
 to dial external hosts directly, the kernel refuses. A Kubernetes
 NetworkPolicy restricts the agent pod's L3/L4 egress to a narrow
 allow-list — DNS, the Istio ambient data path, and the single sibling
-pod it is paired with for outbound calls.
+pod it is paired with for outbound calls. Above that, every egress
+request through the sibling pod is gated by an ext-authz Check
+against the api-server, so each call is authorized per-instance
+before it leaves.
 
 **Credentials.** Real upstream tokens never reach the agent. They
-live in Kubernetes Secrets mounted into a sibling pod, which adds the
-credential header on the wire just before the request leaves the
-cluster. Every credentialed call goes through an ext-authz Check
-first, so injection is gated on per-instance authorization.
+live in Kubernetes Secrets mounted into a sibling pod. For hosts
+where a credential is configured, the sibling pod adds the credential
+header on the wire after the ext-authz Check has authorized the
+request — for everything else, traffic passes through unchanged.
 
 ## Trust boundary
 
@@ -67,7 +70,7 @@ flowchart LR
   agent -->|HTTPS_PROXY| gw
   gw <-->|"ext-authz Check<br/>allow · deny · hold"| api
   api <-.->|HITL hold-open| owner
-  gw -->|inject credential on allow| ext
+  gw -->|"egress on allow<br/>(credential injected if configured)"| ext
 ```
 
 Three AuthorizationPolicies per instance form the cryptographic
@@ -76,16 +79,17 @@ the per-instance ext-authz Service. Each is keyed on the per-instance
 ServiceAccount, so peer instances are denied at the mesh — they can
 resolve the address but the call never lands.
 
-On top of that boundary, every credentialed request runs through a
-second gate. An Envoy filter on the gateway makes a gRPC ext-authz
-Check to the api-server before injecting a credential, with the
-calling instance proven cryptographically by the ServiceAccount on
-the connection. The api-server matches the request against the
-instance's egress rules and answers allow, deny, or hold-open. A
-held-open Check waits while the owner approves or denies the egress
-from the inbox in the UI; if the verdict is deny — or none arrives —
-the Check fails closed and the agent gets a 403 with no credential
-ever injected.
+On top of that boundary, every egress request through the gateway
+runs through a second gate. Envoy makes a gRPC ext-authz Check to the
+api-server before forwarding the request, with the calling instance
+proven cryptographically by the ServiceAccount on the connection. The
+api-server matches the request against the instance's egress rules
+and answers allow, deny, or hold-open. A held-open Check waits while
+the owner approves or denies the egress from the inbox in the UI; if
+the verdict is deny — or none arrives — the Check fails closed and
+the agent gets a 403. For hosts where a credential is configured,
+Envoy injects the credential header after the Check allows, just
+before the request leaves the cluster.
 
 ## Threats and mitigations
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -9,7 +9,7 @@ from the credentials they use to reach external services.
 flowchart LR
   L1["<b>Identity</b><br/>per-instance ServiceAccount<br/>+ SPIFFE cert via Istio mesh"]
   L2["<b>Boundary</b><br/>agent isolated in its own pod,<br/>no ServiceAccount token mounted"]
-  L3["<b>Network</b><br/>NetworkPolicy at L3/L4,<br/>ext-authz on every egress request"]
+  L3["<b>Network</b><br/>NetworkPolicy + AuthorizationPolicy<br/>at L3, L4, and L7"]
   L4["<b>Credentials</b><br/>K8s Secrets stay outside the agent,<br/>injected on the wire after authz"]
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
@@ -28,14 +28,14 @@ Kubernetes API token sitting in the agent's filesystem; istiod issues
 the workload cert independently. There is no co-located sidecar to
 share a namespace with.
 
-- **Network.** Even if the agent process ignored `HTTPS_PROXY` and tried
-to dial external hosts directly, the kernel refuses. A Kubernetes
-NetworkPolicy restricts the agent pod's L3/L4 egress to a narrow
-allow-list — DNS, the Istio ambient data path, and the single sibling
-pod it is paired with for outbound calls. Above that, every egress
-request through the sibling pod is gated by an ext-authz Check
-against the api-server, so each call is authorized per-instance
-before it leaves.
+- **Network.** Multiple layers restrict where the agent can talk. At
+the kernel, a Kubernetes NetworkPolicy locks the agent pod's L3/L4
+egress to a narrow allow-list — DNS, the Istio ambient data path, and
+the single sibling pod it is paired with. At the mesh, Istio
+AuthorizationPolicies key on the per-instance ServiceAccount: peer-pod
+admission is gated at L4, and the harness path on the api-server is
+gated at L7. And every egress request through the sibling pod runs
+through an ext-authz Check at the api-server before being forwarded.
 
 - **Credentials.** Real upstream tokens never reach the agent. They
 live in Kubernetes Secrets mounted into a sibling pod. For hosts

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -33,21 +33,19 @@ every admission is gated on it.
 
 ```mermaid
 flowchart LR
-  user[browser]
-  api[api-server]
-  ext[external services]
-
   subgraph pair[Instance pair]
+    direction LR
     agent[agent pod]
     gw["gateway pod<br/>Envoy"]
   end
 
-  user -->|OIDC JWT| api
+  api[api-server]
+  owner[owner inbox]
+  ext[external services]
+
   agent -->|HTTPS_PROXY| gw
-  gw -->|harness call| api
-  gw -->|ext-authz Check<br/>per credentialed request| api
-  api -->|"allow · deny · hold for HITL"| gw
-  user -.->|verdict from inbox| api
+  gw <-->|"ext-authz Check<br/>allow · deny · hold"| api
+  api <-.->|HITL hold-open| owner
   gw -->|inject credential on allow| ext
 ```
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -21,21 +21,21 @@ flowchart LR
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
-**Identity.** Every workload runs as a per-instance Kubernetes
+- **Identity.** Every workload runs as a per-instance Kubernetes
 ServiceAccount, and istiod stamps that SA into a SPIFFE workload
 certificate as the pod joins the Istio ambient mesh. Admission across
 the mesh is decided on the certificate's SA principal, not on IP or
 port — a peer instance can resolve the address, but the
 AuthorizationPolicy denies the call before it lands.
 
-**Boundary.** The agent runs alone in its own pod, with its own
+- **Boundary.** The agent runs alone in its own pod, with its own
 kernel view, its own filesystem, and no shared address space.
 `automountServiceAccountToken` is false on the pod, so there is no
 Kubernetes API token sitting in the agent's filesystem; istiod issues
 the workload cert independently. There is no co-located sidecar to
 share a namespace with.
 
-**Network.** Even if the agent process ignored `HTTPS_PROXY` and tried
+- **Network.** Even if the agent process ignored `HTTPS_PROXY` and tried
 to dial external hosts directly, the kernel refuses. A Kubernetes
 NetworkPolicy restricts the agent pod's L3/L4 egress to a narrow
 allow-list — DNS, the Istio ambient data path, and the single sibling
@@ -44,13 +44,13 @@ request through the sibling pod is gated by an ext-authz Check
 against the api-server, so each call is authorized per-instance
 before it leaves.
 
-**Credentials.** Real upstream tokens never reach the agent. They
+- **Credentials.** Real upstream tokens never reach the agent. They
 live in Kubernetes Secrets mounted into a sibling pod. For hosts
 where a credential is configured, the sibling pod adds the credential
 header on the wire after the ext-authz Check has authorized the
 request — for everything else, traffic passes through unchanged.
 
-## Trust boundary
+## Authorization flow
 
 Every internal hop carries a SPIFFE identity stamped by istiod, and
 every admission is gated on it.
@@ -73,14 +73,14 @@ flowchart LR
   gw -->|"egress on allow<br/>(credential injected if configured)"| ext
 ```
 
-Three AuthorizationPolicies per instance form the cryptographic
-boundary: gateway admission, the harness path on the api-server, and
-the per-instance ext-authz Service. Each is keyed on the per-instance
-ServiceAccount, so peer instances are denied at the mesh — they can
-resolve the address but the call never lands.
+Three AuthorizationPolicies per instance gate admission
+cryptographically: gateway admission, the harness path on the
+api-server, and the per-instance ext-authz Service. Each is keyed on
+the per-instance ServiceAccount, so peer instances are denied at the
+mesh — they can resolve the address but the call never lands.
 
-On top of that boundary, every egress request through the gateway
-runs through a second gate. Envoy makes a gRPC ext-authz Check to the
+Layered above that, every egress request through the gateway runs
+through a second gate. Envoy makes a gRPC ext-authz Check to the
 api-server before forwarding the request, with the calling instance
 proven cryptographically by the ServiceAccount on the connection. The
 api-server matches the request against the instance's egress rules

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -3,7 +3,7 @@
 How Platform isolates agents from each other, from the cluster, and
 from the credentials they use to reach external services.
 
-## Layers of defence
+## Layers of defense
 
 ```mermaid
 flowchart LR

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -14,34 +14,38 @@ nothing real for the agent to expose in the first place.
 
 ```mermaid
 flowchart LR
-  L1["<b>Identity</b><br/>every workload has a cryptographic name"]
-  L2["<b>Boundary</b><br/>the agent runs alone in its own pod"]
-  L3["<b>Network</b><br/>the kernel decides what an agent can reach"]
-  L4["<b>Credentials</b><br/>real tokens never reach the agent"]
+  L1["<b>Identity</b><br/>per-instance ServiceAccount<br/>+ SPIFFE cert via Istio mesh"]
+  L2["<b>Boundary</b><br/>agent isolated in its own pod,<br/>no ServiceAccount token mounted"]
+  L3["<b>Network</b><br/>NetworkPolicy restricts the agent's<br/>L3/L4 egress to a narrow allow-list"]
+  L4["<b>Credentials</b><br/>K8s Secrets stay outside the agent,<br/>injected on the wire under ext-authz"]
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
-**Identity.** Every workload runs as a per-instance ServiceAccount,
-and istiod stamps that SA into a SPIFFE workload certificate. Mesh
-admission decisions are made on the certificate, not on IP or port —
-a peer instance can resolve the address but its call is denied before
-it lands.
+**Identity.** Every workload runs as a per-instance Kubernetes
+ServiceAccount, and istiod stamps that SA into a SPIFFE workload
+certificate as the pod joins the Istio ambient mesh. Admission across
+the mesh is decided on the certificate's SA principal, not on IP or
+port — a peer instance can resolve the address, but the
+AuthorizationPolicy denies the call before it lands.
 
-**Boundary.** Each agent runs alone in its own pod, with its own
-kernel view, its own filesystem, and no shared address space. The
-agent has no service-account token mounted and no co-located sidecar
-to share a namespace with.
+**Boundary.** The agent runs alone in its own pod, with its own
+kernel view, its own filesystem, and no shared address space.
+`automountServiceAccountToken` is false on the pod, so there is no
+Kubernetes API token sitting in the agent's filesystem; istiod issues
+the workload cert independently. There is no co-located sidecar to
+share a namespace with.
 
 **Network.** Even if the agent process ignored `HTTPS_PROXY` and tried
-to dial external hosts directly, the kernel refuses. A per-pair
-NetworkPolicy restricts the agent's L3/L4 egress to a narrow, fixed
-allow-list — DNS, the mesh, and the single outbound path it is
-permitted to use.
+to dial external hosts directly, the kernel refuses. A Kubernetes
+NetworkPolicy restricts the agent pod's L3/L4 egress to a narrow
+allow-list — DNS, the Istio ambient data path, and the single sibling
+pod it is paired with for outbound calls.
 
-**Credentials.** Real upstream tokens never reach the agent. A
-separate process holds them and adds the credential header on the
-wire, just before the request leaves the cluster. The agent process
-never sees a real token to leak in the first place.
+**Credentials.** Real upstream tokens never reach the agent. They
+live in Kubernetes Secrets mounted into a sibling pod, which adds the
+credential header on the wire just before the request leaves the
+cluster. Every credentialed call goes through an ext-authz Check
+first, so injection is gated on per-instance authorization.
 
 ## Trust boundary
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -8,7 +8,7 @@ from the credentials they use to reach external services.
 ```mermaid
 flowchart LR
   L1["<b>Identity</b><br/>per-instance ServiceAccount<br/>+ SPIFFE cert via Istio mesh"]
-  L2["<b>Boundary</b><br/>agent isolated in its own pod,<br/>no ServiceAccount token mounted"]
+  L2["<b>Boundary</b><br/>agent isolated in its own container,<br/>no SA-token mounted on the pod"]
   L3["<b>Network</b><br/>NetworkPolicy + AuthorizationPolicy<br/>at L3, L4, and L7"]
   L4["<b>Credentials</b><br/>K8s Secrets stay outside the agent,<br/>injected on the wire after authz"]
   L1 ~~~ L2 ~~~ L3 ~~~ L4
@@ -21,12 +21,13 @@ the mesh is decided on the certificate's SA principal, not on IP or
 port — a peer instance can resolve the address, but the
 AuthorizationPolicy denies the call before it lands.
 
-- **Boundary.** The agent runs alone in its own pod, with its own
-kernel view, its own filesystem, and no shared address space.
-`automountServiceAccountToken` is false on the pod, so there is no
-Kubernetes API token sitting in the agent's filesystem; istiod issues
-the workload cert independently. There is no co-located sidecar to
-share a namespace with.
+- **Boundary.** The agent runs in its own container, with its own
+kernel namespaces, its own filesystem, and no shared address space.
+The pod hosts only that one container — no co-located sidecar to
+share a namespace with. `automountServiceAccountToken` is false on
+the pod (a pod-level setting in Kubernetes), so there is no
+Kubernetes API token sitting in the agent's filesystem; istiod
+issues the workload cert independently.
 
 - **Network.** Multiple layers restrict where the agent can talk. At
 the kernel, a Kubernetes NetworkPolicy locks the agent pod's L3/L4
@@ -45,17 +46,22 @@ request — for everything else, traffic passes through unchanged.
 
 ## Security boundary
 
-The pod is the security boundary. Everything inside it — the agent
-process, any tools it spawns, any content it reads — is treated as
-untrusted. The controls above all live outside the pod (in the mesh,
-in the kernel's network stack, in a sibling pod that holds the
-credentials), so that a compromised agent cannot reach beyond what
-its network and identity allow.
+The container is the security boundary. Everything inside it — the
+agent process, any tools it spawns, any content it reads — is
+treated as untrusted. The agent pod hosts a single agent container,
+and the controls above all live outside it (in the mesh, in the
+kernel's network stack, in a sibling pod that holds the credentials),
+so that a compromised agent cannot reach beyond what its network and
+identity allow. Some of those controls are written at the pod level
+rather than per-container — NetworkPolicy and
+`automountServiceAccountToken` are pod-scoped, because that's the
+granularity Kubernetes exposes — but with one container per agent
+pod, the two coincide.
 
-By default, pods run on the cluster's container runtime — typically
-runc — which shares a kernel with the node. The four controls above
-stand regardless, but a kernel-level escape from the agent's
-container reaches the node directly, and from there anything
+By default, containers run on the cluster's container runtime —
+typically runc — which shares a kernel with the node. The four
+controls above stand regardless, but a kernel-level escape from the
+agent's container reaches the node directly, and from there anything
 co-located on it.
 
 For deployments where that risk matters, the cluster operator should

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -1,0 +1,202 @@
+# Security overview
+
+A single-page synthesis of where Platform sits on the security spectrum
+today: what isolation each layer provides, what it does *not* provide,
+and where the architecture would progress to get stronger guarantees.
+
+This page is forward-looking and crosses subsystems. The companion
+[security-model](security-model.md) frames the *why* (execution,
+credentials, confidentiality) for product and security readers; this
+page maps the *what* of today's stack and the gaps it acknowledges.
+The current-state authority is
+[`docs/architecture/security-and-credentials.md`](../architecture/security-and-credentials.md)
+— this page links there rather than restating it.
+
+## Isolation levels
+
+What enforces isolation at each level of the stack:
+
+```mermaid
+flowchart TB
+  subgraph cluster[Cluster]
+    direction TB
+    note_cluster["RuntimeClass (gVisor/Kata)<br/><i>cluster-operator responsibility — Platform does not set</i>"]
+
+    subgraph release_ns[release namespace]
+      direction TB
+      note_relns["istio.io/dataplane-mode=ambient<br/>coarse-perimeter NetworkPolicy<br/>pod-level DENY AuthorizationPolicy on api-server"]
+      apiserver_pod[api-server pod]
+      waypoint_pod[harness waypoint pod]
+    end
+
+    subgraph agent_ns[agent namespace]
+      direction TB
+      note_agentns["istio.io/dataplane-mode=ambient<br/>per-instance AuthorizationPolicies<br/>per-pair agent-egress NetworkPolicy"]
+
+      subgraph pair[Instance pair — per-instance ServiceAccount → SPIFFE]
+        direction LR
+        subgraph agent_pod[agent pod]
+          note_agentpod["automountServiceAccountToken: false<br/><i>no seccomp / AppArmor / dropped caps today</i>"]
+          agent_proc[agent process<br/><i>no in-process sandbox (no bwrap)</i>]
+        end
+        subgraph gw_pod[gateway pod]
+          note_gwpod["mounts owner-scoped K8s Secrets<br/>Envoy SDS, ext-authz HITL"]
+          envoy_proc[Envoy]
+        end
+      end
+    end
+  end
+```
+
+The labels on each box are the mechanisms Platform owns. Italicised
+text marks responsibility that lives *below* Platform (cluster
+operator) or gaps the architecture acknowledges today.
+
+## Trust boundary and data flow
+
+Every internal hop carries a SPIFFE identity stamped by istiod; every
+admission is gated by an AuthorizationPolicy keyed on that identity.
+
+```mermaid
+flowchart LR
+  user[browser<br/>Keycloak JWT]
+  api[api-server]
+  ext[external services<br/>GitHub, Slack, MCP, …]
+
+  subgraph pair[Instance pair — SA principal: per-instance]
+    direction LR
+    agent[agent pod]
+    gw["gateway pod<br/>Envoy + SDS<br/>(mounts owner Secrets)"]
+  end
+
+  subgraph waypoint[harness waypoint]
+    wp[/AuthZ: SA → /api/instances/&lt;id&gt;/*/]
+  end
+
+  subgraph extauthz[per-instance ext-authz Service]
+    ea[/AuthZ: SA only/]
+  end
+
+  user -->|OIDC| api
+  agent -->|HTTPS_PROXY<br/>AuthZ: pair self-talk| gw
+  gw -->|harness path<br/>via waypoint| wp --> api
+  gw -->|ext-authz Check<br/>per-instance Service| ea --> api
+  gw -->|inject credential<br/>SAN-pinned upstream TLS| ext
+```
+
+Three AuthorizationPolicies per instance form the cryptographic
+boundary: gateway admission, harness path-prefix at the waypoint, and
+the per-instance ext-authz Service. Fork pairs (ADR-027) get their own
+SA and narrower per-fork policies layered on top. The per-pair
+NetworkPolicy on agent egress is structural defence-in-depth: it stops
+a misbehaving agent from side-stepping `HTTPS_PROXY` at the kernel
+layer, independent of mesh AuthZ.
+
+## Isolation spectrum
+
+Two axes describe the posture: how strongly the runtime contains
+broken-out code, and how tightly the network constrains where the
+agent can reach.
+
+**Execution sandboxing** — what stands between a compromised process
+and the host kernel:
+
+```mermaid
+flowchart LR
+  nothing[nothing<br/>default runc] --> bwrap[bwrap]
+  bwrap --> nono[nono]
+  nono --> gvisor[gVisor]
+  gvisor --> kata[Kata]
+  kata --> vm[full VM]
+
+  marker(["▲ Platform today"]) -.-> nothing
+```
+
+Platform itself sets no RuntimeClass and applies no in-process
+sandbox. Stronger runtimes (gVisor, Kata) are a cluster-operator
+decision Platform documents and assumes but cannot enforce — see
+[security-model § Execution](security-model.md#execution).
+
+**Network isolation** — what constrains where an agent's traffic can
+go:
+
+```mermaid
+flowchart LR
+  flat[flat namespace<br/>no policy] --> netpol[NetworkPolicy]
+  netpol --> mtls[mesh mTLS]
+  mtls --> wlid[workload-identity authz]
+
+  marker(["▲ Platform today<br/>Istio ambient + per-instance AuthZ<br/>+ per-pair agent egress NetworkPolicy"]) -.-> wlid
+```
+
+The execution and network axes move independently. Platform's
+posture is asymmetric by design: weak on execution sandboxing
+(deferred to the cluster), strong on network and identity (owned by
+the chart).
+
+## Threats today
+
+Every row traces to an accepted ADR or to the architecture page; no
+novel claims are introduced here.
+
+| Threat | Current mitigation | Residual risk | Where it would be addressed |
+|---|---|---|---|
+| Agent steals upstream token | Credential boundary at the pod: Secrets mounted into gateway pod only; Envoy injects on the wire ([ADR-005](../adrs/005-credential-gateway.md), [ADR-033](../adrs/033-envoy-credential-gateway.md)) | Gateway-pod compromise yields credentials in memory | Cluster-level kernel isolation (gVisor/Kata); Envoy CVE cadence |
+| Agent escalates via SA token | `automountServiceAccountToken: false` on both pods of the pair; istiod issues workload cert independently | None material at K8s API surface | — |
+| Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy on gateway admission, keyed on SA principal ([ADR-041](../adrs/041-istio-ambient-mesh.md)) | ztunnel / istiod bugs | Mesh CVE tracking |
+| Agent bypasses `HTTPS_PROXY` to dial external hosts directly | Per-pair agent-egress NetworkPolicy (`<id>-agent-egress`) restricts L3/L4 egress to DNS, paired gateway, and ambient HBONE | DNS tunnelling; abuse of the paired gateway itself | ext-authz HITL on credentialed egress ([ADR-035](../adrs/035-unified-hitl-ux.md)); allow-listing |
+| Route-confusion exfil through the gateway | Per-host filter chains pinned to credential host; SAN-bound upstream TLS validation ([ADR-033 §Threat Model](../adrs/033-envoy-credential-gateway.md#threat-model)) | None structural | — |
+| Cross-tenant fork access to parent surface | Per-fork SA; per-fork AuthorizationPolicies admit fork SA only to `/api/instances/<parent>/mcp` and the parent's ext-authz Service ([ADR-041](../adrs/041-istio-ambient-mesh.md)) | None material | — |
+| Direct pod-IP bypass of the waypoint | Pod-level DENY AuthorizationPolicy on api-server: only the waypoint's SA (harness) or a per-instance SA from agent ns (ext-authz) is admitted | None material | — |
+| Container escape to the node | *No Platform mitigation* — default runc | Full node compromise if a kernel CVE is exploitable | Cluster-level RuntimeClass (gVisor/Kata) provisioned by the operator |
+| Envoy data-path CVE | Upstream Envoy patch cadence (managed by Istio releases) | Window between disclosure and patch | Sandboxed runtime as defence in depth, if the cluster provides one |
+| Confidentiality / prompt-injection exfil | Outbound surface narrowing via ext-authz HITL on credentialed egress; egress NetworkPolicy on non-credentialed traffic | No reliable mitigation industry-wide (see [security-model § Confidentiality](security-model.md#confidentiality)) | Open research problem (CaMeL-style dirty-data tracking, Rule of Two) |
+
+## Staged progression
+
+The position on the spectrum is intentionally uneven: the identity
+and credential layers are strong because Platform owns them
+end-to-end; the runtime sandboxing layer is weak because Platform
+runs on whatever the cluster provides and cannot enforce a stronger
+runtime from inside the chart.
+
+**Where Platform sits today**
+
+- Strong workload identity on every internal hop (SPIFFE via Istio
+  ambient, [ADR-041](../adrs/041-istio-ambient-mesh.md)).
+- Strong credential boundary at the pod (paired-pod topology with
+  Envoy SDS, [ADR-005](../adrs/005-credential-gateway.md),
+  [ADR-033](../adrs/033-envoy-credential-gateway.md),
+  [ADR-038](../adrs/038-paired-gateway-pod.md)).
+- Coarse but correct network controls (per-pair egress NetworkPolicy,
+  three per-instance AuthorizationPolicies, pod-level DENY on the
+  api-server).
+- Confidentiality controls limited to outbound-surface narrowing via
+  HITL ([ADR-035](../adrs/035-unified-hitl-ux.md)).
+
+**Named gaps the architecture acknowledges**
+
+- *Kernel isolation.* Platform assumes the cluster operator provides
+  gVisor or Kata via RuntimeClass; the chart sets no RuntimeClass and
+  the docs are explicit that without one, a kernel-CVE breakout
+  reaches the node.
+- *Container-level hardening.* The agent and gateway pods carry no
+  seccomp profile, no AppArmor profile, and no dropped capabilities
+  today. `readOnlyRootFilesystem` is also off on agent containers.
+- *Process-level sandboxing.* No bwrap or equivalent inside the
+  agent container — every tool the agent invokes runs with the same
+  privileges as the agent process.
+- *Confidentiality.* No general defence against prompt-injection
+  exfiltration along legitimate egress paths beyond shrinking the
+  outbound surface.
+
+Progression along the spectrum means moving each of these gaps one
+step right on the diagrams above. The order is a future decision,
+not a commitment of this document.
+
+## References
+
+- [`docs/architecture/security-and-credentials.md`](../architecture/security-and-credentials.md) — current-state architecture, authoritative for *how*
+- [security-model](security-model.md) — narrative framing of the three risks (execution, credentials, confidentiality)
+- [multi-player](multi-player.md) — identity, ownership, per-user credential isolation
+- ADRs: [005](../adrs/005-credential-gateway.md), [033](../adrs/033-envoy-credential-gateway.md), [035](../adrs/035-unified-hitl-ux.md), [038](../adrs/038-paired-gateway-pod.md), [041](../adrs/041-istio-ambient-mesh.md)


### PR DESCRIPTION
## Summary

Adds [`docs/strategy/security-overview.md`](docs/strategy/security-overview.md) — a single-page strategy doc explaining how Platform isolates agents from each other, from the cluster, and from the credentials they use.

Closes #123.

## What's on the page

- **Layers of defense** — a four-box parallel diagram (Identity · Boundary · Network · Credentials) followed by labelled prose explaining each in concrete K8s/Istio terms (ServiceAccount, SPIFFE, NetworkPolicy, AuthorizationPolicy, ext-authz).
- **Security boundary** — the container is the boundary; everything inside is untrusted. Default runtime is runc, which shares a kernel with the node; cluster operators should add gVisor or Kata via RuntimeClass for kernel-level isolation. Acknowledges that some controls (NetworkPolicy, `automountServiceAccountToken`) are pod-scoped because of K8s API granularity.
- **Authorization flow** — a diagram of the egress path (agent → gateway → external, with the ext-authz check round-trip and HITL hold-open as a side branch), and prose covering the three per-instance AuthorizationPolicies plus the ext-authz egress gate.
- **Threats and mitigations** — a compact 6-row table.

Sits alongside [`security-model.md`](docs/strategy/security-model.md) as a peer strategy doc; links out to [`security-and-credentials.md`](docs/architecture/security-and-credentials.md) for current-state architecture details.

## Why now

The original blocker on #123 ("delay until Istio is added") is resolved — ADR-041 is accepted and the Istio ambient mesh integration is merged, so the security architecture is stable enough to document end-to-end.

## Test plan

- [x] `mise run check` — lint + type-check + helm lint + kubeconform all pass
- [ ] Render the page on the GitHub PR preview and confirm both Mermaid diagrams display
- [ ] Confirm internal links to `security-and-credentials.md` and `security-model.md` resolve

