### PR TITLE
feat(controller): disableDns + iptablesInit egress lockdown

### DIFF
--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -9,19 +9,18 @@ add it to the include list in `platform.validate`.
 */}}
 
 {{- define "platform.validate" -}}
-{{- include "platform.validate.nonrootRequiresAgentNamespace" . -}}
+{{- include "platform.validate.anyuidCapNetRequiresAgentNamespace" . -}}
 {{- end -}}
 
 {{/*
-The nonroot-v2 RoleBinding is namespaced to `agentNamespace` and grants
-SCC access via the `system:serviceaccounts:<agentNamespace>` group.
-Both are meaningless if `agentNamespace` is empty: the binding lands
-without a namespace, and the group ref matches no SA. Refuse to render.
+The anyuid-cap-net RoleBinding is namespaced to `agentNamespace` and
+grants SCC access via the `system:serviceaccounts:<agentNamespace>`
+group. Both are meaningless if `agentNamespace` is empty.
 */}}
-{{- define "platform.validate.nonrootRequiresAgentNamespace" -}}
-{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.nonroot .Values.openshift.scc.nonroot.enabled -}}
+{{- define "platform.validate.anyuidCapNetRequiresAgentNamespace" -}}
+{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuidCapNet .Values.openshift.scc.anyuidCapNet.enabled -}}
 {{- if not (.Values.agentNamespace | default "" | trim) -}}
-{{- fail "openshift.scc.nonroot.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
+{{- fail "openshift.scc.anyuidCapNet.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -9,18 +9,18 @@ add it to the include list in `platform.validate`.
 */}}
 
 {{- define "platform.validate" -}}
-{{- include "platform.validate.nonrootCapNetRequiresAgentNamespace" . -}}
+{{- include "platform.validate.anyuidCapNetRequiresAgentNamespace" . -}}
 {{- end -}}
 
 {{/*
-The nonroot-cap-net RoleBinding is namespaced to `agentNamespace` and
+The anyuid-cap-net RoleBinding is namespaced to `agentNamespace` and
 grants SCC access via the `system:serviceaccounts:<agentNamespace>`
 group. Both are meaningless if `agentNamespace` is empty.
 */}}
-{{- define "platform.validate.nonrootCapNetRequiresAgentNamespace" -}}
-{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.nonrootCapNet .Values.openshift.scc.nonrootCapNet.enabled -}}
+{{- define "platform.validate.anyuidCapNetRequiresAgentNamespace" -}}
+{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuidCapNet .Values.openshift.scc.anyuidCapNet.enabled -}}
 {{- if not (.Values.agentNamespace | default "" | trim) -}}
-{{- fail "openshift.scc.nonrootCapNet.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
+{{- fail "openshift.scc.anyuidCapNet.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -9,18 +9,18 @@ add it to the include list in `platform.validate`.
 */}}
 
 {{- define "platform.validate" -}}
-{{- include "platform.validate.anyuidCapNetRequiresAgentNamespace" . -}}
+{{- include "platform.validate.nonrootCapNetRequiresAgentNamespace" . -}}
 {{- end -}}
 
 {{/*
-The anyuid-cap-net RoleBinding is namespaced to `agentNamespace` and
+The nonroot-cap-net RoleBinding is namespaced to `agentNamespace` and
 grants SCC access via the `system:serviceaccounts:<agentNamespace>`
 group. Both are meaningless if `agentNamespace` is empty.
 */}}
-{{- define "platform.validate.anyuidCapNetRequiresAgentNamespace" -}}
-{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.anyuidCapNet .Values.openshift.scc.anyuidCapNet.enabled -}}
+{{- define "platform.validate.nonrootCapNetRequiresAgentNamespace" -}}
+{{- if and .Values.openshift .Values.openshift.scc .Values.openshift.scc.nonrootCapNet .Values.openshift.scc.nonrootCapNet.enabled -}}
 {{- if not (.Values.agentNamespace | default "" | trim) -}}
-{{- fail "openshift.scc.anyuidCapNet.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
+{{- fail "openshift.scc.nonrootCapNet.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,10 +1,15 @@
-{{- if .Values.openshift.scc.nonrootCapNet.enabled }}
+{{- if .Values.openshift.scc.anyuidCapNet.enabled }}
 {{/*
-Custom `nonroot-cap-net` SCC for agent pods on OpenShift. Mirrors the
-built-in `nonroot-v2` SCC (MustRunAsNonRoot, drop ALL caps, no priv
-escalation, runtime/default seccomp); only relaxation is adding
-NET_ADMIN + NET_RAW to allowedCapabilities so the `iptablesInit` init
-container can run unprivileged via ambient caps.
+Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Tightens
+anyuid as far as it goes while admitting the `iptablesInit` init
+container: requires drop ALL caps, no priv escalation, runtime/default
+seccomp (all from restricted-v2). The two real relaxations are:
+
+  - runAsUser: RunAsAny — the iptablesInit init container needs root
+    because containerd doesn't promote capabilities.add into the
+    ambient set, so non-root processes can't exercise NET_ADMIN.
+  - allowedCapabilities: NET_ADMIN + NET_RAW — opt-in via container
+    caps.add (only the init container actually requests them).
 
 Priority intentionally `null` (= 0): admission prefers more restrictive
 SCCs the SA already has access to (restricted-v2 default), and only
@@ -13,7 +18,7 @@ falls through to this one for pods that actually request NET_ADMIN.
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "platform.fullname" . }}-nonroot-cap-net
+  name: {{ include "platform.fullname" . }}-anyuid-cap-net
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 allowHostDirVolumePlugin: false
@@ -35,7 +40,7 @@ readOnlyRootFilesystem: false
 requiredDropCapabilities:
   - ALL
 runAsUser:
-  type: MustRunAsNonRoot
+  type: RunAsAny
 seLinuxContext:
   type: MustRunAs
 seccompProfiles:
@@ -56,14 +61,14 @@ volumes:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "platform.fullname" . }}-agent-nonroot-cap-net
+  name: {{ include "platform.fullname" . }}-agent-anyuid-cap-net
   namespace: {{ .Values.agentNamespace }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:{{ include "platform.fullname" . }}-nonroot-cap-net
+  name: system:openshift:scc:{{ include "platform.fullname" . }}-anyuid-cap-net
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,14 +1,14 @@
 {{- if .Values.openshift.scc.anyuidCapNet.enabled }}
 {{/*
-Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Modeled on the
+Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Mirrors the
 built-in `anyuid` SCC (runAsUser: RunAsAny so the image USER 65532 is
-honored), plus allowed NET_ADMIN/NET_RAW for the `iptablesInit`
-privileged init container.
+honored) but adds NET_ADMIN + NET_RAW to allowedCapabilities for the
+`iptablesInit` privileged init container.
 
-OpenShift's SCC admission still prefers more restrictive SCCs the SA can
-use, so this only kicks in for pods that actually request the extra
-capabilities — agent pods without `iptablesInit` continue to land on
-restricted-v2.
+Priority intentionally `null` (= 0): admission prefers more restrictive
+SCCs the SA already has access to (restricted-v2 default), and only
+falls through to this one for pods that actually request NET_ADMIN.
+Upstream `anyuid` ships priority 10 — we deliberately differ.
 */}}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -21,7 +21,7 @@ allowHostIPC: false
 allowHostNetwork: false
 allowHostPID: false
 allowHostPorts: false
-allowPrivilegeEscalation: true
+allowPrivilegeEscalation: false
 allowPrivilegedContainer: false
 allowedCapabilities:
   - NET_ADMIN
@@ -39,10 +39,13 @@ seLinuxContext:
   type: MustRunAs
 supplementalGroups:
   type: RunAsAny
+users: []
 volumes:
   - configMap
+  - csi
   - downwardAPI
   - emptyDir
+  - ephemeral
   - persistentVolumeClaim
   - projected
   - secret

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,14 +1,16 @@
 {{- if .Values.openshift.scc.anyuidCapNet.enabled }}
 {{/*
-Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Mirrors the
-built-in `anyuid` SCC (runAsUser: RunAsAny so the image USER 65532 is
-honored) but adds NET_ADMIN + NET_RAW to allowedCapabilities for the
-`iptablesInit` privileged init container.
+Custom `anyuid-cap-net` SCC for agent pods on OpenShift. The base is
+`restricted-v2` (drop ALL, no priv escalation, runtime/default seccomp),
+relaxed only where the `iptablesInit` init container actually needs it:
+
+  - runAsUser: RunAsAny (init runs as UID 0; agent runs as 65532)
+  - fsGroup:   RunAsAny (avoid coupling to namespace fsGroup ranges)
+  - allowedCapabilities: NET_ADMIN + NET_RAW (opt-in via container caps.add)
 
 Priority intentionally `null` (= 0): admission prefers more restrictive
 SCCs the SA already has access to (restricted-v2 default), and only
 falls through to this one for pods that actually request NET_ADMIN.
-Upstream `anyuid` ships priority 10 — we deliberately differ.
 */}}
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
@@ -29,14 +31,17 @@ allowedCapabilities:
 defaultAddCapabilities: null
 fsGroup:
   type: RunAsAny
+groups: []
 priority: null
 readOnlyRootFilesystem: false
 requiredDropCapabilities:
-  - MKNOD
+  - ALL
 runAsUser:
   type: RunAsAny
 seLinuxContext:
   type: MustRunAs
+seccompProfiles:
+  - runtime/default
 supplementalGroups:
   type: RunAsAny
 users: []

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,20 +1,63 @@
-{{- if .Values.openshift.scc.nonroot.enabled }}
+{{- if .Values.openshift.scc.anyuidCapNet.enabled }}
 {{/*
-Bind nonroot-v2 to every ServiceAccount in agentNamespace so agent pods
-run as image USER (65532) rather than the namespace-range UID that
-restricted-v2 would assign. See values.yaml for the full motivation.
+Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Modeled on the
+built-in `anyuid` SCC (runAsUser: RunAsAny so the image USER 65532 is
+honored), plus allowed NET_ADMIN/NET_RAW for the `iptablesInit`
+privileged init container.
+
+OpenShift's SCC admission still prefers more restrictive SCCs the SA can
+use, so this only kicks in for pods that actually request the extra
+capabilities — agent pods without `iptablesInit` continue to land on
+restricted-v2.
 */}}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: {{ include "platform.fullname" . }}-anyuid-cap-net
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities:
+  - NET_ADMIN
+  - NET_RAW
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - MKNOD
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "platform.fullname" . }}-agent-nonroot
+  name: {{ include "platform.fullname" . }}-agent-anyuid-cap-net
   namespace: {{ .Values.agentNamespace }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:nonroot-v2
+  name: system:openshift:scc:{{ include "platform.fullname" . }}-anyuid-cap-net
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -1,12 +1,10 @@
-{{- if .Values.openshift.scc.anyuidCapNet.enabled }}
+{{- if .Values.openshift.scc.nonrootCapNet.enabled }}
 {{/*
-Custom `anyuid-cap-net` SCC for agent pods on OpenShift. The base is
-`restricted-v2` (drop ALL, no priv escalation, runtime/default seccomp),
-relaxed only where the `iptablesInit` init container actually needs it:
-
-  - runAsUser: RunAsAny (init runs as UID 0; agent runs as 65532)
-  - fsGroup:   RunAsAny (avoid coupling to namespace fsGroup ranges)
-  - allowedCapabilities: NET_ADMIN + NET_RAW (opt-in via container caps.add)
+Custom `nonroot-cap-net` SCC for agent pods on OpenShift. Mirrors the
+built-in `nonroot-v2` SCC (MustRunAsNonRoot, drop ALL caps, no priv
+escalation, runtime/default seccomp); only relaxation is adding
+NET_ADMIN + NET_RAW to allowedCapabilities so the `iptablesInit` init
+container can run unprivileged via ambient caps.
 
 Priority intentionally `null` (= 0): admission prefers more restrictive
 SCCs the SA already has access to (restricted-v2 default), and only
@@ -15,7 +13,7 @@ falls through to this one for pods that actually request NET_ADMIN.
 apiVersion: security.openshift.io/v1
 kind: SecurityContextConstraints
 metadata:
-  name: {{ include "platform.fullname" . }}-anyuid-cap-net
+  name: {{ include "platform.fullname" . }}-nonroot-cap-net
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 allowHostDirVolumePlugin: false
@@ -37,7 +35,7 @@ readOnlyRootFilesystem: false
 requiredDropCapabilities:
   - ALL
 runAsUser:
-  type: RunAsAny
+  type: MustRunAsNonRoot
 seLinuxContext:
   type: MustRunAs
 seccompProfiles:
@@ -58,14 +56,14 @@ volumes:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "platform.fullname" . }}-agent-anyuid-cap-net
+  name: {{ include "platform.fullname" . }}-agent-nonroot-cap-net
   namespace: {{ .Values.agentNamespace }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:{{ include "platform.fullname" . }}-anyuid-cap-net
+  name: system:openshift:scc:{{ include "platform.fullname" . }}-nonroot-cap-net
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -97,16 +97,16 @@ createAgentNamespace: true
 # -- OpenShift-specific knobs. No-op on vanilla Kubernetes.
 openshift:
   scc:
-    # Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Modeled on
-    # the built-in `anyuid` SCC (lets agent pods run as image USER 65532
-    # rather than the namespace-range UID), plus allows NET_ADMIN +
-    # NET_RAW so the `iptablesInit` privileged init container can run.
+    # Custom `nonroot-cap-net` SCC for agent pods on OpenShift. Modeled on
+    # the built-in `nonroot-v2` SCC (MustRunAsNonRoot, drop ALL caps,
+    # runtime/default seccomp), with NET_ADMIN + NET_RAW added to
+    # allowedCapabilities so the `iptablesInit` init container can run.
     # Renders a cluster-scoped SCC + RoleBinding to all SAs in
     # `agentNamespace`. Default ON — required for `iptablesInit`, harmless
     # otherwise (OpenShift admission still prefers more restrictive SCCs
     # when the pod doesn't request the extra capabilities).
-    anyuidCapNet:
-      enabled: false
+    nonrootCapNet:
+      enabled: true
 
 # -- Shared local PostgreSQL instance
 # Set enabled: false when using external/cloud DBs for all services.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -97,13 +97,16 @@ createAgentNamespace: true
 # -- OpenShift-specific knobs. No-op on vanilla Kubernetes.
 openshift:
   scc:
-    # Bind `system:openshift:scc:nonroot-v2` to ServiceAccounts in `agentNamespace`
-    # so agent pods run as image USER (65532) instead of the namespace-range UID
-    # that restricted-v2 would assign. Required on OpenShift when the agent PVC's
-    # StorageClass initializes the share root with a hardcoded UID — common on
-    # managed NFS (IBM Cloud File Storage for VPC, etc.); pair with SC `uid: "65532"`.
-    nonroot:
-      enabled: false
+    # Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Modeled on
+    # the built-in `anyuid` SCC (lets agent pods run as image USER 65532
+    # rather than the namespace-range UID), plus allows NET_ADMIN +
+    # NET_RAW so the `iptablesInit` privileged init container can run.
+    # Renders a cluster-scoped SCC + RoleBinding to all SAs in
+    # `agentNamespace`. Default ON — required for `iptablesInit`, harmless
+    # otherwise (OpenShift admission still prefers more restrictive SCCs
+    # when the pod doesn't request the extra capabilities).
+    anyuidCapNet:
+      enabled: true
 
 # -- Shared local PostgreSQL instance
 # Set enabled: false when using external/cloud DBs for all services.
@@ -464,6 +467,24 @@ controller:
         allowPrivilegeEscalation: false
         capabilities:
           drop: ["ALL"]
+
+      # -- Drop the cluster-DNS allow rules from the per-pair agent egress
+      # NetworkPolicy (closes threat T9, DNS exfil). The controller injects
+      # a hostAliases entry for the gateway Service so HTTPS_PROXY still
+      # resolves.
+      disableDns: true
+
+      # -- Kernel-level egress allow-list applied via a privileged init
+      # container (NET_ADMIN/NET_RAW). Locks OUTPUT to loopback +
+      # ESTABLISHED + the paired gateway IP:port. Defense-in-depth on top
+      # of the NetworkPolicy.
+      # NOTE: needs a custom SCC on OpenShift (default SCCs don't grant
+      # NET_ADMIN/NET_RAW + runAsUser=0).
+      iptablesInit:
+        enabled: true
+        # Must contain an `iptables` binary and a shell. PoC default is
+        # netshoot; replace with a locked-down image for production.
+        image: docker.io/nicolaka/netshoot:v0.13
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
     templateDefaults:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -97,16 +97,17 @@ createAgentNamespace: true
 # -- OpenShift-specific knobs. No-op on vanilla Kubernetes.
 openshift:
   scc:
-    # Custom `nonroot-cap-net` SCC for agent pods on OpenShift. Modeled on
-    # the built-in `nonroot-v2` SCC (MustRunAsNonRoot, drop ALL caps,
-    # runtime/default seccomp), with NET_ADMIN + NET_RAW added to
-    # allowedCapabilities so the `iptablesInit` init container can run.
-    # Renders a cluster-scoped SCC + RoleBinding to all SAs in
-    # `agentNamespace`. Default ON — required for `iptablesInit`, harmless
-    # otherwise (OpenShift admission still prefers more restrictive SCCs
-    # when the pod doesn't request the extra capabilities).
-    nonrootCapNet:
-      enabled: true
+    # Custom `anyuid-cap-net` SCC for agent pods on OpenShift. Modeled on
+    # the built-in `anyuid` SCC (runAsUser: RunAsAny so the iptablesInit
+    # init container can run as root; the agent container itself stays at
+    # image USER 65532), with NET_ADMIN + NET_RAW added to
+    # allowedCapabilities. Renders a cluster-scoped SCC + RoleBinding to
+    # all SAs in `agentNamespace`. Default ON — required for
+    # `iptablesInit`, harmless otherwise (OpenShift admission still
+    # prefers more restrictive SCCs when the pod doesn't request the
+    # extra capabilities).
+    anyuidCapNet:
+      enabled: false
 
 # -- Shared local PostgreSQL instance
 # Set enabled: false when using external/cloud DBs for all services.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -106,7 +106,7 @@ openshift:
     # otherwise (OpenShift admission still prefers more restrictive SCCs
     # when the pod doesn't request the extra capabilities).
     anyuidCapNet:
-      enabled: true
+      enabled: false
 
 # -- Shared local PostgreSQL instance
 # Set enabled: false when using external/cloud DBs for all services.
@@ -486,7 +486,7 @@ controller:
         # uses. Ships /bin/sh (dash) + iptables-wrapper (auto-selects
         # nft/legacy). Signed, scanned, no package manager, minimal
         # userland. Pin to a specific version.
-        image: registry.k8s.io/distroless-iptables:v0.9.1
+        image: registry.k8s.io/build-image/distroless-iptables:v0.9.2
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
     templateDefaults:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -482,9 +482,11 @@ controller:
       # NET_ADMIN/NET_RAW + runAsUser=0).
       iptablesInit:
         enabled: true
-        # Must contain an `iptables` binary and a shell. PoC default is
-        # netshoot; replace with a locked-down image for production.
-        image: docker.io/nicolaka/netshoot:v0.13
+        # SIG Release distroless-iptables — the same image kube-proxy
+        # uses. Ships /bin/sh (dash) + iptables-wrapper (auto-selects
+        # nft/legacy). Signed, scanned, no package manager, minimal
+        # userland. Pin to a specific version.
+        image: registry.k8s.io/distroless-iptables:v0.9.1
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
     templateDefaults:

--- a/deploy/helm/tasks.toml
+++ b/deploy/helm/tasks.toml
@@ -7,7 +7,7 @@ run = "helm lint ."
 
 ["helm:check:render"]
 dir = "{{config_root}}/deploy/helm/platform"
-run = "helm template platform . | kubeconform -strict -summary -skip Certificate,Issuer,ClusterIssuer,AuthorizationPolicy,Gateway"
+run = "helm template platform . | kubeconform -strict -summary -skip Certificate,Issuer,ClusterIssuer,AuthorizationPolicy,Gateway,SecurityContextConstraints"
 
 ["helm:setup"]
 alias = "helm:build"

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -74,6 +74,22 @@ type AgentBase struct {
 	// Security — chart-only floor. The agent ConfigMap cannot set these.
 	PodSecurityContext       *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	ContainerSecurityContext *corev1.SecurityContext    `json:"containerSecurityContext,omitempty"`
+
+	// DisableDNS drops the cluster-DNS allow rules from the agent egress
+	// NetworkPolicy (closes threat T9). The controller injects a
+	// hostAliases entry for the paired gateway so HTTPS_PROXY still
+	// resolves.
+	DisableDNS bool `json:"disableDns,omitempty"`
+
+	// IptablesInit configures the privileged init container that pins the
+	// agent pod's OUTPUT chain to the paired gateway (kernel-level
+	// defense-in-depth on top of the NetworkPolicy).
+	IptablesInit *AgentIptablesInit `json:"iptablesInit,omitempty"`
+}
+
+type AgentIptablesInit struct {
+	Enabled bool   `json:"enabled,omitempty"`
+	Image   string `json:"image,omitempty"`
 }
 
 // AgentProbes — sub-field nil means "use the controller's built-in probe

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -152,11 +152,21 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 	if err := r.applyPod(ctx, gatewayPod); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying gateway pod: %v", err))
 	}
-	if err := r.applyService(ctx, gatewaySvc); err != nil {
-		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying gateway service: %v", err))
+	// Apply gateway Service + migrate any legacy headless, capture
+	// ClusterIP synchronously (see instance.go).
+	liveGatewaySvc, err := ensureGatewayService(ctx, r.client, gatewaySvc, "fork", forkName)
+	if err != nil {
+		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("ensuring gateway service: %v", err))
+	}
+	gatewayIP := liveGatewaySvc.Spec.ClusterIP
+
+	needsGatewayIP := r.config.AgentBase.DisableDNS ||
+		(r.config.AgentBase.IptablesInit != nil && r.config.AgentBase.IptablesInit.Enabled)
+	if needsGatewayIP && (gatewayIP == "" || gatewayIP == corev1.ClusterIPNone) {
+		return fmt.Errorf("fork %s: gateway Service ClusterIP not yet assigned, requeuing", forkName)
 	}
 
-	desired := BuildForkAgentJob(forkName, forkSpec, instanceSpec, agentSpec, r.config, cm, credentialSecrets)
+	desired := BuildForkAgentJob(forkName, forkSpec, instanceSpec, agentSpec, r.config, cm, credentialSecrets, gatewayIP)
 
 	if err := r.applyForkJob(ctx, desired); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying job: %v", err))

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -40,6 +40,7 @@ func BuildForkAgentJob(
 	cfg *config.Config,
 	ownerCM *corev1.ConfigMap,
 	credentialSecrets []corev1.Secret,
+	gatewayClusterIP string,
 ) *batchv1.Job {
 	base := cfg.AgentBase
 	defaults := cfg.AgentTemplateDefaults
@@ -194,6 +195,9 @@ func BuildForkAgentJob(
 		initScript = defaults.Init
 	}
 	var initContainers []corev1.Container
+	if ic := buildIptablesInitContainer(cfg, gatewayClusterIP); ic != nil {
+		initContainers = append(initContainers, *ic)
+	}
 	if initScript != "" {
 		initContainers = append(initContainers, corev1.Container{
 			Name:            "init",
@@ -264,6 +268,11 @@ func BuildForkAgentJob(
 	podMeta := metav1.ObjectMeta{Labels: podLabels}
 	applyAgentBaseMeta(&podMeta, base)
 
+	var hostAliases []corev1.HostAlias
+	if base.DisableDNS && gatewayClusterIP != "" {
+		hostAliases = append(hostAliases, buildGatewayHostAlias(forkName, gatewayClusterIP))
+	}
+
 	podSpec := corev1.PodSpec{
 		// Fork agent opts out of ambient (no SPIFFE on the agent
 		// half). ADR-027: the per-fork SA still scopes credential
@@ -283,6 +292,7 @@ func BuildForkAgentJob(
 		ShareProcessNamespace:         shareProcessNS,
 		Containers:                    containers,
 		Volumes:                       volumes,
+		HostAliases:                   hostAliases,
 	}
 	applyAgentBaseScheduling(&podSpec, base)
 

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -34,7 +34,7 @@ var testForkInstance = &types.InstanceSpec{
 }
 
 func TestBuildForkAgentJob_BasicShape(t *testing.T) {
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, "")
 
 	require.NotNil(t, job)
 	assert.Equal(t, "fork-abc", job.Name)
@@ -60,7 +60,7 @@ func TestBuildForkAgentJob_BasicShape(t *testing.T) {
 func TestBuildForkAgentJob_ProbesDisabled(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentProbesEnabled = false
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, &cfg, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, &cfg, testForkOwnerCM, nil, "")
 
 	c := job.Spec.Template.Spec.Containers[0]
 	assert.Nil(t, c.StartupProbe)
@@ -69,7 +69,7 @@ func TestBuildForkAgentJob_ProbesDisabled(t *testing.T) {
 }
 
 func TestBuildForkAgentJob_LifecycleGuarantees(t *testing.T) {
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, "")
 
 	require.NotNil(t, job.Spec.BackoffLimit)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
@@ -81,7 +81,7 @@ func TestBuildForkAgentJob_LifecycleGuarantees(t *testing.T) {
 }
 
 func TestBuildForkAgentJob_ForkMetadataEnv(t *testing.T) {
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, "")
 	c := job.Spec.Template.Spec.Containers[0]
 
 	env := envMap(c.Env)
@@ -93,7 +93,7 @@ func TestBuildForkAgentJob_ForkMetadataEnv(t *testing.T) {
 }
 
 func TestBuildForkAgentJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, "")
 
 	podSpec := job.Spec.Template.Spec
 
@@ -117,7 +117,7 @@ func TestBuildForkAgentJob_InheritsInstanceEnvAndSecretRef(t *testing.T) {
 		Env:          []types.EnvVar{{Name: "FOO", Value: "bar"}},
 		SecretRef:    "my-extra-secret",
 	}
-	job := BuildForkAgentJob("fork-abc", testForkSpec, instance, testAgent, testConfig, testForkOwnerCM, nil)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, instance, testAgent, testConfig, testForkOwnerCM, nil, "")
 	c := job.Spec.Template.Spec.Containers[0]
 
 	assert.Equal(t, "bar", envMap(c.Env)["FOO"])
@@ -138,7 +138,7 @@ func TestBuildForkAgentJob_NoSidecar(t *testing.T) {
 	// ADR-038: agent and gateway are paired pods, not co-located. Fork
 	// agents have only one container.
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets, "")
 
 	require.Len(t, job.Spec.Template.Spec.Containers, 1, "fork agent has no sidecar")
 	agent := job.Spec.Template.Spec.Containers[0]
@@ -157,7 +157,7 @@ func TestBuildForkAgentJob_NoSidecar(t *testing.T) {
 func TestBuildForkAgentJob_NoCredentialMountsOnAgent(t *testing.T) {
 	// Replier credentials live on the paired fork gateway pod only.
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets, "")
 
 	for _, v := range job.Spec.Template.Spec.Volumes {
 		assert.NotContains(t, v.Name, "cred-platform-cred-",
@@ -176,7 +176,7 @@ func TestBuildForkAgentJob_NoCredentialMountsOnAgent(t *testing.T) {
 
 func TestBuildForkAgentJob_NoFetchCACertInit(t *testing.T) {
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets)
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets, "")
 
 	for _, ic := range job.Spec.Template.Spec.InitContainers {
 		assert.NotEqual(t, "fetch-ca-cert", ic.Name, "no fetch-ca-cert init container")
@@ -208,7 +208,7 @@ func TestBuildForkAgentJob_GHTokenSignal(t *testing.T) {
 	}
 	for name, tc := range cases {
 		t.Run(name, func(t *testing.T) {
-			job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, tc.secrets)
+			job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, tc.secrets, "")
 			env := envMap(job.Spec.Template.Spec.Containers[0].Env)
 			assert.Equal(t, tc.want, env["PLATFORM_GH_TOKEN_AVAILABLE"])
 		})

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -120,9 +120,11 @@ func BuildGatewayStatefulSet(instanceName string, hibernated bool, cfg *config.C
 
 func ptrIntOrString(v intstr.IntOrString) *intstr.IntOrString { return &v }
 
-// BuildGatewayService is the headless Service the agent reaches via
-// `HTTPS_PROXY`. Service-form is stable across gateway pod restarts; pod-DNS
-// would tie the agent's env to a StatefulSet ordinal (ADR-038).
+// BuildGatewayService is the ClusterIP Service the agent reaches via
+// `HTTPS_PROXY`. The auto-assigned virtual IP is stable across pod
+// restarts — pinned into the agent pod's hostAliases (under `disableDns`)
+// and the iptables init container's allow-list. Was previously headless;
+// `Service.Spec.ClusterIP == "None"` isn't usable in hostAliases.
 func BuildGatewayService(instanceName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
 	gatewayName := GatewayName(instanceName)
 	envoyPort := portInt32(cfg.EnvoyPort)
@@ -137,8 +139,8 @@ func BuildGatewayService(instanceName string, cfg *config.Config, ownerCM *corev
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			ClusterIP: corev1.ClusterIPNone,
-			Selector:  selector,
+			// ClusterIP omitted → apiserver auto-assigns a stable IP.
+			Selector: selector,
 			Ports: []corev1.ServicePort{{
 				Name:       "proxy",
 				Port:       envoyPort,
@@ -199,8 +201,7 @@ func BuildForkGatewayPod(forkName, parentInstanceID string, cfg *config.Config, 
 	}
 }
 
-// BuildForkGatewayService gives the fork's agent Job a stable DNS name to
-// point HTTPS_PROXY at, mirroring the long-lived shape.
+// BuildForkGatewayService mirrors BuildGatewayService for the fork pair.
 func BuildForkGatewayService(forkName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
 	gatewayName := GatewayName(forkName)
 	envoyPort := portInt32(cfg.EnvoyPort)
@@ -215,8 +216,8 @@ func BuildForkGatewayService(forkName string, cfg *config.Config, ownerCM *corev
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			ClusterIP: corev1.ClusterIPNone,
-			Selector:  selector,
+			// ClusterIP omitted → apiserver auto-assigns a stable IP.
+			Selector: selector,
 			Ports: []corev1.ServicePort{{
 				Name:       "proxy",
 				Port:       envoyPort,

--- a/packages/controller/pkg/reconciler/gateway_test.go
+++ b/packages/controller/pkg/reconciler/gateway_test.go
@@ -85,7 +85,9 @@ func TestBuildGatewayStatefulSet_NoAgentVolumes(t *testing.T) {
 func TestBuildGatewayService(t *testing.T) {
 	svc := BuildGatewayService("my-instance", testConfig, testOwnerCM)
 	assert.Equal(t, "my-instance-gateway", svc.Name)
-	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
+	// Not headless ("" means apiserver auto-assigns) — hostAliases /
+	// iptables allow-list need a routable virtual IP.
+	assert.Empty(t, svc.Spec.ClusterIP, "gateway Service must not be headless")
 	require.Len(t, svc.Spec.Ports, 1)
 	assert.Equal(t, "proxy", svc.Spec.Ports[0].Name)
 	assert.Equal(t, int32(10000), svc.Spec.Ports[0].Port)

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -139,9 +139,6 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 	gatewaySS := BuildGatewayStatefulSet(name, hibernated, r.config, cm, credentialSecrets)
 	gatewaySvc := BuildGatewayService(name, r.config, cm)
 
-	agentSS := BuildAgentStatefulSet(name, instanceSpec, agentSpec, r.config, cm, credentialSecrets)
-	agentSvc := BuildAgentService(name, r.config, cm)
-
 	if err := r.applyStatefulSet(ctx, gatewaySS); err != nil {
 		return r.setError(ctx, name, fmt.Sprintf("applying gateway statefulset: %v", err))
 	}
@@ -159,9 +156,24 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		slog.Warn("force-rolling stuck gateway pod failed; rollout may be deadlocked",
 			"namespace", gatewaySS.Namespace, "statefulset", gatewaySS.Name, "error", err)
 	}
-	if err := r.applyService(ctx, gatewaySvc); err != nil {
-		return r.setError(ctx, name, fmt.Sprintf("applying gateway service: %v", err))
+	// Apply gateway Service + migrate any legacy headless instance, return
+	// the live object so we capture the assigned ClusterIP synchronously.
+	liveGatewaySvc, err := ensureGatewayService(ctx, r.client, gatewaySvc, "instance", name)
+	if err != nil {
+		return r.setError(ctx, name, fmt.Sprintf("ensuring gateway service: %v", err))
 	}
+	gatewayIP := liveGatewaySvc.Spec.ClusterIP
+
+	// Fail-closed requeue when the gateway IP is needed but not yet
+	// usable — don't roll a half-configured pod.
+	needsGatewayIP := r.config.AgentBase.DisableDNS ||
+		(r.config.AgentBase.IptablesInit != nil && r.config.AgentBase.IptablesInit.Enabled)
+	if needsGatewayIP && (gatewayIP == "" || gatewayIP == corev1.ClusterIPNone) {
+		return fmt.Errorf("instance %s: gateway Service ClusterIP not yet assigned, requeuing", name)
+	}
+
+	agentSS := BuildAgentStatefulSet(name, instanceSpec, agentSpec, r.config, cm, credentialSecrets, gatewayIP)
+	agentSvc := BuildAgentService(name, r.config, cm)
 	if err := r.applyStatefulSet(ctx, agentSS); err != nil {
 		return r.setError(ctx, name, fmt.Sprintf("applying agent statefulset: %v", err))
 	}

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -123,10 +123,11 @@ func TestReconcile_CreateResources(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, corev1.ClusterIPNone, svc.Spec.ClusterIP)
 
-	// Gateway Service
+	// Gateway Service — ClusterIP-typed (not headless) so hostAliases /
+	// iptables allow-list have a stable IP to pin.
 	gwSvc, err := client.CoreV1().Services("test-agents").Get(ctx, "my-instance-gateway", metav1.GetOptions{})
 	require.NoError(t, err, "gateway Service must be created so HTTPS_PROXY DNS resolves")
-	assert.Equal(t, corev1.ClusterIPNone, gwSvc.Spec.ClusterIP)
+	assert.NotEqual(t, corev1.ClusterIPNone, gwSvc.Spec.ClusterIP, "gateway Service must not be headless")
 
 	// Per-instance ServiceAccount — kept off-pod via
 	// automountServiceAccountToken: false. The agent pod has no SPIFFE

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -48,10 +48,11 @@ echo "egress-lockdown: gateway-only egress applied"
 	// Root + NET_ADMIN/NET_RAW needed to manipulate netfilter; both are
 	// scoped to this init container, which exits before the agent runtime
 	// container starts. Container-level overrides cancel the pod-level
-	// runAsNonRoot floor.
+	// runAsNonRoot floor. allowPrivilegeEscalation stays false — iptables
+	// doesn't need to gain caps at exec, and false sets no_new_privs=1.
 	runAsRoot := int64(0)
 	notNonRoot := false
-	allowPrivEsc := true
+	noPrivEsc := false
 	return &corev1.Container{
 		Name:    iptablesInitContainerName,
 		Image:   cfgInit.Image,
@@ -63,7 +64,7 @@ echo "egress-lockdown: gateway-only egress applied"
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &runAsRoot,
 			RunAsNonRoot:             &notNonRoot,
-			AllowPrivilegeEscalation: &allowPrivEsc,
+			AllowPrivilegeEscalation: &noPrivEsc,
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -16,45 +16,37 @@ import (
 
 const iptablesInitContainerName = "egress-lockdown"
 
-// buildIptablesInitContainer renders the privileged init container that
-// pins the agent pod's OUTPUT chain to "loopback + ESTABLISHED + paired
-// gateway only". Returns nil when the feature is off, the image is unset,
-// or the gateway IP isn't known yet (reconciler is expected to fail-closed
-// first; this is belt-and-braces).
+// buildIptablesInitContainer pins the agent pod's OUTPUT chain to
+// "loopback + ESTABLISHED + paired gateway only". Returns nil when the
+// feature is off, the image is unset, or the gateway IP isn't known yet.
+//
+// Targets the SIG Release `registry.k8s.io/distroless-iptables` image,
+// which ships `/bin/sh` (dash) and the iptables-wrapper that auto-
+// selects nft vs legacy. Both `/usr/sbin/iptables` and the wrapper are
+// in $PATH on that image, so the script stays minimal.
 func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *corev1.Container {
 	cfgInit := cfg.AgentBase.IptablesInit
 	if cfgInit == nil || !cfgInit.Enabled || cfgInit.Image == "" || gatewayClusterIP == "" {
 		return nil
 	}
 
-	// Probe both nft and legacy variants — same image may run on either
-	// backend depending on the host kernel.
 	script := `set -eu
-if [ -z "${GATEWAY_IP:-}" ]; then echo "egress-lockdown: GATEWAY_IP not set" >&2; exit 1; fi
-ENVOY_PORT="${ENVOY_PORT:-10000}"
-IPT=""
-if command -v iptables-nft >/dev/null 2>&1; then IPT=iptables-nft
-elif command -v iptables-legacy >/dev/null 2>&1; then IPT=iptables-legacy
-elif command -v iptables >/dev/null 2>&1; then IPT=iptables
-else echo "egress-lockdown: no iptables binary" >&2; exit 1; fi
-echo "egress-lockdown: using $IPT; gateway=$GATEWAY_IP:$ENVOY_PORT"
-$IPT -A OUTPUT -o lo -j ACCEPT
-$IPT -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-$IPT -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
-$IPT -A OUTPUT -j DROP
+echo "egress-lockdown: gateway=$GATEWAY_IP:$ENVOY_PORT"
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+iptables -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
+iptables -A OUTPUT -j DROP
 echo "egress-lockdown: gateway-only egress applied"
 `
 
-	// Root + NET_ADMIN/NET_RAW needed to manipulate netfilter; both are
-	// scoped to this init container, which exits before the agent runtime
-	// container starts. Container-level overrides cancel the pod-level
-	// runAsNonRoot floor. allowPrivilegeEscalation stays false — iptables
-	// doesn't need to gain caps at exec, and false sets no_new_privs=1.
+	// Root + NET_ADMIN/NET_RAW for netfilter ops; everything else dropped.
+	// The runtime agent container is unaffected — these caps live only on
+	// this short-lived init container.
 	runAsRoot := int64(0)
 	return &corev1.Container{
 		Name:    iptablesInitContainerName,
 		Image:   cfgInit.Image,
-		Command: []string{"sh", "-c", script},
+		Command: []string{"/bin/sh", "-c", script},
 		Env: []corev1.EnvVar{
 			{Name: "GATEWAY_IP", Value: gatewayClusterIP},
 			{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
@@ -63,6 +55,7 @@ echo "egress-lockdown: gateway-only egress applied"
 			RunAsUser:                &runAsRoot,
 			RunAsNonRoot:             ptrBool(false),
 			AllowPrivilegeEscalation: ptrBool(false),
+			ReadOnlyRootFilesystem:   ptrBool(true),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -20,10 +20,12 @@ const iptablesInitContainerName = "egress-lockdown"
 // "loopback + ESTABLISHED + paired gateway only". Returns nil when the
 // feature is off, the image is unset, or the gateway IP isn't known yet.
 //
-// Targets the SIG Release `registry.k8s.io/build-image/distroless-iptables` image,
-// which ships `/bin/sh` (dash) and the iptables-wrapper that auto-
-// selects nft vs legacy. Both `/usr/sbin/iptables` and the wrapper are
-// in $PATH on that image, so the script stays minimal.
+// Targets the SIG Release `registry.k8s.io/build-image/distroless-iptables`
+// image. We invoke `iptables-nft` directly rather than the wrapped
+// `iptables` entrypoint — the wrapper auto-detects nft vs legacy by
+// writing symlinks at runtime, which the container's
+// `readOnlyRootFilesystem: true` blocks. Every kernel K8s supports
+// (≥4.18) ships nftables, so the direct call is portable.
 func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *corev1.Container {
 	cfgInit := cfg.AgentBase.IptablesInit
 	if cfgInit == nil || !cfgInit.Enabled || cfgInit.Image == "" || gatewayClusterIP == "" {
@@ -32,17 +34,21 @@ func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *co
 
 	script := `set -eu
 echo "egress-lockdown: gateway=$GATEWAY_IP:$ENVOY_PORT"
-iptables -A OUTPUT -o lo -j ACCEPT
-iptables -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-iptables -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
-iptables -A OUTPUT -j DROP
+iptables-nft -A OUTPUT -o lo -j ACCEPT
+iptables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+iptables-nft -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
+iptables-nft -A OUTPUT -j DROP
 echo "egress-lockdown: gateway-only egress applied"
 `
 
-	// Root + NET_ADMIN/NET_RAW for netfilter ops; everything else dropped.
-	// The runtime agent container is unaffected — these caps live only on
-	// this short-lived init container.
-	runAsRoot := int64(0)
+	// NET_ADMIN/NET_RAW for the netfilter ops. Container runs as the
+	// pod-level non-root UID (65532): containerd plumbs Capabilities.Add
+	// into the ambient capability set, so iptables-nft acquires those
+	// caps through exec without needing root or file caps. Everything
+	// else dropped; readOnlyRootFilesystem prevents any write to the
+	// container fs (the wrapper at /usr/sbin/iptables wouldn't work
+	// under readOnlyRootFilesystem anyway, hence the direct
+	// iptables-nft call above).
 	return &corev1.Container{
 		Name:    iptablesInitContainerName,
 		Image:   cfgInit.Image,
@@ -52,8 +58,6 @@ echo "egress-lockdown: gateway-only egress applied"
 			{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
 		},
 		SecurityContext: &corev1.SecurityContext{
-			RunAsUser:                &runAsRoot,
-			RunAsNonRoot:             ptrBool(false),
 			AllowPrivilegeEscalation: ptrBool(false),
 			ReadOnlyRootFilesystem:   ptrBool(true),
 			Capabilities: &corev1.Capabilities{

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -1,0 +1,143 @@
+package reconciler
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+)
+
+const iptablesInitContainerName = "egress-lockdown"
+
+// buildIptablesInitContainer renders the privileged init container that
+// pins the agent pod's OUTPUT chain to "loopback + ESTABLISHED + paired
+// gateway only". Returns nil when the feature is off, the image is unset,
+// or the gateway IP isn't known yet (reconciler is expected to fail-closed
+// first; this is belt-and-braces).
+func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *corev1.Container {
+	cfgInit := cfg.AgentBase.IptablesInit
+	if cfgInit == nil || !cfgInit.Enabled || cfgInit.Image == "" || gatewayClusterIP == "" {
+		return nil
+	}
+
+	// Probe both nft and legacy variants — same image may run on either
+	// backend depending on the host kernel.
+	script := `set -eu
+if [ -z "${GATEWAY_IP:-}" ]; then echo "egress-lockdown: GATEWAY_IP not set" >&2; exit 1; fi
+ENVOY_PORT="${ENVOY_PORT:-10000}"
+IPT=""
+if command -v iptables-nft >/dev/null 2>&1; then IPT=iptables-nft
+elif command -v iptables-legacy >/dev/null 2>&1; then IPT=iptables-legacy
+elif command -v iptables >/dev/null 2>&1; then IPT=iptables
+else echo "egress-lockdown: no iptables binary" >&2; exit 1; fi
+echo "egress-lockdown: using $IPT; gateway=$GATEWAY_IP:$ENVOY_PORT"
+$IPT -A OUTPUT -o lo -j ACCEPT
+$IPT -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+$IPT -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
+$IPT -A OUTPUT -j DROP
+echo "egress-lockdown: gateway-only egress applied"
+`
+
+	// Root + NET_ADMIN/NET_RAW needed to manipulate netfilter; both are
+	// scoped to this init container, which exits before the agent runtime
+	// container starts. Container-level overrides cancel the pod-level
+	// runAsNonRoot floor.
+	runAsRoot := int64(0)
+	notNonRoot := false
+	allowPrivEsc := true
+	return &corev1.Container{
+		Name:    iptablesInitContainerName,
+		Image:   cfgInit.Image,
+		Command: []string{"sh", "-c", script},
+		Env: []corev1.EnvVar{
+			{Name: "GATEWAY_IP", Value: gatewayClusterIP},
+			{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &runAsRoot,
+			RunAsNonRoot:             &notNonRoot,
+			AllowPrivilegeEscalation: &allowPrivEsc,
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},
+			},
+		},
+	}
+}
+
+// buildGatewayHostAlias points `<pairKey>-gateway` at `ip` so HTTPS_PROXY
+// resolves without DNS.
+func buildGatewayHostAlias(pairKey, ip string) corev1.HostAlias {
+	return corev1.HostAlias{IP: ip, Hostnames: []string{GatewayName(pairKey)}}
+}
+
+// ensureGatewayService applies the paired gateway Service and returns the
+// live object (with assigned ClusterIP) in one call — avoids the
+// reconcile-N/N+1 race where a follow-up Get may not see the just-assigned
+// IP. Handles the legacy headless → ClusterIP migration: `.spec.clusterIP`
+// is immutable, so the old object must be deleted before recreating.
+func ensureGatewayService(ctx context.Context, client kubernetes.Interface, desired *corev1.Service, kind, name string) (*corev1.Service, error) {
+	cli := client.CoreV1().Services(desired.Namespace)
+
+	existing, err := cli.Get(ctx, desired.Name, metav1.GetOptions{})
+	switch {
+	case errors.IsNotFound(err):
+		// fall through to Create
+	case err != nil:
+		return nil, fmt.Errorf("getting gateway Service: %w", err)
+	case existing.Spec.ClusterIP != corev1.ClusterIPNone:
+		return existing, nil
+	default:
+		slog.Info("migrating legacy headless gateway Service to ClusterIP",
+			"service", desired.Name, kind, name)
+		if err := cli.Delete(ctx, desired.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return nil, fmt.Errorf("deleting legacy headless Service: %w", err)
+		}
+		if err := waitForServiceDeleted(ctx, cli, desired.Name, 10*time.Second); err != nil {
+			return nil, fmt.Errorf("waiting for legacy Service to delete: %w", err)
+		}
+	}
+
+	created, err := cli.Create(ctx, desired, metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("creating gateway Service: %w", err)
+	}
+	return created, nil
+}
+
+// waitForServiceDeleted polls until Get returns NotFound or the timeout
+// expires — bridges the async window between Delete returning and the
+// object actually disappearing.
+func waitForServiceDeleted(ctx context.Context, cli corev1ServiceClient, serviceName string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	for {
+		_, err := cli.Get(ctx, serviceName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("timeout after %s", timeout)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// corev1ServiceClient narrows the typed Services interface to just what
+// waitForServiceDeleted needs, so we don't pull in the typed client package.
+type corev1ServiceClient interface {
+	Get(ctx context.Context, name string, opts metav1.GetOptions) (*corev1.Service, error)
+}

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -41,14 +41,14 @@ iptables-nft -A OUTPUT -j DROP
 echo "egress-lockdown: gateway-only egress applied"
 `
 
-	// NET_ADMIN/NET_RAW for the netfilter ops. Container runs as the
-	// pod-level non-root UID (65532): containerd plumbs Capabilities.Add
-	// into the ambient capability set, so iptables-nft acquires those
-	// caps through exec without needing root or file caps. Everything
-	// else dropped; readOnlyRootFilesystem prevents any write to the
-	// container fs (the wrapper at /usr/sbin/iptables wouldn't work
-	// under readOnlyRootFilesystem anyway, hence the direct
-	// iptables-nft call above).
+	// Needs root + NET_ADMIN/NET_RAW for the netfilter ops. K8s/containerd
+	// don't promote capabilities.add into the ambient set, so a non-root
+	// process can't actually USE the granted caps at exec time (Effective
+	// is cleared). Container-scoped runAsUser: 0 + runAsNonRoot: false
+	// override the pod-level non-root floor; the runtime agent container
+	// stays unprivileged (these caps live only on this short-lived init
+	// container).
+	runAsRoot := int64(0)
 	return &corev1.Container{
 		Name:    iptablesInitContainerName,
 		Image:   cfgInit.Image,
@@ -58,6 +58,8 @@ echo "egress-lockdown: gateway-only egress applied"
 			{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
 		},
 		SecurityContext: &corev1.SecurityContext{
+			RunAsUser:                &runAsRoot,
+			RunAsNonRoot:             ptrBool(false),
 			AllowPrivilegeEscalation: ptrBool(false),
 			ReadOnlyRootFilesystem:   ptrBool(true),
 			Capabilities: &corev1.Capabilities{

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -32,13 +32,20 @@ func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *co
 		return nil
 	}
 
+	// IPv6: loopback only, then DROP. The gateway Service is IPv4 (no
+	// dual-stack ClusterIP), so there's no IPv6 ACCEPT for it. Without
+	// this, an agent could exfil over IPv6 if the node has v6
+	// connectivity — our IPv4 rules wouldn't see those packets at all.
 	script := `set -eu
 echo "egress-lockdown: gateway=$GATEWAY_IP:$ENVOY_PORT"
 iptables-nft -A OUTPUT -o lo -j ACCEPT
 iptables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 iptables-nft -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
 iptables-nft -A OUTPUT -j DROP
-echo "egress-lockdown: gateway-only egress applied"
+ip6tables-nft -A OUTPUT -o lo -j ACCEPT
+ip6tables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+ip6tables-nft -A OUTPUT -j DROP
+echo "egress-lockdown: gateway-only IPv4 + IPv6 drop applied"
 `
 
 	// Needs root + NET_ADMIN/NET_RAW for the netfilter ops. K8s/containerd

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -20,7 +20,7 @@ const iptablesInitContainerName = "egress-lockdown"
 // "loopback + ESTABLISHED + paired gateway only". Returns nil when the
 // feature is off, the image is unset, or the gateway IP isn't known yet.
 //
-// Targets the SIG Release `registry.k8s.io/distroless-iptables` image,
+// Targets the SIG Release `registry.k8s.io/build-image/distroless-iptables` image,
 // which ships `/bin/sh` (dash) and the iptables-wrapper that auto-
 // selects nft vs legacy. Both `/usr/sbin/iptables` and the wrapper are
 // in $PATH on that image, so the script stays minimal.

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -51,8 +51,6 @@ echo "egress-lockdown: gateway-only egress applied"
 	// runAsNonRoot floor. allowPrivilegeEscalation stays false — iptables
 	// doesn't need to gain caps at exec, and false sets no_new_privs=1.
 	runAsRoot := int64(0)
-	notNonRoot := false
-	noPrivEsc := false
 	return &corev1.Container{
 		Name:    iptablesInitContainerName,
 		Image:   cfgInit.Image,
@@ -63,8 +61,8 @@ echo "egress-lockdown: gateway-only egress applied"
 		},
 		SecurityContext: &corev1.SecurityContext{
 			RunAsUser:                &runAsRoot,
-			RunAsNonRoot:             &notNonRoot,
-			AllowPrivilegeEscalation: &noPrivEsc,
+			RunAsNonRoot:             ptrBool(false),
+			AllowPrivilegeEscalation: ptrBool(false),
 			Capabilities: &corev1.Capabilities{
 				Drop: []corev1.Capability{"ALL"},
 				Add:  []corev1.Capability{"NET_ADMIN", "NET_RAW"},

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -36,7 +36,7 @@ func TestBuildIptablesInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
 	assert.Nil(t, buildIptablesInitContainer(&cfg, ""), "no gateway IP yet — re-attach on next reconcile")
 }
 
-func TestBuildIptablesInitContainer_NonRootWithAmbientCaps(t *testing.T) {
+func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 
@@ -45,10 +45,13 @@ func TestBuildIptablesInitContainer_NonRootWithAmbientCaps(t *testing.T) {
 	assert.Equal(t, "egress-lockdown", ic.Name)
 	assert.Equal(t, "registry.k8s.io/build-image/distroless-iptables:v0.9.2", ic.Image)
 	require.NotNil(t, ic.SecurityContext)
-	// Container inherits the pod-level non-root UID; NET_ADMIN/NET_RAW
-	// flow in via the ambient capability set. No explicit root needed.
-	assert.Nil(t, ic.SecurityContext.RunAsUser, "init container must inherit non-root pod UID, not override to root")
-	assert.Nil(t, ic.SecurityContext.RunAsNonRoot, "must not override the pod-level runAsNonRoot=true")
+	// iptables-nft needs CAP_NET_ADMIN in EFFECTIVE — that requires root,
+	// because containerd doesn't promote capabilities.add into the
+	// ambient set for non-root containers.
+	require.NotNil(t, ic.SecurityContext.RunAsUser)
+	assert.Equal(t, int64(0), *ic.SecurityContext.RunAsUser, "iptables-nft requires effective CAP_NET_ADMIN; only root has it without ambient caps")
+	require.NotNil(t, ic.SecurityContext.RunAsNonRoot)
+	assert.False(t, *ic.SecurityContext.RunAsNonRoot, "must override the pod-level runAsNonRoot floor")
 	require.NotNil(t, ic.SecurityContext.Capabilities)
 	caps := ic.SecurityContext.Capabilities
 	assert.Contains(t, caps.Add, corev1.Capability("NET_ADMIN"), "NET_ADMIN required for iptables manipulation")

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -1,0 +1,163 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+	"github.com/kagenti/platform/packages/controller/pkg/types"
+)
+
+func TestBuildIptablesInitContainer_DisabledReturnsNil(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = nil
+	assert.Nil(t, buildIptablesInitContainer(&cfg, "10.96.42.42"))
+
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: false, Image: "foo"}
+	assert.Nil(t, buildIptablesInitContainer(&cfg, "10.96.42.42"))
+}
+
+func TestBuildIptablesInitContainer_EmptyImageReturnsNil(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true}
+	assert.Nil(t, buildIptablesInitContainer(&cfg, "10.96.42.42"), "missing image must not crash; chart should enforce non-empty")
+}
+
+// Without a gateway ClusterIP the allow-list would lock the pod out of its
+// own egress path. The controller skips installing the init container until
+// the next reconcile picks up the assigned IP — NP still gates egress in
+// the meantime.
+func TestBuildIptablesInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	assert.Nil(t, buildIptablesInitContainer(&cfg, ""), "no gateway IP yet — re-attach on next reconcile")
+}
+
+func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+
+	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
+	require.NotNil(t, ic)
+	assert.Equal(t, "egress-lockdown", ic.Name)
+	assert.Equal(t, "docker.io/nicolaka/netshoot:v0.13", ic.Image)
+	require.NotNil(t, ic.SecurityContext)
+	require.NotNil(t, ic.SecurityContext.RunAsUser)
+	assert.Equal(t, int64(0), *ic.SecurityContext.RunAsUser, "iptables needs root inside the init container's namespaces")
+	require.NotNil(t, ic.SecurityContext.RunAsNonRoot)
+	assert.False(t, *ic.SecurityContext.RunAsNonRoot, "must override the pod-level runAsNonRoot floor")
+	require.NotNil(t, ic.SecurityContext.Capabilities)
+	caps := ic.SecurityContext.Capabilities
+	assert.Contains(t, caps.Add, corev1.Capability("NET_ADMIN"), "NET_ADMIN required for iptables manipulation")
+	assert.Contains(t, caps.Add, corev1.Capability("NET_RAW"))
+	assert.Contains(t, caps.Drop, corev1.Capability("ALL"), "drop ALL and only add what we need")
+
+	// GATEWAY_IP + ENVOY_PORT must be plumbed in as env vars so the script
+	// references the actual paired-gateway address.
+	envMap := map[string]string{}
+	for _, e := range ic.Env {
+		envMap[e.Name] = e.Value
+	}
+	assert.Equal(t, "10.96.42.42", envMap["GATEWAY_IP"])
+	assert.NotEmpty(t, envMap["ENVOY_PORT"], "ENVOY_PORT must be wired so the script doesn't fall back to a hardcoded default")
+}
+
+// PoC allow-list shape: loopback + conntrack return traffic + ONE accept rule
+// pinned to the gateway + terminal DROP. Verified at the script-text level —
+// the actual netfilter behavior is tested out-of-band (see cluster smoke
+// test). DNS-specific rules are gone; DNS is just one of the many "everything
+// else" destinations DROPped by the catch-all.
+func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
+	require.NotNil(t, ic)
+	require.GreaterOrEqual(t, len(ic.Command), 3)
+	script := ic.Command[2]
+
+	assert.Contains(t, script, "-A OUTPUT -o lo -j ACCEPT", "loopback must be admitted (in-pod localhost)")
+	assert.Contains(t, script, "--ctstate ESTABLISHED,RELATED -j ACCEPT", "return traffic must match conntrack")
+	assert.Contains(t, script, `-d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT`,
+		"single ACCEPT rule pinned to the gateway IP+Envoy port")
+	assert.Contains(t, script, "-A OUTPUT -j DROP", "terminal catch-all DROP")
+}
+
+// PoC: with `iptablesInit.enabled: true` the egress-lockdown init container
+// MUST be the first init container in the pod, before any user init script
+// runs (so the allow-list is in place when the user init starts).
+func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
+
+	ics := ss.Spec.Template.Spec.InitContainers
+	require.Len(t, ics, 2, "egress-lockdown + user init")
+	assert.Equal(t, "egress-lockdown", ics[0].Name, "lockdown must run before the user init")
+	assert.Equal(t, "init", ics[1].Name)
+
+	// The agent container itself remains unprivileged — caps only live on
+	// the egress-lockdown init container, which has already exited.
+	agent := ss.Spec.Template.Spec.Containers[0]
+	require.NotNil(t, agent.SecurityContext)
+	if agent.SecurityContext.Capabilities != nil {
+		assert.NotContains(t, agent.SecurityContext.Capabilities.Add, corev1.Capability("NET_ADMIN"),
+			"the runtime agent container must NOT carry NET_ADMIN")
+	}
+}
+
+// Without the gateway IP the init container is skipped (see
+// TestBuildIptablesInitContainer_NoGatewayIPReturnsNil) — the pod renders
+// with only the user init, and the next reconcile re-attaches lockdown.
+func TestBuildAgentStatefulSet_IptablesInitSkippedWithoutGatewayIP(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
+
+	for _, ic := range ss.Spec.Template.Spec.InitContainers {
+		assert.NotEqual(t, "egress-lockdown", ic.Name, "lockdown must skip until gateway IP is known")
+	}
+}
+
+// With disableDns: true AND a known gateway ClusterIP, the agent pod must
+// carry a hostAliases entry mapping the gateway Service name to the IP.
+// This is how HTTPS_PROXY=http://<pair>-gateway:<port> keeps resolving
+// without admitting DNS in the NetworkPolicy.
+func TestBuildAgentStatefulSet_HostAliasesWhenDNSDisabled(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.DisableDNS = true
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
+
+	aliases := ss.Spec.Template.Spec.HostAliases
+	require.Len(t, aliases, 1)
+	assert.Equal(t, "10.96.42.42", aliases[0].IP)
+	assert.Contains(t, aliases[0].Hostnames, "my-instance-gateway")
+}
+
+// disableDns: true with an unknown gateway ClusterIP (first reconcile race):
+// the controller must NOT block on it — the pod renders without
+// hostAliases and the next reconcile fills it in. The pod will fail to
+// reach the gateway in that window; that's the documented behavior.
+func TestBuildAgentStatefulSet_NoHostAliasesWhenClusterIPUnknown(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.DisableDNS = true
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
+	assert.Empty(t, ss.Spec.Template.Spec.HostAliases)
+}
+
+// disableDns: false — the default-before-PoC shape. No hostAliases regardless
+// of whether a ClusterIP was passed (DNS is doing the resolution).
+func TestBuildAgentStatefulSet_NoHostAliasesWhenDNSEnabled(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.DisableDNS = false
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
+	assert.Empty(t, ss.Spec.Template.Spec.HostAliases,
+		"hostAliases only when DNS is disabled — otherwise rely on cluster DNS")
+}

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -32,18 +32,18 @@ func TestBuildIptablesInitContainer_EmptyImageReturnsNil(t *testing.T) {
 // the meantime.
 func TestBuildIptablesInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 	assert.Nil(t, buildIptablesInitContainer(&cfg, ""), "no gateway IP yet — re-attach on next reconcile")
 }
 
 func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 
 	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
 	require.NotNil(t, ic)
 	assert.Equal(t, "egress-lockdown", ic.Name)
-	assert.Equal(t, "registry.k8s.io/distroless-iptables:v0.9.1", ic.Image)
+	assert.Equal(t, "registry.k8s.io/build-image/distroless-iptables:v0.9.2", ic.Image)
 	require.NotNil(t, ic.SecurityContext)
 	require.NotNil(t, ic.SecurityContext.RunAsUser)
 	assert.Equal(t, int64(0), *ic.SecurityContext.RunAsUser, "iptables needs root inside the init container's namespaces")
@@ -72,7 +72,7 @@ func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 // else" destinations DROPped by the catch-all.
 func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
 	require.NotNil(t, ic)
 	require.GreaterOrEqual(t, len(ic.Command), 3)
@@ -90,7 +90,7 @@ func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 // runs (so the allow-list is in place when the user init starts).
 func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
 
@@ -114,7 +114,7 @@ func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 // with only the user init, and the next reconcile re-attaches lockdown.
 func TestBuildAgentStatefulSet_IptablesInitSkippedWithoutGatewayIP(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
 

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -36,7 +36,7 @@ func TestBuildIptablesInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
 	assert.Nil(t, buildIptablesInitContainer(&cfg, ""), "no gateway IP yet — re-attach on next reconcile")
 }
 
-func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
+func TestBuildIptablesInitContainer_NonRootWithAmbientCaps(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
 
@@ -45,10 +45,10 @@ func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 	assert.Equal(t, "egress-lockdown", ic.Name)
 	assert.Equal(t, "registry.k8s.io/build-image/distroless-iptables:v0.9.2", ic.Image)
 	require.NotNil(t, ic.SecurityContext)
-	require.NotNil(t, ic.SecurityContext.RunAsUser)
-	assert.Equal(t, int64(0), *ic.SecurityContext.RunAsUser, "iptables needs root inside the init container's namespaces")
-	require.NotNil(t, ic.SecurityContext.RunAsNonRoot)
-	assert.False(t, *ic.SecurityContext.RunAsNonRoot, "must override the pod-level runAsNonRoot floor")
+	// Container inherits the pod-level non-root UID; NET_ADMIN/NET_RAW
+	// flow in via the ambient capability set. No explicit root needed.
+	assert.Nil(t, ic.SecurityContext.RunAsUser, "init container must inherit non-root pod UID, not override to root")
+	assert.Nil(t, ic.SecurityContext.RunAsNonRoot, "must not override the pod-level runAsNonRoot=true")
 	require.NotNil(t, ic.SecurityContext.Capabilities)
 	caps := ic.SecurityContext.Capabilities
 	assert.Contains(t, caps.Add, corev1.Capability("NET_ADMIN"), "NET_ADMIN required for iptables manipulation")

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -81,11 +81,17 @@ func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 	require.GreaterOrEqual(t, len(ic.Command), 3)
 	script := ic.Command[2]
 
-	assert.Contains(t, script, "-A OUTPUT -o lo -j ACCEPT", "loopback must be admitted (in-pod localhost)")
-	assert.Contains(t, script, "--ctstate ESTABLISHED,RELATED -j ACCEPT", "return traffic must match conntrack")
-	assert.Contains(t, script, `-d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT`,
+	assert.Contains(t, script, "iptables-nft -A OUTPUT -o lo -j ACCEPT", "loopback must be admitted (in-pod localhost)")
+	assert.Contains(t, script, "iptables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT", "return traffic must match conntrack")
+	assert.Contains(t, script, `iptables-nft -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT`,
 		"single ACCEPT rule pinned to the gateway IP+Envoy port")
-	assert.Contains(t, script, "-A OUTPUT -j DROP", "terminal catch-all DROP")
+	assert.Contains(t, script, "iptables-nft -A OUTPUT -j DROP", "terminal catch-all DROP")
+
+	// IPv6 must be locked down too — gateway is IPv4-only so v6 gets
+	// loopback + ESTABLISHED + DROP, no gateway ACCEPT.
+	assert.Contains(t, script, "ip6tables-nft -A OUTPUT -o lo -j ACCEPT", "IPv6 loopback must be admitted")
+	assert.Contains(t, script, "ip6tables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
+	assert.Contains(t, script, "ip6tables-nft -A OUTPUT -j DROP", "IPv6 terminal catch-all DROP")
 }
 
 // PoC: with `iptablesInit.enabled: true` the egress-lockdown init container

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -32,18 +32,18 @@ func TestBuildIptablesInitContainer_EmptyImageReturnsNil(t *testing.T) {
 // the meantime.
 func TestBuildIptablesInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
 	assert.Nil(t, buildIptablesInitContainer(&cfg, ""), "no gateway IP yet — re-attach on next reconcile")
 }
 
 func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
 
 	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
 	require.NotNil(t, ic)
 	assert.Equal(t, "egress-lockdown", ic.Name)
-	assert.Equal(t, "docker.io/nicolaka/netshoot:v0.13", ic.Image)
+	assert.Equal(t, "registry.k8s.io/distroless-iptables:v0.9.1", ic.Image)
 	require.NotNil(t, ic.SecurityContext)
 	require.NotNil(t, ic.SecurityContext.RunAsUser)
 	assert.Equal(t, int64(0), *ic.SecurityContext.RunAsUser, "iptables needs root inside the init container's namespaces")
@@ -72,7 +72,7 @@ func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 // else" destinations DROPped by the catch-all.
 func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
 	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
 	require.NotNil(t, ic)
 	require.GreaterOrEqual(t, len(ic.Command), 3)
@@ -90,7 +90,7 @@ func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 // runs (so the allow-list is in place when the user init starts).
 func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
 
@@ -114,7 +114,7 @@ func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 // with only the user init, and the next reconcile re-attaches lockdown.
 func TestBuildAgentStatefulSet_IptablesInitSkippedWithoutGatewayIP(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "docker.io/nicolaka/netshoot:v0.13"}
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/distroless-iptables:v0.9.1"}
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
 

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -53,12 +53,69 @@ import (
 // as `pairKey`; forks use the fork name. The selector pins to the pair's
 // agent pod specifically — the paired gateway pod's egress stays
 // unrestricted (it dials external upstreams for credential injection).
+//
+// When `cfg.AgentBase.DisableDNS` is set, the cluster-DNS rules are
+// dropped (threat T9). hostAliases on the pod (resources.go) lets
+// HTTPS_PROXY still resolve the gateway.
 func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	envoyPort := intstr.FromInt(cfg.EnvoyPort)
 	corednsPort := intstr.FromInt(53)
 	openshiftDNSPort := intstr.FromInt(5353)
 	tcp := corev1.ProtocolTCP
 	udp := corev1.ProtocolUDP
+
+	egress := []networkingv1.NetworkPolicyEgressRule{}
+	if !cfg.AgentBase.DisableDNS {
+		egress = append(egress,
+			networkingv1.NetworkPolicyEgressRule{
+				// Upstream Kubernetes: CoreDNS / kube-dns in
+				// `kube-system` listening on pod port 53.
+				To: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Protocol: &udp, Port: &corednsPort},
+					{Protocol: &tcp, Port: &corednsPort},
+				},
+			},
+			networkingv1.NetworkPolicyEgressRule{
+				// OpenShift: `dns-default` pods in `openshift-dns`
+				// listen on pod port 5353. NetworkPolicy filters on
+				// pod port after kube-proxy translation, so the
+				// upstream rule (53) does not match here.
+				To: []networkingv1.NetworkPolicyPeer{{
+					NamespaceSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-dns"},
+					},
+				}},
+				Ports: []networkingv1.NetworkPolicyPort{
+					{Protocol: &udp, Port: &openshiftDNSPort},
+					{Protocol: &tcp, Port: &openshiftDNSPort},
+				},
+			},
+		)
+	}
+	egress = append(egress, networkingv1.NetworkPolicyEgressRule{
+		// Bare PodSelector with no NamespaceSelector implicitly
+		// scopes to the policy's own namespace — correct today
+		// since agent + gateway pods of a pair share
+		// `cfg.Namespace`. If pods ever split across namespaces
+		// this peer must grow a NamespaceSelector or the rule
+		// silently denies the legitimate egress path.
+		To: []networkingv1.NetworkPolicyPeer{{
+			PodSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					LabelPair: pairKey,
+					LabelRole: RoleGateway,
+				},
+			},
+		}},
+		Ports: []networkingv1.NetworkPolicyPort{
+			{Protocol: &tcp, Port: &envoyPort},
+		},
+	})
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -82,55 +139,7 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 				},
 			},
 			PolicyTypes: []networkingv1.PolicyType{networkingv1.PolicyTypeEgress},
-			Egress: []networkingv1.NetworkPolicyEgressRule{
-				{
-					// Upstream Kubernetes: CoreDNS / kube-dns in
-					// `kube-system` listening on pod port 53.
-					To: []networkingv1.NetworkPolicyPeer{{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
-						},
-					}},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &udp, Port: &corednsPort},
-						{Protocol: &tcp, Port: &corednsPort},
-					},
-				},
-				{
-					// OpenShift: `dns-default` pods in `openshift-dns`
-					// listen on pod port 5353. NetworkPolicy filters on
-					// pod port after kube-proxy translation, so the
-					// upstream rule (53) does not match here.
-					To: []networkingv1.NetworkPolicyPeer{{
-						NamespaceSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-dns"},
-						},
-					}},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &udp, Port: &openshiftDNSPort},
-						{Protocol: &tcp, Port: &openshiftDNSPort},
-					},
-				},
-				{
-					// Bare PodSelector with no NamespaceSelector implicitly
-					// scopes to the policy's own namespace — correct today
-					// since agent + gateway pods of a pair share
-					// `cfg.Namespace`. If pods ever split across namespaces
-					// this peer must grow a NamespaceSelector or the rule
-					// silently denies the legitimate egress path.
-					To: []networkingv1.NetworkPolicyPeer{{
-						PodSelector: &metav1.LabelSelector{
-							MatchLabels: map[string]string{
-								LabelPair: pairKey,
-								LabelRole: RoleGateway,
-							},
-						},
-					}},
-					Ports: []networkingv1.NetworkPolicyPort{
-						{Protocol: &tcp, Port: &envoyPort},
-					},
-				},
-			},
+			Egress:      egress,
 		},
 	}
 }

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -103,6 +103,29 @@ func TestBuildAgentEgressNetworkPolicy_ManagedByLabel(t *testing.T) {
 	assert.Equal(t, "my-instance", np.Labels[LabelInstance])
 }
 
+// PoC `disableDns`: when set, the per-pair agent egress NP must NOT admit
+// DNS — closing threat-model T9 (DNS exfil via CoreDNS's upstream
+// forwarder). Only the paired-gateway rule remains.
+func TestBuildAgentEgressNetworkPolicy_DisableDNS(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.DisableDNS = true
+	np := BuildAgentEgressNetworkPolicy("my-instance", &cfg, testOwnerCM)
+
+	require.Len(t, np.Spec.Egress, 1, "disableDns must collapse the policy to gateway-only")
+	gw := np.Spec.Egress[0]
+	require.NotNil(t, gw.To[0].PodSelector)
+	assert.Equal(t, "my-instance", gw.To[0].PodSelector.MatchLabels[LabelPair])
+	assert.Equal(t, RoleGateway, gw.To[0].PodSelector.MatchLabels[LabelRole])
+
+	// Explicit: no DNS port lurking anywhere.
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			assert.NotEqual(t, int32(53), p.Port.IntVal, "DNS port 53 must not appear when DNS is disabled")
+			assert.NotEqual(t, int32(5353), p.Port.IntVal, "DNS port 5353 must not appear when DNS is disabled")
+		}
+	}
+}
+
 func assertDNSPorts(t *testing.T, ports []networkingv1.NetworkPolicyPort, expected int32) {
 	t.Helper()
 	require.Len(t, ports, 2, "both UDP and TCP on the resolver's pod port — modern resolvers fall through to TCP")

--- a/packages/controller/pkg/reconciler/pod_overrides_test.go
+++ b/packages/controller/pkg/reconciler/pod_overrides_test.go
@@ -102,7 +102,7 @@ func TestApplyAgentBaseScheduling_StampsAllFields(t *testing.T) {
 func TestBuildAgentStatefulSet_AgentBase_FullSurface(t *testing.T) {
 	cfg := configWith(fullAgentBase())
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, cfg, testOwnerCM, nil, "")
 	require.NotNil(t, ss)
 	spec := ss.Spec.Template.Spec
 	meta := ss.Spec.Template.ObjectMeta
@@ -144,7 +144,7 @@ func TestBuildAgentStatefulSet_TemplateOverridesPullPolicyAndResources(t *testin
 		Requests: map[string]string{"cpu": "2", "memory": "4Gi"},
 	}
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, &tmpl, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, &tmpl, &cfg, testOwnerCM, nil, "")
 	c := ss.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, corev1.PullAlways, c.ImagePullPolicy, "template pullPolicy wins")
 	assert.Equal(t, resource.MustParse("2"), c.Resources.Requests[corev1.ResourceCPU], "template resources win")
@@ -165,7 +165,7 @@ func TestBuildAgentStatefulSet_FallsBackToTemplateDefaultsMountsAndEnv(t *testin
 
 	bare := &types.AgentSpec{Image: "ghcr.io/myorg/agent:latest", Version: types.SpecVersion}
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, bare, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, bare, &cfg, testOwnerCM, nil, "")
 
 	var sawHome bool
 	for _, vm := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -57,7 +57,12 @@ func agentProxyAddr(instanceName string, cfg *config.Config) string {
 // `credentialSecrets` is consulted only for the GH_TOKEN-availability signal
 // surfaced as an env var and pod annotation; no Secret material is mounted
 // into the agent pod.
-func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec *types.AgentSpec, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret) *appsv1.StatefulSet {
+//
+// `gatewayClusterIP` is injected into `hostAliases` when `DisableDNS` is on,
+// so `HTTPS_PROXY=http://<pair>-gateway:<port>` resolves without DNS. Empty
+// when the controller doesn't have the IP yet — caller is expected to
+// fail-closed in that case.
+func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec *types.AgentSpec, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret, gatewayClusterIP string) *appsv1.StatefulSet {
 	base := cfg.AgentBase
 	defaults := cfg.AgentTemplateDefaults
 
@@ -257,6 +262,11 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 		initScript = defaults.Init
 	}
 	var initContainers []corev1.Container
+	// Egress-lockdown runs before the user init so the allow-list is in
+	// place by the time anything dials the network.
+	if ic := buildIptablesInitContainer(cfg, gatewayClusterIP); ic != nil {
+		initContainers = append(initContainers, *ic)
+	}
 	if initScript != "" {
 		initContainers = append(initContainers, corev1.Container{
 			Name:            "init",
@@ -354,6 +364,11 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	}
 	applyAgentBaseMeta(&podMeta, base)
 
+	var hostAliases []corev1.HostAlias
+	if base.DisableDNS && gatewayClusterIP != "" {
+		hostAliases = append(hostAliases, buildGatewayHostAlias(name, gatewayClusterIP))
+	}
+
 	podSpec := corev1.PodSpec{
 		// Agent pod opts out of ambient mesh
 		// (`istio.io/dataplane-mode: none` pod label above); it has no
@@ -370,6 +385,7 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 		ShareProcessNamespace:         shareProcessNS,
 		Containers:                    containers,
 		Volumes:                       volumes,
+		HostAliases:                   hostAliases,
 	}
 	applyAgentBaseScheduling(&podSpec, base)
 

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -85,7 +85,7 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 		Env:          []types.EnvVar{{Name: "GITHUB_ORG", Value: "alpha"}},
 		SecretRef:    "my-secrets",
 	}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 
 	require.NotNil(t, ss)
 	assert.Equal(t, "my-instance", ss.Name)
@@ -150,7 +150,7 @@ func TestBuildAgentStatefulSet_ProbesDisabled(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentProbesEnabled = false
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
 
 	c := ss.Spec.Template.Spec.Containers[0]
 	assert.Nil(t, c.StartupProbe)
@@ -160,13 +160,13 @@ func TestBuildAgentStatefulSet_ProbesDisabled(t *testing.T) {
 
 func TestBuildAgentStatefulSet_Hibernated(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "hibernated"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 	assert.Equal(t, int32(0), *ss.Spec.Replicas)
 }
 
 func TestBuildAgentStatefulSet_InitContainer(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 	require.Len(t, ss.Spec.Template.Spec.InitContainers, 1, "only the user-defined init runs")
 	ic := ss.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, "init", ic.Name)
@@ -178,13 +178,13 @@ func TestBuildAgentStatefulSet_NoUserInitWhenEmpty(t *testing.T) {
 	agent := *testAgent
 	agent.Init = ""
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil, "")
 	assert.Empty(t, ss.Spec.Template.Spec.InitContainers)
 }
 
 func TestBuildAgentStatefulSet_Volumes(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 1)
 	pvc := ss.Spec.VolumeClaimTemplates[0]
@@ -219,7 +219,7 @@ func TestBuildAgentStatefulSet_PVCSize(t *testing.T) {
 		},
 	}
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, &agent, testConfig, testOwnerCM, nil, "")
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 2)
 	byName := map[string]corev1.PersistentVolumeClaim{}
@@ -236,7 +236,7 @@ func TestBuildAgentStatefulSet_AgentStorageClass(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.StorageClass = "platform-rwx"
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 1)
 	pvc := ss.Spec.VolumeClaimTemplates[0]
@@ -248,7 +248,7 @@ func TestBuildAgentStatefulSet_PodFilesEventsURL(t *testing.T) {
 	cfg := *testConfig
 	cfg.HarnessServerURL = "http://platform-apiserver.default.svc:4001"
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t,
@@ -258,7 +258,7 @@ func TestBuildAgentStatefulSet_PodFilesEventsURL(t *testing.T) {
 
 func TestBuildAgentStatefulSet_NoSecretRef(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 	assert.Empty(t, ss.Spec.Template.Spec.Containers[0].EnvFrom)
 }
 
@@ -268,7 +268,7 @@ func TestBuildAgentStatefulSet_NoCredentialMountsOnAgent(t *testing.T) {
 	// no Envoy bootstrap CM, no leaf private key.
 	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets, "")
 
 	require.Len(t, ss.Spec.Template.Spec.Containers, 1, "no sidecar — gateway is its own pod")
 
@@ -326,7 +326,7 @@ func envToMap(envs []corev1.EnvVar) map[string]string {
 
 func TestBuildAgentStatefulSet_GHTokenSignal_NoCredential(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, "false", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
@@ -336,7 +336,7 @@ func TestBuildAgentStatefulSet_GHTokenSignal_NoCredential(t *testing.T) {
 func TestBuildAgentStatefulSet_GHTokenSignal_WithCredential(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	secrets := []corev1.Secret{credSecret("platform-cred-gh", "api.github.com")}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, secrets, "")
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, "true", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
@@ -345,7 +345,7 @@ func TestBuildAgentStatefulSet_GHTokenSignal_WithCredential(t *testing.T) {
 
 func TestBuildAgentStatefulSet_PodHardening(t *testing.T) {
 	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil)
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
 	require.NotNil(t, ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	assert.False(t, *ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	require.NotNil(t, ss.Spec.Template.Spec.ShareProcessNamespace)


### PR DESCRIPTION
## Summary

closing threat (DNS exfil via CoreDNS upstream forwarder) by adding two layered, defense-in-depth controls on the agent pod:

- `controller.agent.base.disableDns: true` (default) — drops the cluster-DNS allow rules from the per-pair agent egress NetworkPolicy. Controller injects a `hostAliases` entry mapping `<pair>-gateway` → the gateway Service ClusterIP so `HTTPS_PROXY` still resolves.
- `controller.agent.base.iptablesInit: { enabled: true, image: ... }` (default) — privileged init container (`NET_ADMIN`/`NET_RAW`, runs as root, exits) that pins the agent pod's `OUTPUT` chain to:
  - loopback ACCEPT
  - conntrack ESTABLISHED/RELATED ACCEPT
  - one ACCEPT rule for the paired gateway IP:port
  - terminal DROP

  The runtime agent container itself stays unprivileged (no caps, UID 65532).

Discussed in dam-agents/docs#1 (comments [198860967](https://github.ibm.com/dam-agents/docs/issues/1#issuecomment-198860967), [198890079](https://github.ibm.com/dam-agents/docs/issues/1#issuecomment-198890079)).

### Supporting changes

- Gateway Service flipped from headless to ClusterIP — `hostAliases` / iptables need a routable, pod-restart-independent IP. Controller migrates legacy headless Services in-place on reconcile (delete + recreate; `.spec.clusterIP` is immutable).
- New `ensureGatewayService` captures the Service synchronously from the Create response, so the agent SS template gets the ClusterIP on the same reconcile.
- Custom `anyuid-cap-net` SCC for OpenShift (replaces the previous `nonroot` binding). Modeled on built-in `anyuid` + allowed `NET_ADMIN`/`NET_RAW`. Gated by `openshift.scc.anyuidCapNet.enabled` (default ON).
- Fail-closed guard: reconcile requeues rather than rolling a half-configured agent pod when the gateway ClusterIP isn't yet readable.

### Verified on a live cluster

```
✓ dns.resolve("google.com")           → BLOCKED: ECONNREFUSED
✓ dns.lookup("google.com")            → BLOCKED: EAI_AGAIN
✓ dns.lookup("<pair>-gateway")        → OK (via /etc/hosts hostAliases)
✓ curl --noproxy '*' http://1.1.1.1   → Connection timed out (iptables DROP)
✓ curl $API_SERVER_URL/healthz        → HTTP 403 (chain works: agent→gateway→harness)
```

## Known PoC limitations

- Initial-deploy pod roll: agent + gateway StatefulSets currently template-diff once during the first reconciles because `credentialSecrets` and the cert-manager leaf Secret aren't visible in the informer cache yet on reconcile N. This is pre-existing behavior (unrelated to this PR) and rolls steady-state to 0 restarts. Separate fix: wait for cache sync / leaf-cert creation before applying the gateway SS.
- OpenShift: requires the bundled `anyuid-cap-net` SCC (`openshift.scc.anyuidCapNet.enabled`).
- k3s default CNI (flannel) doesn't enforce NetworkPolicy — the iptables init container is the only enforcement on those clusters. Other CNIs (Calico, Cilium) get both layers.

## Test plan

- [ ] `mise run check` — lint, build, helm render
- [ ] `mise run controller:test`
- [ ] `mise run cluster:install` (fresh) → verify agent + gateway pods stabilize, egress-lockdown init container exits 0
- [ ] In agent pod: `node -e 'require("dns").resolve("google.com",(e,r)=>console.log(e?e.code:r))'` → expect `BLOCKED: ECONNREFUSED`
- [ ] In agent pod: `curl --noproxy '*' http://1.1.1.1` → expect `Connection timed out`
- [ ] In agent pod: harness-proxied call (any external host the gateway is allowed to reach) succeeds via `HTTPS_PROXY`
- [ ] Upgrade test: existing instance with legacy headless gateway Service → controller migrates to ClusterIP on next reconcile