### PR TITLE
feat(helm): opt-in anyuid SCC binding gated on kata runtime

### DIFF
--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -1,0 +1,32 @@
+{{/*
+Chart-level validators. Each `platform.validate.*` template either
+no-ops or calls `fail` to abort `helm install / upgrade / template`.
+The top-level `platform.validate` dispatches to all of them; it is
+invoked once from `templates/validate.yaml`.
+
+To add a new validator: define `platform.validate.<name>` here and
+add it to the include list in `platform.validate`.
+*/}}
+
+{{- define "platform.validate" -}}
+{{- include "platform.validate.anyuidRequiresKata" . -}}
+{{- end -}}
+
+{{/*
+Granting `system:openshift:scc:anyuid` lets agent containers run as
+UID 0. That is only acceptable when the workload is isolated inside a
+kata-containers microVM — "root" is then guest-VM root, not host root.
+Without kata, anyuid lands the agent at UID 0 on the host's default
+OCI runtime, which defeats the sandbox boundary the platform relies on.
+*/}}
+{{- define "platform.validate.anyuidRequiresKata" -}}
+{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuid .Values.openshift.scc.anyuid.enabled -}}
+{{- $rc := "" -}}
+{{- if and .Values.controller .Values.controller.agent .Values.controller.agent.base -}}
+{{- $rc = .Values.controller.agent.base.runtimeClassName | default "" -}}
+{{- end -}}
+{{- if not (hasPrefix "kata" $rc) -}}
+{{- fail (printf "openshift.scc.anyuid.enabled=true requires controller.agent.base.runtimeClassName to be a kata runtime (got %q). Granting anyuid without kata isolation puts agents at UID 0 on the host's default OCI runtime." $rc) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -10,6 +10,7 @@ add it to the include list in `platform.validate`.
 
 {{- define "platform.validate" -}}
 {{- include "platform.validate.anyuidRequiresKata" . -}}
+{{- include "platform.validate.anyuidRequiresAgentNamespace" . -}}
 {{- end -}}
 
 {{/*
@@ -27,6 +28,20 @@ OCI runtime, which defeats the sandbox boundary the platform relies on.
 {{- end -}}
 {{- if not (hasPrefix "kata" $rc) -}}
 {{- fail (printf "openshift.scc.anyuid.enabled=true requires controller.agent.base.runtimeClassName to be a kata runtime (got %q). Granting anyuid without kata isolation puts agents at UID 0 on the host's default OCI runtime." $rc) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+The anyuid RoleBinding is namespaced to `agentNamespace` and grants
+SCC access via the `system:serviceaccounts:<agentNamespace>` group.
+Both are meaningless if `agentNamespace` is empty: the binding lands
+without a namespace, and the group ref matches no SA. Refuse to render.
+*/}}
+{{- define "platform.validate.anyuidRequiresAgentNamespace" -}}
+{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuid .Values.openshift.scc.anyuid.enabled -}}
+{{- if not (.Values.agentNamespace | default "" | trim) -}}
+{{- fail "openshift.scc.anyuid.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.openshift.scc.anyuid.enabled }}
+{{/*
+OpenShift SCC binding for the agent namespace.
+
+Default OpenShift admission (`restricted-v2`) forces a random UID and
+strips `runAsUser: 0`, which breaks harnesses that need root inside the
+kata-containers sandbox. Binding `system:openshift:scc:anyuid` to the
+`system:serviceaccounts:<agentNamespace>` group lets every per-instance
+ServiceAccount the controller creates (see ADR-041) pick its own UID,
+including 0. Scope is intentionally one namespace — no cluster-wide
+escalation.
+
+`anyuid` does not grant capabilities, host paths, or privileged mode;
+it only loosens the UID constraint. Under kata, "root" is guest-VM root,
+not host root.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "platform.fullname" . }}-agent-anyuid
+  namespace: {{ .Values.agentNamespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:openshift:scc:anyuid
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: system:serviceaccounts:{{ .Values.agentNamespace }}
+{{- end }}

--- a/deploy/helm/platform/templates/validate.yaml
+++ b/deploy/helm/platform/templates/validate.yaml
@@ -1,0 +1,7 @@
+{{/*
+Single entry point for chart-level validation. Validators are defined
+in `_validators.tpl`; they either no-op or call `fail` to abort the
+`helm install / upgrade / template` invocation before any manifest is
+applied. This file intentionally renders to nothing.
+*/}}
+{{- include "platform.validate" . -}}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -94,6 +94,23 @@ agentNamespace: platform-agents
 # -- Whether to create the agent namespace (disable if it already exists or is managed externally)
 createAgentNamespace: true
 
+# -- OpenShift-specific knobs. No-op on vanilla Kubernetes.
+openshift:
+  scc:
+    # Bind `system:openshift:scc:anyuid` to every ServiceAccount in
+    # `agentNamespace` so agent / gateway pods may run as UID 0 (required
+    # for kata-containers workloads that need root inside the sandbox).
+    # Default restricted-v2 admission strips runAsUser=0; flip this on
+    # when running on OpenShift with kata runtime.
+    #
+    # Requires `controller.agent.base.runtimeClassName` to be a kata
+    # runtime (e.g. "kata", "kata-nvidia-gpu"). The chart's validator
+    # refuses to render otherwise — granting anyuid without kata
+    # isolation puts agents at UID 0 on the host's default OCI runtime,
+    # which defeats the sandbox boundary.
+    anyuid:
+      enabled: false
+
 # -- Shared local PostgreSQL instance
 # Set enabled: false when using external/cloud DBs for all services.
 postgres:


### PR DESCRIPTION
Closes #194.

## Summary

- Adds `openshift.scc.anyuid.enabled` (default `false`) and a namespace-scoped `RoleBinding` that grants `system:openshift:scc:anyuid` to all ServiceAccounts in `agentNamespace`. Required on OpenShift when agents need `runAsUser: 0` inside a kata-containers sandbox — the default `restricted-v2` admission strips root regardless of the pod's intent.
- Introduces `templates/_validators.tpl` as the home for chart-level preconditions, dispatched once from `templates/validate.yaml`. Validators refuse to render when `openshift.scc.anyuid.enabled=true` is set without `controller.agent.base.runtimeClassName` being a kata runtime, or when `agentNamespace` is empty/null/whitespace — granting anyuid without kata isolation lands agents at UID 0 on the host's default OCI runtime, which defeats the sandbox boundary the platform relies on.
- No-op on vanilla Kubernetes. Scope is one namespace — no cluster-wide escalation.

SCC admission is evaluated against the per-instance ServiceAccount the controller creates (ADR-041), so binding to the `system:serviceaccounts:<agentNamespace>` group covers every agent and fork SA automatically — controller RBAC unchanged.

## Test plan

- [x] `helm lint` clean
- [x] `helm template | kubeconform -strict` clean
- [x] Defaults render with no anyuid resources
- [x] `anyuid=true` without a kata runtimeClass → `fail` aborts the render with a clear message
- [x] `anyuid=true` with `runtimeClassName=kata` → RoleBinding renders into the right namespace
- [x] `anyuid=true` with `runtimeClassName=kata-nvidia-gpu` → also accepted (any `kata*` prefix)
- [x] `anyuid=true` with `runtimeClassName=foo` → rejected
- [x] `anyuid=true` with empty / null / whitespace `agentNamespace` → rejected
- [ ] On the prod OpenShift cluster, flip both values on in the dev-sandboxed namespace and confirm agent pods are admitted with the `anyuid` SCC annotation and `runtimeClassName: kata`