### PR TITLE
fix(api-server): parse GitHub form-encoded refresh responses

### DIFF
--- a/packages/api-server/src/__tests__/unit/oauth-refresh-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-service.test.ts
@@ -350,6 +350,41 @@ describe("oauth-refresh-service", () => {
     expect(decode(after, "raw_access_token")).toBe("old");
   });
 
+  it("marks expired on GitHub-specific `error=bad_refresh_token` (HTTP 200, form-encoded)", async () => {
+    // GitHub's OAuth endpoint never uses the RFC `invalid_grant` code; a
+    // permanently-dead refresh token comes back as `bad_refresh_token` with
+    // HTTP 200. Treat as hard failure or we'll churn in backoff while the
+    // user's UI shows "Expired" with no way to recover but reconnect.
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    const NOW_MS = 1_700_000_000_000;
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "old", refreshToken: "ref-burned", expiresAt: NOW_MS / 1000 + 30 },
+      metadata: SAMPLE_METADATA,
+    });
+
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        "error=bad_refresh_token&error_description=The+refresh+token+passed+is+incorrect+or+expired.",
+        { status: 200, headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const svc = createOAuthRefreshService({
+      k8sClient: client,
+      fetchImpl,
+      now: () => NOW_MS,
+      log: () => {},
+    });
+    await svc.tick();
+
+    const after = store.get(connectionSecretName("owner-1", "github"))!;
+    expect(after.metadata!.annotations!["agent-platform.ai/connection-status"]).toBe("expired");
+    expect(decode(after, "raw_access_token")).toBe("old");
+  });
+
   it("preserves the existing refresh token when the response omits one (provider doesn't rotate)", async () => {
     const { client, store } = fakeClient();
     const port = createK8sConnectionsPort(client, "owner-1");

--- a/packages/api-server/src/__tests__/unit/oauth-refresh-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-service.test.ts
@@ -266,6 +266,90 @@ describe("oauth-refresh-service", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("parses GitHub-style form-encoded success responses (Accept: application/json ignored)", async () => {
+    // GitHub's /login/oauth/access_token defaults to form-encoded responses
+    // unless Accept: application/json is sent — and even with it, has been
+    // observed to return form-encoded. Regression for issue #212: the refresh
+    // service used to `res.json()` unconditionally, which threw, dropped us
+    // into transient backoff, and let the access token expire untouched.
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    const NOW_MS = 1_700_000_000_000;
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "old", refreshToken: "ref-old", expiresAt: NOW_MS / 1000 + 60 },
+      metadata: {
+        ...SAMPLE_METADATA,
+        tokenUrl: "https://github.com/login/oauth/access_token",
+        clientId: "Iv1.deadbeef",
+        clientSecret: "secret",
+      },
+    });
+
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        "access_token=new-access&refresh_token=new-ref&expires_in=28800&token_type=bearer&scope=repo",
+        { status: 200, headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const svc = createOAuthRefreshService({
+      k8sClient: client,
+      fetchImpl,
+      now: () => NOW_MS,
+      log: () => {},
+    });
+    await svc.tick();
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = (fetchImpl as unknown as ReturnType<typeof vi.fn>).mock.calls[0];
+    const headers = (init as RequestInit).headers as Record<string, string>;
+    expect(headers["Accept"]).toBe("application/json");
+
+    const after = store.get(connectionSecretName("owner-1", "github"))!;
+    expect(decode(after, "raw_access_token")).toBe("new-access");
+    expect(decode(after, "refresh_token")).toBe("new-ref");
+    expect(after.metadata!.annotations!["agent-platform.ai/connection-status"]).toBe("active");
+    expect(after.metadata!.annotations!["agent-platform.ai/expires-at"]).toBe(
+      String(Math.floor(NOW_MS / 1000) + 28800),
+    );
+  });
+
+  it("marks expired on form-encoded `error=invalid_grant` from GitHub (HTTP 200 error body)", async () => {
+    // GitHub returns HTTP 200 with `error=…` when the refresh token is bad.
+    // We have to recognise it as a hard failure rather than treating the
+    // missing access_token as a transient parse miss.
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    const NOW_MS = 1_700_000_000_000;
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "old", refreshToken: "ref-revoked", expiresAt: NOW_MS / 1000 + 30 },
+      metadata: SAMPLE_METADATA,
+    });
+
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        "error=invalid_grant&error_description=The+refresh+token+is+invalid",
+        { status: 200, headers: { "Content-Type": "application/x-www-form-urlencoded" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const svc = createOAuthRefreshService({
+      k8sClient: client,
+      fetchImpl,
+      now: () => NOW_MS,
+      log: () => {},
+    });
+    await svc.tick();
+
+    const after = store.get(connectionSecretName("owner-1", "github"))!;
+    expect(after.metadata!.annotations!["agent-platform.ai/connection-status"]).toBe("expired");
+    expect(decode(after, "raw_access_token")).toBe("old");
+  });
+
   it("preserves the existing refresh token when the response omits one (provider doesn't rotate)", async () => {
     const { client, store } = fakeClient();
     const port = createK8sConnectionsPort(client, "owner-1");

--- a/packages/api-server/src/modules/connections/services/oauth-refresh-service.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh-service.ts
@@ -58,10 +58,17 @@ interface TokenEndpointSuccess {
 }
 
 const HARD_FAILURE_ERRORS = new Set([
+  // RFC 6749 § 5.2 — standard error codes returned by spec-compliant providers.
   "invalid_grant",
   "invalid_client",
   "unauthorized_client",
   "unsupported_grant_type",
+  // GitHub-specific codes: GitHub's OAuth endpoint never uses the RFC names,
+  // it returns these instead. Without them we'd churn in transient backoff on
+  // a permanently-dead refresh token until the access token expired and the
+  // UI flipped the connection to "Expired" via the `expiresAt < now` path.
+  "bad_refresh_token",
+  "incorrect_client_credentials",
 ]);
 
 /**

--- a/packages/api-server/src/modules/connections/services/oauth-refresh-service.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh-service.ts
@@ -57,17 +57,49 @@ interface TokenEndpointSuccess {
   token_type?: string;
 }
 
-interface TokenEndpointError {
-  error: string;
-  error_description?: string;
-}
-
 const HARD_FAILURE_ERRORS = new Set([
   "invalid_grant",
   "invalid_client",
   "unauthorized_client",
   "unsupported_grant_type",
 ]);
+
+/**
+ * OAuth 2.1 token-endpoint bodies are JSON in the spec, but GitHub's endpoint
+ * defaults to `application/x-www-form-urlencoded` unless the request carries
+ * `Accept: application/json`. Try JSON first, then form-encoded — whichever
+ * yields an object. Returns an empty object on total failure; callers treat
+ * missing fields as transient.
+ */
+function parseTokenEndpointBody(
+  body: string,
+  contentType: string | null,
+): Record<string, unknown> {
+  const ct = contentType ?? "";
+  if (ct.includes("application/json")) {
+    try {
+      return JSON.parse(body) as Record<string, unknown>;
+    } catch {
+      // Provider lied about content-type — fall through.
+    }
+  }
+  // Form-encoded fallback. `URLSearchParams` accepts the body even if the
+  // content-type was JSON; if the body wasn't form-encoded either, we end up
+  // with an empty params object.
+  if (body.length > 0 && !body.startsWith("{")) {
+    const parsed = new URLSearchParams(body);
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of parsed) {
+      out[k] = k === "expires_in" ? Number(v) : v;
+    }
+    if (Object.keys(out).length > 0) return out;
+  }
+  try {
+    return JSON.parse(body) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
 
 export function createOAuthRefreshService(deps: {
   k8sClient: K8sClient;
@@ -169,12 +201,41 @@ export function createOAuthRefreshService(deps: {
 
     const res = await fetchImpl(metadata.tokenUrl, {
       method: "POST",
-      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      // GitHub's token endpoint returns `application/x-www-form-urlencoded`
+      // unless explicitly asked for JSON. Without `Accept`, the success-path
+      // JSON.parse below would throw and we'd churn in backoff until the
+      // access token's `expiresAt` slid past now and the UI flipped the
+      // connection to "Expired". The body parser still tolerates a
+      // form-encoded reply defensively for providers that ignore Accept.
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded",
+        Accept: "application/json",
+      },
       body: params,
     });
 
-    if (res.ok) {
-      const data = (await res.json()) as TokenEndpointSuccess;
+    const bodyText = await res.text();
+    const parsed = parseTokenEndpointBody(bodyText, res.headers.get("content-type"));
+
+    // GitHub returns HTTP 200 with `{error: …}` (or `error=…` form-encoded)
+    // when the refresh token is bad. Treat as a hard failure regardless of
+    // status code so the connection lands in `expired` and prompts re-auth
+    // instead of churning in backoff.
+    const errCode = typeof parsed.error === "string" ? parsed.error : null;
+    if (errCode != null && HARD_FAILURE_ERRORS.has(errCode)) {
+      log("warn", "hard refresh failure; marking expired", {
+        owner: item.owner,
+        connection: item.connection,
+        error: errCode,
+        status: res.status,
+      });
+      await markConnectionExpired(deps.k8sClient, item.name);
+      clearBackoff(item.name);
+      return;
+    }
+
+    if (res.ok && typeof parsed.access_token === "string" && parsed.access_token.length > 0) {
+      const data = parsed as TokenEndpointSuccess;
       const expiresAt = data.expires_in
         ? Math.floor(now() / 1000) + data.expires_in
         : undefined;
@@ -197,29 +258,6 @@ export function createOAuthRefreshService(deps: {
         connection: item.connection,
         expiresAt,
       });
-      return;
-    }
-
-    // Treat the body as an OAuth error response. Some providers send JSON,
-    // some send form-encoded — we only inspect JSON; anything else is just
-    // logged as transient.
-    const bodyText = await res.text();
-    let errCode: string | null = null;
-    try {
-      const err = JSON.parse(bodyText) as TokenEndpointError;
-      if (typeof err.error === "string") errCode = err.error;
-    } catch {
-      // Not JSON; fall through to transient.
-    }
-
-    if (errCode != null && HARD_FAILURE_ERRORS.has(errCode)) {
-      log("warn", "hard refresh failure; marking expired", {
-        owner: item.owner,
-        connection: item.connection,
-        error: errCode,
-      });
-      await markConnectionExpired(deps.k8sClient, item.name);
-      clearBackoff(item.name);
       return;
     }
 


### PR DESCRIPTION
## Summary

GitHub's `/login/oauth/access_token` defaults to `application/x-www-form-urlencoded` responses unless the request carries `Accept: application/json`. The refresh loop sent no `Accept` header and called `res.json()` unconditionally — so every GitHub App refresh threw, dropped into backoff, and let the access token expire untouched. After ~8 hours the UI flipped the connection to **Expired** (because `expiresAt < now`, not because the status annotation said so), as reported in #212.

- Send `Accept: application/json` on the refresh POST.
- Parse responses through a shared `parseTokenEndpointBody` helper that handles JSON or form-encoded bodies (mirrors the same dual parsing the initial exchange already does in `oauth-engine.ts`).
- Recognise hard-failure `error=…` bodies regardless of HTTP status — GitHub returns HTTP 200 with form-encoded `error=invalid_grant` when a refresh token is bad. The connection now lands in `expired` (prompting reconnect) instead of churning in backoff.
- Only write new tokens when `access_token` is actually present in the parsed body.

Closes #212

## Test plan

- [x] `mise run check` clean
- [x] `mise run test` — all suites green (282 api-server tests pass)
- [x] New regression test: GitHub-style form-encoded success body refreshes the tokens and writes `expiresAt` (and asserts `Accept: application/json` was sent)
- [x] New regression test: GitHub-style HTTP 200 + form-encoded `error=invalid_grant` flips the connection to `expired` without overwriting the stored access token
- [ ] Manual: reconnect a GitHub App connection, wait past one access-token lifetime, confirm the UI keeps showing `Connected`