### PR TITLE
docs(adrs): rewrite DRAFT multi-agent around delegation + per-pair PVC

### DIFF
--- a/docs/adrs/DRAFT-multi-agent.md
+++ b/docs/adrs/DRAFT-multi-agent.md
@@ -1,52 +1,131 @@
-# DRAFT: Multi-agent collaboration — isolated instances with shared artifacts
+# DRAFT: Multi-agent collaboration — instances calling instances
 
-**Date:** 2026-04-07
+**Date:** 2026-05-12
 **Status:** Proposed
 **Owner:** @tomkis
 
 ## Context
 
-As agent use cases mature beyond single-agent coding tasks, users want multiple specialized agents collaborating — e.g., one agent on Telegram handling family logistics, another on Slack managing work tasks, each with different system prompts, skills, and credential access.
+As agent use cases mature, users want multiple specialized agents collaborating — e.g., a cheap Pi agent acting as primary liaison that escalates to Claude Code only when task complexity warrants it; or a "software factory" where an orchestrator agent dispatches work to specialized workers and consumes their results.
 
-OpenClaw demonstrates this with its multi-agent configuration file, where agents share a single mutable system environment and permissions are enforced partly via prompts. This works for personal use but is problematic for enterprise: mutable shared state, prompt-based security boundaries, and no enforceable isolation between agents.
+[OpenClaw](https://github.com/openclaw/openclaw) demonstrates this with a multi-agent configuration file: all agents share one mutable system environment, permissions are enforced partly via prompts. Workable for personal use, unsuitable for enterprise: mutable shared state, prompt-based security boundaries, no enforceable isolation.
 
-The question: how should Platform model multi-agent collaboration? Should agents share workspaces, run inside a single instance, or be fully isolated with explicit communication channels?
+UXR signal from the Pi launch: cost is the dominant blocker for autonomous scheduling. A multi-agent model that *enables* cost-control patterns (cheap-by-default, escalate on demand) is therefore as much a product feature as it is an architecture choice.
+
+Prior decisions this builds on:
+
+- [ADR-001](001-ephemeral-containers.md) — per-instance ephemeral container with own workspace volume.
+- [ADR-005](005-credential-gateway.md) — per-instance credential scoping.
+- [ADR-007](007-acp-relay.md) — ACP relay as the per-instance control surface.
+- [ADR-012](012-runtime-lifetime.md) — long-lived instance pods.
+- [ADR-015](015-multi-user-auth.md) — multi-user auth.
 
 ## Decision
 
-**Each agent is a separate instance. Agents collaborate through explicitly shared artifacts, not shared workspaces.**
+**Each agent is a separate long-lived instance. Agents collaborate by calling each other through a typed ACP RPC. Per-pair scratch volumes carry bulky artifacts.**
 
-Multi-agent is NOT sub-processes within a single instance. Each agent gets:
+This is **delegation, not hierarchy** — agents are tools other agents may invoke. No parent owns child lifecycle; no recursive ownership tree.
 
-- Its own instance (own pod, own ephemeral container per ADR-012)
-- Its own persistent workspace volume (per ADR-001)
-- Its own credential/permission scope — one agent may have GitHub access, another may not (per ADR-005)
-- Its own system prompt and skill configuration
+### 1. The edge: `allowedCallees` on the caller
 
-Inter-agent communication uses a platform-level **shared artifact mechanism**: the user explicitly declares which artifacts (files, folders) are shared between which instances. This is analogous to sharing a Google Drive folder between employees rather than giving them access to each other's computers.
+The caller's instance spec declares the set of callable callees:
 
-The platform DOES:
-- Allow the user to declare shared artifact mounts between instances
-- Enforce per-instance credential scoping (credentials are per-instance, not per-template)
-- Maintain full isolation between instances by default — sharing is opt-in
+```yaml
+# Alice's instance spec
+spec:
+  allowedCallees:
+    - bob-id
+```
 
-The platform does NOT:
-- Run multiple agents inside a single instance/pod
-- Allow agents to mount each other's full workspaces
-- Rely on prompt-level enforcement for inter-agent boundaries
+A bare ID list. Caller-side declaration. Creating the edge:
+
+- Materializes a Kubernetes `Service` for Bob (`bob-id.<ns>.svc.cluster.local`) — Alice resolves Bob via cluster DNS.
+- Materializes a per-pair `NetworkPolicy` allowing Alice's pod to reach Bob's pod on the ACP port.
+- Provisions a per-pair `PersistentVolumeClaim` owned by Alice; mounted into both Alice's and Bob's pods.
+
+Removing the edge tears all three down.
+
+### 2. Scope: single-user in v1
+
+V1 assumes a single owning user across the pair. Caller-declares is sufficient — there is no consent boundary to negotiate.
+
+V2 (multi-user, see [ADR-015](015-multi-user-auth.md)) **adds callee-side declaration**: Bob's spec must also list Alice. The edge is materialized only when both sides agree. Caller-declares → mutual-consent is additive; no v1 → v2 schema break.
+
+### 3. The call protocol: `bob.invoke()`
+
+Bob's agent-runtime exposes a single opaque method over ACP:
+
+```
+bob.invoke(prompt: string, sessionId?: string) -> response
+```
+
+- **Opaque shape.** No typed methods, no published schema. Bob is exposed in Alice's tool list as one tool: "send a prompt to Bob, get a response."
+- **Alice-controlled session.** `sessionId` is opaque to Alice; reusing it continues a stateful thread with Bob, omitting it starts a fresh one.
+- **Bob sees the call as a user message.** No caller metadata is surfaced to Bob's LLM. From Bob's prompt's perspective, an agent caller is indistinguishable from a human.
+- **Single in-flight per Bob.** Concurrent callers are transparently FIFO-queued at Bob's agent-runtime. Charlie's `invoke` blocks until Bob is free.
+
+### 4. Artifacts: per-pair PVC
+
+Bulky data does not travel in the ACP payload. Each `allowedCallees` edge gets an auto-provisioned PVC:
+
+- **Owned by Alice.** Lives in Alice's namespace, counted against Alice's quota, GC'd with Alice's instance or the edge.
+- **Mounted in both pods.** Symmetric read-write — either side may read or write.
+- **Path layout is platform-managed.** No user-specified globs. Controller decides mount paths.
+
+The intended usage pattern: Alice writes a job spec to the PVC, calls `bob.invoke("process the spec in /work")`, Bob reads the spec, writes large outputs back to the PVC, returns a short summary via ACP. The ACP reply contains references (paths) to bulk artifacts, not the bytes.
+
+### 5. Streaming and lifetime
+
+- **No call cap.** The ACP WebSocket is held open for the duration of `bob.invoke()`. Failure of the WS = failure of the call. No resume mechanism in v1.
+- **Final result only to Alice's LLM.** Bob's progress stream is visible to the operator dashboard (the human watching) but is *not* fed back into Alice's LLM context. Alice's tool call resolves with Bob's final message.
+
+### 6. Cycles forbidden — DAG enforced at admission
+
+A Kubernetes admission webhook on the instance spec rejects an `allowedCallees` write that would close a cycle in the directed graph. Users see immediate "would create cycle" errors at edit time rather than silent reconcile-loop failures.
+
+V1 explicitly forbids cycles. If peer iteration (A↔B) becomes a needed pattern, revisit then with a call-tree budget (see Deferred).
 
 ## Alternatives Considered
 
-**Shared workspace between agents.** Mount one agent's workspace into another. Rejected: violates separation of concerns. Agents should have clearly defined contracts (artifacts) for what they exchange, not unrestricted access to each other's state. This mirrors how teams work — you share a document, not your entire laptop.
+**Hierarchy as a first-class platform concept.** Parent agent owns child lifecycle, schedules it, persists across child runs. *Rejected:* the use cases on the table (Pi-escalates-to-Claude, software factory) are served by delegation. Hierarchy doubles the platform surface for no demonstrated benefit. Revisit only when a use case demonstrably cannot be expressed as a DAG of delegations.
 
-**Multi-agent within a single instance.** Run multiple agent processes in one pod with a shared filesystem. Rejected: conflates isolation boundaries, makes per-agent credential scoping impossible at the platform level, and creates the same mutable-state problems seen in OpenClaw.
+**Continuous shared mounts ("shared Google Drive folder").** Mount a folder from Alice into Bob continuously; communication is implicit via filesystem events. *Rejected after grilling:* conflates "Bob can read Alice's data" with "Alice is asking Bob to do work." Per-pair PVC behind a call boundary is closer to function-call semantics — the act of calling is the act of sharing.
 
-**OpenClaw-style config-file multi-agent.** Single configuration file defining all agents, shared environment, prompt-based permissions. Rejected: prompt-based security is not enforceable — an agent can ignore prompt instructions. Enterprise environments require platform-enforced boundaries. Platform's advantage is platform-level fine-grained control.
+**Spec on the callee (`allowedCallers` on Bob).** Bob declares his attack surface. *Rejected for v1:* in single-user, the caller-declared model is strictly less config (one side touches Alice's spec to grant Alice access). For multi-user v2 we will require both — but that's additive on top of v1.
+
+**Typed methods or MCP-style schema-publish by Bob.** *Rejected for v1:* opaque `invoke()` is the smallest surface that works. Add typed methods only when a use case shows up that an opaque prompt cannot express.
+
+**Per-edge budget, per-instance budget, per-call-tree budget.** *Deferred:* v1 assumes single-user, single-payer; the user can monitor their own bill. Budgets become required when multi-user lands, not before.
+
+**OpenClaw-style config-file multi-agent.** Single config defining all agents, shared environment, prompt-based permissions. *Rejected:* prompt-based security is not enforceable. Platform's value is platform-level isolation.
 
 ## Consequences
 
-- **Stronger isolation by default.** Each agent is sandboxed; compromise of one agent doesn't cascade.
-- **Per-instance credential scoping required.** Current OneCLI integration configures credentials per-template; this needs to move to per-instance. Requires changes to how OneCLI connectors are registered.
-- **Shared artifact mechanism is new work.** The platform needs a first-class concept of shared mounts between instances — likely a new field in the instance ConfigMap spec.
-- **No implicit agent-to-agent communication.** Agents can't "discover" each other unless the user explicitly configures shared artifacts. This is intentional but means orchestration is the user's responsibility for now.
-- **Aligns with employee mental model.** Users think of agents as employees they're hiring — each with their own role, permissions, and shared folders. This maps cleanly to the instance-per-agent model.
+- **Per-instance credential scoping is foundational.** Each pod, each PVC, each credential set scoped to one instance. ([ADR-005](005-credential-gateway.md).)
+- **Controller adds three resources per edge:** Service, NetworkPolicy, PVC. All keyed on `(caller, callee)` pairs. GC follows the caller's instance.
+- **Admission webhook is new infrastructure.** Cycle check requires the controller to read the full edge graph at admission time.
+- **No protocol invention.** `bob.invoke()` is a new ACP method but rides existing relay infra ([ADR-007](007-acp-relay.md)).
+- **Cost amplification risk is unmitigated in v1.** A misbehaving Alice can spam `invoke` and burn Bob's tokens. Mitigated by single-user assumption only.
+- **Aligns with the "agents-as-employees" mental model.** Alice has a Rolodex of colleagues she may call; each call leaves a paper trail (PVC + ACP log); colleagues have their own offices (instances) the user explicitly hired.
+
+## Open Questions
+
+- Caller identity in `allowedCallees`: instance ID, k8s ServiceAccount, or template name?
+- ACP call auth: NetworkPolicy alone enough, or add token check?
+- PVC mount paths on each side; read-write modes?
+- sessionId TTL; cleanup policy on Bob's side?
+- Bob restart mid-call: fail or reconnect?
+- PVC GC: on edge removal, on Alice delete, on Bob delete — who cleans?
+- v2 cycle check across user-owned subgraphs: who validates?
+- Operator dashboard for Bob's stream: standalone view, or merged with caller's session?
+- Tool list shape for Alice's LLM: one `bob.invoke` tool, or split `openSession`/`invoke`/`closeSession`?
+- Reusable Bob templates vs hand-rolled per pair?
+
+## Deferred to v2+
+
+- **Multi-user mutual consent** (`allowedCallers` on callee).
+- **Per-edge / per-call-tree budgets** when multi-user lands.
+- **Call resume / attach** for genuinely long-running calls.
+- **LLM-visible progress stream** for real-time co-ordination.
+- **Cycles with bounded depth** when peer iteration is needed.
+- **Typed Bob methods / MCP-style schemas** when an opaque prompt is insufficient.


### PR DESCRIPTION
## Summary

Rewrites [DRAFT-multi-agent.md](docs/adrs/DRAFT-multi-agent.md) after a grilling session on the model. Replaces the shared-Drive-folder framing with a delegation model: agents are tools other agents may invoke through a typed ACP RPC, with per-pair scratch volumes for bulk artifacts.

Key shifts vs. the prior draft:

- Delegation, not hierarchy — no parent-owns-child.
- Spec moved to the caller (`allowedCallees` on Alice). Single-user v1; mutual-consent v2.
- Per-pair PVC auto-provisioned by controller, not user-declared globs.
- `bob.invoke(prompt, sessionId?)` over ACP; opaque single method.
- Bob is single-tenant FIFO; concurrent callers queue transparently.
- Cycles forbidden — K8s admission webhook on instance spec.
- Per-instance Service + cluster DNS for discovery.
- Open Questions and Deferred v2+ items split out explicitly.

Still DRAFT / Proposed.

## Test plan

- [ ] Read once end-to-end and sanity-check against the Slack thread context (Pi-escalates-to-Claude, software-factory, UXR cost finding).
- [ ] Confirm Open Questions are the right v1-blockers.
- [ ] Confirm Deferred items are intentional v2+, not silent gaps.