### PR TITLE
fix(ci): use numeric pre-release for build-pinned helm chart

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -224,10 +224,10 @@ jobs:
       - uses: azure/setup-helm@v4
       - name: Log in to Quay OCI
         run: echo "${{ secrets.QUAY_PASSWORD }}" | helm registry login quay.io --username ${{ secrets.QUAY_USERNAME }} --password-stdin
-      - name: Package Helm chart (SHA-pinned)
-        run: helm package deploy/helm/platform --version 0.0.0-${{ github.sha }} --app-version ${{ github.sha }}
-      - name: Push SHA-pinned chart
-        run: helm push platform-0.0.0-${{ github.sha }}.tgz oci://quay.io/dam-agents/charts
+      - name: Package Helm chart (build-pinned)
+        run: helm package deploy/helm/platform --version 0.0.0-main.${{ github.run_number }} --app-version ${{ github.sha }}
+      - name: Push build-pinned chart
+        run: helm push platform-0.0.0-main.${{ github.run_number }}.tgz oci://quay.io/dam-agents/charts
       - name: Package Helm chart (main floating tag)
         run: helm package deploy/helm/platform --version 0.0.0-main --app-version ${{ github.sha }}
       - name: Push main-floating chart


### PR DESCRIPTION
## Summary
- The `main` workflow's build-pinned chart was versioned `0.0.0-<git-sha>`. SemVer compares pre-release identifiers lexicographically, so alphanumeric SHAs do not order by build time — Flux's semver range matcher could pick an older build over a newer one.
- Switch the build-pinned version to `0.0.0-main.${{ github.run_number }}`. `run_number` is numeric and monotonic, so semver ordering matches build order.
- The floating `0.0.0-main` chart is unchanged for consumers that depend on it.

## Test plan
- [ ] Merge and confirm the next `main` push publishes `platform-0.0.0-main.<N>.tgz` to `oci://quay.io/dam-agents/charts`.
- [ ] Verify the floating `platform-0.0.0-main.tgz` is still pushed alongside it.
- [ ] Confirm a Flux HelmRelease with a `>=0.0.0-main` / `0.0.0-main.*` semver range picks up the new build.