### PR TITLE
feat(security): NetworkPolicy gates agent egress; agent opts out of ambient

### DIFF
--- a/deploy/helm/platform/templates/migrate-stale-netpols.yaml
+++ b/deploy/helm/platform/templates/migrate-stale-netpols.yaml
@@ -1,33 +1,34 @@
 {{- /*
-ADR-041 migration. Two pre-upgrade clean-ups, both no-ops on a fresh
-install:
+Pre-upgrade clean-ups, all no-ops on a fresh install:
 
-1. Delete stale pair-key NetworkPolicies. The old controller wrote
-   `<id>-egress` / `<id>-gateway-egress` policies in the agent
-   namespace, owner-refed to the instance ConfigMap. ADR-041 retires
-   that mechanism and removes the controller's `networkpolicies`
-   write RBAC, so the new controller cannot delete the leftovers
-   itself. Once the agent namespace flips to ambient, ztunnel
-   encapsulates pod-to-pod traffic on HBONE :15008 — but the stale
-   NPs only admit the application port (10000, 8080), blocking
-   ambient connectivity for every existing instance until it's
-   recreated.
+1. Delete pre-ADR-041 pair-key NetworkPolicies. The old controller wrote
+   `<id>-egress` / `<id>-gateway-egress` policies in the agent namespace
+   without the `agent-platform.ai/managed-by=platform-controller` label.
+   Once the agent namespace flips to ambient, ztunnel encapsulates
+   pod-to-pod traffic on HBONE :15008 — but those stale NPs only admit
+   the application port (10000, 8080), blocking ambient connectivity for
+   every existing instance until it's recreated. The selector is
+   `agent-platform.ai/pair` AND `!agent-platform.ai/managed-by` so the
+   current-shape `<id>-agent-egress` NPs (which carry both labels) are
+   left untouched.
 
-2. Delete in-flight fork ConfigMaps. Pre-upgrade fork pods carry
-   `serviceAccountName == parentInstanceID`. The new
-   `BuildGatewayAuthorizationPolicy(forkName, forkName, ...)` admits
-   only the per-fork SA principal, so any running fork pair fails
-   gateway self-talk after upgrade until the fork is deleted +
-   recreated. Forks are short-lived per-turn Jobs (TTL 60s after
-   completion) so the operational impact is minimal — losing any
-   in-flight turn is acceptable for an upgrade. Owner-refed children
-   (Job + Pod + Service + Envoy bootstrap CM + leaf cert) cascade-
-   delete via the fork ConfigMap.
+2. Delete stale `<id>-gateway-allow` AuthorizationPolicies. Earlier
+   versions wrote one per pair admitting the agent SPIFFE principal at
+   the gateway pod. The agent no longer participates in the mesh (it
+   opts out at the pod level), so this ALLOW now denies legitimate
+   agent → gateway traffic — and the controller no longer writes or
+   GCs it. We sweep them here on upgrade and let the reconciler
+   converge the rest. Selector pins to the controller's labels for
+   precision (managed-by + role=gateway).
 
-`agent-platform.ai/pair` (NPs) and `agent-platform.ai/type=agent-fork`
-(fork CMs) are precise selectors — both labels are stamped by the
-old/current controller and are not used elsewhere. Removable in a
-future minor once every supported deployment has crossed ADR-041.
+3. Delete in-flight fork ConfigMaps. Pre-upgrade fork pods carry
+   `serviceAccountName == parentInstanceID`. Newer fork code uses a
+   per-fork SA distinct from the parent's, so any running fork pair
+   fails its mesh-gated harness/ext-authz hops after upgrade until the
+   fork is deleted and recreated. Forks are short-lived per-turn Jobs
+   (TTL 60s after completion) so the operational impact is minimal.
+   Owner-refed children (Job + Pod + Service + Envoy bootstrap CM +
+   leaf cert) cascade-delete via the fork ConfigMap.
 */ -}}
 {{- $jobName := printf "%s-migrate-stale-netpols" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
 apiVersion: v1
@@ -56,6 +57,9 @@ metadata:
 rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
+    verbs: ["list", "delete"]
+  - apiGroups: ["security.istio.io"]
+    resources: ["authorizationpolicies"]
     verbs: ["list", "delete"]
   - apiGroups: [""]
     resources: ["configmaps"]
@@ -114,24 +118,37 @@ spec:
               set -eo pipefail
               ns={{ .Values.agentNamespace | quote }}
 
-              # 1. Stale pair-key NetworkPolicies. The label
-              #    `agent-platform.ai/pair` was stamped by the old
-              #    controller on every per-instance NetworkPolicy and is
-              #    not used elsewhere, so this selector is precise.
-              np_count=$(kubectl -n "$ns" get networkpolicy -l agent-platform.ai/pair -o name 2>/dev/null | wc -l | tr -d ' ')
-              echo "ADR-041 migration: deleting $np_count stale pair-key NetworkPolicy(s) in $ns"
+              # 1. Pre-ADR-041 pair-key NetworkPolicies. Restricted to NPs
+              #    that lack `agent-platform.ai/managed-by` — current-shape
+              #    `<id>-agent-egress` carries both `pair` and `managed-by`,
+              #    so this selector leaves them alone.
+              np_count=$(kubectl -n "$ns" get networkpolicy -l 'agent-platform.ai/pair,!agent-platform.ai/managed-by' -o name 2>/dev/null | wc -l | tr -d ' ')
+              echo "migration: deleting $np_count pre-ADR-041 NetworkPolicy(s) in $ns"
               if [ "$np_count" != "0" ]; then
-                kubectl -n "$ns" delete networkpolicy -l agent-platform.ai/pair --ignore-not-found
+                kubectl -n "$ns" delete networkpolicy -l 'agent-platform.ai/pair,!agent-platform.ai/managed-by' --ignore-not-found
               fi
 
-              # 2. In-flight fork ConfigMaps. Pre-upgrade fork pods carry
-              #    serviceAccountName == parentInstanceID; the new
-              #    gateway-allow policy admits only the fork SA principal,
-              #    so running forks fail self-talk after upgrade. Deleting
-              #    the fork ConfigMap cascade-removes Job + Pod + Service +
-              #    Envoy bootstrap CM + leaf cert via owner-ref.
+              # 2. Stale `<id>-gateway-allow` AuthorizationPolicies. The
+              #    controller stopped writing these when the agent stopped
+              #    participating in the mesh — but they're still in-cluster
+              #    on upgrade and will deny the agent → gateway hop they
+              #    used to admit (the agent has no SPIFFE now). Selector
+              #    pins to managed-by + role=gateway for precision.
+              ap_count=$(kubectl -n "$ns" get authorizationpolicy -l 'agent-platform.ai/managed-by=platform-controller,agent-platform.ai/role=gateway' -o name 2>/dev/null | wc -l | tr -d ' ')
+              echo "migration: deleting $ap_count stale gateway-allow AuthorizationPolicy(s) in $ns"
+              if [ "$ap_count" != "0" ]; then
+                kubectl -n "$ns" delete authorizationpolicy -l 'agent-platform.ai/managed-by=platform-controller,agent-platform.ai/role=gateway' --ignore-not-found
+              fi
+
+              # 3. In-flight fork ConfigMaps. Pre-current-shape fork pods
+              #    carry serviceAccountName == parentInstanceID; per-fork
+              #    AuthorizationPolicies admit only the fork SA principal,
+              #    so running forks fail their mesh-gated harness/ext-authz
+              #    hops after upgrade. Deleting the fork ConfigMap cascade-
+              #    removes Job + Pod + Service + Envoy bootstrap CM + leaf
+              #    cert via owner-ref.
               fork_count=$(kubectl -n "$ns" get configmap -l agent-platform.ai/type=agent-fork -o name 2>/dev/null | wc -l | tr -d ' ')
-              echo "ADR-041 migration: deleting $fork_count in-flight fork ConfigMap(s) in $ns"
+              echo "migration: deleting $fork_count in-flight fork ConfigMap(s) in $ns"
               if [ "$fork_count" != "0" ]; then
                 kubectl -n "$ns" delete configmap -l agent-platform.ai/type=agent-fork --ignore-not-found
               fi

--- a/docs/adrs/042-agent-egress-network-policy.md
+++ b/docs/adrs/042-agent-egress-network-policy.md
@@ -1,0 +1,120 @@
+# ADR-042: Agent egress is gated by NetworkPolicy; the agent is not a mesh participant
+
+**Date:** 2026-05-13
+**Status:** Accepted
+**Owner:** @pilartomas
+
+## Context
+
+The agent pod runs LLM-driven, attacker-controlled code. Its only legitimate
+intra-cluster destination is the paired gateway pod, which holds credentials
+and gates outbound traffic through Envoy's `ext_authz` filter
+([ADR-035](035-unified-hitl-ux.md)). Every other in-cluster destination —
+Postgres, Redis, Keycloak, the api-server's harness and ext-authz ports,
+another instance's gateway — must be structurally unreachable from the agent.
+
+In an ambient Istio mesh, `istio-cni` installs an iptables redirect that
+rewrites the agent pod's outbound destination to `ztunnel:15008` before the
+kernel NetworkPolicy filter evaluates the packet. NetworkPolicy can therefore
+enforce only "the agent may speak HBONE to ztunnel" — not which destination
+that HBONE tunnel actually carries. Pair-isolation via NP becomes a polite
+suggestion: any in-mesh workload without an explicit deny is reachable.
+
+Replacing NP with Istio AuthorizationPolicy as the primary control was
+considered ([ADR-041](041-istio-ambient-mesh.md) moves in that direction).
+The attempt revealed that ambient policy attachment semantics are not
+reliably auditable: `targetRefs: Service` requires the Service to be
+bound to a waypoint or the policy silently no-ops with `AncestorNotBound`;
+no-selector ALLOWs attach to neighbouring workloads in non-obvious ways and
+switch their default to DENY at L4; ztunnel xDS state can resist policy
+edits with no diagnostic beyond TCP refused. Putting a security guarantee
+on every in-mesh destination via mesh AuthZ requires fanning ALLOWs across
+the cluster and trusting they all converge — a worse cost-benefit than
+admitting that the agent does not need to be in the mesh at all.
+
+## Decision
+
+Take the agent pod out of the mesh; let the kernel NetworkPolicy do the
+job it was designed for.
+
+- **Agent pod opts out of ambient.** Pod label
+  `istio.io/dataplane-mode: none` removes the ztunnel redirect. The agent
+  has no SPIFFE workload identity; its outbound packets show the real
+  destination to NetworkPolicy.
+- **Per-pair `<id>-agent-egress` NetworkPolicy.** Two egress rules:
+  DNS to `kube-system` and the paired gateway pod (`pair=<id>,
+  role=gateway`) on the Envoy proxy port. HBONE 15008 is not admitted;
+  the agent never speaks it.
+- **Gateway pod stays in ambient.** Its SPIFFE principal continues to
+  gate the gateway → harness and gateway → ext-authz hops via the
+  existing per-instance harness-allow and ext-authz-allow
+  AuthorizationPolicies. The gateway's `ext_authz` filter remains the
+  egress gate for everything the agent tunnels through it.
+- **No NetworkPolicies on release-namespace destinations.** Postgres,
+  Redis, Keycloak, the harness Service, the ext-authz Service stay
+  unguarded by NP; the agent has no admitted route to any of them.
+
+The `<id>-gateway-allow` AuthorizationPolicy is retired. With the agent
+out of the mesh, the agent has no SPIFFE principal for an ALLOW policy
+to match. The gateway pod has no ALLOW policy attached, so the mesh
+default-allow applies and ztunnel passes the agent's plaintext
+connection through to Envoy. The NetworkPolicy is the sole gate on that
+hop.
+
+## Alternatives considered
+
+**AuthorizationPolicy as primary intra-cluster control.** Add a
+release-namespace default-deny baseline plus per-instance ALLOWs at
+every destination the gateway dials, and an egress waypoint that
+captures source-side traffic from the agent namespace. Wins: a uniform
+identity story, mesh-keyed audit. Rejected: ambient policy attachment
+semantics differ across L4 vs L7 and across Gateway / Service /
+no-selector targets in ways that fail silently when the policy doesn't
+attach as intended. The failure mode is TCP-refused with no diagnostic,
+and re-running `kubectl apply` does not always converge — ztunnel
+caches xDS state that survives policy edits. A security guarantee that
+hinges on every ALLOW attaching to the right resource is brittle.
+
+**Both pods out of mesh.** Take the gateway out of ambient too. Wins:
+no mesh participation anywhere, simpler. Rejected: the gateway →
+harness and gateway → ext-authz hops would lose SPIFFE attribution and
+need a substitute identity primitive (Bearer token, `:authority`-based
+identity at the harness end, or per-gateway mTLS with platform-managed
+certs). The gateway-side identity wiring already works; discarding it
+to fix an agent-side problem is unjustified.
+
+**NetworkPolicies on every release-namespace destination.** Lock down
+each pod the agent must not reach. Rejected: the controller would
+own a growing inventory of "which destinations is the gateway allowed
+to dial" — that is the data model already encoded in egress rules and
+gated by `ext_authz` on the gateway's Envoy. Spreading NPs to every
+destination couples the security policy to the cluster topology
+instead of the rule model.
+
+## Consequences
+
+- The agent → gateway hop is no longer mTLS-encrypted at the underlay.
+  TLS protection at the application layer is preserved: the agent's
+  `HTTPS_PROXY` tunnel terminates at Envoy on the gateway pod, and
+  Envoy mints the leaf cert agent clients trust via the MITM CA bundle
+  ([ADR-033](033-envoy-credential-gateway.md)).
+- The kernel boundary is robust to mesh control-plane disturbances —
+  ztunnel restart, istiod issuing-cert blips, AuthorizationPolicy edit
+  not yet converged. The agent's egress shape does not depend on any
+  of them.
+- DNS tunneling via CoreDNS's upstream forwarder remains a residual,
+  low-bandwidth exfil channel. The NetworkPolicy must admit DNS to
+  `kube-system`; CoreDNS forwards non-cluster queries upstream by
+  default. Closing this requires per-pod DNS policy or a DNS-aware
+  egress filter, neither in scope here.
+- The gateway pod must accept inbound traffic from a non-mesh source
+  on its Envoy port. Ambient ztunnel-on-inbound passes through
+  plaintext on non-HBONE ports when no ALLOW AuthorizationPolicy is
+  attached to the destination; retiring the gateway-allow policy is
+  what makes that pass-through legal. If a future change re-introduces
+  an ALLOW on the gateway pod, it must explicitly admit the
+  non-principal (out-of-mesh) source or the agent → gateway hop will
+  TCP-refuse.
+- The agent pod has no SPIFFE workload identity. Any future code that
+  tries to authenticate the agent by mesh principal (rather than by
+  the gateway-pod principal on its behalf) will fail closed.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -46,6 +46,7 @@ This directory contains ADRs for the Platform project.
 | [039](039-cli-foundation.md)                  | Platform CLI foundation — TypeScript on Node, npm distribution | @PetrBulanek |
 | [040](040-unified-secret-contributions.md)    | Unified secret contributions — controller-merged at render time | @Tomas2D |
 | [041](041-istio-ambient-mesh.md)              | Istio ambient mesh — SPIFFE identity for every internal hop | @pilartomas |
+| [042](042-agent-egress-network-policy.md)     | Agent egress is gated by NetworkPolicy; the agent is not a mesh participant | @pilartomas |
 | [043](043-agent-pod-config-layers.md)         | Three-layer agent pod configuration — base / templateDefaults / templates | @jezekra1 |
 
 ## Drafts

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-11
+Last verified: 2026-05-13
 
 ## Motivated by
 
@@ -11,7 +11,8 @@ Last verified: 2026-05-11
 - [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy mints per-instance leaf certs, MITMs egress, and injects credential headers
 - [ADR-035 — HITL ext_authz](../adrs/035-unified-hitl-ux.md) — Envoy gates credentialed egress through an api-server ext_authz call
 - [ADR-038 — Paired agent and gateway pods](../adrs/038-paired-gateway-pod.md) — agent and gateway run in two paired pods, with the credential boundary at the pod boundary
-- [ADR-041 — Istio ambient mesh](../adrs/041-istio-ambient-mesh.md) — SPIFFE identity for every internal hop; supersedes ADR-038's NetworkPolicy mechanism, the `x-platform-instance` header, and the pod-IP resolver
+- [ADR-041 — Istio ambient mesh](../adrs/041-istio-ambient-mesh.md) — SPIFFE identity on the gateway-originated hops (harness, ext-authz); the gateway-admission AuthorizationPolicy is retired by ADR-042
+- [ADR-042 — Agent egress is gated by NetworkPolicy; agent is not a mesh participant](../adrs/042-agent-egress-network-policy.md) — the agent → gateway hop is gated at the kernel by per-pair NetworkPolicy; the agent has no SPIFFE identity
 
 ## Overview
 
@@ -27,22 +28,26 @@ Three rules carry the security model:
    every resource the user creates. Per-user credential isolation is the
    `platform.ai/owner` label on the K8s Secret — the controller's selector
    refuses to mount any other owner's Secret into a given owner's gateway pod.
-3. **The trust line is SPIFFE workload identity.** Each instance runs as
-   two paired pods (ADR-038) under one **per-instance ServiceAccount**.
-   Fork pairs (ADR-027) get their **own** per-fork SA — distinct from
-   the parent's — so a compromised fork can't impersonate the parent on
-   the harness path. istiod stamps every pod with a SPIFFE workload
-   cert whose SA name equals the instance (or fork) name. Three
-   per-instance AuthorizationPolicies enforce the boundary
-   cryptographically: the gateway Service ALLOWs only its own SA
-   principal (replaces the pair-key NetworkPolicy from ADR-038); the
-   api-server's harness waypoint ALLOWs that principal to
-   `/api/instances/<id>/*`; the per-instance ext-authz Service ALLOWs
-   only the matching SA. Per-fork policies layer narrowly on top —
-   admitting the fork SA only to `/api/instances/<parent>/mcp` and to
-   the parent's ext-authz Service. Identity no longer flows through
-   pod IPs or the trusted `x-platform-instance` header — both are
-   removed (ADR-041).
+3. **Two boundaries, layered.** The agent → gateway hop is gated at the
+   *kernel* by a per-pair NetworkPolicy ([ADR-042](../adrs/042-agent-egress-network-policy.md));
+   the gateway → api-server hops (harness and ext-authz) are gated at
+   the *mesh* by per-instance Istio AuthorizationPolicies on the
+   gateway pod's SPIFFE principal ([ADR-041](../adrs/041-istio-ambient-mesh.md)).
+   The agent pod opts out of ambient mesh (`istio.io/dataplane-mode:
+   none`) so the kernel sees real destinations rather than HBONE
+   tunnelled to ztunnel; its only admitted intra-cluster destination
+   is the paired gateway pod on the Envoy proxy port. The gateway pod
+   stays in ambient; istiod stamps it with a SPIFFE workload cert whose
+   SA name equals the instance (or fork) name. Two per-instance
+   AuthorizationPolicies enforce the gateway-originated boundary
+   cryptographically: the api-server's harness waypoint ALLOWs the
+   gateway principal to `/api/instances/<id>/*`; the per-instance
+   ext-authz Service ALLOWs only the matching SA. Fork pairs (ADR-027)
+   get their **own** per-fork SA — distinct from the parent's — so a
+   compromised fork can't impersonate the parent on the harness path;
+   per-fork policies layer narrowly on top, admitting the fork's
+   gateway SA only to `/api/instances/<parent>/mcp` and to the
+   parent's ext-authz Service.
 
 Workspace contents are explicitly outside the trust boundary — see the
 security note on [persistence](persistence.md).
@@ -74,7 +79,7 @@ flowchart LR
 
   api-server -->|write K8s Secrets<br/>platform.ai/owner=sub| gatewaypod
   controller -->|render bootstrap + leaf cert<br/>list owner Secrets| gatewaypod
-  controller -->|render agent + paired gateway<br/>+ AuthorizationPolicies<br/>+ per-pair agent egress NetworkPolicy| agentpod
+  controller -->|render agent + paired gateway<br/>+ per-pair agent egress NetworkPolicy<br/>+ harness/ext-authz AuthorizationPolicies| agentpod
 
   agent-runtime -->|HTTPS_PROXY=&lt;instance&gt;-gateway| envoy
   envoy -->|ext_authz Check| api-server
@@ -85,17 +90,23 @@ The credential boundary is the pod: K8s Secrets are mounted into the
 gateway pod only, and the agent pod has no admitted route to TCP 80/443
 other than its paired gateway. Enforcement is layered:
 
-- **Mesh AuthorizationPolicy** (ADR-041) gates *ingress* on the gateway
-  pod by SA principal, so another instance's agent cannot reach this
-  gateway even if the pod IP is known.
 - **Per-pair agent egress NetworkPolicy** (controller-rendered,
-  `<id>-agent-egress`) restricts the agent pod's *egress* at the kernel
-  layer to DNS, its paired gateway pod, and the ambient HBONE port.
-  Without this, an agent process can ignore `HTTPS_PROXY` and dial
-  external hosts directly, escaping Envoy's MITM, credential
-  injection, and ext-authz HITL gates. The NetworkPolicy selects on
-  `pair=<id>, role=agent`, so the gateway pod's own egress (which
-  legitimately dials credentialed upstreams) stays unrestricted.
+  `<id>-agent-egress`) is the sole gate on the agent → paired gateway
+  hop ([ADR-042](../adrs/042-agent-egress-network-policy.md)). The
+  agent pod opts out of ambient mesh, so the kernel sees real
+  destination IPs rather than HBONE tunnelled to ztunnel; the policy
+  admits exactly DNS and the paired gateway pod's Envoy port. HBONE
+  15008 is not admitted — the agent never speaks it.
+- **Gateway Envoy ext_authz** (ADR-035) gates everything the gateway
+  forwards on behalf of the agent — external upstreams via the HITL
+  rule model, and the harness path is special-cased to pass through.
+  This is the destination-side egress gate; no NetworkPolicies on
+  Postgres / Redis / Keycloak / the harness or ext-authz Services are
+  needed because the agent has no admitted route to any of them.
+- **Mesh AuthorizationPolicy** (ADR-041) gates the gateway-originated
+  hops by the gateway pod's SPIFFE principal: harness via the
+  api-server's waypoint, ext-authz on the per-instance Service. The
+  agent has no SPIFFE identity in this model.
 
 The agent pod has no service account token
 (`automountServiceAccountToken: false`), and there is no co-located
@@ -220,32 +231,40 @@ own pair key (`agent-platform.ai/pair`) isolates it from the parent
 instance's pair. See [ADR-027](../adrs/027-slack-user-impersonation.md)
 and [ADR-038](../adrs/038-paired-gateway-pod.md).
 
-## Mesh identity (ADR-041)
+## Intra-cluster identity and admission
 
-Per-instance pair isolation, harness-port admission, and ext-authz
-caller identification all flow through the same SPIFFE primitive:
+The agent and the gateway are gated by different mechanisms — they live
+on opposite sides of the credential boundary, so the threat models
+differ:
 
 - **Per-instance ServiceAccount** in the agent namespace, name ==
-  instance ID. Both pods of the long-lived pair run as this SA. Fork
-  pairs (ADR-027) get their **own** per-fork SA — distinct from the
-  parent's — paired with narrow per-fork AuthorizationPolicies, so a
-  compromised fork cannot reach the parent's full
+  instance ID. Both pods of the long-lived pair run as this SA, but
+  only the *gateway* pod is a mesh participant — istiod stamps it with
+  a SPIFFE workload cert. The agent pod opts out of ambient
+  (`istio.io/dataplane-mode: none`) and carries no SPIFFE identity.
+  Fork pairs (ADR-027) get their **own** per-fork SA — distinct from
+  the parent's — paired with narrow per-fork AuthorizationPolicies, so
+  a compromised fork cannot reach the parent's full
   `/api/instances/<parent>/*` surface. `automountServiceAccountToken`
-  stays false; istiod issues the workload cert independent of SA-token
-  mounts.
-- **Agent → gateway** (CONNECT proxy port) is admitted by an
-  AuthorizationPolicy keyed on the SA the pair runs as. Both pods
-  share the SA so the rule is "self-talk only". Replaces ADR-038's
-  pair-key NetworkPolicy.
+  stays false on both pods; the gateway's SPIFFE cert is independent
+  of SA-token mounts.
+- **Agent → paired gateway** is gated at the kernel by the per-pair
+  `<id>-agent-egress` NetworkPolicy. Two egress rules: DNS to
+  `kube-system`, and the paired gateway pod (`pair=<id>, role=gateway`)
+  on the Envoy proxy port. HBONE 15008 is not admitted; the agent has
+  no ztunnel and never speaks HBONE. Pair pinning is structural — the
+  policy's pod-selector is the gateway pod itself, so a compromised
+  agent has no admitted IP-and-port combination to reach anything
+  else in the cluster.
 - **Gateway → api-server harness.** All agent egress (including the
   harness call) flows through the paired gateway pod's Envoy, so what
-  reaches the mesh is gateway → harness.
-  The harness Service is `<rel>-apiserver-harness`, carrying
-  `istio.io/use-waypoint`; Istio synthesises a waypoint Gateway pod
-  in front of it. A per-instance AuthorizationPolicy on the waypoint
-  ALLOWs the SA principal to `/api/instances/<id>/*`; handlers can
-  treat URL `:id` as authenticated. For forks, an additional per-fork
-  policy admits the fork SA only to `/api/instances/<parent>/mcp` —
+  reaches the mesh is gateway → harness. The harness Service is
+  `<rel>-apiserver-harness`, carrying `istio.io/use-waypoint`; Istio
+  synthesises a waypoint Gateway pod in front of it. A per-instance
+  AuthorizationPolicy on the waypoint ALLOWs the gateway's SA
+  principal to `/api/instances/<id>/*`; handlers can treat URL `:id`
+  as authenticated. For forks, an additional per-fork policy admits
+  the fork *gateway*'s SA only to `/api/instances/<parent>/mcp` —
   pod-files SSE and `/internal/trigger` stay parent-only.
 - **Gateway → api-server ext-authz** routes through a per-instance
   Service `<rel>-extauthz-<id>` rendered by the controller alongside
@@ -255,19 +274,14 @@ caller identification all flow through the same SPIFFE primitive:
   the gate). The destination Service is cryptographically pinned to
   the calling instance; the api-server derives instance ID from the
   gRPC `:authority`.
-- **Pod-level DENY AuthorizationPolicy** on the api-server pod
-  rejects anything that isn't either the waypoint's SA (harness) or a
+- **Pod-level DENY AuthorizationPolicy** on the api-server pod rejects
+  anything that isn't either the waypoint's SA (harness) or a
   per-instance SA from the agent namespace (ext-authz), closing the
   direct pod-IP bypass.
 
-NetworkPolicy retracts to coarse perimeter only — cluster-edge ingress
-and a per-pair *agent egress* policy (`<id>-agent-egress`, controller-
-rendered alongside the gateway-admission AuthorizationPolicy) that
-locks the agent pod's L3/L4 egress to its paired gateway plus DNS and
-ambient HBONE. The pair-pinning here is structural defence-in-depth on
-top of mesh AuthorizationPolicy: the AuthorizationPolicy on each
-gateway pod still cryptographically denies traffic from a non-matching
-SA, but the NetworkPolicy is what keeps the agent process from
-side-stepping `HTTPS_PROXY` and reaching external hosts that the mesh
-doesn't see. The fine-grained pair-key *ingress* policies from
-ADR-038 are gone — Istio AuthorizationPolicy owns that boundary now.
+NetworkPolicy is the security boundary for the agent's egress; mesh
+AuthorizationPolicy is the security boundary for the gateway's egress
+to api-server endpoints. Each pod's gate matches its threat model:
+the agent runs untrusted code and is held at the kernel layer; the
+gateway is platform-controlled and its identity flows through the
+mesh.

--- a/packages/controller/pkg/reconciler/authorization_policy.go
+++ b/packages/controller/pkg/reconciler/authorization_policy.go
@@ -14,29 +14,29 @@ import (
 	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
 
-// ADR-041: per-instance Istio AuthorizationPolicies. The controller writes
-// three per instance:
+// Per-instance Istio AuthorizationPolicies. The controller writes two per
+// instance, both in the release namespace:
 //
-//   1. `<id>-gateway-allow`        — admission to the gateway Service (CONNECT
-//                                    proxy port, agent namespace). ALLOW
-//                                    principal `<td>/ns/<ns>/sa/<id>`.
-//   2. `<id>-harness-allow`        — admission via the api-server's waypoint
+//   1. `<id>-harness-allow`        — admission via the api-server's waypoint
 //                                    Gateway to path `/api/instances/<id>/*`.
-//   3. `<id>-extauthz-allow`       — admission to the per-instance ext-authz
+//   2. `<id>-extauthz-allow`       — admission to the per-instance ext-authz
 //                                    Service. ALLOW principal — same SA.
 //
-// All three pin the principal to the instance's SA. App handlers can treat
-// URL `:id` (harness) or gRPC `:authority` (ext-authz) as already
-// authenticated by the time the request reaches them.
+// Both pin the principal to the instance's SA — but the principal here is
+// the *gateway pod*'s SPIFFE identity. The agent pod is not a mesh
+// participant (no SPIFFE), so all in-cluster identity work happens on the
+// gateway → api-server hops. App handlers can treat URL `:id` (harness) or
+// gRPC `:authority` (ext-authz) as already authenticated by the time the
+// request reaches them. The agent → gateway hop is gated by the per-pair
+// `<id>-agent-egress` NetworkPolicy at the kernel layer, not by mesh AuthZ
+// — see network_policy.go.
 //
 // Forks (ADR-027) get their **own** per-fork SA — distinct from the parent —
 // paired with two release-namespace policies that scope the fork narrowly
 // to the parent's surface: `BuildForkHarnessAuthorizationPolicy` admits the
 // fork SA only to `/api/instances/<parent>/mcp`, and
 // `BuildForkExtAuthzAuthorizationPolicy` admits it to the parent's
-// per-instance ext-authz Service. The fork's gateway-admission policy
-// uses `BuildGatewayAuthorizationPolicy(forkName, forkName, ...)` —
-// "self-talk only" within the fork pair, same shape as long-lived pairs.
+// per-instance ext-authz Service.
 
 const (
 	istioGroup    = "security.istio.io"
@@ -100,48 +100,6 @@ func ownerRefAsMap(r *metav1.OwnerReference) map[string]interface{} {
 		m["blockOwnerDeletion"] = *r.BlockOwnerDeletion
 	}
 	return m
-}
-
-// BuildGatewayAuthorizationPolicy admits traffic to the per-instance gateway
-// Service from the matching SA principal only. Selector matches gateway pods
-// of this pair (so the policy doesn't accidentally apply to anything else
-// with the same Service name in the same ns).
-//
-// `pairKey` is the pair identifier (instance name for long-lived pairs,
-// fork name for fork pairs). `principalInstanceID` is the instance ID
-// whose SA is allowed — for both long-lived and fork pairs this equals
-// `pairKey` since each pair runs as the SA named after its own pairKey
-// ("self-talk only"). The two-parameter shape is preserved so callers
-// can still admit a *different* SA on a pair Service if a future use
-// case ever needs it.
-func BuildGatewayAuthorizationPolicy(pairKey, principalInstanceID string, cfg *config.Config, ownerCM *corev1.ConfigMap) *unstructured.Unstructured {
-	spec := map[string]interface{}{
-		"selector": map[string]interface{}{
-			"matchLabels": map[string]interface{}{
-				LabelPair: pairKey,
-				LabelRole: RoleGateway,
-			},
-		},
-		"action": "ALLOW",
-		"rules": []interface{}{
-			map[string]interface{}{
-				"from": []interface{}{
-					map[string]interface{}{
-						"source": map[string]interface{}{
-							"principals": []interface{}{cfg.PrincipalFor(principalInstanceID)},
-						},
-					},
-				},
-			},
-		},
-	}
-	labels := map[string]string{
-		LabelInstance:                  principalInstanceID,
-		LabelPair:                      pairKey,
-		LabelRole:                      RoleGateway,
-		"agent-platform.ai/managed-by": "platform-controller",
-	}
-	return authzPolicy(pairKey+"-gateway-allow", cfg.Namespace, ownerCM, labels, spec)
 }
 
 // BuildHarnessAuthorizationPolicy admits traffic via the api-server's

--- a/packages/controller/pkg/reconciler/authorization_policy_test.go
+++ b/packages/controller/pkg/reconciler/authorization_policy_test.go
@@ -7,57 +7,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// ADR-041: gateway-admission policy targets the gateway pods of this pair
-// (selector matches LabelPair + LabelRole=gateway) and ALLOWs only the
-// matching SA principal. For long-lived pairs pairKey == principalInstanceID;
-// for forks pairKey == fork name and principalInstanceID == parent instance.
-func TestBuildGatewayAuthorizationPolicy_LongLivedPair(t *testing.T) {
-	p := BuildGatewayAuthorizationPolicy("my-instance", "my-instance", testConfig, testOwnerCM)
-
-	assert.Equal(t, "my-instance-gateway-allow", p.GetName())
-	assert.Equal(t, testConfig.Namespace, p.GetNamespace())
-
-	spec, _ := p.Object["spec"].(map[string]interface{})
-	require.NotNil(t, spec)
-	assert.Equal(t, "ALLOW", spec["action"])
-
-	selector, _ := spec["selector"].(map[string]interface{})
-	matchLabels, _ := selector["matchLabels"].(map[string]interface{})
-	assert.Equal(t, "my-instance", matchLabels[LabelPair])
-	assert.Equal(t, RoleGateway, matchLabels[LabelRole])
-
-	rules, _ := spec["rules"].([]interface{})
-	require.Len(t, rules, 1)
-	rule0, _ := rules[0].(map[string]interface{})
-	from, _ := rule0["from"].([]interface{})
-	source, _ := from[0].(map[string]interface{})["source"].(map[string]interface{})
-	principals, _ := source["principals"].([]interface{})
-	require.Len(t, principals, 1)
-	assert.Equal(t, testConfig.PrincipalFor("my-instance"), principals[0])
-}
-
-// ADR-041 + ADR-027: forks now have their OWN SA, not the parent's.
-// The fork's gateway-admission policy admits only the fork's principal —
-// "self-talk only" within the fork pair — same shape as long-lived pairs.
-// This narrows fork access to the per-fork harness and ext-authz policies
-// rendered separately (see TestBuildForkHarnessAuthorizationPolicy_*).
-func TestBuildGatewayAuthorizationPolicy_ForkUsesForkPrincipal(t *testing.T) {
-	p := BuildGatewayAuthorizationPolicy("fork-abc", "fork-abc", testConfig, testOwnerCM)
-	spec, _ := p.Object["spec"].(map[string]interface{})
-
-	selector, _ := spec["selector"].(map[string]interface{})
-	matchLabels, _ := selector["matchLabels"].(map[string]interface{})
-	assert.Equal(t, "fork-abc", matchLabels[LabelPair], "selector targets the fork's pair")
-
-	rules, _ := spec["rules"].([]interface{})
-	rule0, _ := rules[0].(map[string]interface{})
-	from, _ := rule0["from"].([]interface{})
-	source, _ := from[0].(map[string]interface{})["source"].(map[string]interface{})
-	principals, _ := source["principals"].([]interface{})
-	assert.Equal(t, testConfig.PrincipalFor("fork-abc"), principals[0],
-		"fork pair admits the fork's OWN SA principal, not the parent's")
-}
-
 // ADR-041 + ADR-027: per-fork harness policy admits the fork SA only to
 // `/api/instances/<parent>/mcp` — NOT the parent's full
 // `/api/instances/<parent>/*` surface. This is the credential boundary

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -121,17 +121,12 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, err.Error())
 	}
 
-	// ADR-041: gateway admission — both pods of the fork pair share the
-	// fork SA so this is "self-talk only" (same shape as long-lived pairs).
-	if err := r.applyAuthorizationPolicy(ctx, BuildGatewayAuthorizationPolicy(forkName, forkName, r.config, cm)); err != nil {
-		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying fork gateway authz policy: %v", err))
-	}
-
-	// ADR-041 + ADR-027: per-fork harness policy admits the fork SA only
-	// to `/api/instances/<parent>/mcp` (not the parent's full surface),
-	// and the per-fork ext-authz policy admits the fork SA to the
-	// parent's per-instance ext-authz Service so the parent owner's
-	// HITL rules continue to gate the fork's egress.
+	// ADR-027: per-fork harness policy admits the fork SA only to
+	// `/api/instances/<parent>/mcp` (not the parent's full surface), and
+	// the per-fork ext-authz policy admits the fork SA to the parent's
+	// per-instance ext-authz Service so the parent owner's HITL rules
+	// continue to gate the fork's egress. Both gate the fork *gateway*'s
+	// SPIFFE identity — the fork agent itself is not a mesh participant.
 	if err := r.applyAuthorizationPolicy(ctx, BuildForkHarnessAuthorizationPolicy(forkName, forkSpec.Instance, r.config, cm)); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying fork harness authz policy: %v", err))
 	}
@@ -139,9 +134,9 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying fork ext-authz authz policy: %v", err))
 	}
 
-	// ADR-041: per-pair agent egress NetworkPolicy (same rationale as the
-	// long-lived shape — kernel-level perimeter so the agent process
-	// cannot bypass HTTPS_PROXY).
+	// Per-pair agent egress NetworkPolicy — same shape and rationale as
+	// the long-lived pair: kernel-level boundary gating the agent → fork
+	// gateway hop, agent has no ambient enrolment.
 	if err := r.applyAgentEgressNetworkPolicy(ctx, BuildAgentEgressNetworkPolicy(forkName, r.config, cm)); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, err.Error())
 	}
@@ -195,9 +190,9 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 }
 
 func (r *ForkReconciler) Delete(ctx context.Context, name string) {
-	// Agent-namespace resources (ServiceAccount, gateway-allow policy,
-	// gateway Pod, agent Job, gateway Service, Envoy bootstrap CM, leaf
-	// Cert) are owner-refed to the fork ConfigMap and reaped by K8s GC.
+	// Agent-namespace resources (ServiceAccount, gateway Pod, agent Job,
+	// gateway Service, agent-egress NetworkPolicy, Envoy bootstrap CM,
+	// leaf Cert) are owner-refed to the fork ConfigMap and reaped by K8s GC.
 	//
 	// Release-namespace per-fork policies (harness-allow, ext-authz-allow)
 	// cannot use a cross-namespace ownerRef — same trap as the per-instance

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -76,6 +76,15 @@ func BuildForkAgentJob(
 		LabelPair: forkName,
 		LabelRole: RoleAgent,
 	}
+	// Fork agent opts out of ambient mesh, mirroring the long-lived agent
+	// shape. NetworkPolicy at the kernel is the boundary; the fork gateway
+	// pod remains a mesh participant for SPIFFE-keyed harness + ext-authz
+	// admission via the per-fork AuthorizationPolicies (ADR-041, ADR-027).
+	podLabels := map[string]string{}
+	for k, v := range labels {
+		podLabels[k] = v
+	}
+	podLabels["istio.io/dataplane-mode"] = "none"
 
 	caCertPath := "/etc/platform/ca/ca.crt"
 
@@ -252,18 +261,18 @@ func BuildForkAgentJob(
 	ttl := int32(60)
 	backoff := int32(0)
 
-	podMeta := metav1.ObjectMeta{Labels: labels}
+	podMeta := metav1.ObjectMeta{Labels: podLabels}
 	applyAgentBaseMeta(&podMeta, base)
 
 	podSpec := corev1.PodSpec{
-		// ADR-041 + ADR-027: fork agent runs as the per-fork SA
-		// (its own identity, NOT the parent's). The per-fork
-		// harness AuthorizationPolicy admits this SA only to
-		// `/api/instances/<parent>/mcp` — narrower than the
-		// parent's surface, so a compromised fork (i.e. a
-		// compromised replier) cannot reach pod-files SSE,
-		// `/internal/trigger`, or any other parent-scoped
-		// harness endpoint.
+		// Fork agent opts out of ambient (no SPIFFE on the agent
+		// half). ADR-027: the per-fork SA still scopes credential
+		// reads at the controller level — fork's gateway pod mounts
+		// the replier's Secrets, never the parent's. Harness identity
+		// flows through the fork *gateway*'s SPIFFE principal
+		// (gateway is still in mesh), not the agent's; the per-fork
+		// harness AuthorizationPolicy admits the fork SA only to
+		// `/api/instances/<parent>/mcp`.
 		ServiceAccountName:            forkName,
 		RestartPolicy:                 corev1.RestartPolicyNever,
 		TerminationGracePeriodSeconds: &base.TerminationGracePeriod,

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -47,6 +47,10 @@ func TestBuildForkAgentJob_BasicShape(t *testing.T) {
 	assert.Equal(t, "my-instance", job.Labels["agent-platform.ai/instance"])
 	assert.Equal(t, "fork-abc", job.Labels["agent-platform.ai/pair"])
 	assert.Equal(t, "agent", job.Labels["agent-platform.ai/role"])
+	// Fork agent pod opts out of ambient — same rationale as the long-lived
+	// agent (kernel NP is the egress boundary).
+	assert.Equal(t, "none", job.Spec.Template.Labels["istio.io/dataplane-mode"],
+		"fork agent pod must carry istio.io/dataplane-mode=none")
 
 	require.Len(t, job.OwnerReferences, 1)
 	assert.Equal(t, "fork-uid-123", string(job.OwnerReferences[0].UID))

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -65,10 +65,14 @@ func BuildGatewayStatefulSet(instanceName string, hibernated bool, cfg *config.C
 	}
 
 	podSpec := corev1.PodSpec{
-		// ADR-041: gateway pod runs as the per-instance SA so
-		// its SPIFFE workload identity matches the agent half
-		// of the pair (same SA on both pods). The gateway-side
-		// AuthorizationPolicy ALLOWs only this principal.
+		// Gateway pod runs as the per-instance SA so that its SPIFFE
+		// workload identity is `<td>/ns/<ns>/sa/<id>`. The agent half
+		// of the pair has no SPIFFE (it opts out of ambient — see
+		// resources.go), so the SA is effectively "the gateway's
+		// identity"; the harness + ext-authz AuthorizationPolicies
+		// admit this principal at the api-server end of the gateway →
+		// api-server hops. The agent → gateway hop is gated at the
+		// kernel by the per-pair NetworkPolicy.
 		ServiceAccountName:            instanceName,
 		TerminationGracePeriodSeconds: &gracePeriod,
 		AutomountServiceAccountToken:  &falseVal,
@@ -178,12 +182,13 @@ func BuildForkGatewayPod(forkName, parentInstanceID string, cfg *config.Config, 
 			},
 		},
 		Spec: corev1.PodSpec{
-			// ADR-041 + ADR-027: fork gateway pod runs as the per-fork SA
-			// (its own identity, NOT the parent's). The per-fork
-			// gateway-admission AuthorizationPolicy ALLOWs only this SA
-			// (both pods of the fork pair share it), and per-fork
-			// harness + ext-authz policies admit it to a narrow surface
-			// scoped to the parent.
+			// ADR-027: fork gateway pod runs as the per-fork SA (its own
+			// identity, NOT the parent's). The fork *agent* opts out of
+			// ambient (no SPIFFE on that pod), so this gateway SA is the
+			// SPIFFE principal both per-fork harness and per-fork
+			// ext-authz AuthorizationPolicies admit — narrowly scoped to
+			// the parent's surface (`/api/instances/<parent>/mcp` + the
+			// parent's per-instance ext-authz Service).
 			ServiceAccountName:            forkName,
 			RestartPolicy:                 corev1.RestartPolicyAlways,
 			TerminationGracePeriodSeconds: &gracePeriod,

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -108,12 +108,11 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		return r.setError(ctx, name, fmt.Sprintf("applying ext-authz service: %v", err))
 	}
 
-	// ADR-041: three per-instance AuthorizationPolicies — gateway admission
-	// (agent ns), harness path-prefix at the waypoint (release ns),
-	// ext-authz Service principal (release ns).
-	if err := r.applyAuthorizationPolicy(ctx, BuildGatewayAuthorizationPolicy(name, name, r.config, cm)); err != nil {
-		return r.setError(ctx, name, fmt.Sprintf("applying gateway authz policy: %v", err))
-	}
+	// Two per-instance AuthorizationPolicies in the release namespace —
+	// harness path-prefix at the waypoint, ext-authz Service principal.
+	// Both gate the *gateway pod*'s SPIFFE identity (the only pod of the
+	// pair that's a mesh participant). The agent → gateway hop is gated
+	// by the agent-egress NetworkPolicy below, not by mesh AuthZ.
 	if err := r.applyAuthorizationPolicy(ctx, BuildHarnessAuthorizationPolicy(name, r.config, cm)); err != nil {
 		return r.setError(ctx, name, fmt.Sprintf("applying harness authz policy: %v", err))
 	}
@@ -121,10 +120,11 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		return r.setError(ctx, name, fmt.Sprintf("applying ext-authz authz policy: %v", err))
 	}
 
-	// ADR-041: per-pair agent egress NetworkPolicy. AuthorizationPolicy on
-	// the gateway only gates ingress; without an egress NP the agent
-	// process can bypass HTTPS_PROXY and dial external hosts directly,
-	// escaping Envoy's credential and HITL gates.
+	// Per-pair agent egress NetworkPolicy. Agent pods opt out of ambient
+	// mesh, so kernel NP is the only thing gating agent egress; it admits
+	// DNS and the paired gateway pod's Envoy port, nothing else. The
+	// gateway's Envoy ext_authz filter (ADR-035) gates which destinations
+	// the agent's HTTPS_PROXY traffic reaches past the gateway.
 	if err := r.applyAgentEgressNetworkPolicy(ctx, BuildAgentEgressNetworkPolicy(name, r.config, cm)); err != nil {
 		return r.setError(ctx, name, err.Error())
 	}
@@ -212,14 +212,13 @@ func (r *InstanceReconciler) ensureAgentOwnerReference(ctx context.Context, inst
 func (r *InstanceReconciler) Delete(ctx context.Context, name string) {
 	// Owner references in the agent namespace cascade-delete agent +
 	// gateway StatefulSets, the agent + gateway Services, the per-instance
-	// ServiceAccount, the gateway-admission AuthorizationPolicy, the
-	// Envoy bootstrap ConfigMap, and the cert-manager Certificate / leaf
-	// Secret.
+	// ServiceAccount, the per-pair agent egress NetworkPolicy, the Envoy
+	// bootstrap ConfigMap, and the cert-manager Certificate / leaf Secret.
 	//
-	// ADR-041 release-namespace resources (per-instance ext-authz
-	// Service, harness + ext-authz AuthorizationPolicies) cannot use a
-	// cross-namespace ownerRef — K8s assumes same-namespace ownerRefs and
-	// the GC controller reaps them as orphans. Clean up explicitly.
+	// Release-namespace resources (per-instance ext-authz Service, harness
+	// + ext-authz AuthorizationPolicies) cannot use a cross-namespace
+	// ownerRef — K8s assumes same-namespace ownerRefs and the GC controller
+	// reaps them as orphans. Clean up explicitly.
 	r.deleteReleaseNsInstanceResources(ctx, name)
 
 	// PVCs created via VolumeClaimTemplates on the agent StatefulSet are

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -128,34 +128,35 @@ func TestReconcile_CreateResources(t *testing.T) {
 	require.NoError(t, err, "gateway Service must be created so HTTPS_PROXY DNS resolves")
 	assert.Equal(t, corev1.ClusterIPNone, gwSvc.Spec.ClusterIP)
 
-	// ADR-041: pair-key NetworkPolicies are gone — pair isolation is now
-	// enforced by per-instance Istio AuthorizationPolicies. Coverage for
-	// the new resources lives in service_account_test.go (per-instance SA)
-	// and authorization_policy_test.go.
-
-	// Per-instance ServiceAccount (ADR-041)
+	// Per-instance ServiceAccount — kept off-pod via
+	// automountServiceAccountToken: false. The agent pod has no SPIFFE
+	// identity (ambient opt-out), but the SA still scopes Secret access
+	// at the controller level.
 	sa, err := client.CoreV1().ServiceAccounts("test-agents").Get(ctx, "my-instance", metav1.GetOptions{})
 	require.NoError(t, err, "per-instance ServiceAccount must be created")
 	require.NotNil(t, sa.AutomountServiceAccountToken)
 	assert.False(t, *sa.AutomountServiceAccountToken)
 
-	// Per-instance ext-authz Service in the release namespace (ADR-041)
+	// Per-instance ext-authz Service in the release namespace.
 	_, err = client.CoreV1().Services("default").Get(ctx, "platform-extauthz-my-instance", metav1.GetOptions{})
 	require.NoError(t, err, "per-instance ext-authz Service must be created")
 
-	// ADR-041: per-pair agent egress NetworkPolicy. AuthorizationPolicy
-	// only gates ingress; this closes the symmetric egress hole at the
-	// kernel layer so an agent can't bypass HTTPS_PROXY.
+	// Per-pair agent egress NetworkPolicy — the sole gate on the agent →
+	// paired gateway hop. Agent has no ambient enrolment, so NP sees real
+	// destination IPs and denies anything that isn't DNS or the paired
+	// gateway pod on the Envoy port.
 	np, err := client.NetworkingV1().NetworkPolicies("test-agents").Get(ctx, "my-instance-agent-egress", metav1.GetOptions{})
 	require.NoError(t, err, "per-pair agent egress NetworkPolicy must be created")
 	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels["agent-platform.ai/pair"])
 	assert.Equal(t, "agent", np.Spec.PodSelector.MatchLabels["agent-platform.ai/role"])
 
-	// Pod specs use the per-instance SA (ADR-041)
+	// Pod specs use the per-instance SA. On the gateway, this materialises
+	// as a SPIFFE workload identity used by the harness + ext-authz
+	// AuthorizationPolicies.
 	assert.Equal(t, "my-instance", ss.Spec.Template.Spec.ServiceAccountName,
-		"agent pod must run as the per-instance SA so SPIFFE peer principal == URL :id")
+		"agent pod must run as the per-instance SA")
 	assert.Equal(t, "my-instance", gws.Spec.Template.Spec.ServiceAccountName,
-		"gateway pod must run as the per-instance SA")
+		"gateway pod must run as the per-instance SA (its SPIFFE principal gates harness + ext-authz)")
 
 	// Status written
 	updated, _ := client.CoreV1().ConfigMaps("test-agents").Get(ctx, "my-instance", metav1.GetOptions{})

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -15,33 +15,30 @@ import (
 	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
 
-// Per-pair agent egress NetworkPolicy (ADR-041 "namespace-level egress
-// allowlist" specialised to a single pair).
+// Per-pair agent egress NetworkPolicy.
 //
-// AuthorizationPolicy on the gateway side already pins ingress to the
-// matching SA principal cryptographically — but it is a destination-side
-// gate. Without an egress restriction on the agent pod, the agent process
-// can bypass HTTPS_PROXY and dial external services directly, escaping
-// the Envoy MITM, credential-injection, and ext-authz HITL gates.
-// `kernel-level NetworkPolicy` is what closes that loop: it is identity-
-// blind but enforces at the L3/L4 perimeter regardless of what the agent
-// process does at L7.
+// The agent pod opts out of ambient mesh (`istio.io/dataplane-mode: none`),
+// so no ztunnel iptables redirect intercepts its outbound traffic. Real
+// destination IP/port hit the kernel NetworkPolicy filter, and the agent
+// pod's only admitted intra-cluster destination is its paired gateway pod.
+// All egress that matters — external upstreams, harness, ext-authz — is
+// proxied through the gateway, gated by Envoy's ext_authz filter (ADR-035).
 //
 // Allowed egress:
 //   - DNS to kube-system (TCP/UDP 53) — needed for resolving the gateway
 //     Service hostname.
 //   - The paired gateway pod (`pair=<id>, role=gateway`) on the Envoy
-//     proxy port and HBONE 15008. Per-pair selector pins reachability
-//     to *this* agent's gateway; mesh AuthorizationPolicy still enforces
-//     it cryptographically.
-//   - istio-system on HBONE 15008 — covers ambient-mesh routing where
-//     istio-cni redirects pod egress to ztunnel before NetworkPolicy
-//     enforcement. Without this, in-mesh traffic appears blocked even
-//     though the destination is admitted at the AuthorizationPolicy
-//     layer. (Mirror of the rationale in `migrate-stale-netpols.yaml`.)
+//     proxy port only. The per-pair selector pins reachability to *this*
+//     agent's gateway; the gateway pod itself is the only structural
+//     gate (NP is identity-blind, but L3/L4-pinned to one pod set).
 //
-// Everything else (external internet, other in-cluster Services) is
-// denied at the kernel layer.
+// HBONE port 15008 is deliberately NOT admitted. The agent has no ztunnel
+// and never speaks HBONE; opening 15008 here would just hand the agent a
+// bypass to anything in the mesh.
+//
+// Everything else (external internet, other in-cluster Services like
+// Postgres / Redis / Keycloak, the harness and ext-authz Services
+// directly) is denied at the kernel layer.
 
 // BuildAgentEgressNetworkPolicy renders the per-pair egress NetworkPolicy
 // for the agent pod of `pairKey`. Long-lived pairs use the instance name
@@ -50,7 +47,6 @@ import (
 // unrestricted (it dials external upstreams for credential injection).
 func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	envoyPort := intstr.FromInt(cfg.EnvoyPort)
-	hbonePort := intstr.FromInt(15008)
 	dnsPort := intstr.FromInt(53)
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
@@ -106,17 +102,6 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 					}},
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Protocol: &tcp, Port: &envoyPort},
-						{Protocol: &tcp, Port: &hbonePort},
-					},
-				},
-				{
-					To: []networkingv1.NetworkPolicyPeer{{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "istio-system"},
-						},
-					}},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &tcp, Port: &hbonePort},
 					},
 				},
 			},

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -9,10 +9,11 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// ADR-041: per-pair agent egress NetworkPolicy closes the kernel-level
-// perimeter that mesh AuthorizationPolicy can't (AuthorizationPolicy is
-// destination-side ingress; without an egress NP the agent process can
-// bypass HTTPS_PROXY and dial external hosts directly).
+// Agent pod opts out of ambient mesh, so kernel NetworkPolicy is the sole
+// gate on agent egress. The policy admits exactly DNS + paired gateway
+// pod on the Envoy proxy port — nothing else. HBONE port 15008 is
+// deliberately denied: the agent has no ztunnel and admitting 15008 would
+// give it a route to anything in the mesh.
 func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
 
@@ -23,16 +24,14 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 
 	// Selector pins to THIS pair's agent pod — the gateway pod's egress
 	// stays unrestricted (it dials external upstreams for credential
-	// injection).
+	// injection, gated by ext_authz inside its own Envoy).
 	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels[LabelPair])
 	assert.Equal(t, RoleAgent, np.Spec.PodSelector.MatchLabels[LabelRole])
 
-	// Egress only — ingress is governed by mesh AuthorizationPolicy on
-	// other workloads.
 	require.Len(t, np.Spec.PolicyTypes, 1)
 	assert.Equal(t, networkingv1.PolicyTypeEgress, np.Spec.PolicyTypes[0])
 
-	require.Len(t, np.Spec.Egress, 3, "DNS + paired gateway + istio-system HBONE")
+	require.Len(t, np.Spec.Egress, 2, "DNS + paired gateway, nothing else")
 
 	// DNS to kube-system (resolving the gateway Service hostname).
 	dnsRule := np.Spec.Egress[0]
@@ -47,31 +46,16 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	}
 	assert.True(t, protocols[corev1.ProtocolUDP] && protocols[corev1.ProtocolTCP])
 
-	// Paired gateway pod — per-pair selector pins reachability; mesh
-	// AuthorizationPolicy on the gateway side cryptographically enforces
-	// the same boundary on top.
+	// Paired gateway pod — Envoy proxy port only.
 	gwRule := np.Spec.Egress[1]
 	require.Len(t, gwRule.To, 1)
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "my-instance", gwRule.To[0].PodSelector.MatchLabels[LabelPair])
 	assert.Equal(t, RoleGateway, gwRule.To[0].PodSelector.MatchLabels[LabelRole])
-	// Envoy proxy port + HBONE 15008 (ambient redirect lands here when
-	// istio-cni rewrites the destination port).
-	ports := map[int32]bool{}
-	for _, p := range gwRule.Ports {
-		ports[p.Port.IntVal] = true
-	}
-	assert.True(t, ports[int32(testConfig.EnvoyPort)], "must allow Envoy proxy port")
-	assert.True(t, ports[15008], "must allow HBONE — see migrate-stale-netpols.yaml for the prior incident this guards against")
-
-	// istio-system HBONE — covers the path where istio-cni redirects
-	// outbound to ztunnel before NetworkPolicy filter sees it.
-	hboneRule := np.Spec.Egress[2]
-	require.Len(t, hboneRule.To, 1)
-	require.NotNil(t, hboneRule.To[0].NamespaceSelector)
-	assert.Equal(t, "istio-system", hboneRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
-	require.Len(t, hboneRule.Ports, 1)
-	assert.Equal(t, int32(15008), hboneRule.Ports[0].Port.IntVal)
+	require.Len(t, gwRule.Ports, 1, "Envoy proxy port only — HBONE 15008 must NOT be admitted")
+	assert.Equal(t, int32(testConfig.EnvoyPort), gwRule.Ports[0].Port.IntVal)
+	require.NotNil(t, gwRule.Ports[0].Protocol)
+	assert.Equal(t, corev1.ProtocolTCP, *gwRule.Ports[0].Protocol)
 }
 
 // Fork pair: same shape, keyed on the fork name. ADR-027's fork-pair
@@ -92,6 +76,19 @@ func TestBuildAgentEgressNetworkPolicy_Fork(t *testing.T) {
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "fork-abc", gwRule.To[0].PodSelector.MatchLabels[LabelPair],
 		"fork agent NP must scope to the FORK's gateway, not the parent's")
+}
+
+// HBONE port 15008 must NOT appear anywhere in the agent egress policy.
+// The agent has no ztunnel and never speaks HBONE; admitting 15008 here
+// would let the agent reach any in-mesh destination via ztunnel.
+func TestBuildAgentEgressNetworkPolicy_NoHBONE(t *testing.T) {
+	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
+	for i, rule := range np.Spec.Egress {
+		for _, port := range rule.Ports {
+			assert.NotEqual(t, int32(15008), port.Port.IntVal,
+				"egress rule %d must not admit HBONE 15008", i)
+		}
+	}
 }
 
 // Label-managed-by lets operators bulk-list controller-managed NPs and

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -89,6 +89,24 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 		LabelPair:     name,
 		LabelRole:     RoleAgent,
 	}
+	// Agent pods are deliberately NOT mesh participants. In ambient mode,
+	// istio-cni iptables rewrites every outbound to ztunnel:15008 before
+	// the kernel NetworkPolicy filter sees the real destination, so a
+	// destination-pinned NP cannot enforce "agent → paired gateway only" —
+	// it admits any HBONE-bound packet, i.e. any in-mesh destination.
+	// Opting the agent out at the pod level removes the ztunnel redirect;
+	// the per-pair `<id>-agent-egress` NetworkPolicy then sees real
+	// destination IPs and gates them at L3/L4. The agent has no SPIFFE
+	// identity in this model; mesh-keyed AuthorizationPolicy on the gateway
+	// pod is gone (NP is the gate). The paired gateway pod remains a mesh
+	// participant — its SPIFFE principal still gates gateway → harness and
+	// gateway → ext-authz hops (ADR-041 §"Mesh identity").
+	podLabels := map[string]string{}
+	for k, v := range labels {
+		podLabels[k] = v
+	}
+	podLabels["istio.io/dataplane-mode"] = "none"
+
 	caCertPath := "/etc/platform/ca/ca.crt"
 
 	proxyAddr := agentProxyAddr(name, cfg)
@@ -331,16 +349,18 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	shareProcessNS := &falseVal
 
 	podMeta := metav1.ObjectMeta{
-		Labels:      labels,
+		Labels:      podLabels,
 		Annotations: podAnnotations,
 	}
 	applyAgentBaseMeta(&podMeta, base)
 
 	podSpec := corev1.PodSpec{
-		// ADR-041: per-instance SA gives the pod its SPIFFE
-		// workload identity (`<td>/ns/<ns>/sa/<id>`).
-		// AutomountServiceAccountToken stays false — Istio
-		// identity is independent of SA-token mounts.
+		// Agent pod opts out of ambient mesh
+		// (`istio.io/dataplane-mode: none` pod label above); it has no
+		// SPIFFE workload identity. The per-instance SA still scopes
+		// Secret access at the controller level —
+		// `automountServiceAccountToken: false` keeps the SA token
+		// off-pod (ADR-033 threat model).
 		ServiceAccountName:            name,
 		TerminationGracePeriodSeconds: &base.TerminationGracePeriod,
 		ImagePullSecrets:              pullSecrets,

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -100,7 +100,7 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	// identity in this model; mesh-keyed AuthorizationPolicy on the gateway
 	// pod is gone (NP is the gate). The paired gateway pod remains a mesh
 	// participant — its SPIFFE principal still gates gateway → harness and
-	// gateway → ext-authz hops (ADR-041 §"Mesh identity").
+	// gateway → ext-authz hops (ADR-041).
 	podLabels := map[string]string{}
 	for k, v := range labels {
 		podLabels[k] = v

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -98,6 +98,16 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	assert.Equal(t, "my-instance", ss.Spec.Template.Labels["agent-platform.ai/instance"])
 	assert.Equal(t, "my-instance", ss.Spec.Template.Labels["agent-platform.ai/pair"])
 	assert.Equal(t, "agent", ss.Spec.Template.Labels["agent-platform.ai/role"])
+	// Agent pod opts out of ambient mesh — load-bearing for the per-pair
+	// agent-egress NetworkPolicy: with ambient, istio-cni rewrites every
+	// outbound to ztunnel:15008 before the NP filter sees the destination,
+	// so per-destination rules can't gate effectively.
+	assert.Equal(t, "none", ss.Spec.Template.Labels["istio.io/dataplane-mode"],
+		"agent pod must carry istio.io/dataplane-mode=none so NetworkPolicy is the egress boundary")
+	// The StatefulSet's own selector must NOT include the dataplane-mode
+	// label — otherwise removing it later would orphan existing pods.
+	assert.NotContains(t, ss.Spec.Selector.MatchLabels, "istio.io/dataplane-mode",
+		"selector must remain minimal so ambient enrolment can be flipped without selector churn")
 
 	require.Len(t, ss.Spec.Template.Spec.Containers, 1, "agent only — gateway runs in its own paired pod (ADR-038)")
 	c := ss.Spec.Template.Spec.Containers[0]


### PR DESCRIPTION
## Summary

Closes the rogue-agent lateral-movement path into in-cluster Services
(Postgres, Redis, Keycloak, the harness/ext-authz ports of the api-server,
another instance's gateway).

- **Agent pod opts out of ambient mesh** (`istio.io/dataplane-mode: none`).
  No ztunnel redirect — the kernel NetworkPolicy filter sees real
  destination IPs rather than HBONE tunnelled to `ztunnel:15008`.
- **Per-pair `<id>-agent-egress` NetworkPolicy** is tightened to two
  rules: DNS to `kube-system` and the paired gateway pod on the Envoy
  proxy port. HBONE 15008 is no longer admitted from the agent — the
  agent has no ztunnel and never speaks HBONE.
- **`<id>-gateway-allow` AuthorizationPolicy is retired.** The agent has
  no SPIFFE principal in this model; the gateway pod has no ALLOW
  attached, so ambient's default-allow lets plaintext from the non-mesh
  agent through to Envoy. NetworkPolicy is the sole gate on
  agent → gateway.
- **Gateway pod stays in ambient.** Its SPIFFE principal still gates the
  gateway → harness and gateway → ext-authz hops via the existing
  per-instance `harness-allow` and `ext-authz-allow` policies.
- **Envoy `ext_authz` is the destination-side gate** for everything the
  agent tunnels through the proxy. Host-by-host rule lookup — even a
  permissive ext_authz preset doesn't open lateral paths because
  Postgres / Redis / Keycloak aren't in any rule set; the SNI
  fast-denies and the upstream cluster is never resolved.

Decision recorded in [ADR-042](docs/adrs/042-agent-egress-network-policy.md);
architecture page refreshed.

`migrate-stale-netpols` pre-upgrade hook:
- Tightens the NP sweep to pre-ADR-041 NPs only (selector now requires
  `agent-platform.ai/pair` AND `!agent-platform.ai/managed-by`) so it
  stops at the controller-managed new-shape `<id>-agent-egress`.
- Adds a sweep for stale `<id>-gateway-allow` AuthorizationPolicies left
  over from earlier rollouts.
- Adds `authorizationpolicies` to the migration Role's verbs.

## Test plan

- [x] `mise run check` — lint, type-check, helm lint, kubeconform
- [x] `mise run test` — controller Go tests + TypeScript suites
- [x] `mise run cluster:install` on a fresh lima k3s — agent + gateway
      come up clean
- [x] **Lateral-movement probes (denied):**
  - `agent → postgres pod IP / Service DNS / 5432`: refused at <1ms
  - `agent → redis pod IP / 6379`: refused at <1ms
  - `agent → keycloak pod IP / 8080`: refused at <1ms
  - `agent → gateway HBONE 15008`: refused at <1ms
  - `agent → api-server HBONE 15008`: refused at <1ms
- [x] **Happy path (admitted):**
  - `agent → paired gateway pod:envoy_port`: TCP connect established
  - `agent → api.anthropic.com` via `HTTPS_PROXY`: end-to-end success
- [x] **Proxy-path attack (denied):**
  - `agent → CONNECT platform-postgres.default.svc.cluster.local:5432`
    via `HTTPS_PROXY`: gateway returns `200 OK` for the tunnel, but the
    TLS Client Hello hits `ext_authz` which fast-denies on SNI mismatch
    (~2ms). `pg_stat_activity` after 5 probe attempts confirms zero
    incoming connections from the gateway pod IP.
- [x] **Looser-preset agent**: same probes against a second instance
      with the trusted-host preset + Anthropic credential mounted —
      postgres remains unreachable; ext_authz still denies per-host.
- [x] **Cluster state**: zero `<id>-gateway-allow` AuthorizationPolicies
      in `platform-agents`; only `<id>-harness-allow` and
      `<id>-extauthz-allow` in the release namespace.