### PR TITLE
feat(secrets): Bob Shell provider preset with twin secrets

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -363,6 +363,8 @@ apiServer:
     # Mise (toolchain manager)
     - mise.jdx.dev
     - cdn.mise.run
+    # Bob Shell (IBM)
+    - api.us-east.bob.ibm.com
 
   # -- Optional platform-wide defaults for OAuth app credentials. When a field
   # is set the connect form for the matching app collapses the corresponding

--- a/docs/adrs/044-provider-twin-secrets.md
+++ b/docs/adrs/044-provider-twin-secrets.md
@@ -1,0 +1,173 @@
+# ADR-044: Provider twin secrets — multiple injection points per credential
+
+**Date:** 2026-05-14
+**Status:** Accepted
+**Owner:** @xjacka
+
+## Context
+
+A provider preset (ADR-028) binds one credential to one Envoy injection: a
+`hostPattern` plus an `InjectionConfig` that names a header and an
+optional `valueFormat`. Bob Shell breaks that mould — its backend reads
+the same credential from **two wire positions on the same host**:
+
+- `Authorization: Bearer <token>` for chat / model-info endpoints.
+- `?key=<token>` URL parameter for `/key/info`, `/user/info`, and a few
+  admin endpoints (Bob's HTTP client emits the value in both places, but
+  the URL-keyed routes ignore the header).
+
+Today's Envoy filter chain already supports both forms (the `credential_injector`
+filter writes the header; a per-route Lua filter then moves the value
+from a throwaway header into the URL parameter and strips the header — see
+ADR-033 §Credential injection). But each filter is bound to its own K8s
+Secret, so making both work for one provider required the operator to
+create two manually-configured generic Secrets:
+
+1. One with `injectionConfig: { headerName: "Authorization", valueFormat: "Bearer {value}" }`.
+2. A second on the same host with `injectionConfig: { headerName: "X-Bobshell-Internal", queryParamName: "key" }`.
+
+That's hostile for a provider preset card (Settings → Providers): the
+user can only express one wire position per "preset"; the second secret
+has to be hand-crafted, granted separately, rotated separately, deleted
+separately. Adding Bob without solving this means every new operator
+re-discovers the same two-step manual setup.
+
+## Decision
+
+**A provider preset mode declares all its wire injection points up front
+in the registry. The api-server fans the credential out across multiple
+linked K8s Secrets — a "primary" plus one "twin" per extra injection —
+and cascades every lifecycle operation. From the user's perspective the
+provider is one card and one credential.**
+
+### Registry shape
+
+`ProviderPresetMode` gets an optional `extraInjections: readonly InjectionConfig[]`
+field. Each entry is a complete `{ headerName, valueFormat?, queryParamName? }`
+tuple on the same host as the primary. Bob declares:
+
+```ts
+extraInjections: [{ headerName: "X-Bobshell-Internal", queryParamName: "key" }]
+```
+
+The primary's injection is whatever the preset's `mode.injection` says
+(or the default `Authorization: Bearer {value}` fall-through).
+
+### Twin secrets
+
+When `secrets-service.create` lands a primary for a preset that declares
+`extraInjections`, it also creates one K8s Secret per entry:
+
+- Same `value` (same wire-level token).
+- Same `hostPattern` — twins always live on the primary's host.
+- The entry's `InjectionConfig`. No `envMappings` (the primary carries them).
+- No `pathPattern` — the primary's scope already governs which routes
+  the credential applies to.
+- A linking annotation `agent-platform.ai/primary-secret-id: <primary-id>`
+  so the service layer can rediscover the twins.
+
+The display name carries a `(?queryParam)` / `(HeaderName)` suffix so
+admins inspecting `kubectl get secrets` can tell what each twin does.
+
+### Lifecycle cascade
+
+The service layer treats twins as derived state, never user-visible:
+
+- **`list`** — twins are filtered out (`primarySecretId` set).
+- **`create`** — primary first, then twins in a transaction-like loop.
+  Any twin write failure rolls back every prior twin + the primary so
+  the user never sees a half-injected secret. The user-facing
+  `SecretView` carries only the primary's id.
+- **`update`** — primary is patched first; `value` and `hostPattern`
+  changes cascade onto every twin. `envMappings`, `pathPattern`, and
+  `injectionConfig` do **not** propagate — twins have none of those by
+  design. ADR-040 fanout (egress-rules sync, secrets-rev bump) runs once,
+  keyed on the primary's id.
+- **`delete`** — twins first, primary last. A mid-cascade failure leaves
+  the primary intact and the user can retry (twins are findable by the
+  primary id annotation). Reversing the order would orphan twins if the
+  primary delete went through but a twin delete failed afterward.
+- **`getAgentAccess`** — twin ids are filtered out so the user view only
+  shows primaries.
+- **`setAgentAccess`** — primaries-only on the user side. Each primary
+  in the request expands to `[primary, ...twins]` before persisting the
+  grant list, so the controller mounts every linked Secret and renders
+  every Envoy filter. Twin ids supplied directly are silently dropped
+  (defence in depth: a buggy caller can't grant a lone twin).
+- **`listGrantedAgents`** — uses the existing grant index. Returns the
+  same agents whether keyed on primary or twin id (setAgentAccess writes
+  both into every grant), and callers always pass primary ids anyway.
+
+The controller is unchanged. ADR-033's Envoy filter rendering already
+processes every mounted K8s Secret independently; twins look exactly
+like additional generic secrets at that layer.
+
+## Alternatives Considered
+
+**Extend `InjectionConfig` to carry multiple wire points per Secret.**
+One K8s Secret would render N Envoy filters. Rejected: requires changes
+to the Go reconciler's rendering loop, the K8s annotation schema, and
+the SDS file convention (multiple inline strings per Secret). Twin
+secrets pile zero new work onto the controller — every twin is just
+another generic Secret it already knows how to render.
+
+**Expose twins to the user as separate secrets.** Drop the linking
+annotation; let the user see and manage both rows directly. Rejected:
+the user came to add "Bob", not "Bob (header)" and "Bob (URL param)";
+each subsequent op (grant, rotate, delete) doubles in steps and the
+provider card abstraction stops making sense.
+
+**Skip the registry and do it client-side from the preset card.** The
+Bob card calls `create` twice with different `injectionConfig` payloads
+each time. Rejected: every primary-cascade operation (rotate, change
+host, grant, revoke, delete) becomes the UI's responsibility, with no
+server-side guarantee they stay coupled. Also leaks the second secret
+into `list()` and `setAgentAccess`. The whole point of moving to a
+registry-driven model is one source of truth for "what does this
+provider need on the wire."
+
+**One generic per wire point at agent-create time, no twin coupling.**
+Effectively today's manual workaround. Rejected: scales like O(presets ×
+wire-points) of operator toil; rotating a token means N edits with no
+atomicity; deleting "Bob" means hunting for N secrets.
+
+## Consequences
+
+- **Provider presets can model real-world auth shapes that need the
+  credential in multiple wire positions.** No per-provider service-layer
+  branches; everything reads from `PROVIDERS[type].modes[].extraInjections`.
+- **K8s annotation schema grows one optional annotation**
+  (`agent-platform.ai/primary-secret-id`). Parse-tolerant — missing or
+  malformed annotation means the Secret is treated as a stand-alone
+  primary (ADR-040's parse-tolerance posture).
+- **Twin manual-deletion is an unsupported state.** If an operator
+  `kubectl delete`s a twin out-of-band, the primary keeps working for
+  its own injection but the twin's wire path goes silently dark.
+  Subsequent grant operations re-expand only against the twins that
+  still exist. Recovery: delete the primary and recreate via the
+  provider card. The service does not auto-heal — a registry-vs-actual
+  diff pass on every `setAgentAccess` was rejected as out of scope.
+- **Registry changes are not retroactive.** Adding a new `extraInjections`
+  entry to a preset doesn't mint twins for already-created primaries.
+  Operators must recreate the primary to pick up the new wire point.
+  Acceptable today because the registry is internal config, not user
+  data; document if it ever becomes a frequent migration concern.
+- **Concurrency window on create.** Twin creation isn't atomic with the
+  primary at the K8s level; the rollback path is best-effort. In the
+  worst case the user retries — `create` is idempotent at the user level
+  (a new id is minted each time), so there's no state to disambiguate.
+- **Test coverage.** `secrets-service-fanout.test.ts` covers create,
+  list filter, update cascade (value + host, with `envMappings` proven
+  non-cascading), delete order, grant expansion, getAgentAccess filter,
+  defensive twin-id drop on grant, revoke-all, and partial-create
+  rollback. Ten tests, each a distinct code path.
+
+## Related ADRs
+
+- [ADR-028](028-generic-secret-injection-config.md) — `injectionConfig`
+  schema; extended here from "one per secret" to "one per wire point
+  with twin secrets per provider preset."
+- [ADR-033](033-envoy-credential-gateway.md) — Envoy filter rendering
+  and the Lua URL-rewrite path that the `?key=` twin depends on.
+- [ADR-040](040-unified-secret-contributions.md) — fanout model. Twin
+  edits inherit the primary's fanout path; no second fanout pipe.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -48,6 +48,7 @@ This directory contains ADRs for the Platform project.
 | [041](041-istio-ambient-mesh.md)              | Istio ambient mesh — SPIFFE identity for every internal hop | @pilartomas |
 | [042](042-agent-egress-network-policy.md)     | Agent egress is gated by NetworkPolicy; the agent is not a mesh participant | @pilartomas |
 | [043](043-agent-pod-config-layers.md)         | Three-layer agent pod configuration — base / templateDefaults / templates | @jezekra1 |
+| [044](044-provider-twin-secrets.md)           | Provider twin secrets — multiple injection points per credential | @xjacka |
 
 ## Drafts
 

--- a/packages/agents/bob/Dockerfile
+++ b/packages/agents/bob/Dockerfile
@@ -1,13 +1,6 @@
 ARG BASE_IMAGE=platform-base
 FROM ${BASE_IMAGE}
 
-# SECURITY NOTE — autonomy posture
-# Bob runs with `--yolo` and the shim auto-accepts every
-# `session/request_permission`, so no UI confirmation chips. Trust
-# boundary is the Envoy egress sidecar (ADR-033/038): no SA token,
-# no Secret mounts, every outbound req goes through ext_authz.
-# To re-enable per-tool confirmation, patch the shim's pickAllowOption()
-# upstream — don't do it locally.
 
 USER root
 

--- a/packages/agents/bob/README.md
+++ b/packages/agents/bob/README.md
@@ -7,72 +7,64 @@ Platform agent running [Bob Shell](https://internal.bob.ibm.com/docs/shell) — 
 | Component | Source | Purpose |
 |---|---|---|
 | Harness | `bobshell` (IBM internal S3 distribution) | Bob CLI in `--experimental-acp` mode + native TUI |
-| ACP bridge | `bob-acp-shim.mjs` (verbatim from upstream Bob) | Translates Bob's session/update events into the shape the platform UI expects; auto-approves `session/request_permission` because Bob launches with `--yolo` |
+| ACP bridge | `bob-acp-shim.mjs` (verbatim from upstream Bob) | Translates Bob's session/update events into the shape the platform UI expects; auto-approves `session/request_permission` (Bob's ACP doesn't actually issue per-tool HITL requests for built-in tools — see autonomy posture below) |
 | Storage | `/home/agent` PVC (ADR-027) | Bob's session index lives under `~/.bob/`; survives pod restarts |
 
 ## Authentication
 
 Bob expects `BOBSHELL_API_KEY` in the pod env. On the platform the agent only ever sees a **placeholder** — the real key is materialized at the Envoy sidecar, never in the agent container.
 
-1. **Create a generic secret on the platform** scoped to the Bob backend host. The default header injection (`Authorization: Bearer {value}` on `prod.ibm-bob-staging.cloud.ibm.com`) is what Bob's HTTP client sends out, so a single secret with the host pattern + default config is enough for `/key/info` and the chat endpoints.
+1. **Open Settings → Providers → Bob Shell** and paste your Bob API key. The provider preset creates a secret pinned to `prod.ibm-bob-staging.cloud.ibm.com` (the host Bob's bundle uses for `/v1/model/info`, `/key/info`, `/chat/completions` etc.) with the default `Authorization: Bearer {value}` injection plus a twin entry on the same host that handles the `?key=` URL parameter Bob appends to several admin endpoints. `BOBSHELL_API_KEY` is seeded as `sk-placeholder` — the literal content is irrelevant because Envoy overwrites the wire value, but the prefix matches what Bob displays in its outbound-request logs. The Advanced disclosure lets you set the default model and tenant-scoping flags (see below) — those flow as additional env-mappings rather than free-form env vars in the agent dialog.
 
-   ```yaml
-   # via the Configure Agent UI
-   hostPattern: prod.ibm-bob-staging.cloud.ibm.com
-   injectionConfig:
-     headerName: Authorization       # default
-     valueFormat: "Bearer {value}"   # default
-   envMappings:
-     - { envName: BOBSHELL_API_KEY, placeholder: sk-dummy }
-   ```
-
-2. **Grant the secret to the Bob agent instance**. The next pod restart picks up the env var and the Envoy filter chain.
+2. **Grant the secret to the Bob agent instance** from Configure Agent → Secrets. The next pod restart picks up `BOBSHELL_API_KEY` and any pinned `BOB_*` envs along with the Envoy filter chain.
 
 The flow per request: Bob's `fetch()` sets `Authorization: Bearer sk-dummy` and tunnels through `HTTPS_PROXY` → Envoy terminates TLS using the platform CA → `credential_injector` rewrites the header to the real `Bearer sk-…` from the K8s Secret → upstream sees the valid token. See [`docs/architecture/security-and-credentials.md`](../../../docs/architecture/security-and-credentials.md) and [ADR-033](../../../docs/adrs/033-envoy-credential-gateway.md).
 
 ### Endpoints that read the key from the URL
 
-Some Bob backends (`/key/info?key=<value>` is the practical example) read the credential from a URL query parameter instead of `Authorization`. Bob's client happens to send the value in both places, but if you ever hit an endpoint that only accepts the URL form, create a **second** secret on the same host with `queryParamName: key`. The platform groups multiple secrets per host into a single Envoy filter chain — see [ADR-033 §Credential injection](../../../docs/adrs/033-envoy-credential-gateway.md#credential-injection) for the URL-query rewrite path.
+Some Bob backends (`/key/info?key=<value>`) read the credential from a URL query parameter. The provider preset's `extraInjections` automatically creates a second "twin" K8s Secret on the same host with `queryParamName: key`; the platform-side service cascades grants/updates/deletes onto it. See [ADR-044](../../../docs/adrs/044-provider-twin-secrets.md) for the twin-secret pattern and [ADR-033 §Credential injection](../../../docs/adrs/033-envoy-credential-gateway.md#credential-injection) for the Envoy URL-rewrite path.
 
-## Autonomy posture (`--yolo`)
+## Autonomy posture
 
-Bob runs with `bob --experimental-acp --yolo --auth-method api-key` (in [`bob-acp-shim.mjs`](bob-acp-shim.mjs)). The shim also auto-selects the first `allow_always` / `allow_once` option on every `session/request_permission` callback, so the platform UI never shows a permission chip for Bob the way it does for Claude / Codex / Pi.
+Bob runs with `bob --experimental-acp --yolo --auth-method api-key` (in [`bob-acp-shim.mjs`](bob-acp-shim.mjs)) and the shim auto-approves any `session/request_permission` Bob does emit, so the platform UI never shows a per-tool confirmation chip for Bob.
 
-This matches upstream Bob's deployment shape and is **deliberate** — the trust boundary is the per-instance Envoy egress sidecar (ADR-033/038), not in-agent prompts. Bob can write into its workdir and exec shell commands freely, but every outbound HTTP request still goes through the credential gateway with `ext_authz` / egress-rules enforcement, the agent container has no SA token, no Secret volume mounts, and no Envoy config it can rewrite.
+This is **forced by Bob upstream**, not a platform choice: every Bob built-in tool's `shouldConfirmExecute()` returns `false` when `!isInteractive()`, so even in `default`/`auto_edit` mode Bob never calls `client.requestPermission()` via ACP for shell exec or file writes — those modes just refuse the tool outright with a "not allowed in non-interactive mode" error. `--yolo` is the only setting under which Bob's ACP mode actually runs tools.
 
-If you need per-tool human-in-the-loop confirmation for Bob, that has to be re-introduced upstream — the shim's `pickAllowOption()` would need to fall through to an interactive path. The longer SECURITY NOTE in [`Dockerfile`](Dockerfile) covers the boundary in more detail.
+The trust boundary is the per-instance Envoy egress sidecar (ADR-033/038): every outbound HTTP request goes through the credential gateway with `ext_authz` / egress-rules enforcement, the agent container has no SA token, no Secret volume mounts, and no Envoy config it can rewrite.
 
 ## Configuration
 
-Bob accepts settings from two channels: env vars it reads directly (resolved by Bob's runtime — set them in the Configure Agent → Env tab) and CLI flags that have no env equivalent (the harness scripts translate platform env vars into the right flag).
+Bob accepts settings from two channels: env vars it reads directly (resolved by Bob's runtime) and CLI flags that have no env equivalent (the harness scripts translate platform env vars into the right flag). The Bob Shell provider preset pins the most common ones; the rest stay free-form in **Configure Agent → Env**.
 
-### Env vars Bob reads directly
+### Pinned via the Bob Shell provider (Settings → Providers → Bob Shell → Advanced)
 
-Set them as custom env vars in the **Configure Agent** dialog → Env tab. They reach Bob's process unchanged.
-
-| Env var | Effect |
-|---|---|
-| `BOBSHELL_API_KEY` | API key the Envoy sidecar swaps to the real value on the wire. Already wired by the secret's `envMappings`; no manual entry needed. |
-| `BOB_SHELL_MODEL` | Default model for new sessions. Examples: `gemini-2.5-pro`, `gpt-5.6`, `claude-sonnet-5`. Empty → Bob picks its built-in default. |
-| `BOBSHELL_HIDE_ENVS` | Set to `1` to suppress the env-var banner Bob prints at startup. |
-| `BOB_SHELL_PRE_CHECK_AUTO_APPROVED` | Set to `1` to make Bob run a safety pre-check before executing auto-approved commands. Recommended on top of the shim's `--yolo` posture. |
-| `BOB_SHELL_SYSTEM_MD` | Path to a markdown file appended to Bob's system prompt. Lives on the workspace PVC. |
-| `IBM_TELEMETRY_ENABLED` | Set to `false` to opt out of Bob's telemetry. |
-
-### Platform env vars translated to CLI flags
-
-These are Bob CLI flags with no env equivalent — the harness scripts (`harness-chat.sh` and `harness-terminal.sh`) translate `BOB_*` env vars into the flag form before spawning Bob. Set them the same way (Configure Agent → Env tab).
+These ride on the secret's `envMappings`, so every agent granted the Bob secret inherits them automatically — no per-agent re-entry.
 
 | Env var | Translated to | Effect |
 |---|---|---|
+| `BOBSHELL_API_KEY` | n/a (env-only) | API key the Envoy sidecar swaps to the real value on the wire. Always emitted. |
+| `BOB_SHELL_MODEL` | n/a (env-only) | Default model for new sessions. Examples: `premium-shell`, `codestral-2508`, `claude-sonnet-5`. Empty → Bob's built-in default. |
 | `BOB_INSTANCE_ID` | `--instance-id` | Sets the `x-instance-id` header on Bob's outbound API calls (IBM tenant scoping). |
-| `BOB_TEAM_ID` | `--team-id` | Sets the `x-team-id` header (IBM tenant scoping). |
+| `BOB_TEAM_ID` | `--team-id` | Sets the `x-team-id` header. |
 | `BOB_MAX_COINS` | `--max-coins` | Budget cap — Bob exits with code 1 if exceeded. |
 | `BOB_CHAT_MODE` | `--chat-mode` | One of `plan`, `code`, `advanced`, `ask`. Sets the default chat persona for new sessions. |
 
+Per-agent overrides for any of these still work — set the same env name in **Configure Agent → Env** and it wins over the inherited pin.
+
+### Free-form env vars (Configure Agent → Env)
+
+Less common toggles, not surfaced on the provider card.
+
+| Env var | Effect |
+|---|---|
+| `BOBSHELL_HIDE_ENVS` | Set to `1` to suppress the env-var banner Bob prints at startup. |
+| `BOB_SHELL_PRE_CHECK_AUTO_APPROVED` | Set to `1` to make Bob run a safety pre-check before executing auto-approved commands. Recommended on top of `--yolo`. |
+| `BOB_SHELL_SYSTEM_MD` | Path to a markdown file appended to Bob's system prompt. Lives on the workspace PVC. |
+| `IBM_TELEMETRY_ENABLED` | Set to `false` to opt out of Bob's telemetry. |
+
 Settings that **cannot** be configured this way without changes to the shim:
 
-- **Approval mode** — the shim hardcodes `--yolo` and auto-selects the first `allow_*` option on every `session/request_permission`. Moving Bob to `default` or `auto_edit` mode would require reworking `pickAllowOption()` in [`bob-acp-shim.mjs`](bob-acp-shim.mjs). See the SECURITY NOTE in [`Dockerfile`](Dockerfile) for why we accept the YOLO posture today.
+- **Per-tool HITL** — Bob's experimental ACP mode has no working `client.requestPermission()` path for built-in tools (every `shouldConfirmExecute` short-circuits in non-interactive mode). The platform UI inbox is not used for Bob.
 - **Auth method** — the shim spawns Bob with `--auth-method api-key`. OAuth / Vertex paths would need a different shim invocation.
 - **Sandbox** — Bob's `--sandbox` runs commands inside a separate sandbox subprocess. Overlaps with the platform's K8s-level sandboxing model (ADR-033); leave off.
 
@@ -81,7 +73,7 @@ Settings that **cannot** be configured this way without changes to the shim:
 | Script | Behavior |
 |---|---|
 | `harness-chat.sh` | Translates the `BOB_*` env vars and `exec`s `node /app/bob-acp-shim.mjs`. Bob advertises `agentCapabilities.loadSession: false` over ACP, so every `session/new` from agent-runtime spawns a fresh Bob session — chat resume is not possible at the ACP layer. |
-| `harness-terminal.sh` | Same flag translation, then `exec bob --yolo --auth-method api-key`. Each terminal open starts a **fresh** Bob TUI session — Bob persists sessions in a project-scoped numeric index, not per-UUID files (the way pi-agent and claude-code do), so `$HARNESS_SESSION_ID` can't be mapped one-to-one. Users can browse prior sessions from inside the TUI with `--list-sessions` if needed. |
+| `harness-terminal.sh` | Same flag translation, then `exec bob --approval-mode=auto_edit --auth-method api-key`. TUI mode is interactive — `auto_edit` lets Bob prompt the user in the terminal for risky tools; `--yolo` (which the ACP shim must use) would auto-approve everything. Each terminal open starts a **fresh** Bob TUI session — Bob persists sessions in a project-scoped numeric index, not per-UUID files (the way pi-agent and claude-code do), so `$HARNESS_SESSION_ID` can't be mapped one-to-one. Users can browse prior sessions from inside the TUI with `--list-sessions` if needed. |
 
 ## Persistence
 

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -64,10 +64,26 @@
 import { spawn } from "node:child_process";
 import { promises as fsp } from "node:fs";
 import { dirname } from "node:path";
+import readline from "node:readline";
 
 const TRACE = process.env.BOB_SHIM_TRACE === "1";
 const thinkToolCallIds = new Set();
 let lastThoughtText = "";
+
+// Shim-faked ACP setSessionMode: `<mode>X</mode>` prepended per prompt.
+const AVAILABLE_MODES = [
+  { id: "ask", name: "Ask" },
+  { id: "code", name: "Code" },
+  { id: "plan", name: "Plan" },
+  { id: "advanced", name: "Advanced" },
+];
+let currentModeId = (() => {
+  const env = process.env.BOB_CHAT_MODE;
+  if (env && AVAILABLE_MODES.some((m) => m.id === env)) return env;
+  return "ask";
+})();
+const pendingNewSessionIds = new Set();
+let pendingModeSwitch = null;
 
 // agent_message_chunk state machine. Bob wraps reasoning in <thinking>…
 // </thinking>; the actual user-facing text is whatever lives outside the
@@ -96,7 +112,73 @@ const bob = spawn("bob", ["--experimental-acp", "--yolo", "--auth-method", "api-
   env: process.env,
 });
 
-process.stdin.pipe(bob.stdin);
+const clientStdin = readline.createInterface({ input: process.stdin });
+clientStdin.on("line", (line) => {
+  if (TRACE) process.stderr.write(`[client→shim] ${line}\n`);
+  handleClientLine(line);
+});
+clientStdin.on("close", () => {
+  try { bob.stdin.end(); } catch {}
+});
+
+function forwardToBob(line) {
+  if (!bob.stdin.writable) return;
+  bob.stdin.write(line + "\n");
+}
+
+function handleClientLine(line) {
+  let f;
+  try { f = JSON.parse(line); } catch { return forwardToBob(line); }
+
+  const isClientRequest = f.id !== undefined && typeof f.method === "string";
+
+  if (isClientRequest && f.method === "session/new") {
+    pendingNewSessionIds.add(f.id);
+    return forwardToBob(line);
+  }
+
+  if (isClientRequest && f.method === "session/set_mode") {
+    const modeId = typeof f.params?.modeId === "string" ? f.params.modeId : null;
+    const sessionId = f.params?.sessionId;
+    if (modeId && modeId !== currentModeId && AVAILABLE_MODES.some((m) => m.id === modeId)) {
+      currentModeId = modeId;
+      pendingModeSwitch = modeId;
+      if (sessionId) {
+        emitToClient({
+          jsonrpc: "2.0",
+          method: "session/update",
+          params: {
+            sessionId,
+            update: { sessionUpdate: "current_mode_update", currentModeId: modeId },
+          },
+        });
+      }
+    }
+    emitToClient({ jsonrpc: "2.0", id: f.id, result: null });
+    return;
+  }
+
+  // One-shot mode switch: prepend an instruction to the next prompt asking
+  // the LLM to call the switch-mode tool. Bob's system prompt teaches the
+  // exact XML form, so the LLM should comply, after which Bob's bundle
+  // updates its internal mode for subsequent turns.
+  if (isClientRequest && f.method === "session/prompt" && pendingModeSwitch) {
+    try {
+      const prompt = f.params?.prompt;
+      if (Array.isArray(prompt)) {
+        const firstText = prompt.find((p) => p?.type === "text" && typeof p?.text === "string");
+        if (firstText) {
+          const instruction = `[System: switch to ${pendingModeSwitch} mode now using the switch-mode tool, then continue.]\n\n`;
+          firstText.text = instruction + firstText.text;
+          pendingModeSwitch = null;
+          return forwardToBob(JSON.stringify(f));
+        }
+      }
+    } catch { /* fall through */ }
+  }
+
+  forwardToBob(line);
+}
 
 function sendToBob(frame) {
   if (!bob.stdin.writable) return;
@@ -318,11 +400,7 @@ function handleLine(line) {
   const isAgentRequest = f.id !== undefined && typeof f.method === "string";
 
   if (isAgentRequest && f.method === "session/request_permission") {
-    const sid = f.params?.sessionId;
-    // Surface the embedded toolCall so platform UI shows a chip. Don't synthesize
-    // a completed update — bob emits its own tool_call_update once the op
-    // actually finishes, which keeps the chip honest on failures.
-    emitToolCallOpen(sid, f.params?.toolCall);
+    emitToolCallOpen(f.params?.sessionId, f.params?.toolCall);
     const optionId = pickAllowOption(f.params?.options);
     sendToBob({
       jsonrpc: "2.0",
@@ -342,6 +420,25 @@ function handleLine(line) {
   // Reset streaming state at turn boundary (session/prompt reply).
   if (f.id !== undefined && f.result?.stopReason) {
     flushMessageStateAtTurnEnd();
+    return passthrough(line);
+  }
+
+  if (f.id !== undefined && pendingNewSessionIds.has(f.id)) {
+    pendingNewSessionIds.delete(f.id);
+    if (f.result) {
+      const patched = {
+        ...f,
+        result: {
+          ...f.result,
+          modes: {
+            availableModes: AVAILABLE_MODES.map((m) => ({ ...m })),
+            currentModeId,
+          },
+        },
+      };
+      process.stdout.write(JSON.stringify(patched) + "\n");
+      return;
+    }
     return passthrough(line);
   }
 

--- a/packages/agents/bob/harness-terminal.sh
+++ b/packages/agents/bob/harness-terminal.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-# Mirror the shim's spawn shape (`--yolo --auth-method api-key`) so
-# the TUI uses the same auth path as chat. No --experimental-acp.
+# TUI is interactive — auto_edit lets Bob prompt the user for risky tools
+# in the terminal itself (yolo would auto-approve everything, no prompts).
 #
 # BOBSHELL_NO_RELAUNCH=true: bob re-execs itself with stdio:"inherit"
 # at startup, which breaks the TTY chain in node-pty (relaunched
@@ -21,4 +21,4 @@ set --
 [ -n "$BOB_TEAM_ID" ]     && set -- "$@" --team-id     "$BOB_TEAM_ID"
 [ -n "$BOB_MAX_COINS" ]   && set -- "$@" --max-coins   "$BOB_MAX_COINS"
 [ -n "$BOB_CHAT_MODE" ]   && set -- "$@" --chat-mode   "$BOB_CHAT_MODE"
-exec /opt/node24/bin/node /usr/local/lib/node_modules/bobshell/bundle/bob.js --yolo --auth-method api-key "$@"
+exec /opt/node24/bin/node /usr/local/lib/node_modules/bobshell/bundle/bob.js --approval-mode=auto_edit --auth-method api-key "$@"

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -64,6 +64,7 @@ export type {
   EnvMapping,
   InjectionConfig,
   IbmLitellmModelPins,
+  BobModelPins,
 } from "./modules/secrets/types.js";
 export {
   DEFAULT_ENV_PLACEHOLDER,
@@ -77,6 +78,9 @@ export {
   IBM_LITELLM_DEFAULT_MODEL_PINS,
   ibmLitellmEnvMappings,
   ibmLitellmPinsFromEnvMappings,
+  bobEnvMappings,
+  bobPinsFromEnvMappings,
+  BOB_CHAT_MODES,
 } from "./modules/secrets/types.js";
 export { updateSecretInputSchema } from "./modules/secrets/schemas.js";
 

--- a/packages/api-server-api/src/modules/secrets/schemas.ts
+++ b/packages/api-server-api/src/modules/secrets/schemas.ts
@@ -5,7 +5,7 @@ import { ENV_NAME_RE, QUERY_PARAM_RE } from "./types.js";
 // file so UI code can import these without dragging in @trpc/server
 // transitively via router.ts.
 
-export const secretTypeSchema = z.enum(["anthropic", "ibm-litellm", "openai", "generic"]);
+export const secretTypeSchema = z.enum(["anthropic", "ibm-litellm", "openai", "bob", "generic"]);
 
 export const envMappingSchema = z.object({
   envName: z

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -1,4 +1,4 @@
-export type SecretType = "anthropic" | "ibm-litellm" | "openai" | "generic";
+export type SecretType = "anthropic" | "ibm-litellm" | "openai" | "bob" | "generic";
 
 /**
  * SecretTypes that have a {@link PROVIDERS} registry entry — the providers
@@ -7,7 +7,7 @@ export type SecretType = "anthropic" | "ibm-litellm" | "openai" | "generic";
  * AND adding a {@link PROVIDERS} entry; TypeScript will fail if either
  * half is missing.
  */
-export type ProviderPresetType = "anthropic" | "ibm-litellm" | "openai";
+export type ProviderPresetType = "anthropic" | "ibm-litellm" | "openai" | "bob";
 
 /**
  * Declares a pod env var to inject into every agent instance that has access
@@ -140,6 +140,56 @@ export function ibmLitellmPinsFromEnvMappings(
   };
 }
 
+export interface BobModelPins {
+  model?: string;
+  instanceId?: string;
+  teamId?: string;
+  maxCoins?: string;
+  chatMode?: string;
+}
+
+// api.us-east must stay uncredentialed (401 on a real token) — that
+// host is in trustedHosts, not here.
+const BOB_HOST = "prod.ibm-bob-staging.cloud.ibm.com";
+const BOB_PLACEHOLDER = "sk-placeholder";
+
+export function bobEnvMappings(pins: BobModelPins = {}): EnvMapping[] {
+  const out: EnvMapping[] = [
+    { envName: "BOBSHELL_API_KEY", placeholder: BOB_PLACEHOLDER },
+  ];
+  const push = (envName: string, value?: string) => {
+    const trimmed = value?.trim();
+    if (trimmed) out.push({ envName, placeholder: trimmed });
+  };
+  push("BOB_SHELL_MODEL", pins.model);
+  push("BOB_INSTANCE_ID", pins.instanceId);
+  push("BOB_TEAM_ID", pins.teamId);
+  push("BOB_MAX_COINS", pins.maxCoins);
+  push("BOB_CHAT_MODE", pins.chatMode);
+  return out;
+}
+
+export function bobPinsFromEnvMappings(
+  envMappings: readonly EnvMapping[] | undefined,
+): BobModelPins {
+  const lookup = (name: string) =>
+    envMappings?.find((m) => m.envName === name)?.placeholder;
+  const pins: BobModelPins = {};
+  const model = lookup("BOB_SHELL_MODEL");
+  const instanceId = lookup("BOB_INSTANCE_ID");
+  const teamId = lookup("BOB_TEAM_ID");
+  const maxCoins = lookup("BOB_MAX_COINS");
+  const chatMode = lookup("BOB_CHAT_MODE");
+  if (model) pins.model = model;
+  if (instanceId) pins.instanceId = instanceId;
+  if (teamId) pins.teamId = teamId;
+  if (maxCoins) pins.maxCoins = maxCoins;
+  if (chatMode) pins.chatMode = chatMode;
+  return pins;
+}
+
+export const BOB_CHAT_MODES = ["plan", "code", "advanced", "ask"] as const;
+
 /**
  * One auth mode of a provider preset. Most presets have exactly one mode
  * (a Bearer API key); Anthropic has two (oauth + api-key) which differ in
@@ -158,6 +208,8 @@ export interface ProviderPresetMode {
   /** Override the default `Authorization: Bearer {value}` injection.
    *  Set for Anthropic api-key mode (`x-api-key`); omit elsewhere. */
   injection?: InjectionConfig;
+  /** Twin K8s Secret per entry; lifecycle cascaded by service. See ADR-044. */
+  extraInjections?: readonly InjectionConfig[];
 }
 
 /**
@@ -230,6 +282,19 @@ export const PROVIDERS = {
         defaultEnvMappings: [
           { envName: "OPENAI_API_KEY", placeholder: DEFAULT_ENV_PLACEHOLDER },
         ],
+      },
+    ],
+  },
+  bob: {
+    id: "bob",
+    displayName: "Bob Shell",
+    hostPattern: BOB_HOST,
+    modes: [
+      {
+        key: "api-key",
+        label: "API Key",
+        defaultEnvMappings: bobEnvMappings(),
+        extraInjections: [{ headerName: "X-Bobshell-Internal", queryParamName: "key" }],
       },
     ],
   },

--- a/packages/api-server/src/__tests__/unit/secrets-service-fanout.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-fanout.test.ts
@@ -30,14 +30,27 @@ interface SyncCall {
 
 function makePort(initial: K8sStoredSecret[]) {
   const store = new Map(initial.map((s) => [s.id, s]));
-  const created: { id: string; envMappings?: EnvMapping[] }[] = [];
+  const created: {
+    id: string;
+    name: string;
+    envMappings?: EnvMapping[];
+    primarySecretId?: string;
+    injectionConfig?: K8sStoredSecret["injectionConfig"];
+  }[] = [];
   const updated: { id: string; patch: Record<string, unknown> }[] = [];
+  const deleted: string[] = [];
   const port: K8sSecretsPort = {
     async listSecrets() {
       return Array.from(store.values());
     },
     async createSecret(input) {
-      created.push({ id: input.id, envMappings: input.envMappings });
+      created.push({
+        id: input.id,
+        name: input.name,
+        envMappings: input.envMappings,
+        primarySecretId: input.primarySecretId,
+        injectionConfig: input.injectionConfig,
+      });
       store.set(input.id, {
         id: input.id,
         name: input.name,
@@ -47,6 +60,7 @@ function makePort(initial: K8sStoredSecret[]) {
         ...(input.envMappings ? { envMappings: input.envMappings } : {}),
         ...(input.injectionConfig ? { injectionConfig: input.injectionConfig } : {}),
         ...(input.authMode ? { authMode: input.authMode } : {}),
+        ...(input.primarySecretId ? { primarySecretId: input.primarySecretId } : {}),
         createdAt: new Date().toISOString(),
       });
     },
@@ -70,19 +84,23 @@ function makePort(initial: K8sStoredSecret[]) {
       return { before, after };
     },
     async deleteSecret(id) {
+      deleted.push(id);
       store.delete(id);
     },
   };
-  return { port, store, created, updated };
+  return { port, store, created, updated, deleted };
 }
 
 function makeGrants(initial: GrantedAgentSummary[] = []) {
   const bumps: { cmName: string; hash: string }[] = [];
+  const secretGrantCalls: { agentId: string; secretIds: readonly string[] }[] = [];
   const port: AgentGrantsPort = {
     async get(): Promise<AgentGrants> {
       return { grantedSecretIds: [], grantedConnectionIds: [] };
     },
-    async setSecretGrants() {},
+    async setSecretGrants(agentId, secretIds) {
+      secretGrantCalls.push({ agentId, secretIds });
+    },
     async setConnectionGrants() {},
     async listAgentsGrantedSecret() {
       return initial;
@@ -91,7 +109,7 @@ function makeGrants(initial: GrantedAgentSummary[] = []) {
       bumps.push({ cmName, hash });
     },
   };
-  return { port, bumps };
+  return { port, bumps, secretGrantCalls };
 }
 
 function makeSyncRecorder() {
@@ -415,5 +433,220 @@ describe("secrets-service.listGrantedAgents (ADR-040)", () => {
       ownerSub: "owner-1",
     });
     expect(await svc.listGrantedAgents("secret-x")).toEqual([]);
+  });
+});
+
+describe("secrets-service — extraInjections (twin secrets, e.g. Bob)", () => {
+  it("create() mints a twin per extraInjections entry, linked via primarySecretId", async () => {
+    const { port, created, store } = makePort([]);
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({
+      type: "bob",
+      name: "Bob Shell",
+      value: "sk-bob-foo",
+    });
+    // Two K8s Secrets created: the primary + one twin from Bob's
+    // `extraInjections` registry entry.
+    expect(created).toHaveLength(2);
+    const [primary, twin] = created;
+    expect(primary!.id).toBe(view.id);
+    expect(primary!.primarySecretId).toBeUndefined();
+    expect(twin!.primarySecretId).toBe(view.id);
+    expect(twin!.injectionConfig?.queryParamName).toBe("key");
+    expect(twin!.injectionConfig?.headerName).toBe("X-Bobshell-Internal");
+    // The twin has no env mappings — credentials only, env is the primary's job.
+    expect(twin!.envMappings).toBeUndefined();
+    // K8s store carries the link annotation so subsequent reads can find twins.
+    const twinStored = store.get(twin!.id);
+    expect(twinStored?.primarySecretId).toBe(view.id);
+  });
+
+  it("list() hides twins from the user-facing view", async () => {
+    const { port } = makePort([]);
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    const view = await svc.list();
+    expect(view).toHaveLength(1);
+    expect(view[0]!.type).toBe("bob");
+  });
+
+  it("update({ value }) cascades the new value onto every twin", async () => {
+    const { port, updated } = makePort([]);
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    await svc.update({ id: view.id, value: "sk-bob-rotated" });
+    // Primary + twin both got the new value.
+    const valueUpdates = updated.filter((u) => u.patch.value === "sk-bob-rotated");
+    expect(valueUpdates).toHaveLength(2);
+    expect(valueUpdates.map((u) => u.id).sort()).toEqual(
+      [view.id, ...valueUpdates.filter((u) => u.id !== view.id).map((u) => u.id)].sort(),
+    );
+  });
+
+  it("update({ hostPattern }) cascades onto twins; envMappings does NOT", async () => {
+    const { port, updated } = makePort([]);
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    const hostBefore = updated.length;
+    await svc.update({
+      id: view.id,
+      hostPattern: "alt.bob.ibm.com",
+      envMappings: [{ envName: "BOBSHELL_API_KEY", placeholder: "ph" }, { envName: "BOB_SHELL_MODEL", placeholder: "premium-shell" }],
+    });
+    const cascaded = updated.slice(hostBefore);
+    // Primary update + twin host cascade. The twin must NOT receive
+    // envMappings — twins have none by design.
+    const twinUpdates = cascaded.filter((u) => u.id !== view.id);
+    expect(twinUpdates).toHaveLength(1);
+    expect(twinUpdates[0]!.patch.envMappings).toBeUndefined();
+    expect(twinUpdates[0]!.patch.hostPattern).toBe("alt.bob.ibm.com");
+  });
+
+  it("delete() removes twins before the primary", async () => {
+    const { port, deleted } = makePort([]);
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    await svc.delete(view.id);
+    // Two deletes; primary is last so we don't leave dangling twins on failure.
+    expect(deleted).toHaveLength(2);
+    expect(deleted[deleted.length - 1]).toBe(view.id);
+  });
+
+  it("setAgentAccess expands primary IDs to include their twins in the K8s grant", async () => {
+    const { port } = makePort([]);
+    const { port: grants, secretGrantCalls } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    await svc.setAgentAccess("agent-a", { secretIds: [view.id] });
+    expect(secretGrantCalls).toHaveLength(1);
+    const persistedIds = secretGrantCalls[0]!.secretIds;
+    expect(persistedIds).toContain(view.id);
+    // Twin IDs come along for the ride so the controller mounts both.
+    expect(persistedIds.length).toBe(2);
+  });
+
+  it("getAgentAccess hides twin IDs from the user view", async () => {
+    const { port } = makePort([]);
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants: {
+        async get() {
+          return { grantedSecretIds: [], grantedConnectionIds: [] };
+        },
+        async setSecretGrants() {},
+        async setConnectionGrants() {},
+        async listAgentsGrantedSecret() {
+          return [];
+        },
+        async bumpSecretsRev() {},
+      },
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    // Stub `grants.get` to return the expanded list (primary + twin).
+    const allSecrets = await port.listSecrets();
+    const twinId = allSecrets.find((s) => s.primarySecretId === view.id)!.id;
+    const svc2 = createSecretsService({
+      k8sPort: port,
+      grants: {
+        async get() {
+          return {
+            grantedSecretIds: [view.id, twinId],
+            grantedConnectionIds: [],
+          };
+        },
+        async setSecretGrants() {},
+        async setConnectionGrants() {},
+        async listAgentsGrantedSecret() {
+          return [];
+        },
+        async bumpSecretsRev() {},
+      },
+      ownerSub: "owner-1",
+    });
+    const access = await svc2.getAgentAccess("agent-a");
+    expect(access.secretIds).toEqual([view.id]);
+  });
+
+  it("setAgentAccess with empty list revokes both primary and twin grants", async () => {
+    const { port } = makePort([]);
+    const { port: grants, secretGrantCalls } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    await svc.setAgentAccess("agent-a", { secretIds: [] });
+    expect(secretGrantCalls).toHaveLength(1);
+    expect(secretGrantCalls[0]!.secretIds).toEqual([]);
+  });
+
+  it("setAgentAccess silently drops twin IDs passed in the input", async () => {
+    const { port } = makePort([]);
+    const { port: grants, secretGrantCalls } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    const view = await svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" });
+    const all = await port.listSecrets();
+    const twinId = all.find((s) => s.primarySecretId === view.id)!.id;
+    // Caller passes a twin ID by mistake → must be filtered out, so a lone
+    // twin can't be granted without its primary.
+    await svc.setAgentAccess("agent-a", { secretIds: [twinId] });
+    expect(secretGrantCalls[0]!.secretIds).toEqual([]);
+  });
+
+  it("create() rolls the primary back if a twin write fails", async () => {
+    const { port, store } = makePort([]);
+    // Wrap createSecret so any twin (one with primarySecretId set) throws —
+    // the primary succeeds, the twin fails, and the cleanup pass must
+    // leave the store empty.
+    const originalCreate = port.createSecret;
+    port.createSecret = async (input) => {
+      if (input.primarySecretId) throw new Error("twin write boom");
+      await originalCreate.call(port, input);
+    };
+    const { port: grants } = makeGrants();
+    const svc = createSecretsService({
+      k8sPort: port,
+      grants,
+      ownerSub: "owner-1",
+    });
+    await expect(
+      svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" }),
+    ).rejects.toThrow("twin write boom");
+    expect(store.size).toBe(0);
   });
 });

--- a/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
+++ b/packages/api-server/src/modules/secrets/infrastructure/k8s-secrets-port.ts
@@ -21,6 +21,8 @@ const ANN_AUTH_MODE = "agent-platform.ai/auth-mode";
 const ANN_VALUE_FORMAT = "agent-platform.ai/injection-value-format";
 const ANN_QUERY_PARAM = "agent-platform.ai/injection-query-param";
 const ANN_ENV_MAPPINGS = "agent-platform.ai/env-mappings";
+// Twin → primary link. Set on extraInjections-derived secrets.
+const ANN_PRIMARY_ID = "agent-platform.ai/primary-secret-id";
 
 export type AuthMode = "api-key" | "oauth";
 
@@ -118,6 +120,7 @@ export interface K8sStoredSecret {
   createdAt: string;
   authMode?: AuthMode;
   envMappings?: EnvMapping[];
+  primarySecretId?: string;
 }
 
 export interface K8sSecretsPort {
@@ -132,6 +135,7 @@ export interface K8sSecretsPort {
     injectionConfig?: InjectionConfig;
     authMode?: AuthMode;
     envMappings?: EnvMapping[];
+    primarySecretId?: string;
   }): Promise<void>;
   /**
    * Apply the patch and return the before/after view so the service layer
@@ -217,6 +221,7 @@ function parseStoredSecret(s: k8s.V1Secret): K8sStoredSecret | null {
       /* malformed annotation — controller falls back to legacy switch */
     }
   }
+  if (ann[ANN_PRIMARY_ID]) stored.primarySecretId = ann[ANN_PRIMARY_ID];
   return stored;
 }
 
@@ -231,7 +236,7 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
         .filter((s): s is K8sStoredSecret => s !== null);
     },
 
-    async createSecret({ id, name, type, value, hostPattern, pathPattern, injectionConfig, authMode, envMappings }) {
+    async createSecret({ id, name, type, value, hostPattern, pathPattern, injectionConfig, authMode, envMappings, primarySecretId }) {
       const secretType = isProviderPresetType(type as SecretType) ? type : "generic";
       const { headerName, valueFormat } = resolveInjection(secretType, authMode, injectionConfig);
       const annotations: Record<string, string> = {
@@ -253,6 +258,7 @@ export function createK8sSecretsPort(client: K8sClient, ownerSub: string): K8sSe
       if (injectionConfig?.queryParamName) {
         annotations[ANN_QUERY_PARAM] = injectionConfig.queryParamName;
       }
+      if (primarySecretId) annotations[ANN_PRIMARY_ID] = primarySecretId;
 
       const body: k8s.V1Secret = {
         metadata: {

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -4,6 +4,7 @@ import {
   isProviderPresetType,
   PROVIDERS,
   type EnvMapping,
+  type InjectionConfig,
   type SecretsService,
   type CreateSecretInput,
   type UpdateSecretInput,
@@ -33,6 +34,23 @@ function registryEnvMappings(type: SecretType, authMode?: string): EnvMapping[] 
     ? preset.modes.find((m) => m.key === authMode)
     : preset.modes[0];
   return mode?.defaultEnvMappings;
+}
+
+function registryExtraInjections(
+  type: SecretType,
+  authMode?: string,
+): readonly InjectionConfig[] {
+  if (type === "generic") return [];
+  const preset = PROVIDERS[type];
+  const mode = authMode
+    ? preset.modes.find((m) => m.key === authMode)
+    : preset.modes[0];
+  return mode?.extraInjections ?? [];
+}
+
+function twinDisplayName(primaryName: string, injection: InjectionConfig): string {
+  const tag = injection.queryParamName ? `?${injection.queryParamName}` : injection.headerName;
+  return `${primaryName} (${tag})`;
 }
 
 // `secrets-rev` hashes only what affects the agent pod's env. hostPattern,
@@ -128,7 +146,7 @@ export function createSecretsService(deps: {
   return {
     async list() {
       const secrets = await deps.k8sPort.listSecrets();
-      return secrets.map(toSecretView);
+      return secrets.filter((s) => !s.primarySecretId).map(toSecretView);
     },
 
     async create(input: CreateSecretInput) {
@@ -165,6 +183,42 @@ export function createSecretsService(deps: {
         ...(authMode ? { authMode } : {}),
         ...(envMappings?.length ? { envMappings } : {}),
       });
+      const createdTwinIds: string[] = [];
+      try {
+        for (const inj of registryExtraInjections(input.type, authMode)) {
+          const twinId = randomUUID();
+          await deps.k8sPort.createSecret({
+            id: twinId,
+            name: twinDisplayName(input.name, inj),
+            type: input.type,
+            value: input.value,
+            hostPattern,
+            injectionConfig: inj,
+            primarySecretId: id,
+          });
+          createdTwinIds.push(twinId);
+        }
+      } catch (err) {
+        for (const twinId of createdTwinIds) {
+          try {
+            await deps.k8sPort.deleteSecret(twinId);
+          } catch (cleanupErr) {
+            console.warn(
+              `secrets-service: orphan twin K8s Secret ${twinId} (primary ${id}, type ${input.type}) — manual cleanup required:`,
+              cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+            );
+          }
+        }
+        try {
+          await deps.k8sPort.deleteSecret(id);
+        } catch (cleanupErr) {
+          console.warn(
+            `secrets-service: orphan primary K8s Secret ${id} (type ${input.type}) — manual cleanup required:`,
+            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
+          );
+        }
+        throw err;
+      }
       const view: SecretView = {
         id,
         name: input.name,
@@ -198,8 +252,21 @@ export function createSecretsService(deps: {
       // save was lost instead of a silent success and a closed dialog.
       if (!result) throw new TRPCError({ code: "NOT_FOUND" });
       const { before, after } = result;
+
+      const valueChanged = patch.value !== undefined;
       const hostChanged = hostOrPathChanged(before, after);
       const envChanged = envMappingsChanged(before, after);
+      if (valueChanged || hostChanged) {
+        const allSecretsForTwins = await deps.k8sPort.listSecrets();
+        const twins = allSecretsForTwins.filter((s) => s.primarySecretId === id);
+        for (const twin of twins) {
+          await deps.k8sPort.updateSecret(twin.id, {
+            ...(valueChanged ? { value: patch.value } : {}),
+            ...(hostChanged ? { hostPattern: after.hostPattern } : {}),
+          });
+        }
+      }
+
       if (!hostChanged && !envChanged) return;
       if (!deps.connectionRules || !deps.ownerSub) return;
 
@@ -233,12 +300,22 @@ export function createSecretsService(deps: {
     },
 
     async delete(id) {
+      // Twins first; primary last on success so retry-after-failure is clean.
+      const allSecrets = await deps.k8sPort.listSecrets();
+      const twinIds = allSecrets
+        .filter((s) => s.primarySecretId === id)
+        .map((s) => s.id);
+      for (const twinId of twinIds) {
+        await deps.k8sPort.deleteSecret(twinId);
+      }
       await deps.k8sPort.deleteSecret(id);
     },
 
     async getAgentAccess(agentId: string) {
       const grants = await deps.grants.get(agentId);
-      return { secretIds: grants.grantedSecretIds };
+      const allSecrets = await deps.k8sPort.listSecrets();
+      const twinIds = new Set(allSecrets.filter((s) => s.primarySecretId).map((s) => s.id));
+      return { secretIds: grants.grantedSecretIds.filter((id) => !twinIds.has(id)) };
     },
 
     async listGrantedAgents(secretId: string) {
@@ -250,20 +327,28 @@ export function createSecretsService(deps: {
     },
 
     async setAgentAccess(agentId: string, access: AgentAccess) {
-      await deps.grants.setSecretGrants(agentId, access.secretIds);
+      const allSecrets = await deps.k8sPort.listSecrets();
+      const twinIds = new Set(allSecrets.filter((s) => s.primarySecretId).map((s) => s.id));
+      const twinsByPrimary = new Map<string, string[]>();
+      for (const s of allSecrets) {
+        if (!s.primarySecretId) continue;
+        const list = twinsByPrimary.get(s.primarySecretId) ?? [];
+        list.push(s.id);
+        twinsByPrimary.set(s.primarySecretId, list);
+      }
+      const primaries = access.secretIds.filter((id) => !twinIds.has(id));
+      const expanded = [
+        ...primaries,
+        ...primaries.flatMap((id) => twinsByPrimary.get(id) ?? []),
+      ];
+      await deps.grants.setSecretGrants(agentId, expanded);
 
-      // Sync `connection:<id>` egress rules against the new grant list.
-      // Always-selective: empty list = no rules.
       if (deps.connectionRules && deps.ownerSub) {
-        const allSecrets = await deps.k8sPort.listSecrets();
-        // ownedSourceIds = every owner secret id, granted or not — scopes
-        // the sync's revoke pass to this module's rows so app-connection
-        // rules (sharing the `connection:<id>` prefix) stay untouched.
         const ownedSourceIds = new Set(allSecrets.map((s) => s.id));
         await deps.connectionRules.syncForAgent({
           agentId,
           decidedBy: deps.ownerSub,
-          grants: buildHostGrantsMap(allSecrets, access.secretIds),
+          grants: buildHostGrantsMap(allSecrets, expanded),
           ownedSourceIds,
         });
       }

--- a/packages/ui/src/modules/settings/components/bob/card.tsx
+++ b/packages/ui/src/modules/settings/components/bob/card.tsx
@@ -1,0 +1,43 @@
+import { bobEnvMappings, PROVIDERS, type SecretView } from "../../../../types.js";
+import { useProviderActions } from "../use-provider-actions.js";
+import { BobConnected } from "./connected.js";
+import { BobForm } from "./form.js";
+
+const NAME = PROVIDERS.bob.displayName;
+
+/** Self-contained card for the Bob Shell preset. The form's Advanced
+ *  disclosure may have changed any pin (model, tenant, budget, chat mode),
+ *  so we mint a fresh env-var bundle on every save. */
+export function BobCard({ secret }: { secret?: SecretView }) {
+  const actions = useProviderActions();
+
+  if (secret) {
+    return (
+      <BobConnected
+        secret={secret}
+        onRemove={() => actions.remove(secret.id, `Remove ${NAME} API key?`, "Remove Key")}
+        onSave={({ value, pins }) =>
+          actions.update({
+            id: secret.id,
+            value,
+            envMappings: bobEnvMappings(pins),
+          })
+        }
+      />
+    );
+  }
+
+  return (
+    <BobForm
+      variant="wizard"
+      onSave={({ value, pins }) =>
+        actions.create({
+          type: "bob",
+          name: NAME,
+          value,
+          envMappings: bobEnvMappings(pins),
+        })
+      }
+    />
+  );
+}

--- a/packages/ui/src/modules/settings/components/bob/connected.tsx
+++ b/packages/ui/src/modules/settings/components/bob/connected.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+
+import {
+  type BobModelPins,
+  bobPinsFromEnvMappings,
+  PROVIDERS,
+  type SecretView,
+} from "../../../../types.js";
+import { ProviderConnectedShell } from "../shared/provider-connected-shell.js";
+import { BobForm } from "./form.js";
+
+export function BobConnected({
+  secret,
+  onRemove,
+  onSave,
+}: {
+  secret: SecretView;
+  onRemove: () => Promise<void>;
+  onSave: (input: { value: string; pins: BobModelPins }) => Promise<void>;
+}) {
+  const [editing, setEditing] = useState(false);
+  const currentPins = bobPinsFromEnvMappings(secret.envMappings);
+
+  if (editing) {
+    return (
+      <BobForm
+        variant="edit"
+        initialPins={currentPins}
+        onCancel={() => setEditing(false)}
+        onSave={async (input) => {
+          await onSave(input);
+          setEditing(false);
+        }}
+      />
+    );
+  }
+
+  return (
+    <ProviderConnectedShell
+      title={PROVIDERS.bob.displayName}
+      subtitle={
+        currentPins.model ? (
+          <>
+            Model: <span className="font-mono">{currentPins.model}</span>
+          </>
+        ) : (
+          <>Default model</>
+        )
+      }
+      onEdit={() => setEditing(true)}
+      onRemove={onRemove}
+    />
+  );
+}

--- a/packages/ui/src/modules/settings/components/bob/form.tsx
+++ b/packages/ui/src/modules/settings/components/bob/form.tsx
@@ -1,0 +1,235 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { ChevronDown, ChevronRight, X } from "lucide-react";
+import { useState } from "react";
+import { useForm, type UseFormRegisterReturn } from "react-hook-form";
+import { z } from "zod";
+
+import { BOB_CHAT_MODES, type BobModelPins } from "../../../../types.js";
+import { CardIcon } from "../shared/card-icon.js";
+import { IconButton } from "../shared/icon-button.js";
+import { MODES, stripWhitespace } from "./modes.js";
+
+const bobCredentialSchema = z
+  .object({
+    value: z.string(),
+    model: z.string(),
+    instanceId: z.string(),
+    teamId: z.string(),
+    maxCoins: z.string(),
+    chatMode: z.string(),
+  })
+  .superRefine((data, ctx) => {
+    if (stripWhitespace(data.value).length === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["value"],
+        message: "Required",
+      });
+    }
+    // maxCoins is a numeric budget cap; reject anything that isn't a positive
+    // integer when set. Empty is fine (Bob omits the flag).
+    if (data.maxCoins.trim() !== "" && !/^[1-9]\d*$/.test(data.maxCoins.trim())) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["maxCoins"],
+        message: "Must be a positive integer",
+      });
+    }
+    const cm = data.chatMode.trim();
+    if (cm !== "" && !BOB_CHAT_MODES.includes(cm as (typeof BOB_CHAT_MODES)[number])) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["chatMode"],
+        message: `Must be one of: ${BOB_CHAT_MODES.join(", ")}`,
+      });
+    }
+  });
+
+type FormValues = z.infer<typeof bobCredentialSchema>;
+
+export function BobForm({
+  variant,
+  initialPins,
+  onSave,
+  onCancel,
+}: {
+  variant: "wizard" | "edit";
+  initialPins?: BobModelPins;
+  onSave: (input: { value: string; pins: BobModelPins }) => Promise<void>;
+  onCancel?: () => void;
+}) {
+  const pins = initialPins ?? {};
+  const { register, handleSubmit, watch, formState } = useForm<FormValues>({
+    resolver: zodResolver(bobCredentialSchema),
+    mode: "onChange",
+    defaultValues: {
+      value: "",
+      model: pins.model ?? "",
+      instanceId: pins.instanceId ?? "",
+      teamId: pins.teamId ?? "",
+      maxCoins: pins.maxCoins ?? "",
+      chatMode: pins.chatMode ?? "",
+    },
+  });
+  const { errors, isSubmitting, isValid } = formState;
+  // Open the advanced disclosure by default in edit mode when any pin is set —
+  // otherwise the user has to hunt for the model field they came to change.
+  const hasAnyPin = Object.values(pins).some((v) => v && v.trim() !== "");
+  const [advancedOpen, setAdvancedOpen] = useState(variant === "edit" && hasAnyPin);
+
+  const isEdit = variant === "edit";
+  const submitDisabled = isSubmitting || !isValid;
+  const value = watch("value");
+
+  const onSubmit = handleSubmit(async (values) => {
+    await onSave({
+      value: stripWhitespace(values.value),
+      pins: {
+        model: values.model.trim() || undefined,
+        instanceId: values.instanceId.trim() || undefined,
+        teamId: values.teamId.trim() || undefined,
+        maxCoins: values.maxCoins.trim() || undefined,
+        chatMode: values.chatMode.trim() || undefined,
+      },
+    });
+  });
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className={`rounded-xl border-2 p-5 anim-in flex flex-col gap-4 ${
+        isEdit
+          ? "border-accent bg-accent-light shadow-brutal-accent"
+          : "border-warning bg-warning-light shadow-brutal"
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        <CardIcon variant={isEdit ? "accent" : "warning"} />
+        <div className="flex-1 min-w-0">
+          <div className="text-[15px] font-bold text-text">Bob Shell</div>
+          <div className="text-[12px] text-text-muted">
+            {isEdit
+              ? "Paste a new token to replace the existing one. Advanced settings are passed to Bob as CLI flags / env."
+              : "IBM's AI shell assistant. Paste your Bob API key to get started."}
+          </div>
+        </div>
+        {onCancel && (
+          <IconButton onClick={onCancel} title="Cancel" hoverTone="neutral">
+            <X size={13} />
+          </IconButton>
+        )}
+      </div>
+
+      <div className="flex gap-3">
+        <input
+          className="w-full h-10 rounded-lg border-2 border-border-light bg-bg px-4 text-[14px] text-text outline-none transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-glow)] placeholder:text-text-muted"
+          type="password"
+          autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
+          data-form-type="other"
+          placeholder={MODES["api-key"].placeholder}
+          {...register("value")}
+        />
+        <button
+          type="submit"
+          className="btn-brutal h-10 rounded-lg border-2 border-accent-hover bg-accent px-6 text-[13px] font-semibold text-white disabled:opacity-40 shrink-0 shadow-brutal-accent"
+          disabled={submitDisabled}
+        >
+          {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
+        </button>
+      </div>
+
+      {errors.value && value.length > 0 && errors.value.message !== "Required" && (
+        <div className="text-[12px] font-medium text-danger">{errors.value.message}</div>
+      )}
+
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen((o) => !o)}
+        className="flex items-center gap-1.5 text-[12px] font-semibold text-text-muted hover:text-text -mt-1 self-start"
+      >
+        {advancedOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        Advanced — model & tenant scoping
+      </button>
+
+      {advancedOpen && (
+        <div className="grid grid-cols-1 gap-3">
+          <PinField
+            label="Model"
+            hint="BOB_SHELL_MODEL — empty → Bob's built-in default."
+            placeholder="premium-shell"
+            error={errors.model?.message}
+            register={register("model")}
+          />
+          <PinField
+            label="Instance ID"
+            hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping for outbound API calls."
+            error={errors.instanceId?.message}
+            register={register("instanceId")}
+          />
+          <PinField
+            label="Team ID"
+            hint="BOB_TEAM_ID → --team-id."
+            error={errors.teamId?.message}
+            register={register("teamId")}
+          />
+          <PinField
+            label="Max coins"
+            hint="BOB_MAX_COINS → --max-coins. Budget cap; Bob exits when exceeded."
+            placeholder="(no cap)"
+            error={errors.maxCoins?.message}
+            register={register("maxCoins")}
+          />
+          <PinField
+            label="Chat mode"
+            hint={`BOB_CHAT_MODE → --chat-mode. One of: ${BOB_CHAT_MODES.join(", ")}.`}
+            placeholder="(Bob default)"
+            list="bob-chat-modes"
+            error={errors.chatMode?.message}
+            register={register("chatMode")}
+          />
+          <datalist id="bob-chat-modes">
+            {BOB_CHAT_MODES.map((m) => (
+              <option key={m} value={m} />
+            ))}
+          </datalist>
+        </div>
+      )}
+    </form>
+  );
+}
+
+function PinField({
+  label,
+  hint,
+  placeholder,
+  list,
+  error,
+  register,
+}: {
+  label: string;
+  hint: string;
+  placeholder?: string;
+  list?: string;
+  error?: string;
+  register: UseFormRegisterReturn;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <label className="text-[12px] font-semibold text-text-secondary">{label}</label>
+      <input
+        className="h-9 rounded-lg border-2 border-border-light bg-bg px-3 text-[13px] font-mono text-text outline-none focus:border-accent"
+        type="text"
+        autoComplete="off"
+        data-1p-ignore
+        data-lpignore="true"
+        placeholder={placeholder}
+        list={list}
+        {...register}
+      />
+      <div className="text-[11px] text-text-muted">{hint}</div>
+      {error && <div className="text-[11px] font-medium text-danger">{error}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/settings/components/bob/modes.ts
+++ b/packages/ui/src/modules/settings/components/bob/modes.ts
@@ -1,0 +1,17 @@
+/** Bob Shell is single-mode (Bearer API token). Length-1 shape kept for
+ *  symmetry with `anthropic/modes.ts` and `ibm-litellm/modes.ts`. */
+export const MODE_KEYS = ["api-key"] as const;
+export type Mode = (typeof MODE_KEYS)[number];
+
+export const MODES = {
+  "api-key": {
+    label: "API Key",
+    placeholder: "sk-…",
+  },
+} as const satisfies Record<Mode, { label: string; placeholder: string }>;
+
+// Reuse the whitespace-stripping policy from other presets: pasted-from-terminal
+// tokens often pick up newlines, and the exact-match envoy injection makes that fatal.
+export function stripWhitespace(value: string): string {
+  return value.replace(/\s+/g, "");
+}

--- a/packages/ui/src/modules/settings/components/provider-cards.ts
+++ b/packages/ui/src/modules/settings/components/provider-cards.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 
 import type { ProviderPresetType, SecretView } from "../../../types.js";
 import { AnthropicCard } from "./anthropic/card.js";
+import { BobCard } from "./bob/card.js";
 import { IbmLitellmCard } from "./ibm-litellm/card.js";
 import { OpenAICard } from "./openai/card.js";
 
@@ -15,4 +16,5 @@ export const PROVIDER_CARDS = {
   anthropic: AnthropicCard,
   "ibm-litellm": IbmLitellmCard,
   openai: OpenAICard,
+  bob: BobCard,
 } satisfies Record<ProviderPresetType, ComponentType<{ secret?: SecretView }>>;

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -176,6 +176,7 @@ export function mcpHostnameFromSecretName(name: string): string {
 }
 
 export type {
+  BobModelPins,
   EgressPreset,
   EnvMapping,
   EnvVar,
@@ -187,6 +188,9 @@ export type {
   SecretType,
 } from "api-server-api";
 export {
+  BOB_CHAT_MODES,
+  bobEnvMappings,
+  bobPinsFromEnvMappings,
   DEFAULT_ENV_PLACEHOLDER,
   DEFAULT_INJECTION_CONFIG,
   IBM_LITELLM_DEFAULT_MODEL_PINS,


### PR DESCRIPTION
Closes: https://github.com/dam-agents/dam/issues/187

- Add `bob` to `PROVIDERS` registry (host, env factory, chat-mode pins).
- New `ProviderPresetMode.extraInjections` — service mints a "twin" K8s Secret per entry, linked to the primary by annotation. Twin lifecycle (create-with-rollback, value/host cascade, delete-twins-first, grant expansion, twin-id filter on user views) handled in `secrets-service`. Pattern documented in ADR-044.
- UI provider card under `packages/ui/.../bob/` mirroring ibm-litellm.
- Bob ACP shim: readline stdin interceptor, mode picker injection into `session/new` response, instruction-based mode switch via the `switch-mode` tool on `session/set_mode`.
- Add `api.us-east.bob.ibm.com` to trustedHosts (uncredentialed startup ping; real credential injection stays on `prod.ibm-bob-staging`).
- harness-terminal.sh uses `--approval-mode=auto_edit` (TUI prompts); ACP shim stays on `--yolo` (Bob upstream has no working ACP HITL hook).