### PR TITLE
fix(security): admit agent-egress DNS port-only across k8s distros

### DIFF
--- a/docs/adrs/042-agent-egress-network-policy.md
+++ b/docs/adrs/042-agent-egress-network-policy.md
@@ -42,9 +42,12 @@ job it was designed for.
   has no SPIFFE workload identity; its outbound packets show the real
   destination to NetworkPolicy.
 - **Per-pair `<id>-agent-egress` NetworkPolicy.** Two egress rules:
-  DNS to `kube-system` and the paired gateway pod (`pair=<id>,
-  role=gateway`) on the Envoy proxy port. HBONE 15008 is not admitted;
-  the agent never speaks it.
+  DNS on TCP/UDP 53 (port-only, no namespace selector — cluster DNS
+  lives in `kube-system` on upstream k8s and `openshift-dns` on
+  OpenShift, and the agent can only generate DNS-shaped traffic on
+  53 regardless of which pod backs the resolver Service), and the
+  paired gateway pod (`pair=<id>, role=gateway`) on the Envoy proxy
+  port. HBONE 15008 is not admitted; the agent never speaks it.
 - **Gateway pod stays in ambient.** Its SPIFFE principal continues to
   gate the gateway → harness and gateway → ext-authz hops via the
   existing per-instance harness-allow and ext-authz-allow
@@ -103,10 +106,10 @@ instead of the rule model.
   not yet converged. The agent's egress shape does not depend on any
   of them.
 - DNS tunneling via CoreDNS's upstream forwarder remains a residual,
-  low-bandwidth exfil channel. The NetworkPolicy must admit DNS to
-  `kube-system`; CoreDNS forwards non-cluster queries upstream by
-  default. Closing this requires per-pod DNS policy or a DNS-aware
-  egress filter, neither in scope here.
+  low-bandwidth exfil channel. The NetworkPolicy must admit DNS on
+  port 53; CoreDNS (and OpenShift's dns-default) forwards non-cluster
+  queries upstream by default. Closing this requires per-pod DNS
+  policy or a DNS-aware egress filter, neither in scope here.
 - The gateway pod must accept inbound traffic from a non-mesh source
   on its Envoy port. Ambient ztunnel-on-inbound passes through
   plaintext on non-HBONE ports when no ALLOW AuthorizationPolicy is

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -249,13 +249,16 @@ differ:
   stays false on both pods; the gateway's SPIFFE cert is independent
   of SA-token mounts.
 - **Agent → paired gateway** is gated at the kernel by the per-pair
-  `<id>-agent-egress` NetworkPolicy. Two egress rules: DNS to
-  `kube-system`, and the paired gateway pod (`pair=<id>, role=gateway`)
-  on the Envoy proxy port. HBONE 15008 is not admitted; the agent has
-  no ztunnel and never speaks HBONE. Pair pinning is structural — the
-  policy's pod-selector is the gateway pod itself, so a compromised
-  agent has no admitted IP-and-port combination to reach anything
-  else in the cluster.
+  `<id>-agent-egress` NetworkPolicy. Two egress rules: DNS on TCP/UDP
+  53 (port-only, no namespace selector — cluster DNS lives in
+  different namespaces across distributions, and the security delta
+  of pinning is negligible since the agent can only generate
+  DNS-shaped traffic on 53), and the paired gateway pod (`pair=<id>,
+  role=gateway`) on the Envoy proxy port. HBONE 15008 is not admitted;
+  the agent has no ztunnel and never speaks HBONE. Pair pinning is
+  structural — the policy's pod-selector is the gateway pod itself,
+  so a compromised agent has no admitted IP-and-port combination to
+  reach anything else in the cluster.
 - **Gateway → api-server harness.** All agent egress (including the
   harness call) flows through the paired gateway pod's Envoy, so what
   reaches the mesh is gateway → harness. The harness Service is

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -25,8 +25,15 @@ import (
 // proxied through the gateway, gated by Envoy's ext_authz filter (ADR-035).
 //
 // Allowed egress:
-//   - DNS to kube-system (TCP/UDP 53) — needed for resolving the gateway
-//     Service hostname.
+//   - DNS (TCP/UDP 53) to any peer. The rule is port-only — no
+//     namespace selector — because cluster DNS lives in different
+//     namespaces across distributions (`kube-system` on upstream k8s,
+//     `openshift-dns` on OpenShift, others elsewhere) and pinning to a
+//     namespace label silently drops every lookup on the wrong distro.
+//     The security delta over namespace-pinned DNS is negligible: the
+//     agent can only generate DNS-shaped traffic on port 53, and the
+//     destination is a kube-proxy-translated IP whose backing pod's
+//     namespace is incidental.
 //   - The paired gateway pod (`pair=<id>, role=gateway`) on the Envoy
 //     proxy port only. The per-pair selector pins reachability to *this*
 //     agent's gateway; the gateway pod itself is the only structural
@@ -75,11 +82,10 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 			Egress: []networkingv1.NetworkPolicyEgressRule{
 				{
-					To: []networkingv1.NetworkPolicyPeer{{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
-						},
-					}},
+					// Port-only DNS: no `To` peer. Cluster DNS lives in
+					// `kube-system` on upstream k8s and `openshift-dns`
+					// on OpenShift; pinning a namespace silently breaks
+					// the other distro.
 					Ports: []networkingv1.NetworkPolicyPort{
 						{Protocol: &udp, Port: &dnsPort},
 						{Protocol: &tcp, Port: &dnsPort},

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -33,11 +33,14 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 
 	require.Len(t, np.Spec.Egress, 2, "DNS + paired gateway, nothing else")
 
-	// DNS to kube-system (resolving the gateway Service hostname).
+	// DNS is admitted port-only (no `To` peer). Cluster DNS lives in
+	// `kube-system` on upstream k8s and `openshift-dns` on OpenShift;
+	// pinning a namespace silently breaks the other distro. The security
+	// delta is negligible — the agent can only generate DNS-shaped
+	// traffic on 53.
 	dnsRule := np.Spec.Egress[0]
-	require.Len(t, dnsRule.To, 1)
-	require.NotNil(t, dnsRule.To[0].NamespaceSelector)
-	assert.Equal(t, "kube-system", dnsRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	assert.Empty(t, dnsRule.To,
+		"DNS rule must be port-only; pinning a namespace breaks portability across k8s distributions")
 	assert.Len(t, dnsRule.Ports, 2, "both UDP/53 and TCP/53 — modern resolvers fall through to TCP")
 	protocols := map[corev1.Protocol]bool{}
 	for _, p := range dnsRule.Ports {


### PR DESCRIPTION
## Summary

- The `<id>-agent-egress` NetworkPolicy pinned DNS to `namespaceSelector: kubernetes.io/metadata.name=kube-system`. On OpenShift, cluster DNS lives in `openshift-dns` (the ClusterIP in `/etc/resolv.conf` is backed by `dns-default-*` pods there), so every lookup — including the agent resolving its paired gateway's Service hostname — dropped to the default-deny and the agent produced no egress at all.
- Drop the namespace selector. The DNS rule is now port-only: UDP/TCP 53 to any peer. The security delta over namespace-pinned DNS is negligible — the agent can only generate DNS-shaped traffic on 53, and the destination is a kube-proxy-translated IP whose backing pod's namespace is incidental. This is portable across k8s, OpenShift, EKS, GKE, etc.
- Docs (ADR-042, `security-and-credentials.md`) updated to reflect the rationale.

## Test plan

- [x] `mise run check` (lint, vet, build, helm lint/render, tsc)
- [x] `mise run test` (controller unit tests including `network_policy_test.go`)
- [ ] Smoke on OpenShift: confirm an instance's agent pod resolves the paired gateway Service and produces egress (previously TCP-refused)
- [ ] Smoke on k3s/lima: regression check — DNS + gateway egress still works, nothing else is reachable