### PR TITLE
fix(controller): Envoy SDS observes kubelet Secret rotations

### DIFF
--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -613,6 +613,16 @@ static_resources:
                             sds_config:
                               path_config_source:
                                 path: {{ $.CredentialsRoot }}/{{ $cred.VolumeName }}/{{ $.CredentialFile }}
+                                # Watch the Secret-volume mount root, not the
+                                # sds.yaml path. Kubelet rotates the ..data
+                                # symlink inside the mount when a Secret
+                                # changes; the leaf symlink at the mount root
+                                # never gets renamed, so Envoy's default
+                                # path-only inotify never fires and a refreshed
+                                # access token never reaches the in-memory SDS
+                                # resource. See envoy PathConfigSource docs.
+                                watched_directory:
+                                  path: {{ $.CredentialsRoot }}/{{ $cred.VolumeName }}
                           header: "{{ $cred.HeaderName }}"
 {{- if $cred.QueryParamName }}
                   # Query-param injection. credential_injector wrote the

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -366,6 +366,14 @@ func TestBuildEnvoyBootstrapConfigMap(t *testing.T) {
 	assert.NotContains(t, yaml, "127.0.0.1", "gateway listener must not bind loopback under the paired-pod model")
 	assert.Contains(t, yaml, "api.example.com", "filter chain must match by SNI on the host")
 	assert.Contains(t, yaml, "/etc/envoy/credentials/cred-platform-cred-aaa/sds.yaml")
+	// path_config_source must declare `watched_directory` pointing at the
+	// Secret-volume mount root — otherwise Envoy never observes the kubelet
+	// symlink swap that delivers a rotated token. Regression for the
+	// refresh-but-stale-injection bug (gateways kept serving the pre-refresh
+	// access token).
+	assert.Contains(t, yaml, "watched_directory:")
+	assert.Contains(t, yaml, "path: /etc/envoy/credentials/cred-platform-cred-aaa",
+		"watched_directory must point at the Secret-volume mount root for kubelet's symlink swap to be detected")
 	assert.Contains(t, yaml, "internal_listener", "must declare an internal listener")
 	assert.Contains(t, yaml, "envoy.bootstrap.internal_listener", "must enable the internal_listener bootstrap extension")
 	assert.Contains(t, yaml, "tls_inspector", "internal listener must inspect SNI")


### PR DESCRIPTION
## Summary

ADR-033 promises *"kubelet syncs the mounted file, Envoy file-watch picks it up — no restart, no user impact"* for token rotation. In practice the OAuth refresh loop writes the new tokens into the K8s Secret, kubelet propagates the new bytes to the gateway pod's mount, but Envoy keeps injecting the **pre-rotation** access token — and the agent gateway happily authenticates with a credential the api-server has long since replaced.

## Root cause

The rendered Envoy bootstrap (`packages/controller/pkg/reconciler/envoy.go:612-615`) uses:

```yaml
sds_config:
  path_config_source:
    path: /etc/envoy/credentials/cred-<name>/sds.yaml
```

No `watched_directory`. From [`PathConfigSource`](https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/config_source.proto) docs:

> If `watched_directory` is not configured, ConfigSource will watch the path for changes itself. This requires the file to be atomically replaced (i.e. by `rename`). This is **not compatible with how Kubernetes ConfigMap and Secret volumes work — those use symlinks.**

Kubelet rotates the `..data` symlink inside the mount, so the leaf `sds.yaml` symlink's *path* is unchanged (its resolution differs). Envoy's path-only inotify never fires, the in-memory SDS resource stays stale, and the credential the `credential_injector` filter writes into the upstream request is the old one.

## Fix

Add `watched_directory` pointing at the Secret-volume mount root, so Envoy watches the parent directory for the kubelet symlink swap (the Envoy-recommended pattern for K8s Secret/ConfigMap volumes). Applies to every credentialed pod the controller renders under the ADR-038 paired-gateway-pod topology.

A regression assertion lands in \`TestBuildEnvoyBootstrapConfigMap\` so the clause can't silently disappear again.

Related: #212 (which surfaced this — the OAuth refresh loop *is* writing fresh tokens, but the gateway never used them).

## Test plan

- [x] \`mise run check\` clean
- [x] \`mise run test\` — all controller, api-server, UI, CLI tests pass
- [x] New assertion: rendered bootstrap contains \`watched_directory:\` plus a \`path:\` line pointing at the Secret-volume mount root
- [ ] Manual: in \`cluster:install\`, rotate a connection Secret (or wait for the refresh loop to fire), \`kubectl exec\` into the gateway pod's Envoy container to confirm \`cat /etc/envoy/credentials/cred-<name>/sds.yaml\` is the new value AND that an outbound request from the paired agent pod sees the new bearer token