### PR TITLE
fix(helm): render explicit ClusterRole for custom SCC `use` grant

### DIFF
--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -58,6 +58,27 @@ volumes:
   - projected
   - secret
 ---
+{{/*
+Grant `use` on the custom SCC. OpenShift auto-generates
+`system:openshift:scc:<name>` ClusterRoles only for built-in SCCs
+(restricted-v2, nonroot-v2, anyuid, …); for custom SCCs no ClusterRole
+is created, so we render one ourselves. SCC is cluster-scoped, so the
+rule must live in a ClusterRole (Role can only reference namespaced
+resources). The RoleBinding below stays namespace-scoped so the grant
+is limited to `agentNamespace`.
+*/}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "platform.fullname" . }}-anyuid-cap-net-use
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["security.openshift.io"]
+    resources: ["securitycontextconstraints"]
+    resourceNames: ["{{ include "platform.fullname" . }}-anyuid-cap-net"]
+    verbs: ["use"]
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
@@ -68,7 +89,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "platform.fullname" . }}-anyuid-cap-net
+  name: {{ include "platform.fullname" . }}-anyuid-cap-net-use
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io

--- a/deploy/helm/platform/templates/agent-scc.yaml
+++ b/deploy/helm/platform/templates/agent-scc.yaml
@@ -68,7 +68,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: system:openshift:scc:{{ include "platform.fullname" . }}-anyuid-cap-net
+  name: {{ include "platform.fullname" . }}-anyuid-cap-net
 subjects:
   - kind: Group
     apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Summary

The `agent-scc.yaml` RoleBinding pointed at `ClusterRole/system:openshift:scc:<fullname>-anyuid-cap-net`, relying on OpenShift's auto-generation of `use` ClusterRoles for SCCs. That auto-generation only runs for built-in SCCs (`restricted-v2`, `nonroot-v2`, `anyuid`, …) — neither the prefixed nor the bare-name ClusterRole is ever created for our custom SCC. The binding is dangling, so admission rejects agent pods that need the custom SCC with:

```
provider "<fullname>-anyuid-cap-net": Forbidden: not usable by user or serviceaccount
```

This PR renders an explicit `<fullname>-anyuid-cap-net-use` ClusterRole with `verbs: [use]` on the SCC's `resourceNames`, and points the existing namespace-scoped RoleBinding at it.

Why ClusterRole (not Role): SCC is a cluster-scoped resource, and Kubernetes RBAC requires a ClusterRole to grant any verb on cluster-scoped resources. The binding itself stays a namespace-scoped `RoleBinding`, so the grant is still limited to `agentNamespace`.

Naming stays outside the `system:openshift:` prefix, which is reserved for OpenShift-managed objects.

Verified in prod cluster (OpenShift 4.20.19):
- `kubectl get clusterrole system:openshift:scc:dam-platform-anyuid-cap-net` → NotFound
- `kubectl auth can-i use scc/dam-platform-anyuid-cap-net --as=system:serviceaccount:dam-dev-sandboxed:<sa>` → `no`
- Built-in SCCs (`anyuid`, `nonroot-v2`, `restricted-v2`, `hostmount-anyuid`, `hostmount-anyuid-v2`) → all have their `system:openshift:scc:<name>` ClusterRole

## Test plan

- [x] `mise run helm:check:lint`
- [x] `mise run helm:check:render`
- [ ] Deploy to prod, recreate an instance with `iptablesInit` enabled, verify admission under `dam-platform-anyuid-cap-net`