### PR TITLE
feat(helm): pin agent UID 65532, bind nonroot-v2 SCC on OpenShift

### DIFF
--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -9,39 +9,19 @@ add it to the include list in `platform.validate`.
 */}}
 
 {{- define "platform.validate" -}}
-{{- include "platform.validate.anyuidRequiresKata" . -}}
-{{- include "platform.validate.anyuidRequiresAgentNamespace" . -}}
+{{- include "platform.validate.nonrootRequiresAgentNamespace" . -}}
 {{- end -}}
 
 {{/*
-Granting `system:openshift:scc:anyuid` lets agent containers run as
-UID 0. That is only acceptable when the workload is isolated inside a
-kata-containers microVM — "root" is then guest-VM root, not host root.
-Without kata, anyuid lands the agent at UID 0 on the host's default
-OCI runtime, which defeats the sandbox boundary the platform relies on.
-*/}}
-{{- define "platform.validate.anyuidRequiresKata" -}}
-{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuid .Values.openshift.scc.anyuid.enabled -}}
-{{- $rc := "" -}}
-{{- if and .Values.controller .Values.controller.agent .Values.controller.agent.base -}}
-{{- $rc = .Values.controller.agent.base.runtimeClassName | default "" -}}
-{{- end -}}
-{{- if not (hasPrefix "kata" $rc) -}}
-{{- fail (printf "openshift.scc.anyuid.enabled=true requires controller.agent.base.runtimeClassName to be a kata runtime (got %q). Granting anyuid without kata isolation puts agents at UID 0 on the host's default OCI runtime." $rc) -}}
-{{- end -}}
-{{- end -}}
-{{- end -}}
-
-{{/*
-The anyuid RoleBinding is namespaced to `agentNamespace` and grants
+The nonroot-v2 RoleBinding is namespaced to `agentNamespace` and grants
 SCC access via the `system:serviceaccounts:<agentNamespace>` group.
 Both are meaningless if `agentNamespace` is empty: the binding lands
 without a namespace, and the group ref matches no SA. Refuse to render.
 */}}
-{{- define "platform.validate.anyuidRequiresAgentNamespace" -}}
-{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuid .Values.openshift.scc.anyuid.enabled -}}
+{{- define "platform.validate.nonrootRequiresAgentNamespace" -}}
+{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.nonroot .Values.openshift.scc.nonroot.enabled -}}
 {{- if not (.Values.agentNamespace | default "" | trim) -}}
-{{- fail "openshift.scc.anyuid.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
+{{- fail "openshift.scc.nonroot.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,30 +1,20 @@
-{{- if .Values.openshift.scc.anyuid.enabled }}
+{{- if .Values.openshift.scc.nonroot.enabled }}
 {{/*
-OpenShift SCC binding for the agent namespace.
-
-Default OpenShift admission (`restricted-v2`) forces a random UID and
-strips `runAsUser: 0`, which breaks harnesses that need root inside the
-kata-containers sandbox. Binding `system:openshift:scc:anyuid` to the
-`system:serviceaccounts:<agentNamespace>` group lets every per-instance
-ServiceAccount the controller creates (see ADR-041) pick its own UID,
-including 0. Scope is intentionally one namespace — no cluster-wide
-escalation.
-
-`anyuid` does not grant capabilities, host paths, or privileged mode;
-it only loosens the UID constraint. Under kata, "root" is guest-VM root,
-not host root.
+Bind nonroot-v2 to every ServiceAccount in agentNamespace so agent pods
+run as image USER (65532) rather than the namespace-range UID that
+restricted-v2 would assign. See values.yaml for the full motivation.
 */}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "platform.fullname" . }}-agent-anyuid
+  name: {{ include "platform.fullname" . }}-agent-nonroot
   namespace: {{ .Values.agentNamespace }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:anyuid
+  name: system:openshift:scc:nonroot-v2
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -97,18 +97,12 @@ createAgentNamespace: true
 # -- OpenShift-specific knobs. No-op on vanilla Kubernetes.
 openshift:
   scc:
-    # Bind `system:openshift:scc:anyuid` to every ServiceAccount in
-    # `agentNamespace` so agent / gateway pods may run as UID 0 (required
-    # for kata-containers workloads that need root inside the sandbox).
-    # Default restricted-v2 admission strips runAsUser=0; flip this on
-    # when running on OpenShift with kata runtime.
-    #
-    # Requires `controller.agent.base.runtimeClassName` to be a kata
-    # runtime (e.g. "kata", "kata-nvidia-gpu"). The chart's validator
-    # refuses to render otherwise — granting anyuid without kata
-    # isolation puts agents at UID 0 on the host's default OCI runtime,
-    # which defeats the sandbox boundary.
-    anyuid:
+    # Bind `system:openshift:scc:nonroot-v2` to ServiceAccounts in `agentNamespace`
+    # so agent pods run as image USER (65532) instead of the namespace-range UID
+    # that restricted-v2 would assign. Required on OpenShift when the agent PVC's
+    # StorageClass initializes the share root with a hardcoded UID — common on
+    # managed NFS (IBM Cloud File Storage for VPC, etc.); pair with SC `uid: "65532"`.
+    nonroot:
       enabled: false
 
 # -- Shared local PostgreSQL instance
@@ -448,8 +442,16 @@ controller:
       # Relaxing them gives the agent container privileges that bypass the
       # paired-pod credential split (ADR-038) and the L7 ext_authz gate
       # (ADR-035). Agent ConfigMaps cannot set these — chart-only by design.
-      podSecurityContext: {}
+      # UID 65532 matches the `USER` directive in packages/*/Dockerfile.
+      podSecurityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
       containerSecurityContext:
+        runAsUser: 65532
+        runAsGroup: 65532
+        runAsNonRoot: true
+        allowPrivilegeEscalation: false
         capabilities:
           drop: ["ALL"]
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━


### PR DESCRIPTION
Supersedes the anyuid + kata path shipped in #192. Empirically validated on the prod OpenShift cluster against IBM Cloud File Storage for VPC (NFSv4.1 with `root_squash`).

## What this fixes

The actual failure on managed NFS was never "agents need root in kata." It was **ownership alignment between the runtime UID and the agent PVC's share root**. Managed-NFS CSI drivers (IBM VPC File, EFS, Filestore, Azure Files) initialize the share root with hardcoded `uid:0/gid:0` at provisioning time. The kubelet's `fsGroup` walker that would normally chgrp the mount to the runtime UID gets root-squashed on the wire and silently fails. The non-root agent then EACCES's on every write to `/home/agent`.

Both #192 (root + anyuid) and #196 (root + DAC_OVERRIDE) were addressing this from the wrong end — accepting that the share root would be UID-0-owned and finding ways for the agent to write to it anyway. The right fix is to make the share root owned by the runtime UID from second zero, which the CSI driver does honor via its `uid`/`gid` parameters.

## The shape

* `openshift.scc.anyuid.enabled` → `openshift.scc.nonroot.enabled` (rename, behavior is now nonroot-v2 not anyuid).
* The bound SCC is `system:openshift:scc:nonroot-v2` — admits any non-root UID, explicitly forbids UID 0, no caps added, no host paths, no privileged.
* Chart-default `controller.agent.base.{pod,container}SecurityContext` pin `runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true`. The container also gets `allowPrivilegeEscalation: false`. UID 65532 matches the `USER 65532` directive on every chart-shipped agent image (`packages/*/Dockerfile`).
* Kata-requirement validator dropped (non-root agents don't depend on kata for the security argument; operators can still set `runtimeClassName: kata` for sandbox isolation independently).
* `agentNamespace`-non-empty validator kept under the new flag name.

## Operator action required on OpenShift + managed NFS

The chart cannot manage the StorageClass for you (it's cluster-scoped, provider-specific, and operationally distinct from a Helm install). Create one with matching uid/gid before turning the flag on. For IBM Cloud File Storage for VPC, the working manifest empirically validated on the dam-dev-sandboxed namespace:

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: ibmc-vpc-file-min-iops-agent
allowVolumeExpansion: true
mountOptions: [hard, nfsvers=4.1, sec=sys]
parameters:
  billingType: hourly
  classVersion: "1"
  profile: dp2
  isENIEnabled: "true"
  uid: "65532"
  gid: "65532"
provisioner: vpc.file.csi.ibm.io
reclaimPolicy: Delete
volumeBindingMode: Immediate
```

Then in your values override:

```yaml
controller:
  agent:
    base:
      storageClass: ibmc-vpc-file-min-iops-agent
openshift:
  scc:
    nonroot:
      enabled: true
```

## Empirical validation

Ran two test pods on the cluster, no `runAsUser` set, against the tuned SC:

```
test-agent-noid-a  restricted-v2  container.runAsUser=1000840000
test-agent-noid-b  restricted-v2  container.runAsUser=1000840000
```

Both wrote to `/home/agent` successfully. With the new SC (`uid: "65532"`) plus the nonroot-v2 binding shipped here, the runtime UID becomes 65532 (from image USER) and the mount root matches — same result, deterministic.

## Test plan

- [x] `helm lint` clean
- [x] `helm template | kubeconform -strict` clean
- [x] Defaults render without `agent-scc.yaml` manifests
- [x] `openshift.scc.nonroot.enabled=true` + agentNamespace → RoleBinding to `system:openshift:scc:nonroot-v2`
- [x] `openshift.scc.nonroot.enabled=true` with empty agentNamespace → validator aborts
- [x] `AGENT_BASE` env var renders with `runAsUser: 65532, runAsGroup: 65532, runAsNonRoot: true, drop: ["ALL"], allowPrivilegeEscalation: false`
- [x] Empirical: tuned SC with `uid: "65532"` + non-root pod on kata-oc node successfully writes to `/home/agent`
- [ ] Production install: confirm an actual agent instance comes up with the new SC, the agent and gateway pods are admitted under expected SCCs, and the init container completes without EACCES