### PR TITLE
fix(ui): persist new sessions eagerly and refresh titles on re-entry

### DIFF
--- a/packages/ui/src/modules/sessions/api/queries.ts
+++ b/packages/ui/src/modules/sessions/api/queries.ts
@@ -9,9 +9,12 @@ export const acpSessionsKeys = {
 };
 
 /**
- * The session list lives on the agent pod, not the platform DB; it's only
- * meaningful when the instance is `running`. Pass `enabled: false` (e.g. while
- * waking) to keep the query in cache without firing requests.
+ * Sessions list with live ACP enrichment (title, updatedAt) overlaid on the
+ * platform DB rows. Pass `enabled: false` (e.g. while the instance is waking)
+ * to keep the query in cache without firing requests.
+ *
+ * `refetchOnMount: "always"` because the title is harness-set after the first
+ * turn — a returning user must see the updated title without a manual refresh.
  *
  * meta.errorToast is intentionally vague — sustained outages get the toast
  * once per outage via the global query cache wiring.
@@ -27,6 +30,8 @@ export function useAcpSessions(
     queryFn: live
       ? () => api.sessions.list.query({ instanceId, includeChannel })
       : skipToken,
+    refetchOnMount: "always",
+    staleTime: 5_000,
     meta: { errorToast: "Couldn't refresh session list" },
   });
 }

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -1,0 +1,135 @@
+import { SessionMode, SessionType, type SessionView } from "api-server-api";
+import { Trash2 } from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const LONG_PRESS_MS = 400;
+
+interface Props {
+  session: SessionView;
+  active: boolean;
+  hasPending: boolean;
+  onResume: () => void;
+  onDelete: () => void;
+}
+
+export function SessionRow({ session: s, active, hasPending, onResume, onDelete }: Props) {
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const didLongPress = useRef(false);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const startPress = useCallback(() => {
+    didLongPress.current = false;
+    timerRef.current = setTimeout(() => {
+      didLongPress.current = true;
+      setMenuOpen(true);
+    }, LONG_PRESS_MS);
+  }, []);
+
+  const endPress = useCallback(() => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const handleClick = useCallback(() => {
+    if (didLongPress.current) {
+      didLongPress.current = false;
+      return;
+    }
+    if (menuOpen) {
+      setMenuOpen(false);
+      return;
+    }
+    onResume();
+  }, [onResume, menuOpen]);
+
+  // Close menu on outside tap
+  useEffect(() => {
+    if (!menuOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node))
+        setMenuOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [menuOpen]);
+
+  // Show "(no title · abcd1234)" while the harness hasn't named the session
+  // — the id suffix keeps untitled rows distinguishable from each other.
+  const titleLabel = s.title || `(no title · ${s.sessionId.slice(0, 8)})`;
+  const titleClass = s.title
+    ? active ? "text-accent font-bold" : "text-text font-medium"
+    : "text-text-muted italic";
+
+  return (
+    <div
+      className={`group relative flex items-center gap-1 px-4 py-3 cursor-pointer border-b border-border-light transition-colors hover:bg-accent-light select-none ${active ? "bg-accent-light border-l-[3px] border-l-accent" : ""}`}
+      onClick={handleClick}
+      onTouchStart={startPress}
+      onTouchEnd={endPress}
+      onTouchCancel={endPress}
+      onContextMenu={(e) => {
+        e.preventDefault();
+        setMenuOpen(true);
+      }}
+    >
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        <div className="flex items-center gap-1.5">
+          {hasPending && (
+            <span
+              className="w-2 h-2 rounded-full bg-warning anim-pulse shrink-0"
+              title="Pending permission request"
+            />
+          )}
+          <span className={`text-[13px] truncate ${titleClass}`}>
+            {titleLabel}
+          </span>
+          {s.mode === SessionMode.Terminal && (
+            <span className="text-[9px] font-bold uppercase tracking-wider text-accent bg-accent-light rounded px-1 py-0.5 shrink-0">
+              terminal
+            </span>
+          )}
+          {(s.type === SessionType.ChannelSlack || s.type === SessionType.ChannelTelegram) && (
+            <span className="text-[9px] font-bold uppercase tracking-wider text-text-muted bg-border-light rounded px-1 py-0.5 shrink-0">
+              {s.type === SessionType.ChannelSlack ? "slack" : "telegram"}
+            </span>
+          )}
+        </div>
+        <span className="text-[11px] text-text-muted">
+          {new Date(s.updatedAt ?? s.createdAt).toLocaleString()}
+        </span>
+      </div>
+      {/* Desktop: hover-visible delete button */}
+      <button
+        className="shrink-0 h-6 w-6 rounded-md flex items-center justify-center text-text-muted opacity-0 group-hover:opacity-100 hover:text-danger transition-all"
+        onClick={(e) => {
+          e.stopPropagation();
+          onDelete();
+        }}
+        title="Delete session"
+      >
+        <Trash2 size={12} />
+      </button>
+      {/* Context menu — long press (mobile) or right-click */}
+      {menuOpen && (
+        <div
+          ref={menuRef}
+          className="absolute right-3 top-2 z-30 rounded-lg border-2 border-border bg-surface py-1 anim-scale-in shadow-brutal-sm"
+        >
+          <button
+            className="flex items-center gap-2 w-full px-4 py-2 text-[13px] text-danger hover:bg-danger-light transition-colors"
+            onClick={(e) => {
+              e.stopPropagation();
+              setMenuOpen(false);
+              onDelete();
+            }}
+          >
+            <Trash2 size={13} /> Delete session
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -1,11 +1,12 @@
-import { SessionMode, SessionType } from "api-server-api";
-import { ArrowLeft, Plus, RefreshCw, Trash2 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import type { SessionMode } from "api-server-api";
+import { ArrowLeft, Plus, RefreshCw } from "lucide-react";
+import { useCallback } from "react";
 
 import { useStore } from "../../../store.js";
 import { InstanceApprovalsTray } from "../../approvals/components/instance-approvals-tray.js";
 import { useInstancesList } from "../../instances/api/queries.js";
 import { useAcpSessions } from "../api/queries.js";
+import { SessionRow } from "./session-row.js";
 
 export function SessionsSidebar({
   onResumeSession,
@@ -110,140 +111,3 @@ export function SessionsSidebar({
   );
 }
 
-const LONG_PRESS_MS = 400;
-
-function SessionRow({
-  session: s,
-  active,
-  hasPending,
-  onResume,
-  onDelete,
-}: {
-  session: {
-    sessionId: string;
-    title?: string | null;
-    type: string;
-    mode?: SessionMode;
-    createdAt: string;
-    updatedAt?: string | null;
-  };
-  active: boolean;
-  hasPending: boolean;
-  onResume: () => void;
-  onDelete: () => void;
-}) {
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const didLongPress = useRef(false);
-  const [menuOpen, setMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  const startPress = useCallback(() => {
-    didLongPress.current = false;
-    timerRef.current = setTimeout(() => {
-      didLongPress.current = true;
-      setMenuOpen(true);
-    }, LONG_PRESS_MS);
-  }, []);
-
-  const endPress = useCallback(() => {
-    if (timerRef.current) {
-      clearTimeout(timerRef.current);
-      timerRef.current = null;
-    }
-  }, []);
-
-  const handleClick = useCallback(() => {
-    if (didLongPress.current) {
-      didLongPress.current = false;
-      return;
-    }
-    if (menuOpen) {
-      setMenuOpen(false);
-      return;
-    }
-    onResume();
-  }, [onResume, menuOpen]);
-
-  // Close menu on outside tap
-  useEffect(() => {
-    if (!menuOpen) return;
-    const handler = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node))
-        setMenuOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [menuOpen]);
-
-  return (
-    <div
-      className={`group relative flex items-center gap-1 px-4 py-3 cursor-pointer border-b border-border-light transition-colors hover:bg-accent-light select-none ${active ? "bg-accent-light border-l-[3px] border-l-accent" : ""}`}
-      onClick={handleClick}
-      onTouchStart={startPress}
-      onTouchEnd={endPress}
-      onTouchCancel={endPress}
-      onContextMenu={(e) => {
-        e.preventDefault();
-        setMenuOpen(true);
-      }}
-    >
-      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
-        <div className="flex items-center gap-1.5">
-          {hasPending && (
-            <span
-              className="w-2 h-2 rounded-full bg-warning anim-pulse shrink-0"
-              title="Pending permission request"
-            />
-          )}
-          <span
-            className={`text-[13px] truncate ${active ? "text-accent font-bold" : "text-text font-medium"}`}
-          >
-            {s.title || s.sessionId.slice(0, 12)}
-          </span>
-          {s.mode === SessionMode.Terminal && (
-            <span className="text-[9px] font-bold uppercase tracking-wider text-accent bg-accent-light rounded px-1 py-0.5 shrink-0">
-              terminal
-            </span>
-          )}
-          {(s.type === SessionType.ChannelSlack || s.type === SessionType.ChannelTelegram) && (
-            <span className="text-[9px] font-bold uppercase tracking-wider text-text-muted bg-border-light rounded px-1 py-0.5 shrink-0">
-              {s.type === SessionType.ChannelSlack ? "slack" : "telegram"}
-            </span>
-          )}
-        </div>
-        <span className="text-[11px] text-text-muted">
-          {new Date(s.updatedAt ?? s.createdAt).toLocaleString()}
-        </span>
-      </div>
-      {/* Desktop: hover-visible delete button */}
-      <button
-        className="shrink-0 h-6 w-6 rounded-md flex items-center justify-center text-text-muted opacity-0 group-hover:opacity-100 hover:text-danger transition-all"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        title="Delete session"
-      >
-        <Trash2 size={12} />
-      </button>
-      {/* Context menu — long press (mobile) or right-click */}
-      {menuOpen && (
-        <div
-          ref={menuRef}
-          className="absolute right-3 top-2 z-30 rounded-lg border-2 border-border bg-surface py-1 anim-scale-in shadow-brutal-sm"
-        >
-          <button
-            className="flex items-center gap-2 w-full px-4 py-2 text-[13px] text-danger hover:bg-danger-light transition-colors"
-            onClick={(e) => {
-              e.stopPropagation();
-              setMenuOpen(false);
-              onDelete();
-            }}
-          >
-            <Trash2 size={13} /> Delete session
-          </button>
-        </div>
-      )}
-    </div>
-  );
-}

--- a/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
@@ -1,8 +1,6 @@
 import type { ClientSideConnection } from "@agentclientprotocol/sdk/dist/acp.js";
-import { SessionMode } from "api-server-api";
-import { useCallback, useRef } from "react";
+import { useCallback } from "react";
 
-import { api } from "../../../api.js";
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
 import type { Attachment, Message } from "../../../types.js";
@@ -20,17 +18,16 @@ interface LiveConnection {
  *
  *   - `sendPrompt(text, attachments)` writes optimistic user + assistant
  *     bubbles into the projection, ensures a live connection (which the
- *     orchestrator hands in), forwards the prompt over ACP, registers the
- *     session with the platform DB on first successful turn, and finalizes
- *     the assistant bubble.
+ *     orchestrator hands in), forwards the prompt over ACP, and finalizes
+ *     the assistant bubble. Session persistence to the platform DB happens
+ *     eagerly inside the engagement hook, so a refresh mid-turn still
+ *     leaves the session in the sidebar.
  *
  *   - `stopAgent()` finalizes every streaming bubble locally so the UI
  *     reacts even if `cancel` hangs, then calls SDK cancel best-effort.
  *
- * The `persistedSessionsRef` dedup is local to this hook — only sendPrompt
- * reads it. `connectionRef` and `engagedSessionIdRef` come from the
- * orchestrator's connection layer; they will move into useAcpConnection
- * in a later step.
+ * `connectionRef` and `engagedSessionIdRef` come from the orchestrator's
+ * connection layer; they will move into useAcpConnection in a later step.
  */
 export function useAcpPrompt(
   selectedInstance: string | null,
@@ -44,12 +41,6 @@ export function useAcpPrompt(
 } {
   const setMessages = useStore((s) => s.setMessages);
   const addLog = useStore((s) => s.addLog);
-  const showToast = useStore((s) => s.showToast);
-
-  // Sessions already upserted to the platform DB. Lazy upsert (only after
-  // the first successful prompt) prevents empty rows in the sidebar when
-  // the user opens the app and closes it without sending anything.
-  const persistedSessionsRef = useRef<Set<string>>(new Set());
 
   const sendPrompt = useCallback(async (text: string, attachments?: Attachment[]) => {
     if ((!text && (!attachments || attachments.length === 0)) || !selectedInstance) return;
@@ -86,22 +77,6 @@ export function useAcpPrompt(
       const r = await conn.prompt({ sessionId: sid, prompt: promptBlocks });
       addLog("done", { stopReason: r.stopReason });
 
-      // Persist to the platform DB lazily, only once the session has real
-      // content. Await the create before invalidating the session-list
-      // query — otherwise the refetch races the server's DB write, sees no
-      // row for this session, and the user has to hit Refresh for it to
-      // appear.
-      if (!persistedSessionsRef.current.has(sid)) {
-        persistedSessionsRef.current.add(sid);
-        try {
-          await api.sessions.create.mutate({ sessionId: sid, instanceId: selectedInstance, mode: SessionMode.Chat });
-        } catch (err) {
-          showToast({
-            kind: "warning",
-            message: `Session won't appear in the list: ${err instanceof Error ? err.message : "sync failed"}`,
-          });
-        }
-      }
       // Belt-and-braces: if platform_turn_ended somehow didn't fire (server
       // variant without our extension), force-close our bubble anyway.
       setMessages((p) => p.map((m) => m.id === aId ? { ...m, streaming: false, queued: false } : m));
@@ -117,7 +92,7 @@ export function useAcpPrompt(
       queryClient.invalidateQueries({ queryKey: acpSessionsKeys.all });
       textareaRef.current?.focus();
     }
-  }, [selectedInstance, ensureConnection, engagedSessionIdRef, addLog, setMessages, showToast, textareaRef]);
+  }, [selectedInstance, ensureConnection, engagedSessionIdRef, addLog, setMessages, textareaRef]);
 
   const stopAgent = useCallback(async () => {
     const conn = connectionRef.current?.connection;

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session-engagement.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session-engagement.ts
@@ -1,9 +1,13 @@
 import type { ClientSideConnection } from "@agentclientprotocol/sdk/dist/acp.js";
 import type { McpServer } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
+import { SessionMode } from "api-server-api";
 import { useCallback, useRef } from "react";
 
+import { api } from "../../../api.js";
+import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
 import type { SessionConfigPayload } from "../../acp/types.js";
+import { acpSessionsKeys } from "../api/queries.js";
 
 /**
  * Owns the "engage a live ACP connection with the active session" decision.
@@ -37,6 +41,7 @@ export function useAcpSessionEngagement(
 } {
   const setSessionId = useStore((s) => s.setSessionId);
   const addLog = useStore((s) => s.addLog);
+  const showToast = useStore((s) => s.showToast);
 
   const engagedSessionIdRef = useRef<string | null>(null);
 
@@ -63,9 +68,23 @@ export function useAcpSessionEngagement(
       setSessionId(s.sessionId);
       engagedSessionIdRef.current = s.sessionId;
       addLog("session", { sessionId: s.sessionId });
+      // Persist to the platform DB as soon as the runtime returns a session
+      // id — refreshing or navigating away mid-turn must still leave the
+      // session in the sidebar. Fire-and-forget; engage only ever runs from
+      // a user-initiated send, so this can't create rows for chats the user
+      // never sent in.
+      api.sessions.create
+        .mutate({ sessionId: s.sessionId, instanceId: selectedInstance, mode: SessionMode.Chat })
+        .then(() => queryClient.invalidateQueries({ queryKey: acpSessionsKeys.all }))
+        .catch((err) => {
+          showToast({
+            kind: "warning",
+            message: `Couldn't save this session to your history: ${err instanceof Error ? err.message : "sync failed"}`,
+          });
+        });
       await applySavedPreferences(conn, s.sessionId, s);
     }
-  }, [selectedInstance, selectedMcpServers, captureSessionConfig, applySavedPreferences, setSessionId, addLog]);
+  }, [selectedInstance, selectedMcpServers, captureSessionConfig, applySavedPreferences, setSessionId, addLog, showToast]);
 
   const clear = useCallback(() => {
     engagedSessionIdRef.current = null;


### PR DESCRIPTION
## Summary

- **Persist new sessions to the DB eagerly (fixes #21).** `sessions.create` now runs right after `conn.newSession` returns instead of after the first prompt resolves. A refresh or navigation mid-turn no longer leaves the session missing from the sidebar.
- **"(no title)" placeholder in muted style** when the harness hasn't named the session yet, replacing the session-id slice that read like a title.
- **`refetchOnMount: "always"`** on the sessions list query so returning to a chat view picks up titles set after the first turn without a manual refresh.

## Test plan

- [ ] Open a new chat, send a prompt, while it's still streaming refresh the page → session is in the sidebar.
- [ ] Same scenario but navigate to agents list and back instead of refreshing → session is in the sidebar.
- [ ] Start a chat with no title yet — sidebar row reads `(no title)` in muted italic, not a 12-char id slice.
- [ ] After the first turn finishes and the harness assigns a title, navigate away and back → updated title is visible without pressing Refresh.
- [ ] Existing sessions (resume path) still work — title rendering, mode badge, delete confirm dialog all unchanged.