### PR TITLE
feat(ui): terminal session reconnect on disconnect

### DIFF
--- a/packages/ui/src/modules/sessions/components/terminal.tsx
+++ b/packages/ui/src/modules/sessions/components/terminal.tsx
@@ -4,7 +4,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Terminal as XTerm } from "@xterm/xterm";
 import { decodeFrame, encodeDataFrame, encodeResize, OP_EXIT, OP_INPUT, OP_OUTPUT } from "api-server-api";
 import { Loader2, TerminalIcon, XCircle } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { getAccessToken } from "../../../auth.js";
 
@@ -15,6 +15,11 @@ export function Terminal({ instanceId, sessionId, fresh, onConnected }: { instan
   const termRef = useRef<XTerm | null>(null);
   const [state, setState] = useState<ConnectionState>("connecting");
   const [exitCode, setExitCode] = useState<number | null>(null);
+  const [reconnectKey, setReconnectKey] = useState(0);
+  const handleReconnect = useCallback(() => {
+    setState("connecting");
+    setReconnectKey((k) => k + 1);
+  }, []);
 
   // After React commits "live" the connecting overlay unmounts; refocus then.
   useEffect(() => {
@@ -100,11 +105,10 @@ export function Terminal({ instanceId, sessionId, fresh, onConnected }: { instan
       termRef.current = null;
       container.innerHTML = "";
     };
-    // `fresh` and `onConnected` are intentionally captured once at mount —
-    // re-running the effect when `fresh` flips post-connect would tear down
-    // and recreate the WS, undoing the kill-and-respawn we just did.
+    // `fresh` and `onConnected` are intentionally captured once at mount.
+    // `reconnectKey` triggers a full teardown+reconnect cycle.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [instanceId, sessionId]);
+  }, [instanceId, sessionId, reconnectKey]);
 
   return (
     <div className="flex flex-1 flex-col min-h-0 relative">
@@ -120,7 +124,13 @@ export function Terminal({ instanceId, sessionId, fresh, onConnected }: { instan
         <div className="absolute inset-0 z-10 flex items-center justify-center bg-bg/80 backdrop-blur-sm">
           <div className="flex flex-col items-center gap-3 text-center">
             <XCircle size={24} className="text-danger" />
-            <p className="text-[14px] text-text-secondary">Terminal disconnected</p>
+            <p className="text-[14px] text-text-secondary">Session disconnected</p>
+            <button
+              className="rounded-md border border-border-light bg-surface-raised px-4 py-2 text-[13px] text-text-primary hover:bg-surface-hover transition-colors"
+              onClick={handleReconnect}
+            >
+              Reconnect
+            </button>
           </div>
         </div>
       )}


### PR DESCRIPTION
## Summary

- Adds a "Reconnect" button to the terminal disconnect overlay, replacing the dead-end "Terminal disconnected" message
- On click, tears down the old xterm/WebSocket and opens a fresh connection — the existing relay calls `ensureReady()` which wakes hibernated pods, and `harness-terminal.sh` resumes the Claude Code session from its on-disk `.jsonl`
- Works for all disconnect causes: pod hibernation, another tab taking over, network drops

Closes #85

## Test plan

- [x] `mise run check` passes (lint + type-check)
- [x] Manual: open terminal → disconnect (hibernate pod) → verify "Reconnect" button appears → click → session resumes with conversation history