### PR TITLE
feat(ci): build Bob image on main and enable Bob by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -184,10 +184,41 @@ jobs:
           cache-from: type=gha,scope=pi-agent
           cache-to: type=gha,mode=max,scope=pi-agent
 
+  build-bob:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: build-images
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/bob
+          tags: type=sha,prefix=,format=long
+      - uses: docker/build-push-action@v6
+        with:
+          context: packages/agents/bob
+          file: packages/agents/bob/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ github.sha }}
+          cache-from: type=gha,scope=bob
+          cache-to: type=gha,mode=max,scope=bob
+
   helm-package:
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [build-images, build-claude-code, build-google-workspace-agent, build-code-guardian, build-pi-agent]
+    needs: [build-images, build-claude-code, build-google-workspace-agent, build-code-guardian, build-pi-agent, build-bob]
     steps:
       - uses: actions/checkout@v4
       - uses: azure/setup-helm@v4

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -557,7 +557,7 @@ agentTemplates:
       - $HOME/.claude/skills/
 
   - name: bob
-    enabled: false
+    enabled: true
     description: "Bob shell agent"
     image:
       repository: quay.io/dam-agents/bob

--- a/packages/agents/bob/README.md
+++ b/packages/agents/bob/README.md
@@ -1,6 +1,6 @@
 # Bob Agent
 
-Platform agent running [Bob Shell](https://bob-shell.com/) — IBM's general-purpose AI shell assistant. Built on the platform-base image with an ACP translation shim and a per-instance Envoy egress sidecar that injects the Bob API key on outbound traffic.
+Platform agent running [Bob Shell](https://internal.bob.ibm.com/docs/shell) — IBM's general-purpose AI shell assistant. Built on the platform-base image with an ACP translation shim and a per-instance Envoy egress sidecar that injects the Bob API key on outbound traffic.
 
 ## Stack
 


### PR DESCRIPTION
## Summary

- Add `build-bob` job to [`.github/workflows/main.yml`](.github/workflows/main.yml) CD pipeline so every push to `main` builds and pushes `quay.io/dam-agents/bob:<sha>` (mirrors `build-pi-agent`). Wired into `helm-package: needs:` so the `platform-0.0.0-main` floating chart waits for it.
- Flip `agentTemplates[bob].enabled` from `false` to `true` in default [`values.yaml`](deploy/helm/platform/values.yaml) so the Bob agent-template ConfigMap is rendered by default — required for the IBM Cloud DEV environment to surface Bob in the agent picker.
- Fix the Bob Shell docs link in [`packages/agents/bob/README.md`](packages/agents/bob/README.md) from the bogus `bob-shell.com` to `internal.bob.ibm.com/docs/shell`.

## Why

PR #180 added the Bob agent code + Helm template + bob-acp-shim, but:
1. `main.yml` was never updated to actually build the Bob image, so `bob:<sha>` did not exist on quay — even though the `platform-0.0.0-main` chart referenced it.
2. Bob was opt-in (`enabled: false`) in default values, so the agent-template ConfigMap was not rendered on environments that consume default values.

Net effect: Bob was invisible in the agent picker on IBM Cloud DEV. This PR fixes both gaps.

## Test plan

- [ ] CI: `build-bob` job runs and pushes `quay.io/dam-agents/bob:<sha>` for this PR's merge commit
- [ ] CI: `helm-package` succeeds and bundles the Bob template in `platform-0.0.0-main`
- [ ] After deploy: `kubectl get configmaps -n platform-agents -l agent-platform.ai/type=agent-template` lists `bob`
- [ ] UI: "Add Agent" dialog shows Bob in the agent picker
- [ ] Smoke: create a Bob instance; pod reaches `Running`, no `ImagePullBackOff`