### PR TITLE
fix(security): admit agent-egress DNS on OpenShift dns-default pod port

### DIFF
--- a/docs/adrs/042-agent-egress-network-policy.md
+++ b/docs/adrs/042-agent-egress-network-policy.md
@@ -41,13 +41,16 @@ job it was designed for.
   `istio.io/dataplane-mode: none` removes the ztunnel redirect. The agent
   has no SPIFFE workload identity; its outbound packets show the real
   destination to NetworkPolicy.
-- **Per-pair `<id>-agent-egress` NetworkPolicy.** Two egress rules:
-  DNS on TCP/UDP 53 (port-only, no namespace selector — cluster DNS
-  lives in `kube-system` on upstream k8s and `openshift-dns` on
-  OpenShift, and the agent can only generate DNS-shaped traffic on
-  53 regardless of which pod backs the resolver Service), and the
-  paired gateway pod (`pair=<id>, role=gateway`) on the Envoy proxy
-  port. HBONE 15008 is not admitted; the agent never speaks it.
+- **Per-pair `<id>-agent-egress` NetworkPolicy.** Three egress rules:
+  DNS to `kube-system` on UDP/TCP 53 (CoreDNS / kube-dns on upstream
+  Kubernetes listens on pod port 53), DNS to `openshift-dns` on
+  UDP/TCP 5353 (OpenShift's `dns-default` pods listen on 5353 and the
+  cluster DNS Service does 53→5353 translation — NetworkPolicy
+  evaluates pod port after kube-proxy translation, so 53 silently
+  drops every lookup on OpenShift), and the paired gateway pod
+  (`pair=<id>, role=gateway`) on the Envoy proxy port. A cluster runs
+  cluster DNS in only one of those namespaces; the unused rule is
+  harmless. HBONE 15008 is not admitted; the agent never speaks it.
 - **Gateway pod stays in ambient.** Its SPIFFE principal continues to
   gate the gateway → harness and gateway → ext-authz hops via the
   existing per-instance harness-allow and ext-authz-allow
@@ -106,10 +109,11 @@ instead of the rule model.
   not yet converged. The agent's egress shape does not depend on any
   of them.
 - DNS tunneling via CoreDNS's upstream forwarder remains a residual,
-  low-bandwidth exfil channel. The NetworkPolicy must admit DNS on
-  port 53; CoreDNS (and OpenShift's dns-default) forwards non-cluster
-  queries upstream by default. Closing this requires per-pod DNS
-  policy or a DNS-aware egress filter, neither in scope here.
+  low-bandwidth exfil channel. The NetworkPolicy must admit DNS to
+  the cluster resolver namespace; CoreDNS (and OpenShift's
+  `dns-default`) forwards non-cluster queries upstream by default.
+  Closing this requires per-pod DNS policy or a DNS-aware egress
+  filter, neither in scope here.
 - The gateway pod must accept inbound traffic from a non-mesh source
   on its Envoy port. Ambient ztunnel-on-inbound passes through
   plaintext on non-HBONE ports when no ALLOW AuthorizationPolicy is

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -249,16 +249,17 @@ differ:
   stays false on both pods; the gateway's SPIFFE cert is independent
   of SA-token mounts.
 - **Agent → paired gateway** is gated at the kernel by the per-pair
-  `<id>-agent-egress` NetworkPolicy. Two egress rules: DNS on TCP/UDP
-  53 (port-only, no namespace selector — cluster DNS lives in
-  different namespaces across distributions, and the security delta
-  of pinning is negligible since the agent can only generate
-  DNS-shaped traffic on 53), and the paired gateway pod (`pair=<id>,
-  role=gateway`) on the Envoy proxy port. HBONE 15008 is not admitted;
-  the agent has no ztunnel and never speaks HBONE. Pair pinning is
-  structural — the policy's pod-selector is the gateway pod itself,
-  so a compromised agent has no admitted IP-and-port combination to
-  reach anything else in the cluster.
+  `<id>-agent-egress` NetworkPolicy. Three egress rules: DNS to
+  `kube-system` on UDP/TCP 53 (upstream Kubernetes), DNS to
+  `openshift-dns` on UDP/TCP 5353 (OpenShift's `dns-default` pods
+  listen on 5353 and NetworkPolicy evaluates pod port after
+  kube-proxy translation), and the paired gateway pod (`pair=<id>,
+  role=gateway`) on the Envoy proxy port. A cluster runs cluster DNS
+  in only one of those namespaces; the unused rule is harmless. HBONE
+  15008 is not admitted; the agent has no ztunnel and never speaks
+  HBONE. Pair pinning is structural — the policy's pod-selector is
+  the gateway pod itself, so a compromised agent has no admitted
+  IP-and-port combination to reach anything else in the cluster.
 - **Gateway → api-server harness.** All agent egress (including the
   harness call) flows through the paired gateway pod's Envoy, so what
   reaches the mesh is gateway → harness. The harness Service is

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -25,15 +25,16 @@ import (
 // proxied through the gateway, gated by Envoy's ext_authz filter (ADR-035).
 //
 // Allowed egress:
-//   - DNS (TCP/UDP 53) to any peer. The rule is port-only — no
-//     namespace selector — because cluster DNS lives in different
-//     namespaces across distributions (`kube-system` on upstream k8s,
-//     `openshift-dns` on OpenShift, others elsewhere) and pinning to a
-//     namespace label silently drops every lookup on the wrong distro.
-//     The security delta over namespace-pinned DNS is negligible: the
-//     agent can only generate DNS-shaped traffic on port 53, and the
-//     destination is a kube-proxy-translated IP whose backing pod's
-//     namespace is incidental.
+//   - DNS to `kube-system` on UDP/TCP 53. CoreDNS / kube-dns pods on
+//     upstream Kubernetes listen on 53 directly, so the kernel sees
+//     53 as the destination port after kube-proxy translation.
+//   - DNS to `openshift-dns` on UDP/TCP 5353. OpenShift's `dns-default`
+//     pods listen on 5353; the cluster DNS Service (172.30.0.10:53)
+//     targets pod port 5353, and NetworkPolicy evaluates pod-IP and
+//     pod-port after kube-proxy translation, not the Service port.
+//     Pinning to 53 here would silently drop every lookup on
+//     OpenShift. Both rules are admitted; a given cluster runs DNS in
+//     only one of these namespaces, so the unused rule is harmless.
 //   - The paired gateway pod (`pair=<id>, role=gateway`) on the Envoy
 //     proxy port only. The per-pair selector pins reachability to *this*
 //     agent's gateway; the gateway pod itself is the only structural
@@ -54,7 +55,8 @@ import (
 // unrestricted (it dials external upstreams for credential injection).
 func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	envoyPort := intstr.FromInt(cfg.EnvoyPort)
-	dnsPort := intstr.FromInt(53)
+	corednsPort := intstr.FromInt(53)
+	openshiftDNSPort := intstr.FromInt(5353)
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
 
@@ -82,13 +84,31 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
 			Egress: []networkingv1.NetworkPolicyEgressRule{
 				{
-					// Port-only DNS: no `To` peer. Cluster DNS lives in
-					// `kube-system` on upstream k8s and `openshift-dns`
-					// on OpenShift; pinning a namespace silently breaks
-					// the other distro.
+					// Upstream Kubernetes: CoreDNS / kube-dns in
+					// `kube-system` listening on pod port 53.
+					To: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+						},
+					}},
 					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &udp, Port: &dnsPort},
-						{Protocol: &tcp, Port: &dnsPort},
+						{Protocol: &udp, Port: &corednsPort},
+						{Protocol: &tcp, Port: &corednsPort},
+					},
+				},
+				{
+					// OpenShift: `dns-default` pods in `openshift-dns`
+					// listen on pod port 5353. NetworkPolicy filters on
+					// pod port after kube-proxy translation, so the
+					// upstream rule (53) does not match here.
+					To: []networkingv1.NetworkPolicyPeer{{
+						NamespaceSelector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-dns"},
+						},
+					}},
+					Ports: []networkingv1.NetworkPolicyPort{
+						{Protocol: &udp, Port: &openshiftDNSPort},
+						{Protocol: &tcp, Port: &openshiftDNSPort},
 					},
 				},
 				{

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -31,26 +31,27 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	require.Len(t, np.Spec.PolicyTypes, 1)
 	assert.Equal(t, networkingv1.PolicyTypeEgress, np.Spec.PolicyTypes[0])
 
-	require.Len(t, np.Spec.Egress, 2, "DNS + paired gateway, nothing else")
+	require.Len(t, np.Spec.Egress, 3, "kube-system DNS + openshift-dns DNS + paired gateway, nothing else")
 
-	// DNS is admitted port-only (no `To` peer). Cluster DNS lives in
-	// `kube-system` on upstream k8s and `openshift-dns` on OpenShift;
-	// pinning a namespace silently breaks the other distro. The security
-	// delta is negligible — the agent can only generate DNS-shaped
-	// traffic on 53.
-	dnsRule := np.Spec.Egress[0]
-	assert.Empty(t, dnsRule.To,
-		"DNS rule must be port-only; pinning a namespace breaks portability across k8s distributions")
-	assert.Len(t, dnsRule.Ports, 2, "both UDP/53 and TCP/53 — modern resolvers fall through to TCP")
-	protocols := map[corev1.Protocol]bool{}
-	for _, p := range dnsRule.Ports {
-		protocols[*p.Protocol] = true
-		assert.Equal(t, int32(53), p.Port.IntVal)
-	}
-	assert.True(t, protocols[corev1.ProtocolUDP] && protocols[corev1.ProtocolTCP])
+	// Upstream Kubernetes: CoreDNS / kube-dns in `kube-system` listening
+	// on pod port 53.
+	corednsRule := np.Spec.Egress[0]
+	require.Len(t, corednsRule.To, 1)
+	require.NotNil(t, corednsRule.To[0].NamespaceSelector)
+	assert.Equal(t, "kube-system", corednsRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	assertDNSPorts(t, corednsRule.Ports, 53)
+
+	// OpenShift: dns-default in `openshift-dns` listening on pod port
+	// 5353. NetworkPolicy filters on pod port after kube-proxy
+	// translation, so the upstream rule (53) does not match here.
+	openshiftRule := np.Spec.Egress[1]
+	require.Len(t, openshiftRule.To, 1)
+	require.NotNil(t, openshiftRule.To[0].NamespaceSelector)
+	assert.Equal(t, "openshift-dns", openshiftRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
+	assertDNSPorts(t, openshiftRule.Ports, 5353)
 
 	// Paired gateway pod — Envoy proxy port only.
-	gwRule := np.Spec.Egress[1]
+	gwRule := np.Spec.Egress[2]
 	require.Len(t, gwRule.To, 1)
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "my-instance", gwRule.To[0].PodSelector.MatchLabels[LabelPair])
@@ -75,7 +76,7 @@ func TestBuildAgentEgressNetworkPolicy_Fork(t *testing.T) {
 	// The gateway-pod egress rule must reference the FORK's gateway, not
 	// the parent's — otherwise the fork agent could reach the parent's
 	// gateway and inject under the parent owner's credentials.
-	gwRule := np.Spec.Egress[1]
+	gwRule := np.Spec.Egress[2]
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "fork-abc", gwRule.To[0].PodSelector.MatchLabels[LabelPair],
 		"fork agent NP must scope to the FORK's gateway, not the parent's")
@@ -100,4 +101,15 @@ func TestBuildAgentEgressNetworkPolicy_ManagedByLabel(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
 	assert.Equal(t, "platform-controller", np.Labels["agent-platform.ai/managed-by"])
 	assert.Equal(t, "my-instance", np.Labels[LabelInstance])
+}
+
+func assertDNSPorts(t *testing.T, ports []networkingv1.NetworkPolicyPort, expected int32) {
+	t.Helper()
+	require.Len(t, ports, 2, "both UDP and TCP on the resolver's pod port — modern resolvers fall through to TCP")
+	protocols := map[corev1.Protocol]bool{}
+	for _, p := range ports {
+		protocols[*p.Protocol] = true
+		assert.Equal(t, expected, p.Port.IntVal)
+	}
+	assert.True(t, protocols[corev1.ProtocolUDP] && protocols[corev1.ProtocolTCP])
 }


### PR DESCRIPTION
## Summary

- PR #191 collapsed the agent-egress DNS rule to port-only (53). That was wrong on OpenShift: `dns-default` pods in `openshift-dns` listen on **pod port 5353**, with kube-proxy translating Service port 53 → pod port 5353. NetworkPolicy filters on pod IP and pod port after kube-proxy translation, so the port-53 rule never matched the OpenShift resolver and every lookup dropped to the egress default-deny.
- Restore namespace-pinned DNS and add the OpenShift variant alongside the upstream one:
  - `kube-system` + UDP/TCP **53** — CoreDNS / kube-dns on upstream Kubernetes
  - `openshift-dns` + UDP/TCP **5353** — `dns-default` on OpenShift
- A cluster runs cluster DNS in only one of those namespaces, so the unused rule is harmless. Both keep DNS egress pinned to the resolver namespace — meaningfully tighter than "any peer on 53", since the agent can no longer reach an arbitrary pod that happens to listen on the DNS port.
- Docs (ADR-042, `security-and-credentials.md`) updated to match.

## Test plan

- [x] `mise run check` (lint, vet, build, helm lint/render, tsc)
- [x] `mise run test` (controller unit tests including the updated `network_policy_test.go`)
- [ ] Smoke on OpenShift: agent pod resolves the paired gateway's Service hostname and produces egress
- [ ] Smoke on k3s/lima: regression check — DNS + gateway egress still works, nothing else is reachable