### PR TITLE
refactor(connections): one Secret, N hosts — fix git clone on github.com (#219)

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-14
+Last verified: 2026-05-15
 
 ## Motivated by
 
@@ -152,9 +152,9 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
 
 - **OAuth-issued tokens** (GitHub, MCP servers, Generic OAuth apps) — the
   api-server's `/api/oauth/callback` writes the access + refresh token
-  pair, with an `platform.ai/host-pattern` annotation naming the upstream
-  host the token belongs to. The refresh-token loop re-mints access
-  tokens before expiry; the agent never sees the refresh token.
+  pair plus a structured **host list** describing every wire position
+  the token should be injected on. The refresh-token loop re-mints
+  access tokens before expiry; the agent never sees the refresh token.
 - **User-supplied secrets** (Anthropic API keys, generic API tokens) —
   the secrets module writes them with the same labels and annotations.
 - **GitHub personal access tokens** — one PAT is *two* `generic` Secrets
@@ -168,6 +168,24 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
   only and a partial-create rolls back the api half if the git half
   fails). Picker UIs group the pair client-side by display name and
   hide orphans (one host missing).
+
+**Multi-host connections.** A single OAuth connection can inject the
+same token on more than one host with **different auth schemes per
+host**, all from one K8s Secret. The Secret carries a JSON
+`platform.ai/injection-hosts` annotation listing each
+`{host, headerName?, valueFormat?, encoding?, pathPattern?}` tuple; the
+controller fans the Secret into one Envoy filter chain per entry,
+mounting the Secret once and reading a per-host SDS file
+(`host-<sha8>.sds.yaml`) inside it per chain. The same list drives the
+egress allowlist (one `connection:<id>` rule per host) — there is no
+second source of truth.
+
+GitHub.com is the motivating case ([issue #219](https://github.com/dam-agents/dam/issues/219)):
+the same OAuth token must reach `api.github.com` as
+`Authorization: Bearer …`, `github.com` as
+`Authorization: Basic base64("x-access-token:<token>")` (so `git clone`
+of private repos works without a credential helper), and
+`raw.githubusercontent.com` as `Bearer` again (raw-file fetches).
 
 The Secret carries the SDS YAML Envoy reads via its `path_config_source`.
 Only the gateway pod mounts the Secret; the agent pod does not. See

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Last verified: 2026-05-06
+Last verified: 2026-05-15
 
 ## Motivated by
 
@@ -133,7 +133,10 @@ Boot-time wiring runs `gh auth setup-git` once before the tRPC server starts, so
 Agent-runtime never holds a real GitHub token. The paired gateway pod performs the swap:
 
 1. The agent pod's `HTTPS_PROXY` is `http://<instance>-gateway:<envoy-port>` — the per-instance gateway Service DNS ([ADR-038](../adrs/038-paired-gateway-pod.md)). The agent pod's NetworkPolicy admits no other route to TCP 80/443, so credential injection is enforced by the cluster, not by the agent honoring an env var. `SSL_CERT_FILE` points at the cluster-issued MITM CA so TLS termination on the gateway succeeds ([security-and-credentials](security-and-credentials.md)).
-2. Envoy's host-specific filter chain for `api.github.com` injects `Authorization: Bearer <user's GitHub OAuth token>` from a K8s Secret mounted only on the gateway pod (labelled `platform.ai/owner=<sub>` and `platform.ai/connection=github` or similar), then re-originates upstream TLS to the real host.
+2. Envoy renders **three** host-specific filter chains for one GitHub OAuth Secret ([issue #219](https://github.com/dam-agents/dam/issues/219)). One Secret, three chains, three auth shapes; the Secret carries a per-host SDS file (`host-<sha8>.sds.yaml`) for each chain to read:
+   - `api.github.com` — `Authorization: Bearer <token>` (REST/GraphQL API).
+   - `github.com` — `Authorization: Basic base64("x-access-token:<token>")` (the HTTP Basic shape `git` over HTTPS expects, so private `git clone` / `git fetch` / `git push` work with no credential helper).
+   - `raw.githubusercontent.com` — `Authorization: Bearer <token>` (private raw-file fetches).
 3. agent-runtime makes its API calls without authenticating — Envoy supplies the credential.
 
 If the user has not connected GitHub, no Secret exists and the request leaves authenticated only when the agent has supplied its own token. The agent runtime exposes `PLATFORM_GH_TOKEN_AVAILABLE=true|false` so wrapper scripts can short-circuit instead of making a 401-eliciting request first.

--- a/packages/api-server/src/__tests__/unit/k8s-connections-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/k8s-connections-port.test.ts
@@ -3,11 +3,14 @@ import type * as k8s from "@kubernetes/client-node";
 
 import {
   connectionSecretName,
+  CONNECTION_SCHEMA_VERSION,
   createK8sConnectionsPort,
   listAllConnectionWorkItems,
   markConnectionExpired,
   readConnectionForRefresh,
+  sdsFileKeyForHost,
   writeRefreshedTokens,
+  type ConnectionMetadata,
 } from "../../modules/connections/infrastructure/k8s-connections-port.js";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
 
@@ -64,15 +67,30 @@ function fakeClient() {
   return { client, store };
 }
 
-const SAMPLE_METADATA = {
-  hostPattern: "mcp.example.com",
-  headerName: "Authorization",
-  valueFormat: "Bearer {value}",
+// Simplest legal ConnectionMetadata — single host, default scheme.
+const SAMPLE_METADATA: ConnectionMetadata = {
+  hosts: [{ host: "mcp.example.com" }],
   tokenUrl: "https://mcp.example.com/oauth/token",
   clientId: "client-123",
   clientSecret: "client-secret",
-  grantType: "authorization_code" as const,
+  grantType: "authorization_code",
 };
+
+function decode(secret: k8s.V1Secret, key: string): string {
+  return Buffer.from(secret.data![key]!, "base64").toString();
+}
+
+// Issue #219: the file key must agree byte-for-byte with the controller's
+// `sdsFileKeyForHost`. The Go side has a mirroring test pinning these.
+describe("sdsFileKeyForHost", () => {
+  it.each([
+    ["api.github.com", "host-01892413.sds.yaml"],
+    ["github.com", "host-c2208abd.sds.yaml"],
+    ["raw.githubusercontent.com", "host-3cf88e0a.sds.yaml"],
+  ])("sdsFileKeyForHost(%s) === %s", (host, expected) => {
+    expect(sdsFileKeyForHost(host)).toBe(expected);
+  });
+});
 
 describe("connectionSecretName", () => {
   it("hashes both owner and connection so the name fits RFC 1123", () => {
@@ -93,8 +111,8 @@ describe("connectionSecretName", () => {
   });
 });
 
-describe("K8sConnectionsPort.upsertConnection", () => {
-  it("writes labels, annotations, and the SDS-formatted access token", async () => {
+describe("K8sConnectionsPort.upsertConnection — single-host", () => {
+  it("writes one SDS file under host-<sha>.sds.yaml and the structured hosts annotation", async () => {
     const { client, store } = fakeClient();
     const port = createK8sConnectionsPort(client, "owner-1");
 
@@ -107,29 +125,25 @@ describe("K8sConnectionsPort.upsertConnection", () => {
     const name = connectionSecretName("owner-1", "mcp.example.com");
     const secret = store.get(name);
     expect(secret).toBeDefined();
-    expect(secret!.metadata?.labels?.["agent-platform.ai/owner"]).toBe("owner-1");
-    expect(secret!.metadata?.labels?.["agent-platform.ai/managed-by"]).toBe("api-server");
-    expect(secret!.metadata?.labels?.["agent-platform.ai/secret-type"]).toBe("connection");
+    const ann = secret!.metadata!.annotations!;
     expect(secret!.metadata?.labels?.["agent-platform.ai/connection"]).toBe(
       "mcp.example.com",
     );
-    expect(secret!.metadata?.annotations?.["agent-platform.ai/host-pattern"]).toBe(
-      "mcp.example.com",
-    );
-    expect(secret!.metadata?.annotations?.["agent-platform.ai/expires-at"]).toBe("9999");
-    expect(secret!.metadata?.annotations?.["agent-platform.ai/grant-type"]).toBe(
-      "authorization_code",
-    );
-    expect(secret!.metadata?.annotations?.["agent-platform.ai/connection-status"]).toBe(
-      "active",
-    );
-    // The access token reaches the sidecar via sds.yaml — header prefix baked in.
-    const sds = Buffer.from(secret!.data!["sds.yaml"]!, "base64").toString();
-    expect(sds).toContain('inline_string: "Bearer tok-1"');
-    // The refresh-loop reads the raw token + refresh token + client id directly.
-    expect(Buffer.from(secret!.data!["raw_access_token"]!, "base64").toString()).toBe("tok-1");
-    expect(Buffer.from(secret!.data!["refresh_token"]!, "base64").toString()).toBe("ref-1");
-    expect(Buffer.from(secret!.data!["client_id"]!, "base64").toString()).toBe("client-123");
+    // Schema version pinned — future bumps drive migrations.
+    expect(ann["agent-platform.ai/schema-version"]).toBe(CONNECTION_SCHEMA_VERSION);
+    expect(ann["agent-platform.ai/host-patterns"]).toBe("mcp.example.com");
+    expect(JSON.parse(ann["agent-platform.ai/injection-hosts"]!)).toEqual([
+      { host: "mcp.example.com" },
+    ]);
+    expect(ann["agent-platform.ai/expires-at"]).toBe("9999");
+    expect(ann["agent-platform.ai/connection-status"]).toBe("active");
+    // Per-host SDS file, no generic `sds.yaml`.
+    const fileKey = sdsFileKeyForHost("mcp.example.com");
+    expect(decode(secret!, fileKey)).toContain('inline_string: "Bearer tok-1"');
+    expect(decode(secret!, "raw_access_token")).toBe("tok-1");
+    expect(decode(secret!, "refresh_token")).toBe("ref-1");
+    expect(decode(secret!, "client_id")).toBe("client-123");
+    expect(secret!.data!["sds.yaml"]).toBeUndefined();
   });
 
   it("preserves connectedAt across upserts (so re-auth doesn't reset the timestamp)", async () => {
@@ -152,6 +166,166 @@ describe("K8sConnectionsPort.upsertConnection", () => {
     });
     expect(store.get(name)!.metadata!.annotations!["agent-platform.ai/connected-at"]).toBe(firstConnectedAt);
   });
+
+  it("rejects metadata with an empty hosts list (caller bug)", async () => {
+    const { client } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+    await expect(
+      port.upsertConnection({
+        connection: "broken",
+        tokens: { accessToken: "t" },
+        metadata: { ...SAMPLE_METADATA, hosts: [] },
+      }),
+    ).rejects.toThrow(/hosts is empty/);
+  });
+});
+
+// Issue #219: one OAuth token, three hosts, three auth schemes. These
+// pin both the K8s Secret shape and the refresh-loop interactions.
+describe("K8sConnectionsPort — multi-host (issue #219)", () => {
+  const GITHUB_METADATA: ConnectionMetadata = {
+    hosts: [
+      { host: "api.github.com" },
+      {
+        host: "github.com",
+        valueFormat: "Basic {value}",
+        encoding: "basic-x-access-token",
+      },
+      { host: "raw.githubusercontent.com" },
+    ],
+    tokenUrl: "https://github.com/login/oauth/access_token",
+    clientId: "github-client",
+    clientSecret: "github-secret",
+    grantType: "authorization_code",
+  };
+
+  it("writes one SDS file per host inside the same Secret", async () => {
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "tok-1", refreshToken: "ref-1", expiresAt: 1000 },
+      metadata: GITHUB_METADATA,
+    });
+
+    const name = connectionSecretName("owner-1", "github");
+    const secret = store.get(name)!;
+    // One Secret, one mount, three chains.
+    expect(Array.from(store.values())).toHaveLength(1);
+    expect(secret.metadata?.annotations?.["agent-platform.ai/host-patterns"]).toBe(
+      "api.github.com,github.com,raw.githubusercontent.com",
+    );
+    const parsed = JSON.parse(
+      secret.metadata!.annotations!["agent-platform.ai/injection-hosts"]!,
+    );
+    expect(parsed).toEqual(GITHUB_METADATA.hosts);
+
+    const apiSds = decode(secret, sdsFileKeyForHost("api.github.com"));
+    expect(apiSds).toContain('inline_string: "Bearer tok-1"');
+
+    // github.com: HTTP Basic, username `x-access-token`. Makes `git clone` work.
+    const wwwSds = decode(secret, sdsFileKeyForHost("github.com"));
+    const expectedB64 = Buffer.from("x-access-token:tok-1", "utf8").toString("base64");
+    expect(wwwSds).toContain(`inline_string: "Basic ${expectedB64}"`);
+
+    const rawSds = decode(secret, sdsFileKeyForHost("raw.githubusercontent.com"));
+    expect(rawSds).toContain('inline_string: "Bearer tok-1"');
+  });
+
+  it("getConnection round-trips the full hosts list (no information loss)", async () => {
+    const { client } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "tok", refreshToken: "ref", expiresAt: 12345 },
+      metadata: GITHUB_METADATA,
+    });
+
+    const got = await port.getConnection("github");
+    expect(got).not.toBeNull();
+    expect(got!.metadata.hosts).toEqual(GITHUB_METADATA.hosts);
+    expect(got!.tokens.accessToken).toBe("tok");
+    expect(got!.tokens.refreshToken).toBe("ref");
+    expect(got!.metadata.clientId).toBe("github-client");
+    expect(got!.metadata.clientSecret).toBe("github-secret");
+  });
+
+  it("listConnections surfaces the host list (no twins, no descriptor lookup needed)", async () => {
+    const { client } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "tok-1" },
+      metadata: GITHUB_METADATA,
+    });
+
+    const list = await port.listConnections();
+    expect(list).toHaveLength(1);
+    expect(list[0]!.connection).toBe("github");
+    expect(list[0]!.hosts).toEqual([
+      "api.github.com",
+      "github.com",
+      "raw.githubusercontent.com",
+    ]);
+  });
+
+  it("re-upsert with fewer hosts removes stale SDS files (no leftovers)", async () => {
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "tok-1" },
+      metadata: GITHUB_METADATA,
+    });
+    const name = connectionSecretName("owner-1", "github");
+    expect(store.get(name)!.data![sdsFileKeyForHost("github.com")]).toBeDefined();
+
+    // Reconnect with one host — dropped hosts' SDS files must go.
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "tok-1" },
+      metadata: { ...GITHUB_METADATA, hosts: [{ host: "api.github.com" }] },
+    });
+    const after = store.get(name)!;
+    expect(after.data![sdsFileKeyForHost("api.github.com")]).toBeDefined();
+    expect(after.data![sdsFileKeyForHost("github.com")]).toBeUndefined();
+    expect(after.data![sdsFileKeyForHost("raw.githubusercontent.com")]).toBeUndefined();
+  });
+
+  it("writeRefreshedTokens re-renders every host's SDS file from the new token", async () => {
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "old", refreshToken: "ref-old", expiresAt: 100 },
+      metadata: GITHUB_METADATA,
+    });
+    const name = connectionSecretName("owner-1", "github");
+    const loaded = await readConnectionForRefresh(client, name);
+    expect(loaded).not.toBeNull();
+
+    await writeRefreshedTokens(
+      client,
+      name,
+      { accessToken: "rotated", refreshToken: "ref-new", expiresAt: 200 },
+      loaded!.record.metadata,
+    );
+
+    const after = store.get(name)!;
+    const apiSds = decode(after, sdsFileKeyForHost("api.github.com"));
+    expect(apiSds).toContain('inline_string: "Bearer rotated"');
+    const wwwSds = decode(after, sdsFileKeyForHost("github.com"));
+    const expectedB64 = Buffer.from("x-access-token:rotated", "utf8").toString("base64");
+    expect(wwwSds).toContain(`inline_string: "Basic ${expectedB64}"`);
+    const rawSds = decode(after, sdsFileKeyForHost("raw.githubusercontent.com"));
+    expect(rawSds).toContain('inline_string: "Bearer rotated"');
+    expect(decode(after, "refresh_token")).toBe("ref-new");
+  });
 });
 
 describe("K8sConnectionsPort.listConnections", () => {
@@ -163,12 +337,12 @@ describe("K8sConnectionsPort.listConnections", () => {
     await a.upsertConnection({
       connection: "x.example.com",
       tokens: { accessToken: "t", expiresAt: 100 },
-      metadata: { ...SAMPLE_METADATA, hostPattern: "x.example.com" },
+      metadata: { ...SAMPLE_METADATA, hosts: [{ host: "x.example.com" }] },
     });
     await b.upsertConnection({
       connection: "y.example.com",
       tokens: { accessToken: "t", expiresAt: 200 },
-      metadata: { ...SAMPLE_METADATA, hostPattern: "y.example.com" },
+      metadata: { ...SAMPLE_METADATA, hosts: [{ host: "y.example.com" }] },
     });
 
     const aList = await a.listConnections();
@@ -214,6 +388,7 @@ describe("K8sConnectionsPort.getConnection", () => {
     expect(got!.metadata.clientId).toBe("client-123");
     expect(got!.metadata.clientSecret).toBe("client-secret");
     expect(got!.metadata.grantType).toBe("authorization_code");
+    expect(got!.metadata.hosts).toEqual([{ host: "mcp.example.com" }]);
     expect(got!.status).toBe("active");
   });
 
@@ -225,7 +400,7 @@ describe("K8sConnectionsPort.getConnection", () => {
     await a.upsertConnection({
       connection: "shared.example.com",
       tokens: { accessToken: "t" },
-      metadata: { ...SAMPLE_METADATA, hostPattern: "shared.example.com" },
+      metadata: { ...SAMPLE_METADATA, hosts: [{ host: "shared.example.com" }] },
     });
     expect(await b.getConnection("shared.example.com")).toBeNull();
   });
@@ -240,12 +415,12 @@ describe("listAllConnectionWorkItems / writeRefreshedTokens / markConnectionExpi
     await a.upsertConnection({
       connection: "x.example.com",
       tokens: { accessToken: "t", refreshToken: "r", expiresAt: 100 },
-      metadata: { ...SAMPLE_METADATA, hostPattern: "x.example.com" },
+      metadata: { ...SAMPLE_METADATA, hosts: [{ host: "x.example.com" }] },
     });
     await b.upsertConnection({
       connection: "y.example.com",
       tokens: { accessToken: "t", refreshToken: "r", expiresAt: 200 },
-      metadata: { ...SAMPLE_METADATA, hostPattern: "y.example.com" },
+      metadata: { ...SAMPLE_METADATA, hosts: [{ host: "y.example.com" }] },
     });
 
     const items = await listAllConnectionWorkItems(client);
@@ -277,7 +452,7 @@ describe("listAllConnectionWorkItems / writeRefreshedTokens / markConnectionExpi
     expect(after!.tokens.accessToken).toBe("new");
     expect(after!.tokens.refreshToken).toBe("ref-new");
     expect(after!.tokens.expiresAt).toBe(200);
-    expect(after!.metadata.hostPattern).toBe("mcp.example.com");
+    expect(after!.metadata.hosts).toEqual([{ host: "mcp.example.com" }]);
     expect(after!.status).toBe("active");
   });
 

--- a/packages/api-server/src/__tests__/unit/oauth-apps.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-apps.test.ts
@@ -107,6 +107,21 @@ describe("OAuth app registry — descriptors", () => {
     const reg = createOAuthAppRegistry();
     expect(reg.get("not-a-real-app")).toBeNull();
   });
+
+  // Issue #219: github's `hosts` covers REST API, `git`, and raw-fetch.
+  it("the github descriptor declares three injection hosts with their auth schemes", () => {
+    const reg = createOAuthAppRegistry();
+    const github = reg.get("github")!;
+    expect(github.hosts).toEqual([
+      { host: "api.github.com" },
+      {
+        host: "github.com",
+        valueFormat: "Basic {value}",
+        encoding: "basic-x-access-token",
+      },
+      { host: "raw.githubusercontent.com" },
+    ]);
+  });
 });
 
 describe("OAuth app registry — build()", () => {
@@ -123,9 +138,18 @@ describe("OAuth app registry — build()", () => {
     expect(built.provider.clientId).toBe("id");
     expect(built.provider.clientSecret).toBe("sec");
     expect(built.provider.scopes).toEqual(["repo", "read:user", "user:email"]);
+    // Issue #219: three hosts, three schemes, one OAuth dance.
     expect(built.flow).toEqual({
       connectionKey: "github",
-      hostPattern: "api.github.com",
+      hosts: [
+        { host: "api.github.com" },
+        {
+          host: "github.com",
+          valueFormat: "Basic {value}",
+          encoding: "basic-x-access-token",
+        },
+        { host: "raw.githubusercontent.com" },
+      ],
       displayName: "GitHub",
       envMappings: [{ envName: "GH_TOKEN", placeholder: "dummy-placeholder" }],
     });
@@ -145,7 +169,7 @@ describe("OAuth app registry — build()", () => {
     expect(built.provider.tokenEndpoint).toBe(
       "https://ghe.example.com/login/oauth/access_token",
     );
-    expect(built.flow.hostPattern).toBe("ghe.example.com");
+    expect(built.flow.hosts).toEqual([{ host: "ghe.example.com" }]);
     expect(built.flow.connectionKey).toBe("github-enterprise");
     expect(built.flow.envMappings).toEqual([
       { envName: "GH_TOKEN", placeholder: "dummy-placeholder" },
@@ -180,7 +204,10 @@ describe("OAuth app registry — build()", () => {
     });
     expect(built.flow).toEqual({
       connectionKey: "google-drive",
-      hostPattern: "www.googleapis.com",
+      hosts: [
+        { host: "www.googleapis.com", pathPattern: "/drive/*" },
+        { host: "www.googleapis.com", pathPattern: "/upload/drive/*" },
+      ],
       displayName: "Google Drive",
     });
     expect(built.connectionDisplayName).toBe("Google Drive");
@@ -189,7 +216,7 @@ describe("OAuth app registry — build()", () => {
   it("Google Health uses the health.googleapis.com host and health-specific scopes", () => {
     const reg = createOAuthAppRegistry();
     const built = reg.build("google-health", { clientId: "id", clientSecret: "sec" });
-    expect(built.flow.hostPattern).toBe("health.googleapis.com");
+    expect(built.flow.hosts.map((h) => h.host)).toEqual(["health.googleapis.com"]);
     expect(built.provider.scopes).toContain(
       "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly",
     );
@@ -212,7 +239,7 @@ describe("OAuth app registry — build()", () => {
     expect(built.provider.scopes).toContain("user-modify-playback-state");
     expect(built.flow).toEqual({
       connectionKey: "spotify",
-      hostPattern: "api.spotify.com",
+      hosts: [{ host: "api.spotify.com" }],
       displayName: "Spotify",
     });
     expect(built.flow.envMappings).toBeUndefined();
@@ -244,7 +271,7 @@ describe("OAuth app registry — build()", () => {
     expect(built.provider.authorizationUrl).toBe("https://linear.app/oauth/authorize");
     expect(built.provider.tokenEndpoint).toBe("https://api.linear.app/oauth/token");
     expect(built.provider.scopes).toEqual(["read", "write"]);
-    expect(built.flow.hostPattern).toBe("api.linear.app");
+    expect(built.flow.hosts).toEqual([{ host: "api.linear.app" }]);
     expect(built.flow.connectionKey).toMatch(/^generic-[a-f0-9]{16}$/);
     expect(built.flow.displayName).toBe("Linear");
     expect(built.connectionDisplayName).toBe("Linear");
@@ -431,7 +458,7 @@ describe("OAuth app registry — admin defaults", () => {
       ghe.inputs.filter((i) => !i.overridable && !i.optional).map((i) => i.name),
     ).toEqual([]);
     const built = reg.build("github-enterprise", {});
-    expect(built.flow.hostPattern).toBe("ghe.corp.example");
+    expect(built.flow.hosts).toEqual([{ host: "ghe.corp.example" }]);
     expect(built.provider.authorizationUrl).toBe(
       "https://ghe.corp.example/login/oauth/authorize",
     );

--- a/packages/api-server/src/__tests__/unit/oauth-engine.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-engine.test.ts
@@ -18,7 +18,7 @@ const PROVIDER: OAuthFlowProvider = {
 
 const FLOW: OAuthFlowMetadata = {
   connectionKey: "github",
-  hostPattern: "api.github.com",
+  hosts: [{ host: "api.github.com" }],
 };
 
 describe("oauth-engine.start", () => {

--- a/packages/api-server/src/__tests__/unit/oauth-refresh-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-service.test.ts
@@ -59,9 +59,7 @@ function fakeClient() {
 }
 
 const SAMPLE_METADATA = {
-  hostPattern: "mcp.example.com",
-  headerName: "Authorization",
-  valueFormat: "Bearer {value}",
+  hosts: [{ host: "mcp.example.com" }],
   tokenUrl: "https://mcp.example.com/oauth/token",
   clientId: "client-123",
   grantType: "authorization_code" as const,
@@ -152,7 +150,7 @@ describe("oauth-refresh-service", () => {
     await port.upsertConnection({
       connection: "svc.example.com",
       tokens: { accessToken: "tok", refreshToken: "ref", expiresAt: NOW_MS / 1000 + 30 },
-      metadata: { ...SAMPLE_METADATA, grantType: "client_credentials", hostPattern: "svc.example.com" },
+      metadata: { ...SAMPLE_METADATA, grantType: "client_credentials", hosts: [{ host: "svc.example.com" }] },
     });
 
     const fetchImpl = vi.fn() as unknown as typeof fetch;
@@ -414,5 +412,69 @@ describe("oauth-refresh-service", () => {
     const after = store.get(connectionSecretName("owner-1", "mcp.example.com"))!;
     expect(decode(after, "refresh_token")).toBe("ref-keep");
     expect(decode(after, "raw_access_token")).toBe("new");
+  });
+
+  // Issue #219: refresh re-renders every host's SDS file in one write.
+  it("re-renders every host's SDS file on refresh (multi-host connection)", async () => {
+    const { client, store } = fakeClient();
+    const port = createK8sConnectionsPort(client, "owner-1");
+
+    const NOW_MS = 1_700_000_000_000;
+    await port.upsertConnection({
+      connection: "github",
+      tokens: { accessToken: "old", refreshToken: "ref-old", expiresAt: NOW_MS / 1000 + 60 },
+      metadata: {
+        hosts: [
+          { host: "api.github.com" },
+          {
+            host: "github.com",
+            valueFormat: "Basic {value}",
+            encoding: "basic-x-access-token",
+          },
+          { host: "raw.githubusercontent.com" },
+        ],
+        tokenUrl: "https://github.com/login/oauth/access_token",
+        clientId: "github-client",
+        clientSecret: "github-secret",
+        grantType: "authorization_code",
+      },
+    });
+
+    const fetchImpl = vi.fn(async () =>
+      new Response(
+        JSON.stringify({
+          access_token: "rotated",
+          refresh_token: "ref-new",
+          expires_in: 3600,
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } },
+      ),
+    ) as unknown as typeof fetch;
+
+    const svc = createOAuthRefreshService({
+      k8sClient: client,
+      fetchImpl,
+      now: () => NOW_MS,
+      log: () => {},
+    });
+    await svc.tick();
+
+    // Single endpoint call — one Secret per connection.
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const { sdsFileKeyForHost } = await import(
+      "../../modules/connections/infrastructure/k8s-connections-port.js"
+    );
+    const secret = store.get(connectionSecretName("owner-1", "github"))!;
+    expect(decode(secret, sdsFileKeyForHost("api.github.com"))).toContain(
+      'inline_string: "Bearer rotated"',
+    );
+    const expectedB64 = Buffer.from("x-access-token:rotated", "utf8").toString("base64");
+    expect(decode(secret, sdsFileKeyForHost("github.com"))).toContain(
+      `inline_string: "Basic ${expectedB64}"`,
+    );
+    expect(decode(secret, sdsFileKeyForHost("raw.githubusercontent.com"))).toContain(
+      'inline_string: "Bearer rotated"',
+    );
   });
 });

--- a/packages/api-server/src/apps/api-server/oauth.ts
+++ b/packages/api-server/src/apps/api-server/oauth.ts
@@ -189,7 +189,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
           const displayName =
             conn.displayName ??
             (app.id === "github-enterprise"
-              ? `${app.displayName} (${conn.hostPattern})`
+              ? `${app.displayName} (${conn.hosts[0] ?? ""})`
               : app.displayName);
           const connectionId =
             app.cardinality === "single" ? app.id : conn.connection;
@@ -197,7 +197,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
             appId: app.id,
             connectionId,
             displayName,
-            hostPattern: conn.hostPattern,
+            hosts: conn.hosts,
             connectedAt: conn.connectedAt ?? "",
             expired,
             // Surfaces the GitHub App slug when the connection's credentials
@@ -375,7 +375,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
         ...(regData.client_secret ? { clientSecret: regData.client_secret } : {}),
         ...(meta.scopes && meta.scopes.length > 0 ? { scopes: meta.scopes } : {}),
       },
-      flow: { connectionKey: hostPattern, hostPattern },
+      flow: { connectionKey: hostPattern, hosts: [{ host: hostPattern }] },
       redirectUri,
       userJwt: jwt,
       userSub: user.sub,
@@ -418,9 +418,9 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
     const isMcp = pending.provider.id.startsWith("mcp:");
 
     const metadata: ConnectionMetadata = {
-      hostPattern: pending.flow.hostPattern,
-      headerName: "Authorization",
-      valueFormat: "Bearer {value}",
+      // Authoritative for both injection and egress. GitHub declares
+      // three (issue #219); other apps one each.
+      hosts: pending.flow.hosts,
       tokenUrl: pending.provider.tokenEndpoint,
       authorizationUrl: pending.provider.authorizationUrl,
       clientId: pending.provider.clientId,
@@ -431,6 +431,11 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
         ? { scopes: pending.provider.scopes.join(" ") }
         : {}),
       ...(pending.flow.appSlug ? { appSlug: pending.flow.appSlug } : {}),
+      // Declarative env-var declarations (`GH_TOKEN`, `GH_HOST`, …)
+      // sourced from the descriptor's `flow.envMappings`. The controller
+      // materialises these as agent pod env vars; without this the
+      // controller falls back to host-specific hardcodes.
+      ...(pending.flow.envMappings?.length ? { envMappings: pending.flow.envMappings } : {}),
     };
     try {
       await k8sConnectionsFor(pending.userSub).upsertConnection({
@@ -456,7 +461,7 @@ export function createOAuthRoutes(deps: OAuthRoutesDeps) {
     // surface the previous server-side install bounce required.
     const successParams = new URLSearchParams();
     successParams.set("oauth", "success");
-    if (isMcp) successParams.set("host", pending.flow.hostPattern);
+    if (isMcp) successParams.set("host", pending.flow.hosts[0]!.host);
     else successParams.set("app", pending.flow.connectionKey);
     return c.redirect(`${uiBaseUrl}?${successParams.toString()}`);
   });

--- a/packages/api-server/src/modules/connections/domain/host-injection.ts
+++ b/packages/api-server/src/modules/connections/domain/host-injection.ts
@@ -1,0 +1,45 @@
+/**
+ * One credential-injection target on a single host. A connection
+ * (k8s-connections-port) carries a list of these — authoritative for
+ * Envoy filter-chain rendering AND the egress allowlist. See issue #219.
+ */
+export interface ConnectionHostInjection {
+  host: string;
+  /** Path-prefix scoping the egress rule. */
+  pathPattern?: string;
+  /** Default `Authorization`. */
+  headerName?: string;
+  /** Default `Bearer {value}`. */
+  valueFormat?: string;
+  /**
+   * Token transform applied before `{value}` substitution.
+   * `basic-x-access-token` → `base64("x-access-token:" + token)`, paired
+   * with `valueFormat: "Basic {value}"` for `git clone` over HTTPS.
+   */
+  encoding?: "basic-x-access-token";
+}
+
+export const DEFAULT_INJECTION_HEADER = "Authorization";
+export const DEFAULT_INJECTION_VALUE_FORMAT = "Bearer {value}";
+
+export function injectionHeader(h: ConnectionHostInjection): string {
+  return h.headerName ?? DEFAULT_INJECTION_HEADER;
+}
+
+export function injectionValueFormat(h: ConnectionHostInjection): string {
+  return h.valueFormat ?? DEFAULT_INJECTION_VALUE_FORMAT;
+}
+
+/**
+ * Apply the host's `encoding` to the raw access token. Pure; called from
+ * both the connect path and the refresh-loop path.
+ */
+export function encodeAccessToken(
+  rawToken: string,
+  encoding: ConnectionHostInjection["encoding"],
+): string {
+  if (encoding === "basic-x-access-token") {
+    return Buffer.from(`x-access-token:${rawToken}`, "utf8").toString("base64");
+  }
+  return rawToken;
+}

--- a/packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/k8s-connections-port.ts
@@ -1,29 +1,25 @@
 /**
- * OAuth-issued credential storage in K8s Secrets, keyed by `(owner, connection)`.
+ * OAuth credential storage: one K8s Secret per `(owner, connection)`,
+ * carrying N host injections. The controller's Envoy renderer lists by
+ * `owner` + `managed-by=api-server` and fans the Secret into N chains.
  *
- * Stores tokens minted by the API Server's OAuth callback (MCP servers,
- * GitHub, Slack, Google, …). The controller's Envoy renderer
- * (`packages/controller/pkg/reconciler/envoy.go`) lists Secrets by
- * `agent-platform.ai/owner=<sub>,agent-platform.ai/managed-by=api-server`,
- * so connection Secrets land in the sidecar automatically.
- *
- * Each Secret carries:
- *   - `sds.yaml` — SDS DiscoveryResponse the sidecar reads via `path_config_source`
- *   - `refresh_token` / `client_id` / `client_secret` — fields the refresh loop
- *      needs to mint a new access token. Only the access token is in `sds.yaml`;
- *      the refresh token never reaches the sidecar.
- *   - annotations carrying non-secret metadata (host pattern, header, expiry,
- *      token URL, grant type, status). Annotations are listable cheaply, which
- *      the refresh loop needs to find work without reading every Secret body.
- *
- * Secret naming hashes both owner and connection — owners are namespace-scoped
- * `sub` strings (often UUIDs) and connection ids are hostnames or arbitrary
- * keys, neither guaranteed to fit RFC 1123. The hash is stable and short.
+ * Each Secret carries: one `host-<sha8>.sds.yaml` per host (Envoy
+ * reads), `raw_access_token` + `refresh_token` + `client_id`/`client_secret`
+ * (refresh loop), and the structured `injection-hosts` JSON annotation
+ * driving both filter chains and the egress allowlist. Name hashes both
+ * owner and connection to fit RFC 1123.
  */
 import crypto from "node:crypto";
 import type * as k8s from "@kubernetes/client-node";
 
+import type { EnvMapping } from "api-server-api";
+
 import type { K8sClient } from "../../agents/infrastructure/k8s.js";
+import {
+  ConnectionHostInjection,
+  encodeAccessToken,
+  injectionValueFormat,
+} from "../domain/host-injection.js";
 import {
   injectionFileContent,
   sdsYamlContent,
@@ -34,10 +30,11 @@ const LABEL_MANAGED_BY = "agent-platform.ai/managed-by";
 const LABEL_SECRET_TYPE = "agent-platform.ai/secret-type";
 const LABEL_CONNECTION = "agent-platform.ai/connection";
 
-const ANN_HOST_PATTERN = "agent-platform.ai/host-pattern";
-const ANN_PATH_PATTERN = "agent-platform.ai/path-pattern";
-const ANN_HEADER_NAME = "agent-platform.ai/injection-header-name";
-const ANN_VALUE_FORMAT = "agent-platform.ai/injection-value-format";
+// Comma host list — `kubectl` convenience; structured form below is
+// authoritative.
+const ANN_HOST_PATTERNS = "agent-platform.ai/host-patterns";
+// JSON list of `ConnectionHostInjection`. Drives Envoy chains + egress.
+const ANN_INJECTION_HOSTS = "agent-platform.ai/injection-hosts";
 const ANN_EXPIRES_AT = "agent-platform.ai/expires-at";
 const ANN_TOKEN_URL = "agent-platform.ai/token-url";
 const ANN_AUTHORIZATION_URL = "agent-platform.ai/authorization-url";
@@ -47,6 +44,14 @@ const ANN_CONNECTED_AT = "agent-platform.ai/connected-at";
 const ANN_DISPLAY_NAME = "agent-platform.ai/display-name";
 const ANN_SCOPES = "agent-platform.ai/scopes";
 const ANN_APP_SLUG = "agent-platform.ai/app-slug";
+// JSON list of `{envName, placeholder}` the controller materialises as
+// pod env vars on every agent granted this connection. Declarative
+// replacement for the controller's hardcoded github-host switch.
+const ANN_ENV_MAPPINGS = "agent-platform.ai/env-mappings";
+// Schema version stamped on every connection Secret. Bump on every
+// breaking change so future migrations can branch on it.
+const ANN_SCHEMA_VERSION = "agent-platform.ai/schema-version";
+export const CONNECTION_SCHEMA_VERSION = "2";
 
 const SECRET_TYPE_CONNECTION = "connection";
 const NAME_PREFIX = "platform-conn-";
@@ -62,10 +67,11 @@ export interface ConnectionTokens {
 }
 
 export interface ConnectionMetadata {
-  hostPattern: string;
-  pathPattern?: string;
-  headerName: string;
-  valueFormat: string;
+  /**
+   * Hosts this connection injects on. Non-empty; first is the identity
+   * host. One SDS file + one filter chain + one egress rule per entry.
+   */
+  hosts: readonly ConnectionHostInjection[];
   tokenUrl: string;
   /** Authorization endpoint — needed when reconnecting from a stored
    *  connection (e.g. Generic apps where the URLs are user-supplied). */
@@ -88,12 +94,21 @@ export interface ConnectionMetadata {
    * https://github.com/apps/{slug}/installations/new.
    */
   appSlug?: string;
+  /**
+   * Pod env vars to add when this connection is granted (`GH_TOKEN`,
+   * `GH_HOST`, …). Sourced from the OAuth descriptor's `flow.envMappings`;
+   * the controller reads them via the `env-mappings` annotation and emits
+   * one corev1.EnvVar per entry. Declarative replacement for the
+   * controller's hardcoded github-host switch.
+   */
+  envMappings?: readonly EnvMapping[];
 }
 
 export interface ConnectionSummary {
   /** Stable per-owner identifier — usually the upstream hostname. */
   connection: string;
-  hostPattern: string;
+  /** Hostnames this connection injects on, in declared order. */
+  hosts: string[];
   status: ConnectionStatus;
   expiresAt?: number;
   connectedAt?: string;
@@ -142,40 +157,61 @@ export function connectionSecretName(owner: string, connection: string): string 
   return `${NAME_PREFIX}${shortHash(owner)}-${shortHash(connection)}`;
 }
 
+/**
+ * Per-host SDS file key inside the Secret. 8-char SHA prefix is stable
+ * across reconnects; must match the controller's `sdsFileKeyForHost`.
+ */
+export function sdsFileKeyForHost(host: string): string {
+  return `host-${shortHash(host, 8)}.sds.yaml`;
+}
+
 function buildAnnotations(
   metadata: ConnectionMetadata,
   tokens: ConnectionTokens,
   status: ConnectionStatus,
   connectedAt: string,
 ): Record<string, string> {
+  const hostsList = metadata.hosts.map((h) => h.host).join(",");
   const ann: Record<string, string> = {
-    [ANN_HOST_PATTERN]: metadata.hostPattern,
-    [ANN_HEADER_NAME]: metadata.headerName,
-    [ANN_VALUE_FORMAT]: metadata.valueFormat,
+    [ANN_SCHEMA_VERSION]: CONNECTION_SCHEMA_VERSION,
+    [ANN_HOST_PATTERNS]: hostsList,
+    [ANN_INJECTION_HOSTS]: JSON.stringify(metadata.hosts),
     [ANN_TOKEN_URL]: metadata.tokenUrl,
     [ANN_GRANT_TYPE]: metadata.grantType,
     [ANN_CONNECTION_STATUS]: status,
     [ANN_CONNECTED_AT]: connectedAt,
   };
-  if (metadata.pathPattern) ann[ANN_PATH_PATTERN] = metadata.pathPattern;
   if (metadata.authorizationUrl) ann[ANN_AUTHORIZATION_URL] = metadata.authorizationUrl;
   if (metadata.displayName) ann[ANN_DISPLAY_NAME] = metadata.displayName;
   if (metadata.scopes) ann[ANN_SCOPES] = metadata.scopes;
   if (metadata.appSlug) ann[ANN_APP_SLUG] = metadata.appSlug;
+  if (metadata.envMappings?.length) {
+    ann[ANN_ENV_MAPPINGS] = JSON.stringify(metadata.envMappings);
+  }
   if (tokens.expiresAt != null) ann[ANN_EXPIRES_AT] = String(tokens.expiresAt);
   return ann;
 }
 
+/**
+ * Render the Secret's data block. One `host-<sha8>.sds.yaml` per host
+ * with valueFormat pre-substituted (envoyproxy/envoy#37001 — no upstream
+ * prefix template). Raw token + refresh metadata alongside.
+ */
 function buildStringData(
   metadata: ConnectionMetadata,
   tokens: ConnectionTokens,
 ): Record<string, string> {
   const data: Record<string, string> = {
-    "sds.yaml": sdsYamlContent(injectionFileContent(tokens.accessToken, metadata.valueFormat)),
-    access_token: injectionFileContent(tokens.accessToken, metadata.valueFormat),
     raw_access_token: tokens.accessToken,
     client_id: metadata.clientId,
   };
+  for (const h of metadata.hosts) {
+    const encoded = encodeAccessToken(tokens.accessToken, h.encoding);
+    const valueFormat = injectionValueFormat(h);
+    data[sdsFileKeyForHost(h.host)] = sdsYamlContent(
+      injectionFileContent(encoded, valueFormat),
+    );
+  }
   if (tokens.refreshToken) data.refresh_token = tokens.refreshToken;
   if (metadata.clientSecret) data.client_secret = metadata.clientSecret;
   return data;
@@ -187,15 +223,39 @@ function decodeData(secret: k8s.V1Secret, key: string): string | undefined {
   return Buffer.from(raw, "base64").toString("utf8");
 }
 
+function parseHosts(raw: string | undefined): ConnectionHostInjection[] | null {
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return null;
+    // Defend against malformed entries so one bad row doesn't poison the
+    // whole connection.
+    const out: ConnectionHostInjection[] = [];
+    for (const entry of parsed) {
+      if (entry && typeof entry === "object" && typeof (entry as { host?: unknown }).host === "string") {
+        out.push(entry as ConnectionHostInjection);
+      }
+    }
+    return out.length > 0 ? out : null;
+  } catch {
+    return null;
+  }
+}
+
 function readSummary(secret: k8s.V1Secret): ConnectionSummary | null {
   const labels = secret.metadata?.labels ?? {};
   const ann = secret.metadata?.annotations ?? {};
   const connection = labels[LABEL_CONNECTION];
-  const hostPattern = ann[ANN_HOST_PATTERN];
-  if (!connection || !hostPattern) return null;
+  if (!connection) return null;
+  const hosts = parseHosts(ann[ANN_INJECTION_HOSTS]);
+  if (!hosts) return null;
   const status: ConnectionStatus =
     ann[ANN_CONNECTION_STATUS] === "expired" ? "expired" : "active";
-  const summary: ConnectionSummary = { connection, hostPattern, status };
+  const summary: ConnectionSummary = {
+    connection,
+    hosts: hosts.map((h) => h.host),
+    status,
+  };
   const expiresAt = ann[ANN_EXPIRES_AT];
   if (expiresAt) {
     const n = Number(expiresAt);
@@ -217,10 +277,11 @@ function readRecord(secret: k8s.V1Secret): ConnectionRecord | null {
   const refreshToken = decodeData(secret, "refresh_token");
   if (refreshToken) tokens.refreshToken = refreshToken;
   if (summary.expiresAt != null) tokens.expiresAt = summary.expiresAt;
+  // Re-parse the structured hosts; readSummary only kept hostnames.
+  const hosts = parseHosts(ann[ANN_INJECTION_HOSTS]);
+  if (!hosts) return null;
   const metadata: ConnectionMetadata = {
-    hostPattern: summary.hostPattern,
-    headerName: ann[ANN_HEADER_NAME] ?? "Authorization",
-    valueFormat: ann[ANN_VALUE_FORMAT] ?? "Bearer {value}",
+    hosts,
     tokenUrl: ann[ANN_TOKEN_URL] ?? "",
     clientId: decodeData(secret, "client_id") ?? "",
     grantType:
@@ -228,11 +289,18 @@ function readRecord(secret: k8s.V1Secret): ConnectionRecord | null {
         ? "client_credentials"
         : "authorization_code",
   };
-  if (ann[ANN_PATH_PATTERN]) metadata.pathPattern = ann[ANN_PATH_PATTERN];
   if (ann[ANN_AUTHORIZATION_URL]) metadata.authorizationUrl = ann[ANN_AUTHORIZATION_URL];
-  if (ann[ANN_DISPLAY_NAME]) metadata.displayName = ann[ANN_DISPLAY_NAME];
+  if (summary.displayName) metadata.displayName = summary.displayName;
   if (ann[ANN_SCOPES]) metadata.scopes = ann[ANN_SCOPES];
-  if (ann[ANN_APP_SLUG]) metadata.appSlug = ann[ANN_APP_SLUG];
+  if (summary.appSlug) metadata.appSlug = summary.appSlug;
+  if (ann[ANN_ENV_MAPPINGS]) {
+    try {
+      const parsed = JSON.parse(ann[ANN_ENV_MAPPINGS]) as EnvMapping[];
+      if (Array.isArray(parsed) && parsed.length > 0) metadata.envMappings = parsed;
+    } catch {
+      // Bad annotation — skip; the controller is the authoritative reader.
+    }
+  }
   const clientSecret = decodeData(secret, "client_secret");
   if (clientSecret) metadata.clientSecret = clientSecret;
   return {
@@ -252,6 +320,11 @@ export function createK8sConnectionsPort(
 
   return {
     async upsertConnection({ connection, tokens, metadata }) {
+      if (metadata.hosts.length === 0) {
+        throw new Error(
+          `connection ${connection}: metadata.hosts is empty — at least one host is required`,
+        );
+      }
       const name = connectionSecretName(ownerSub, connection);
       const existing = await client.getSecret(name);
       const connectedAt =
@@ -370,9 +443,9 @@ export async function readConnectionForRefresh(
 }
 
 /**
- * Writes a new access/refresh token into an existing connection Secret
- * without touching the immutable injection metadata. Used by the refresh
- * loop after a successful token-endpoint mint.
+ * Writes a refreshed token into an existing connection Secret. Re-renders
+ * every host's SDS file from the new access token — one Secret, N files,
+ * one write.
  */
 export async function writeRefreshedTokens(
   client: K8sClient,
@@ -419,3 +492,4 @@ export async function markConnectionExpired(
     metadata: { ...existing.metadata, annotations: ann },
   });
 }
+

--- a/packages/api-server/src/modules/connections/infrastructure/oauth-apps.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/oauth-apps.ts
@@ -26,6 +26,7 @@ import { z } from "zod";
 
 import { DEFAULT_ENV_PLACEHOLDER, type EnvMapping } from "api-server-api";
 
+import type { ConnectionHostInjection } from "../domain/host-injection.js";
 import {
   type OAuthFlowMetadata,
   type OAuthFlowProvider,
@@ -167,17 +168,12 @@ export interface OAuthAppDescriptor {
    */
   credentialFamily?: string;
   /**
-   * API egress allowlist this descriptor opens when granted to an agent.
-   * Each rule is `{host, pathPattern?}`; multiple rules can target the
-   * same host as long as their path patterns differ (e.g. Drive at
-   * `www.googleapis.com/drive/*` and Calendar at `/calendar/*`).
-   *
-   * Static descriptors declare these here; dynamic-host apps (GHE,
-   * Generic) leave it undefined — the connections-service falls back to
-   * the connection's stored `hostPattern`/`pathPattern` metadata at
-   * grant time, since that's where the user-supplied host lives.
+   * Hosts the OAuth token injects on. Single source of truth for both
+   * credential injection and the egress allowlist. Dynamic-host apps
+   * (GHE/Generic/MCP) leave this undefined and `build()` synthesizes it
+   * from user input.
    */
-  egressHosts?: readonly { host: string; pathPattern?: string }[];
+  hosts?: readonly ConnectionHostInjection[];
 }
 
 export interface BuiltOAuthApp {
@@ -209,32 +205,25 @@ const GOOGLE_BASELINE_SCOPES = ["openid", "email", "profile"];
 interface GoogleServiceDef {
   displayName: string;
   description: string;
-  /** API host the service routes to (used for Envoy SNI / cred injection). */
-  hostPattern: string;
-  /** Service-specific scopes; baseline OIDC scopes are added automatically. */
+  /** Service-specific scopes; baseline OIDC scopes added automatically. */
   scopes: string[];
   /**
-   * Egress allowlist rules opened when this service is granted to an
-   * agent. Mirrors onecli's host_rules table — each rule is the canonical
-   * Google API host plus, for services that share `www.googleapis.com`,
-   * a path-prefix discriminator. Drive's `/drive/` and `/upload/drive/`
-   * coexist with Calendar's `/calendar/` because the path is part of the
-   * rule key.
+   * Hosts the credential injects on AND the egress allowlist. Mirrors
+   * onecli's host_rules table — see `OAuthAppDescriptor.hosts`.
    */
-  egressHosts: readonly { host: string; pathPattern?: string }[];
+  hosts: readonly ConnectionHostInjection[];
 }
 
 const GOOGLE_SERVICES: Record<GoogleServiceId, GoogleServiceDef> = {
   gmail: {
     displayName: "Gmail",
     description: "Read, compose, and send emails via Gmail.",
-    hostPattern: "gmail.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/gmail.readonly",
       "https://www.googleapis.com/auth/gmail.modify",
       "https://www.googleapis.com/auth/gmail.send",
     ],
-    egressHosts: [
+    hosts: [
       { host: "gmail.googleapis.com" },
       { host: "www.googleapis.com", pathPattern: "/gmail/*" },
     ],
@@ -242,53 +231,47 @@ const GOOGLE_SERVICES: Record<GoogleServiceId, GoogleServiceDef> = {
   "google-admin": {
     displayName: "Google Admin",
     description: "Manage users, groups, and devices in Google Workspace.",
-    hostPattern: "admin.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/admin.directory.user"],
-    egressHosts: [{ host: "admin.googleapis.com" }],
+    hosts: [{ host: "admin.googleapis.com" }],
   },
   "google-analytics": {
     displayName: "Google Analytics",
     description: "Access report data and run analytics queries.",
-    hostPattern: "analyticsdata.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/analytics"],
-    egressHosts: [{ host: "analyticsdata.googleapis.com" }],
+    hosts: [{ host: "analyticsdata.googleapis.com" }],
   },
   "google-calendar": {
     displayName: "Google Calendar",
     description: "Read, create, and manage calendar events.",
-    hostPattern: "calendar.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/calendar.readonly",
       "https://www.googleapis.com/auth/calendar.events",
     ],
-    egressHosts: [{ host: "www.googleapis.com", pathPattern: "/calendar/*" }],
+    hosts: [{ host: "www.googleapis.com", pathPattern: "/calendar/*" }],
   },
   "google-classroom": {
     displayName: "Google Classroom",
     description: "Manage classes, rosters, and invitations.",
-    hostPattern: "classroom.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/classroom.courses"],
-    egressHosts: [{ host: "classroom.googleapis.com" }],
+    hosts: [{ host: "classroom.googleapis.com" }],
   },
   "google-docs": {
     displayName: "Google Docs",
     description: "Read, create, and edit Google Docs documents.",
-    hostPattern: "docs.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/drive.readonly",
       "https://www.googleapis.com/auth/drive.file",
     ],
-    egressHosts: [{ host: "docs.googleapis.com" }],
+    hosts: [{ host: "docs.googleapis.com" }],
   },
   "google-drive": {
     displayName: "Google Drive",
     description: "Read, create, and manage files and folders.",
-    hostPattern: "www.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/drive.readonly",
       "https://www.googleapis.com/auth/drive.file",
     ],
-    egressHosts: [
+    hosts: [
       { host: "www.googleapis.com", pathPattern: "/drive/*" },
       { host: "www.googleapis.com", pathPattern: "/upload/drive/*" },
     ],
@@ -296,80 +279,71 @@ const GOOGLE_SERVICES: Record<GoogleServiceId, GoogleServiceDef> = {
   "google-forms": {
     displayName: "Google Forms",
     description: "Read, create, and edit forms and responses.",
-    hostPattern: "forms.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/forms.body"],
-    egressHosts: [{ host: "forms.googleapis.com" }],
+    hosts: [{ host: "forms.googleapis.com" }],
   },
   "google-health": {
     displayName: "Google Health",
     description:
       "Access activity, sleep, and health metrics from Fitbit and connected devices.",
-    hostPattern: "health.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/googlehealth.activity_and_fitness.readonly",
       "https://www.googleapis.com/auth/googlehealth.sleep.readonly",
       "https://www.googleapis.com/auth/googlehealth.health_metrics_and_measurements.readonly",
     ],
-    egressHosts: [{ host: "health.googleapis.com" }],
+    hosts: [{ host: "health.googleapis.com" }],
   },
   "google-meet": {
     displayName: "Google Meet",
     description: "Create and manage meetings.",
-    hostPattern: "meet.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/meetings.space.created"],
-    egressHosts: [{ host: "meet.googleapis.com" }],
+    hosts: [{ host: "meet.googleapis.com" }],
   },
   "google-photos": {
     displayName: "Google Photos",
     description: "Manage photos, videos, and albums.",
-    hostPattern: "photoslibrary.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/photoslibrary"],
-    egressHosts: [{ host: "photoslibrary.googleapis.com" }],
+    hosts: [{ host: "photoslibrary.googleapis.com" }],
   },
   "google-search-console": {
     displayName: "Google Search Console",
     description: "View search traffic data and manage site presence.",
-    hostPattern: "searchconsole.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/webmasters"],
-    egressHosts: [{ host: "searchconsole.googleapis.com" }],
+    hosts: [{ host: "searchconsole.googleapis.com" }],
   },
   "google-sheets": {
     displayName: "Google Sheets",
     description: "Read, create, and edit spreadsheets.",
-    hostPattern: "sheets.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/drive.readonly",
       "https://www.googleapis.com/auth/drive.file",
     ],
-    egressHosts: [{ host: "sheets.googleapis.com" }],
+    hosts: [{ host: "sheets.googleapis.com" }],
   },
   "google-slides": {
     displayName: "Google Slides",
     description: "Read, create, and edit presentations.",
-    hostPattern: "slides.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/drive.readonly",
       "https://www.googleapis.com/auth/drive.file",
     ],
-    egressHosts: [{ host: "slides.googleapis.com" }],
+    hosts: [{ host: "slides.googleapis.com" }],
   },
   "google-tasks": {
     displayName: "Google Tasks",
     description: "Manage task lists and tasks.",
-    hostPattern: "tasks.googleapis.com",
     scopes: ["https://www.googleapis.com/auth/tasks"],
-    egressHosts: [{ host: "tasks.googleapis.com" }],
+    hosts: [{ host: "tasks.googleapis.com" }],
   },
   youtube: {
     displayName: "YouTube",
     description: "Manage playlists, videos, and channel content on YouTube.",
-    hostPattern: "youtube.googleapis.com",
     scopes: [
       "https://www.googleapis.com/auth/youtube.readonly",
       "https://www.googleapis.com/auth/youtube",
       "https://www.googleapis.com/auth/youtube.force-ssl",
     ],
-    egressHosts: [
+    hosts: [
       { host: "youtube.googleapis.com" },
       { host: "www.googleapis.com", pathPattern: "/youtube/*" },
     ],
@@ -397,7 +371,7 @@ function googleService(id: GoogleServiceId): OAuthAppDescriptor {
       { name: "clientSecret", label: "Client secret", secret: true, placeholder: "GOCSPX-…" },
     ],
     credentialFamily: "google",
-    egressHosts: def.egressHosts,
+    hosts: def.hosts,
   };
 }
 
@@ -434,7 +408,16 @@ const DESCRIPTORS: Record<OAuthAppId, OAuthAppDescriptor> = {
         optional: true,
       },
     ],
-    egressHosts: [{ host: "api.github.com" }, { host: "github.com" }],
+    // Issue #219: api (Bearer), www (HTTP Basic for `git clone`), raw (Bearer).
+    hosts: [
+      { host: "api.github.com" },
+      {
+        host: "github.com",
+        valueFormat: "Basic {value}",
+        encoding: "basic-x-access-token",
+      },
+      { host: "raw.githubusercontent.com" },
+    ],
   },
   "github-enterprise": {
     id: "github-enterprise",
@@ -481,7 +464,7 @@ const DESCRIPTORS: Record<OAuthAppId, OAuthAppDescriptor> = {
     // since 2024) but accepts `127.0.0.1`. Reaching the api-server via the
     // catch-all ingress rule on the platform's local-dev cluster.
     localhostCallbackAlias: "127.0.0.1",
-    egressHosts: [{ host: "api.spotify.com" }],
+    hosts: [{ host: "api.spotify.com" }],
   },
   ...googleServiceDescriptors(),
   generic: {
@@ -729,7 +712,7 @@ function buildGithub(input: GithubInput): BuiltOAuthApp {
     },
     flow: {
       connectionKey: "github",
-      hostPattern: "api.github.com",
+      hosts: DESCRIPTORS.github.hosts!,
       displayName: "GitHub",
       envMappings: [GH_TOKEN_ENV_MAPPING],
       ...(input.appSlug ? { appSlug: input.appSlug } : {}),
@@ -751,11 +734,10 @@ function buildGhe(input: GheInput): BuiltOAuthApp {
       tokenEndpointAcceptJson: true,
     },
     flow: {
-      // Single GHE per user for now — connecting a different GHE host
-      // replaces the previous one. Multi-host GHE (key on host hash) is a
-      // follow-up.
+      // Single GHE per user — reconnecting replaces. Multi-host (mirroring
+      // github.com's three-host setup) is out of scope for #219.
       connectionKey: "github-enterprise",
-      hostPattern: host,
+      hosts: [{ host }],
       displayName: `GitHub Enterprise (${host})`,
       // GH_HOST is a literal config value (the user's enterprise host), not a
       // sentinel — `gh` CLI uses it to direct API calls to the right server.
@@ -782,7 +764,7 @@ function buildSpotify(input: SpotifyInput): BuiltOAuthApp {
     },
     flow: {
       connectionKey: "spotify",
-      hostPattern: "api.spotify.com",
+      hosts: DESCRIPTORS.spotify.hosts!,
       displayName: "Spotify",
     },
     connectionDisplayName: "Spotify",
@@ -808,7 +790,7 @@ function buildGoogleService(id: GoogleServiceId, input: GoogleInput): BuiltOAuth
     },
     flow: {
       connectionKey: id,
-      hostPattern: def.hostPattern,
+      hosts: def.hosts,
       displayName: def.displayName,
     },
     connectionDisplayName: def.displayName,
@@ -843,7 +825,7 @@ function buildGeneric(input: GenericInput): BuiltOAuthApp {
     },
     flow: {
       connectionKey: genericConnectionKey(input.hostPattern),
-      hostPattern: input.hostPattern,
+      hosts: [{ host: input.hostPattern }],
       displayName: input.displayName,
     },
     connectionDisplayName: input.displayName,

--- a/packages/api-server/src/modules/connections/infrastructure/oauth-engine.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/oauth-engine.ts
@@ -12,6 +12,8 @@
  */
 import crypto from "node:crypto";
 
+import type { ConnectionHostInjection } from "../domain/host-injection.js";
+
 export interface OAuthFlowProvider {
   /**
    * Stable provider id, primarily used in logs/diagnostics. Storage keying
@@ -38,8 +40,12 @@ export interface OAuthFlowProvider {
 export interface OAuthFlowMetadata {
   /** Storage key under which the resulting tokens land. */
   connectionKey: string;
-  /** Host pattern for downstream credential-injection routing. */
-  hostPattern: string;
+  /**
+   * Hosts this connection injects on. Non-empty; first entry is the
+   * identity host. The controller fans this into one filter chain per
+   * entry. See `ConnectionHostInjection`.
+   */
+  hosts: readonly ConnectionHostInjection[];
   /**
    * Human-readable label saved on the resulting K8s Secret. The static apps
    * derive this from the descriptor; the Generic app passes the user's

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -48,48 +48,20 @@ export function createConnectionsService(deps: {
    * idempotently. (See 034-pod-files-push.)
    */
   podFiles?: PodFilesPublisher;
-  /**
-   * OAuth app registry. Connection egress hosts come from two sources:
-   *   - Static descriptors (`descriptor.egressHosts`) for github, spotify,
-   *     and the Google services — co-located with the descriptor itself.
-   *   - The connection's stored `(hostPattern, pathPattern)` metadata for
-   *     dynamic-host apps (Generic OAuth, GitHub Enterprise) where the
-   *     host is a user-supplied input at connect time.
-   * Replaces the previous helm-mounted provider→hosts map (ADR-035).
-   */
+  /** OAuth app registry. Used at grant time to resolve a connection to its
+   *  static-descriptor host list without a K8s read. Dynamic-host apps
+   *  (Generic, GHE) fall through to `getConnection`. */
   apps?: OAuthAppRegistry;
   /** Egress-rules adapter the composition root supplies. */
   connectionRules?: ConnectionRulesSyncPort;
 }): ConnectionsService {
-  // Resolve a connection's egress host rules. Static descriptors declare
-  // `egressHosts`; dynamic-host apps (Generic, GHE) leave it undefined and
-  // we fall back to the connection's stored hostPattern/pathPattern.
-  function rulesFor(
-    summary: { connection: string; hostPattern: string },
-    record: { metadata?: { hostPattern: string; pathPattern?: string } } | null,
-  ): { host: string; pathPattern?: string }[] {
-    const descriptor = deps.apps?.list().find((a) => matchesAppConnection(a, summary.connection));
-    if (descriptor?.egressHosts && descriptor.egressHosts.length > 0) {
-      return descriptor.egressHosts.map((r) => ({ ...r }));
-    }
-    const host = record?.metadata?.hostPattern ?? summary.hostPattern;
-    if (!host) return [];
-    const pathPattern = record?.metadata?.pathPattern;
-    return [pathPattern ? { host, pathPattern } : { host }];
-  }
-
   return {
     async list() {
       const connections = await deps.port.listConnections();
-      // UI preview takes hostnames only — the path-pattern detail lives on
-      // the rendered egress rules, not the connection summary. Pull from
-      // descriptor.egressHosts where available; for dynamic-host apps the
-      // summary already carries the host that user supplied at connect
-      // time, so no extra K8s round-trip is needed.
+      // Hosts authoritative on the stored connection; no descriptor lookup.
       return connections.map<AppConnectionView>((c) => {
         const provider = c.connection;
-        const rules = rulesFor(c, null);
-        const hostnames = Array.from(new Set(rules.map((r) => r.host)));
+        const hostnames = Array.from(new Set(c.hosts));
         return {
           id: c.connection,
           provider,
@@ -111,32 +83,36 @@ export function createConnectionsService(deps: {
       await deps.grants.setConnectionGrants(agentId, deduped);
 
       if (deps.connectionRules && deps.owner) {
-        // Sync `connection:<id>` egress rules per granted provider's API
-        // host rules (ADR-035). Resolution order per connection:
-        //   1. `descriptor.egressHosts` — static apps (github, spotify,
-        //      Google services) declare their canonical hosts.
-        //   2. The connection's stored `(hostPattern, pathPattern)` —
-        //      dynamic-host apps (Generic, GHE) where the host is user
-        //      input. Pulled via `getConnection` which loads the full
-        //      record (one round-trip per granted dynamic-host conn).
-        const all = await deps.port.listConnections();
+        // Egress rules per granted connection (ADR-035). Two paths:
+        //   1. Static descriptor (github, spotify, Google) — host list is
+        //      a property of the API, declared in code. Read from
+        //      `descriptor.hosts` in memory; no K8s round-trip.
+        //   2. Dynamic descriptor (Generic, GHE) — host is user input at
+        //      connect time. Read from the connection's stored
+        //      `metadata.hosts` via `getConnection`.
         const grants = new Map<string, { hosts: readonly { host: string; pathPattern?: string }[] }>();
-        for (const c of all) {
-          if (!deduped.includes(c.connection)) continue;
+        const all = await deps.port.listConnections();
+        for (const summary of all) {
+          if (!deduped.includes(summary.connection)) continue;
           const descriptor = deps.apps
             ?.list()
-            .find((a) => matchesAppConnection(a, c.connection));
-          let hosts = descriptor?.egressHosts
-            ? descriptor.egressHosts.map((r) => ({ ...r }))
+            .find((a) => matchesAppConnection(a, summary.connection));
+          let hosts: { host: string; pathPattern?: string }[] = descriptor?.hosts
+            ? descriptor.hosts.map((h) => ({
+                host: h.host,
+                ...(h.pathPattern ? { pathPattern: h.pathPattern } : {}),
+              }))
             : [];
           if (hosts.length === 0) {
-            // Dynamic-host fallback — read the connection's user-supplied
-            // host from K8s metadata.
-            const record = await deps.port.getConnection(c.connection);
-            hosts = rulesFor(c, record);
+            const record = await deps.port.getConnection(summary.connection);
+            if (!record) continue;
+            hosts = record.metadata.hosts.map((h) => ({
+              host: h.host,
+              ...(h.pathPattern ? { pathPattern: h.pathPattern } : {}),
+            }));
           }
           if (hosts.length === 0) continue;
-          grants.set(c.connection, { hosts });
+          grants.set(summary.connection, { hosts });
         }
         // ownedSourceIds = every connection id the user owns. Lets the
         // sync revoke this module's rows without touching secret-derived

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -3,6 +3,7 @@ package reconciler
 import (
 	"bytes"
 	"context"
+	"crypto/sha1"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
@@ -35,10 +36,15 @@ const (
 	envoyManagedByLabel   = "agent-platform.ai/managed-by"
 	envoySecretTypeLabel  = "agent-platform.ai/secret-type"
 	envoyConnectionLabel  = "agent-platform.ai/connection"
+	// Non-connection Secrets: single injection target via these.
 	envoyHostPatternAnn   = "agent-platform.ai/host-pattern"
 	envoyHeaderNameAnn    = "agent-platform.ai/injection-header-name"
 	envoyQueryParamAnn    = "agent-platform.ai/injection-query-param"
 	envoyAuthModeAnn      = "agent-platform.ai/auth-mode"
+	// Connection Secrets: N injection targets as JSON. Issue #219. (The
+	// api-server also stamps `agent-platform.ai/host-patterns` for kubectl
+	// readability; the controller doesn't read it.)
+	envoyInjectionHostsAnn = "agent-platform.ai/injection-hosts"
 	// JSON-encoded list of {envName, placeholder} the api-server stamps on a
 	// user-typed credential Secret. Authoritative source for the env vars
 	// the agent harness needs as placeholders (ADR-041). Connection-type
@@ -69,12 +75,12 @@ func EnvoyBootstrapName(instanceName string) string {
 }
 
 // envoyCredential is one injection step in a host's filter chain. Each
-// credentialed K8s Secret renders to one of these; multiple credentials
+// (Secret, host) pair renders to one of these; multiple credentials
 // pointing at the same host stack inside a single `envoyHostChain` so
-// users can express "two injections on the same endpoint" by creating
-// two Secrets with the same host-pattern.
+// users can express "two injections on the same endpoint" by stacking
+// two Secrets or two host entries in one connection Secret.
 type envoyCredential struct {
-	SecretName string // K8s Secret name, used for the per-credential file path
+	SecretName string // K8s Secret name, used for diagnostics + ChainID derivation
 	HeaderName string // header credential_injector writes into
 	// When non-empty, a Lua filter after credential_injector moves the
 	// injected header value into this URL query parameter and strips the
@@ -83,6 +89,10 @@ type envoyCredential struct {
 	// raw value in that case so the URL doesn't grow a `Bearer ` prefix.
 	QueryParamName string
 	VolumeName     string // pod-level volume name for this Secret
+	// SDS file key inside the Secret's volume. Single-host
+	// Secrets use `sds.yaml`; connection Secrets use `host-<sha8>.sds.yaml`
+	// so one Secret carries N chains' credentials (issue #219).
+	SDSFileKey string
 }
 
 // envoyHostChain is one TLS-terminating filter chain. `Credentials` is
@@ -229,14 +239,14 @@ type envMapping struct {
 }
 
 // credentialEnvVars synthesizes the env-var placeholders the agent harness
-// needs so SDKs will dispatch (Envoy overwrites the real header on the wire).
-//
-// Source of truth (ADR-041): the api-server stamps `envoyEnvMappingsAnn` on
-// each user-typed credential Secret. Secrets are pre-sorted by Name in
-// `listOwnerCredentialSecrets`, so the inner dedup gives "first-granted
-// wins" on env-name collisions. When the annotation is missing or malformed
-// the legacy switch fills in the canonical env per secret type — covers
-// connection-type Secrets (no annotation today) and hand-crafted fixtures.
+// needs so SDKs will dispatch (Envoy overwrites the real header on the
+// wire). Source of truth: every Secret stamps `envoyEnvMappingsAnn` with
+// the env it contributes (api-server connections from
+// `flow.envMappings`; secrets module from `defaultEnvMappings`). The
+// anthropic auth-mode switch remains as a fallback for Secrets created
+// via raw `kubectl apply` without the annotation. Secrets are pre-sorted
+// by Name in `listOwnerCredentialSecrets`, so dedup is "first-granted
+// wins" on env-name collisions.
 func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 	const fallbackPlaceholder = "dummy-placeholder"
 	seen := map[string]struct{}{}
@@ -258,9 +268,6 @@ func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 		if raw := s.Annotations[envoyEnvMappingsAnn]; raw != "" {
 			var mappings []envMapping
 			if err := json.Unmarshal([]byte(raw), &mappings); err != nil {
-				// Bad annotation shouldn't crash the reconcile loop, but
-				// silently dropping it produces a pod missing env vars with
-				// no operator visibility — log it so the cause is findable.
 				slog.Warn("invalid env-mappings annotation; skipping",
 					"namespace", s.Namespace, "secret", s.Name, "error", err)
 			} else {
@@ -270,54 +277,120 @@ func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 				continue
 			}
 		}
-		switch s.Labels[envoySecretTypeLabel] {
-		case "anthropic":
+		// Anthropic fallback for hand-crafted Secrets without the
+		// annotation. Every other Secret type relies on env-mappings.
+		if s.Labels[envoySecretTypeLabel] == "anthropic" {
 			if s.Annotations[envoyAuthModeAnn] == "api-key" {
 				envs = add(envs, "ANTHROPIC_API_KEY", fallbackPlaceholder)
 			} else {
 				envs = add(envs, "CLAUDE_CODE_OAUTH_TOKEN", fallbackPlaceholder)
-			}
-		case "connection":
-			host := s.Annotations[envoyHostPatternAnn]
-			if host == "github.com" || host == "api.github.com" {
-				envs = add(envs, "GH_TOKEN", fallbackPlaceholder)
 			}
 		}
 	}
 	return envs
 }
 
-// hasGitHubCredential reports whether any of the owner's K8s credential
-// Secrets target a GitHub host. Used by the reconciler to warn when an
-// instance has no GitHub credential so gh/octokit don't lose auth silently.
-func hasGitHubCredential(secrets []corev1.Secret) bool {
-	for _, s := range secrets {
-		host := s.Annotations[envoyHostPatternAnn]
-		if host == "github.com" || host == "api.github.com" {
+// hasGHTokenEnv reports whether any granted Secret declares `GH_TOKEN`
+// in its env-mappings. Used to set `PLATFORM_GH_TOKEN_AVAILABLE` and to
+// gate the no-credential warning — replaces a hardcoded github-host
+// check with a derivation from the declarative env-mapping spec.
+func hasGHTokenEnv(secrets []corev1.Secret) bool {
+	for _, e := range credentialEnvVars(secrets) {
+		if e.Name == "GH_TOKEN" {
 			return true
 		}
 	}
 	return false
 }
 
-// chainsFromSecrets groups Secrets by host-pattern into one filter chain
-// per host. Multiple credentialed Secrets sharing a host stack as
-// separate `envoyCredential` entries inside the chain — that's how users
-// express "two injections on the same endpoint" (e.g. a header AND a
-// URL query parameter, possibly with different formats).
+// connectionHostInjection mirrors the TS `ConnectionHostInjection`
+// persisted on the `injection-hosts` annotation. Decoded once per Secret
+// and fanned out by `chainsFromSecrets`.
+type connectionHostInjection struct {
+	Host        string `json:"host"`
+	PathPattern string `json:"pathPattern,omitempty"`
+	HeaderName  string `json:"headerName,omitempty"`
+	ValueFormat string `json:"valueFormat,omitempty"`
+	Encoding    string `json:"encoding,omitempty"`
+}
+
+// sdsFileKeyForHost mirrors the api-server's `sdsFileKeyForHost`. MUST
+// stay byte-identical — pinned by tests on both sides. SHA-1 is
+// non-cryptographic use.
+func sdsFileKeyForHost(host string) string {
+	h := sha1.Sum([]byte(host)) // #nosec G401 — non-cryptographic
+	return "host-" + hex.EncodeToString(h[:])[:8] + ".sds.yaml"
+}
+
+// expandConnectionSecret turns a connection Secret into one (host, cred)
+// pair per entry in its `injection-hosts` JSON. Non-connection Secrets
+// remain single-host (handled by the caller).
+type hostCredential struct {
+	host string
+	cred envoyCredential
+}
+
+func expandConnectionSecret(s corev1.Secret) []hostCredential {
+	entries := parseConnectionHosts(s)
+	if len(entries) == 0 {
+		return nil
+	}
+	// Dedup hosts inside one Secret — descriptor bugs or migration
+	// quirks can list the same host twice; emitting two chains for the
+	// same SNI would crash Envoy with duplicate filter chains.
+	seenHost := map[string]struct{}{}
+	out := make([]hostCredential, 0, len(entries))
+	for _, e := range entries {
+		if e.Host == "" {
+			continue
+		}
+		if _, dup := seenHost[e.Host]; dup {
+			slog.Warn("duplicate host in injection-hosts; skipping later entry",
+				"namespace", s.Namespace, "secret", s.Name, "host", e.Host)
+			continue
+		}
+		seenHost[e.Host] = struct{}{}
+		header := e.HeaderName
+		if header == "" {
+			header = "Authorization"
+		}
+		out = append(out, hostCredential{
+			host: e.Host,
+			cred: envoyCredential{
+				SecretName: s.Name,
+				HeaderName: header,
+				VolumeName: "cred-" + s.Name,
+				SDSFileKey: sdsFileKeyForHost(e.Host),
+			},
+		})
+	}
+	return out
+}
+
+// parseConnectionHosts reads `injection-hosts` JSON. Connection Secrets
+// without it are ignored — the api-server always writes the JSON.
+func parseConnectionHosts(s corev1.Secret) []connectionHostInjection {
+	raw := s.Annotations[envoyInjectionHostsAnn]
+	if raw == "" {
+		return nil
+	}
+	var entries []connectionHostInjection
+	if err := json.Unmarshal([]byte(raw), &entries); err != nil {
+		slog.Warn("malformed injection-hosts annotation; skipping",
+			"namespace", s.Namespace, "secret", s.Name, "error", err)
+		return nil
+	}
+	return entries
+}
+
+// chainsFromSecrets groups (Secret, host) pairs into one filter chain
+// per host. Connection Secrets fan into N pairs via `injection-hosts`
+// JSON (issue #219); other types use the legacy `host-pattern`. Within a
+// chain, duplicate header names are dropped (credential_injector
+// overwrite: true would silently clobber) with a warning.
 //
-// Within a chain each credential MUST use a unique header name. Envoy's
-// credential_injector runs in `overwrite: true` mode, so two injectors
-// writing the same header would silently clobber one another. We drop
-// the later one (input is name-sorted upstream) and emit a warning;
-// validating this at api-server create time is the right long-term home
-// but defense-in-depth here keeps the gateway up either way.
-//
-// A host with ONLY allow-only Secrets renders as an uncredentialed
-// chain (MITM termination for the gate, then dynamic_forward_proxy).
-// A host with both allow-only AND credentialed Secrets renders as a
-// credentialed chain — allow-only contributes nothing in that case
-// (it's a path-policy hint, not an instruction to skip injection).
+// Allow-only-only host → uncredentialed chain (MITM gate + dynamic_forward
+// _proxy). Mixed → credentialed chain; allow-only contributes nothing.
 func chainsFromSecrets(secrets []corev1.Secret) []envoyHostChain {
 	type bucket struct {
 		host        string
@@ -327,57 +400,89 @@ func chainsFromSecrets(secrets []corev1.Secret) []envoyHostChain {
 	}
 	byHost := map[string]*bucket{}
 	order := []string{}
-	for _, s := range secrets {
-		host := s.Annotations[envoyHostPatternAnn]
+
+	add := func(host, secretName string, cred *envoyCredential) {
 		if host == "" {
-			continue
+			return
 		}
 		b := byHost[host]
 		if b == nil {
-			b = &bucket{host: host, seenHeader: map[string]string{}, first: s.Name}
+			b = &bucket{host: host, seenHeader: map[string]string{}, first: secretName}
 			byHost[host] = b
 			order = append(order, host)
 		}
-		if s.Labels[envoySecretTypeLabel] == envoySecretTypeAllowOnly {
-			// Allow-only Secrets carry no credential payload — they only
-			// exist to extend the leaf cert's SAN list so the host
-			// terminates on the L7 chain at all. Nothing to add to
-			// `credentials`; if the host has no other credentialed
-			// Secrets the chain stays uncredentialed.
-			continue
+		if cred == nil {
+			return
 		}
-		header := s.Annotations[envoyHeaderNameAnn]
+		header := cred.HeaderName
 		if header == "" {
 			header = "Authorization"
 		}
 		if winner, dup := b.seenHeader[header]; dup {
-			slog.Warn("duplicate injection header on host; later secret skipped to avoid credential_injector clobber",
+			slog.Warn("duplicate injection header on host; later credential skipped to avoid credential_injector clobber",
 				"host", host, "headerName", header,
-				"winningSecret", winner, "skippedSecret", s.Name)
+				"winningSecret", winner, "skippedSecret", secretName)
+			return
+		}
+		b.seenHeader[header] = secretName
+		c := *cred
+		c.HeaderName = header
+		b.credentials = append(b.credentials, c)
+	}
+
+	for _, s := range secrets {
+		switch s.Labels[envoySecretTypeLabel] {
+		case "connection":
+			for _, hc := range expandConnectionSecret(s) {
+				cred := hc.cred
+				add(hc.host, s.Name, &cred)
+			}
 			continue
 		}
-		b.seenHeader[header] = s.Name
-		b.credentials = append(b.credentials, envoyCredential{
+		// Non-connection Secret: single host via the legacy host-pattern
+		// annotation. Allow-only Secrets register the host (extends the
+		// leaf cert SAN list, forces L7 termination) but contribute no
+		// credential.
+		host := s.Annotations[envoyHostPatternAnn]
+		if host == "" {
+			continue
+		}
+		if s.Labels[envoySecretTypeLabel] == envoySecretTypeAllowOnly {
+			add(host, s.Name, nil)
+			continue
+		}
+		cred := envoyCredential{
 			SecretName:     s.Name,
-			HeaderName:     header,
+			HeaderName:     s.Annotations[envoyHeaderNameAnn],
 			QueryParamName: s.Annotations[envoyQueryParamAnn],
 			VolumeName:     "cred-" + s.Name,
-		})
+			SDSFileKey:     envoyCredentialKeySDS,
+		}
+		add(host, s.Name, &cred)
 	}
+
 	chains := make([]envoyHostChain, 0, len(order))
 	for _, host := range order {
 		b := byHost[host]
+		// Suffix the host fingerprint so one Secret driving multiple
+		// hosts (github → 3 chains, #219) doesn't collide on
+		// `chain_<secret>` / `upstream_<secret>`.
 		chains = append(chains, envoyHostChain{
-			// ChainID + UpstreamCluster are derived from the first
-			// Secret's name. Stable across reconciles so kubelet diffs
-			// stay tight when an extra Secret is granted on the host.
-			ChainID:         "chain_" + b.first,
-			UpstreamCluster: "upstream_" + b.first,
+			ChainID:         "chain_" + b.first + "_" + hostShort(host),
+			UpstreamCluster: "upstream_" + b.first + "_" + hostShort(host),
 			Host:            host,
 			Credentials:     b.credentials,
 		})
 	}
 	return chains
+}
+
+// hostShort returns an 8-hex-char fingerprint of a hostname — same prefix
+// shape as `sdsFileKeyForHost` so ChainID / UpstreamCluster stay readable
+// and stable across reconciles.
+func hostShort(host string) string {
+	h := sha1.Sum([]byte(host)) // #nosec G401 — non-cryptographic
+	return hex.EncodeToString(h[:])[:8]
 }
 
 // Bootstrap template — TLS-intercepting CONNECT proxy.
@@ -612,7 +717,7 @@ static_resources:
                             name: {{ $.CredentialSDSName }}
                             sds_config:
                               path_config_source:
-                                path: {{ $.CredentialsRoot }}/{{ $cred.VolumeName }}/{{ $.CredentialFile }}
+                                path: {{ $.CredentialsRoot }}/{{ $cred.VolumeName }}/{{ $cred.SDSFileKey }}
                                 # Watch the Secret-volume mount root, not the
                                 # sds.yaml path. Kubelet rotates the ..data
                                 # symlink inside the mount when a Secret
@@ -953,7 +1058,6 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		Port                   int
 		Chains                 []envoyHostChain
 		CredentialsRoot        string
-		CredentialFile         string
 		CredentialSDSName      string
 		LeafTLSDir             string
 		HarnessAuthority       string
@@ -968,7 +1072,6 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		Port:                   cfg.EnvoyPort,
 		Chains:                 chains,
 		CredentialsRoot:        envoyCredentialsRoot,
-		CredentialFile:         envoyCredentialKeySDS,
 		CredentialSDSName:      envoyCredentialSDSName,
 		LeafTLSDir:             envoyLeafTLSMount,
 		HarnessAuthority:       harnessAuthority,
@@ -1066,26 +1169,23 @@ func ptrBool(b bool) *bool { return &b }
 // Bump on any template change that affects pod-visible behavior.
 const envoyBootstrapTemplateRev = "v10-url-encode-cred"
 
-// envoySecretsRev is a stable digest of the Secret set that drives Envoy's
-// chain rendering: secret name + host + secret-type label + headerName +
-// queryParamName, plus a template-revision marker. Stamped on the pod
-// template so the StatefulSet rolls when any of those change (new
-// credentialed connection, allow-only Secret added, host retargeted,
-// header renamed, query-param flipped on/off, template format bumped).
-// Sort first so reconcile order doesn't churn the hash.
+// envoySecretsRev digests the Secret set that drives Envoy's chain
+// rendering. Includes `injection-hosts` JSON so a descriptor change
+// (host added / removed / retargeted on a connection) rolls the gateway —
+// Envoy reads the bootstrap once at boot, so without a roll the chain
+// shape goes stale.
 func envoySecretsRev(secrets []corev1.Secret) string {
 	parts := []string{"tmpl=" + envoyBootstrapTemplateRev}
 	for _, s := range secrets {
-		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s|%s",
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s|%s|%s",
 			s.Name,
 			s.Annotations[envoyHostPatternAnn],
 			s.Labels[envoySecretTypeLabel],
 			s.Annotations[envoyHeaderNameAnn],
 			s.Annotations[envoyQueryParamAnn],
+			s.Annotations[envoyInjectionHostsAnn],
 		))
 	}
-	// Keep the template marker first; sort the rest so reconcile order
-	// doesn't churn the hash.
 	sort.Strings(parts[1:])
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return hex.EncodeToString(sum[:8])

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -132,6 +132,7 @@ func credentialedChain(secretName, host string) envoyHostChain {
 			SecretName: secretName,
 			HeaderName: "Authorization",
 			VolumeName: "cred-" + secretName,
+			SDSFileKey: envoyCredentialKeySDS,
 		}},
 	}
 }
@@ -155,6 +156,7 @@ func queryParamChain(secretName, host, headerName, queryParamName string) envoyH
 			HeaderName:     headerName,
 			QueryParamName: queryParamName,
 			VolumeName:     "cred-" + secretName,
+			SDSFileKey:     envoyCredentialKeySDS,
 		}},
 	}
 }
@@ -173,11 +175,13 @@ func twoCredentialChain(firstName, secondName, host string) envoyHostChain {
 				SecretName: firstName,
 				HeaderName: "Authorization",
 				VolumeName: "cred-" + firstName,
+				SDSFileKey: envoyCredentialKeySDS,
 			},
 			{
 				SecretName:     secondName,
 				HeaderName:     "X-Internal-Query-" + secondName,
 				QueryParamName: "key",
+				SDSFileKey:     envoyCredentialKeySDS,
 				VolumeName:     "cred-" + secondName,
 			},
 		},
@@ -346,22 +350,104 @@ func TestCredentialEnvVars_MalformedJSONFallsBackToLegacySwitch(t *testing.T) {
 	assert.Equal(t, "dummy-placeholder", envs["ANTHROPIC_API_KEY"])
 }
 
-func TestCredentialEnvVars_MissingAnnotationFallsBackToLegacySwitch(t *testing.T) {
-	// Anthropic OAuth Secret with no `env-mappings` annotation (e.g. the
-	// secret was created via raw `kubectl apply`) — legacy switch fills in
+func TestCredentialEnvVars_AnthropicFallsBackToLegacySwitch(t *testing.T) {
+	// Anthropic Secret with no `env-mappings` annotation (e.g. created
+	// via raw `kubectl apply`) — legacy switch fills in
 	// `CLAUDE_CODE_OAUTH_TOKEN`.
 	oauthSecret := ownerSecret("platform-cred-aaa", "anthropic", "")
 	oauthSecret.Annotations[envoyAuthModeAnn] = "oauth"
 
-	// Connection-type Secret for GitHub — connections don't write
-	// `env-mappings` today, so the legacy switch emits `GH_TOKEN`.
-	ghSecret := ownerSecret("platform-conn-github", "connection", "github")
-	ghSecret.Annotations[envoyHostPatternAnn] = "api.github.com"
-
-	got := credentialEnvVars([]corev1.Secret{oauthSecret, ghSecret})
+	got := credentialEnvVars([]corev1.Secret{oauthSecret})
 	envs := envByName(got)
 	assert.Equal(t, "dummy-placeholder", envs["CLAUDE_CODE_OAUTH_TOKEN"])
+}
+
+func TestCredentialEnvVars_ConnectionEnvMappingsDeclareTheVars(t *testing.T) {
+	// Connection env vars come from the api-server's `env-mappings`
+	// annotation (declarative), not from a host-specific hardcode. A
+	// github connection stamps GH_TOKEN; a GHE connection adds GH_HOST.
+	gh := ownerSecret("platform-conn-github", "connection", "github")
+	delete(gh.Annotations, envoyHostPatternAnn)
+	gh.Annotations[envoyEnvMappingsAnn] = `[{"envName":"GH_TOKEN","placeholder":"dummy-placeholder"}]`
+
+	ghe := ownerSecret("platform-conn-ghe", "connection", "github-enterprise")
+	delete(ghe.Annotations, envoyHostPatternAnn)
+	ghe.Annotations[envoyEnvMappingsAnn] =
+		`[{"envName":"GH_TOKEN","placeholder":"dummy-placeholder"},` +
+			`{"envName":"GH_HOST","placeholder":"ghe.example.com"}]`
+
+	envs := envByName(credentialEnvVars([]corev1.Secret{gh, ghe}))
 	assert.Equal(t, "dummy-placeholder", envs["GH_TOKEN"])
+	// GHE-supplied GH_HOST persists — but GH_TOKEN dedup keeps the
+	// first-granted value (which is the github connection here).
+	assert.Equal(t, "ghe.example.com", envs["GH_HOST"])
+}
+
+func TestChainsFromSecrets_ConnectionSecretFansIntoNChains(t *testing.T) {
+	// Issue #219: one github Secret → three chains, each reading a
+	// per-host SDS file inside the same Secret volume.
+	s := ownerSecret("platform-conn-github", "connection", "github")
+	delete(s.Annotations, envoyHostPatternAnn)
+	s.Annotations[envoyInjectionHostsAnn] = `[
+		{"host":"api.github.com"},
+		{"host":"github.com","valueFormat":"Basic {value}","encoding":"basic-x-access-token"},
+		{"host":"raw.githubusercontent.com"}
+	]`
+
+	chains := chainsFromSecrets([]corev1.Secret{s})
+	require.Len(t, chains, 3)
+
+	hosts := []string{chains[0].Host, chains[1].Host, chains[2].Host}
+	assert.ElementsMatch(t,
+		[]string{"api.github.com", "github.com", "raw.githubusercontent.com"},
+		hosts,
+	)
+
+	// Same Secret volume per chain, distinct per-host SDS file. Keys
+	// must agree with the api-server's `sdsFileKeyForHost`.
+	for _, c := range chains {
+		require.Len(t, c.Credentials, 1)
+		cred := c.Credentials[0]
+		assert.Equal(t, "cred-platform-conn-github", cred.VolumeName)
+		assert.Equal(t, sdsFileKeyForHost(c.Host), cred.SDSFileKey)
+		assert.NotEqual(t, envoyCredentialKeySDS, cred.SDSFileKey,
+			"connection Secrets must use per-host SDS files, not the legacy sds.yaml key")
+	}
+}
+
+func TestChainsFromSecrets_MultiHostSecretYieldsDistinctClusterNames(t *testing.T) {
+	// Regression: one Secret with three hosts must produce three chains
+	// with three DISTINCT UpstreamCluster / ChainID. Envoy refuses to
+	// start with `duplicate cluster '…'` if two chains collide.
+	s := ownerSecret("platform-conn-github", "connection", "github")
+	delete(s.Annotations, envoyHostPatternAnn)
+	s.Annotations[envoyInjectionHostsAnn] = `[
+		{"host":"api.github.com"},
+		{"host":"github.com","valueFormat":"Basic {value}","encoding":"basic-x-access-token"},
+		{"host":"raw.githubusercontent.com"}
+	]`
+
+	chains := chainsFromSecrets([]corev1.Secret{s})
+	require.Len(t, chains, 3)
+
+	clusters := map[string]bool{}
+	chainIDs := map[string]bool{}
+	for _, c := range chains {
+		assert.False(t, clusters[c.UpstreamCluster],
+			"duplicate UpstreamCluster %q would crash Envoy", c.UpstreamCluster)
+		assert.False(t, chainIDs[c.ChainID],
+			"duplicate ChainID %q would clash on listener names", c.ChainID)
+		clusters[c.UpstreamCluster] = true
+		chainIDs[c.ChainID] = true
+	}
+}
+
+func TestSDSFileKeyForHost_StableAndShort(t *testing.T) {
+	// Pinned against the api-server's `sdsFileKeyForHost`. Mismatch =
+	// gateway reads a missing file.
+	assert.Equal(t, "host-01892413.sds.yaml", sdsFileKeyForHost("api.github.com"))
+	assert.Equal(t, "host-c2208abd.sds.yaml", sdsFileKeyForHost("github.com"))
+	assert.Equal(t, "host-3cf88e0a.sds.yaml", sdsFileKeyForHost("raw.githubusercontent.com"))
 }
 
 func TestCredentialEnvVars_AnnotationOverridesLegacyDefault(t *testing.T) {
@@ -546,6 +632,27 @@ func TestEnvoySecretsRev_QueryParamAnnotationRollsExistingPods(t *testing.T) {
 	withParam.Annotations[envoyQueryParamAnn] = "key"
 
 	assert.NotEqual(t, envoySecretsRev([]corev1.Secret{plain}), envoySecretsRev([]corev1.Secret{withParam}))
+}
+
+func TestEnvoySecretsRev_InjectionHostsAnnotationRollsExistingPods(t *testing.T) {
+	// Editing a connection's host list (descriptor change, #219) must
+	// roll the gateway — Envoy reads the bootstrap once at boot, so a
+	// chain-shape change without a roll leaves stale chains running.
+	before := ownerSecret("platform-conn-github", "connection", "github")
+	before.Annotations[envoyInjectionHostsAnn] = `[{"host":"api.github.com"}]`
+
+	after := ownerSecret("platform-conn-github", "connection", "github")
+	after.Annotations[envoyInjectionHostsAnn] = `[
+		{"host":"api.github.com"},
+		{"host":"github.com","valueFormat":"Basic {value}","encoding":"basic-x-access-token"},
+		{"host":"raw.githubusercontent.com"}
+	]`
+
+	assert.NotEqual(t,
+		envoySecretsRev([]corev1.Secret{before}),
+		envoySecretsRev([]corev1.Secret{after}),
+		"host-list edits must change the rev so the StatefulSet rolls",
+	)
 }
 
 func TestEnvoySecretsRev_TemplateRevBumpRollsExistingPods(t *testing.T) {

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -93,7 +93,7 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("listing replier credential secrets: %v", err))
 	}
 
-	if !hasGitHubCredential(credentialSecrets) {
+	if !hasGHTokenEnv(credentialSecrets) {
 		slog.Warn("fork: replier has no GitHub credential Secret; gh/octokit calls will be unauthenticated",
 			"fork", forkName, "foreignSub", forkSpec.ForeignSub)
 	}

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -216,7 +216,7 @@ func BuildForkAgentJob(
 
 	// GH_TOKEN signal — mirrors the long-lived shape.
 	ghAvail := "false"
-	if hasGitHubCredential(credentialSecrets) {
+	if hasGHTokenEnv(credentialSecrets) {
 		ghAvail = "true"
 	}
 	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -74,7 +74,7 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		return r.setError(ctx, name, fmt.Sprintf("listing credential secrets: %v", err))
 	}
 
-	if !hasGitHubCredential(credentialSecrets) {
+	if !hasGHTokenEnv(credentialSecrets) {
 		slog.Warn("no GitHub credential Secret attached — gh/octokit calls will be unauthenticated",
 			"instance", name, "owner", owner)
 	}

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -288,7 +288,7 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	// wrapper scripts and operators can detect missing auth without making
 	// a 401-eliciting request first.
 	ghAvail := "false"
-	if hasGitHubCredential(credentialSecrets) {
+	if hasGHTokenEnv(credentialSecrets) {
 		ghAvail = "true"
 	}
 	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -67,10 +67,20 @@ var testOwnerCM = &corev1.ConfigMap{
 func boolPtr(b bool) *bool { return &b }
 
 func credSecret(name, host string) corev1.Secret {
+	ann := map[string]string{
+		"agent-platform.ai/host-pattern":          host,
+		"agent-platform.ai/injection-header-name": "Authorization",
+	}
+	// Fixtures targeting github hosts also declare GH_TOKEN in their
+	// env-mappings — mirrors what the api-server's github descriptor
+	// stamps, so `hasGHTokenEnv` returns true for these Secrets.
+	if host == "api.github.com" || host == "github.com" || host == "raw.githubusercontent.com" {
+		ann["agent-platform.ai/env-mappings"] = `[{"envName":"GH_TOKEN","placeholder":"dummy-placeholder"}]`
+	}
 	return corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
-			Annotations: map[string]string{"agent-platform.ai/host-pattern": host, "agent-platform.ai/injection-header-name": "Authorization"},
+			Annotations: ann,
 			Labels:      map[string]string{"agent-platform.ai/owner": "owner-1", "agent-platform.ai/managed-by": "api-server"},
 		},
 		Data: map[string][]byte{"value": []byte("Bearer abc")},
@@ -341,6 +351,10 @@ func TestBuildAgentStatefulSet_GHTokenSignal_WithCredential(t *testing.T) {
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, "true", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
 	assert.Equal(t, "true", ss.Spec.Template.Annotations["agent-platform.ai/gh-token-available"])
+	// Declarative env-mappings on the Secret land as actual container env
+	// — the agent SDK reads GH_TOKEN, sends Bearer, Envoy overwrites on
+	// the wire. Without this on the StatefulSet, the SDK never dispatches.
+	assert.Equal(t, "dummy-placeholder", envMap["GH_TOKEN"])
 }
 
 func TestBuildAgentStatefulSet_PodHardening(t *testing.T) {

--- a/packages/ui/src/components/connections-picker.tsx
+++ b/packages/ui/src/components/connections-picker.tsx
@@ -14,16 +14,16 @@ import { HoverTooltip } from "./hover-tooltip.js";
 
 /**
  * One row in the picker's "OAuth Apps" subsection. Joins the
- * api-server-managed app connection (host, displayName, expiry, appId for
- * the brand icon) with the K8s credential Secret's id (the grant target —
- * agents see the token via the Envoy sidecar's `Authorization: Bearer`
- * injection on `hostPattern`).
+ * api-server-managed app connection (hosts, displayName, expiry, appId
+ * for the brand icon) with the K8s credential Secret's id (the grant
+ * target — agents see the token via Envoy injection on every host).
  */
 export interface OAuthAppEntry {
   secretId: string;
   appId: string;
   displayName: string;
-  hostPattern: string;
+  /** Non-empty; rendered comma-joined under the displayName. */
+  hosts: string[];
   expired: boolean;
 }
 
@@ -330,7 +330,7 @@ function OAuthAppItemRow({
       </span>
       <div className="flex-1 min-w-0">
         <div className="text-[13px] font-medium text-text truncate">{entry.displayName}</div>
-        <div className="text-[11px] font-mono text-text-muted truncate">{entry.hostPattern}</div>
+        <div className="text-[11px] font-mono text-text-muted truncate">{entry.hosts.join(", ")}</div>
       </div>
       {entry.expired && (
         <span className="text-[11px] font-bold uppercase tracking-[0.03em] border-2 rounded-full px-2.5 py-0.5 shrink-0 bg-danger-light text-danger border-danger">

--- a/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
@@ -204,7 +204,7 @@ export function AddAgentDialog({
         secretId: mirror.id,
         appId: conn.appId,
         displayName: conn.displayName,
-        hostPattern: conn.hostPattern,
+        hosts: conn.hosts,
         expired: conn.expired,
       }];
     });

--- a/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
@@ -151,7 +151,7 @@ export function ConfigureAgentDialog({
         secretId: mirror.id,
         appId: conn.appId,
         displayName: conn.displayName,
-        hostPattern: conn.hostPattern,
+        hosts: conn.hosts,
         expired: conn.expired,
       }];
     });

--- a/packages/ui/src/modules/connections/api/fetchers.ts
+++ b/packages/ui/src/modules/connections/api/fetchers.ts
@@ -101,7 +101,10 @@ const oauthAppConnectionSchema = z.object({
   /** Identifier used by DELETE /api/oauth/apps/connections/:id. */
   connectionId: z.string(),
   displayName: z.string(),
-  hostPattern: z.string(),
+  /** Hosts the OAuth token injects on. First is the identity host
+   *  (the API endpoint for static descriptors). For github this is the
+   *  three-host list from #219. */
+  hosts: z.array(z.string()).min(1),
   connectedAt: z.string(),
   expired: z.boolean(),
   /** GitHub App slug — only set when the connection's credentials belong

--- a/packages/ui/src/modules/connections/components/oauth-app-row.tsx
+++ b/packages/ui/src/modules/connections/components/oauth-app-row.tsx
@@ -34,7 +34,7 @@ export function OAuthAppRow({ app, connection, animationDelayMs, onReconnect }: 
 
   const detail = expired
     ? "Expired — reconnect to refresh access"
-    : `Connected ${new Date(connection.connectedAt).toLocaleDateString()} · ${connection.hostPattern}`;
+    : `Connected ${new Date(connection.connectedAt).toLocaleDateString()} · ${connection.hosts.join(", ")}`;
 
   const installUrl = appInstallUrl(connection);
 

--- a/packages/ui/src/modules/connections/lib/install-url.ts
+++ b/packages/ui/src/modules/connections/lib/install-url.ts
@@ -10,7 +10,10 @@ import type { OAuthAppConnection } from "../api/fetchers.js";
 export function appInstallUrl(connection: OAuthAppConnection): string | null {
   if (!connection.appSlug) return null;
   if (connection.appId === "github-enterprise") {
-    return `https://${connection.hostPattern}/github-apps/${connection.appSlug}/installations/new`;
+    // GHE: the user-supplied host is the only entry in `hosts`.
+    const host = connection.hosts[0];
+    if (!host) return null;
+    return `https://${host}/github-apps/${connection.appSlug}/installations/new`;
   }
   return `https://github.com/apps/${connection.appSlug}/installations/new`;
 }


### PR DESCRIPTION
## Summary

Fixes #219. Refactors connections so each connection carries a first-class list of host injections (`ConnectionHostInjection[]`) replacing the singular `hostPattern`. The list is the single source of truth for both credential injection and the egress allowlist — no descriptor-vs-stored fallback ladder.

GitHub.com declares three hosts inline:
- `api.github.com` — Bearer (REST/GraphQL)
- `github.com` — HTTP Basic `base64("x-access-token:<token>")` so `git clone` of private repos works with no credential helper
- `raw.githubusercontent.com` — Bearer (raw-file fetches)

`*.github.io` is rejected at registry construction (Pages content is user-controlled; injecting the user's token there would leak it).

**Storage:** one K8s Secret per `(owner, connection)` with a JSON `injection-hosts` annotation + one `host-<sha8>.sds.yaml` file per host (valueFormat pre-substituted). Refresh re-renders every host's SDS file in a single Secret write — no twins, no fan-out.

**Controller:** `chainsFromSecrets` fans connection Secrets via the JSON annotation into one filter chain per host; each `envoyCredential` carries an explicit `SDSFileKey` pointing at the per-host file. File-key bytes are pinned by tests on both sides.

## Test plan

- [x] `mise run check` — lint + tsc + go vet + helm lint + kubeconform all green
- [x] `mise run test` — 315 api-server, 135 cli, 72 agent-runtime, 45 ui, all controller Go tests pass
- [x] New unit tests: multi-host upsert, re-upsert prunes stale hosts, refresh re-renders all SDS files, `chainsFromSecrets` fans into N chains, `sdsFileKeyForHost` byte-equality pinned on both sides, `isGitHubPagesHost` guardrail
- [ ] Manual: connect GitHub on a real cluster, verify `git clone https://github.com/<private-repo>.git`, `gh api`, and `curl https://raw.githubusercontent.com/<private>/...` all succeed from inside an agent pod