### PR TITLE
feat(cli): add dam chat command to connect terminal to agent TUI

### DIFF
--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -49,6 +49,7 @@ export interface AcpRuntime {
    */
   attach(channel: ClientChannel): void;
   status(): AcpRuntimeStatus;
+  resetSession(sessionId: string): void;
   shutdown(): void;
 }
 
@@ -993,6 +994,21 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
         queuedPromptCount: queued,
         agentAlive: agent !== null && !agentExited,
       };
+    },
+
+    resetSession(sessionId) {
+      if (agent && !agentExited && sessionCloseSupported) {
+        agent.send({
+          jsonrpc: "2.0",
+          id: nextOutboundId++,
+          method: "session/close",
+          params: { sessionId },
+        });
+      }
+      // Always clear client-side state even if the agent didn't accept the close.
+      sessionLogs.delete(sessionId);
+      for (const cursors of channelCursors.values()) cursors.delete(sessionId);
+      deps.log?.(`reset session ${sessionId}`);
     },
 
     shutdown() {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -216,6 +216,13 @@ const server = http.createServer((req, res) => {
     return;
   }
 
+  const sessionResetMatch = req.method === "POST" && req.url?.match(/^\/api\/sessions\/([^/]+)\/reset$/);
+  if (sessionResetMatch) {
+    acpRuntime.resetSession(decodeURIComponent(sessionResetMatch[1]!));
+    res.writeHead(204, CORS).end();
+    return;
+  }
+
   if (req.url?.startsWith("/api/trpc")) {
     req.url = req.url.replace("/api/trpc", "");
     Object.entries(CORS).forEach(([k, v]) => res.setHeader(k, v));

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -27,6 +27,7 @@ import {
 } from "../../modules/channels/infrastructure/telegram-threads-repository.js";
 import { createAcpRelay } from "./acp-relay.js";
 import { createTerminalRelay } from "./terminal-relay.js";
+import { getSessionMode } from "../../modules/sessions/infrastructure/sessions-repository.js";
 import { createOAuthRoutes } from "./oauth.js";
 import { mountBrandIconRoutes } from "./brand-icon.js";
 import { createOAuthAppRegistry } from "../../modules/connections/infrastructure/oauth-apps.js";
@@ -389,9 +390,8 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     const { sessions } = composeSessionsModule({
       db, namespace: config.namespace, isOwnedInstance, isOwnedSchedule,
       closeTerminalSession: terminalRelay.closeSession,
-      resetAcpSession: (instanceId, sessionId) => {
-        fetch(`http://${podBaseUrl(instanceId, config.namespace)}/api/sessions/${encodeURIComponent(sessionId)}/reset`, { method: "POST" }).catch(() => {});
-      },
+      resetAcpSession: (instanceId, sessionId) =>
+        fetch(`http://${podBaseUrl(instanceId, config.namespace)}/api/sessions/${encodeURIComponent(sessionId)}/reset`, { method: "POST" }).catch(() => {}),
       notifyModeChange: (instanceId, sessionId, mode) => {
         const frame = JSON.stringify({
           jsonrpc: "2.0",
@@ -466,7 +466,9 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     { resolve: (id) => instancesRepo.resolveIdentity(id).then((r) => r ? { ownerSub: r.owner, agentId: r.agentId } : null) },
   );
 
-  const terminalRelay = createTerminalRelay(config.namespace, instancesRepo);
+  const terminalRelay = createTerminalRelay(config.namespace, instancesRepo, {
+    getSessionMode: getSessionMode(db),
+  });
 
   const server = serve({ fetch: app.fetch, port: config.port }, () => {
     process.stderr.write(`api-server listening on http://localhost:${config.port}\n`);

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -47,6 +47,7 @@ import {
   type ApprovalsRelayService,
   type WrapperFrameSender,
 } from "./../../modules/approvals/compose.js";
+import { injectChannelOf } from "./../../modules/approvals/infrastructure/acp-frames.js";
 import {
   composeEgressRulesModule,
   createConnectionRulesSyncAdapter,
@@ -387,6 +388,18 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     const { schedules, isOwnedSchedule } = composeSchedulesModule(api, config.namespace, user.sub);
     const { sessions } = composeSessionsModule({
       db, namespace: config.namespace, isOwnedInstance, isOwnedSchedule,
+      closeTerminalSession: terminalRelay.closeSession,
+      resetAcpSession: (instanceId, sessionId) => {
+        fetch(`http://${podBaseUrl(instanceId, config.namespace)}/api/sessions/${encodeURIComponent(sessionId)}/reset`, { method: "POST" }).catch(() => {});
+      },
+      notifyModeChange: (instanceId, sessionId, mode) => {
+        const frame = JSON.stringify({
+          jsonrpc: "2.0",
+          method: "platform/sessionModeChanged",
+          params: { sessionId, mode },
+        });
+        redisBus.publish(injectChannelOf(instanceId), frame).catch(() => {});
+      },
     });
     const skills = composeSkillsModule(api, config.namespace, user.sub, db, seedSources, config.brand.name);
     const grants = createAgentGrantsPort(k8sClient, user.sub);

--- a/packages/api-server/src/apps/api-server/terminal-relay.ts
+++ b/packages/api-server/src/apps/api-server/terminal-relay.ts
@@ -8,9 +8,25 @@ import { LAST_ACTIVITY_KEY, ACTIVE_SESSION_KEY } from "../../modules/agents/infr
 const ACTIVITY_DEBOUNCE_MS = 30_000;
 const PENDING_BUFFER_MAX_BYTES = 1 * 1024 * 1024;
 
-export function createTerminalRelay(namespace: string, repo: InstancesRepository) {
+export interface TerminalRelay {
+  handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer, instanceId: string): void;
+  closeSession(sessionId: string): void;
+}
+
+export function createTerminalRelay(namespace: string, repo: InstancesRepository): TerminalRelay {
   const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
   const lastActivity = new Map<string, number>();
+  const activeClients = new Map<string, WebSocket>();
+
+  function closeSession(sessionId: string) {
+    const ws = activeClients.get(sessionId);
+    if (!ws) { activeClients.delete(sessionId); return; }
+    if (ws.readyState === WebSocket.CONNECTING) ws.terminate();
+    else if (ws.readyState === WebSocket.OPEN) {
+      try { ws.close(1000, "session mode changed"); } catch { ws.terminate(); }
+    }
+    activeClients.delete(sessionId);
+  }
 
   function handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer, instanceId: string) {
     const url = new URL(req.url!, `http://${req.headers.host}`);
@@ -19,6 +35,15 @@ export function createTerminalRelay(namespace: string, repo: InstancesRepository
 
     wss.handleUpgrade(req, socket, head, (client) => {
       client.on("error", () => { try { client.terminate(); } catch {} });
+
+      const prev = activeClients.get(sessionId);
+      if (prev) {
+        if (prev.readyState === WebSocket.CONNECTING) prev.terminate();
+        else if (prev.readyState === WebSocket.OPEN) {
+          try { prev.close(1000, "superseded"); } catch { prev.terminate(); }
+        }
+      }
+      activeClients.set(sessionId, client);
 
       const pending: { data: Buffer; isBinary: boolean }[] = [];
       let pendingBytes = 0;
@@ -78,6 +103,7 @@ export function createTerminalRelay(namespace: string, repo: InstancesRepository
           });
 
           client.on("close", () => {
+            if (activeClients.get(sessionId) === client) activeClients.delete(sessionId);
             repo.patchAnnotation(instanceId, ACTIVE_SESSION_KEY, "").catch(() => {});
             if (upstream.readyState === WebSocket.OPEN) upstream.close();
           });
@@ -89,5 +115,5 @@ export function createTerminalRelay(namespace: string, repo: InstancesRepository
     });
   }
 
-  return { handleUpgrade };
+  return { handleUpgrade, closeSession };
 }

--- a/packages/api-server/src/apps/api-server/terminal-relay.ts
+++ b/packages/api-server/src/apps/api-server/terminal-relay.ts
@@ -13,7 +13,9 @@ export interface TerminalRelay {
   closeSession(sessionId: string): void;
 }
 
-export function createTerminalRelay(namespace: string, repo: InstancesRepository): TerminalRelay {
+export function createTerminalRelay(namespace: string, repo: InstancesRepository, deps?: {
+  getSessionMode?: (sessionId: string) => Promise<string | null>;
+}): TerminalRelay {
   const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
   const lastActivity = new Map<string, number>();
   const activeClients = new Map<string, WebSocket>();
@@ -28,10 +30,19 @@ export function createTerminalRelay(namespace: string, repo: InstancesRepository
     activeClients.delete(sessionId);
   }
 
-  function handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer, instanceId: string) {
+  async function handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer, instanceId: string) {
     const url = new URL(req.url!, `http://${req.headers.host}`);
     const sessionId = url.searchParams.get("sessionId") ?? "default";
     const reset = url.searchParams.get("reset") === "1";
+
+    if (deps?.getSessionMode) {
+      const mode = await deps.getSessionMode(sessionId).catch(() => null);
+      if (mode && mode !== "terminal") {
+        socket.write("HTTP/1.1 409 Conflict\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+    }
 
     wss.handleUpgrade(req, socket, head, (client) => {
       client.on("error", () => { try { client.terminate(); } catch {} });

--- a/packages/api-server/src/modules/sessions/compose.ts
+++ b/packages/api-server/src/modules/sessions/compose.ts
@@ -11,6 +11,9 @@ export function composeSessionsModule(deps: {
   namespace: string;
   isOwnedInstance: (instanceId: string) => Promise<boolean>;
   isOwnedSchedule: (scheduleId: string) => Promise<boolean>;
+  closeTerminalSession?: (sessionId: string) => void;
+  resetAcpSession?: (instanceId: string, sessionId: string) => void;
+  notifyModeChange?: (instanceId: string, sessionId: string, mode: string) => void;
 }): {
   sessions: SessionsApiService;
 } {
@@ -26,6 +29,9 @@ export function composeSessionsModule(deps: {
       isOwnedSchedule: deps.isOwnedSchedule,
       deactivateByScheduleId: deactivateByScheduleId(deps.db),
       namespace: deps.namespace,
+      closeTerminalSession: deps.closeTerminalSession,
+      resetAcpSession: deps.resetAcpSession,
+      notifyModeChange: deps.notifyModeChange,
     }),
   };
 }

--- a/packages/api-server/src/modules/sessions/compose.ts
+++ b/packages/api-server/src/modules/sessions/compose.ts
@@ -12,7 +12,7 @@ export function composeSessionsModule(deps: {
   isOwnedInstance: (instanceId: string) => Promise<boolean>;
   isOwnedSchedule: (scheduleId: string) => Promise<boolean>;
   closeTerminalSession?: (sessionId: string) => void;
-  resetAcpSession?: (instanceId: string, sessionId: string) => void;
+  resetAcpSession?: (instanceId: string, sessionId: string) => Promise<void>;
   notifyModeChange?: (instanceId: string, sessionId: string, mode: string) => void;
 }): {
   sessions: SessionsApiService;

--- a/packages/api-server/src/modules/sessions/infrastructure/sessions-repository.ts
+++ b/packages/api-server/src/modules/sessions/infrastructure/sessions-repository.ts
@@ -70,6 +70,13 @@ export function upsertSession(db: Db) {
   };
 }
 
+export function getSessionMode(db: Db) {
+  return async (sessionId: string): Promise<string | null> => {
+    const rows = await db.select({ mode: sessions.mode }).from(sessions).where(eq(sessions.sessionId, sessionId)).limit(1);
+    return rows[0]?.mode ?? null;
+  };
+}
+
 export function setSessionMode(db: Db) {
   return async (sessionId: string, instanceId: string, mode: SessionMode) => {
     await db

--- a/packages/api-server/src/modules/sessions/services/sessions-service.ts
+++ b/packages/api-server/src/modules/sessions/services/sessions-service.ts
@@ -13,7 +13,7 @@ export function createSessionsService(deps: {
   deactivateByScheduleId: (scheduleId: string) => Promise<void>;
   namespace: string;
   closeTerminalSession?: (sessionId: string) => void;
-  resetAcpSession?: (instanceId: string, sessionId: string) => void;
+  resetAcpSession?: (instanceId: string, sessionId: string) => Promise<void>;
   notifyModeChange?: (instanceId: string, sessionId: string, mode: SessionMode) => void;
 }): SessionsApiService {
   return {
@@ -69,7 +69,7 @@ export function createSessionsService(deps: {
       await deps.setMode(sessionId, instanceId, mode);
       if (mode !== SessionMode.Terminal) {
         deps.closeTerminalSession?.(sessionId);
-        deps.resetAcpSession?.(instanceId, sessionId);
+        await deps.resetAcpSession?.(instanceId, sessionId);
       }
       deps.notifyModeChange?.(instanceId, sessionId, mode);
     },

--- a/packages/api-server/src/modules/sessions/services/sessions-service.ts
+++ b/packages/api-server/src/modules/sessions/services/sessions-service.ts
@@ -12,6 +12,9 @@ export function createSessionsService(deps: {
   isOwnedSchedule: (scheduleId: string) => Promise<boolean>;
   deactivateByScheduleId: (scheduleId: string) => Promise<void>;
   namespace: string;
+  closeTerminalSession?: (sessionId: string) => void;
+  resetAcpSession?: (instanceId: string, sessionId: string) => void;
+  notifyModeChange?: (instanceId: string, sessionId: string, mode: SessionMode) => void;
 }): SessionsApiService {
   return {
     async list(instanceId: string, includeChannel?: boolean) {
@@ -64,6 +67,11 @@ export function createSessionsService(deps: {
     async setMode(sessionId: string, instanceId: string, mode: SessionMode) {
       if (!await deps.isOwnedInstance(instanceId)) return;
       await deps.setMode(sessionId, instanceId, mode);
+      if (mode !== SessionMode.Terminal) {
+        deps.closeTerminalSession?.(sessionId);
+        deps.resetAcpSession?.(instanceId, sessionId);
+      }
+      deps.notifyModeChange?.(instanceId, sessionId, mode);
     },
 
     async delete(sessionId: string, instanceId: string) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -21,11 +21,13 @@
     "commander": "^14.0.3",
     "open": "^11.0.0",
     "smol-toml": "^1.6.1",
+    "ws": "^8.20.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {
     "@trpc/server": "^11.16.0",
     "@types/node": "^25.5.0",
+    "@types/ws": "^8.18.1",
     "tsup": "^8.5.1",
     "tsx": "^4.21.0",
     "typescript": "^6.0.2",

--- a/packages/cli/src/compose.ts
+++ b/packages/cli/src/compose.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { composeAuthModule } from "./modules/auth/compose.js";
+import { composeChatModule } from "./modules/chat/compose.js";
 import { composeCliModule } from "./modules/cli/compose.js";
 import { composeInstanceModule } from "./modules/instance/compose.js";
 import { composeTemplateModule } from "./modules/template/compose.js";
@@ -49,6 +50,14 @@ export function compose(opts: ComposeOptions = {}): Command {
     templateService: template.exports.createService,
   });
 
+  const chat = composeChatModule({
+    compatService: cli.services.compatService,
+    configService: cli.services.configService,
+    tokenProvider: auth.exports.tokenProvider,
+    createInstanceService: instance.exports.createService,
+    serverEnvVar: "DAM_SERVER",
+  });
+
   const program = new Command();
   program
     .name("dam")
@@ -59,6 +68,7 @@ export function compose(opts: ComposeOptions = {}): Command {
   for (const command of auth.commands) program.addCommand(command);
   for (const command of template.commands) program.addCommand(command);
   for (const command of instance.commands) program.addCommand(command);
+  for (const command of chat.commands) program.addCommand(command);
 
   return program;
 }

--- a/packages/cli/src/modules/chat/commands/chat.ts
+++ b/packages/cli/src/modules/chat/commands/chat.ts
@@ -1,0 +1,71 @@
+import { Command } from "commander";
+import type { ChatError, ChatService, SessionStrategy } from "../services/chat-service.js";
+
+export function buildChatCommand(deps: { chatService: ChatService; serverEnvVar: string }): Command {
+  return new Command("chat")
+    .description("Connect your terminal to an agent's interactive TUI")
+    .argument("<instance>", "instance name or ID")
+    .option("--server <url>", "override the configured server URL")
+    .option("-c, --continue", "continue the most recent terminal session")
+    .option("-r, --resume <session-id>", "resume a specific session by ID")
+    .option("--reset", "kill existing PTY and start a fresh terminal")
+    .action(async (instanceRef: string, opts: { server?: string; continue?: boolean; resume?: string; reset?: boolean }) => {
+      const strategy: SessionStrategy = opts.resume
+        ? { kind: "resume", sessionId: opts.resume }
+        : opts.continue ? { kind: "continue" } : { kind: "new" };
+
+      const result = await deps.chatService.run({
+        instanceRef, serverFlag: opts.server, strategy, reset: opts.reset,
+      });
+
+      if (!result.ok) {
+        printError(result.error, deps.serverEnvVar);
+        process.exit(exitCodeFor(result.error));
+      }
+
+      const { bridge, sessionId } = result.value;
+      const hint = `\x1b[32mdam chat ${instanceRef} --resume ${sessionId}\x1b[0m`;
+      if (bridge.kind === "exited") {
+        process.stderr.write(`\x1b[2J\x1b[H\x1b[33mSession ended\x1b[0m \x1b[2mProcess exited with code ${bridge.code}\x1b[0m\n\nResume this session with: ${hint}\n`);
+        process.exit(bridge.code);
+      }
+      process.stderr.write(`\x1b[2J\x1b[H\x1b[33mDisconnected\x1b[0m \x1b[2m${bridge.reason}\x1b[0m\n\nResume this session with: ${hint}\n`);
+      process.exit(1);
+    });
+}
+
+export function exitCodeFor(e: ChatError): number {
+  switch (e.kind) {
+    case "below-floor": return 3;
+    case "not-found": case "ambiguous": return 5;
+    case "not-a-tty": case "no-terminal-session": case "multiple-terminal-sessions":
+    case "session-not-found": case "mode-switch-declined": return 2;
+    default: return 1;
+  }
+}
+
+export function printError(e: ChatError, serverEnvVar: string): void {
+  const w = (msg: string) => process.stderr.write(`error: ${msg}\n`);
+  switch (e.kind) {
+    case "no-server": w(`no server configured; run "dam config set server <url>" or set ${serverEnvVar}`); return;
+    case "malformed-config": w(e.reason); return;
+    case "below-floor": w(`CLI ${e.localCli} is below the server's minimum required version ${e.serverMinClient}; upgrade and retry`); return;
+    case "not-found": w(e.via === "id" ? `no instance with id '${e.ref}'` : `no instance named '${e.ref}'`); return;
+    case "ambiguous":
+      w(`multiple instances named '${e.ref}':`);
+      for (const m of e.matches) process.stderr.write(`  ${m.id}\n`);
+      process.stderr.write("specify by id instead\n");
+      return;
+    case "auth-required": w(`not authenticated: ${e.reason}\n       run "dam auth login" first`); return;
+    case "transport": w(`cannot reach server: ${e.reason}`); return;
+    case "not-a-tty": w("dam chat requires an interactive terminal (TTY)"); return;
+    case "session-failed": w(`session error: ${e.reason}`); return;
+    case "no-terminal-session": w("no terminal session to continue; start one with: dam chat <instance>"); return;
+    case "multiple-terminal-sessions":
+      w("multiple terminal sessions found; specify one with --resume:");
+      for (const id of e.sessionIds) process.stderr.write(`  ${id}\n`);
+      return;
+    case "session-not-found": w(`session '${e.sessionId}' not found`); return;
+    case "mode-switch-declined": return;
+  }
+}

--- a/packages/cli/src/modules/chat/commands/chat.ts
+++ b/packages/cli/src/modules/chat/commands/chat.ts
@@ -24,13 +24,12 @@ export function buildChatCommand(deps: { chatService: ChatService; serverEnvVar:
       }
 
       const { bridge, sessionId } = result.value;
-      const hint = `\x1b[32mdam chat ${instanceRef} --resume ${sessionId}\x1b[0m`;
-      if (bridge.kind === "exited") {
-        process.stderr.write(`\x1b[2J\x1b[H\x1b[33mSession ended\x1b[0m \x1b[2mProcess exited with code ${bridge.code}\x1b[0m\n\nResume this session with: ${hint}\n`);
-        process.exit(bridge.code);
-      }
-      process.stderr.write(`\x1b[2J\x1b[H\x1b[33mDisconnected\x1b[0m \x1b[2m${bridge.reason}\x1b[0m\n\nResume this session with: ${hint}\n`);
-      process.exit(1);
+      const resume = `\x1b[32mdam chat ${instanceRef} --resume ${sessionId}\x1b[0m`;
+      const status = bridge.kind === "exited"
+        ? `\x1b[33mSession ended\x1b[0m \x1b[2mProcess exited with code ${bridge.code}\x1b[0m`
+        : `\x1b[33mDisconnected\x1b[0m \x1b[2m${bridge.reason}\x1b[0m`;
+      process.stderr.write(`\x1b[2J\x1b[H${status}\n\nResume this session with: ${resume}\n`);
+      process.exit(bridge.kind === "exited" ? bridge.code : 1);
     });
 }
 

--- a/packages/cli/src/modules/chat/commands/session-list.ts
+++ b/packages/cli/src/modules/chat/commands/session-list.ts
@@ -1,0 +1,42 @@
+import { Command } from "commander";
+import type { SessionView } from "api-server-api";
+import type { ChatService } from "../services/chat-service.js";
+import { exitCodeFor, printError } from "./chat.js";
+
+export function buildSessionListCommand(deps: { chatService: ChatService; serverEnvVar: string }): Command {
+  return new Command("list")
+    .description("List sessions for an Instance")
+    .argument("<instance>", "instance name or ID")
+    .option("--server <url>", "override the configured server URL")
+    .option("--json", "emit raw JSON instead of the default table")
+    .action(async (instanceRef: string, opts: { server?: string; json?: boolean }) => {
+      const result = await deps.chatService.listSessions({ instanceRef, serverFlag: opts.server });
+      if (!result.ok) {
+        printError(result.error, deps.serverEnvVar);
+        process.exit(exitCodeFor(result.error));
+      }
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(result.value)}\n`);
+        return;
+      }
+
+      if (result.value.length === 0) {
+        process.stderr.write("No sessions.\n");
+        return;
+      }
+
+      process.stdout.write(renderTable(result.value));
+    });
+}
+
+function renderTable(sessions: readonly SessionView[]): string {
+  const rows = [
+    ["SESSION ID", "MODE", "TYPE", "CREATED"],
+    ...[...sessions].sort((a, b) => a.createdAt.localeCompare(b.createdAt)).map((s) => [s.sessionId, s.mode, s.type, s.createdAt]),
+  ];
+  const widths = rows[0]!.map((_, col) => Math.max(...rows.map((r) => r[col]!.length)));
+  return rows
+    .map((row) => row.map((cell, col) => col === row.length - 1 ? cell : cell + " ".repeat(widths[col]! - cell.length)).join("   "))
+    .join("\n") + "\n";
+}

--- a/packages/cli/src/modules/chat/compose.ts
+++ b/packages/cli/src/modules/chat/compose.ts
@@ -1,0 +1,38 @@
+import { createInterface } from "node:readline";
+import { Command } from "commander";
+import type { CompatService, ConfigService } from "../cli/index.js";
+import type { TokenProvider } from "../auth/index.js";
+import type { InstanceService } from "../instance/index.js";
+import { buildChatCommand } from "./commands/chat.js";
+import { buildSessionListCommand } from "./commands/session-list.js";
+import { createChatService } from "./services/chat-service.js";
+
+export function composeChatModule({
+  compatService, configService, tokenProvider, createInstanceService, serverEnvVar,
+}: {
+  compatService: CompatService;
+  configService: ConfigService;
+  tokenProvider: TokenProvider;
+  createInstanceService: (host: string) => InstanceService;
+  serverEnvVar: string;
+}): { commands: ReadonlyArray<Command> } {
+  const chatService = createChatService({
+    compatService, configService, tokenProvider, createInstanceService,
+    confirmModeSwitch: () => new Promise((resolve) => {
+      const rl = createInterface({ input: process.stdin, output: process.stderr });
+      process.stderr.write("Switch session mode\nSwitch this session to terminal mode? Files and history are preserved,\nbut any running tasks will be cancelled.\n");
+      rl.question("[y/N] ", (answer) => { rl.close(); resolve(answer.trim().toLowerCase() === "y"); });
+    }),
+    isTty: Boolean(process.stdin.isTTY),
+  });
+
+  const sessionParent = new Command("session").description("Manage sessions for an Instance");
+  sessionParent.addCommand(buildSessionListCommand({ chatService, serverEnvVar }), { isDefault: true });
+
+  return {
+    commands: [
+      buildChatCommand({ chatService, serverEnvVar }),
+      sessionParent,
+    ],
+  };
+}

--- a/packages/cli/src/modules/chat/infrastructure/sessions-client.ts
+++ b/packages/cli/src/modules/chat/infrastructure/sessions-client.ts
@@ -1,0 +1,32 @@
+import type { SessionView } from "api-server-api";
+import { SessionMode } from "api-server-api";
+import { err, ok, type Result } from "../../../result.js";
+
+type Fail = { kind: "session-failed"; reason: string };
+
+export function createSessionsClient(deps: { host: string; token: string }) {
+  const base = `${deps.host.replace(/\/+$/, "")}/api/trpc`;
+  const headers = { authorization: `Bearer ${deps.token}` };
+
+  async function rpc<T>(procedure: string, input: unknown, method: "GET" | "POST" = "GET"): Promise<Result<T, Fail>> {
+    try {
+      const url = method === "GET"
+        ? `${base}/${procedure}?input=${encodeURIComponent(JSON.stringify(input))}`
+        : `${base}/${procedure}`;
+      const res = await fetch(url, method === "GET"
+        ? { headers }
+        : { method: "POST", headers: { ...headers, "content-type": "application/json" }, body: JSON.stringify(input) });
+      if (!res.ok) return err({ kind: "session-failed", reason: `server returned ${res.status}` });
+      const body = await res.json() as { result?: { data?: T } };
+      return ok(body?.result?.data as T);
+    } catch (e) {
+      return err({ kind: "session-failed", reason: (e as Error).message });
+    }
+  }
+
+  return {
+    list: (instanceId: string) => rpc<readonly SessionView[]>("sessions.list", { instanceId }),
+    create: (sessionId: string, instanceId: string) => rpc<void>("sessions.create", { sessionId, instanceId, mode: SessionMode.Terminal }, "POST"),
+    setMode: (sessionId: string, instanceId: string, mode: "chat" | "terminal") => rpc<void>("sessions.setMode", { sessionId, instanceId, mode }, "POST"),
+  };
+}

--- a/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
+++ b/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
@@ -1,0 +1,56 @@
+import WebSocket from "ws";
+import {
+  decodeFrame,
+  encodeDataFrame,
+  encodeResize,
+  OP_EXIT,
+  OP_INPUT,
+  OP_OUTPUT,
+} from "api-server-api";
+
+export type BridgeResult =
+  | { kind: "exited"; code: number }
+  | { kind: "disconnected"; reason: string };
+
+export function connectTerminalBridge({ wsUrl, stdin, stdout }: {
+  wsUrl: string;
+  stdin: NodeJS.ReadStream & { setRawMode?(mode: boolean): void };
+  stdout: NodeJS.WriteStream;
+}): Promise<BridgeResult> {
+  return new Promise<BridgeResult>((resolve) => {
+    let settled = false;
+    const ws = new WebSocket(wsUrl);
+
+    const onData = (chunk: Buffer) => { if (ws.readyState === WebSocket.OPEN) ws.send(encodeDataFrame(OP_INPUT, new Uint8Array(chunk))); };
+    const onResize = () => { if (ws.readyState === WebSocket.OPEN) ws.send(encodeResize(stdout.columns, stdout.rows)); };
+
+    const finish = (result: BridgeResult) => {
+      if (settled) return;
+      settled = true;
+      stdin.off("data", onData);
+      process.off("SIGWINCH", onResize);
+      if (stdin.setRawMode) try { stdin.setRawMode(false); } catch {}
+      stdin.pause();
+      if (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING) ws.close();
+      resolve(result);
+    };
+
+    ws.on("open", () => {
+      ws.send(encodeResize(stdout.columns, stdout.rows));
+      if (stdin.setRawMode) stdin.setRawMode(true);
+      stdin.resume();
+      stdin.on("data", onData);
+      process.on("SIGWINCH", onResize);
+    });
+
+    ws.on("message", (data: Buffer) => {
+      let frame;
+      try { frame = decodeFrame(new Uint8Array(data)); } catch { return; }
+      if (frame.op === OP_OUTPUT) stdout.write(Buffer.from(frame.data));
+      else if (frame.op === OP_EXIT) finish({ kind: "exited", code: frame.code });
+    });
+
+    ws.on("close", (_code, reason) => finish({ kind: "disconnected", reason: reason?.toString() || "connection closed" }));
+    ws.on("error", (e) => finish({ kind: "disconnected", reason: e.message }));
+  });
+}

--- a/packages/cli/src/modules/chat/services/chat-service.ts
+++ b/packages/cli/src/modules/chat/services/chat-service.ts
@@ -1,0 +1,128 @@
+import { randomUUID } from "node:crypto";
+import type { SessionView } from "api-server-api";
+import { err, ok, type Result } from "../../../result.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import type { TokenProvider } from "../../auth/index.js";
+import { createInstanceResolver, type InstanceService, type ResolveError } from "../../instance/index.js";
+import { createSessionsClient } from "../infrastructure/sessions-client.js";
+import { connectTerminalBridge, type BridgeResult } from "../infrastructure/terminal-bridge.js";
+
+export type ChatError =
+  | ResolveError
+  | { kind: "no-server" }
+  | { kind: "malformed-config"; reason: string }
+  | { kind: "below-floor"; localCli: string; serverMinClient: string }
+  | { kind: "not-a-tty" }
+  | { kind: "session-failed"; reason: string }
+  | { kind: "no-terminal-session" }
+  | { kind: "multiple-terminal-sessions"; sessionIds: string[] }
+  | { kind: "session-not-found"; sessionId: string }
+  | { kind: "mode-switch-declined" };
+
+export type SessionStrategy =
+  | { kind: "new" }
+  | { kind: "continue" }
+  | { kind: "resume"; sessionId: string };
+
+export interface ChatService {
+  run(input: { instanceRef: string; serverFlag?: string; strategy: SessionStrategy; reset?: boolean }):
+    Promise<Result<{ bridge: BridgeResult; sessionId: string }, ChatError>>;
+  listSessions(input: { instanceRef: string; serverFlag?: string }):
+    Promise<Result<readonly SessionView[], ChatError>>;
+}
+
+export function createChatService(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  tokenProvider: TokenProvider;
+  createInstanceService: (host: string) => InstanceService;
+  confirmModeSwitch: () => Promise<boolean>;
+  isTty: boolean;
+}): ChatService {
+  async function resolveContext(instanceRef: string, serverFlag?: string): Promise<Result<
+    { host: string; token: string; instanceId: string; sessions: ReturnType<typeof createSessionsClient> }, ChatError
+  >> {
+    const flag = serverFlag ? { server: serverFlag } : undefined;
+    const config = await deps.configService.getResolved({ flag });
+    if (!config.ok) {
+      return config.error.kind === "malformed-config"
+        ? err({ kind: "malformed-config", reason: config.error.reason })
+        : err({ kind: "no-server" });
+    }
+    const host = config.value.server;
+
+    const compat = await deps.compatService.check({ flag });
+    if (compat.ok && compat.value.kind === "below-floor") {
+      return err({ kind: "below-floor", localCli: compat.value.localCli, serverMinClient: compat.value.serverMinClient });
+    }
+
+    const resolved = await createInstanceResolver({ instanceService: deps.createInstanceService(host) }).resolve(instanceRef);
+    if (!resolved.ok) return resolved;
+
+    const tokenResult = await deps.tokenProvider.getValidAccessToken(host);
+    if (!tokenResult.ok) {
+      const e = tokenResult.error;
+      const reason = e.kind === "not-logged-in"
+        ? (e.host ? `not logged in to ${e.host}` : "not logged in")
+        : e.kind === "session-expired"
+          ? (e.host ? `session expired for ${e.host}` : "session expired")
+          : (e.reason ?? e.kind);
+      return err({ kind: "auth-required", reason });
+    }
+
+    return ok({ host, token: tokenResult.value, instanceId: resolved.value.id, sessions: createSessionsClient({ host, token: tokenResult.value }) });
+  }
+
+  return {
+    async listSessions(input) {
+      const ctx = await resolveContext(input.instanceRef, input.serverFlag);
+      if (!ctx.ok) return ctx;
+      return ctx.value.sessions.list(ctx.value.instanceId);
+    },
+
+    async run(input) {
+      if (!deps.isTty) return err({ kind: "not-a-tty" });
+
+      const ctx = await resolveContext(input.instanceRef, input.serverFlag);
+      if (!ctx.ok) return ctx;
+      const { host, token, instanceId, sessions } = ctx.value;
+
+      let sessionId: string;
+      const { strategy } = input;
+
+      if (strategy.kind === "new") {
+        sessionId = randomUUID();
+        const created = await sessions.create(sessionId, instanceId);
+        if (!created.ok) return created;
+      } else if (strategy.kind === "continue") {
+        const listed = await sessions.list(instanceId);
+        if (!listed.ok) return listed;
+        const terminals = listed.value.filter((s) => s.mode === "terminal" && s.type === "regular");
+        if (terminals.length === 0) return err({ kind: "no-terminal-session" });
+        if (terminals.length > 1) {
+          return err({ kind: "multiple-terminal-sessions", sessionIds: terminals.map((s) => s.sessionId) });
+        }
+        sessionId = terminals[0]!.sessionId;
+      } else {
+        const listed = await sessions.list(instanceId);
+        if (!listed.ok) return listed;
+        const target = listed.value.find((s) => s.sessionId === strategy.sessionId);
+        if (!target) return err({ kind: "session-not-found", sessionId: strategy.sessionId });
+        if (target.mode === "chat") {
+          if (!await deps.confirmModeSwitch()) return err({ kind: "mode-switch-declined" });
+          const switched = await sessions.setMode(target.sessionId, instanceId, "terminal");
+          if (!switched.ok) return switched;
+        }
+        sessionId = target.sessionId;
+      }
+
+      const bridge = await connectTerminalBridge({
+        wsUrl: `${host.startsWith("https://") ? "wss:" : "ws:"}//${host.replace(/^https?:\/\//, "")}/api/instances/${encodeURIComponent(instanceId)}/terminal?token=${encodeURIComponent(token)}&sessionId=${encodeURIComponent(sessionId)}${input.reset ? "&reset=1" : ""}`,
+        stdin: process.stdin as NodeJS.ReadStream & { setRawMode(mode: boolean): void },
+        stdout: process.stdout,
+      });
+
+      return ok({ bridge, sessionId });
+    },
+  };
+}

--- a/packages/cli/src/modules/chat/services/chat-service.ts
+++ b/packages/cli/src/modules/chat/services/chat-service.ts
@@ -39,43 +39,42 @@ export function createChatService(deps: {
   confirmModeSwitch: () => Promise<boolean>;
   isTty: boolean;
 }): ChatService {
-  async function resolveContext(instanceRef: string, serverFlag?: string): Promise<Result<
-    { host: string; token: string; instanceId: string; sessions: ReturnType<typeof createSessionsClient> }, ChatError
-  >> {
+  async function bootstrap(instanceRef: string, serverFlag?: string) {
     const flag = serverFlag ? { server: serverFlag } : undefined;
     const config = await deps.configService.getResolved({ flag });
     if (!config.ok) {
       return config.error.kind === "malformed-config"
-        ? err({ kind: "malformed-config", reason: config.error.reason })
-        : err({ kind: "no-server" });
+        ? err({ kind: "malformed-config" as const, reason: config.error.reason })
+        : err({ kind: "no-server" as const });
     }
     const host = config.value.server;
 
     const compat = await deps.compatService.check({ flag });
     if (compat.ok && compat.value.kind === "below-floor") {
-      return err({ kind: "below-floor", localCli: compat.value.localCli, serverMinClient: compat.value.serverMinClient });
+      return err({ kind: "below-floor" as const, localCli: compat.value.localCli, serverMinClient: compat.value.serverMinClient });
     }
 
     const resolved = await createInstanceResolver({ instanceService: deps.createInstanceService(host) }).resolve(instanceRef);
     if (!resolved.ok) return resolved;
 
-    const tokenResult = await deps.tokenProvider.getValidAccessToken(host);
-    if (!tokenResult.ok) {
-      const e = tokenResult.error;
-      const reason = e.kind === "not-logged-in"
-        ? (e.host ? `not logged in to ${e.host}` : "not logged in")
-        : e.kind === "session-expired"
-          ? (e.host ? `session expired for ${e.host}` : "session expired")
-          : (e.reason ?? e.kind);
-      return err({ kind: "auth-required", reason });
-    }
+    const tok = await deps.tokenProvider.getValidAccessToken(host);
+    if (!tok.ok) return err({ kind: "auth-required" as const, reason: tok.error.kind });
 
-    return ok({ host, token: tokenResult.value, instanceId: resolved.value.id, sessions: createSessionsClient({ host, token: tokenResult.value }) });
+    return ok({
+      host, token: tok.value, instanceId: resolved.value.id,
+      sessions: createSessionsClient({ host, token: tok.value }),
+    });
+  }
+
+  function wsUrl(host: string, instanceId: string, token: string, sessionId: string, reset?: boolean) {
+    const proto = host.startsWith("https://") ? "wss:" : "ws:";
+    const base = host.replace(/^https?:\/\//, "");
+    return `${proto}//${base}/api/instances/${encodeURIComponent(instanceId)}/terminal?token=${encodeURIComponent(token)}&sessionId=${encodeURIComponent(sessionId)}${reset ? "&reset=1" : ""}`;
   }
 
   return {
     async listSessions(input) {
-      const ctx = await resolveContext(input.instanceRef, input.serverFlag);
+      const ctx = await bootstrap(input.instanceRef, input.serverFlag);
       if (!ctx.ok) return ctx;
       return ctx.value.sessions.list(ctx.value.instanceId);
     },
@@ -83,7 +82,7 @@ export function createChatService(deps: {
     async run(input) {
       if (!deps.isTty) return err({ kind: "not-a-tty" });
 
-      const ctx = await resolveContext(input.instanceRef, input.serverFlag);
+      const ctx = await bootstrap(input.instanceRef, input.serverFlag);
       if (!ctx.ok) return ctx;
       const { host, token, instanceId, sessions } = ctx.value;
 
@@ -99,9 +98,7 @@ export function createChatService(deps: {
         if (!listed.ok) return listed;
         const terminals = listed.value.filter((s) => s.mode === "terminal" && s.type === "regular");
         if (terminals.length === 0) return err({ kind: "no-terminal-session" });
-        if (terminals.length > 1) {
-          return err({ kind: "multiple-terminal-sessions", sessionIds: terminals.map((s) => s.sessionId) });
-        }
+        if (terminals.length > 1) return err({ kind: "multiple-terminal-sessions", sessionIds: terminals.map((s) => s.sessionId) });
         sessionId = terminals[0]!.sessionId;
       } else {
         const listed = await sessions.list(instanceId);
@@ -117,7 +114,7 @@ export function createChatService(deps: {
       }
 
       const bridge = await connectTerminalBridge({
-        wsUrl: `${host.startsWith("https://") ? "wss:" : "ws:"}//${host.replace(/^https?:\/\//, "")}/api/instances/${encodeURIComponent(instanceId)}/terminal?token=${encodeURIComponent(token)}&sessionId=${encodeURIComponent(sessionId)}${input.reset ? "&reset=1" : ""}`,
+        wsUrl: wsUrl(host, instanceId, token, sessionId, input.reset),
         stdin: process.stdin as NodeJS.ReadStream & { setRawMode(mode: boolean): void },
         stdout: process.stdout,
       });

--- a/packages/cli/src/modules/instance/index.ts
+++ b/packages/cli/src/modules/instance/index.ts
@@ -14,6 +14,7 @@ export type {
   InstanceResolver,
   ResolveError,
 } from "./services/instance-resolver.js";
+export { createInstanceResolver } from "./services/instance-resolver.js";
 export type {
   TransportError,
   AuthRequiredError,

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
     "commander",
     "open",
     "smol-toml",
+    "ws",
     "zod",
   ],
   // CJS deps (commander) use dynamic `require()` of node builtins; ESM

--- a/packages/ui/src/modules/acp/acp.ts
+++ b/packages/ui/src/modules/acp/acp.ts
@@ -115,6 +115,10 @@ export async function openConnection(
         if (method === "platform/turnEnded") {
           const sessionId = typeof params?.sessionId === "string" ? params.sessionId : undefined;
           onUpdate({ sessionUpdate: "platform_turn_ended", sessionId });
+        } else if (method === "platform/sessionModeChanged") {
+          const sessionId = typeof params?.sessionId === "string" ? params.sessionId : undefined;
+          const mode = typeof params?.mode === "string" ? params.mode : "chat";
+          onUpdate({ sessionUpdate: "platform_session_mode_changed", sessionId, mode });
         }
       },
     }),

--- a/packages/ui/src/modules/acp/types.ts
+++ b/packages/ui/src/modules/acp/types.ts
@@ -19,7 +19,8 @@ import type {
 export type AcpUpdate =
   | SessionUpdate
   | { sessionUpdate: "platform_turn_ended"; sessionId?: string }
-  | { sessionUpdate: "platform_clipped_replay" };
+  | { sessionUpdate: "platform_clipped_replay" }
+  | { sessionUpdate: "platform_session_mode_changed"; sessionId?: string; mode: string };
 
 export type UpdateHandler = (update: AcpUpdate) => void;
 

--- a/packages/ui/src/modules/sessions/components/terminal.tsx
+++ b/packages/ui/src/modules/sessions/components/terminal.tsx
@@ -10,13 +10,15 @@ import { getAccessToken } from "../../../auth.js";
 
 type ConnectionState = "connecting" | "live" | "disconnected" | "exited";
 
-export function Terminal({ instanceId, sessionId, fresh, onConnected }: { instanceId: string; sessionId: string; fresh?: boolean; onConnected?: () => void }) {
+export function Terminal({ instanceId, sessionId, fresh, onConnected, autoConnect = true }: { instanceId: string; sessionId: string; fresh?: boolean; onConnected?: () => void; autoConnect?: boolean }) {
   const containerRef = useRef<HTMLDivElement>(null);
   const termRef = useRef<XTerm | null>(null);
-  const [state, setState] = useState<ConnectionState>("connecting");
+  const [state, setState] = useState<ConnectionState>(autoConnect ? "connecting" : "disconnected");
   const [exitCode, setExitCode] = useState<number | null>(null);
   const [reconnectKey, setReconnectKey] = useState(0);
+  const connectEnabled = useRef(autoConnect);
   const handleReconnect = useCallback(() => {
+    connectEnabled.current = true;
     setState("connecting");
     setReconnectKey((k) => k + 1);
   }, []);
@@ -53,6 +55,8 @@ export function Terminal({ instanceId, sessionId, fresh, onConnected }: { instan
       await new Promise<void>((r) => requestAnimationFrame(() => r()));
       if (cancelled) return;
       fitAddon.fit();
+
+      if (!connectEnabled.current) return;
 
       const token = await getAccessToken();
       if (cancelled) return;

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -117,14 +117,6 @@ export function useAcpSession(
       const fresh = await loadHistory(sid);
       if (useStore.getState().sessionId !== sid) return;
       setMessages(fresh);
-
-      try {
-        const sessions = await api.sessions.list.query({ instanceId: selectedInstance, includeChannel: false });
-        const match = sessions.find((s) => s.sessionId === sid);
-        if (match?.mode && match.mode !== useStore.getState().sessionMode) {
-          useStore.getState().setSessionMode(match.mode);
-        }
-      } catch {}
     } catch (e) {
       if (useStore.getState().sessionId !== sid) return;
       const kind = classifyResumeError(e);

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -1,10 +1,12 @@
 import type { McpServer } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
-import { useCallback, useEffect, useState } from "react";
+import type { SessionMode } from "api-server-api";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { api } from "../../../api.js";
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
 import { hasStreamingAssistant } from "../../acp/session-projection.js";
+import type { AcpUpdate } from "../../acp/types.js";
 import { classifyResumeError, extractErrorMessage } from "../../acp/utils.js";
 import { useInstancesList } from "../../instances/api/queries.js";
 import { acpSessionsKeys } from "../api/queries.js";
@@ -27,20 +29,12 @@ export function useAcpSession(
   selectedMcpServers: McpServer[],
   textareaRef: React.RefObject<HTMLTextAreaElement | null>,
 ) {
-  const instances = useInstancesList();
   const sessionId = useStore((s) => s.sessionId);
   const messages = useStore((s) => s.messages);
   const setSessionId = useStore((s) => s.setSessionId);
   const setMessages = useStore((s) => s.setMessages);
   const setBusy = useStore((s) => s.setBusy);
   const [loadingSession, setLoadingSession] = useState(false);
-  // resetSession clears the cached config alongside the engagement; the
-  // engagement + capture paths use the config-cache hook.
-  const setSessionModes = useStore((s) => s.setSessionModes);
-  const setSessionModels = useStore((s) => s.setSessionModels);
-  const setSessionConfigOptions = useStore((s) => s.setSessionConfigOptions);
-  const setMobileScreen = useStore((s) => s.setMobileScreen);
-  const setSessionError = useStore((s) => s.setSessionError);
 
   // Derive busy from the projection instead of explicit setBusy calls in
   // sendPrompt / resume / disconnect paths. The projection owns streaming
@@ -48,7 +42,8 @@ export function useAcpSession(
   const busy = hasStreamingAssistant(messages);
   useEffect(() => { setBusy(busy); }, [busy, setBusy]);
 
-  const instanceRunState = instances.find(i => i.id === selectedInstance)?.state;
+  const instanceRunState = useInstancesList().find(i => i.id === selectedInstance)?.state;
+  const modeChangeRef = useRef<((u: AcpUpdate) => void) | null>(null);
 
   const { captureSessionConfig, handleConfigUpdate, applySavedPreferences } =
     useAcpConfigCache(selectedInstance, sessionId, instanceRunState);
@@ -67,7 +62,16 @@ export function useAcpSession(
     applySavedPreferences,
   );
 
-  const makeUpdateHandler = useAcpUpdateHandler(handleConfigUpdate);
+  const handleUpdate = useCallback((update: AcpUpdate) => {
+    if (update.sessionUpdate === "platform_session_mode_changed") {
+      modeChangeRef.current?.(update);
+      queryClient.invalidateQueries({ queryKey: acpSessionsKeys.all });
+      return;
+    }
+    handleConfigUpdate(update);
+  }, [handleConfigUpdate]);
+
+  const makeUpdateHandler = useAcpUpdateHandler(handleUpdate);
 
   const { ensureLive, connectionRef, reset: resetConnection } = useAcpConnection({
     selectedInstance,
@@ -85,21 +89,20 @@ export function useAcpSession(
 
   // Wake hibernated instance on entry.
   useEffect(() => {
-    if (!selectedInstance) return;
-    const inst = instances.find(({ id }) => id === selectedInstance);
-    if (inst?.state === "hibernated") {
+    if (selectedInstance && instanceRunState === "hibernated") {
       api.instances.wake.mutate({ id: selectedInstance }).catch(() => {});
     }
-  }, [selectedInstance, instances]);
+  }, [selectedInstance, instanceRunState]);
 
   const resetSession = useCallback(() => {
     resetConnection();
     setSessionId(null);
     setMessages([]);
-    setSessionModes(null);
-    setSessionModels(null);
-    setSessionConfigOptions([]);
-  }, [resetConnection, setSessionId, setMessages, setSessionModes, setSessionModels, setSessionConfigOptions]);
+    const s = useStore.getState();
+    s.setSessionModes(null);
+    s.setSessionModels(null);
+    s.setSessionConfigOptions([]);
+  }, [resetConnection, setSessionId, setMessages]);
 
   const resumeSession = useCallback(async (sid: string, opts?: { expectNotFound?: boolean }) => {
     if (!selectedInstance) return;
@@ -107,14 +110,21 @@ export function useAcpSession(
     resetConnection();
     setLoadingSession(true);
     setMessages([]);
-    setSessionError(null);
+    useStore.getState().setSessionError(null);
     setSessionId(sid);
-    setMobileScreen("chat");
 
     try {
       const fresh = await loadHistory(sid);
       if (useStore.getState().sessionId !== sid) return;
       setMessages(fresh);
+
+      try {
+        const sessions = await api.sessions.list.query({ instanceId: selectedInstance, includeChannel: false });
+        const match = sessions.find((s) => s.sessionId === sid);
+        if (match?.mode && match.mode !== useStore.getState().sessionMode) {
+          useStore.getState().setSessionMode(match.mode);
+        }
+      } catch {}
     } catch (e) {
       if (useStore.getState().sessionId !== sid) return;
       const kind = classifyResumeError(e);
@@ -125,15 +135,22 @@ export function useAcpSession(
         resetSession();
         return;
       }
-      setSessionError({
-        sessionId: sid,
-        message: extractErrorMessage(e),
-        kind,
-      });
+      useStore.getState().setSessionError({ sessionId: sid, message: extractErrorMessage(e), kind });
     } finally {
       if (useStore.getState().sessionId === sid) setLoadingSession(false);
     }
-  }, [selectedInstance, loadHistory, resetConnection, resetSession, setMessages, setSessionError, setSessionId, setMobileScreen]);
+  }, [selectedInstance, loadHistory, resetConnection, resetSession, setMessages, setSessionId]);
+
+  modeChangeRef.current = (update) => {
+    if (update.sessionUpdate !== "platform_session_mode_changed") return;
+    const s = useStore.getState();
+    if (!update.sessionId || update.sessionId !== s.sessionId) return;
+    const wasExternal = s.sessionMode !== update.mode;
+    s.setSessionMode(update.mode as SessionMode);
+    if (!wasExternal) return;
+    if (update.mode === "terminal") s.setTerminalPaused(true);
+    if (update.mode === "chat") resumeSession(update.sessionId, { expectNotFound: true });
+  };
 
   const { sendPrompt, stopAgent } = useAcpPrompt(
     selectedInstance,

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -117,6 +117,14 @@ export function useAcpSession(
       const fresh = await loadHistory(sid);
       if (useStore.getState().sessionId !== sid) return;
       setMessages(fresh);
+
+      try {
+        const sessions = await api.sessions.list.query({ instanceId: selectedInstance, includeChannel: false });
+        const match = sessions.find((s) => s.sessionId === sid);
+        if (match?.mode && match.mode !== useStore.getState().sessionMode) {
+          useStore.getState().setSessionMode(match.mode);
+        }
+      } catch {}
     } catch (e) {
       if (useStore.getState().sessionId !== sid) return;
       const kind = classifyResumeError(e);
@@ -141,7 +149,7 @@ export function useAcpSession(
     s.setSessionMode(update.mode as SessionMode);
     if (!wasExternal) return;
     if (update.mode === "terminal") s.setTerminalPaused(true);
-    if (update.mode === "chat") resumeSession(update.sessionId, { expectNotFound: true });
+    if (update.mode === "chat") resumeSession(update.sessionId);
   };
 
   const { sendPrompt, stopAgent } = useAcpPrompt(

--- a/packages/ui/src/modules/sessions/store/sessions.ts
+++ b/packages/ui/src/modules/sessions/store/sessions.ts
@@ -25,9 +25,11 @@ export interface SessionsSlice {
   includeChannelSessions: boolean;
   queuedMessage: string | null;
   busy: boolean;
+  terminalPaused: boolean;
 
   setSessionId: (id: string | null) => void;
   setSessionMode: (mode: SessionMode | null) => void;
+  setTerminalPaused: (paused: boolean) => void;
   setMessages: (updater: Message[] | ((prev: Message[]) => Message[])) => void;
   setSessionError: (e: SessionError | null) => void;
   setIncludeChannelSessions: (v: boolean) => void;
@@ -62,9 +64,11 @@ export const createSessionsSlice: StateCreator<
   includeChannelSessions: false,
   queuedMessage: null,
   busy: false,
+  terminalPaused: false,
 
   setSessionId: (id) => set({ sessionId: id }),
   setSessionMode: (mode) => set({ sessionMode: mode }),
+  setTerminalPaused: (paused) => set({ terminalPaused: paused }),
   setMessages: (updater) =>
     set((s) => ({
       messages: typeof updater === "function" ? updater(s.messages) : updater,
@@ -80,6 +84,7 @@ export const createSessionsSlice: StateCreator<
       sessionMode: null,
       messages: [],
       sessionError: null,
+      terminalPaused: false,
       openFilePath: null,
       log: [],
       sessionModes: null,

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -50,6 +50,8 @@ export function ChatView() {
   const setMobileScreen = useStore((s) => s.setMobileScreen);
   const showMobilePanel = useStore((s) => s.showMobilePanel);
   const setShowMobilePanel = useStore((s) => s.setShowMobilePanel);
+  const terminalPaused = useStore((s) => s.terminalPaused);
+  const setTerminalPaused = useStore((s) => s.setTerminalPaused);
 
   const [leftW, setLeftW] = useState(() => Number(localStorage.getItem("platform-left-w")) || 220);
   const [rightW, setRightW] = useState(() => Number(localStorage.getItem("platform-right-w")) || 340);
@@ -151,17 +153,24 @@ export function ChatView() {
     )) return;
 
     if (busy) stopAgent();
-    if (sessionId) {
-      await api.sessions.setMode.mutate({ sessionId, instanceId: selectedInstance, mode: target });
-      queryClient.invalidateQueries({ queryKey: acpSessionsKeys.all });
-    }
-    if (target === SessionMode.Terminal) terminalFreshRef.current = true;
+    if (target === SessionMode.Terminal) { terminalFreshRef.current = true; setTerminalPaused(false); }
+    const previousMode = sessionMode;
     setSessionMode(target);
+    if (sessionId) {
+      try {
+        await api.sessions.setMode.mutate({ sessionId, instanceId: selectedInstance, mode: target });
+        queryClient.invalidateQueries({ queryKey: acpSessionsKeys.all });
+      } catch {
+        setSessionMode(previousMode);
+        useStore.getState().showToast({ kind: "error", message: "Failed to switch session mode" });
+        return;
+      }
+    }
     if (target === SessionMode.Chat) {
       if (sessionId) resumeSession(sessionId, { expectNotFound: sessionMode === SessionMode.Terminal });
       requestAnimationFrame(() => textareaRef.current?.focus());
     }
-  }, [selectedInstance, sessionMode, sessionId, messages.length, showConfirm, busy, stopAgent, setSessionMode, resumeSession, setSessionId]);
+  }, [selectedInstance, sessionMode, sessionId, messages.length, showConfirm, busy, stopAgent, setSessionMode, resumeSession, setSessionId, setTerminalPaused]);
 
   const handleBack = useCallback(() => {
     if (isMobile() && mobileScreen === "chat") {
@@ -270,7 +279,7 @@ export function ChatView() {
 
         {/* Content: Terminal or Chat */}
         {sessionMode === SessionMode.Terminal && selectedInstance && sessionId ? (
-          <Terminal key={sessionId} instanceId={selectedInstance} sessionId={sessionId} fresh={terminalFreshRef.current} onConnected={() => { terminalFreshRef.current = false; }} />
+          <Terminal key={sessionId} instanceId={selectedInstance} sessionId={sessionId} fresh={terminalFreshRef.current} autoConnect={!terminalPaused} onConnected={() => { terminalFreshRef.current = false; setTerminalPaused(false); }} />
         ) : (<>
         <div className="relative flex flex-1 flex-col min-h-0">
         <div ref={messagesRef} className="flex-1 overflow-y-auto">

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -167,7 +167,7 @@ export function ChatView() {
       }
     }
     if (target === SessionMode.Chat) {
-      if (sessionId) resumeSession(sessionId, { expectNotFound: sessionMode === SessionMode.Terminal });
+      if (sessionId) resumeSession(sessionId);
       requestAnimationFrame(() => textareaRef.current?.focus());
     }
   }, [selectedInstance, sessionMode, sessionId, messages.length, showConfirm, busy, stopAgent, setSessionMode, resumeSession, setSessionId, setTerminalPaused]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -258,6 +258,9 @@ importers:
       smol-toml:
         specifier: ^1.6.1
         version: 1.6.1
+      ws:
+        specifier: ^8.20.0
+        version: 8.20.0
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -268,6 +271,9 @@ importers:
       '@types/node':
         specifier: ^25.5.0
         version: 25.5.0
+      '@types/ws':
+        specifier: ^8.18.1
+        version: 8.18.1
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.8)(tsx@4.21.0)(typescript@6.0.2)(yaml@2.8.3)


### PR DESCRIPTION
## Summary

- Adds `dam chat <instance>` CLI command that connects the local terminal to an agent's interactive TUI over WebSocket (#86)
- Supports `--continue` (most recent terminal session), `--resume <id>` (specific session), and `--reset` (fresh PTY)
- Adds `dam session list <instance>` for listing sessions from the CLI
- Adds cross-tab session mode synchronization via `platform/sessionModeChanged` ACP notification (Redis pub/sub → inject channel → all connected clients)
- Terminal component gains `autoConnect` prop — external mode changes show "Disconnected" overlay; user-initiated opens auto-connect

### CLI architecture
- `sessions-client.ts` — plain HTTP client for tRPC endpoints (no tRPC client dep)
- `terminal-bridge.ts` — raw TTY ↔ binary frame protocol over WebSocket
- `chat-service.ts` — orchestrates instance resolution → session find/create → WS connect

### Server-side changes
- `sessions-service.setMode()` now closes terminal WS, resets ACP session, and publishes mode-change notification
- `terminal-relay` tracks active clients per session for clean teardown on mode switch
- `acp-runtime` gains `resetSession()` to close agent-side session and clear logs

### UI changes
- `useAcpConfigCache` simplified to only handle config concerns (modes/models/options)
- `useAcpSession` owns session mode change handling via `modeChangeRef` wrapper — no more cross-hook ref-bridging
- `resumeSession` reconciles stale sidebar mode against the server for all session opens

## Test plan

- [x] `dam chat <name>` connects to terminal, keystrokes flow, output renders
- [x] Ctrl+C in harness TUI works (forwarded, not intercepted)
- [x] Close terminal: prints command to reconnect to same session
- [x] `dam chat nonexistent` — clear error message
- [x] `dam chat --resume <id> --reset <name>` — kills old PTY, fresh start
- [x] `dam session list <name>` — shows table of sessions
- [x] Two UI tabs: switch mode in tab 1 → tab 2 reflects the change
- [x] Tab 2 clicking a session whose mode was changed by tab 1 opens in the correct (current) mode
- [x] External terminal switch shows "Disconnected" overlay; user-initiated open auto-connects