### PR TITLE
feat(helm): ship custom SCC granting DAC_OVERRIDE for kata agents

### DIFF
--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,30 +1,104 @@
 {{- if .Values.openshift.scc.anyuid.enabled }}
 {{/*
-OpenShift SCC binding for the agent namespace.
+OpenShift SCC for agent pods on this chart.
 
-Default OpenShift admission (`restricted-v2`) forces a random UID and
-strips `runAsUser: 0`, which breaks harnesses that need root inside the
-kata-containers sandbox. Binding `system:openshift:scc:anyuid` to the
-`system:serviceaccounts:<agentNamespace>` group lets every per-instance
-ServiceAccount the controller creates (see ADR-041) pick its own UID,
-including 0. Scope is intentionally one namespace — no cluster-wide
-escalation.
+Stock OpenShift admission (`restricted-v2`) forces a random UID from
+the namespace range and refuses any cap additions, which breaks
+harnesses that need root inside the kata-containers sandbox. Stock
+`anyuid` permits any UID but explicitly forbids cap additions
+(`allowedCapabilities: null`), which is fine until you hit an NFS-
+backed home PVC: if the underlying NFS server enforces `root_squash`
+(IBM Cloud File Storage for VPC does, and the knob is not customer-
+configurable), every root write is translated to UID 99 (`nobody`)
+on the share. Files persist as 99-owned, and the kata-guest kernel
+then EACCES's subsequent writes because UID 0 with `drop: ["ALL"]`
+has no `CAP_DAC_OVERRIDE` to bypass DAC.
 
-`anyuid` does not grant capabilities, host paths, or privileged mode;
-it only loosens the UID constraint. Under kata, "root" is guest-VM root,
-not host root.
+This SCC is the minimal escalation that resolves the EACCES while
+keeping the security posture we already accepted (root + kata):
+identical to `anyuid` for UID / privilege / volume / SELinux rules,
+plus `DAC_OVERRIDE` as the single allowed capability addition. The
+NFS server still squashes — that's outside our control — but the
+kata-guest DAC check is now bypassable for the agent, so the
+in-guest open/write succeeds and lands on the share as UID 99.
+
+Containment remains the kata VM boundary. `DAC_OVERRIDE` grants
+"ignore file-permission checks inside the guest filesystem view"
+and nothing else: no `SYS_ADMIN`, no `NET_*`, no `SETUID`, no
+module load. The cluster-wide blast radius of this manifest is
+exactly the one ServiceAccount group bound below.
+
+`priority: 9` is one below stock `anyuid` (10), so OpenShift's
+SCC picker does not pre-empt anyuid for pods that don't need
+the cap — the binding below is what actually grants its use.
+*/}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "platform.fullname" . }}-agent-kata
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/description: |
+      Equivalent to the stock `anyuid` SCC plus the single capability
+      `DAC_OVERRIDE`. Intended for kata-isolated agent pods whose home
+      PVC is NFS-backed with root_squash enforced server-side. Created
+      and bound by the {{ .Chart.Name }} chart; manage via Helm.
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowedCapabilities:
+  - DAC_OVERRIDE
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+priority: 9
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - "*"
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - csi
+  - downwardAPI
+  - emptyDir
+  - ephemeral
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
+{{/*
+Bind the SCC to every ServiceAccount in `agentNamespace`. The
+controller (ADR-041) creates per-instance and per-fork SAs in
+that namespace; binding via the group makes every one of them
+automatically eligible. Scope is namespace-local, no cluster-
+wide privilege.
+
+OpenShift auto-generates the `system:openshift:scc:<name>`
+ClusterRole when the SCC is created — same mechanism that
+gives stock `system:openshift:scc:anyuid` for free.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "platform.fullname" . }}-agent-anyuid
+  name: {{ include "platform.fullname" . }}-agent-kata-scc
   namespace: {{ .Values.agentNamespace }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:anyuid
+  name: system:openshift:scc:{{ include "platform.fullname" . }}-agent-kata
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -97,17 +97,36 @@ createAgentNamespace: true
 # -- OpenShift-specific knobs. No-op on vanilla Kubernetes.
 openshift:
   scc:
-    # Bind `system:openshift:scc:anyuid` to every ServiceAccount in
-    # `agentNamespace` so agent / gateway pods may run as UID 0 (required
-    # for kata-containers workloads that need root inside the sandbox).
-    # Default restricted-v2 admission strips runAsUser=0; flip this on
-    # when running on OpenShift with kata runtime.
+    # Create a custom SCC (`<release>-platform-agent-kata`) equivalent
+    # to stock `anyuid` plus the single capability `DAC_OVERRIDE`, and
+    # bind it to every ServiceAccount in `agentNamespace`. Required when
+    # running agents under kata-containers on OpenShift:
+    #
+    #   * Default `restricted-v2` admission forces a namespace-range UID
+    #     and refuses cap additions, blocking root in the kata guest.
+    #   * Stock `anyuid` permits root but explicitly forbids cap adds
+    #     (`allowedCapabilities: null`), which breaks any deployment
+    #     whose agent home PVC is NFS-backed with `root_squash` enforced
+    #     server-side — root writes get translated to UID 99 (`nobody`)
+    #     on the share, files persist as 99-owned, and subsequent kata-
+    #     guest writes EACCES because UID 0 with `drop: ALL` lacks
+    #     `CAP_DAC_OVERRIDE` to bypass the DAC check.
+    #
+    # The custom SCC adds back exactly that one capability — no host
+    # paths, no host network, no SYS_ADMIN, no NET_*, no SETUID.
+    # Containment remains the kata VM boundary. See templates/agent-scc.yaml
+    # for the full SCC manifest and reasoning.
     #
     # Requires `controller.agent.base.runtimeClassName` to be a kata
     # runtime (e.g. "kata", "kata-nvidia-gpu"). The chart's validator
-    # refuses to render otherwise — granting anyuid without kata
-    # isolation puts agents at UID 0 on the host's default OCI runtime,
-    # which defeats the sandbox boundary.
+    # refuses to render otherwise — granting the SCC without kata
+    # isolation puts agents at UID 0 with DAC_OVERRIDE on the host's
+    # default OCI runtime, which defeats the sandbox boundary.
+    #
+    # Operators flipping this on must also override
+    # `controller.agent.base.containerSecurityContext` to set
+    # `runAsUser: 0` and `add: ["DAC_OVERRIDE"]` — the chart-default
+    # security context stays locked-down on purpose.
     anyuid:
       enabled: false
 


### PR DESCRIPTION
## Summary

Replaces the stock `system:openshift:scc:anyuid` binding shipped in #192 with a chart-managed SCC (`<release>-platform-agent-kata`) that is identical to `anyuid` *plus* the single capability `DAC_OVERRIDE`. Same gating flag (`openshift.scc.anyuid.enabled`), same validator preconditions (kata runtimeClass + non-empty agentNamespace), tighter underneath.

### Why DAC_OVERRIDE

Stock `anyuid` permits any UID but explicitly forbids cap additions (`allowedCapabilities: null`). On deployments whose agent home PVC is NFS-backed with `root_squash` enforced server-side — IBM Cloud File Storage for VPC, the default on IBM Cloud OpenShift clusters, and the knob is not customer-configurable per the driver source ([`pkg/ibmcsidriver/constants.go`](https://github.com/IBM/ibm-vpc-file-csi-driver/blob/master/pkg/ibmcsidriver/constants.go) has no `rootSquash` parameter) and per IBM's own service docs — root writes get translated to UID 99 (`nobody`) on the share. Files persist as 99-owned, and subsequent kata-guest writes EACCES because UID 0 with `drop: ["ALL"]` lacks `CAP_DAC_OVERRIDE` to bypass the in-guest DAC check.

`DAC_OVERRIDE` is the surgical fix: it grants "ignore file-permission checks inside the guest filesystem view" and nothing else — no `SYS_ADMIN`, no `NET_*`, no `SETUID`, no module load. Containment remains the kata VM boundary. The NFS server continues to squash root writes regardless, so the agent's "I'm root" view is purely a kata-guest illusion the share doesn't honor — which is actually a useful additional containment property.

### Why a custom SCC rather than `add`-ing to stock

No existing SCC on a stock OpenShift install permits adding `DAC_OVERRIDE`:

- `anyuid`, `restricted-v2`, `nonroot-v2`, `hostnetwork-v2` — `allowedCapabilities` is `null` or `["NET_BIND_SERVICE"]` only
- `privileged`, all `nvidia-*` — `allowedCapabilities: ["*"]` but grant far more than DAC_OVERRIDE (host paths, host network, all caps)
- `sandboxed-containers-operator-scc` — `MustRunAsNonRoot`, incompatible with the root requirement

`priority: 9` keeps stock `anyuid` (10) as the default pick for pods that don't need the cap; the namespace-scoped RoleBinding to `system:openshift:scc:<release>-platform-agent-kata` is what actually grants its use.

## Test plan

- [x] `helm lint` clean
- [x] `helm template | kubeconform -strict` clean (SCC CRD is in kubeconform's skip list — 1 of 5 skipped resources)
- [x] Defaults render with no SCC manifests at all
- [x] `openshift.scc.anyuid.enabled=true` + kata + agentNamespace → both SCC and RoleBinding render with the right names
- [x] Validator still rejects `anyuid.enabled=true` without a kata runtimeClass
- [x] Validator still rejects `anyuid.enabled=true` with empty/null/whitespace `agentNamespace`
- [ ] On the prod OpenShift cluster: install with the flag on, confirm the SCC is created and the agent pod is admitted under it (`openshift.io/scc: <release>-platform-agent-kata` annotation) and the agent process can write to its NFS-backed `/home/agent`