### PR TITLE
feat(cli): `dam agent create` — interactive end-to-end setup

### DIFF
--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -5,11 +5,11 @@ Last verified: 2026-05-14
 ## Motivated by
 
 - [ADR-039 — Platform CLI foundation](../adrs/039-cli-foundation.md) — TypeScript Node package distributed via npm; reuses the api-server tRPC contract; flat config under XDG-standard locations; server-advertised compatibility floor.
-- [ADR-037 — Remote terminal](../adrs/037-remote-terminal.md) — predecessor; established the "terminal" session mode the CLI complements with `dam shell` (a future verb).
+- [ADR-037 — Remote terminal](../adrs/037-remote-terminal.md) — predecessor; established the "terminal" session mode the CLI complements with `dam chat` (a future verb).
 
 ## Overview
 
-The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam instance` group (`list`, `get`, `create`, `delete`, `restart`); and `dam template list`. Command groups are singular to align with `gh`, `git`, and `docker` conventions. Future verbs — `dam shell`, `dam import` — slot into their own modules and consume the Token Provider seam from `auth` plus the Instance Resolver seam from `instance`.
+The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam instance` group (`list`, `get`, `create`, `delete`, `restart`); the `dam agent` group (`create`); and `dam template list`. Command groups are singular to align with `gh`, `git`, and `docker` conventions. Future verbs — `dam chat`, `dam import` — slot into their own modules and consume the Token Provider seam from `auth` plus the Instance Resolver seam from `instance`.
 
 The CLI shares types directly with the api-server via a shared contract package, so server-side type changes reach the CLI without codegen or manual mirroring. tRPC routes are reached through `@trpc/client` typed against the contract's `AppRouter`; the auth probes (`/api/auth/config`, OIDC discovery) stay as raw `fetch` because they are not tRPC.
 
@@ -82,3 +82,18 @@ The CLI presents Instances as single, atomic entities. The server-side Agent ↔
 - **`--wait`** on `create` and `restart` polls `instances.get` every 2 seconds and settles on `state === "running"` (success) or `state === "error"` (terminal). `restart --wait` sleeps 2 seconds before the first poll so the controller has time to observe the pod deletion — otherwise the first poll might see stale `running` state from the doomed pod. Default timeout is 120 seconds; on timeout the instance is left as-is (no rollback) and the command exits non-zero. Under `--json`, every exit path emits a valid `Instance` payload on stdout: the success branch reuses the snapshot the wait loop already observed, and the timeout / non-wait branches refresh via `instances.get` with a fallback to the post-mutation snapshot if the refresh fails, so scripted callers never see empty stdout.
 
 `dam template list` exposes the agent templates the operator has installed on the active host (the `claude-code`, `pi-agent`, etc. ConfigMaps the controller reads at boot). Templates are read-only from the CLI's perspective; operators add or remove them via Helm.
+
+## Interactive agent setup
+
+`dam agent create` is the interactive complement to `dam instance create`. It walks the user through name → template → model provider → optional GitHub PAT in a single TTY-bound flow and ends with the same agent + instance + grants that the web UI's "Add agent" dialog produces. The scripted entry point is unchanged — `dam instance create <name> --template <id>` stays the path for shell scripts and CI, and `dam agent create` refuses to run when stdin is not a TTY (pointing the caller back at `instance create`).
+
+Each step lines up with one server-side mutation, in the same order the web UI's `useCreateAgent` runs them:
+
+1. **Model provider** — singleton per type (Anthropic, IBM LiteLLM, OpenAI), matching the web UI's provider cards. The picker lists existing provider Secrets and offers "Add new..."; the add-new sub-flow auto-names the Secret with `PROVIDERS[type].displayName` and routes through `secrets.create`. If a Secret of the chosen type already exists, the flow offers to replace its value (`secrets.update`) instead of duplicating.
+2. **GitHub PAT** *(optional)* — a single PAT is two `generic` Secrets (see [security-and-credentials.md](security-and-credentials.md#credential-storage)); the picker groups them client-side and hides orphans. New PATs go through `secrets.createGithubPat`, which creates both halves atomically server-side.
+3. **`agents.create` → `instances.create` → `secrets.setAgentAccess`** — grants are persisted as `granted-secret-ids` annotations on the *instance* ConfigMap, so the grant call has to come after `instances.create`. `setAgentAccess` runs inside a 5× / 2s retry to bridge the K8s-API visibility race for the just-created ConfigMap. The controller rolls the pod once when the grant lands; one rolling restart per agent is the cost.
+4. **Wait for `running`** — same 120 s timeout the `instance --wait` path uses. Timeout is success (the instance exists, the pod is slow); pod-failure state and Ctrl+C during the wait exit non-zero without rolling back.
+
+Anything created during the run (new provider Secret, new GitHub PAT pair, the agent) is tracked in a small ledger; a failure in any of the post-prompt mutations triggers one cleanup pass — `agents.delete` cascade-tears-down the instance and its grants, then any new Secrets are deleted by id. Picked-existing and replace-existing paths stay out of the ledger: the replace path overwrote the value in place, and the old value is unrecoverable. Anything the cleanup itself can't delete surfaces as an orphan summary so the user knows what to remove manually.
+
+The post-success hint points at `dam chat <name>` (the chat verb is a future module). Interrupting at any prompt before the mutation chain exits cleanly with no orphans; interrupting during the wait leaves the agent in place with the same delete-hint, on the basis that the user chose to interrupt and the agent's existence is their call from there.

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-13
+Last verified: 2026-05-14
 
 ## Motivated by
 
@@ -157,6 +157,17 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
   tokens before expiry; the agent never sees the refresh token.
 - **User-supplied secrets** (Anthropic API keys, generic API tokens) —
   the secrets module writes them with the same labels and annotations.
+- **GitHub personal access tokens** — one PAT is *two* `generic` Secrets
+  that share a display name. The `api.github.com` half stores the raw
+  PAT, injects `Authorization: Bearer {value}`, and projects `GH_TOKEN`
+  into the agent pod's env for the `gh` CLI. The `github.com` half
+  stores `base64("x-access-token:" + PAT)` and injects
+  `Authorization: Basic {value}` for `git clone` over HTTPS. Both
+  halves are written atomically via `secrets.createGithubPat` (the
+  mutation owns the base64 wrapping so callers send `{name, token}`
+  only and a partial-create rolls back the api half if the git half
+  fails). Picker UIs group the pair client-side by display name and
+  hide orphans (one host missing).
 
 The Secret carries the SDS YAML Envoy reads via its `path_config_source`.
 Only the gateway pod mounts the Secret; the agent pod does not. See

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -60,6 +60,8 @@ export type {
   CreateSecretInput,
   CreateGithubPatInput,
   CreateGithubPatOutput,
+  UpdateGithubPatInput,
+  UpdateGithubPatOutput,
   UpdateSecretInput,
   AgentAccess,
   SecretsService,

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -58,6 +58,8 @@ export type {
   ProviderPresetType,
   SecretView,
   CreateSecretInput,
+  CreateGithubPatInput,
+  CreateGithubPatOutput,
   UpdateSecretInput,
   AgentAccess,
   SecretsService,

--- a/packages/api-server-api/src/modules/secrets/router.ts
+++ b/packages/api-server-api/src/modules/secrets/router.ts
@@ -68,6 +68,16 @@ export const secretsRouter = t.router({
     )
     .mutation(({ ctx, input }) => ctx.secrets.createGithubPat(input)),
 
+  updateGithubPat: t.procedure
+    .input(
+      z.object({
+        apiSecretId: z.string().min(1),
+        gitSecretId: z.string().min(1),
+        token: z.string().min(1),
+      }),
+    )
+    .mutation(({ ctx, input }) => ctx.secrets.updateGithubPat(input)),
+
   update: t.procedure.input(updateSecretInputSchema).mutation(({ ctx, input }) => ctx.secrets.update(input)),
 
   delete: t.procedure

--- a/packages/api-server-api/src/modules/secrets/router.ts
+++ b/packages/api-server-api/src/modules/secrets/router.ts
@@ -59,6 +59,15 @@ export const secretsRouter = t.router({
     )
     .mutation(({ ctx, input }) => ctx.secrets.create(input)),
 
+  createGithubPat: t.procedure
+    .input(
+      z.object({
+        name: z.string().min(1).max(100),
+        token: z.string().min(1),
+      }),
+    )
+    .mutation(({ ctx, input }) => ctx.secrets.createGithubPat(input)),
+
   update: t.procedure.input(updateSecretInputSchema).mutation(({ ctx, input }) => ctx.secrets.update(input)),
 
   delete: t.procedure

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -346,6 +346,23 @@ export interface AgentAccess {
   secretIds: string[];
 }
 
+/**
+ * Input for {@link SecretsService.createGithubPat}. A single GitHub PAT is
+ * fanned out server-side into two `generic` secrets that share this `name`:
+ * one for `api.github.com` (Bearer / `GH_TOKEN`) and one for `github.com`
+ * (Basic, with the value pre-wrapped as `base64("x-access-token:" + token)`).
+ */
+export interface CreateGithubPatInput {
+  name: string;
+  token: string;
+}
+
+export interface CreateGithubPatOutput {
+  name: string;
+  apiSecretId: string;
+  gitSecretId: string;
+}
+
 /** Minimal agent shape returned by `listGrantedAgents` — used by the UI's
  *  env-affecting edit confirmation to show which agents will roll. */
 export interface GrantedAgentSummary {
@@ -356,6 +373,7 @@ export interface GrantedAgentSummary {
 export interface SecretsService {
   list(): Promise<SecretView[]>;
   create(input: CreateSecretInput): Promise<SecretView>;
+  createGithubPat(input: CreateGithubPatInput): Promise<CreateGithubPatOutput>;
   update(input: UpdateSecretInput): Promise<void>;
   delete(id: string): Promise<void>;
   getAgentAccess(agentId: string): Promise<AgentAccess>;

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -363,6 +363,23 @@ export interface CreateGithubPatOutput {
   gitSecretId: string;
 }
 
+/**
+ * Input for {@link SecretsService.updateGithubPat}. Replaces the token on
+ * an existing PAT pair by id, re-wrapping the github.com half's basic-
+ * auth value server-side so callers send `{apiSecretId, gitSecretId,
+ * token}` only.
+ */
+export interface UpdateGithubPatInput {
+  apiSecretId: string;
+  gitSecretId: string;
+  token: string;
+}
+
+export interface UpdateGithubPatOutput {
+  apiSecretId: string;
+  gitSecretId: string;
+}
+
 /** Minimal agent shape returned by `listGrantedAgents` — used by the UI's
  *  env-affecting edit confirmation to show which agents will roll. */
 export interface GrantedAgentSummary {
@@ -374,6 +391,7 @@ export interface SecretsService {
   list(): Promise<SecretView[]>;
   create(input: CreateSecretInput): Promise<SecretView>;
   createGithubPat(input: CreateGithubPatInput): Promise<CreateGithubPatOutput>;
+  updateGithubPat(input: UpdateGithubPatInput): Promise<UpdateGithubPatOutput>;
   update(input: UpdateSecretInput): Promise<void>;
   delete(id: string): Promise<void>;
   getAgentAccess(agentId: string): Promise<AgentAccess>;

--- a/packages/api-server/src/__tests__/unit/agent-grants-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/agent-grants-port.test.ts
@@ -150,6 +150,15 @@ describe("createAgentGrantsPort.setSecretGrants", () => {
     await port.setSecretGrants("agent-1", ["aaa"]);
     expect(patches.map((p) => p.name).sort()).toEqual(["inst-1", "inst-2"]);
   });
+
+  it("throws when no instance ConfigMaps exist (race indicator — caller retries)", async () => {
+    const { client, patches } = fakeClient([]);
+    const port = createAgentGrantsPort(client, "owner-1");
+    await expect(port.setSecretGrants("agent-1", ["aaa"])).rejects.toThrow(
+      /no instance ConfigMaps/,
+    );
+    expect(patches).toEqual([]);
+  });
 });
 
 describe("createAgentGrantsPort.setConnectionGrants", () => {
@@ -166,6 +175,15 @@ describe("createAgentGrantsPort.setConnectionGrants", () => {
     expect(patches.at(-1)!.body).toEqual({
       metadata: { annotations: { [ANN_GRANTED_CONNECTION_IDS]: "github,slack" } },
     });
+  });
+
+  it("throws when no instance ConfigMaps exist (race indicator — caller retries)", async () => {
+    const { client, patches } = fakeClient([]);
+    const port = createAgentGrantsPort(client, "owner-1");
+    await expect(port.setConnectionGrants("agent-1", ["github"])).rejects.toThrow(
+      /no instance ConfigMaps/,
+    );
+    expect(patches).toEqual([]);
   });
 });
 

--- a/packages/api-server/src/__tests__/unit/secrets-service-create-github-pat.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-create-github-pat.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+
+import { createSecretsService } from "../../modules/secrets/services/secrets-service.js";
+import type {
+  K8sSecretsPort,
+  K8sStoredSecret,
+} from "../../modules/secrets/infrastructure/k8s-secrets-port.js";
+import type {
+  AgentGrants,
+  AgentGrantsPort,
+} from "../../modules/agents/infrastructure/agent-grants-port.js";
+
+type CreateCall = Parameters<K8sSecretsPort["createSecret"]>[0];
+
+function makePort(opts: { failSecondCreate?: boolean } = {}) {
+  const store = new Map<string, K8sStoredSecret>();
+  const created: CreateCall[] = [];
+  const deleted: string[] = [];
+  const port: K8sSecretsPort = {
+    async listSecrets() {
+      return Array.from(store.values());
+    },
+    async createSecret(input) {
+      if (opts.failSecondCreate && created.length === 1) {
+        throw new Error("boom on second create");
+      }
+      created.push(input);
+      store.set(input.id, {
+        id: input.id,
+        name: input.name,
+        type: input.type,
+        hostPattern: input.hostPattern,
+        ...(input.pathPattern ? { pathPattern: input.pathPattern } : {}),
+        ...(input.envMappings ? { envMappings: input.envMappings } : {}),
+        ...(input.injectionConfig ? { injectionConfig: input.injectionConfig } : {}),
+        ...(input.authMode ? { authMode: input.authMode } : {}),
+        createdAt: new Date().toISOString(),
+      });
+    },
+    async updateSecret() {
+      return null;
+    },
+    async deleteSecret(id) {
+      deleted.push(id);
+      store.delete(id);
+    },
+  };
+  return { port, store, created, deleted };
+}
+
+function makeGrants() {
+  const port: AgentGrantsPort = {
+    async get(): Promise<AgentGrants> {
+      return { grantedSecretIds: [], grantedConnectionIds: [] };
+    },
+    async setSecretGrants() {},
+    async setConnectionGrants() {},
+    async listAgentsGrantedSecret() {
+      return [];
+    },
+    async bumpSecretsRev() {},
+  };
+  return { port };
+}
+
+describe("secrets-service.createGithubPat", () => {
+  it("creates two generic secrets with matching name and returns both ids", async () => {
+    const { port, created, store } = makePort();
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    const result = await svc.createGithubPat({ name: "guido", token: "ghp_test123" });
+
+    expect(result.name).toBe("guido");
+    expect(result.apiSecretId).toBeTruthy();
+    expect(result.gitSecretId).toBeTruthy();
+    expect(result.apiSecretId).not.toBe(result.gitSecretId);
+    expect(store.size).toBe(2);
+
+    expect(created).toHaveLength(2);
+    const apiCall = created[0]!;
+    const gitCall = created[1]!;
+
+    expect(apiCall).toMatchObject({
+      type: "generic",
+      name: "guido",
+      value: "ghp_test123",
+      hostPattern: "api.github.com",
+      injectionConfig: { headerName: "Authorization", valueFormat: "Bearer {value}" },
+      envMappings: [{ envName: "GH_TOKEN", placeholder: "dummy-placeholder" }],
+    });
+
+    const expectedBasic = Buffer.from("x-access-token:ghp_test123").toString("base64");
+    expect(gitCall).toMatchObject({
+      type: "generic",
+      name: "guido",
+      value: expectedBasic,
+      hostPattern: "github.com",
+      injectionConfig: { headerName: "Authorization", valueFormat: "Basic {value}" },
+    });
+    expect(gitCall.envMappings).toBeUndefined();
+
+    expect(apiCall.id).toBe(result.apiSecretId);
+    expect(gitCall.id).toBe(result.gitSecretId);
+  });
+
+  it("rolls back the first secret if the second create fails", async () => {
+    const { port, created, deleted, store } = makePort({ failSecondCreate: true });
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await expect(
+      svc.createGithubPat({ name: "guido", token: "ghp_test123" }),
+    ).rejects.toThrow("boom on second create");
+
+    expect(created).toHaveLength(1);
+    expect(deleted).toEqual([created[0]!.id]);
+    expect(store.size).toBe(0);
+  });
+});

--- a/packages/api-server/src/__tests__/unit/secrets-service-update-anthropic-mode.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-update-anthropic-mode.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest";
+import { PROVIDERS, type EnvMapping } from "api-server-api";
+
+import { createSecretsService } from "../../modules/secrets/services/secrets-service.js";
+import type {
+  AuthMode,
+  K8sSecretsPort,
+  K8sStoredSecret,
+} from "../../modules/secrets/infrastructure/k8s-secrets-port.js";
+import type {
+  AgentGrants,
+  AgentGrantsPort,
+} from "../../modules/agents/infrastructure/agent-grants-port.js";
+
+interface UpdateCall {
+  id: string;
+  authMode?: AuthMode;
+  envMappings?: EnvMapping[];
+  injectionConfig?: unknown;
+  value?: string;
+}
+
+const ANTHROPIC_API_KEY_MAPPING = PROVIDERS.anthropic.modes.find((m) => m.key === "api-key")!
+  .defaultEnvMappings;
+const ANTHROPIC_OAUTH_MAPPING = PROVIDERS.anthropic.modes.find((m) => m.key === "oauth")!
+  .defaultEnvMappings;
+
+function makePort(existing: K8sStoredSecret) {
+  const store = new Map([[existing.id, existing]]);
+  const updates: UpdateCall[] = [];
+  const port: K8sSecretsPort = {
+    async listSecrets() {
+      return Array.from(store.values());
+    },
+    async createSecret() {},
+    async updateSecret(id, patch) {
+      const before = store.get(id);
+      if (!before) return null;
+      updates.push({ id, ...patch });
+      const after: K8sStoredSecret = {
+        ...before,
+        ...(patch.authMode !== undefined ? { authMode: patch.authMode } : {}),
+        ...(patch.envMappings !== undefined ? { envMappings: patch.envMappings } : {}),
+      };
+      store.set(id, after);
+      return { before, after };
+    },
+    async deleteSecret() {},
+  };
+  return { port, updates };
+}
+
+function makeGrants() {
+  const port: AgentGrantsPort = {
+    async get(): Promise<AgentGrants> {
+      return { grantedSecretIds: [], grantedConnectionIds: [] };
+    },
+    async setSecretGrants() {},
+    async setConnectionGrants() {},
+    async listAgentsGrantedSecret() {
+      return [];
+    },
+    async bumpSecretsRev() {},
+  };
+  return { port };
+}
+
+function anthropicSecret(authMode: AuthMode): K8sStoredSecret {
+  return {
+    id: "secret-1",
+    name: "Anthropic",
+    type: "anthropic",
+    hostPattern: "api.anthropic.com",
+    createdAt: new Date().toISOString(),
+    authMode,
+  };
+}
+
+describe("secrets-service.update — Anthropic auth-mode rotation", () => {
+  it("api-key → oauth: rewrites env, clears injection config, flips auth-mode", async () => {
+    const { port, updates } = makePort(anthropicSecret("api-key"));
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await svc.update({ id: "secret-1", value: "sk-ant-oat01-newtoken" });
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      id: "secret-1",
+      value: "sk-ant-oat01-newtoken",
+      authMode: "oauth",
+      envMappings: ANTHROPIC_OAUTH_MAPPING,
+      injectionConfig: null,
+    });
+  });
+
+  it("oauth → api-key: rewrites env, clears injection config, flips auth-mode", async () => {
+    const { port, updates } = makePort(anthropicSecret("oauth"));
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await svc.update({ id: "secret-1", value: "sk-ant-api03-newkey" });
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      authMode: "api-key",
+      envMappings: ANTHROPIC_API_KEY_MAPPING,
+      injectionConfig: null,
+    });
+  });
+
+  it("no-op when the new value's prefix matches the existing mode", async () => {
+    const { port, updates } = makePort(anthropicSecret("api-key"));
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await svc.update({ id: "secret-1", value: "sk-ant-api03-anothernewkey" });
+
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.authMode).toBeUndefined();
+    expect(updates[0]?.envMappings).toBeUndefined();
+    expect(updates[0]?.injectionConfig).toBeUndefined();
+  });
+
+  it("does not touch non-Anthropic secrets", async () => {
+    const ibm: K8sStoredSecret = {
+      id: "secret-2",
+      name: "IBM LiteLLM",
+      type: "ibm-litellm",
+      hostPattern: "ete-litellm.example",
+      createdAt: new Date().toISOString(),
+    };
+    const { port, updates } = makePort(ibm);
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await svc.update({ id: "secret-2", value: "sk-litellm-new" });
+
+    expect(updates[0]?.authMode).toBeUndefined();
+    expect(updates[0]?.envMappings).toBeUndefined();
+    expect(updates[0]?.injectionConfig).toBeUndefined();
+  });
+
+  it("caller-supplied envMappings wins over the rotation", async () => {
+    const { port, updates } = makePort(anthropicSecret("api-key"));
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    const explicit: EnvMapping[] = [{ envName: "CUSTOM_VAR", placeholder: "x" }];
+    await svc.update({
+      id: "secret-1",
+      value: "sk-ant-oat01-newtoken",
+      envMappings: explicit,
+    });
+
+    // The early-return guard inside the service skips the rotation
+    // helper when the caller supplied envMappings — explicit beats
+    // implicit. The K8sPort therefore receives the caller's mappings
+    // unchanged and no authMode flip.
+    expect(updates[0]?.envMappings).toEqual(explicit);
+    expect(updates[0]?.authMode).toBeUndefined();
+  });
+});

--- a/packages/api-server/src/__tests__/unit/secrets-service-update-anthropic-mode.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-update-anthropic-mode.test.ts
@@ -20,8 +20,6 @@ interface UpdateCall {
   value?: string;
 }
 
-const ANTHROPIC_API_KEY_MAPPING = PROVIDERS.anthropic.modes.find((m) => m.key === "api-key")!
-  .defaultEnvMappings;
 const ANTHROPIC_OAUTH_MAPPING = PROVIDERS.anthropic.modes.find((m) => m.key === "oauth")!
   .defaultEnvMappings;
 
@@ -90,21 +88,6 @@ describe("secrets-service.update — Anthropic auth-mode rotation", () => {
       value: "sk-ant-oat01-newtoken",
       authMode: "oauth",
       envMappings: ANTHROPIC_OAUTH_MAPPING,
-      injectionConfig: null,
-    });
-  });
-
-  it("oauth → api-key: rewrites env, clears injection config, flips auth-mode", async () => {
-    const { port, updates } = makePort(anthropicSecret("oauth"));
-    const { port: grants } = makeGrants();
-    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
-
-    await svc.update({ id: "secret-1", value: "sk-ant-api03-newkey" });
-
-    expect(updates).toHaveLength(1);
-    expect(updates[0]).toMatchObject({
-      authMode: "api-key",
-      envMappings: ANTHROPIC_API_KEY_MAPPING,
       injectionConfig: null,
     });
   });

--- a/packages/api-server/src/__tests__/unit/secrets-service-update-github-pat.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-update-github-pat.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from "vitest";
+
+import { createSecretsService } from "../../modules/secrets/services/secrets-service.js";
+import type {
+  K8sSecretsPort,
+  K8sStoredSecret,
+} from "../../modules/secrets/infrastructure/k8s-secrets-port.js";
+import type {
+  AgentGrants,
+  AgentGrantsPort,
+} from "../../modules/agents/infrastructure/agent-grants-port.js";
+
+interface UpdateCall {
+  id: string;
+  value?: string;
+}
+
+function makePort(opts: { failSecondUpdate?: boolean; missingIds?: string[] } = {}) {
+  const store = new Map<string, K8sStoredSecret>();
+  // Seed both halves of an existing PAT pair so updateSecret has something
+  // to read for before/after diffs.
+  store.set("api-1", {
+    id: "api-1",
+    name: "GitHub",
+    type: "generic",
+    hostPattern: "api.github.com",
+    createdAt: new Date().toISOString(),
+  });
+  store.set("git-1", {
+    id: "git-1",
+    name: "GitHub",
+    type: "generic",
+    hostPattern: "github.com",
+    createdAt: new Date().toISOString(),
+  });
+  const updates: UpdateCall[] = [];
+  const port: K8sSecretsPort = {
+    async listSecrets() {
+      return Array.from(store.values());
+    },
+    async createSecret() {},
+    async updateSecret(id, patch) {
+      if (opts.missingIds?.includes(id)) return null;
+      if (opts.failSecondUpdate && updates.length === 1) {
+        throw new Error("boom on second update");
+      }
+      const before = store.get(id);
+      if (!before) return null;
+      updates.push({ id, value: patch.value });
+      return { before, after: before };
+    },
+    async deleteSecret(id) {
+      store.delete(id);
+    },
+  };
+  return { port, updates };
+}
+
+function makeGrants() {
+  const port: AgentGrantsPort = {
+    async get(): Promise<AgentGrants> {
+      return { grantedSecretIds: [], grantedConnectionIds: [] };
+    },
+    async setSecretGrants() {},
+    async setConnectionGrants() {},
+    async listAgentsGrantedSecret() {
+      return [];
+    },
+    async bumpSecretsRev() {},
+  };
+  return { port };
+}
+
+describe("secrets-service.updateGithubPat", () => {
+  it("updates both halves with token + base64-wrapped basic auth", async () => {
+    const { port, updates } = makePort();
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    const result = await svc.updateGithubPat({
+      apiSecretId: "api-1",
+      gitSecretId: "git-1",
+      token: "ghp_newtoken",
+    });
+
+    expect(result).toEqual({ apiSecretId: "api-1", gitSecretId: "git-1" });
+    expect(updates).toHaveLength(2);
+    expect(updates[0]).toEqual({ id: "api-1", value: "ghp_newtoken" });
+    expect(updates[1]).toEqual({
+      id: "git-1",
+      value: Buffer.from("x-access-token:ghp_newtoken").toString("base64"),
+    });
+  });
+
+  it("throws NOT_FOUND when the api half doesn't exist", async () => {
+    const { port } = makePort({ missingIds: ["api-1"] });
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await expect(
+      svc.updateGithubPat({ apiSecretId: "api-1", gitSecretId: "git-1", token: "ghp_x" }),
+    ).rejects.toMatchObject({ code: "NOT_FOUND" });
+  });
+
+  it("surfaces the original error when the git half update fails", async () => {
+    const { port, updates } = makePort({ failSecondUpdate: true });
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+
+    await expect(
+      svc.updateGithubPat({ apiSecretId: "api-1", gitSecretId: "git-1", token: "ghp_x" }),
+    ).rejects.toThrow("boom on second update");
+    // The api half was updated before the failure — documented partial-
+    // failure behavior in the service comment.
+    expect(updates).toHaveLength(1);
+    expect(updates[0]?.id).toBe("api-1");
+  });
+});

--- a/packages/api-server/src/__tests__/unit/secrets-service-update-github-pat.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-update-github-pat.test.ts
@@ -15,7 +15,7 @@ interface UpdateCall {
   value?: string;
 }
 
-function makePort(opts: { failSecondUpdate?: boolean; missingIds?: string[] } = {}) {
+function makePort(opts: { missingIds?: string[] } = {}) {
   const store = new Map<string, K8sStoredSecret>();
   // Seed both halves of an existing PAT pair so updateSecret has something
   // to read for before/after diffs.
@@ -41,9 +41,6 @@ function makePort(opts: { failSecondUpdate?: boolean; missingIds?: string[] } = 
     async createSecret() {},
     async updateSecret(id, patch) {
       if (opts.missingIds?.includes(id)) return null;
-      if (opts.failSecondUpdate && updates.length === 1) {
-        throw new Error("boom on second update");
-      }
       const before = store.get(id);
       if (!before) return null;
       updates.push({ id, value: patch.value });
@@ -100,19 +97,5 @@ describe("secrets-service.updateGithubPat", () => {
     await expect(
       svc.updateGithubPat({ apiSecretId: "api-1", gitSecretId: "git-1", token: "ghp_x" }),
     ).rejects.toMatchObject({ code: "NOT_FOUND" });
-  });
-
-  it("surfaces the original error when the git half update fails", async () => {
-    const { port, updates } = makePort({ failSecondUpdate: true });
-    const { port: grants } = makeGrants();
-    const svc = createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
-
-    await expect(
-      svc.updateGithubPat({ apiSecretId: "api-1", gitSecretId: "git-1", token: "ghp_x" }),
-    ).rejects.toThrow("boom on second update");
-    // The api half was updated before the failure — documented partial-
-    // failure behavior in the service comment.
-    expect(updates).toHaveLength(1);
-    expect(updates[0]?.id).toBe("api-1");
   });
 });

--- a/packages/api-server/src/modules/agents/infrastructure/agent-grants-port.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-grants-port.ts
@@ -109,6 +109,16 @@ export function createAgentGrantsPort(client: K8sClient, ownerSub: string): Agen
 
     async setSecretGrants(agentId, ids) {
       const cms = await listInstancesForAgent(agentId);
+      // setAgentAccess is only meaningful for agents that already have an
+      // instance — grants live on the instance ConfigMap. An empty list
+      // here means the caller raced ahead of the controller's CM create;
+      // surface it as an error so callers can retry instead of silently
+      // dropping the grant.
+      if (cms.length === 0) {
+        throw new Error(
+          `setSecretGrants: no instance ConfigMaps for agent ${agentId} (race with instance creation? retry)`,
+        );
+      }
       // Always-selective: write the literal (possibly empty) value.
       const annotations = { [ANN_GRANTED_SECRET_IDS]: ids.join(",") };
       await Promise.all(
@@ -118,6 +128,11 @@ export function createAgentGrantsPort(client: K8sClient, ownerSub: string): Agen
 
     async setConnectionGrants(agentId, ids) {
       const cms = await listInstancesForAgent(agentId);
+      if (cms.length === 0) {
+        throw new Error(
+          `setConnectionGrants: no instance ConfigMaps for agent ${agentId} (race with instance creation? retry)`,
+        );
+      }
       const annotations = { [ANN_GRANTED_CONNECTION_IDS]: ids.join(",") };
       await Promise.all(
         cms.map((cm) => patchAnnotations(cm.metadata!.name!, annotations)),

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -18,6 +18,7 @@ import {
   type AgentAccess,
 } from "api-server-api";
 import type {
+  AuthMode,
   K8sSecretsPort,
   K8sStoredSecret,
 } from "./../infrastructure/k8s-secrets-port.js";
@@ -56,6 +57,30 @@ function registryExtraInjections(
 function twinDisplayName(primaryName: string, injection: InjectionConfig): string {
   const tag = injection.queryParamName ? `?${injection.queryParamName}` : injection.headerName;
   return `${primaryName} (${tag})`;
+}
+
+/**
+ * Anthropic-only: if the new value's prefix indicates a different auth
+ * mode than the secret currently has, return the registry's env
+ * mappings for the new mode plus the new mode key. `update` uses this
+ * to re-bake injection + env when a CLI replace path swaps key formats.
+ * Returns `null` when no rotation is needed (non-Anthropic secret,
+ * same mode, or secret not found — the K8sPort will surface NOT_FOUND
+ * downstream).
+ */
+async function anthropicModeRotationFor(
+  k8sPort: K8sSecretsPort,
+  id: string,
+  newValue: string,
+): Promise<{ authMode: AuthMode; envMappings: EnvMapping[] } | null> {
+  const secrets = await k8sPort.listSecrets();
+  const existing = secrets.find((s) => s.id === id);
+  if (!existing || existing.type !== "anthropic") return null;
+  const newAuthMode: AuthMode = newValue.startsWith("sk-ant-oat") ? "oauth" : "api-key";
+  if (newAuthMode === existing.authMode) return null;
+  const mode = PROVIDERS.anthropic.modes.find((m) => m.key === newAuthMode);
+  if (!mode) return null;
+  return { authMode: newAuthMode, envMappings: [...mode.defaultEnvMappings] };
 }
 
 // `secrets-rev` hashes only what affects the agent pod's env. hostPattern,
@@ -304,13 +329,37 @@ export function createSecretsService(deps: {
     },
 
     async update({ id, ...patch }: UpdateSecretInput) {
+      // Anthropic value swaps re-discriminate the auth mode from the new
+      // value's prefix and rewrite envMappings + injectionConfig to match.
+      // Without this, replacing an API key (stored as
+      // `x-api-key: {value}`, env `ANTHROPIC_API_KEY`) with an OAuth
+      // token (needs `Authorization: Bearer {value}`, env
+      // `CLAUDE_CODE_OAUTH_TOKEN`) leaves the injection metadata stuck
+      // at the old mode — Anthropic receives `x-api-key: sk-ant-oat…`
+      // and rejects with "Invalid API key". The same prefix rule lives
+      // in `create` above; this just teaches `update` to redo it when
+      // the caller didn't supply envMappings explicitly (the web UI's
+      // Anthropic Edit form does, the CLI's replace path does not).
+      const rotation =
+        patch.value !== undefined && patch.envMappings === undefined
+          ? await anthropicModeRotationFor(deps.k8sPort, id, patch.value)
+          : null;
       const result = await deps.k8sPort.updateSecret(id, {
         ...(patch.name !== undefined ? { name: patch.name } : {}),
         ...(patch.value !== undefined ? { value: patch.value } : {}),
         ...(patch.hostPattern !== undefined ? { hostPattern: patch.hostPattern } : {}),
         ...(patch.pathPattern !== undefined ? { pathPattern: patch.pathPattern } : {}),
-        ...(patch.injectionConfig !== undefined ? { injectionConfig: patch.injectionConfig } : {}),
-        ...(patch.envMappings !== undefined ? { envMappings: patch.envMappings } : {}),
+        ...(patch.injectionConfig !== undefined
+          ? { injectionConfig: patch.injectionConfig }
+          : rotation
+            ? { injectionConfig: null }
+            : {}),
+        ...(patch.envMappings !== undefined
+          ? { envMappings: patch.envMappings }
+          : rotation
+            ? { envMappings: rotation.envMappings }
+            : {}),
+        ...(rotation ? { authMode: rotation.authMode } : {}),
       });
       // ADR-040 fanout. Host edits → re-sync egress_rules per granted
       // agent (hot, no roll). envMappings edits → bump secrets-rev so the

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -10,6 +10,8 @@ import {
   type InjectionConfig,
   type SecretsService,
   type CreateSecretInput,
+  type UpdateGithubPatInput,
+  type UpdateGithubPatOutput,
   type UpdateSecretInput,
   type SecretType,
   type SecretView,
@@ -273,6 +275,32 @@ export function createSecretsService(deps: {
         apiSecretId: apiSecret.id,
         gitSecretId: gitSecret.id,
       };
+    },
+
+    async updateGithubPat(input: UpdateGithubPatInput): Promise<UpdateGithubPatOutput> {
+      // Re-wrap the github.com half server-side so callers send `{token}`
+      // only — same shape symmetry as createGithubPat.
+      //
+      // Value-only update: envMappings / hostPattern / injectionConfig
+      // stay the same, so neither the `secrets-rev` rolling-restart
+      // signal nor the connection-rules sync fires. The gateway pod's
+      // Envoy picks up the new value via SDS without a pod restart.
+      //
+      // Partial-failure note: if the github.com update throws, the
+      // api.github.com half already holds the new token while the
+      // github.com half still holds the prior wrapped value. The raw
+      // prior value isn't recoverable from the SDS file (the format
+      // template is baked into it), so we don't attempt to restore —
+      // surface the original error and let the caller retry. In
+      // practice this leaves `gh` working with the new token and
+      // `git clone` working with the old; a retry of `updateGithubPat`
+      // converges both halves.
+      const basicValue = Buffer.from(`x-access-token:${input.token}`).toString("base64");
+      const apiResult = await deps.k8sPort.updateSecret(input.apiSecretId, { value: input.token });
+      if (!apiResult) throw new TRPCError({ code: "NOT_FOUND", message: "api.github.com secret not found" });
+      const gitResult = await deps.k8sPort.updateSecret(input.gitSecretId, { value: basicValue });
+      if (!gitResult) throw new TRPCError({ code: "NOT_FOUND", message: "github.com secret not found" });
+      return { apiSecretId: input.apiSecretId, gitSecretId: input.gitSecretId };
     },
 
     async update({ id, ...patch }: UpdateSecretInput) {

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -1,8 +1,11 @@
 import { createHash, randomUUID } from "node:crypto";
 import { TRPCError } from "@trpc/server";
 import {
+  DEFAULT_ENV_PLACEHOLDER,
   isProviderPresetType,
   PROVIDERS,
+  type CreateGithubPatInput,
+  type CreateGithubPatOutput,
   type EnvMapping,
   type InjectionConfig,
   type SecretsService,
@@ -143,95 +146,133 @@ export function createSecretsService(deps: {
    *  Falls back to agentId as name when unwired. */
   listOwnedAgentSummaries?: () => Promise<readonly { id: string; name: string }[]>;
 }): SecretsService {
+  async function createOne(input: CreateSecretInput): Promise<SecretView> {
+    const hostPattern = hostPatternFor(input.type, input.hostPattern);
+    const id = randomUUID();
+    // Anthropic OAuth tokens are `sk-ant-oat…`; API keys are `sk-ant-api…`.
+    // Both share the `sk-ant-` prefix, so the discriminator is the segment
+    // immediately after.
+    const authMode =
+      input.type === "anthropic"
+        ? input.value.startsWith("sk-ant-oat")
+          ? "oauth"
+          : "api-key"
+        : undefined;
+    // Default preset envMappings when the caller didn't supply any.
+    // Sources the bundle from the PROVIDERS registry — adding a new
+    // preset requires only one entry there, not a branch here.
+    const envMappings: EnvMapping[] | undefined =
+      input.envMappings?.length
+        ? input.envMappings
+        : registryEnvMappings(input.type, authMode);
+    // Path pattern: presets that scope to a path (currently only OpenAI's
+    // `/v1/*`) take it from the registry; generic secrets respect the
+    // user-supplied value.
+    const pathPattern = pathPatternFor(input.type) ?? input.pathPattern;
+    await deps.k8sPort.createSecret({
+      id,
+      name: input.name,
+      type: input.type,
+      value: input.value,
+      hostPattern,
+      ...(pathPattern ? { pathPattern } : {}),
+      ...(input.injectionConfig ? { injectionConfig: input.injectionConfig } : {}),
+      ...(authMode ? { authMode } : {}),
+      ...(envMappings?.length ? { envMappings } : {}),
+    });
+    const createdTwinIds: string[] = [];
+    try {
+      for (const inj of registryExtraInjections(input.type, authMode)) {
+        const twinId = randomUUID();
+        await deps.k8sPort.createSecret({
+          id: twinId,
+          name: twinDisplayName(input.name, inj),
+          type: input.type,
+          value: input.value,
+          hostPattern,
+          injectionConfig: inj,
+          primarySecretId: id,
+        });
+        createdTwinIds.push(twinId);
+      }
+    } catch (err) {
+      for (const twinId of createdTwinIds) {
+        try {
+          await deps.k8sPort.deleteSecret(twinId);
+        } catch (cleanupErr) {
+          console.warn(
+            `secrets-service: orphan twin K8s Secret ${twinId} (primary ${id}, type ${input.type}) — manual cleanup required:`,
+            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+          );
+        }
+      }
+      try {
+        await deps.k8sPort.deleteSecret(id);
+      } catch (cleanupErr) {
+        console.warn(
+          `secrets-service: orphan primary K8s Secret ${id} (type ${input.type}) — manual cleanup required:`,
+          cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+        );
+      }
+      throw err;
+    }
+    const view: SecretView = {
+      id,
+      name: input.name,
+      type: input.type,
+      hostPattern,
+      createdAt: new Date().toISOString(),
+    };
+    if (pathPattern) view.pathPattern = pathPattern;
+    if (input.type === "generic" && input.injectionConfig) {
+      view.injectionConfig = input.injectionConfig;
+    }
+    if (envMappings?.length) view.envMappings = envMappings;
+    return view;
+  }
+
   return {
     async list() {
       const secrets = await deps.k8sPort.listSecrets();
       return secrets.filter((s) => !s.primarySecretId).map(toSecretView);
     },
 
-    async create(input: CreateSecretInput) {
-      const hostPattern = hostPatternFor(input.type, input.hostPattern);
-      const id = randomUUID();
-      // Anthropic OAuth tokens are `sk-ant-oat…`; API keys are `sk-ant-api…`.
-      // Both share the `sk-ant-` prefix, so the discriminator is the segment
-      // immediately after.
-      const authMode =
-        input.type === "anthropic"
-          ? input.value.startsWith("sk-ant-oat")
-            ? "oauth"
-            : "api-key"
-          : undefined;
-      // Default preset envMappings when the caller didn't supply any.
-      // Sources the bundle from the PROVIDERS registry — adding a new
-      // preset requires only one entry there, not a branch here.
-      const envMappings: EnvMapping[] | undefined =
-        input.envMappings?.length
-          ? input.envMappings
-          : registryEnvMappings(input.type, authMode);
-      // Path pattern: presets that scope to a path (currently only OpenAI's
-      // `/v1/*`) take it from the registry; generic secrets respect the
-      // user-supplied value.
-      const pathPattern = pathPatternFor(input.type) ?? input.pathPattern;
-      await deps.k8sPort.createSecret({
-        id,
+    create: createOne,
+
+    async createGithubPat(input: CreateGithubPatInput): Promise<CreateGithubPatOutput> {
+      // Basic auth header value for the github.com half: HTTP Basic decodes
+      // the base64-wrapped `username:password` form. Using the literal
+      // `x-access-token` username is GitHub's documented pattern for PATs.
+      const basicValue = Buffer.from(`x-access-token:${input.token}`).toString("base64");
+      const apiSecret = await createOne({
+        type: "generic",
         name: input.name,
-        type: input.type,
-        value: input.value,
-        hostPattern,
-        ...(pathPattern ? { pathPattern } : {}),
-        ...(input.injectionConfig ? { injectionConfig: input.injectionConfig } : {}),
-        ...(authMode ? { authMode } : {}),
-        ...(envMappings?.length ? { envMappings } : {}),
+        value: input.token,
+        hostPattern: "api.github.com",
+        injectionConfig: { headerName: "Authorization", valueFormat: "Bearer {value}" },
+        envMappings: [{ envName: "GH_TOKEN", placeholder: DEFAULT_ENV_PLACEHOLDER }],
       });
-      const createdTwinIds: string[] = [];
+      let gitSecret: SecretView;
       try {
-        for (const inj of registryExtraInjections(input.type, authMode)) {
-          const twinId = randomUUID();
-          await deps.k8sPort.createSecret({
-            id: twinId,
-            name: twinDisplayName(input.name, inj),
-            type: input.type,
-            value: input.value,
-            hostPattern,
-            injectionConfig: inj,
-            primarySecretId: id,
-          });
-          createdTwinIds.push(twinId);
-        }
+        gitSecret = await createOne({
+          type: "generic",
+          name: input.name,
+          value: basicValue,
+          hostPattern: "github.com",
+          injectionConfig: { headerName: "Authorization", valueFormat: "Basic {value}" },
+        });
       } catch (err) {
-        for (const twinId of createdTwinIds) {
-          try {
-            await deps.k8sPort.deleteSecret(twinId);
-          } catch (cleanupErr) {
-            console.warn(
-              `secrets-service: orphan twin K8s Secret ${twinId} (primary ${id}, type ${input.type}) — manual cleanup required:`,
-              cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
-            );
-          }
-        }
-        try {
-          await deps.k8sPort.deleteSecret(id);
-        } catch (cleanupErr) {
-          console.warn(
-            `secrets-service: orphan primary K8s Secret ${id} (type ${input.type}) — manual cleanup required:`,
-            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
-          );
-        }
+        // Roll back the api.github.com half so a partial failure doesn't
+        // leave a half-configured PAT behind. Suppress secondary delete
+        // errors — the original cause is what the caller needs to see.
+        await deps.k8sPort.deleteSecret(apiSecret.id).catch(() => {});
         throw err;
       }
-      const view: SecretView = {
-        id,
+      return {
         name: input.name,
-        type: input.type,
-        hostPattern,
-        createdAt: new Date().toISOString(),
+        apiSecretId: apiSecret.id,
+        gitSecretId: gitSecret.id,
       };
-      if (pathPattern) view.pathPattern = pathPattern;
-      if (input.type === "generic" && input.injectionConfig) {
-        view.injectionConfig = input.injectionConfig;
-      }
-      if (envMappings?.length) view.envMappings = envMappings;
-      return view;
     },
 
     async update({ id, ...patch }: UpdateSecretInput) {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -16,6 +16,7 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@clack/prompts": "1.3.0",
     "@trpc/client": "^11.16.0",
     "api-server-api": "workspace:*",
     "commander": "^14.0.3",

--- a/packages/cli/src/__tests__/group-github-pats.test.ts
+++ b/packages/cli/src/__tests__/group-github-pats.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "vitest";
+import { groupGithubPats, type SecretLike } from "../modules/agent/lib/group-github-pats.js";
+
+function s(id: string, name: string, hostPattern: string, type = "generic"): SecretLike {
+  return { id, name, type, hostPattern };
+}
+
+describe("groupGithubPats", () => {
+  it("returns empty for empty input", () => {
+    expect(groupGithubPats([])).toEqual([]);
+  });
+
+  it("returns one entry for a complete pair", () => {
+    const pairs = groupGithubPats([
+      s("api-1", "alice", "api.github.com"),
+      s("git-1", "alice", "github.com"),
+    ]);
+    expect(pairs).toEqual([{ name: "alice", apiSecretId: "api-1", gitSecretId: "git-1" }]);
+  });
+
+  it("returns multiple pairs sorted by name", () => {
+    const pairs = groupGithubPats([
+      s("git-b", "bob", "github.com"),
+      s("api-a", "alice", "api.github.com"),
+      s("api-b", "bob", "api.github.com"),
+      s("git-a", "alice", "github.com"),
+    ]);
+    expect(pairs.map((p) => p.name)).toEqual(["alice", "bob"]);
+  });
+
+  it("drops orphan with only api.github.com half", () => {
+    expect(groupGithubPats([s("api-1", "alice", "api.github.com")])).toEqual([]);
+  });
+
+  it("drops group with duplicate halves on the same host", () => {
+    expect(
+      groupGithubPats([
+        s("api-1", "alice", "api.github.com"),
+        s("api-2", "alice", "api.github.com"),
+      ]),
+    ).toEqual([]);
+  });
+
+  it("ignores non-GitHub secrets and keeps only complete pairs", () => {
+    const pairs = groupGithubPats([
+      s("anthropic-1", "Anthropic", "api.anthropic.com", "anthropic"),
+      s("api-1", "alice", "api.github.com"),
+      s("git-1", "alice", "github.com"),
+      s("api-2", "orphan", "api.github.com"),
+    ]);
+    expect(pairs).toEqual([{ name: "alice", apiSecretId: "api-1", gitSecretId: "git-1" }]);
+  });
+});

--- a/packages/cli/src/__tests__/group-github-pats.test.ts
+++ b/packages/cli/src/__tests__/group-github-pats.test.ts
@@ -6,10 +6,6 @@ function s(id: string, name: string, hostPattern: string, type = "generic"): Sec
 }
 
 describe("groupGithubPats", () => {
-  it("returns empty for empty input", () => {
-    expect(groupGithubPats([])).toEqual([]);
-  });
-
   it("returns one entry for a complete pair", () => {
     const pairs = groupGithubPats([
       s("api-1", "alice", "api.github.com"),
@@ -18,27 +14,8 @@ describe("groupGithubPats", () => {
     expect(pairs).toEqual([{ name: "alice", apiSecretId: "api-1", gitSecretId: "git-1" }]);
   });
 
-  it("returns multiple pairs sorted by name", () => {
-    const pairs = groupGithubPats([
-      s("git-b", "bob", "github.com"),
-      s("api-a", "alice", "api.github.com"),
-      s("api-b", "bob", "api.github.com"),
-      s("git-a", "alice", "github.com"),
-    ]);
-    expect(pairs.map((p) => p.name)).toEqual(["alice", "bob"]);
-  });
-
   it("drops orphan with only api.github.com half", () => {
     expect(groupGithubPats([s("api-1", "alice", "api.github.com")])).toEqual([]);
-  });
-
-  it("drops group with duplicate halves on the same host", () => {
-    expect(
-      groupGithubPats([
-        s("api-1", "alice", "api.github.com"),
-        s("api-2", "alice", "api.github.com"),
-      ]),
-    ).toEqual([]);
   });
 
   it("ignores non-GitHub secrets and keeps only complete pairs", () => {

--- a/packages/cli/src/compose.ts
+++ b/packages/cli/src/compose.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { composeAgentModule } from "./modules/agent/compose.js";
 import { composeAuthModule } from "./modules/auth/compose.js";
 import { composeChatModule } from "./modules/chat/compose.js";
 import { composeCliModule } from "./modules/cli/compose.js";
@@ -49,6 +50,14 @@ export function compose(opts: ComposeOptions = {}): Command {
     serverEnvVar: "DAM_SERVER",
     templateService: template.exports.createService,
   });
+  const agent = composeAgentModule({
+    tokenProvider: auth.exports.tokenProvider,
+    configService: cli.services.configService,
+    compatService: cli.services.compatService,
+    serverEnvVar: "DAM_SERVER",
+    templateService: template.exports.createService,
+    instanceService: instance.exports.createService,
+  });
 
   const chat = composeChatModule({
     compatService: cli.services.compatService,
@@ -69,6 +78,7 @@ export function compose(opts: ComposeOptions = {}): Command {
   for (const command of template.commands) program.addCommand(command);
   for (const command of instance.commands) program.addCommand(command);
   for (const command of chat.commands) program.addCommand(command);
+  for (const command of agent.commands) program.addCommand(command);
 
   return program;
 }

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -135,7 +135,7 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
     process.stderr.write(
       "error: dam agent create requires an interactive terminal; use `dam instance create` for scripted setup\n",
     );
-    process.exit(1);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
 
   intro("dam agent create");
@@ -258,6 +258,11 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   // it exhausts, we surface a hint pointing the user at the UI.
   spin.message("Granting provider access...");
   const grantedIds = [provider.secretId];
+  // PAT halves grant individually — the Bob preset (PR #225) routes its
+  // twins through `primarySecretId` expansion server-side, but PATs lack
+  // that field and stay paired only by shared `name`. If PATs ever migrate
+  // to the twin-secret model, drop the second push: passing `apiSecretId`
+  // alone will expand to both.
   if (githubPat) grantedIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
   try {
     await withRetry(() =>
@@ -720,6 +725,11 @@ async function withRetry<T>(
     try {
       return await fn();
     } catch (e) {
+      // Definitive rejections (the server made up its mind) — retrying
+      // burns ~8s behind a spinner for no chance of success. The
+      // visibility-race that motivates the retry surfaces as
+      // INTERNAL_SERVER_ERROR / transport failure, not these codes.
+      if (classifyFailure(e) === "rollback") throw e;
       if (attempt === maxAttempts - 1) throw e;
       await new Promise((r) => setTimeout(r, delayMs));
     }

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -1,0 +1,45 @@
+import { intro, outro } from "@clack/prompts";
+import { Command } from "commander";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import type { InstanceService } from "../../instance/index.js";
+import type { TemplateService } from "../../template/index.js";
+import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
+
+/**
+ * Deps for `dam agent create`. Mirrors `dam instance create`'s shape so
+ * the orchestration verbs added in issues 003–006 can drop in without
+ * widening the interface.
+ */
+export interface CreateAgentCommandDeps {
+  compatService: CompatService;
+  configService: ConfigService;
+  createInstanceService: (host: string) => InstanceService;
+  createTemplateService: (host: string) => TemplateService;
+  createTrpcClient: (host: string) => TrpcClient;
+  serverEnvVar: string;
+}
+
+interface CliOpts {
+  server?: string;
+}
+
+export function buildCreateCommand(_deps: CreateAgentCommandDeps): Command {
+  return new Command("create")
+    .description("Interactively create an agent and a running instance")
+    .option("--server <url>", "override the configured server URL for this call")
+    .action(async (opts: CliOpts) => {
+      await runCreate(opts);
+    });
+}
+
+async function runCreate(_opts: CliOpts): Promise<void> {
+  if (!process.stdin.isTTY) {
+    process.stderr.write(
+      "error: dam agent create requires an interactive terminal; use `dam instance create` for scripted setup\n",
+    );
+    process.exit(1);
+  }
+
+  intro("dam agent create");
+  outro("nothing to do yet — full flow lands in subsequent issues");
+}

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -395,7 +395,7 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubPatPair | null> {
 
   if (pairs.length === 0) {
     log.info("No GitHub PAT configured yet.");
-    const add = await confirm({ message: "Add one?", initialValue: false });
+    const add = await confirm({ message: "Add one?", initialValue: true });
     if (isCancel(add)) cancelAndExit();
     if (!add) return null;
     return addNewGithubPat(trpc);
@@ -423,21 +423,16 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubPatPair | null> {
   return found;
 }
 
+// Default display name baked into new PATs — mirrors the providers
+// pattern of using a fixed label so the user can paste a token and
+// move on. Renaming for multi-account setups stays in the web UI.
+const DEFAULT_GITHUB_PAT_NAME = "GitHub";
+
 async function addNewGithubPat(trpc: TrpcClient): Promise<GithubPatPair> {
   // Loop on `secrets.createGithubPat` failure (F1 from the spec).
   while (true) {
-    const name = await text({
-      message: "Name",
-      placeholder: "my-github",
-      validate(v) {
-        if (!v || v.trim() === "") return "Required";
-        return undefined;
-      },
-    });
-    if (isCancel(name)) cancelAndExit();
-
     const token = await password({
-      message: "Personal access token",
+      message: "GitHub personal access token",
       validate(v) {
         if (!v || v.trim() === "") return "Required";
         return undefined;
@@ -446,7 +441,10 @@ async function addNewGithubPat(trpc: TrpcClient): Promise<GithubPatPair> {
     if (isCancel(token)) cancelAndExit();
 
     try {
-      const created = await trpc.secrets.createGithubPat.mutate({ name, token });
+      const created = await trpc.secrets.createGithubPat.mutate({
+        name: DEFAULT_GITHUB_PAT_NAME,
+        token,
+      });
       return {
         name: created.name,
         apiSecretId: created.apiSecretId,

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -188,7 +188,7 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
         [
           `✓ Agent created: ${name}`,
           `✓ Provider: ${provider.name} (${provider.type})`,
-          `→ Next: dam shell ${name}`,
+          `→ Next: dam chat ${name}`,
         ].join("\n"),
       );
       process.exit(EXIT_INSTANCE_SUCCESS);
@@ -219,7 +219,7 @@ function cancelAndExit(): never {
   process.exit(0);
 }
 
-type ProviderType = "anthropic" | "ibm-litellm";
+type ProviderType = "anthropic" | "ibm-litellm" | "openai";
 
 interface ProviderSelection {
   secretId: string;
@@ -246,7 +246,7 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
   }
   const existing = list.filter(
     (s): s is typeof s & { type: ProviderType } =>
-      s.type === "anthropic" || s.type === "ibm-litellm",
+      s.type === "anthropic" || s.type === "ibm-litellm" || s.type === "openai",
   );
 
   if (existing.length === 0) {
@@ -286,13 +286,14 @@ async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
       options: [
         { value: "anthropic", label: "Anthropic" },
         { value: "ibm-litellm", label: "IBM LiteLLM" },
+        { value: "openai", label: "OpenAI" },
       ],
     });
     if (isCancel(type)) cancelAndExit();
 
     const name = await text({
       message: "Name",
-      placeholder: type === "anthropic" ? "my-anthropic-key" : "my-ibm-litellm-key",
+      placeholder: placeholderFor(type),
       validate(v) {
         if (!v || v.trim() === "") return "Required";
         return undefined;
@@ -316,6 +317,14 @@ async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
       log.error(`Failed to create secret: ${errorReason(e)}`);
       // Fall through to next loop iteration.
     }
+  }
+}
+
+function placeholderFor(type: ProviderType): string {
+  switch (type) {
+    case "anthropic": return "my-anthropic-key";
+    case "ibm-litellm": return "my-ibm-litellm-key";
+    case "openai": return "my-openai-key";
   }
 }
 

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -17,6 +17,7 @@ import {
 import { waitForRunning } from "../../instance/services/wait-for-state.js";
 import type { TemplateService } from "../../template/index.js";
 import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
+import { groupGithubPats, type GithubPatPair } from "../lib/group-github-pats.js";
 
 const WAIT_TIMEOUT_SECONDS = 120;
 
@@ -131,7 +132,10 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   const trpc = deps.createTrpcClient(host);
   const provider = await pickProvider(trpc);
 
-  // --- Steps 4 + 5 + 6: agents.create → instances.create → setAgentAccess ---
+  // --- Step 4: optional GitHub PAT ----------------------------------
+  const githubPat = await pickGithubPat(trpc);
+
+  // --- Steps 5 + 6 + 7: agents.create → instances.create → setAgentAccess ---
   // Grants live as `granted-secret-ids` annotations on the *instance*
   // ConfigMap, not the agent. setAgentAccess before any instance exists
   // is a silent no-op, so the order has to be: agent → instance → grant.
@@ -167,10 +171,12 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
     // to the api-server's listConfigMaps when setAgentAccess fires; without
     // the retry the patch silently targets zero ConfigMaps and the grant
     // is lost. Matches the web UI's 5× / 2s wait.
+    const grantedIds = [provider.secretId];
+    if (githubPat) grantedIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
     await withRetry(() =>
       trpc.secrets.setAgentAccess.mutate({
         agentId,
-        secretIds: [provider.secretId],
+        secretIds: grantedIds,
       }),
     );
   } catch (e) {
@@ -191,17 +197,18 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   });
 
   switch (waitResult.kind) {
-    case "ready":
+    case "ready": {
       spin.stop("Instance running");
-      outro(
-        [
-          `✓ Agent created: ${name}`,
-          `✓ Provider: ${provider.name} (${provider.type})`,
-          `→ Next: dam chat ${name}`,
-        ].join("\n"),
-      );
+      const lines = [
+        `✓ Agent created: ${name}`,
+        `✓ Provider: ${provider.name} (${provider.type})`,
+        ...(githubPat ? [`✓ GitHub: ${githubPat.name}`] : []),
+        `→ Next: dam chat ${name}`,
+      ];
+      outro(lines.join("\n"));
       process.exit(EXIT_INSTANCE_SUCCESS);
       return;
+    }
     case "error":
       spin.stop(`Instance entered error state: ${waitResult.instance.error ?? "unknown"}`);
       note(`dam instance get ${name}`, "Inspect");
@@ -362,6 +369,91 @@ async function addOrReplaceProvider(
       return { secretId: created.id, name: created.name, type };
     } catch (e) {
       log.error(`Failed to create secret: ${errorReason(e)}`);
+      // Fall through to next loop iteration.
+    }
+  }
+}
+
+/**
+ * Optional GitHub PAT step. Returns `null` if the user skipped.
+ *
+ * A PAT lives server-side as two `generic` secrets sharing a `name` —
+ * one for `api.github.com` (Bearer / `gh` CLI / `GH_TOKEN` env), one
+ * for `github.com` (Basic / `git clone`). `groupGithubPats` filters
+ * `secrets.list()` down to fully-paired entries, hiding orphans the
+ * user can't actually grant.
+ */
+async function pickGithubPat(trpc: TrpcClient): Promise<GithubPatPair | null> {
+  let list;
+  try {
+    list = await trpc.secrets.list.query();
+  } catch (e) {
+    cancel(`failed to list secrets: ${errorReason(e)}`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  const pairs = groupGithubPats(list);
+
+  if (pairs.length === 0) {
+    log.info("No GitHub PAT configured yet.");
+    const add = await confirm({ message: "Add one?", initialValue: false });
+    if (isCancel(add)) cancelAndExit();
+    if (!add) return null;
+    return addNewGithubPat(trpc);
+  }
+
+  const NEW = "__new__";
+  const SKIP = "__skip__";
+  const picked = await select<string>({
+    message: "GitHub PAT",
+    options: [
+      ...pairs.map((p) => ({ value: p.name, label: p.name })),
+      { value: NEW, label: "Add new..." },
+      { value: SKIP, label: "Skip" },
+    ],
+  });
+  if (isCancel(picked)) cancelAndExit();
+  if (picked === SKIP) return null;
+  if (picked === NEW) return addNewGithubPat(trpc);
+
+  const found = pairs.find((p) => p.name === picked);
+  if (!found) {
+    cancel("internal: picked PAT not in list");
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  return found;
+}
+
+async function addNewGithubPat(trpc: TrpcClient): Promise<GithubPatPair> {
+  // Loop on `secrets.createGithubPat` failure (F1 from the spec).
+  while (true) {
+    const name = await text({
+      message: "Name",
+      placeholder: "my-github",
+      validate(v) {
+        if (!v || v.trim() === "") return "Required";
+        return undefined;
+      },
+    });
+    if (isCancel(name)) cancelAndExit();
+
+    const token = await password({
+      message: "Personal access token",
+      validate(v) {
+        if (!v || v.trim() === "") return "Required";
+        return undefined;
+      },
+    });
+    if (isCancel(token)) cancelAndExit();
+
+    try {
+      const created = await trpc.secrets.createGithubPat.mutate({ name, token });
+      return {
+        name: created.name,
+        apiSecretId: created.apiSecretId,
+        gitSecretId: created.gitSecretId,
+      };
+    } catch (e) {
+      log.error(`Failed to create GitHub PAT: ${errorReason(e)}`);
       // Fall through to next loop iteration.
     }
   }

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -481,7 +481,7 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> 
     const add = await confirm({ message: "Add one?", initialValue: true });
     if (isCancel(add)) cancelAndExit();
     if (!add) return null;
-    return addNewGithubPat(trpc);
+    return addOrReplaceGithubPat(trpc, pairs);
   }
 
   const NEW = "__new__";
@@ -496,7 +496,7 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> 
   });
   if (isCancel(picked)) cancelAndExit();
   if (picked === SKIP) return null;
-  if (picked === NEW) return addNewGithubPat(trpc);
+  if (picked === NEW) return addOrReplaceGithubPat(trpc, pairs);
 
   const found = pairs.find((p) => p.name === picked);
   if (!found) {
@@ -511,9 +511,52 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> 
 // move on. Renaming for multi-account setups stays in the web UI.
 const DEFAULT_GITHUB_PAT_NAME = "GitHub";
 
-async function addNewGithubPat(trpc: TrpcClient): Promise<GithubSelection> {
-  // Loop on `secrets.createGithubPat` failure (F1 from the spec).
+async function addOrReplaceGithubPat(
+  trpc: TrpcClient,
+  existing: readonly GithubPatPair[],
+): Promise<GithubSelection> {
+  // Singleton-by-default-name: if a PAT named DEFAULT_GITHUB_PAT_NAME
+  // already exists, offer to replace its token (mirrors the providers'
+  // replace-existing flow). Default to NOT replacing — overwriting a
+  // working token is the destructive option.
+  const collide = existing.find((p) => p.name === DEFAULT_GITHUB_PAT_NAME);
+
+  // Loop on `secrets.createGithubPat` / `secrets.updateGithubPat`
+  // failure (F1 from the spec).
   while (true) {
+    if (collide) {
+      const replace = await confirm({
+        message: `A GitHub PAT named "${DEFAULT_GITHUB_PAT_NAME}" already exists. Replace its token?`,
+        initialValue: false,
+      });
+      if (isCancel(replace)) cancelAndExit();
+
+      if (!replace) {
+        return { ...collide, createdNew: false };
+      }
+
+      const token = await password({
+        message: "New GitHub personal access token",
+        validate(v) {
+          if (!v || v.trim() === "") return "Required";
+          return undefined;
+        },
+      });
+      if (isCancel(token)) cancelAndExit();
+
+      try {
+        await trpc.secrets.updateGithubPat.mutate({
+          apiSecretId: collide.apiSecretId,
+          gitSecretId: collide.gitSecretId,
+          token,
+        });
+        return { ...collide, createdNew: false };
+      } catch (e) {
+        log.error(`Failed to replace GitHub PAT: ${errorReason(e)}`);
+        continue;
+      }
+    }
+
     const token = await password({
       message: "GitHub personal access token",
       validate(v) {

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -1,4 +1,4 @@
-import { cancel, intro, isCancel, log, note, outro, password, select, spinner, text } from "@clack/prompts";
+import { cancel, confirm, intro, isCancel, log, note, outro, password, select, spinner, text } from "@clack/prompts";
 import { Command } from "commander";
 import { PROVIDERS, type Instance } from "api-server-api";
 import type { CompatService, ConfigService } from "../../cli/index.js";
@@ -236,13 +236,18 @@ interface ProviderSelection {
   type: ProviderType;
 }
 
+type ExistingProvider = { id: string; name: string; type: ProviderType };
+
 /**
- * Provider step. Lists existing Anthropic / IBM LiteLLM secrets so the
- * user can grant one (or add a new one inline). The server's `PROVIDERS`
- * preset fills in host / header / env defaults — the CLI only sends
- * `{ type, name, value }` to `secrets.create`.
+ * Provider step. Lists existing Anthropic / IBM LiteLLM / OpenAI secrets
+ * so the user can grant one (or add a new one inline). The server's
+ * `PROVIDERS` preset fills in host / header / env defaults — the CLI
+ * only sends `{ type, name, value }` to `secrets.create`.
  *
- * OpenAI is in the schema but deliberately not offered here (spec).
+ * Singleton-per-type — when the user picks "Add new..." for a type that
+ * already exists, the sub-flow offers to replace its API key instead of
+ * creating a duplicate. Matches the web UI's provider cards.
+ *
  * Anthropic is API-key only — the OAuth flow stays in the web UI.
  */
 async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
@@ -253,14 +258,16 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
     cancel(`failed to list secrets: ${errorReason(e)}`);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
-  const existing = list.filter(
-    (s): s is typeof s & { type: ProviderType } =>
-      s.type === "anthropic" || s.type === "ibm-litellm" || s.type === "openai",
-  );
+  const existing: ExistingProvider[] = list
+    .filter(
+      (s): s is typeof s & { type: ProviderType } =>
+        s.type === "anthropic" || s.type === "ibm-litellm" || s.type === "openai",
+    )
+    .map((s) => ({ id: s.id, name: s.name, type: s.type }));
 
   if (existing.length === 0) {
     log.info("No model providers configured yet — let's add one.");
-    return addNewProvider(trpc);
+    return addOrReplaceProvider(trpc, existing);
   }
 
   const NEW = "__new__";
@@ -273,7 +280,7 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
   });
   if (isCancel(picked)) cancelAndExit();
 
-  if (picked === NEW) return addNewProvider(trpc);
+  if (picked === NEW) return addOrReplaceProvider(trpc, existing);
 
   const found = existing.find((s) => s.id === picked);
   if (!found) {
@@ -285,10 +292,13 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
   return { secretId: found.id, name: found.name, type: found.type };
 }
 
-async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
-  // Re-prompt on `secrets.create` failure (F1 from the spec). Loops the
-  // whole sub-flow rather than trying to preserve previously-entered
-  // fields — three prompts is short enough that re-typing isn't painful.
+async function addOrReplaceProvider(
+  trpc: TrpcClient,
+  existing: readonly ExistingProvider[],
+): Promise<ProviderSelection> {
+  // Loops on server-side create/update failures (F1 from the spec) —
+  // re-types the type prompt rather than preserving prior input; three
+  // prompts is short enough that re-typing isn't painful.
   while (true) {
     const type = await select<ProviderType>({
       message: "Provider type",
@@ -299,6 +309,39 @@ async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
       ],
     });
     if (isCancel(type)) cancelAndExit();
+
+    const existingOfType = existing.find((s) => s.type === type);
+
+    if (existingOfType) {
+      // Singleton-per-type. Default to NOT replacing — overwriting a
+      // working key is the destructive option; the user has to opt in.
+      const replace = await confirm({
+        message: `A ${PROVIDERS[type].displayName} key already exists. Replace its API key?`,
+        initialValue: false,
+      });
+      if (isCancel(replace)) cancelAndExit();
+
+      if (!replace) {
+        return { secretId: existingOfType.id, name: existingOfType.name, type };
+      }
+
+      const apiKey = await password({
+        message: `New ${PROVIDERS[type].displayName} API key`,
+        validate(v) {
+          if (!v || v.trim() === "") return "Required";
+          return undefined;
+        },
+      });
+      if (isCancel(apiKey)) cancelAndExit();
+
+      try {
+        await trpc.secrets.update.mutate({ id: existingOfType.id, value: apiKey });
+        return { secretId: existingOfType.id, name: existingOfType.name, type };
+      } catch (e) {
+        log.error(`Failed to replace API key: ${errorReason(e)}`);
+        continue;
+      }
+    }
 
     // Match the web UI's provider cards: auto-name the secret with the
     // preset's displayName ("Anthropic", "IBM LiteLLM ETE Proxy", "OpenAI")

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -131,10 +131,13 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   const trpc = deps.createTrpcClient(host);
   const provider = await pickProvider(trpc);
 
-  // --- Steps 4 + 5 + 6: agents.create → setAgentAccess → instances.create ---
-  // Granting the provider secret *before* `instances.create` is what
-  // makes this a single pod boot. Reversing the order would force a
-  // rolling restart once the grant lands.
+  // --- Steps 4 + 5 + 6: agents.create → instances.create → setAgentAccess ---
+  // Grants live as `granted-secret-ids` annotations on the *instance*
+  // ConfigMap, not the agent. setAgentAccess before any instance exists
+  // is a silent no-op, so the order has to be: agent → instance → grant.
+  // Mirrors `useCreateAgent` in packages/ui/src/modules/agents/api/mutations.ts.
+  // The grant lands after pod boot and the controller rolls the pod
+  // once to pick it up.
   const spin = spinner();
   spin.start("Creating agent...");
 
@@ -148,24 +151,30 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
 
-  spin.message("Granting provider access...");
-  try {
-    await trpc.secrets.setAgentAccess.mutate({
-      agentId,
-      secretIds: [provider.secretId],
-    });
-  } catch (e) {
-    spin.stop("Failed to grant provider access");
-    process.stderr.write(`error: ${errorReason(e)}\n`);
-    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
-  }
-
   spin.message("Creating instance...");
   let instance: Instance;
   try {
     instance = await trpc.instances.create.mutate({ name, agentId });
   } catch (e) {
     spin.stop("Failed to create instance");
+    process.stderr.write(`error: ${errorReason(e)}\n`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+
+  spin.message("Granting provider access...");
+  try {
+    // Retry — the just-created instance ConfigMap may not yet be visible
+    // to the api-server's listConfigMaps when setAgentAccess fires; without
+    // the retry the patch silently targets zero ConfigMaps and the grant
+    // is lost. Matches the web UI's 5× / 2s wait.
+    await withRetry(() =>
+      trpc.secrets.setAgentAccess.mutate({
+        agentId,
+        secretIds: [provider.secretId],
+      }),
+    );
+  } catch (e) {
+    spin.stop("Failed to grant provider access");
     process.stderr.write(`error: ${errorReason(e)}\n`);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
@@ -318,6 +327,23 @@ async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
       // Fall through to next loop iteration.
     }
   }
+}
+
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts = 5,
+  delayMs = 2000,
+): Promise<T> {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      if (attempt === maxAttempts - 1) throw e;
+      await new Promise((r) => setTimeout(r, delayMs));
+    }
+  }
+  // Unreachable — loop either returns or throws on the last attempt.
+  throw new Error("withRetry: exhausted attempts");
 }
 
 function placeholderFor(type: ProviderType): string {

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -1,13 +1,28 @@
-import { intro, outro } from "@clack/prompts";
+import { cancel, intro, isCancel, note, outro, select, spinner, text } from "@clack/prompts";
 import { Command } from "commander";
+import type { Instance } from "api-server-api";
 import type { CompatService, ConfigService } from "../../cli/index.js";
 import type { InstanceService } from "../../instance/index.js";
+import { validateInstanceName } from "../../instance/commands/create-helpers.js";
+import {
+  describeConfigError,
+  formatTransportError,
+  printCompatResolveError,
+} from "../../instance/commands/errors.js";
+import {
+  EXIT_INSTANCE_BELOW_FLOOR,
+  EXIT_INSTANCE_RUNTIME_FAILURE,
+  EXIT_INSTANCE_SUCCESS,
+} from "../../instance/commands/exit-codes.js";
+import { waitForRunning } from "../../instance/services/wait-for-state.js";
 import type { TemplateService } from "../../template/index.js";
 import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
 
+const WAIT_TIMEOUT_SECONDS = 120;
+
 /**
  * Deps for `dam agent create`. Mirrors `dam instance create`'s shape so
- * the orchestration verbs added in issues 003–006 can drop in without
+ * the orchestration verbs added in issues 004–006 can drop in without
  * widening the interface.
  */
 export interface CreateAgentCommandDeps {
@@ -23,16 +38,16 @@ interface CliOpts {
   server?: string;
 }
 
-export function buildCreateCommand(_deps: CreateAgentCommandDeps): Command {
+export function buildCreateCommand(deps: CreateAgentCommandDeps): Command {
   return new Command("create")
     .description("Interactively create an agent and a running instance")
     .option("--server <url>", "override the configured server URL for this call")
     .action(async (opts: CliOpts) => {
-      await runCreate(opts);
+      await runCreate(opts, deps);
     });
 }
 
-async function runCreate(_opts: CliOpts): Promise<void> {
+async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<void> {
   if (!process.stdin.isTTY) {
     process.stderr.write(
       "error: dam agent create requires an interactive terminal; use `dam instance create` for scripted setup\n",
@@ -41,5 +56,147 @@ async function runCreate(_opts: CliOpts): Promise<void> {
   }
 
   intro("dam agent create");
-  outro("nothing to do yet — full flow lands in subsequent issues");
+
+  const flag = opts.server ? { server: opts.server } : undefined;
+
+  // --- Compat pre-flight ----------------------------------------------
+  const compat = await deps.compatService.check({ flag });
+  if (!compat.ok) {
+    printCompatResolveError(compat.error, deps.serverEnvVar);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  const verdict = compat.value;
+  if (verdict.kind === "below-floor") {
+    process.stderr.write(
+      `error: CLI ${verdict.localCli} is below the server's minimum required version ${verdict.serverMinClient}; upgrade and retry\n`,
+    );
+    process.exit(EXIT_INSTANCE_BELOW_FLOOR);
+  }
+  if (verdict.kind === "behind-current") {
+    process.stderr.write(
+      `warning: CLI ${verdict.localCli} is behind server ${verdict.serverVersion}; consider upgrading\n`,
+    );
+  }
+
+  const cfg = await deps.configService.getResolved({ flag });
+  if (!cfg.ok) {
+    process.stderr.write(`error: ${describeConfigError(cfg.error)}\n`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  const host = cfg.value.server;
+
+  // --- Step 1: name --------------------------------------------------
+  const name = await text({
+    message: "Agent name",
+    placeholder: "my-agent",
+    validate(value) {
+      const check = validateInstanceName(value ?? "");
+      if (check.ok) return undefined;
+      if (check.error === "reserved-prefix") {
+        return "name cannot start with `inst-` (reserved for IDs)";
+      }
+      return "name cannot be empty";
+    },
+  });
+  if (isCancel(name)) return cancelAndExit();
+
+  // --- Step 2: template ----------------------------------------------
+  const templateSvc = deps.createTemplateService(host);
+  const tmplResult = await templateSvc.list();
+  if (!tmplResult.ok) {
+    if (tmplResult.error.kind === "auth-required") {
+      cancel(`not authenticated: ${tmplResult.error.reason}`);
+      process.stderr.write("hint: run `dam auth login` first\n");
+    } else {
+      cancel(formatTransportError(tmplResult.error.reason, host));
+    }
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  if (tmplResult.value.length === 0) {
+    cancel("no templates available on this server");
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+
+  const templateId = await select<string>({
+    message: "Template",
+    options: tmplResult.value.map((t) => ({
+      value: t.id,
+      label: t.name,
+      ...(t.description ? { hint: t.description } : {}),
+    })),
+  });
+  if (isCancel(templateId)) return cancelAndExit();
+
+  // --- Steps 3 + 4: agents.create then instances.create --------------
+  const trpc = deps.createTrpcClient(host);
+  const spin = spinner();
+  spin.start("Creating agent...");
+
+  let agentId: string;
+  try {
+    const agent = await trpc.agents.create.mutate({ name, templateId });
+    agentId = agent.id;
+  } catch (e) {
+    spin.stop("Failed to create agent");
+    process.stderr.write(`error: ${errorReason(e)}\n`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+
+  spin.message("Creating instance...");
+  let instance: Instance;
+  try {
+    instance = await trpc.instances.create.mutate({ name, agentId });
+  } catch (e) {
+    spin.stop("Failed to create instance");
+    process.stderr.write(`error: ${errorReason(e)}\n`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+
+  // --- Step 5: wait for running --------------------------------------
+  spin.message(`Waiting for instance to start (state: ${instance.state})...`);
+  const svc = deps.createInstanceService(host);
+  const waitResult = await waitForRunning(svc, instance.id, {
+    timeoutSeconds: WAIT_TIMEOUT_SECONDS,
+    graceSeconds: 0,
+    onStateChange: (state) => {
+      spin.message(`Waiting for instance to start (state: ${state})...`);
+    },
+  });
+
+  switch (waitResult.kind) {
+    case "ready":
+      spin.stop("Instance running");
+      outro(`✓ Agent created: ${name}\n→ Next: dam shell ${name}`);
+      process.exit(EXIT_INSTANCE_SUCCESS);
+      return;
+    case "error":
+      spin.stop(`Instance entered error state: ${waitResult.instance.error ?? "unknown"}`);
+      note(`dam instance get ${name}`, "Inspect");
+      process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+      return;
+    case "timeout":
+      // The agent + instance both exist server-side; the pod is just slow.
+      // Per spec: warn and exit 0. The user can check progress with
+      // `dam instance get`.
+      spin.stop(`Instance still starting after ${WAIT_TIMEOUT_SECONDS}s (state: ${waitResult.lastState})`);
+      note(`dam instance get ${name}`, "Check status");
+      process.exit(EXIT_INSTANCE_SUCCESS);
+      return;
+    case "transport":
+      spin.stop(`Lost connection while waiting: ${waitResult.reason}`);
+      note(`dam instance get ${name}`, "Check status");
+      process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+      return;
+  }
+}
+
+function cancelAndExit(): void {
+  cancel("Cancelled");
+  process.exit(0);
+}
+
+function errorReason(e: unknown): string {
+  if (e instanceof Error) return e.message;
+  if (typeof e === "string") return e;
+  return "unknown failure";
 }

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -21,6 +21,88 @@ import { groupGithubPats, type GithubPatPair } from "../lib/group-github-pats.js
 
 const WAIT_TIMEOUT_SECONDS = 120;
 
+// TRPCError codes where the server definitively rejected a mutation — the
+// resource was never created, so rolling back what we created in this run
+// is safe. Codes outside this set (INTERNAL_SERVER_ERROR, transport) are
+// ambiguous: the mutation may have succeeded server-side, and a rollback
+// delete would destroy real state. Mirrors `dam instance create`'s
+// ROLLBACK_CODES.
+const ROLLBACK_CODES: ReadonlySet<string> = new Set([
+  "CONFLICT",
+  "BAD_REQUEST",
+  "NOT_FOUND",
+  "UNAUTHORIZED",
+  "FORBIDDEN",
+  "PRECONDITION_FAILED",
+  "UNIMPLEMENTED",
+  "RESOURCE_EXHAUSTED",
+]);
+
+interface Cleanup {
+  /** Secret IDs created during this run (provider + both halves of any
+   *  new GitHub PAT pair). */
+  newSecretIds: string[];
+  /** Set once `agents.create` has returned an id. Cascade-deletes the
+   *  instance and its grants via the K8s OwnerReference chain when
+   *  passed to `agents.delete`. */
+  agentId: string | null;
+}
+
+function trpcCode(e: unknown): string | undefined {
+  if (typeof e !== "object" || e === null) return undefined;
+  return (e as { data?: { code?: string } }).data?.code;
+}
+
+function classifyFailure(e: unknown): "rollback" | "ambiguous" {
+  const code = trpcCode(e);
+  return code !== undefined && ROLLBACK_CODES.has(code) ? "rollback" : "ambiguous";
+}
+
+/**
+ * Best-effort tear-down of everything in the ledger. Agent first (cascade
+ * tears down the instance via OwnerReferences), then any new secrets.
+ * Whatever fails to delete is returned as orphan info so the caller can
+ * surface it. One pass — if the api-server is down, the orphan list is
+ * the best we can do.
+ */
+async function deleteCreated(
+  trpc: TrpcClient,
+  cleanup: Cleanup,
+): Promise<{ orphanAgent: string | null; orphanSecrets: string[] }> {
+  let orphanAgent: string | null = null;
+  const orphanSecrets: string[] = [];
+  if (cleanup.agentId) {
+    try {
+      await trpc.agents.delete.mutate({ id: cleanup.agentId });
+    } catch {
+      orphanAgent = cleanup.agentId;
+    }
+  }
+  for (const id of cleanup.newSecretIds) {
+    try {
+      await trpc.secrets.delete.mutate({ id });
+    } catch {
+      orphanSecrets.push(id);
+    }
+  }
+  return { orphanAgent, orphanSecrets };
+}
+
+function formatOrphans(
+  orphanAgent: string | null,
+  orphanSecrets: readonly string[],
+): string | null {
+  if (!orphanAgent && orphanSecrets.length === 0) return null;
+  const lines = ["Cleanup partially failed. Manual cleanup needed:"];
+  if (orphanAgent) {
+    lines.push(`  Agent: ${orphanAgent} (delete via web UI or \`dam instance delete\`)`);
+  }
+  if (orphanSecrets.length > 0) {
+    lines.push(`  Secrets: ${orphanSecrets.join(", ")} (delete via web UI's secrets page)`);
+  }
+  return lines.join("\n");
+}
+
 /**
  * Deps for `dam agent create`. Mirrors `dam instance create`'s shape so
  * the orchestration verbs added in issues 004–006 can drop in without
@@ -127,32 +209,30 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   });
   if (isCancel(templateId)) return cancelAndExit();
 
-  // --- Step 3: model provider ---------------------------------------
+  // --- Rollback bookkeeping ------------------------------------------
+  // Anything created during *this* run goes here so a cancel between
+  // prompts (Critical #1) or a downstream mutation failure can clean it
+  // up. Pickers push into this ledger immediately on successful create
+  // so the entry is in place by the time control returns. Existing
+  // secrets that the user picked or replaced stay out: a replace-
+  // existing path overwrote the value in place and the old value isn't
+  // recoverable, so rollback would be destructive.
   const trpc = deps.createTrpcClient(host);
-  const provider = await pickProvider(trpc);
+  const cleanup: Cleanup = { newSecretIds: [], agentId: null };
+
+  // --- Step 3: model provider ---------------------------------------
+  const provider = await pickProvider(trpc, cleanup);
 
   // --- Step 4: optional GitHub PAT ----------------------------------
-  const githubPat = await pickGithubPat(trpc);
+  const githubPat = await pickGithubPat(trpc, cleanup);
 
-  // --- Rollback bookkeeping ------------------------------------------
-  // Anything created during *this* run goes here so a downstream
-  // mutation failure can clean it up. Existing secrets that the user
-  // picked or replaced stay out: a replace-existing path overwrote the
-  // value in place and the old value isn't recoverable, so rollback
-  // would be destructive.
-  const cleanup: Cleanup = { newSecretIds: [], agentId: null };
-  if (provider.createdNew) cleanup.newSecretIds.push(provider.secretId);
-  if (githubPat?.createdNew) {
-    cleanup.newSecretIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
-  }
-
-  // --- Steps 5 + 6 + 7: agents.create → instances.create → setAgentAccess ---
-  // Grants live as `granted-secret-ids` annotations on the *instance*
-  // ConfigMap, not the agent. setAgentAccess before any instance exists
-  // is a silent no-op, so the order has to be: agent → instance → grant.
-  // Mirrors `useCreateAgent` in packages/ui/src/modules/agents/api/mutations.ts.
-  // The grant lands after pod boot and the controller rolls the pod
-  // once to pick it up.
+  // --- Steps 5 + 6: agents.create → instances.create -----------------
+  // Two-stage failure handling: stage 1 (agent + instance) discriminates
+  // by TRPCError code. Definitive rejections (ROLLBACK_CODES) mean the
+  // resource was never created, so deleting what *we* created is safe;
+  // ambiguous codes (INTERNAL_SERVER_ERROR, network) may leave real
+  // state behind, so we don't auto-delete — we surface a hint and let
+  // the user inspect. Mirrors `dam instance create`'s policy.
   const spin = spinner();
   spin.start("Creating agent...");
 
@@ -163,23 +243,36 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
 
     spin.message("Creating instance...");
     instance = await trpc.instances.create.mutate({ name, agentId: agent.id });
+  } catch (e) {
+    spin.stop("Setup failed");
+    await handleStage1Failure(trpc, cleanup, e);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
 
-    spin.message("Granting provider access...");
-    // Retry — the just-created instance ConfigMap may not yet be visible
-    // to the api-server's listConfigMaps when setAgentAccess fires; without
-    // the retry the patch silently targets zero ConfigMaps and the grant
-    // is lost. Matches the web UI's 5× / 2s wait.
-    const grantedIds = [provider.secretId];
-    if (githubPat) grantedIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
+  // --- Step 7: setAgentAccess ---------------------------------------
+  // Past this point we have a real agent + instance on the server.
+  // Stage 2 (granting provider access) NEVER rolls back — the agent
+  // and instance are user state and may have value even without a
+  // grant. The retry bridges the K8s-API visibility race for the just-
+  // created instance ConfigMap (matches the web UI's 5×/2s wait); if
+  // it exhausts, we surface a hint pointing the user at the UI.
+  spin.message("Granting provider access...");
+  const grantedIds = [provider.secretId];
+  if (githubPat) grantedIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
+  try {
     await withRetry(() =>
       trpc.secrets.setAgentAccess.mutate({
-        agentId: agent.id,
+        agentId: cleanup.agentId!,
         secretIds: grantedIds,
       }),
     );
   } catch (e) {
-    spin.stop("Setup failed");
-    await rollback(trpc, cleanup, errorReason(e));
+    spin.stop("Grant failed");
+    log.error(`Failed to grant provider access: ${errorReason(e)}`);
+    log.warn(
+      `Agent ${name} was created but the credential grant did not land. ` +
+        `Configure access via the web UI, or run \`dam instance delete ${name}\` to start over.`,
+    );
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
 
@@ -253,58 +346,74 @@ function cancelAndExit(): never {
   process.exit(0);
 }
 
-interface Cleanup {
-  /** Secret IDs created during this run (S1 + both halves of S2). */
-  newSecretIds: string[];
-  /** Set once agents.create has returned an id. Cascade-deletes the
-   *  instance and its grants via the K8s OwnerReference chain when
-   *  passed to agents.delete. */
-  agentId: string | null;
+/**
+ * Cancel path for prompts that run after a picker has already created a
+ * new secret. Best-effort cleanup of anything tracked in the ledger
+ * before exiting — without this a user who hits Ctrl+C between provider
+ * and GitHub steps would leak the just-created provider secret.
+ *
+ * Exits 0 (cancel is a user action, not an error).
+ */
+async function cancelAndCleanup(
+  trpc: TrpcClient,
+  cleanup: Cleanup,
+): Promise<never> {
+  cancel("Cancelled");
+  await flushCleanup(trpc, cleanup);
+  process.exit(0);
 }
 
 /**
- * Reverse anything we created in this run after a downstream mutation
- * blew up. Deletes the agent first (cascade tears down the instance
- * via OwnerReferences), then any new secrets. Whatever fails to delete
- * gets surfaced as an orphan summary so the user knows what to clean
- * up manually.
- *
- * One pass — we don't retry rollback. If the api-server is down, the
- * orphan list is the best we can do.
+ * Best-effort tear-down of everything in the ledger, surfacing whatever
+ * we couldn't delete as a warning. Shared by the cancel-path
+ * (`cancelAndCleanup`) and the stage-1 rollback path (`handleStage1Failure`
+ * on a definitive TRPCError).
  */
-async function rollback(
+async function flushCleanup(trpc: TrpcClient, cleanup: Cleanup): Promise<void> {
+  if (cleanup.agentId === null && cleanup.newSecretIds.length === 0) return;
+  const { orphanAgent, orphanSecrets } = await deleteCreated(trpc, cleanup);
+  const summary = formatOrphans(orphanAgent, orphanSecrets);
+  if (summary) log.warn(summary);
+}
+
+/**
+ * Stage 1 (agents.create + instances.create) failure handler.
+ *
+ * Discriminates by TRPCError code via `classifyFailure`: definitive
+ * codes mean the server rejected the mutation outright and any resource
+ * we created is safe to tear down. Ambiguous codes (INTERNAL_SERVER_ERROR,
+ * transport) may mean the mutation actually succeeded server-side, so
+ * we keep our hands off real state and surface what we know about — the
+ * user inspects via the web UI.
+ *
+ * Mirrors `tryRollbackAgent` in `dam instance create`'s flow; extended
+ * here to also list any new secrets we created during the picker steps.
+ */
+async function handleStage1Failure(
   trpc: TrpcClient,
   cleanup: Cleanup,
-  originalError: string,
+  originalError: unknown,
 ): Promise<void> {
-  let orphanAgent: string | null = null;
-  const orphanSecrets: string[] = [];
-
-  if (cleanup.agentId) {
-    try {
-      await trpc.agents.delete.mutate({ id: cleanup.agentId });
-    } catch {
-      orphanAgent = cleanup.agentId;
-    }
-  }
-  for (const id of cleanup.newSecretIds) {
-    try {
-      await trpc.secrets.delete.mutate({ id });
-    } catch {
-      orphanSecrets.push(id);
-    }
+  const reason = errorReason(originalError);
+  if (classifyFailure(originalError) === "rollback") {
+    await flushCleanup(trpc, cleanup);
+    log.error(`Failed to create agent: ${reason}`);
+    return;
   }
 
-  log.error(`Failed to create agent: ${originalError}`);
-  if (orphanAgent || orphanSecrets.length > 0) {
-    const lines = ["Cleanup partially failed. Manual cleanup needed:"];
-    if (orphanAgent) {
-      lines.push(`  Agent: ${orphanAgent} (delete via web UI or \`dam instance delete\`)`);
-    }
-    if (orphanSecrets.length > 0) {
-      lines.push(`  Secrets: ${orphanSecrets.join(", ")} (delete via web UI's secrets page)`);
-    }
-    log.error(lines.join("\n"));
+  // Ambiguous outcome — agent and/or instance may or may not have been
+  // created server-side. Don't delete anything; just tell the user what
+  // we tried to create so they can investigate.
+  log.error(`Failed to create agent: ${reason}`);
+  const lines: string[] = [];
+  if (cleanup.agentId) lines.push(`  Agent: ${cleanup.agentId}`);
+  if (cleanup.newSecretIds.length > 0) {
+    lines.push(`  Secrets: ${cleanup.newSecretIds.join(", ")}`);
+  }
+  if (lines.length > 0) {
+    log.warn(
+      ["These may have been created server-side; check via the web UI:", ...lines].join("\n"),
+    );
   }
 }
 
@@ -335,12 +444,16 @@ type ExistingProvider = { id: string; name: string; type: ProviderType };
  *
  * Anthropic is API-key only — the OAuth flow stays in the web UI.
  */
-async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
+async function pickProvider(
+  trpc: TrpcClient,
+  cleanup: Cleanup,
+): Promise<ProviderSelection> {
   let list;
   try {
     list = await trpc.secrets.list.query();
   } catch (e) {
     cancel(`failed to list secrets: ${errorReason(e)}`);
+    await flushCleanup(trpc, cleanup);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
   const existing: ExistingProvider[] = list
@@ -352,7 +465,7 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
 
   if (existing.length === 0) {
     log.info("No model providers configured yet — let's add one.");
-    return addOrReplaceProvider(trpc, existing);
+    return addOrReplaceProvider(trpc, cleanup, existing);
   }
 
   const NEW = "__new__";
@@ -363,15 +476,16 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
       { value: NEW, label: "Add new..." },
     ],
   });
-  if (isCancel(picked)) cancelAndExit();
+  if (isCancel(picked)) return cancelAndCleanup(trpc, cleanup);
 
-  if (picked === NEW) return addOrReplaceProvider(trpc, existing);
+  if (picked === NEW) return addOrReplaceProvider(trpc, cleanup, existing);
 
   const found = existing.find((s) => s.id === picked);
   if (!found) {
     // Defensive — `picked` was sourced from `existing`. If we ever hit
     // this it means the picker handed us something unexpected.
     cancel("internal: picked provider not in list");
+    await flushCleanup(trpc, cleanup);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
   return { secretId: found.id, name: found.name, type: found.type, createdNew: false };
@@ -379,6 +493,7 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
 
 async function addOrReplaceProvider(
   trpc: TrpcClient,
+  cleanup: Cleanup,
   existing: readonly ExistingProvider[],
 ): Promise<ProviderSelection> {
   // Loops on server-side create/update failures (F1 from the spec) —
@@ -393,7 +508,7 @@ async function addOrReplaceProvider(
         { value: "openai", label: "OpenAI" },
       ],
     });
-    if (isCancel(type)) cancelAndExit();
+    if (isCancel(type)) return cancelAndCleanup(trpc, cleanup);
 
     const existingOfType = existing.find((s) => s.type === type);
 
@@ -404,7 +519,7 @@ async function addOrReplaceProvider(
         message: `A ${PROVIDERS[type].displayName} key already exists. Replace its API key?`,
         initialValue: false,
       });
-      if (isCancel(replace)) cancelAndExit();
+      if (isCancel(replace)) return cancelAndCleanup(trpc, cleanup);
 
       if (!replace) {
         return { secretId: existingOfType.id, name: existingOfType.name, type, createdNew: false };
@@ -417,7 +532,7 @@ async function addOrReplaceProvider(
           return undefined;
         },
       });
-      if (isCancel(apiKey)) cancelAndExit();
+      if (isCancel(apiKey)) return cancelAndCleanup(trpc, cleanup);
 
       try {
         await trpc.secrets.update.mutate({ id: existingOfType.id, value: apiKey });
@@ -440,10 +555,13 @@ async function addOrReplaceProvider(
         return undefined;
       },
     });
-    if (isCancel(apiKey)) cancelAndExit();
+    if (isCancel(apiKey)) return cancelAndCleanup(trpc, cleanup);
 
     try {
       const created = await trpc.secrets.create.mutate({ type, name, value: apiKey });
+      // Track immediately so any cancel/throw between here and runCreate
+      // reaching the rollback ledger doesn't orphan the new secret.
+      cleanup.newSecretIds.push(created.id);
       return { secretId: created.id, name: created.name, type, createdNew: true };
     } catch (e) {
       log.error(`Failed to create secret: ${errorReason(e)}`);
@@ -466,12 +584,16 @@ interface GithubSelection extends GithubPatPair {
  * `secrets.list()` down to fully-paired entries, hiding orphans the
  * user can't actually grant.
  */
-async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> {
+async function pickGithubPat(
+  trpc: TrpcClient,
+  cleanup: Cleanup,
+): Promise<GithubSelection | null> {
   let list;
   try {
     list = await trpc.secrets.list.query();
   } catch (e) {
     cancel(`failed to list secrets: ${errorReason(e)}`);
+    await flushCleanup(trpc, cleanup);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
   const pairs = groupGithubPats(list);
@@ -479,9 +601,9 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> 
   if (pairs.length === 0) {
     log.info("No GitHub PAT configured yet.");
     const add = await confirm({ message: "Add one?", initialValue: true });
-    if (isCancel(add)) cancelAndExit();
+    if (isCancel(add)) return cancelAndCleanup(trpc, cleanup);
     if (!add) return null;
-    return addOrReplaceGithubPat(trpc, pairs);
+    return addOrReplaceGithubPat(trpc, cleanup, pairs);
   }
 
   const NEW = "__new__";
@@ -494,13 +616,14 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> 
       { value: SKIP, label: "Skip" },
     ],
   });
-  if (isCancel(picked)) cancelAndExit();
+  if (isCancel(picked)) return cancelAndCleanup(trpc, cleanup);
   if (picked === SKIP) return null;
-  if (picked === NEW) return addOrReplaceGithubPat(trpc, pairs);
+  if (picked === NEW) return addOrReplaceGithubPat(trpc, cleanup, pairs);
 
   const found = pairs.find((p) => p.name === picked);
   if (!found) {
     cancel("internal: picked PAT not in list");
+    await flushCleanup(trpc, cleanup);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
   return { ...found, createdNew: false };
@@ -513,6 +636,7 @@ const DEFAULT_GITHUB_PAT_NAME = "GitHub";
 
 async function addOrReplaceGithubPat(
   trpc: TrpcClient,
+  cleanup: Cleanup,
   existing: readonly GithubPatPair[],
 ): Promise<GithubSelection> {
   // Singleton-by-default-name: if a PAT named DEFAULT_GITHUB_PAT_NAME
@@ -529,7 +653,7 @@ async function addOrReplaceGithubPat(
         message: `A GitHub PAT named "${DEFAULT_GITHUB_PAT_NAME}" already exists. Replace its token?`,
         initialValue: false,
       });
-      if (isCancel(replace)) cancelAndExit();
+      if (isCancel(replace)) return cancelAndCleanup(trpc, cleanup);
 
       if (!replace) {
         return { ...collide, createdNew: false };
@@ -542,7 +666,7 @@ async function addOrReplaceGithubPat(
           return undefined;
         },
       });
-      if (isCancel(token)) cancelAndExit();
+      if (isCancel(token)) return cancelAndCleanup(trpc, cleanup);
 
       try {
         await trpc.secrets.updateGithubPat.mutate({
@@ -564,13 +688,16 @@ async function addOrReplaceGithubPat(
         return undefined;
       },
     });
-    if (isCancel(token)) cancelAndExit();
+    if (isCancel(token)) return cancelAndCleanup(trpc, cleanup);
 
     try {
       const created = await trpc.secrets.createGithubPat.mutate({
         name: DEFAULT_GITHUB_PAT_NAME,
         token,
       });
+      // Track immediately so any cancel/throw between here and runCreate
+      // reaching the rollback ledger doesn't orphan the new pair.
+      cleanup.newSecretIds.push(created.apiSecretId, created.gitSecretId);
       return {
         name: created.name,
         apiSecretId: created.apiSecretId,

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -1,4 +1,4 @@
-import { cancel, intro, isCancel, note, outro, select, spinner, text } from "@clack/prompts";
+import { cancel, intro, isCancel, log, note, outro, password, select, spinner, text } from "@clack/prompts";
 import { Command } from "commander";
 import type { Instance } from "api-server-api";
 import type { CompatService, ConfigService } from "../../cli/index.js";
@@ -127,8 +127,14 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   });
   if (isCancel(templateId)) return cancelAndExit();
 
-  // --- Steps 3 + 4: agents.create then instances.create --------------
+  // --- Step 3: model provider ---------------------------------------
   const trpc = deps.createTrpcClient(host);
+  const provider = await pickProvider(trpc);
+
+  // --- Steps 4 + 5 + 6: agents.create → setAgentAccess → instances.create ---
+  // Granting the provider secret *before* `instances.create` is what
+  // makes this a single pod boot. Reversing the order would force a
+  // rolling restart once the grant lands.
   const spin = spinner();
   spin.start("Creating agent...");
 
@@ -138,6 +144,18 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
     agentId = agent.id;
   } catch (e) {
     spin.stop("Failed to create agent");
+    process.stderr.write(`error: ${errorReason(e)}\n`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+
+  spin.message("Granting provider access...");
+  try {
+    await trpc.secrets.setAgentAccess.mutate({
+      agentId,
+      secretIds: [provider.secretId],
+    });
+  } catch (e) {
+    spin.stop("Failed to grant provider access");
     process.stderr.write(`error: ${errorReason(e)}\n`);
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
@@ -166,7 +184,13 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   switch (waitResult.kind) {
     case "ready":
       spin.stop("Instance running");
-      outro(`✓ Agent created: ${name}\n→ Next: dam shell ${name}`);
+      outro(
+        [
+          `✓ Agent created: ${name}`,
+          `✓ Provider: ${provider.name} (${provider.type})`,
+          `→ Next: dam shell ${name}`,
+        ].join("\n"),
+      );
       process.exit(EXIT_INSTANCE_SUCCESS);
       return;
     case "error":
@@ -190,9 +214,109 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   }
 }
 
-function cancelAndExit(): void {
+function cancelAndExit(): never {
   cancel("Cancelled");
   process.exit(0);
+}
+
+type ProviderType = "anthropic" | "ibm-litellm";
+
+interface ProviderSelection {
+  secretId: string;
+  name: string;
+  type: ProviderType;
+}
+
+/**
+ * Provider step. Lists existing Anthropic / IBM LiteLLM secrets so the
+ * user can grant one (or add a new one inline). The server's `PROVIDERS`
+ * preset fills in host / header / env defaults — the CLI only sends
+ * `{ type, name, value }` to `secrets.create`.
+ *
+ * OpenAI is in the schema but deliberately not offered here (spec).
+ * Anthropic is API-key only — the OAuth flow stays in the web UI.
+ */
+async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
+  let list;
+  try {
+    list = await trpc.secrets.list.query();
+  } catch (e) {
+    cancel(`failed to list secrets: ${errorReason(e)}`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  const existing = list.filter(
+    (s): s is typeof s & { type: ProviderType } =>
+      s.type === "anthropic" || s.type === "ibm-litellm",
+  );
+
+  if (existing.length === 0) {
+    log.info("No model providers configured yet — let's add one.");
+    return addNewProvider(trpc);
+  }
+
+  const NEW = "__new__";
+  const picked = await select<string>({
+    message: "Model provider",
+    options: [
+      ...existing.map((s) => ({ value: s.id, label: `${s.name} (${s.type})` })),
+      { value: NEW, label: "Add new..." },
+    ],
+  });
+  if (isCancel(picked)) cancelAndExit();
+
+  if (picked === NEW) return addNewProvider(trpc);
+
+  const found = existing.find((s) => s.id === picked);
+  if (!found) {
+    // Defensive — `picked` was sourced from `existing`. If we ever hit
+    // this it means the picker handed us something unexpected.
+    cancel("internal: picked provider not in list");
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  return { secretId: found.id, name: found.name, type: found.type };
+}
+
+async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
+  // Re-prompt on `secrets.create` failure (F1 from the spec). Loops the
+  // whole sub-flow rather than trying to preserve previously-entered
+  // fields — three prompts is short enough that re-typing isn't painful.
+  while (true) {
+    const type = await select<ProviderType>({
+      message: "Provider type",
+      options: [
+        { value: "anthropic", label: "Anthropic" },
+        { value: "ibm-litellm", label: "IBM LiteLLM" },
+      ],
+    });
+    if (isCancel(type)) cancelAndExit();
+
+    const name = await text({
+      message: "Name",
+      placeholder: type === "anthropic" ? "my-anthropic-key" : "my-ibm-litellm-key",
+      validate(v) {
+        if (!v || v.trim() === "") return "Required";
+        return undefined;
+      },
+    });
+    if (isCancel(name)) cancelAndExit();
+
+    const apiKey = await password({
+      message: "API key",
+      validate(v) {
+        if (!v || v.trim() === "") return "Required";
+        return undefined;
+      },
+    });
+    if (isCancel(apiKey)) cancelAndExit();
+
+    try {
+      const created = await trpc.secrets.create.mutate({ type, name, value: apiKey });
+      return { secretId: created.id, name: created.name, type };
+    } catch (e) {
+      log.error(`Failed to create secret: ${errorReason(e)}`);
+      // Fall through to next loop iteration.
+    }
+  }
 }
 
 function errorReason(e: unknown): string {

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -68,20 +68,20 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   }
   const verdict = compat.value;
   if (verdict.kind === "below-floor") {
-    process.stderr.write(
-      `error: CLI ${verdict.localCli} is below the server's minimum required version ${verdict.serverMinClient}; upgrade and retry\n`,
+    cancel(
+      `CLI ${verdict.localCli} is below the server's minimum required version ${verdict.serverMinClient}; upgrade and retry`,
     );
     process.exit(EXIT_INSTANCE_BELOW_FLOOR);
   }
   if (verdict.kind === "behind-current") {
-    process.stderr.write(
-      `warning: CLI ${verdict.localCli} is behind server ${verdict.serverVersion}; consider upgrading\n`,
+    log.warn(
+      `CLI ${verdict.localCli} is behind server ${verdict.serverVersion}; consider upgrading`,
     );
   }
 
   const cfg = await deps.configService.getResolved({ flag });
   if (!cfg.ok) {
-    process.stderr.write(`error: ${describeConfigError(cfg.error)}\n`);
+    cancel(describeConfigError(cfg.error));
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
   const host = cfg.value.server;
@@ -106,8 +106,7 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   const tmplResult = await templateSvc.list();
   if (!tmplResult.ok) {
     if (tmplResult.error.kind === "auth-required") {
-      cancel(`not authenticated: ${tmplResult.error.reason}`);
-      process.stderr.write("hint: run `dam auth login` first\n");
+      cancel(`not authenticated: ${tmplResult.error.reason}\nhint: run \`dam auth login\` first`);
     } else {
       cancel(formatTransportError(tmplResult.error.reason, host));
     }
@@ -135,6 +134,18 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   // --- Step 4: optional GitHub PAT ----------------------------------
   const githubPat = await pickGithubPat(trpc);
 
+  // --- Rollback bookkeeping ------------------------------------------
+  // Anything created during *this* run goes here so a downstream
+  // mutation failure can clean it up. Existing secrets that the user
+  // picked or replaced stay out: a replace-existing path overwrote the
+  // value in place and the old value isn't recoverable, so rollback
+  // would be destructive.
+  const cleanup: Cleanup = { newSecretIds: [], agentId: null };
+  if (provider.createdNew) cleanup.newSecretIds.push(provider.secretId);
+  if (githubPat?.createdNew) {
+    cleanup.newSecretIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
+  }
+
   // --- Steps 5 + 6 + 7: agents.create → instances.create → setAgentAccess ---
   // Grants live as `granted-secret-ids` annotations on the *instance*
   // ConfigMap, not the agent. setAgentAccess before any instance exists
@@ -145,28 +156,15 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
   const spin = spinner();
   spin.start("Creating agent...");
 
-  let agentId: string;
-  try {
-    const agent = await trpc.agents.create.mutate({ name, templateId });
-    agentId = agent.id;
-  } catch (e) {
-    spin.stop("Failed to create agent");
-    process.stderr.write(`error: ${errorReason(e)}\n`);
-    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
-  }
-
-  spin.message("Creating instance...");
   let instance: Instance;
   try {
-    instance = await trpc.instances.create.mutate({ name, agentId });
-  } catch (e) {
-    spin.stop("Failed to create instance");
-    process.stderr.write(`error: ${errorReason(e)}\n`);
-    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
-  }
+    const agent = await trpc.agents.create.mutate({ name, templateId });
+    cleanup.agentId = agent.id;
 
-  spin.message("Granting provider access...");
-  try {
+    spin.message("Creating instance...");
+    instance = await trpc.instances.create.mutate({ name, agentId: agent.id });
+
+    spin.message("Granting provider access...");
     // Retry — the just-created instance ConfigMap may not yet be visible
     // to the api-server's listConfigMaps when setAgentAccess fires; without
     // the retry the patch silently targets zero ConfigMaps and the grant
@@ -175,26 +173,46 @@ async function runCreate(opts: CliOpts, deps: CreateAgentCommandDeps): Promise<v
     if (githubPat) grantedIds.push(githubPat.apiSecretId, githubPat.gitSecretId);
     await withRetry(() =>
       trpc.secrets.setAgentAccess.mutate({
-        agentId,
+        agentId: agent.id,
         secretIds: grantedIds,
       }),
     );
   } catch (e) {
-    spin.stop("Failed to grant provider access");
-    process.stderr.write(`error: ${errorReason(e)}\n`);
+    spin.stop("Setup failed");
+    await rollback(trpc, cleanup, errorReason(e));
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
 
-  // --- Step 5: wait for running --------------------------------------
+  // --- Step 8: wait for running --------------------------------------
+  // Past this point we have a real agent + instance + grants on the
+  // server. Failures from here on do NOT trigger rollback — the user
+  // can inspect/clean up via `dam instance get` / `dam instance delete`.
   spin.message(`Waiting for instance to start (state: ${instance.state})...`);
   const svc = deps.createInstanceService(host);
-  const waitResult = await waitForRunning(svc, instance.id, {
-    timeoutSeconds: WAIT_TIMEOUT_SECONDS,
-    graceSeconds: 0,
-    onStateChange: (state) => {
-      spin.message(`Waiting for instance to start (state: ${state})...`);
-    },
-  });
+
+  // SIGINT during the wait: stop the spinner, point at the live agent,
+  // exit non-zero. Don't rollback — the user chose to interrupt; the
+  // agent's existence is their call from here. The handler runs once;
+  // we remove it on natural wait completion to restore default behavior.
+  const onSigint = () => {
+    spin.stop("Cancelled");
+    log.warn(`Agent ${name} already exists; delete with \`dam instance delete ${name}\` if not needed.`);
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  };
+  process.once("SIGINT", onSigint);
+
+  let waitResult;
+  try {
+    waitResult = await waitForRunning(svc, instance.id, {
+      timeoutSeconds: WAIT_TIMEOUT_SECONDS,
+      graceSeconds: 0,
+      onStateChange: (state) => {
+        spin.message(`Waiting for instance to start (state: ${state})...`);
+      },
+    });
+  } finally {
+    process.removeListener("SIGINT", onSigint);
+  }
 
   switch (waitResult.kind) {
     case "ready": {
@@ -235,12 +253,72 @@ function cancelAndExit(): never {
   process.exit(0);
 }
 
+interface Cleanup {
+  /** Secret IDs created during this run (S1 + both halves of S2). */
+  newSecretIds: string[];
+  /** Set once agents.create has returned an id. Cascade-deletes the
+   *  instance and its grants via the K8s OwnerReference chain when
+   *  passed to agents.delete. */
+  agentId: string | null;
+}
+
+/**
+ * Reverse anything we created in this run after a downstream mutation
+ * blew up. Deletes the agent first (cascade tears down the instance
+ * via OwnerReferences), then any new secrets. Whatever fails to delete
+ * gets surfaced as an orphan summary so the user knows what to clean
+ * up manually.
+ *
+ * One pass — we don't retry rollback. If the api-server is down, the
+ * orphan list is the best we can do.
+ */
+async function rollback(
+  trpc: TrpcClient,
+  cleanup: Cleanup,
+  originalError: string,
+): Promise<void> {
+  let orphanAgent: string | null = null;
+  const orphanSecrets: string[] = [];
+
+  if (cleanup.agentId) {
+    try {
+      await trpc.agents.delete.mutate({ id: cleanup.agentId });
+    } catch {
+      orphanAgent = cleanup.agentId;
+    }
+  }
+  for (const id of cleanup.newSecretIds) {
+    try {
+      await trpc.secrets.delete.mutate({ id });
+    } catch {
+      orphanSecrets.push(id);
+    }
+  }
+
+  log.error(`Failed to create agent: ${originalError}`);
+  if (orphanAgent || orphanSecrets.length > 0) {
+    const lines = ["Cleanup partially failed. Manual cleanup needed:"];
+    if (orphanAgent) {
+      lines.push(`  Agent: ${orphanAgent} (delete via web UI or \`dam instance delete\`)`);
+    }
+    if (orphanSecrets.length > 0) {
+      lines.push(`  Secrets: ${orphanSecrets.join(", ")} (delete via web UI's secrets page)`);
+    }
+    log.error(lines.join("\n"));
+  }
+}
+
 type ProviderType = "anthropic" | "ibm-litellm" | "openai";
 
 interface ProviderSelection {
   secretId: string;
   name: string;
   type: ProviderType;
+  /** True when this run created the secret (eligible for rollback if a
+   *  later mutation fails). False for picked-existing and for replace-
+   *  existing — in the latter the secret was overwritten in place, but
+   *  the old value isn't recoverable so rollback would be destructive. */
+  createdNew: boolean;
 }
 
 type ExistingProvider = { id: string; name: string; type: ProviderType };
@@ -296,7 +374,7 @@ async function pickProvider(trpc: TrpcClient): Promise<ProviderSelection> {
     cancel("internal: picked provider not in list");
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
-  return { secretId: found.id, name: found.name, type: found.type };
+  return { secretId: found.id, name: found.name, type: found.type, createdNew: false };
 }
 
 async function addOrReplaceProvider(
@@ -329,7 +407,7 @@ async function addOrReplaceProvider(
       if (isCancel(replace)) cancelAndExit();
 
       if (!replace) {
-        return { secretId: existingOfType.id, name: existingOfType.name, type };
+        return { secretId: existingOfType.id, name: existingOfType.name, type, createdNew: false };
       }
 
       const apiKey = await password({
@@ -343,7 +421,7 @@ async function addOrReplaceProvider(
 
       try {
         await trpc.secrets.update.mutate({ id: existingOfType.id, value: apiKey });
-        return { secretId: existingOfType.id, name: existingOfType.name, type };
+        return { secretId: existingOfType.id, name: existingOfType.name, type, createdNew: false };
       } catch (e) {
         log.error(`Failed to replace API key: ${errorReason(e)}`);
         continue;
@@ -366,12 +444,17 @@ async function addOrReplaceProvider(
 
     try {
       const created = await trpc.secrets.create.mutate({ type, name, value: apiKey });
-      return { secretId: created.id, name: created.name, type };
+      return { secretId: created.id, name: created.name, type, createdNew: true };
     } catch (e) {
       log.error(`Failed to create secret: ${errorReason(e)}`);
       // Fall through to next loop iteration.
     }
   }
+}
+
+interface GithubSelection extends GithubPatPair {
+  /** True only when both halves were created during this run. */
+  createdNew: boolean;
 }
 
 /**
@@ -383,7 +466,7 @@ async function addOrReplaceProvider(
  * `secrets.list()` down to fully-paired entries, hiding orphans the
  * user can't actually grant.
  */
-async function pickGithubPat(trpc: TrpcClient): Promise<GithubPatPair | null> {
+async function pickGithubPat(trpc: TrpcClient): Promise<GithubSelection | null> {
   let list;
   try {
     list = await trpc.secrets.list.query();
@@ -420,7 +503,7 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubPatPair | null> {
     cancel("internal: picked PAT not in list");
     process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
   }
-  return found;
+  return { ...found, createdNew: false };
 }
 
 // Default display name baked into new PATs — mirrors the providers
@@ -428,7 +511,7 @@ async function pickGithubPat(trpc: TrpcClient): Promise<GithubPatPair | null> {
 // move on. Renaming for multi-account setups stays in the web UI.
 const DEFAULT_GITHUB_PAT_NAME = "GitHub";
 
-async function addNewGithubPat(trpc: TrpcClient): Promise<GithubPatPair> {
+async function addNewGithubPat(trpc: TrpcClient): Promise<GithubSelection> {
   // Loop on `secrets.createGithubPat` failure (F1 from the spec).
   while (true) {
     const token = await password({
@@ -449,6 +532,7 @@ async function addNewGithubPat(trpc: TrpcClient): Promise<GithubPatPair> {
         name: created.name,
         apiSecretId: created.apiSecretId,
         gitSecretId: created.gitSecretId,
+        createdNew: true,
       };
     } catch (e) {
       log.error(`Failed to create GitHub PAT: ${errorReason(e)}`);

--- a/packages/cli/src/modules/agent/commands/create.ts
+++ b/packages/cli/src/modules/agent/commands/create.ts
@@ -1,6 +1,6 @@
 import { cancel, intro, isCancel, log, note, outro, password, select, spinner, text } from "@clack/prompts";
 import { Command } from "commander";
-import type { Instance } from "api-server-api";
+import { PROVIDERS, type Instance } from "api-server-api";
 import type { CompatService, ConfigService } from "../../cli/index.js";
 import type { InstanceService } from "../../instance/index.js";
 import { validateInstanceName } from "../../instance/commands/create-helpers.js";
@@ -300,18 +300,13 @@ async function addNewProvider(trpc: TrpcClient): Promise<ProviderSelection> {
     });
     if (isCancel(type)) cancelAndExit();
 
-    const name = await text({
-      message: "Name",
-      placeholder: placeholderFor(type),
-      validate(v) {
-        if (!v || v.trim() === "") return "Required";
-        return undefined;
-      },
-    });
-    if (isCancel(name)) cancelAndExit();
+    // Match the web UI's provider cards: auto-name the secret with the
+    // preset's displayName ("Anthropic", "IBM LiteLLM ETE Proxy", "OpenAI")
+    // instead of asking the user. Lets the user paste a key and move on.
+    const name = PROVIDERS[type].displayName;
 
     const apiKey = await password({
-      message: "API key",
+      message: `${PROVIDERS[type].displayName} API key`,
       validate(v) {
         if (!v || v.trim() === "") return "Required";
         return undefined;
@@ -344,14 +339,6 @@ async function withRetry<T>(
   }
   // Unreachable — loop either returns or throws on the last attempt.
   throw new Error("withRetry: exhausted attempts");
-}
-
-function placeholderFor(type: ProviderType): string {
-  switch (type) {
-    case "anthropic": return "my-anthropic-key";
-    case "ibm-litellm": return "my-ibm-litellm-key";
-    case "openai": return "my-openai-key";
-  }
 }
 
 function errorReason(e: unknown): string {

--- a/packages/cli/src/modules/agent/compose.ts
+++ b/packages/cli/src/modules/agent/compose.ts
@@ -1,0 +1,54 @@
+import { Command } from "commander";
+import type { TokenProvider } from "../auth/index.js";
+import type { CompatService, ConfigService } from "../cli/index.js";
+import type { InstanceService } from "../instance/index.js";
+import type { TemplateService } from "../template/index.js";
+import { createBearerSupplier } from "../shared/trpc/bearer-supplier.js";
+import { createTrpcClient, type TrpcClient } from "../shared/trpc/trpc-client.js";
+import { buildCreateCommand } from "./commands/create.js";
+
+/**
+ * Composition options for the `agent` module. Mirrors `instance`'s
+ * compose surface — the host (Active Host URL) is resolved per-command
+ * after commander parses `--server`, so the module exposes factories
+ * the command actions invoke with the resolved host.
+ */
+export interface AgentModuleOptions {
+  tokenProvider: TokenProvider;
+  configService: ConfigService;
+  compatService: CompatService;
+  /** Env var name for the server URL — surfaced in the
+   *  `no server configured` hints in command actions. */
+  serverEnvVar: string;
+  /** Per-host factory for the template service (used by issue 003 to
+   *  fetch the template picker's option list). */
+  templateService: (host: string) => TemplateService;
+  /** Per-host factory for the instance service (used by issue 006 to
+   *  poll instance state after creation). */
+  instanceService: (host: string) => InstanceService;
+}
+
+export interface AgentModule {
+  commands: ReadonlyArray<Command>;
+}
+
+export function composeAgentModule(opts: AgentModuleOptions): AgentModule {
+  const buildTrpc = (host: string): TrpcClient =>
+    createTrpcClient({ host, getToken: createBearerSupplier(opts.tokenProvider, host) });
+
+  const parent = new Command("agent").description(
+    "Create and manage agents interactively",
+  );
+  parent.addCommand(
+    buildCreateCommand({
+      compatService: opts.compatService,
+      configService: opts.configService,
+      createInstanceService: opts.instanceService,
+      createTemplateService: opts.templateService,
+      createTrpcClient: buildTrpc,
+      serverEnvVar: opts.serverEnvVar,
+    }),
+  );
+
+  return { commands: [parent] };
+}

--- a/packages/cli/src/modules/agent/lib/group-github-pats.ts
+++ b/packages/cli/src/modules/agent/lib/group-github-pats.ts
@@ -1,0 +1,53 @@
+/**
+ * Client-side grouping for the GitHub-PAT picker. A single PAT is stored
+ * server-side as two `generic` secrets sharing a `name` — one for
+ * `api.github.com` (Bearer / `gh` CLI / `GH_TOKEN` env), one for
+ * `github.com` (Basic / `git clone`). See spec's two-secret rationale.
+ *
+ * For the picker to display one row per PAT, we filter to those two
+ * hosts, group by name, and keep only groups where both halves exist.
+ * Orphans (one host only, or duplicates on the same host) are dropped
+ * — surfacing partial pairs would let users pick a "PAT" that can't
+ * actually fulfil `setAgentAccess`'s contract.
+ */
+
+export interface SecretLike {
+  id: string;
+  name: string;
+  type: string;
+  hostPattern: string;
+}
+
+export interface GithubPatPair {
+  name: string;
+  /** Host = `api.github.com`. Bearer injection + `GH_TOKEN` env. */
+  apiSecretId: string;
+  /** Host = `github.com`. Basic injection. */
+  gitSecretId: string;
+}
+
+const API_HOST = "api.github.com";
+const GIT_HOST = "github.com";
+
+export function groupGithubPats(secrets: readonly SecretLike[]): GithubPatPair[] {
+  const byName = new Map<string, { api: string[]; git: string[] }>();
+  for (const s of secrets) {
+    const slot = s.hostPattern === API_HOST ? "api" : s.hostPattern === GIT_HOST ? "git" : null;
+    if (!slot) continue;
+    let group = byName.get(s.name);
+    if (!group) {
+      group = { api: [], git: [] };
+      byName.set(s.name, group);
+    }
+    group[slot].push(s.id);
+  }
+
+  const pairs: GithubPatPair[] = [];
+  for (const [name, group] of byName) {
+    if (group.api.length === 1 && group.git.length === 1) {
+      pairs.push({ name, apiSecretId: group.api[0]!, gitSecretId: group.git[0]! });
+    }
+  }
+  pairs.sort((a, b) => a.name.localeCompare(b.name));
+  return pairs;
+}

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -18,6 +18,7 @@ export default defineConfig({
   // Ship a self-contained dist/bin.js. Node-builtins stay external; runtime
   // deps fold into the bundle so `node dist/bin.js` works from anywhere.
   noExternal: [
+    "@clack/prompts",
     "@trpc/client",
     "@trpc/server",
     "api-server-api",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -243,6 +243,9 @@ importers:
 
   packages/cli:
     dependencies:
+      '@clack/prompts':
+        specifier: 1.3.0
+        version: 1.3.0
       '@trpc/client':
         specifier: ^11.16.0
         version: 11.16.0(@trpc/server@11.16.0(typescript@6.0.2))(typescript@6.0.2)
@@ -1132,6 +1135,14 @@ packages:
 
   '@chat-adapter/telegram@4.26.0':
     resolution: {integrity: sha512-PE2HoCQ4648VNKZTuHFanQNoYzM/niNoSbDyYlPq6VOoB5qsoo1ctR8TERyl1EfPBNexWZpSWYrrnQPr15LUfA==}
+
+  '@clack/core@1.3.0':
+    resolution: {integrity: sha512-xJPHpAmEQUBrXSLx0gF+q5K/IyihXpsHZcha+jB+tyahsKRK3Dxo4D0coZDewHo12NhiuzC3dTtMPbm53GEAAA==}
+    engines: {node: '>= 20.12.0'}
+
+  '@clack/prompts@1.3.0':
+    resolution: {integrity: sha512-GgcWwRCs/xPtaqlMy8qRhPnZf9vlWcWZNHAitnVQ3yk7JmSralSiq5q07yaffYE8SogtDm7zFeKccx1QNVARpw==}
+    engines: {node: '>= 20.12.0'}
 
   '@codemirror/autocomplete@6.20.1':
     resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
@@ -3737,8 +3748,17 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-string-truncated-width@3.0.3:
+    resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
+
+  fast-string-width@3.0.2:
+    resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
+
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
+  fast-wrap-ansi@0.2.0:
+    resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
 
   fast-xml-builder@1.1.5:
     resolution: {integrity: sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==}
@@ -5301,6 +5321,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
 
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
@@ -7183,6 +7206,18 @@ snapshots:
       chat: 4.26.0
     transitivePeerDependencies:
       - supports-color
+
+  '@clack/core@1.3.0':
+    dependencies:
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
+
+  '@clack/prompts@1.3.0':
+    dependencies:
+      '@clack/core': 1.3.0
+      fast-string-width: 3.0.2
+      fast-wrap-ansi: 0.2.0
+      sisteransi: 1.0.5
 
   '@codemirror/autocomplete@6.20.1':
     dependencies:
@@ -9826,7 +9861,17 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-string-truncated-width@3.0.3: {}
+
+  fast-string-width@3.0.2:
+    dependencies:
+      fast-string-truncated-width: 3.0.3
+
   fast-uri@3.1.0: {}
+
+  fast-wrap-ansi@0.2.0:
+    dependencies:
+      fast-string-width: 3.0.2
 
   fast-xml-builder@1.1.5:
     dependencies:
@@ -11696,6 +11741,8 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  sisteransi@1.0.5: {}
 
   smart-buffer@4.2.0: {}
 


### PR DESCRIPTION
Closes #211.

## Summary

Adds `dam agent create`: a single interactive CLI command that walks a developer through the full new-agent flow — name, template, model provider, optional GitHub PAT — and ends with a running instance. Everything the web UI's "Add agent" dialog covers, now reachable without leaving the terminal.

`dam instance create` is unchanged and remains the scripted entry point.

## Test plan

- [ ] `dam agent create` on a fresh cluster (no providers, no PATs) walks through provider add-new and GitHub add-one paths and ends with a running agent.
- [ ] Re-running with existing provider / GitHub PAT shows them in the pickers and grants both halves of the GitHub pair.
- [ ] Replacing an existing provider key or GitHub PAT updates in place (no duplicates).
- [ ] Replacing an Anthropic API key with an OAuth token (or vice versa) correctly rotates env + injection header.
- [ ] Cancelling at any prompt before agent creation exits cleanly with no orphan resources.
- [ ] `dam agent create < /dev/null` errors out pointing at `dam instance create`.