### PR TITLE
fix(controller): probe iptables backend, fall back to legacy for Kata

### DIFF
--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -21,11 +21,16 @@ const iptablesInitContainerName = "egress-lockdown"
 // feature is off, the image is unset, or the gateway IP isn't known yet.
 //
 // Targets the SIG Release `registry.k8s.io/build-image/distroless-iptables`
-// image. We invoke `iptables-nft` directly rather than the wrapped
-// `iptables` entrypoint — the wrapper auto-detects nft vs legacy by
-// writing symlinks at runtime, which the container's
-// `readOnlyRootFilesystem: true` blocks. Every kernel K8s supports
-// (≥4.18) ships nftables, so the direct call is portable.
+// image, which ships both `iptables-nft` and `iptables-legacy`. We
+// invoke the backend binary directly rather than the wrapped `iptables`
+// entrypoint — the wrapper auto-detects nft vs legacy by writing
+// symlinks at runtime, which the container's `readOnlyRootFilesystem:
+// true` blocks. The script probes nft first and falls back to legacy:
+// Kata Containers guest kernels (used by OpenShift Sandboxed Containers
+// and others) commonly ship `CONFIG_IP_NF_IPTABLES_LEGACY=y` but not
+// `CONFIG_NF_TABLES`, so `iptables-nft` fails with
+// "Failed to initialize nft: Protocol not supported" while
+// `iptables-legacy` works against the same kernel.
 func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *corev1.Container {
 	cfgInit := cfg.AgentBase.IptablesInit
 	if cfgInit == nil || !cfgInit.Enabled || cfgInit.Image == "" || gatewayClusterIP == "" {
@@ -36,15 +41,33 @@ func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *co
 	// dual-stack ClusterIP), so there's no IPv6 ACCEPT for it. Without
 	// this, an agent could exfil over IPv6 if the node has v6
 	// connectivity — our IPv4 rules wouldn't see those packets at all.
+	//
+	// Probe by listing the default OUTPUT chain — if the backend's
+	// netlink subsystem isn't compiled into the running kernel, the list
+	// itself errors out before any rule application. Fail-closed when
+	// both backends are unusable: defense-in-depth is the whole point of
+	// this container, so the pod must not silently fall back to
+	// NetworkPolicy-only.
 	script := `set -eu
 echo "egress-lockdown: gateway=$GATEWAY_IP:$ENVOY_PORT"
-iptables-nft -A OUTPUT -o lo -j ACCEPT
-iptables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-iptables-nft -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
-iptables-nft -A OUTPUT -j DROP
-ip6tables-nft -A OUTPUT -o lo -j ACCEPT
-ip6tables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
-ip6tables-nft -A OUTPUT -j DROP
+if iptables-nft -nL OUTPUT >/dev/null 2>&1; then
+    IPT=iptables-nft
+    IP6T=ip6tables-nft
+elif iptables-legacy -nL OUTPUT >/dev/null 2>&1; then
+    IPT=iptables-legacy
+    IP6T=ip6tables-legacy
+else
+    echo "egress-lockdown: FATAL — neither iptables-nft nor iptables-legacy works against this kernel (CONFIG_NF_TABLES and CONFIG_IP_NF_IPTABLES both absent?)" >&2
+    exit 1
+fi
+echo "egress-lockdown: backend=$IPT"
+"$IPT" -A OUTPUT -o lo -j ACCEPT
+"$IPT" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+"$IPT" -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
+"$IPT" -A OUTPUT -j DROP
+"$IP6T" -A OUTPUT -o lo -j ACCEPT
+"$IP6T" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
+"$IP6T" -A OUTPUT -j DROP
 echo "egress-lockdown: gateway-only IPv4 + IPv6 drop applied"
 `
 

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -73,6 +73,10 @@ func TestBuildIptablesInitContainer_HasCapsAndRunsAsRoot(t *testing.T) {
 // the actual netfilter behavior is tested out-of-band (see cluster smoke
 // test). DNS-specific rules are gone; DNS is just one of the many "everything
 // else" destinations DROPped by the catch-all.
+//
+// Rule application uses $IPT / $IP6T because the script probes nft first
+// and falls back to iptables-legacy (Kata guest kernels often ship legacy
+// xtables but not nf_tables).
 func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
@@ -81,17 +85,24 @@ func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 	require.GreaterOrEqual(t, len(ic.Command), 3)
 	script := ic.Command[2]
 
-	assert.Contains(t, script, "iptables-nft -A OUTPUT -o lo -j ACCEPT", "loopback must be admitted (in-pod localhost)")
-	assert.Contains(t, script, "iptables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT", "return traffic must match conntrack")
-	assert.Contains(t, script, `iptables-nft -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT`,
+	// Backend probe: nft first, then legacy, fail-closed if neither works.
+	assert.Contains(t, script, "iptables-nft -nL OUTPUT", "must probe nft backend")
+	assert.Contains(t, script, "IPT=iptables-nft", "nft is the preferred backend")
+	assert.Contains(t, script, "iptables-legacy -nL OUTPUT", "must probe legacy backend as fallback")
+	assert.Contains(t, script, "IPT=iptables-legacy", "legacy is the Kata fallback")
+	assert.Contains(t, script, "exit 1", "must fail-closed when no backend works — NetworkPolicy alone is not enough")
+
+	assert.Contains(t, script, `"$IPT" -A OUTPUT -o lo -j ACCEPT`, "loopback must be admitted (in-pod localhost)")
+	assert.Contains(t, script, `"$IPT" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT`, "return traffic must match conntrack")
+	assert.Contains(t, script, `"$IPT" -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT`,
 		"single ACCEPT rule pinned to the gateway IP+Envoy port")
-	assert.Contains(t, script, "iptables-nft -A OUTPUT -j DROP", "terminal catch-all DROP")
+	assert.Contains(t, script, `"$IPT" -A OUTPUT -j DROP`, "terminal catch-all DROP")
 
 	// IPv6 must be locked down too — gateway is IPv4-only so v6 gets
 	// loopback + ESTABLISHED + DROP, no gateway ACCEPT.
-	assert.Contains(t, script, "ip6tables-nft -A OUTPUT -o lo -j ACCEPT", "IPv6 loopback must be admitted")
-	assert.Contains(t, script, "ip6tables-nft -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT")
-	assert.Contains(t, script, "ip6tables-nft -A OUTPUT -j DROP", "IPv6 terminal catch-all DROP")
+	assert.Contains(t, script, `"$IP6T" -A OUTPUT -o lo -j ACCEPT`, "IPv6 loopback must be admitted")
+	assert.Contains(t, script, `"$IP6T" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT`)
+	assert.Contains(t, script, `"$IP6T" -A OUTPUT -j DROP`, "IPv6 terminal catch-all DROP")
 }
 
 // PoC: with `iptablesInit.enabled: true` the egress-lockdown init container


### PR DESCRIPTION
## Summary

- The `egress-lockdown` init container hard-pinned `iptables-nft`, which fails on Kata Containers guest kernels (OpenShift Sandboxed Containers and similar) with `iptables: Failed to initialize nft: Protocol not supported`. Kata's stock netfilter fragment enables `CONFIG_IP_NF_IPTABLES_LEGACY=y` but omits `CONFIG_NF_TABLES`.
- Script now probes `iptables-nft -nL OUTPUT`, falls back to `iptables-legacy`, applies the same allow-list via `\$IPT` / `\$IP6T`.
- Fail-closes (exit 1) with a loud error if neither backend works — defense-in-depth is the whole point of this init container, so we don't silently degrade to NetworkPolicy-only.

Originally introduced in #214; this fixes the OpenShift/Kata blocker reported with the log line `egress-lockdown: gateway=172.30.47.64:10000` followed by `iptables: Failed to initialize nft: Protocol not supported`.

## Test plan

- [x] `mise run controller:test` — reconciler tests green
- [x] `mise run controller:check` — `go vet` + build clean
- [x] `sh -n` on the embedded script — syntax OK
- [ ] Validate on the OpenShift cluster that originally hit the error: egress-lockdown init container reaches `egress-lockdown: backend=iptables-legacy` and `egress-lockdown: gateway-only IPv4 + IPv6 drop applied`
- [ ] Validate on regular (non-Kata) clusters that `iptables-nft` is still the chosen backend