### PR TITLE
fix(api-server): MCP OAuth discovery follows RFC 9728 protected-resource flow

### DIFF
--- a/packages/api-server/src/__tests__/unit/mcp-discovery.test.ts
+++ b/packages/api-server/src/__tests__/unit/mcp-discovery.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from "vitest";
+
+import { discoverMcpAuth } from "../../modules/connections/infrastructure/mcp-discovery.js";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function notFound(): Response {
+  return new Response("not found", { status: 404 });
+}
+
+function mockFetch(handler: (url: string) => Response | Promise<Response>) {
+  return vi.fn(async (input: RequestInfo | URL) => {
+    const url = typeof input === "string" ? input : input instanceof URL ? input.toString() : input.url;
+    return handler(url);
+  }) as unknown as typeof fetch;
+}
+
+describe("discoverMcpAuth", () => {
+  it("follows protected-resource metadata to a separate authorization server", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url === "https://mcp.example.com/.well-known/oauth-protected-resource") {
+        return jsonResponse({
+          authorization_servers: ["https://auth.example.com"],
+          scopes_supported: ["mcp:read", "offline_access"],
+        });
+      }
+      if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+        });
+      }
+      return notFound();
+    });
+
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/sse"), { fetchImpl });
+
+    expect(meta).toEqual({
+      authorizationEndpoint: "https://auth.example.com/authorize",
+      tokenEndpoint: "https://auth.example.com/token",
+      registrationEndpoint: "https://auth.example.com/register",
+      scopes: ["mcp:read", "offline_access"],
+      source: "https://auth.example.com/.well-known/oauth-authorization-server",
+    });
+  });
+
+  it("prefers PRM scopes over AS scopes_supported", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url.endsWith("/.well-known/oauth-protected-resource")) {
+        return jsonResponse({
+          authorization_servers: ["https://auth.example.com"],
+          scopes_supported: ["resource:scope"],
+        });
+      }
+      if (url.endsWith("/.well-known/oauth-authorization-server")) {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+          scopes_supported: ["everything"],
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta?.scopes).toEqual(["resource:scope"]);
+  });
+
+  it("falls back to AS scopes_supported when PRM omits them", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url.endsWith("/.well-known/oauth-protected-resource")) {
+        return jsonResponse({ authorization_servers: ["https://auth.example.com"] });
+      }
+      if (url.endsWith("/.well-known/oauth-authorization-server")) {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+          scopes_supported: ["everything"],
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta?.scopes).toEqual(["everything"]);
+  });
+
+  it("tries the path-aware PRM URL before the bare-origin form (RFC 9728 §3.1)", async () => {
+    const calls: string[] = [];
+    const fetchImpl = mockFetch((url) => {
+      calls.push(url);
+      if (url === "https://mcp.example.com/.well-known/oauth-protected-resource/mcp") {
+        return jsonResponse({ authorization_servers: ["https://auth.example.com"] });
+      }
+      if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/mcp"), { fetchImpl });
+    expect(meta?.authorizationEndpoint).toBe("https://auth.example.com/authorize");
+    expect(calls[0]).toBe("https://mcp.example.com/.well-known/oauth-protected-resource/mcp");
+  });
+
+  it("falls back to bare-origin PRM when the path-aware variant 404s", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url === "https://mcp.example.com/.well-known/oauth-protected-resource") {
+        return jsonResponse({ authorization_servers: ["https://auth.example.com"] });
+      }
+      if (url === "https://auth.example.com/.well-known/oauth-authorization-server") {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/mcp"), { fetchImpl });
+    expect(meta?.authorizationEndpoint).toBe("https://auth.example.com/authorize");
+  });
+
+  it("falls back to treating the MCP origin as the AS when PRM is missing", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url === "https://mcp.example.com/.well-known/oauth-authorization-server") {
+        return jsonResponse({
+          authorization_endpoint: "https://mcp.example.com/authorize",
+          token_endpoint: "https://mcp.example.com/token",
+          registration_endpoint: "https://mcp.example.com/register",
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/sse"), { fetchImpl });
+    expect(meta?.authorizationEndpoint).toBe("https://mcp.example.com/authorize");
+  });
+
+  it("falls back to OIDC discovery when oauth-authorization-server is absent", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url.endsWith("/.well-known/oauth-protected-resource")) {
+        return jsonResponse({ authorization_servers: ["https://auth.example.com"] });
+      }
+      if (url === "https://auth.example.com/.well-known/openid-configuration") {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/authorize",
+          token_endpoint: "https://auth.example.com/token",
+          registration_endpoint: "https://auth.example.com/register",
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta?.source).toBe("https://auth.example.com/.well-known/openid-configuration");
+  });
+
+  it("respects AS path component when fetching RFC 8414 metadata", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url.endsWith("/.well-known/oauth-protected-resource")) {
+        return jsonResponse({ authorization_servers: ["https://auth.example.com/tenant-a"] });
+      }
+      if (url === "https://auth.example.com/.well-known/oauth-authorization-server/tenant-a") {
+        return jsonResponse({
+          authorization_endpoint: "https://auth.example.com/tenant-a/authorize",
+          token_endpoint: "https://auth.example.com/tenant-a/token",
+          registration_endpoint: "https://auth.example.com/tenant-a/register",
+        });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta?.tokenEndpoint).toBe("https://auth.example.com/tenant-a/token");
+  });
+
+  it("returns null when no discovery shape succeeds", async () => {
+    const fetchImpl = mockFetch(() => notFound());
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta).toBeNull();
+  });
+
+  it("rejects AS metadata missing required endpoints", async () => {
+    const fetchImpl = mockFetch((url) => {
+      if (url.endsWith("/.well-known/oauth-protected-resource")) {
+        return jsonResponse({ authorization_servers: ["https://auth.example.com"] });
+      }
+      if (url.endsWith("/.well-known/oauth-authorization-server")) {
+        return jsonResponse({ authorization_endpoint: "https://auth.example.com/authorize" });
+      }
+      return notFound();
+    });
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta).toBeNull();
+  });
+
+  it("does not propagate network errors", async () => {
+    const fetchImpl = vi.fn(async () => {
+      throw new Error("boom");
+    }) as unknown as typeof fetch;
+    const meta = await discoverMcpAuth(new URL("https://mcp.example.com/"), { fetchImpl });
+    expect(meta).toBeNull();
+  });
+});

--- a/packages/api-server/src/apps/api-server/oauth.ts
+++ b/packages/api-server/src/apps/api-server/oauth.ts
@@ -25,6 +25,7 @@ import {
   type OAuthAppDescriptor,
   type OAuthAppRegistry,
 } from "../../modules/connections/infrastructure/oauth-apps.js";
+import { discoverMcpAuth } from "../../modules/connections/infrastructure/mcp-discovery.js";
 
 // ---------------------------------------------------------------------------
 // Routes
@@ -319,29 +320,25 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
   });
 
   /**
-   * Kicks off an MCP OAuth flow: discovers the AS metadata at the MCP
-   * server's origin, registers a public client via DCR, then hands off to
-   * the engine for the PKCE auth-code dance.
+   * Kicks off an MCP OAuth flow. Discovery follows the MCP 2025-06-18
+   * authorization spec: fetch the resource's RFC 9728 protected-resource
+   * metadata to learn the authorization server, then RFC 8414 AS metadata
+   * to learn the endpoints. Falls back to treating the MCP origin as the
+   * AS for older servers. Then DCR (RFC 7591) and hand off to the engine
+   * for the PKCE auth-code dance.
    */
   oauth.post("/api/oauth/start", async (c) => {
     const user = c.get("user");
     const jwt = getUserJwt(c);
     const body = await c.req.json<{ mcpServerUrl: string }>();
     const mcpUrl = new URL(body.mcpServerUrl);
-    const origin = mcpUrl.origin;
     const hostPattern = mcpUrl.hostname;
 
-    const metaRes = await fetch(`${origin}/.well-known/oauth-authorization-server`);
-    if (!metaRes.ok) {
+    const meta = await discoverMcpAuth(mcpUrl);
+    if (!meta) {
       return c.json({ error: "MCP server does not support OAuth discovery" }, 400);
     }
-    const meta = (await metaRes.json()) as {
-      authorization_endpoint: string;
-      token_endpoint: string;
-      registration_endpoint?: string;
-    };
-
-    if (!meta.registration_endpoint) {
+    if (!meta.registrationEndpoint) {
       return c.json(
         { error: "MCP server does not support dynamic client registration" },
         400,
@@ -349,7 +346,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
     }
 
     const redirectUri = `${uiBaseUrl}/api/oauth/callback`;
-    const regRes = await fetch(meta.registration_endpoint, {
+    const regRes = await fetch(meta.registrationEndpoint, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
@@ -372,10 +369,11 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
     const { authUrl, state } = engine.start({
       provider: {
         id: `mcp:${hostPattern}`,
-        authorizationUrl: meta.authorization_endpoint,
-        tokenEndpoint: meta.token_endpoint,
+        authorizationUrl: meta.authorizationEndpoint,
+        tokenEndpoint: meta.tokenEndpoint,
         clientId: regData.client_id,
         ...(regData.client_secret ? { clientSecret: regData.client_secret } : {}),
+        ...(meta.scopes && meta.scopes.length > 0 ? { scopes: meta.scopes } : {}),
       },
       flow: { connectionKey: hostPattern, hostPattern },
       redirectUri,

--- a/packages/api-server/src/modules/connections/infrastructure/mcp-discovery.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/mcp-discovery.ts
@@ -1,0 +1,148 @@
+/**
+ * MCP authorization discovery (MCP spec 2025-06-18, §"Authorization").
+ *
+ * The MCP server is the OAuth-protected *resource* (RFC 9728), not the
+ * authorization server. Discovery is therefore two-stage:
+ *
+ *   1. Fetch the resource's `oauth-protected-resource` metadata to learn
+ *      which authorization server(s) it trusts and the scopes it expects.
+ *   2. Fetch each AS's `oauth-authorization-server` metadata (RFC 8414,
+ *      OIDC fallback) to get authorize / token / registration endpoints.
+ *
+ * A non-spec-compliant fallback treats the MCP origin itself as the AS —
+ * older deployments host AS metadata directly at the MCP origin and we
+ * keep working with them.
+ */
+
+export interface McpAuthMetadata {
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint?: string;
+  /**
+   * Scopes the protected-resource document declared, or what the AS
+   * advertises if the PRM omitted them. Drives the `scope` parameter on
+   * the authorize URL — many MCP providers (Atlassian, Linear) require
+   * specific resource scopes (e.g. `read:jira-user offline_access`) and
+   * issue tokens without `offline_access` if it isn't requested.
+   */
+  scopes?: string[];
+  /** Diagnostic: which discovery URL produced the AS metadata. */
+  source: string;
+}
+
+interface ProtectedResourceMetadata {
+  authorization_servers?: string[];
+  scopes_supported?: string[];
+}
+
+interface AsMetadata {
+  authorization_endpoint?: string;
+  token_endpoint?: string;
+  registration_endpoint?: string;
+  scopes_supported?: string[];
+}
+
+export interface DiscoverMcpAuthOptions {
+  /** Override for tests. */
+  fetchImpl?: typeof fetch;
+  /** Per-request timeout. Default 5s. */
+  timeoutMs?: number;
+}
+
+export async function discoverMcpAuth(
+  mcpUrl: URL,
+  opts: DiscoverMcpAuthOptions = {},
+): Promise<McpAuthMetadata | null> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const timeoutMs = opts.timeoutMs ?? 5000;
+
+  const prm = await fetchProtectedResource(mcpUrl, fetchImpl, timeoutMs);
+  const asUrls =
+    prm?.authorization_servers && prm.authorization_servers.length > 0
+      ? prm.authorization_servers
+      : // Legacy fallback: the MCP origin itself acts as the AS. Required for
+        // pre-2025-06 MCP servers that never published PRM.
+        [mcpUrl.origin];
+
+  for (const asUrl of asUrls) {
+    const result = await fetchAuthServer(asUrl, fetchImpl, timeoutMs);
+    if (!result) continue;
+    const { meta, source } = result;
+    if (!meta.authorization_endpoint || !meta.token_endpoint) continue;
+    const scopes = prm?.scopes_supported ?? meta.scopes_supported;
+    return {
+      authorizationEndpoint: meta.authorization_endpoint,
+      tokenEndpoint: meta.token_endpoint,
+      ...(meta.registration_endpoint
+        ? { registrationEndpoint: meta.registration_endpoint }
+        : {}),
+      ...(scopes && scopes.length > 0 ? { scopes } : {}),
+      source,
+    };
+  }
+  return null;
+}
+
+async function fetchProtectedResource(
+  mcpUrl: URL,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<ProtectedResourceMetadata | null> {
+  // RFC 9728 §3.1: path-aware variant appends the resource path after the
+  // well-known segment. Bare-origin variant covers servers that publish a
+  // single PRM doc per origin regardless of resource path.
+  const pathSuffix = mcpUrl.pathname === "/" ? "" : mcpUrl.pathname.replace(/\/$/, "");
+  const candidates = pathSuffix
+    ? [
+        `${mcpUrl.origin}/.well-known/oauth-protected-resource${pathSuffix}`,
+        `${mcpUrl.origin}/.well-known/oauth-protected-resource`,
+      ]
+    : [`${mcpUrl.origin}/.well-known/oauth-protected-resource`];
+  for (const url of candidates) {
+    const data = await fetchJson<ProtectedResourceMetadata>(url, fetchImpl, timeoutMs);
+    if (data && Array.isArray(data.authorization_servers)) return data;
+  }
+  return null;
+}
+
+async function fetchAuthServer(
+  asUrl: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<{ meta: AsMetadata; source: string } | null> {
+  // RFC 8414 §3: .well-known goes between host and path, preserving any
+  // path component on the issuer URL. OIDC discovery places it after the
+  // issuer path. Try every shape — providers disagree.
+  const parsed = new URL(asUrl);
+  const basePath = parsed.pathname.replace(/\/$/, "");
+  const origin = parsed.origin;
+  const candidates = [
+    `${origin}/.well-known/oauth-authorization-server${basePath}`,
+    `${origin}${basePath}/.well-known/oauth-authorization-server`,
+    `${origin}/.well-known/openid-configuration${basePath}`,
+    `${origin}${basePath}/.well-known/openid-configuration`,
+  ];
+  // Deduplicate (basePath === "" collapses all four to two unique URLs).
+  const seen = new Set<string>();
+  for (const url of candidates) {
+    if (seen.has(url)) continue;
+    seen.add(url);
+    const meta = await fetchJson<AsMetadata>(url, fetchImpl, timeoutMs);
+    if (meta) return { meta, source: url };
+  }
+  return null;
+}
+
+async function fetchJson<T>(
+  url: string,
+  fetchImpl: typeof fetch,
+  timeoutMs: number,
+): Promise<T | null> {
+  try {
+    const res = await fetchImpl(url, { signal: AbortSignal.timeout(timeoutMs) });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary

- `/api/oauth/start` fetched AS metadata directly from the MCP origin (`/.well-known/oauth-authorization-server`), which returns 400 for spec-compliant MCP servers whose authorization server lives on a different host (Atlassian, Linear, Asana, Cloudflare-hosted, etc.). The MCP 2025-06-18 auth spec treats the MCP server as an OAuth-protected resource (RFC 9728) and points at its AS via protected-resource metadata.
- New `mcp-discovery` module performs two-stage discovery: RFC 9728 protected-resource metadata (path-aware then bare-origin) → RFC 8414 AS metadata with OIDC fallback. Legacy fallback treats the MCP origin as the AS so older non-compliant servers keep working.
- `/api/oauth/start` threads PRM `scopes_supported` into the engine so the authorize URL carries `scope=…` — required by providers that gate `offline_access` on an explicit scope request.

## Test plan

- [x] `mise run check` (lint + tsc + helm) clean
- [x] `mise run test` — 280 api-server tests pass, including 10 new `mcp-discovery` tests covering PRM → separate AS, path-aware PRM, AS path components, OIDC fallback, origin-as-AS legacy fallback, scopes precedence, and failure modes
- [ ] Manual: add a hosted MCP server (e.g. an Atlassian or Linear MCP endpoint) from the UI and confirm the consent screen renders