### PR TITLE
fix(cli): normalize trailing slash in chat websocket URL

### DIFF
--- a/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
+++ b/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
@@ -28,7 +28,7 @@ export function connectTerminalBridge({
   return new Promise<BridgeResult>((resolve) => {
     let settled = false;
     const proto = host.startsWith("https://") ? "wss:" : "ws:";
-    const base = host.replace(/^https?:\/\//, "");
+    const base = host.replace(/^https?:\/\//, "").replace(/\/+$/, "");
     const sep = terminalPath.includes("?") ? "&" : "?";
     const ws = new WebSocket(
       `${proto}//${base}${terminalPath}${sep}token=${encodeURIComponent(token)}`,


### PR DESCRIPTION
## Summary

- The WebSocket URL builder for `dam chat` (now in `terminal-bridge.ts` after refactor 9185a7b5 moved it out of `chat-service.ts`) strips the `http(s)://` scheme but does **not** strip a trailing slash from the configured server host. With `server = "http://host/"`, this produces `ws://host//api/...`. Through a dev-server proxy (e.g. Vite) the upgrade request never matches the proxy rule, no HTTP response comes back, and the `ws` client stays in CONNECTING forever — leaving `dam chat` hanging silently with no output and no error.
- Normalize the host the same way every other URL builder in the CLI already does (`.replace(/\/+$/, "")` — see `trpc-client.ts`, `sessions-client.ts`, `version-probe.ts`, `auth-config-probe.ts`, `oidc-discovery.ts`).

> Note: an earlier version of this PR patched `wsUrl` in `chat-service.ts`. That symbol no longer exists — commit 9185a7b5 moved WS URL construction into `terminal-bridge.ts` without porting the normalization, reintroducing #218. This PR re-applies the fix at the new location.

Fixes #218

## Test plan

- [ ] Set `server = "http://api-server.localtest.me:4444/"` (trailing slash) in CLI config; `dam chat <instance>` connects normally instead of hanging.
- [ ] Same config without trailing slash continues to work.
- [ ] `mise run cli:check` passes.