### PR TITLE
docs: add security overview strategy page

### DIFF
--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -1,0 +1,130 @@
+# Security overview
+
+How Platform isolates agents from each other, from the cluster, and
+from the credentials they use to reach external services.
+
+## Layers of defense
+
+```mermaid
+flowchart LR
+  L1["<b>Identity</b><br/>SPIFFE cert via Istio mesh"]
+  L2["<b>Boundary</b><br/>Agent isolated in its own container"]
+  L3["<b>Network</b><br/>NetworkPolicy + AuthorizationPolicy"]
+  L4["<b>Credentials</b><br/>Injected on egress"]
+  L1 ~~~ L2 ~~~ L3 ~~~ L4
+```
+
+- **Identity.** Every workload runs as a per-instance Kubernetes
+ServiceAccount, and istiod stamps that SA into a SPIFFE workload
+certificate as the pod joins the Istio ambient mesh. Admission across
+the mesh is decided on the certificate's SA principal, not on IP or
+port — a peer instance can resolve the address, but the
+AuthorizationPolicy denies the call before it lands.
+
+- **Boundary.** The agent runs in its own container, with its own
+kernel namespaces, its own filesystem, and no shared address space.
+The pod hosts only that one container — no co-located sidecar to
+share a namespace with. `automountServiceAccountToken` is false on
+the pod (a pod-level setting in Kubernetes), so there is no
+Kubernetes API token sitting in the agent's filesystem; istiod
+issues the workload cert independently.
+
+- **Network.** Multiple layers restrict where the agent can talk. At
+the kernel, a Kubernetes NetworkPolicy locks the agent pod's L3/L4
+egress to a narrow allow-list — DNS, the Istio ambient data path, and
+the single sibling gateway pod it is paired with. At the mesh, Istio
+AuthorizationPolicies key on the per-instance ServiceAccount: peer-pod
+admission is gated at L4, and the harness path on the api-server is
+gated at L7. And every egress request through the sibling pod runs
+through an ext-authz check at the api-server before being forwarded.
+
+- **Credentials.** Real upstream tokens never reach the agent. They
+live in Kubernetes Secrets mounted into a sibling gateway pod. For hosts
+where a credential is configured, the sibling pod adds the credential
+header on the wire after the ext-authz check has authorized the
+request — for everything else, traffic passes through unchanged.
+
+## Security boundary
+
+The container is the security boundary. Everything inside it — the
+agent process, any tools it spawns, any content it reads — is
+treated as untrusted. The agent pod hosts a single agent container,
+and the controls above all live outside it (in the mesh, in the
+kernel's network stack, in a sibling pod that holds the credentials),
+so that a compromised agent cannot reach beyond what its network and
+identity allow. Some of those controls are written at the pod level
+rather than per-container — NetworkPolicy and
+`automountServiceAccountToken` are pod-scoped, because that's the
+granularity Kubernetes exposes — but with one container per agent
+pod, the two coincide.
+
+By default, containers run on the cluster's container runtime —
+typically runc — which shares a kernel with the node. The four
+controls above stand regardless, but a kernel-level escape from the
+agent's container reaches the node directly, and from there anything
+co-located on it.
+
+For deployments where that risk matters, the cluster operator should
+run Platform's pods under a stronger runtime — [gVisor](https://gvisor.dev/)
+or [Kata Containers](https://katacontainers.io/) — via a Kubernetes
+RuntimeClass. Platform itself does not pin a RuntimeClass; the
+choice of substrate sits with whoever operates the cluster. See
+[security-model § Execution](security-model.md#execution) for the
+longer framing.
+
+## Authorization flow
+
+Every internal hop carries a SPIFFE identity stamped by istiod, and
+every admission is gated on it.
+
+```mermaid
+flowchart LR
+  subgraph pair[Instance pair]
+    direction LR
+    agent[agent pod]
+    gw["gateway pod<br/>Envoy"]
+  end
+
+  api[api-server]
+  owner[owner inbox]
+  ext[external services]
+
+  agent -->|HTTPS_PROXY| gw
+  gw <-->|"ext-authz Check<br/>allow · deny · hold"| api
+  api <-.->|HITL hold-open| owner
+  gw -->|"egress on allow<br/>(credential injected if configured)"| ext
+```
+
+Three AuthorizationPolicies per instance gate admission
+cryptographically: gateway admission, the harness path on the
+api-server, and the per-instance ext-authz Service. Each is keyed on
+the per-instance ServiceAccount, so peer instances are denied at the
+mesh — they can resolve the address but the call never lands.
+
+Layered above that, every egress request through the gateway runs
+through a second gate. Envoy makes a gRPC ext-authz Check to the
+api-server before forwarding the request, with the calling instance
+proven cryptographically by the ServiceAccount on the connection. The
+api-server matches the request against the instance's egress rules
+and answers allow, deny, or hold-open. A held-open Check waits while
+the owner approves or denies the egress from the inbox in the UI; if
+the verdict is deny — or none arrives — the Check fails closed and
+the agent gets a 403. For hosts where a credential is configured,
+Envoy injects the credential header after the Check allows, just
+before the request leaves the cluster.
+
+## Threats and mitigations
+
+| Threat | Mitigation |
+|---|---|
+| Agent steals an upstream token | Credentials live only in the gateway pod; Envoy injects them on the wire and the agent sees no real token |
+| Agent escalates via its ServiceAccount token | `automountServiceAccountToken: false` on both pods — istiod issues the workload cert without a mounted SA-token |
+| Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy denies traffic from any non-matching ServiceAccount |
+| Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy restricts L3/L4 egress to DNS, the paired gateway, and the ambient mesh |
+| Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |
+| Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (ext-authz) |
+
+## See also
+
+- [security-and-credentials](../architecture/security-and-credentials.md) — current-state architecture details
+- [security-model](security-model.md) — narrative framing of the three risks: execution, credentials, confidentiality

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -1,7 +1,13 @@
 # Security overview
 
-How Platform isolates agents from each other, from the cluster, and
-from the credentials they use to reach external services.
+How Platform keeps an AI agent from doing damage — to other agents, to
+the cluster it runs on, or to the accounts it's allowed to use.
+
+The starting assumption is that the agent is **untrusted**. It runs
+code and makes web requests on its own; we have to plan for the case
+where it goes off the rails and tries to leak a password, contact a
+server it shouldn't, or attack something running nearby. So we build
+real walls around it, and we never assume good behaviour.
 
 ## Layers of defense
 
@@ -14,74 +20,83 @@ flowchart LR
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
-- **Identity.** Every workload runs as a per-instance Kubernetes
-ServiceAccount, and istiod stamps that SA into a SPIFFE workload
-certificate as the pod joins the Istio ambient mesh. Admission across
-the mesh is decided on the certificate's SA principal, not on IP or
-port — a peer instance can resolve the address, but the
-AuthorizationPolicy denies the call before it lands.
+- **Identity.** Every workload gets a unique ID card — technically a
+SPIFFE workload certificate, issued by Istio's identity service
+(`istiod`) when the pod joins the mesh. When the agent (or anything
+acting on its behalf) calls another service in the cluster, a guard at
+the destination checks the ID before letting the call through. The
+guard cares about *who* is calling, not which IP or port they came
+from. An agent from a different instance can find the address, but its
+call gets turned away at the door.
 
-- **Boundary.** The agent runs in its own container, with its own
-kernel namespaces, its own filesystem, and no shared address space.
-The pod hosts only that one container — no co-located sidecar to
-share a namespace with. `automountServiceAccountToken` is false on
-the pod (a pod-level setting in Kubernetes), so there is no
-Kubernetes API token sitting in the agent's filesystem; istiod
-issues the workload cert independently.
+- **Boundary.** The agent runs in its own container — a sealed room
+with its own filesystem and its own kernel namespaces, sharing nothing
+with anyone else. We put exactly one container in each pod, so the
+agent has no roommate it could share memory or a network namespace
+with. The pod also has no Kubernetes login token mounted
+(`automountServiceAccountToken: false`): even if the agent tries to
+ask Kubernetes "what else is around?", it has no credentials to do so.
+The SPIFFE ID is delivered another way that doesn't put a token on
+disk.
 
-- **Network.** Multiple layers restrict where the agent can talk. At
-the kernel, a Kubernetes NetworkPolicy locks the agent pod's L3/L4
-egress to a single destination — the sibling gateway pod it is paired
-with. DNS is removed from the allow-list entirely; the controller
-injects a hostAliases entry so `HTTPS_PROXY` resolves the gateway
-Service without a name lookup, closing the cluster-DNS exfil channel.
-A privileged init container writes a matching iptables OUTPUT
-allow-list inside the pod's network namespace, defense-in-depth in
-case CNI NetworkPolicy enforcement ever fails open. At the mesh,
-Istio AuthorizationPolicies key on the per-instance ServiceAccount:
-peer-pod admission is gated at L4, and the harness path on the
-api-server is gated at L7. And every egress request through the
-sibling pod runs through an ext-authz check at the api-server before
-being forwarded.
+- **Network.** Several locks restrict where the agent can talk. At the
+kernel — the part of the OS that decides which network packets are
+allowed out — a Kubernetes NetworkPolicy lets the agent's pod reach
+exactly one place: the sibling **gateway pod** we paired it with.
+Nothing else. No peer pods, no internet directly, and no DNS — the
+controller injects a hostAliases entry into the pod so `HTTPS_PROXY`
+can resolve the gateway's name without ever doing a DNS lookup, which
+closes a sneaky exfil channel where the agent could smuggle data out
+in DNS queries. As a backup of the same lock, a privileged init
+container writes a matching `iptables` rule inside the pod; if
+NetworkPolicy enforcement ever broke, this second layer would still
+hold. At the mesh layer, Istio AuthorizationPolicies key on each
+instance's ServiceAccount — peer instances are denied at the network
+level, and the harness path on the api-server is gated the same way.
+And every outgoing request through the gateway pod runs through an
+extra `ext-authz` check at the api-server before being forwarded.
 
-- **Credentials.** Real upstream tokens never reach the agent. They
-live in Kubernetes Secrets mounted into a sibling gateway pod. For hosts
-where a credential is configured, the sibling pod adds the credential
-header on the wire after the ext-authz check has authorized the
-request — for everything else, traffic passes through unchanged.
+- **Credentials.** Real upstream passwords (API keys, OAuth tokens)
+never reach the agent. They live in Kubernetes Secrets that only the
+gateway pod can read. When the agent wants to call something like
+GitHub, the request goes through the gateway pod. For hosts where a
+credential is configured, the gateway adds the credential header onto
+the wire after the `ext-authz` check has approved the call — for
+everything else, traffic passes through unchanged.
 
 ## Security boundary
 
-The container is the security boundary. Everything inside it — the
-agent process, any tools it spawns, any content it reads — is
-treated as untrusted. The agent pod hosts a single agent container,
-and the controls above all live outside it (in the mesh, in the
-kernel's network stack, in a sibling pod that holds the credentials),
-so that a compromised agent cannot reach beyond what its network and
-identity allow. Some of those controls are written at the pod level
-rather than per-container — NetworkPolicy and
-`automountServiceAccountToken` are pod-scoped, because that's the
-granularity Kubernetes exposes — but with one container per agent
-pod, the two coincide.
+The container is the wall. Everything inside it — the agent process,
+any tools it starts, any content it reads — is treated as untrusted.
+The agent pod hosts a single agent container, and the controls above
+all live *outside* it: in the mesh, in the kernel's network stack, in
+the sibling gateway pod that holds the credentials. A compromised
+agent can't reach any of them. A few of these controls technically
+apply to the pod rather than to the container itself (Kubernetes only
+lets you set NetworkPolicy and the token-mount option at the pod
+level), but because we only put one container in each pod, the pod
+and the container coincide.
 
-By default, containers run on the cluster's container runtime —
-typically runc — which shares a kernel with the node. The four
-controls above stand regardless, but a kernel-level escape from the
-agent's container reaches the node directly, and from there anything
-co-located on it.
+By default the container runs on the cluster's normal container
+runtime — usually `runc` — which shares a kernel with the host
+machine. The four controls above all still stand, but if an attacker
+ever broke out of the container into the kernel, they'd be on the host
+directly. That's a known, hard problem in the container world.
 
-For deployments where that risk matters, the cluster operator should
-run Platform's pods under a stronger runtime — [gVisor](https://gvisor.dev/)
-or [Kata Containers](https://katacontainers.io/) — via a Kubernetes
-RuntimeClass. Platform itself does not pin a RuntimeClass; the
-choice of substrate sits with whoever operates the cluster. See
+If you're running Platform somewhere where that risk matters, the
+cluster operator should swap in a stronger runtime —
+[gVisor](https://gvisor.dev/), which intercepts the container's system
+calls, or [Kata Containers](https://katacontainers.io/), which gives
+each pod its own lightweight virtual machine. The choice is set with
+a Kubernetes RuntimeClass. Platform itself doesn't force a choice;
+that decision belongs to whoever operates the cluster. See
 [security-model § Execution](security-model.md#execution) for the
 longer framing.
 
 ## Authorization flow
 
-Every internal hop carries a SPIFFE identity stamped by istiod, and
-every admission is gated on it.
+Every internal hop carries a SPIFFE ID stamped by `istiod`, and every
+door checks it.
 
 ```mermaid
 flowchart LR
@@ -101,37 +116,40 @@ flowchart LR
   gw -->|"egress on allow<br/>(credential injected if configured)"| ext
 ```
 
-Three AuthorizationPolicies per instance gate admission
-cryptographically: gateway admission, the harness path on the
-api-server, and the per-instance ext-authz Service. Each is keyed on
-the per-instance ServiceAccount, so peer instances are denied at the
-mesh — they can resolve the address but the call never lands.
+Three AuthorizationPolicies sit at the doors that matter: the gateway
+pod's door, the harness path on the api-server, and the per-instance
+`ext-authz` service. Each one only admits the matching instance's
+SPIFFE ID, so peer instances are denied at the mesh — they can resolve
+the address but the call never lands.
 
-Layered above that, every egress request through the gateway runs
-through a second gate. Envoy makes a gRPC ext-authz Check to the
-api-server before forwarding the request, with the calling instance
-proven cryptographically by the ServiceAccount on the connection. The
-api-server matches the request against the instance's egress rules
-and answers allow, deny, or hold-open. A held-open Check waits while
-the owner approves or denies the egress from the inbox in the UI; if
-the verdict is deny — or none arrives — the Check fails closed and
-the agent gets a 403. For hosts where a credential is configured,
-Envoy injects the credential header after the Check allows, just
-before the request leaves the cluster.
+On top of that, every outgoing request through the gateway runs
+through a second gate. Envoy (the program running inside the gateway
+pod) makes a gRPC `ext-authz` Check to the api-server before
+forwarding the request, with the calling instance proven
+cryptographically by the ServiceAccount on the connection. The
+api-server looks the request up against the instance's egress rules
+and answers one of three things:
+
+- **Allow** — forward the request and, if a credential is configured
+  for the destination host, stamp it on just before it leaves.
+- **Deny** — refuse. The agent gets a 403.
+- **Hold-open** — pause the Check while the owner approves or denies
+  it from the inbox in the UI. If the verdict is deny, or no answer
+  arrives, the Check fails closed and the agent still gets a 403.
 
 ## Threats and mitigations
 
 | Threat | Mitigation |
 |---|---|
-| Agent steals an upstream token | Credentials live only in the gateway pod; Envoy injects them on the wire and the agent sees no real token |
-| Agent escalates via its ServiceAccount token | `automountServiceAccountToken: false` on both pods — istiod issues the workload cert without a mounted SA-token |
+| Agent steals an upstream token | Tokens live only in the gateway pod; Envoy injects them on the wire and the agent never sees a real one |
+| Agent escalates via its ServiceAccount token | `automountServiceAccountToken: false` on both pods — `istiod` issues the SPIFFE workload cert without a mounted SA-token |
 | Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy denies traffic from any non-matching ServiceAccount |
-| Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy admits only the paired gateway pod; a kernel iptables OUTPUT allow-list inside the pod enforces the same shape independently |
+| Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy admits only the paired gateway pod; a kernel `iptables` rule inside the pod enforces the same shape independently |
 | Agent exfiltrates data through cluster DNS | The agent has no DNS egress at all; the controller injects a hostAliases entry so `HTTPS_PROXY` resolves the gateway Service without a lookup |
 | Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |
-| Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (ext-authz) |
+| Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (`ext-authz`) |
 
 ## See also
 
-- [security-and-credentials](../architecture/security-and-credentials.md) — current-state architecture details
-- [security-model](security-model.md) — narrative framing of the three risks: execution, credentials, confidentiality
+- [security-and-credentials](../architecture/security-and-credentials.md) — the technical details of how this is wired today
+- [security-model](security-model.md) — the longer story behind the three big risks: execution, credentials, confidentiality

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -82,7 +82,9 @@ By default the container runs on the cluster's normal container
 runtime — usually `runc` — which shares a kernel with the host
 machine. The four controls above all still stand, but if an attacker
 ever broke out of the container into the kernel, they'd be on the host
-directly. That's a known, hard problem in the container world.
+directly. That's a known, hard problem in the container world — the
+runc container-escape CVEs disclosed in November 2025 and the "Copy
+Fail" Linux-kernel LPE in April 2026 are recent examples.
 
 If you're running Platform somewhere where that risk matters, the
 cluster operator should swap in a stronger runtime —
@@ -152,6 +154,7 @@ and answers one of three things:
 | Agent exfiltrates data through cluster DNS | The agent has no DNS egress at all; the controller injects a hostAliases entry so `HTTPS_PROXY` resolves the gateway Service without a lookup |
 | Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |
 | Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (`ext-authz`) |
+| Agent escapes the container into the host kernel (the late-2025 runc CVEs; Linux kernel LPEs like "Copy Fail") | Not closed by any control above — all four layers run on top of the host kernel. Only a runtime that doesn't share that kernel fully mitigates: gVisor intercepts the container's syscalls in userspace; Kata Containers gives each pod its own lightweight VM. The cluster operator opts in via RuntimeClass — see [Security boundary](#security-boundary) above |
 
 ## See also
 

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -20,15 +20,16 @@ flowchart LR
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
-- **Identity.** Identity authorizes the calls the gateway pod makes
-back into the platform on the agent's behalf — the api-server's
-harness path that the agent's LLM uses, and the per-instance
-`ext-authz` service that approves every outgoing request. Istio's
-identity service (`istiod`) hands the gateway a SPIFFE workload
-certificate, an unforgeable ID card tied to the pod's Kubernetes
-ServiceAccount. AuthorizationPolicies on those api-server endpoints
-only admit the matching instance's gateway, so one instance can never
-call another's harness or ext-authz.
+- **Identity.** Some calls go *back into* the platform on the agent's
+behalf — the gateway pod talks to the api-server's harness (the
+channel the agent's LLM uses) and to a per-instance `ext-authz`
+service that approves outgoing requests. Both of those have to be
+authorized: only the gateway from the matching instance is allowed
+in. Istio's identity service (`istiod`) gives each gateway pod a
+digital ID card — a SPIFFE certificate, signed by the cluster and
+impossible to forge. The doors on those api-server endpoints check
+the ID and admit only the right one, so one instance can never call
+another instance's harness or ext-authz.
 
 - **Boundary.** The agent runs in its own container — a sealed room
 with its own filesystem and its own kernel namespaces, sharing nothing

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -20,14 +20,19 @@ flowchart LR
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
-- **Identity.** Every workload gets a unique ID card — technically a
-SPIFFE workload certificate, issued by Istio's identity service
-(`istiod`) when the pod joins the mesh. When the agent (or anything
-acting on its behalf) calls another service in the cluster, a guard at
-the destination checks the ID before letting the call through. The
-guard cares about *who* is calling, not which IP or port they came
-from. An agent from a different instance can find the address, but its
-call gets turned away at the door.
+- **Identity.** Identity in Platform is not about keeping the agent
+penned in — that job belongs to the network layer below. It's about
+*authorizing the calls that the gateway pod makes back into the
+platform on the agent's behalf*: the api-server's harness path that
+the agent's LLM uses, and the per-instance `ext-authz` service that
+approves every outgoing request. When the gateway pod knocks on those
+doors, it has to prove who it is. Istio's identity service (`istiod`)
+hands the gateway a SPIFFE workload certificate — an unforgeable ID
+card tied to the pod's Kubernetes ServiceAccount. The api-server
+endpoints carry AuthorizationPolicies that only admit the matching
+instance's gateway, so one instance can never call another's harness
+or ext-authz. The agent pod itself has no SPIFFE identity at all — it
+is deliberately kept out of the mesh.
 
 - **Boundary.** The agent runs in its own container — a sealed room
 with its own filesystem and its own kernel namespaces, sharing nothing
@@ -42,19 +47,18 @@ disk.
 - **Network.** Several locks restrict where the agent can talk. At the
 kernel — the part of the OS that decides which network packets are
 allowed out — a Kubernetes NetworkPolicy lets the agent's pod reach
-exactly one place: the sibling **gateway pod** we paired it with.
-Nothing else. No peer pods, no internet directly, and no DNS — the
-controller injects a hostAliases entry into the pod so `HTTPS_PROXY`
-can resolve the gateway's name without ever doing a DNS lookup, which
-closes a sneaky exfil channel where the agent could smuggle data out
-in DNS queries. As a backup of the same lock, a privileged init
-container writes a matching `iptables` rule inside the pod; if
-NetworkPolicy enforcement ever broke, this second layer would still
-hold. At the mesh layer, Istio AuthorizationPolicies key on each
-instance's ServiceAccount — peer instances are denied at the network
-level, and the harness path on the api-server is gated the same way.
-And every outgoing request through the gateway pod runs through an
-extra `ext-authz` check at the api-server before being forwarded.
+exactly one place: the sibling **gateway pod** we paired it with. The
+rule pins to that specific pod by label (`pair=<id>, role=gateway`),
+so even other instances' gateways are out of reach. No peer pods, no
+internet directly, and no DNS — the controller injects a hostAliases
+entry into the pod so `HTTPS_PROXY` can resolve the gateway's name
+without ever doing a DNS lookup, which closes a sneaky exfil channel
+where the agent could smuggle data out in DNS queries. As a backup of
+the same lock, a privileged init container writes a matching
+`iptables` rule inside the pod; if NetworkPolicy enforcement ever
+broke, this second layer would still hold. Every outgoing request the
+gateway pod then forwards on the agent's behalf runs through an
+`ext-authz` check at the api-server before leaving the cluster.
 
 - **Credentials.** Real upstream passwords (API keys, OAuth tokens)
 never reach the agent. They live in Kubernetes Secrets that only the
@@ -143,7 +147,8 @@ and answers one of three things:
 |---|---|
 | Agent steals an upstream token | Tokens live only in the gateway pod; Envoy injects them on the wire and the agent never sees a real one |
 | Agent escalates via its ServiceAccount token | `automountServiceAccountToken: false` on both pods — `istiod` issues the SPIFFE workload cert without a mounted SA-token |
-| Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy denies traffic from any non-matching ServiceAccount |
+| Agent reaches a peer instance's gateway | Per-pair NetworkPolicy pins admission to the paired gateway pod by label; no other instance's gateway is reachable from the agent at the kernel |
+| Gateway calls a peer instance's harness or `ext-authz` | AuthorizationPolicies on each api-server endpoint only admit the matching instance's gateway SPIFFE principal |
 | Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy admits only the paired gateway pod; a kernel `iptables` rule inside the pod enforces the same shape independently |
 | Agent exfiltrates data through cluster DNS | The agent has no DNS egress at all; the controller injects a hostAliases entry so `HTTPS_PROXY` resolves the gateway Service without a lookup |
 | Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -20,19 +20,15 @@ flowchart LR
   L1 ~~~ L2 ~~~ L3 ~~~ L4
 ```
 
-- **Identity.** Identity in Platform is not about keeping the agent
-penned in — that job belongs to the network layer below. It's about
-*authorizing the calls that the gateway pod makes back into the
-platform on the agent's behalf*: the api-server's harness path that
-the agent's LLM uses, and the per-instance `ext-authz` service that
-approves every outgoing request. When the gateway pod knocks on those
-doors, it has to prove who it is. Istio's identity service (`istiod`)
-hands the gateway a SPIFFE workload certificate — an unforgeable ID
-card tied to the pod's Kubernetes ServiceAccount. The api-server
-endpoints carry AuthorizationPolicies that only admit the matching
-instance's gateway, so one instance can never call another's harness
-or ext-authz. The agent pod itself has no SPIFFE identity at all — it
-is deliberately kept out of the mesh.
+- **Identity.** Identity authorizes the calls the gateway pod makes
+back into the platform on the agent's behalf — the api-server's
+harness path that the agent's LLM uses, and the per-instance
+`ext-authz` service that approves every outgoing request. Istio's
+identity service (`istiod`) hands the gateway a SPIFFE workload
+certificate, an unforgeable ID card tied to the pod's Kubernetes
+ServiceAccount. AuthorizationPolicies on those api-server endpoints
+only admit the matching instance's gateway, so one instance can never
+call another's harness or ext-authz.
 
 - **Boundary.** The agent runs in its own container — a sealed room
 with its own filesystem and its own kernel namespaces, sharing nothing

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -117,11 +117,13 @@ flowchart LR
   gw -->|"egress on allow<br/>(credential injected if configured)"| ext
 ```
 
-Three AuthorizationPolicies sit at the doors that matter: the gateway
-pod's door, the harness path on the api-server, and the per-instance
-`ext-authz` service. Each one only admits the matching instance's
-SPIFFE ID, so peer instances are denied at the mesh — they can resolve
-the address but the call never lands.
+Two AuthorizationPolicies sit at the doors that matter: the harness
+path on the api-server, and the per-instance `ext-authz` service.
+Each one only admits the gateway whose SPIFFE ID belongs to the right
+instance, so one instance can never call another instance's harness
+or ext-authz — the address resolves, but the call never lands. The
+gateway pod itself has no AuthorizationPolicy in front of it; the
+agent's NetworkPolicy is the only gate on the agent → gateway hop.
 
 On top of that, every outgoing request through the gateway runs
 through a second gate. Envoy (the program running inside the gateway

--- a/docs/strategy/security-overview.md
+++ b/docs/strategy/security-overview.md
@@ -31,12 +31,18 @@ issues the workload cert independently.
 
 - **Network.** Multiple layers restrict where the agent can talk. At
 the kernel, a Kubernetes NetworkPolicy locks the agent pod's L3/L4
-egress to a narrow allow-list — DNS, the Istio ambient data path, and
-the single sibling gateway pod it is paired with. At the mesh, Istio
-AuthorizationPolicies key on the per-instance ServiceAccount: peer-pod
-admission is gated at L4, and the harness path on the api-server is
-gated at L7. And every egress request through the sibling pod runs
-through an ext-authz check at the api-server before being forwarded.
+egress to a single destination — the sibling gateway pod it is paired
+with. DNS is removed from the allow-list entirely; the controller
+injects a hostAliases entry so `HTTPS_PROXY` resolves the gateway
+Service without a name lookup, closing the cluster-DNS exfil channel.
+A privileged init container writes a matching iptables OUTPUT
+allow-list inside the pod's network namespace, defense-in-depth in
+case CNI NetworkPolicy enforcement ever fails open. At the mesh,
+Istio AuthorizationPolicies key on the per-instance ServiceAccount:
+peer-pod admission is gated at L4, and the harness path on the
+api-server is gated at L7. And every egress request through the
+sibling pod runs through an ext-authz check at the api-server before
+being forwarded.
 
 - **Credentials.** Real upstream tokens never reach the agent. They
 live in Kubernetes Secrets mounted into a sibling gateway pod. For hosts
@@ -120,7 +126,8 @@ before the request leaves the cluster.
 | Agent steals an upstream token | Credentials live only in the gateway pod; Envoy injects them on the wire and the agent sees no real token |
 | Agent escalates via its ServiceAccount token | `automountServiceAccountToken: false` on both pods — istiod issues the workload cert without a mounted SA-token |
 | Agent reaches a peer instance's gateway | Per-instance AuthorizationPolicy denies traffic from any non-matching ServiceAccount |
-| Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy restricts L3/L4 egress to DNS, the paired gateway, and the ambient mesh |
+| Agent bypasses the proxy to call external hosts directly | Per-pair agent-egress NetworkPolicy admits only the paired gateway pod; a kernel iptables OUTPUT allow-list inside the pod enforces the same shape independently |
+| Agent exfiltrates data through cluster DNS | The agent has no DNS egress at all; the controller injects a hostAliases entry so `HTTPS_PROXY` resolves the gateway Service without a lookup |
 | Route-confusion exfil through the gateway | Per-host Envoy filter chains pinned to each credential's host, with SAN-bound upstream TLS validation |
 | Direct pod-IP bypass of the api-server | Pod-level DENY AuthorizationPolicy admits only the waypoint's SA (harness) or a per-instance SA (ext-authz) |
 


### PR DESCRIPTION
## Summary
- Continues #164, which was merged as 8a0a68c3 and then reverted in #227.
- Re-applies the cherry-picked commit as a draft so the security overview strategy page can land again after addressing the concerns that triggered the revert.

## Test plan
- [ ] Render the docs site locally and verify the security-overview page renders with all Mermaid diagrams intact.
- [ ] Confirm internal cross-links (e.g., from `docs/architecture.md`) still resolve.
- [ ] Re-review the page against the feedback that motivated the revert before marking ready for review.