### PR TITLE
feat(controller): IP-direct proxy + namespace deny-all NP + np-gate init

### DIFF
--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -10,6 +10,7 @@ add it to the include list in `platform.validate`.
 
 {{- define "platform.validate" -}}
 {{- include "platform.validate.anyuidCapNetRequiresAgentNamespace" . -}}
+{{- include "platform.validate.egressLockdownModeExclusive" . -}}
 {{- end -}}
 
 {{/*
@@ -22,5 +23,22 @@ group. Both are meaningless if `agentNamespace` is empty.
 {{- if not (.Values.agentNamespace | default "" | trim) -}}
 {{- fail "openshift.scc.anyuidCapNet.enabled=true requires agentNamespace to be set. The RoleBinding is namespace-scoped and grants SCC access via the system:serviceaccounts:<agentNamespace> group; an empty value makes both meaningless." -}}
 {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+`iptablesInit` and `npGateInit` are the two egress-lockdown modes —
+exactly one belongs on a given pod. iptablesInit programs in-pod
+kernel rules (needs netfilter modules in the guest); npGateInit
+verifies the cluster NetworkPolicy is enforced before releasing the
+workload (works on guests without netfilter, e.g. Kata/CoCo).
+Running both at once isn't wrong per se but it almost always means
+the operator misunderstood the model. Fail loudly so the choice is
+explicit.
+*/}}
+{{- define "platform.validate.egressLockdownModeExclusive" -}}
+{{- $base := .Values.controller.agent.base -}}
+{{- if and $base.iptablesInit $base.iptablesInit.enabled $base.npGateInit $base.npGateInit.enabled -}}
+{{- fail "controller.agent.base.iptablesInit.enabled and npGateInit.enabled are mutually exclusive. iptablesInit programs in-pod kernel rules (plain OCI runtime); npGateInit verifies NetworkPolicy is enforced before releasing the workload (Kata/CoCo where the guest kernel lacks netfilter). Enable exactly one — see values.yaml for the two-mode comment." -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -27,18 +27,13 @@ group. Both are meaningless if `agentNamespace` is empty.
 {{- end -}}
 
 {{/*
-`iptablesInit` and `npGateInit` are the two egress-lockdown modes —
-exactly one belongs on a given pod. iptablesInit programs in-pod
-kernel rules (needs netfilter modules in the guest); npGateInit
-verifies the cluster NetworkPolicy is enforced before releasing the
-workload (works on guests without netfilter, e.g. Kata/CoCo).
-Running both at once isn't wrong per se but it almost always means
-the operator misunderstood the model. Fail loudly so the choice is
-explicit.
+iptablesInit and npGateInit are the two egress-lockdown modes —
+exactly one belongs on a given pod. See values.yaml for the two-mode
+comment.
 */}}
 {{- define "platform.validate.egressLockdownModeExclusive" -}}
 {{- $base := .Values.controller.agent.base -}}
 {{- if and $base.iptablesInit $base.iptablesInit.enabled $base.npGateInit $base.npGateInit.enabled -}}
-{{- fail "controller.agent.base.iptablesInit.enabled and npGateInit.enabled are mutually exclusive. iptablesInit programs in-pod kernel rules (plain OCI runtime); npGateInit verifies NetworkPolicy is enforced before releasing the workload (Kata/CoCo where the guest kernel lacks netfilter). Enable exactly one — see values.yaml for the two-mode comment." -}}
+{{- fail "controller.agent.base.iptablesInit.enabled and npGateInit.enabled are mutually exclusive — enable exactly one. See values.yaml for the two-mode comment." -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/agent-deny-all-egress-np.yaml
+++ b/deploy/helm/platform/templates/agent-deny-all-egress-np.yaml
@@ -1,23 +1,9 @@
 {{- /*
-Namespace-scoped deny-all egress NetworkPolicy for agent pods.
-
-The per-pair `<id>-agent-egress` NetworkPolicies layer ALLOW rules on top
-of this baseline (NetworkPolicies combine additively when they select the
-same pod). The result: an agent pod has no egress unless a per-pair NP
-explicitly admits a destination — fail-closed by default.
-
-This matters because OVN-K programs per-pair NPs after observing the
-pod's labels — there's an async window between "pod has interface" and
-"specific allow rules in OVS flow tables." Without this baseline, that
-window is wide-open egress. With it, the window is no-egress. Combined
-with the in-pod NP-gate init container the agent never starts running
-until enforcement is verified.
-
-Why role-scoped (not empty podSelector): the paired gateway pod needs
-broad outbound (arbitrary external hosts for credential injection per
-ADR-035). Catching the gateway in a deny-all would force a parallel
-"allow everything sensible" gateway NP that's operationally equivalent
-to no NP. Scoping the deny to `role: agent` is the cleaner expression.
+Namespace-scoped deny-all egress baseline for agent pods. Per-pair
+NetworkPolicies (controller-rendered) layer allow rules on top — agent
+pods have no egress unless a per-pair NP admits the destination.
+Role-scoped to `agent` so the paired gateway pod (which needs broad
+outbound for credential injection per ADR-035) is untouched.
 */}}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/deploy/helm/platform/templates/agent-deny-all-egress-np.yaml
+++ b/deploy/helm/platform/templates/agent-deny-all-egress-np.yaml
@@ -1,0 +1,37 @@
+{{- /*
+Namespace-scoped deny-all egress NetworkPolicy for agent pods.
+
+The per-pair `<id>-agent-egress` NetworkPolicies layer ALLOW rules on top
+of this baseline (NetworkPolicies combine additively when they select the
+same pod). The result: an agent pod has no egress unless a per-pair NP
+explicitly admits a destination — fail-closed by default.
+
+This matters because OVN-K programs per-pair NPs after observing the
+pod's labels — there's an async window between "pod has interface" and
+"specific allow rules in OVS flow tables." Without this baseline, that
+window is wide-open egress. With it, the window is no-egress. Combined
+with the in-pod NP-gate init container the agent never starts running
+until enforcement is verified.
+
+Why role-scoped (not empty podSelector): the paired gateway pod needs
+broad outbound (arbitrary external hosts for credential injection per
+ADR-035). Catching the gateway in a deny-all would force a parallel
+"allow everything sensible" gateway NP that's operationally equivalent
+to no NP. Scoping the deny to `role: agent` is the cleaner expression.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-egress-deny-all
+  namespace: {{ .Values.agentNamespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    agent-platform.ai/managed-by: platform-helm
+    agent-platform.ai/role: agent
+spec:
+  podSelector:
+    matchLabels:
+      agent-platform.ai/role: agent
+  policyTypes:
+    - Egress
+  egress: []

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -515,7 +515,7 @@ controller:
         # smallest reasonable footprint. Digest-pinned to neutralize the
         # mutable-tag supply-chain surface; rotate manually when newer
         # busybox releases land.
-        image: docker.io/library/busybox:1.36@sha256:543181ecb2c3e8c807bf086deb688ebe61b65e84335eb487260ee5fd37ee30b2
+        image: docker.io/library/busybox:1.37@sha256:18ac7a6883a86416ade8178063c26deff577cd831445f5c5ac5c7a931cb60983
         # Canary destination the probe expects to be DROPped by the NP.
         # Defaults (empty) to the kubelet-injected
         # KUBERNETES_SERVICE_HOST:KUBERNETES_SERVICE_PORT — the

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -508,20 +508,24 @@ controller:
       # the OVN-K async-programming race for runtimes where `iptablesInit`
       # can't run (Kata/CoCo, where the guest kernel lacks netfilter).
       # No privileged caps required — pure userspace TCP probes.
-      #
-      # Typical config: enable when iptablesInit is disabled (Kata/CoCo).
-      # Both can run simultaneously without conflict — the iptables init
-      # closes the race kernel-side, the NP-gate verifies the cluster
-      # layer also converged.
       npGateInit:
         enabled: false
-        image: docker.io/library/busybox:1.36
+        # busybox provides both `nc` and `sh` in one minimal image. K8s
+        # SIG distroless variants don't bundle nc, so this is the
+        # smallest reasonable footprint. Digest-pinned to neutralize the
+        # mutable-tag supply-chain surface; rotate manually when newer
+        # busybox releases land.
+        image: docker.io/library/busybox:1.36@sha256:543181ecb2c3e8c807bf086deb688ebe61b65e84335eb487260ee5fd37ee30b2
         # Canary destination the probe expects to be DROPped by the NP.
-        # 1.1.1.1:443 is widely reachable when egress is open AND will
-        # certainly be denied by an egress NP that only admits the
-        # paired gateway. Picks 8.8.8.8 if Cloudflare is blocked.
-        deniedHost: 1.1.1.1
-        deniedPort: 443
+        # Defaults (empty) to the kubelet-injected
+        # KUBERNETES_SERVICE_HOST:KUBERNETES_SERVICE_PORT — the
+        # kube-apiserver Service IP, always reachable in-cluster when NP
+        # is permissive, always denied by the agent egress NP
+        # (gateway-only), no external uptime dependency. Override with
+        # an explicit host:port only if you have a cluster-specific
+        # canary you trust more.
+        deniedHost: ""
+        deniedPort: 0
         # Hard deadline before the init container fails the pod. OVN-K
         # typically converges in well under a second; 30s is generous
         # for cold node churn / controller restart scenarios.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -493,8 +493,9 @@ controller:
       npGateInit:
         enabled: false
         # busybox provides nc + sh in one image. K8s SIG distroless
-        # variants don't bundle nc. Digest-pinned; rotate manually.
-        image: docker.io/library/busybox:1.37@sha256:18ac7a6883a86416ade8178063c26deff577cd831445f5c5ac5c7a931cb60983
+        # variants don't bundle nc. Digest pins the multi-arch manifest
+        # list — resolves to amd64/arm64/etc at pull time. Rotate manually.
+        image: docker.io/library/busybox:1.37@sha256:1487d0af5f52b4ba31c7e465126ee2123fe3f2305d638e7827681e7cf6c83d5e
         # Hard deadline before the init container fails the pod. OVN-K
         # typically converges in well under a second; 30s is generous
         # for cold node churn / controller restart scenarios.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -472,57 +472,33 @@ controller:
           drop: ["ALL"]
 
       # ━━━ EGRESS LOCKDOWN — pick ONE mode ━━━
-      # The agent's egress is structurally pinned to its paired gateway:
-      # HTTPS_PROXY is set to the gateway ClusterIP literal (no DNS), the
-      # per-pair NetworkPolicy admits only that destination, and the
-      # chart-rendered `agent-egress-deny-all` NP denies everything by
-      # default. The race-closing layer below picks the mechanism that
-      # gates main-container startup on enforcement being in force.
+      # Two mutually-exclusive layers (the chart validates). Both ride
+      # on top of HTTPS_PROXY (IP-direct), the per-pair NetworkPolicy,
+      # and the namespace deny-all baseline.
       #
-      # Two modes:
+      #   - iptablesInit: privileged init container, plain OCI runtime.
+      #     Requires netfilter modules in the guest.
       #
-      #   - iptablesInit (no-sandbox / plain OCI runtime): privileged init
-      #     container programs in-pod iptables rules. Closes the race
-      #     deterministically at the kernel layer. Needs netfilter modules
-      #     in the guest, which Kata/CoCo guest kernels strip.
-      #
-      #   - npGateInit (OpenShift + Kata / CoCo): unprivileged init
-      #     container probes a known-denied destination until the cluster
-      #     NetworkPolicy is verifiably enforcing the deny, then releases
-      #     the agent. Pure userspace TCP probe; no caps needed; works
-      #     against any guest kernel.
-      #
-      # Enable exactly one — they're mutually exclusive in practice.
+      #   - npGateInit: unprivileged init container, works on guests
+      #     without netfilter (Kata/CoCo on OpenShift Sandboxed Containers).
       iptablesInit:
         enabled: true
-        # SIG Release distroless-iptables — the same image kube-proxy
-        # uses. Ships /bin/sh (dash) + iptables-wrapper (auto-selects
-        # nft/legacy). Signed, scanned, no package manager, minimal
-        # userland. Pin to a specific version.
+        # SIG Release distroless-iptables — same image kube-proxy uses.
+        # Ships sh + iptables-wrapper; pinned by tag.
         image: registry.k8s.io/build-image/distroless-iptables:v0.9.2
 
       # -- Userspace init container that blocks the agent's main
       # container until the egress NetworkPolicy is verifiably enforced.
-      # Probes a known-denied destination (must time out) AND the paired
-      # gateway (must be reachable); only releases when both hold. Closes
-      # the OVN-K async-programming race for runtimes where `iptablesInit`
-      # can't run (Kata/CoCo, where the guest kernel lacks netfilter).
-      # No privileged caps required — pure userspace TCP probes.
+      # Pure userspace TCP probe; no caps; works against any guest kernel.
       npGateInit:
         enabled: false
-        # busybox provides both `nc` and `sh` in one minimal image. K8s
-        # SIG distroless variants don't bundle nc, so this is the
-        # smallest reasonable footprint. Digest-pinned to neutralize the
-        # mutable-tag supply-chain surface; rotate manually when newer
-        # busybox releases land.
+        # busybox provides nc + sh in one image. K8s SIG distroless
+        # variants don't bundle nc. Digest-pinned; rotate manually.
         image: docker.io/library/busybox:1.37@sha256:18ac7a6883a86416ade8178063c26deff577cd831445f5c5ac5c7a931cb60983
-        # Canary destination the probe expects to be DROPped by the NP.
-        # Defaults (empty) to the kubelet-injected
-        # KUBERNETES_SERVICE_HOST:KUBERNETES_SERVICE_PORT — the
-        # kube-apiserver Service IP, always reachable in-cluster when NP
-        # is permissive, always denied by the agent egress NP
-        # (gateway-only), no external uptime dependency. Override with
-        # an explicit host:port only if you have a cluster-specific
+        # Canary destination expected to be DROPped by the NP. Empty
+        # defaults to kubelet's KUBERNETES_SERVICE_HOST:PORT
+        # (kube-apiserver), which is always reachable when NP is
+        # permissive and always denied otherwise. Override only for a
         # canary you trust more.
         deniedHost: ""
         deniedPort: 0

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -495,13 +495,6 @@ controller:
         # busybox provides nc + sh in one image. K8s SIG distroless
         # variants don't bundle nc. Digest-pinned; rotate manually.
         image: docker.io/library/busybox:1.37@sha256:18ac7a6883a86416ade8178063c26deff577cd831445f5c5ac5c7a931cb60983
-        # Canary destination expected to be DROPped by the NP. Empty
-        # defaults to kubelet's KUBERNETES_SERVICE_HOST:PORT
-        # (kube-apiserver), which is always reachable when NP is
-        # permissive and always denied otherwise. Override only for a
-        # canary you trust more.
-        deniedHost: ""
-        deniedPort: 0
         # Hard deadline before the init container fails the pod. OVN-K
         # typically converges in well under a second; 30s is generous
         # for cold node churn / controller restart scenarios.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -471,18 +471,28 @@ controller:
         capabilities:
           drop: ["ALL"]
 
-      # -- Drop the cluster-DNS allow rules from the per-pair agent egress
-      # NetworkPolicy (closes threat T9, DNS exfil). The controller injects
-      # a hostAliases entry for the gateway Service so HTTPS_PROXY still
-      # resolves.
-      disableDns: true
-
-      # -- Kernel-level egress allow-list applied via a privileged init
-      # container (NET_ADMIN/NET_RAW). Locks OUTPUT to loopback +
-      # ESTABLISHED + the paired gateway IP:port. Defense-in-depth on top
-      # of the NetworkPolicy.
-      # NOTE: needs a custom SCC on OpenShift (default SCCs don't grant
-      # NET_ADMIN/NET_RAW + runAsUser=0).
+      # ━━━ EGRESS LOCKDOWN — pick ONE mode ━━━
+      # The agent's egress is structurally pinned to its paired gateway:
+      # HTTPS_PROXY is set to the gateway ClusterIP literal (no DNS), the
+      # per-pair NetworkPolicy admits only that destination, and the
+      # chart-rendered `agent-egress-deny-all` NP denies everything by
+      # default. The race-closing layer below picks the mechanism that
+      # gates main-container startup on enforcement being in force.
+      #
+      # Two modes:
+      #
+      #   - iptablesInit (no-sandbox / plain OCI runtime): privileged init
+      #     container programs in-pod iptables rules. Closes the race
+      #     deterministically at the kernel layer. Needs netfilter modules
+      #     in the guest, which Kata/CoCo guest kernels strip.
+      #
+      #   - npGateInit (OpenShift + Kata / CoCo): unprivileged init
+      #     container probes a known-denied destination until the cluster
+      #     NetworkPolicy is verifiably enforcing the deny, then releases
+      #     the agent. Pure userspace TCP probe; no caps needed; works
+      #     against any guest kernel.
+      #
+      # Enable exactly one — they're mutually exclusive in practice.
       iptablesInit:
         enabled: true
         # SIG Release distroless-iptables — the same image kube-proxy
@@ -490,6 +500,32 @@ controller:
         # nft/legacy). Signed, scanned, no package manager, minimal
         # userland. Pin to a specific version.
         image: registry.k8s.io/build-image/distroless-iptables:v0.9.2
+
+      # -- Userspace init container that blocks the agent's main
+      # container until the egress NetworkPolicy is verifiably enforced.
+      # Probes a known-denied destination (must time out) AND the paired
+      # gateway (must be reachable); only releases when both hold. Closes
+      # the OVN-K async-programming race for runtimes where `iptablesInit`
+      # can't run (Kata/CoCo, where the guest kernel lacks netfilter).
+      # No privileged caps required — pure userspace TCP probes.
+      #
+      # Typical config: enable when iptablesInit is disabled (Kata/CoCo).
+      # Both can run simultaneously without conflict — the iptables init
+      # closes the race kernel-side, the NP-gate verifies the cluster
+      # layer also converged.
+      npGateInit:
+        enabled: false
+        image: docker.io/library/busybox:1.36
+        # Canary destination the probe expects to be DROPped by the NP.
+        # 1.1.1.1:443 is widely reachable when egress is open AND will
+        # certainly be denied by an egress NP that only admits the
+        # paired gateway. Picks 8.8.8.8 if Cloudflare is blocked.
+        deniedHost: 1.1.1.1
+        deniedPort: 443
+        # Hard deadline before the init container fails the pod. OVN-K
+        # typically converges in well under a second; 30s is generous
+        # for cold node churn / controller restart scenarios.
+        timeoutSeconds: 30
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
     templateDefaults:

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -94,10 +94,6 @@ type AgentIptablesInit struct {
 type AgentNPGateInit struct {
 	Enabled bool   `json:"enabled,omitempty"`
 	Image   string `json:"image,omitempty"`
-	// Canary destination the probe expects to be DROPped. Empty defaults
-	// to kubelet's KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT.
-	DeniedHost string `json:"deniedHost,omitempty"`
-	DeniedPort int    `json:"deniedPort,omitempty"`
 	// Bound on probe convergence; fail-closed on timeout.
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 }

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -80,12 +80,9 @@ type AgentBase struct {
 	// defense-in-depth on top of the NetworkPolicy).
 	IptablesInit *AgentIptablesInit `json:"iptablesInit,omitempty"`
 
-	// NPGateInit configures an unprivileged init container that blocks the
-	// agent's main container until the egress NetworkPolicy is verifiably
-	// enforced. Probes a known-denied destination (loop until DROPped) and
-	// the paired gateway (must be reachable) before exiting. Closes the
-	// OVN-K async-programming race for runtimes where IptablesInit can't
-	// run (Kata/CoCo guests lack netfilter modules — see PR #234).
+	// NPGateInit configures an unprivileged init container that gates the
+	// agent's main container on egress NetworkPolicy being verifiably
+	// enforced. Used where IptablesInit can't run.
 	NPGateInit *AgentNPGateInit `json:"npGateInit,omitempty"`
 }
 
@@ -97,13 +94,11 @@ type AgentIptablesInit struct {
 type AgentNPGateInit struct {
 	Enabled bool   `json:"enabled,omitempty"`
 	Image   string `json:"image,omitempty"`
-	// DeniedHost / DeniedPort is the canary destination the probe expects
-	// to be DROPped by the NetworkPolicy. Defaults to 1.1.1.1:443.
+	// Canary destination the probe expects to be DROPped. Empty defaults
+	// to kubelet's KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT.
 	DeniedHost string `json:"deniedHost,omitempty"`
 	DeniedPort int    `json:"deniedPort,omitempty"`
-	// TimeoutSeconds bounds how long the probe will wait for NP to converge.
-	// On timeout the init container fail-closes (exit 1 → pod stays in
-	// Init:CrashLoopBackOff, never starts the agent).
+	// Bound on probe convergence; fail-closed on timeout.
 	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 }
 

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -75,21 +75,36 @@ type AgentBase struct {
 	PodSecurityContext       *corev1.PodSecurityContext `json:"podSecurityContext,omitempty"`
 	ContainerSecurityContext *corev1.SecurityContext    `json:"containerSecurityContext,omitempty"`
 
-	// DisableDNS drops the cluster-DNS allow rules from the agent egress
-	// NetworkPolicy (closes threat T9). The controller injects a
-	// hostAliases entry for the paired gateway so HTTPS_PROXY still
-	// resolves.
-	DisableDNS bool `json:"disableDns,omitempty"`
-
 	// IptablesInit configures the privileged init container that pins the
 	// agent pod's OUTPUT chain to the paired gateway (kernel-level
 	// defense-in-depth on top of the NetworkPolicy).
 	IptablesInit *AgentIptablesInit `json:"iptablesInit,omitempty"`
+
+	// NPGateInit configures an unprivileged init container that blocks the
+	// agent's main container until the egress NetworkPolicy is verifiably
+	// enforced. Probes a known-denied destination (loop until DROPped) and
+	// the paired gateway (must be reachable) before exiting. Closes the
+	// OVN-K async-programming race for runtimes where IptablesInit can't
+	// run (Kata/CoCo guests lack netfilter modules — see PR #234).
+	NPGateInit *AgentNPGateInit `json:"npGateInit,omitempty"`
 }
 
 type AgentIptablesInit struct {
 	Enabled bool   `json:"enabled,omitempty"`
 	Image   string `json:"image,omitempty"`
+}
+
+type AgentNPGateInit struct {
+	Enabled bool   `json:"enabled,omitempty"`
+	Image   string `json:"image,omitempty"`
+	// DeniedHost / DeniedPort is the canary destination the probe expects
+	// to be DROPped by the NetworkPolicy. Defaults to 1.1.1.1:443.
+	DeniedHost string `json:"deniedHost,omitempty"`
+	DeniedPort int    `json:"deniedPort,omitempty"`
+	// TimeoutSeconds bounds how long the probe will wait for NP to converge.
+	// On timeout the init container fail-closes (exit 1 → pod stays in
+	// Init:CrashLoopBackOff, never starts the agent).
+	TimeoutSeconds int `json:"timeoutSeconds,omitempty"`
 }
 
 // AgentProbes — sub-field nil means "use the controller's built-in probe

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -160,9 +160,7 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap) er
 	}
 	gatewayIP := liveGatewaySvc.Spec.ClusterIP
 
-	needsGatewayIP := r.config.AgentBase.DisableDNS ||
-		(r.config.AgentBase.IptablesInit != nil && r.config.AgentBase.IptablesInit.Enabled)
-	if needsGatewayIP && (gatewayIP == "" || gatewayIP == corev1.ClusterIPNone) {
+	if gatewayIP == "" || gatewayIP == corev1.ClusterIPNone {
 		return fmt.Errorf("fork %s: gateway Service ClusterIP not yet assigned, requeuing", forkName)
 	}
 

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -89,8 +89,11 @@ func BuildForkAgentJob(
 
 	caCertPath := "/etc/platform/ca/ca.crt"
 
-	// Paired gateway Service DNS — stable across the fork lifetime.
-	proxyAddr := fmt.Sprintf("http://%s:%d", GatewayName(forkName), cfg.EnvoyPort)
+	// Paired gateway's ClusterIP literal — IP-direct so HTTPS_PROXY has
+	// zero DNS dependency. The fork reconciler requeues until the gateway
+	// Service has been assigned a ClusterIP (see fork.go), so the IP is
+	// always known by the time we get here.
+	proxyAddr := fmt.Sprintf("http://%s:%d", gatewayClusterIP, cfg.EnvoyPort)
 
 	env := []corev1.EnvVar{
 		{Name: "HTTPS_PROXY", Value: proxyAddr},
@@ -198,6 +201,9 @@ func BuildForkAgentJob(
 	if ic := buildIptablesInitContainer(cfg, gatewayClusterIP); ic != nil {
 		initContainers = append(initContainers, *ic)
 	}
+	if ic := buildNPGateInitContainer(cfg, gatewayClusterIP); ic != nil {
+		initContainers = append(initContainers, *ic)
+	}
 	if initScript != "" {
 		initContainers = append(initContainers, corev1.Container{
 			Name:            "init",
@@ -268,11 +274,6 @@ func BuildForkAgentJob(
 	podMeta := metav1.ObjectMeta{Labels: podLabels}
 	applyAgentBaseMeta(&podMeta, base)
 
-	var hostAliases []corev1.HostAlias
-	if base.DisableDNS && gatewayClusterIP != "" {
-		hostAliases = append(hostAliases, buildGatewayHostAlias(forkName, gatewayClusterIP))
-	}
-
 	podSpec := corev1.PodSpec{
 		// Fork agent opts out of ambient (no SPIFFE on the agent
 		// half). ADR-027: the per-fork SA still scopes credential
@@ -292,7 +293,6 @@ func BuildForkAgentJob(
 		ShareProcessNamespace:         shareProcessNS,
 		Containers:                    containers,
 		Volumes:                       volumes,
-		HostAliases:                   hostAliases,
 	}
 	applyAgentBaseScheduling(&podSpec, base)
 

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -81,15 +81,16 @@ func TestBuildForkAgentJob_LifecycleGuarantees(t *testing.T) {
 }
 
 func TestBuildForkAgentJob_ForkMetadataEnv(t *testing.T) {
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, "")
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, nil, "10.96.42.42")
 	c := job.Spec.Template.Spec.Containers[0]
 
 	env := envMap(c.Env)
 	assert.Equal(t, "fork-abc", env["PLATFORM_FORK_ID"])
 	assert.Equal(t, "kc|user-42", env["PLATFORM_FOREIGN_SUB"])
 	assert.Equal(t, "my-instance", env["ADK_INSTANCE_ID"])
-	// HTTPS_PROXY targets the fork's OWN gateway — not the parent's.
-	assert.Equal(t, "http://fork-abc-gateway:10000", env["HTTPS_PROXY"])
+	// HTTPS_PROXY is IP-direct — the fork's OWN gateway ClusterIP, not
+	// the parent's. The fork reconciler passes its own gateway IP.
+	assert.Equal(t, "http://10.96.42.42:10000", env["HTTPS_PROXY"])
 }
 
 func TestBuildForkAgentJob_MountsInstancePVC_NotVolumeClaimTemplate(t *testing.T) {
@@ -138,15 +139,15 @@ func TestBuildForkAgentJob_NoSidecar(t *testing.T) {
 	// ADR-038: agent and gateway are paired pods, not co-located. Fork
 	// agents have only one container.
 	secrets := []corev1.Secret{credSecret("platform-cred-replier-x", "api.example.com")}
-	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets, "")
+	job := BuildForkAgentJob("fork-abc", testForkSpec, testForkInstance, testAgent, testConfig, testForkOwnerCM, secrets, "10.96.42.42")
 
 	require.Len(t, job.Spec.Template.Spec.Containers, 1, "fork agent has no sidecar")
 	agent := job.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, "agent", agent.Name)
 
 	envM := envMap(agent.Env)
-	assert.Equal(t, "http://fork-abc-gateway:10000", envM["HTTP_PROXY"])
-	assert.Equal(t, "http://fork-abc-gateway:10000", envM["HTTPS_PROXY"])
+	assert.Equal(t, "http://10.96.42.42:10000", envM["HTTP_PROXY"])
+	assert.Equal(t, "http://10.96.42.42:10000", envM["HTTPS_PROXY"])
 
 	require.NotNil(t, job.Spec.Template.Spec.AutomountServiceAccountToken)
 	assert.False(t, *job.Spec.Template.Spec.AutomountServiceAccountToken)

--- a/packages/controller/pkg/reconciler/fork_test.go
+++ b/packages/controller/pkg/reconciler/fork_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	apitypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"gopkg.in/yaml.v3"
 
 	"github.com/kagenti/platform/packages/controller/pkg/config"
@@ -23,6 +24,15 @@ import (
 func setupForkReconciler(t *testing.T, agents map[string]*corev1.ConfigMap, objects ...runtime.Object) (*ForkReconciler, *fake.Clientset) {
 	t.Helper()
 	client := fake.NewSimpleClientset(objects...)
+	// See setupReconciler — fake clientset doesn't assign ClusterIPs;
+	// reactor stamps a stable IP so the fork reconciler can proceed.
+	client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		svc := action.(k8stesting.CreateAction).GetObject().(*corev1.Service)
+		if svc.Spec.ClusterIP == "" {
+			svc.Spec.ClusterIP = "10.96.42.42"
+		}
+		return false, svc, nil
+	})
 	cfg := &config.Config{
 		Namespace:          "test-agents",
 		ReleaseNamespace:   "default",

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -121,10 +121,10 @@ func BuildGatewayStatefulSet(instanceName string, hibernated bool, cfg *config.C
 func ptrIntOrString(v intstr.IntOrString) *intstr.IntOrString { return &v }
 
 // BuildGatewayService is the ClusterIP Service the agent reaches via
-// `HTTPS_PROXY`. The auto-assigned virtual IP is stable across pod
-// restarts — pinned into the agent pod's hostAliases (under `disableDns`)
-// and the iptables init container's allow-list. Was previously headless;
-// `Service.Spec.ClusterIP == "None"` isn't usable in hostAliases.
+// `HTTPS_PROXY`. The auto-assigned virtual IP is what HTTPS_PROXY uses
+// directly (IP-literal, no DNS) and what the iptables init container's
+// allow-list / np-gate probe target. Was previously headless;
+// `Service.Spec.ClusterIP == "None"` isn't usable as a literal target.
 func BuildGatewayService(instanceName string, cfg *config.Config, ownerCM *corev1.ConfigMap) *corev1.Service {
 	gatewayName := GatewayName(instanceName)
 	envoyPort := portInt32(cfg.EnvoyPort)

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -164,11 +164,10 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 	}
 	gatewayIP := liveGatewaySvc.Spec.ClusterIP
 
-	// Fail-closed requeue when the gateway IP is needed but not yet
-	// usable — don't roll a half-configured pod.
-	needsGatewayIP := r.config.AgentBase.DisableDNS ||
-		(r.config.AgentBase.IptablesInit != nil && r.config.AgentBase.IptablesInit.Enabled)
-	if needsGatewayIP && (gatewayIP == "" || gatewayIP == corev1.ClusterIPNone) {
+	// Fail-closed requeue when the gateway IP isn't yet usable —
+	// HTTPS_PROXY is IP-direct and both iptables/np-gate init containers
+	// need the IP, so we never render a half-configured pod.
+	if gatewayIP == "" || gatewayIP == corev1.ClusterIPNone {
 		return fmt.Errorf("instance %s: gateway Service ClusterIP not yet assigned, requeuing", name)
 	}
 

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -164,9 +164,8 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 	}
 	gatewayIP := liveGatewaySvc.Spec.ClusterIP
 
-	// Fail-closed requeue when the gateway IP isn't yet usable —
-	// HTTPS_PROXY is IP-direct and both iptables/np-gate init containers
-	// need the IP, so we never render a half-configured pod.
+	// HTTPS_PROXY + init containers all need the gateway ClusterIP;
+	// requeue until it's assigned.
 	if gatewayIP == "" || gatewayIP == corev1.ClusterIPNone {
 		return fmt.Errorf("instance %s: gateway Service ClusterIP not yet assigned, requeuing", name)
 	}

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
@@ -40,6 +41,17 @@ func newFakeDynamic() *dynfake.FakeDynamicClient {
 func setupReconciler(t *testing.T, agents map[string]*corev1.ConfigMap, objects ...runtime.Object) (*InstanceReconciler, *fake.Clientset) {
 	t.Helper()
 	client := fake.NewSimpleClientset(objects...)
+	// The fake clientset doesn't simulate kube-apiserver's ClusterIP
+	// assignment, but the reconciler now requires it on every path
+	// (HTTPS_PROXY is IP-direct). Reactor stamps a stable IP onto any
+	// ClusterIP-typed Service at Create so reconcile can proceed.
+	client.PrependReactor("create", "services", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		svc := action.(k8stesting.CreateAction).GetObject().(*corev1.Service)
+		if svc.Spec.ClusterIP == "" {
+			svc.Spec.ClusterIP = "10.96.42.42"
+		}
+		return false, svc, nil
+	})
 	cfg := &config.Config{
 		Namespace:         "test-agents",
 		ReleaseNamespace:  "default",
@@ -109,9 +121,10 @@ func TestReconcile_CreateResources(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int32(1), *ss.Spec.Replicas)
 
-	// Proxy URL targets the paired gateway Service (ADR-038).
+	// Proxy URL is the paired gateway's ClusterIP literal — IP-direct so
+	// the egress NP can deny DNS entirely (ADR-038).
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
-	assert.Equal(t, "http://my-instance-gateway:10000", envMap["HTTPS_PROXY"])
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTPS_PROXY"])
 
 	// Gateway StatefulSet — also replicas=1
 	gws, err := client.AppsV1().StatefulSets("test-agents").Get(ctx, "my-instance-gateway", metav1.GetOptions{})

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -100,12 +100,6 @@ echo "egress-lockdown: gateway-only IPv4 + IPv6 drop applied"
 	}
 }
 
-// buildGatewayHostAlias points `<pairKey>-gateway` at `ip` so HTTPS_PROXY
-// resolves without DNS.
-func buildGatewayHostAlias(pairKey, ip string) corev1.HostAlias {
-	return corev1.HostAlias{IP: ip, Hostnames: []string{GatewayName(pairKey)}}
-}
-
 // ensureGatewayService applies the paired gateway Service and returns the
 // live object (with assigned ClusterIP) in one call — avoids the
 // reconcile-N/N+1 race where a follow-up Get may not see the just-assigned

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -143,41 +143,12 @@ func TestBuildAgentStatefulSet_IptablesInitSkippedWithoutGatewayIP(t *testing.T)
 	}
 }
 
-// With disableDns: true AND a known gateway ClusterIP, the agent pod must
-// carry a hostAliases entry mapping the gateway Service name to the IP.
-// This is how HTTPS_PROXY=http://<pair>-gateway:<port> keeps resolving
-// without admitting DNS in the NetworkPolicy.
-func TestBuildAgentStatefulSet_HostAliasesWhenDNSDisabled(t *testing.T) {
+// hostAliases is no longer used — HTTPS_PROXY is IP-direct so there's no
+// hostname to override. Pod render must not carry stale hostAliases under
+// any code path.
+func TestBuildAgentStatefulSet_NoHostAliases(t *testing.T) {
 	cfg := *testConfig
-	cfg.AgentBase.DisableDNS = true
 	instance := &types.InstanceSpec{DesiredState: "running"}
 	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
-
-	aliases := ss.Spec.Template.Spec.HostAliases
-	require.Len(t, aliases, 1)
-	assert.Equal(t, "10.96.42.42", aliases[0].IP)
-	assert.Contains(t, aliases[0].Hostnames, "my-instance-gateway")
-}
-
-// disableDns: true with an unknown gateway ClusterIP (first reconcile race):
-// the controller must NOT block on it — the pod renders without
-// hostAliases and the next reconcile fills it in. The pod will fail to
-// reach the gateway in that window; that's the documented behavior.
-func TestBuildAgentStatefulSet_NoHostAliasesWhenClusterIPUnknown(t *testing.T) {
-	cfg := *testConfig
-	cfg.AgentBase.DisableDNS = true
-	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "")
-	assert.Empty(t, ss.Spec.Template.Spec.HostAliases)
-}
-
-// disableDns: false — the default-before-PoC shape. No hostAliases regardless
-// of whether a ClusterIP was passed (DNS is doing the resolution).
-func TestBuildAgentStatefulSet_NoHostAliasesWhenDNSEnabled(t *testing.T) {
-	cfg := *testConfig
-	cfg.AgentBase.DisableDNS = false
-	instance := &types.InstanceSpec{DesiredState: "running"}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, &cfg, testOwnerCM, nil, "10.96.42.42")
-	assert.Empty(t, ss.Spec.Template.Spec.HostAliases,
-		"hostAliases only when DNS is disabled — otherwise rely on cluster DNS")
+	assert.Empty(t, ss.Spec.Template.Spec.HostAliases, "no hostAliases — proxy URL is IP-direct")
 }

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -15,33 +15,17 @@ import (
 	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
 
-// Per-pair agent egress NetworkPolicy.
-//
-// The agent pod opts out of ambient mesh (`istio.io/dataplane-mode: none`),
-// so no ztunnel iptables redirect intercepts its outbound traffic. Real
-// destination IP/port hit the kernel NetworkPolicy filter, and the agent
-// pod's only admitted destination is its paired gateway pod. All egress
-// that matters — external upstreams, harness, ext-authz — is proxied
-// through the gateway, gated by Envoy's ext_authz filter (ADR-035).
-//
-// DNS is deliberately NOT admitted (threat T9, DNS exfil). HTTPS_PROXY is
-// set to the gateway's ClusterIP literal so no DNS lookups happen
-// in-pod. HBONE port 15008 is also NOT admitted — the agent has no
-// ztunnel and never speaks HBONE; opening 15008 here would just hand the
-// agent a bypass to anything in the mesh.
-//
-// Combined with the namespace-scope `agent-egress-deny-all` baseline NP
-// (chart-rendered), the agent pod's egress is "paired gateway only"
-// fail-closed: the baseline denies everything, this per-pair NP allows
-// only the gateway. Both layers together close the OVN-K async-
-// programming race — see np_gate_init.go for the in-pod readiness probe
-// that gates main-container startup on policy convergence.
+// Per-pair agent egress NetworkPolicy. Agent opts out of ambient mesh
+// (`istio.io/dataplane-mode: none`) so NetworkPolicy sees real
+// destinations, not ztunnel-redirected ones. Combined with the
+// chart-rendered namespace-scope deny-all baseline, the agent's only
+// admitted destination is its paired gateway. All other egress —
+// external, harness, ext-authz — flows through the gateway (ADR-035).
 
-// BuildAgentEgressNetworkPolicy renders the per-pair egress NetworkPolicy
-// for the agent pod of `pairKey`. Long-lived pairs use the instance name
-// as `pairKey`; forks use the fork name. The selector pins to the pair's
-// agent pod specifically — the paired gateway pod's egress stays
-// unrestricted (it dials external upstreams for credential injection).
+// BuildAgentEgressNetworkPolicy renders the per-pair egress NP for the
+// agent pod of `pairKey`. Long-lived pairs use the instance name;
+// forks use the fork name. Selector pins to the pair's agent pod —
+// the paired gateway pod's egress stays unrestricted.
 func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	envoyPort := intstr.FromInt(cfg.EnvoyPort)
 	tcp := corev1.ProtocolTCP

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -20,84 +20,33 @@ import (
 // The agent pod opts out of ambient mesh (`istio.io/dataplane-mode: none`),
 // so no ztunnel iptables redirect intercepts its outbound traffic. Real
 // destination IP/port hit the kernel NetworkPolicy filter, and the agent
-// pod's only admitted intra-cluster destination is its paired gateway pod.
-// All egress that matters — external upstreams, harness, ext-authz — is
-// proxied through the gateway, gated by Envoy's ext_authz filter (ADR-035).
+// pod's only admitted destination is its paired gateway pod. All egress
+// that matters — external upstreams, harness, ext-authz — is proxied
+// through the gateway, gated by Envoy's ext_authz filter (ADR-035).
 //
-// Allowed egress:
-//   - DNS to `kube-system` on UDP/TCP 53. CoreDNS / kube-dns pods on
-//     upstream Kubernetes listen on 53 directly, so the kernel sees
-//     53 as the destination port after kube-proxy translation.
-//   - DNS to `openshift-dns` on UDP/TCP 5353. OpenShift's `dns-default`
-//     pods listen on 5353; the cluster DNS Service (172.30.0.10:53)
-//     targets pod port 5353, and NetworkPolicy evaluates pod-IP and
-//     pod-port after kube-proxy translation, not the Service port.
-//     Pinning to 53 here would silently drop every lookup on
-//     OpenShift. Both rules are admitted; a given cluster runs DNS in
-//     only one of these namespaces, so the unused rule is harmless.
-//   - The paired gateway pod (`pair=<id>, role=gateway`) on the Envoy
-//     proxy port only. The per-pair selector pins reachability to *this*
-//     agent's gateway; the gateway pod itself is the only structural
-//     gate (NP is identity-blind, but L3/L4-pinned to one pod set).
+// DNS is deliberately NOT admitted (threat T9, DNS exfil). HTTPS_PROXY is
+// set to the gateway's ClusterIP literal so no DNS lookups happen
+// in-pod. HBONE port 15008 is also NOT admitted — the agent has no
+// ztunnel and never speaks HBONE; opening 15008 here would just hand the
+// agent a bypass to anything in the mesh.
 //
-// HBONE port 15008 is deliberately NOT admitted. The agent has no ztunnel
-// and never speaks HBONE; opening 15008 here would just hand the agent a
-// bypass to anything in the mesh.
-//
-// Everything else (external internet, other in-cluster Services like
-// Postgres / Redis / Keycloak, the harness and ext-authz Services
-// directly) is denied at the kernel layer.
+// Combined with the namespace-scope `agent-egress-deny-all` baseline NP
+// (chart-rendered), the agent pod's egress is "paired gateway only"
+// fail-closed: the baseline denies everything, this per-pair NP allows
+// only the gateway. Both layers together close the OVN-K async-
+// programming race — see np_gate_init.go for the in-pod readiness probe
+// that gates main-container startup on policy convergence.
 
 // BuildAgentEgressNetworkPolicy renders the per-pair egress NetworkPolicy
 // for the agent pod of `pairKey`. Long-lived pairs use the instance name
 // as `pairKey`; forks use the fork name. The selector pins to the pair's
 // agent pod specifically — the paired gateway pod's egress stays
 // unrestricted (it dials external upstreams for credential injection).
-//
-// When `cfg.AgentBase.DisableDNS` is set, the cluster-DNS rules are
-// dropped (threat T9). hostAliases on the pod (resources.go) lets
-// HTTPS_PROXY still resolve the gateway.
 func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *corev1.ConfigMap) *networkingv1.NetworkPolicy {
 	envoyPort := intstr.FromInt(cfg.EnvoyPort)
-	corednsPort := intstr.FromInt(53)
-	openshiftDNSPort := intstr.FromInt(5353)
 	tcp := corev1.ProtocolTCP
-	udp := corev1.ProtocolUDP
 
-	egress := []networkingv1.NetworkPolicyEgressRule{}
-	if !cfg.AgentBase.DisableDNS {
-		egress = append(egress,
-			networkingv1.NetworkPolicyEgressRule{
-				// Upstream Kubernetes: CoreDNS / kube-dns in
-				// `kube-system` listening on pod port 53.
-				To: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "kube-system"},
-					},
-				}},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{Protocol: &udp, Port: &corednsPort},
-					{Protocol: &tcp, Port: &corednsPort},
-				},
-			},
-			networkingv1.NetworkPolicyEgressRule{
-				// OpenShift: `dns-default` pods in `openshift-dns`
-				// listen on pod port 5353. NetworkPolicy filters on
-				// pod port after kube-proxy translation, so the
-				// upstream rule (53) does not match here.
-				To: []networkingv1.NetworkPolicyPeer{{
-					NamespaceSelector: &metav1.LabelSelector{
-						MatchLabels: map[string]string{"kubernetes.io/metadata.name": "openshift-dns"},
-					},
-				}},
-				Ports: []networkingv1.NetworkPolicyPort{
-					{Protocol: &udp, Port: &openshiftDNSPort},
-					{Protocol: &tcp, Port: &openshiftDNSPort},
-				},
-			},
-		)
-	}
-	egress = append(egress, networkingv1.NetworkPolicyEgressRule{
+	egress := []networkingv1.NetworkPolicyEgressRule{{
 		// Bare PodSelector with no NamespaceSelector implicitly
 		// scopes to the policy's own namespace — correct today
 		// since agent + gateway pods of a pair share
@@ -115,7 +64,7 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerCM *
 		Ports: []networkingv1.NetworkPolicyPort{
 			{Protocol: &tcp, Port: &envoyPort},
 		},
-	})
+	}}
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -9,13 +9,10 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// Agent pod opts out of ambient mesh, so kernel NetworkPolicy is the
-// gate on agent egress. The policy admits exactly the paired gateway
-// pod on the Envoy proxy port — nothing else, no DNS. HTTPS_PROXY is
-// IP-direct so DNS is unnecessary; the namespace-scope deny-all baseline
-// (chart-rendered) handles default-deny. HBONE port 15008 is
-// deliberately denied: the agent has no ztunnel and admitting 15008
-// would give it a route to anything in the mesh.
+// Per-pair NP admits exactly the paired gateway on the Envoy port —
+// nothing else, no DNS, no HBONE. Combined with the chart-rendered
+// namespace deny-all baseline, this is the only allow rule for the
+// agent.
 func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
 
@@ -24,9 +21,8 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	require.Len(t, np.OwnerReferences, 1)
 	assert.Equal(t, "my-instance", np.OwnerReferences[0].Name)
 
-	// Selector pins to THIS pair's agent pod — the gateway pod's egress
-	// stays unrestricted (it dials external upstreams for credential
-	// injection, gated by ext_authz inside its own Envoy).
+	// Selector pins to this pair's agent pod — gateway pod is
+	// unaffected (ADR-035 gates its egress at L7 ext_authz).
 	assert.Equal(t, "my-instance", np.Spec.PodSelector.MatchLabels[LabelPair])
 	assert.Equal(t, RoleAgent, np.Spec.PodSelector.MatchLabels[LabelRole])
 
@@ -47,10 +43,7 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	assert.Equal(t, corev1.ProtocolTCP, *gwRule.Ports[0].Protocol)
 }
 
-// Fork pair: same shape, keyed on the fork name. ADR-027's fork-pair
-// isolation property only holds because the agent NP scopes the agent's
-// egress to its OWN gateway — without this, a compromised fork agent
-// could dial the parent's gateway directly.
+// Fork pair: same shape, keyed on the fork name (ADR-027 isolation).
 func TestBuildAgentEgressNetworkPolicy_Fork(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("fork-abc", testConfig, testForkOwnerCM)
 
@@ -58,17 +51,14 @@ func TestBuildAgentEgressNetworkPolicy_Fork(t *testing.T) {
 	assert.Equal(t, "fork-abc", np.Spec.PodSelector.MatchLabels[LabelPair])
 	assert.Equal(t, RoleAgent, np.Spec.PodSelector.MatchLabels[LabelRole])
 
-	// The gateway-pod egress rule must reference the FORK's gateway, not
-	// the parent's — otherwise the fork agent could reach the parent's
-	// gateway and inject under the parent owner's credentials.
+	// Gateway peer must scope to the fork's own gateway (ADR-027).
 	gwRule := np.Spec.Egress[0]
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "fork-abc", gwRule.To[0].PodSelector.MatchLabels[LabelPair],
-		"fork agent NP must scope to the FORK's gateway, not the parent's")
+		"fork agent NP must scope to the fork's own gateway")
 }
 
-// DNS deny is now structural: no DNS ports appear anywhere because
-// HTTPS_PROXY is IP-direct and the agent has no other reason to resolve.
+// DNS deny is structural — proxy is IP-direct.
 func TestBuildAgentEgressNetworkPolicy_NoDNS(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
 	for _, rule := range np.Spec.Egress {
@@ -79,9 +69,7 @@ func TestBuildAgentEgressNetworkPolicy_NoDNS(t *testing.T) {
 	}
 }
 
-// HBONE port 15008 must NOT appear anywhere in the agent egress policy.
-// The agent has no ztunnel and never speaks HBONE; admitting 15008 here
-// would let the agent reach any in-mesh destination via ztunnel.
+// HBONE port 15008 must NOT appear in the agent egress policy.
 func TestBuildAgentEgressNetworkPolicy_NoHBONE(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
 	for i, rule := range np.Spec.Egress {

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -9,11 +9,13 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 )
 
-// Agent pod opts out of ambient mesh, so kernel NetworkPolicy is the sole
-// gate on agent egress. The policy admits exactly DNS + paired gateway
-// pod on the Envoy proxy port — nothing else. HBONE port 15008 is
-// deliberately denied: the agent has no ztunnel and admitting 15008 would
-// give it a route to anything in the mesh.
+// Agent pod opts out of ambient mesh, so kernel NetworkPolicy is the
+// gate on agent egress. The policy admits exactly the paired gateway
+// pod on the Envoy proxy port — nothing else, no DNS. HTTPS_PROXY is
+// IP-direct so DNS is unnecessary; the namespace-scope deny-all baseline
+// (chart-rendered) handles default-deny. HBONE port 15008 is
+// deliberately denied: the agent has no ztunnel and admitting 15008
+// would give it a route to anything in the mesh.
 func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
 
@@ -31,27 +33,10 @@ func TestBuildAgentEgressNetworkPolicy_LongLivedPair(t *testing.T) {
 	require.Len(t, np.Spec.PolicyTypes, 1)
 	assert.Equal(t, networkingv1.PolicyTypeEgress, np.Spec.PolicyTypes[0])
 
-	require.Len(t, np.Spec.Egress, 3, "kube-system DNS + openshift-dns DNS + paired gateway, nothing else")
-
-	// Upstream Kubernetes: CoreDNS / kube-dns in `kube-system` listening
-	// on pod port 53.
-	corednsRule := np.Spec.Egress[0]
-	require.Len(t, corednsRule.To, 1)
-	require.NotNil(t, corednsRule.To[0].NamespaceSelector)
-	assert.Equal(t, "kube-system", corednsRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
-	assertDNSPorts(t, corednsRule.Ports, 53)
-
-	// OpenShift: dns-default in `openshift-dns` listening on pod port
-	// 5353. NetworkPolicy filters on pod port after kube-proxy
-	// translation, so the upstream rule (53) does not match here.
-	openshiftRule := np.Spec.Egress[1]
-	require.Len(t, openshiftRule.To, 1)
-	require.NotNil(t, openshiftRule.To[0].NamespaceSelector)
-	assert.Equal(t, "openshift-dns", openshiftRule.To[0].NamespaceSelector.MatchLabels["kubernetes.io/metadata.name"])
-	assertDNSPorts(t, openshiftRule.Ports, 5353)
+	require.Len(t, np.Spec.Egress, 1, "paired gateway only — no DNS, no anything else")
 
 	// Paired gateway pod — Envoy proxy port only.
-	gwRule := np.Spec.Egress[2]
+	gwRule := np.Spec.Egress[0]
 	require.Len(t, gwRule.To, 1)
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "my-instance", gwRule.To[0].PodSelector.MatchLabels[LabelPair])
@@ -76,10 +61,22 @@ func TestBuildAgentEgressNetworkPolicy_Fork(t *testing.T) {
 	// The gateway-pod egress rule must reference the FORK's gateway, not
 	// the parent's — otherwise the fork agent could reach the parent's
 	// gateway and inject under the parent owner's credentials.
-	gwRule := np.Spec.Egress[2]
+	gwRule := np.Spec.Egress[0]
 	require.NotNil(t, gwRule.To[0].PodSelector)
 	assert.Equal(t, "fork-abc", gwRule.To[0].PodSelector.MatchLabels[LabelPair],
 		"fork agent NP must scope to the FORK's gateway, not the parent's")
+}
+
+// DNS deny is now structural: no DNS ports appear anywhere because
+// HTTPS_PROXY is IP-direct and the agent has no other reason to resolve.
+func TestBuildAgentEgressNetworkPolicy_NoDNS(t *testing.T) {
+	np := BuildAgentEgressNetworkPolicy("my-instance", testConfig, testOwnerCM)
+	for _, rule := range np.Spec.Egress {
+		for _, p := range rule.Ports {
+			assert.NotEqual(t, int32(53), p.Port.IntVal, "DNS port 53 must not appear")
+			assert.NotEqual(t, int32(5353), p.Port.IntVal, "DNS port 5353 must not appear")
+		}
+	}
 }
 
 // HBONE port 15008 must NOT appear anywhere in the agent egress policy.
@@ -103,36 +100,3 @@ func TestBuildAgentEgressNetworkPolicy_ManagedByLabel(t *testing.T) {
 	assert.Equal(t, "my-instance", np.Labels[LabelInstance])
 }
 
-// PoC `disableDns`: when set, the per-pair agent egress NP must NOT admit
-// DNS — closing threat-model T9 (DNS exfil via CoreDNS's upstream
-// forwarder). Only the paired-gateway rule remains.
-func TestBuildAgentEgressNetworkPolicy_DisableDNS(t *testing.T) {
-	cfg := *testConfig
-	cfg.AgentBase.DisableDNS = true
-	np := BuildAgentEgressNetworkPolicy("my-instance", &cfg, testOwnerCM)
-
-	require.Len(t, np.Spec.Egress, 1, "disableDns must collapse the policy to gateway-only")
-	gw := np.Spec.Egress[0]
-	require.NotNil(t, gw.To[0].PodSelector)
-	assert.Equal(t, "my-instance", gw.To[0].PodSelector.MatchLabels[LabelPair])
-	assert.Equal(t, RoleGateway, gw.To[0].PodSelector.MatchLabels[LabelRole])
-
-	// Explicit: no DNS port lurking anywhere.
-	for _, rule := range np.Spec.Egress {
-		for _, p := range rule.Ports {
-			assert.NotEqual(t, int32(53), p.Port.IntVal, "DNS port 53 must not appear when DNS is disabled")
-			assert.NotEqual(t, int32(5353), p.Port.IntVal, "DNS port 5353 must not appear when DNS is disabled")
-		}
-	}
-}
-
-func assertDNSPorts(t *testing.T, ports []networkingv1.NetworkPolicyPort, expected int32) {
-	t.Helper()
-	require.Len(t, ports, 2, "both UDP and TCP on the resolver's pod port — modern resolvers fall through to TCP")
-	protocols := map[corev1.Protocol]bool{}
-	for _, p := range ports {
-		protocols[*p.Protocol] = true
-		assert.Equal(t, expected, p.Port.IntVal)
-	}
-	assert.True(t, protocols[corev1.ProtocolUDP] && protocols[corev1.ProtocolTCP])
-}

--- a/packages/controller/pkg/reconciler/np_gate_init.go
+++ b/packages/controller/pkg/reconciler/np_gate_init.go
@@ -1,0 +1,98 @@
+package reconciler
+
+import (
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+)
+
+const npGateInitContainerName = "np-gate"
+
+// buildNPGateInitContainer renders an unprivileged init container that
+// blocks the agent's main container until the egress NetworkPolicy is
+// verifiably enforced.
+//
+// Threat: OVN-K programs NetworkPolicy ACLs asynchronously after the pod's
+// netns is set up. There's a small window (typically ms, occasionally
+// longer under churn) where the pod can egress before its NPs are in
+// force. The iptables init container closes this race deterministically
+// by setting rules inside the pod — but on Kata/CoCo guest kernels that
+// lack netfilter modules (see PR #234), the iptables path is unavailable.
+// This gate is the alternative: probe an outside-the-allow-list
+// destination until it's DROPped, then exit so the agent can start.
+//
+// Probe shape: TCP-connect to a canary IP (default 1.1.1.1:443) with a
+// short timeout. While the connect succeeds, NP isn't in force yet — wait
+// and retry. Once the connect fails (timeout/RST), NP is enforcing the
+// deny. Also confirm the paired gateway IS reachable — guards against
+// "everything denied" false positives on clusters with broken outbound.
+//
+// Fail-closed: timeout → exit 1 → pod stays in Init:CrashLoopBackOff. The
+// agent main container never starts. Operationally noisy; security-wise
+// the only correct behavior.
+//
+// Returns nil when the feature is off, the image is unset, or the
+// gateway IP is unknown — caller is expected to either skip this init or
+// requeue the reconcile (see needsGatewayIP gating in instance.go/fork.go).
+func buildNPGateInitContainer(cfg *config.Config, gatewayClusterIP string) *corev1.Container {
+	cfgGate := cfg.AgentBase.NPGateInit
+	if cfgGate == nil || !cfgGate.Enabled || cfgGate.Image == "" || gatewayClusterIP == "" {
+		return nil
+	}
+
+	deniedHost := cfgGate.DeniedHost
+	if deniedHost == "" {
+		deniedHost = "1.1.1.1"
+	}
+	deniedPort := cfgGate.DeniedPort
+	if deniedPort == 0 {
+		deniedPort = 443
+	}
+	timeoutSeconds := cfgGate.TimeoutSeconds
+	if timeoutSeconds == 0 {
+		timeoutSeconds = 30
+	}
+
+	// `nc -w 2 -z` returns 0 when the TCP connect succeeds, non-zero on
+	// timeout/refused/drop. We invert the denied-host check (success on
+	// non-zero) and combine with the positive gateway check (success on
+	// zero) — both must hold for the gate to release.
+	script := `set -u
+deadline=$(($(date +%s) + ${TIMEOUT_SECONDS}))
+echo "np-gate: probing denied=${DENIED_HOST}:${DENIED_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}, deadline=${TIMEOUT_SECONDS}s"
+while [ "$(date +%s)" -lt "${deadline}" ]; do
+    if ! nc -w 2 -z "${DENIED_HOST}" "${DENIED_PORT}" 2>/dev/null; then
+        if nc -w 2 -z "${GATEWAY_IP}" "${ENVOY_PORT}" 2>/dev/null; then
+            echo "np-gate: NetworkPolicy enforced (denied ${DENIED_HOST}:${DENIED_PORT} blocked, gateway ${GATEWAY_IP}:${ENVOY_PORT} reachable)"
+            exit 0
+        fi
+    fi
+    sleep 0.3
+done
+echo "np-gate: FATAL — NetworkPolicy did not converge within ${TIMEOUT_SECONDS}s (denied=${DENIED_HOST}:${DENIED_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT})" >&2
+exit 1
+`
+
+	return &corev1.Container{
+		Name:    npGateInitContainerName,
+		Image:   cfgGate.Image,
+		Command: []string{"/bin/sh", "-c", script},
+		Env: []corev1.EnvVar{
+			{Name: "GATEWAY_IP", Value: gatewayClusterIP},
+			{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
+			{Name: "DENIED_HOST", Value: deniedHost},
+			{Name: "DENIED_PORT", Value: fmt.Sprintf("%d", deniedPort)},
+			{Name: "TIMEOUT_SECONDS", Value: fmt.Sprintf("%d", timeoutSeconds)},
+		},
+		SecurityContext: &corev1.SecurityContext{
+			RunAsNonRoot:             ptrBool(true),
+			AllowPrivilegeEscalation: ptrBool(false),
+			ReadOnlyRootFilesystem:   ptrBool(true),
+			Capabilities: &corev1.Capabilities{
+				Drop: []corev1.Capability{"ALL"},
+			},
+		},
+	}
+}

--- a/packages/controller/pkg/reconciler/np_gate_init.go
+++ b/packages/controller/pkg/reconciler/np_gate_init.go
@@ -12,36 +12,20 @@ const npGateInitContainerName = "np-gate"
 
 // buildNPGateInitContainer renders an unprivileged init container that
 // blocks the agent's main container until the egress NetworkPolicy is
-// verifiably enforced.
+// verifiably enforced — used on runtimes where the in-pod iptables init
+// can't run (Kata/CoCo guest kernels without netfilter).
 //
-// Threat: OVN-K programs NetworkPolicy ACLs asynchronously after the pod's
-// netns is set up. There's a small window (typically ms, occasionally
-// longer under churn) where the pod can egress before its NPs are in
-// force. The iptables init container closes this race deterministically
-// by setting rules inside the pod — but on Kata/CoCo guest kernels that
-// lack netfilter modules (see PR #234), the iptables path is unavailable.
-// This gate is the alternative: probe an outside-the-allow-list
-// destination until it's DROPped, then exit so the agent can start.
+// Probes a canary destination expected to be denied AND the paired
+// gateway expected to be reachable; only releases when both hold.
+// Defaults to the kube-apiserver Service IP (KUBERNETES_SERVICE_HOST /
+// KUBERNETES_SERVICE_PORT auto-injected by kubelet) — operators can
+// override via `npGateInit.deniedHost` / `.deniedPort`.
 //
-// Probe shape: TCP-connect to a canary destination with a short timeout.
-// While the connect succeeds, NP isn't in force yet — wait and retry.
-// Once the connect fails (timeout/RST), NP is enforcing the deny. Also
-// confirm the paired gateway IS reachable — guards against "everything
-// denied" false positives on clusters with broken outbound.
+// Fail-closed: timeout → exit 1 → pod stays in Init:CrashLoopBackOff.
 //
-// Default canary: the kube-apiserver Service IP, auto-injected into
-// every pod by kubelet as KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT.
-// Always reachable in-cluster when NP is permissive, always denied by
-// our agent egress NP (gateway-only), no external uptime dependency.
-// Operators can override via `npGateInit.deniedHost` / `.deniedPort`.
-//
-// Fail-closed: timeout → exit 1 → pod stays in Init:CrashLoopBackOff. The
-// agent main container never starts. Operationally noisy; security-wise
-// the only correct behavior.
-//
-// Returns nil when the feature is off, the image is unset, or the
-// gateway IP is unknown — caller is expected to either skip this init or
-// requeue the reconcile (see needsGatewayIP gating in instance.go/fork.go).
+// Returns nil when the feature is off or inputs aren't ready. The
+// instance and fork reconcilers requeue until the gateway ClusterIP is
+// assigned, so this never sees an empty IP at steady state.
 func buildNPGateInitContainer(cfg *config.Config, gatewayClusterIP string) *corev1.Container {
 	cfgGate := cfg.AgentBase.NPGateInit
 	if cfgGate == nil || !cfgGate.Enabled || cfgGate.Image == "" || gatewayClusterIP == "" {
@@ -54,15 +38,9 @@ func buildNPGateInitContainer(cfg *config.Config, gatewayClusterIP string) *core
 	}
 
 	// DENIED_HOST / DENIED_PORT default to the kubelet-injected
-	// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT when operator
-	// doesn't override. The shell parameter expansion `${X:-fallback}`
-	// resolves at script start, so the env vars set by kubelet are
-	// honored without us having to plumb them through here.
-	//
-	// `nc -w 2 -z` returns 0 when the TCP connect succeeds, non-zero on
-	// timeout/refused/drop. We invert the denied-host check (success on
-	// non-zero) and combine with the positive gateway check (success on
-	// zero) — both must hold for the gate to release.
+	// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT — shell
+	// parameter expansion `${X:-fallback}` honors the kubelet values
+	// unless the operator overrode them in env below.
 	script := `set -u
 DENIED_HOST="${DENIED_HOST:-${KUBERNETES_SERVICE_HOST}}"
 DENIED_PORT="${DENIED_PORT:-${KUBERNETES_SERVICE_PORT}}"
@@ -86,10 +64,8 @@ exit 1
 		{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
 		{Name: "TIMEOUT_SECONDS", Value: fmt.Sprintf("%d", timeoutSeconds)},
 	}
-	// Only inject DENIED_HOST/DENIED_PORT when the operator overrides
-	// the kube-apiserver default. Leaving them unset lets kubelet's
-	// auto-injected KUBERNETES_SERVICE_HOST/PORT flow through the
-	// `${X:-fallback}` expansion in the script.
+	// Only inject when overridden — empty values would mask kubelet's
+	// KUBERNETES_SERVICE_HOST/PORT injection.
 	if cfgGate.DeniedHost != "" {
 		env = append(env, corev1.EnvVar{Name: "DENIED_HOST", Value: cfgGate.DeniedHost})
 	}

--- a/packages/controller/pkg/reconciler/np_gate_init.go
+++ b/packages/controller/pkg/reconciler/np_gate_init.go
@@ -15,11 +15,13 @@ const npGateInitContainerName = "np-gate"
 // verifiably enforced — used on runtimes where the in-pod iptables init
 // can't run (Kata/CoCo guest kernels without netfilter).
 //
-// Probes a canary destination expected to be denied AND the paired
-// gateway expected to be reachable; only releases when both hold.
-// Defaults to the kube-apiserver Service IP (KUBERNETES_SERVICE_HOST /
-// KUBERNETES_SERVICE_PORT auto-injected by kubelet) — operators can
-// override via `npGateInit.deniedHost` / `.deniedPort`.
+// Probes the kube-apiserver Service (kubelet-injected
+// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT) expecting the NP
+// to DROP it, and the paired gateway expecting it to be reachable;
+// only releases when both hold. Hard-coded to the kube-apiserver
+// because it's the only target that's always actively listening AND
+// always silently DROPped by the agent egress NP — other choices
+// admit TCP-RST false positives that `nc -z` can't distinguish.
 //
 // Fail-closed: timeout → exit 1 → pod stays in Init:CrashLoopBackOff.
 //
@@ -37,25 +39,21 @@ func buildNPGateInitContainer(cfg *config.Config, gatewayClusterIP string) *core
 		timeoutSeconds = 30
 	}
 
-	// DENIED_HOST / DENIED_PORT default to the kubelet-injected
-	// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT — shell
-	// parameter expansion `${X:-fallback}` honors the kubelet values
-	// unless the operator overrode them in env below.
+	// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT are auto-injected
+	// by kubelet into every pod — no plumbing needed here.
 	script := `set -u
-DENIED_HOST="${DENIED_HOST:-${KUBERNETES_SERVICE_HOST}}"
-DENIED_PORT="${DENIED_PORT:-${KUBERNETES_SERVICE_PORT}}"
 deadline=$(($(date +%s) + ${TIMEOUT_SECONDS}))
-echo "np-gate: probing denied=${DENIED_HOST}:${DENIED_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}, deadline=${TIMEOUT_SECONDS}s"
+echo "np-gate: probing denied=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}, deadline=${TIMEOUT_SECONDS}s"
 while [ "$(date +%s)" -lt "${deadline}" ]; do
-    if ! nc -w 2 -z "${DENIED_HOST}" "${DENIED_PORT}" 2>/dev/null; then
+    if ! nc -w 2 -z "${KUBERNETES_SERVICE_HOST}" "${KUBERNETES_SERVICE_PORT}" 2>/dev/null; then
         if nc -w 2 -z "${GATEWAY_IP}" "${ENVOY_PORT}" 2>/dev/null; then
-            echo "np-gate: NetworkPolicy enforced (denied ${DENIED_HOST}:${DENIED_PORT} blocked, gateway ${GATEWAY_IP}:${ENVOY_PORT} reachable)"
+            echo "np-gate: NetworkPolicy enforced (denied ${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} blocked, gateway ${GATEWAY_IP}:${ENVOY_PORT} reachable)"
             exit 0
         fi
     fi
     sleep 0.3
 done
-echo "np-gate: FATAL — NetworkPolicy did not converge within ${TIMEOUT_SECONDS}s (denied=${DENIED_HOST}:${DENIED_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT})" >&2
+echo "np-gate: FATAL — NetworkPolicy did not converge within ${TIMEOUT_SECONDS}s (denied=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT})" >&2
 exit 1
 `
 
@@ -63,14 +61,6 @@ exit 1
 		{Name: "GATEWAY_IP", Value: gatewayClusterIP},
 		{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
 		{Name: "TIMEOUT_SECONDS", Value: fmt.Sprintf("%d", timeoutSeconds)},
-	}
-	// Only inject when overridden — empty values would mask kubelet's
-	// KUBERNETES_SERVICE_HOST/PORT injection.
-	if cfgGate.DeniedHost != "" {
-		env = append(env, corev1.EnvVar{Name: "DENIED_HOST", Value: cfgGate.DeniedHost})
-	}
-	if cfgGate.DeniedPort != 0 {
-		env = append(env, corev1.EnvVar{Name: "DENIED_PORT", Value: fmt.Sprintf("%d", cfgGate.DeniedPort)})
 	}
 
 	return &corev1.Container{

--- a/packages/controller/pkg/reconciler/np_gate_init.go
+++ b/packages/controller/pkg/reconciler/np_gate_init.go
@@ -23,11 +23,17 @@ const npGateInitContainerName = "np-gate"
 // This gate is the alternative: probe an outside-the-allow-list
 // destination until it's DROPped, then exit so the agent can start.
 //
-// Probe shape: TCP-connect to a canary IP (default 1.1.1.1:443) with a
-// short timeout. While the connect succeeds, NP isn't in force yet — wait
-// and retry. Once the connect fails (timeout/RST), NP is enforcing the
-// deny. Also confirm the paired gateway IS reachable — guards against
-// "everything denied" false positives on clusters with broken outbound.
+// Probe shape: TCP-connect to a canary destination with a short timeout.
+// While the connect succeeds, NP isn't in force yet — wait and retry.
+// Once the connect fails (timeout/RST), NP is enforcing the deny. Also
+// confirm the paired gateway IS reachable — guards against "everything
+// denied" false positives on clusters with broken outbound.
+//
+// Default canary: the kube-apiserver Service IP, auto-injected into
+// every pod by kubelet as KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT.
+// Always reachable in-cluster when NP is permissive, always denied by
+// our agent egress NP (gateway-only), no external uptime dependency.
+// Operators can override via `npGateInit.deniedHost` / `.deniedPort`.
 //
 // Fail-closed: timeout → exit 1 → pod stays in Init:CrashLoopBackOff. The
 // agent main container never starts. Operationally noisy; security-wise
@@ -42,24 +48,24 @@ func buildNPGateInitContainer(cfg *config.Config, gatewayClusterIP string) *core
 		return nil
 	}
 
-	deniedHost := cfgGate.DeniedHost
-	if deniedHost == "" {
-		deniedHost = "1.1.1.1"
-	}
-	deniedPort := cfgGate.DeniedPort
-	if deniedPort == 0 {
-		deniedPort = 443
-	}
 	timeoutSeconds := cfgGate.TimeoutSeconds
 	if timeoutSeconds == 0 {
 		timeoutSeconds = 30
 	}
 
+	// DENIED_HOST / DENIED_PORT default to the kubelet-injected
+	// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT when operator
+	// doesn't override. The shell parameter expansion `${X:-fallback}`
+	// resolves at script start, so the env vars set by kubelet are
+	// honored without us having to plumb them through here.
+	//
 	// `nc -w 2 -z` returns 0 when the TCP connect succeeds, non-zero on
 	// timeout/refused/drop. We invert the denied-host check (success on
 	// non-zero) and combine with the positive gateway check (success on
 	// zero) — both must hold for the gate to release.
 	script := `set -u
+DENIED_HOST="${DENIED_HOST:-${KUBERNETES_SERVICE_HOST}}"
+DENIED_PORT="${DENIED_PORT:-${KUBERNETES_SERVICE_PORT}}"
 deadline=$(($(date +%s) + ${TIMEOUT_SECONDS}))
 echo "np-gate: probing denied=${DENIED_HOST}:${DENIED_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}, deadline=${TIMEOUT_SECONDS}s"
 while [ "$(date +%s)" -lt "${deadline}" ]; do
@@ -75,17 +81,27 @@ echo "np-gate: FATAL — NetworkPolicy did not converge within ${TIMEOUT_SECONDS
 exit 1
 `
 
+	env := []corev1.EnvVar{
+		{Name: "GATEWAY_IP", Value: gatewayClusterIP},
+		{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
+		{Name: "TIMEOUT_SECONDS", Value: fmt.Sprintf("%d", timeoutSeconds)},
+	}
+	// Only inject DENIED_HOST/DENIED_PORT when the operator overrides
+	// the kube-apiserver default. Leaving them unset lets kubelet's
+	// auto-injected KUBERNETES_SERVICE_HOST/PORT flow through the
+	// `${X:-fallback}` expansion in the script.
+	if cfgGate.DeniedHost != "" {
+		env = append(env, corev1.EnvVar{Name: "DENIED_HOST", Value: cfgGate.DeniedHost})
+	}
+	if cfgGate.DeniedPort != 0 {
+		env = append(env, corev1.EnvVar{Name: "DENIED_PORT", Value: fmt.Sprintf("%d", cfgGate.DeniedPort)})
+	}
+
 	return &corev1.Container{
 		Name:    npGateInitContainerName,
 		Image:   cfgGate.Image,
 		Command: []string{"/bin/sh", "-c", script},
-		Env: []corev1.EnvVar{
-			{Name: "GATEWAY_IP", Value: gatewayClusterIP},
-			{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
-			{Name: "DENIED_HOST", Value: deniedHost},
-			{Name: "DENIED_PORT", Value: fmt.Sprintf("%d", deniedPort)},
-			{Name: "TIMEOUT_SECONDS", Value: fmt.Sprintf("%d", timeoutSeconds)},
-		},
+		Env:     env,
 		SecurityContext: &corev1.SecurityContext{
 			RunAsNonRoot:             ptrBool(true),
 			AllowPrivilegeEscalation: ptrBool(false),

--- a/packages/controller/pkg/reconciler/np_gate_init_test.go
+++ b/packages/controller/pkg/reconciler/np_gate_init_test.go
@@ -1,0 +1,102 @@
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
+)
+
+func TestBuildNPGateInitContainer_DisabledReturnsNil(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.NPGateInit = nil
+	assert.Nil(t, buildNPGateInitContainer(&cfg, "10.96.42.42"))
+
+	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: false, Image: "busybox"}
+	assert.Nil(t, buildNPGateInitContainer(&cfg, "10.96.42.42"))
+}
+
+func TestBuildNPGateInitContainer_EmptyImageReturnsNil(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true}
+	assert.Nil(t, buildNPGateInitContainer(&cfg, "10.96.42.42"), "missing image must not crash; chart enforces non-empty")
+}
+
+// Without a gateway ClusterIP the positive-probe target is unknown — the
+// init can't tell "NP applied" from "everything broken." Skip until the
+// next reconcile picks up the assigned IP (caller's needsGatewayIP gate).
+func TestBuildNPGateInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}
+	assert.Nil(t, buildNPGateInitContainer(&cfg, ""), "no gateway IP yet — re-attach on next reconcile")
+}
+
+func TestBuildNPGateInitContainer_NoCapsUnprivileged(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}
+
+	ic := buildNPGateInitContainer(&cfg, "10.96.42.42")
+	require.NotNil(t, ic)
+	assert.Equal(t, "np-gate", ic.Name)
+	assert.Equal(t, "busybox:1.36", ic.Image)
+	require.NotNil(t, ic.SecurityContext)
+	// Pure userspace TCP probe — no caps, no root, no writable rootfs.
+	// Same security floor as a normal unprivileged sidecar.
+	require.NotNil(t, ic.SecurityContext.RunAsNonRoot)
+	assert.True(t, *ic.SecurityContext.RunAsNonRoot, "np-gate must run unprivileged")
+	require.NotNil(t, ic.SecurityContext.Capabilities)
+	assert.Contains(t, ic.SecurityContext.Capabilities.Drop, corev1.Capability("ALL"))
+	assert.Empty(t, ic.SecurityContext.Capabilities.Add, "no capabilities — pure TCP probe")
+}
+
+func TestBuildNPGateInitContainer_ProbeShape(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{
+		Enabled:        true,
+		Image:          "busybox:1.36",
+		DeniedHost:     "1.1.1.1",
+		DeniedPort:     443,
+		TimeoutSeconds: 30,
+	}
+
+	ic := buildNPGateInitContainer(&cfg, "10.96.42.42")
+	require.NotNil(t, ic)
+	require.GreaterOrEqual(t, len(ic.Command), 3)
+	script := ic.Command[2]
+
+	// Probe shape: nc against denied host expected to FAIL, against
+	// gateway expected to SUCCEED. Both must hold before exit 0.
+	assert.Contains(t, script, `nc -w 2 -z "${DENIED_HOST}" "${DENIED_PORT}"`, "TCP probe against canary denied destination")
+	assert.Contains(t, script, `nc -w 2 -z "${GATEWAY_IP}" "${ENVOY_PORT}"`, "positive probe against the paired gateway")
+	assert.Contains(t, script, "exit 1", "fail-closed on timeout — NP didn't converge")
+	assert.Contains(t, script, "exit 0", "release the workload when both probes match expectation")
+
+	envMap := map[string]string{}
+	for _, e := range ic.Env {
+		envMap[e.Name] = e.Value
+	}
+	assert.Equal(t, "10.96.42.42", envMap["GATEWAY_IP"])
+	assert.Equal(t, "1.1.1.1", envMap["DENIED_HOST"])
+	assert.Equal(t, "443", envMap["DENIED_PORT"])
+	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
+	assert.NotEmpty(t, envMap["ENVOY_PORT"])
+}
+
+func TestBuildNPGateInitContainer_Defaults(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}
+
+	ic := buildNPGateInitContainer(&cfg, "10.96.42.42")
+	require.NotNil(t, ic)
+	envMap := map[string]string{}
+	for _, e := range ic.Env {
+		envMap[e.Name] = e.Value
+	}
+	// Defaults fill in when chart doesn't override.
+	assert.Equal(t, "1.1.1.1", envMap["DENIED_HOST"])
+	assert.Equal(t, "443", envMap["DENIED_PORT"])
+	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
+}

--- a/packages/controller/pkg/reconciler/np_gate_init_test.go
+++ b/packages/controller/pkg/reconciler/np_gate_init_test.go
@@ -52,12 +52,12 @@ func TestBuildNPGateInitContainer_NoCapsUnprivileged(t *testing.T) {
 	assert.Empty(t, ic.SecurityContext.Capabilities.Add, "no capabilities — pure TCP probe")
 }
 
-func TestBuildNPGateInitContainer_ProbeShape(t *testing.T) {
+func TestBuildNPGateInitContainer_ProbeShapeWithOverride(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{
 		Enabled:        true,
 		Image:          "busybox:1.36",
-		DeniedHost:     "1.1.1.1",
+		DeniedHost:     "10.0.0.1",
 		DeniedPort:     443,
 		TimeoutSeconds: 30,
 	}
@@ -73,19 +73,29 @@ func TestBuildNPGateInitContainer_ProbeShape(t *testing.T) {
 	assert.Contains(t, script, `nc -w 2 -z "${GATEWAY_IP}" "${ENVOY_PORT}"`, "positive probe against the paired gateway")
 	assert.Contains(t, script, "exit 1", "fail-closed on timeout — NP didn't converge")
 	assert.Contains(t, script, "exit 0", "release the workload when both probes match expectation")
+	// Shell fallback to kubelet env vars when operator doesn't override.
+	assert.Contains(t, script, `DENIED_HOST="${DENIED_HOST:-${KUBERNETES_SERVICE_HOST}}"`,
+		"DENIED_HOST falls back to KUBERNETES_SERVICE_HOST")
+	assert.Contains(t, script, `DENIED_PORT="${DENIED_PORT:-${KUBERNETES_SERVICE_PORT}}"`,
+		"DENIED_PORT falls back to KUBERNETES_SERVICE_PORT")
 
 	envMap := map[string]string{}
 	for _, e := range ic.Env {
 		envMap[e.Name] = e.Value
 	}
 	assert.Equal(t, "10.96.42.42", envMap["GATEWAY_IP"])
-	assert.Equal(t, "1.1.1.1", envMap["DENIED_HOST"])
+	assert.Equal(t, "10.0.0.1", envMap["DENIED_HOST"], "operator override sets the env var")
 	assert.Equal(t, "443", envMap["DENIED_PORT"])
 	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
 	assert.NotEmpty(t, envMap["ENVOY_PORT"])
 }
 
-func TestBuildNPGateInitContainer_Defaults(t *testing.T) {
+// Default config (no operator override) must NOT set DENIED_HOST /
+// DENIED_PORT env vars — that lets kubelet's auto-injected
+// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT flow through the
+// shell fallback. Setting empty-valued env vars would mask kubelet's
+// values, so the absence is load-bearing.
+func TestBuildNPGateInitContainer_DefaultsUseKubeAPIServer(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}
 
@@ -95,8 +105,9 @@ func TestBuildNPGateInitContainer_Defaults(t *testing.T) {
 	for _, e := range ic.Env {
 		envMap[e.Name] = e.Value
 	}
-	// Defaults fill in when chart doesn't override.
-	assert.Equal(t, "1.1.1.1", envMap["DENIED_HOST"])
-	assert.Equal(t, "443", envMap["DENIED_PORT"])
+	_, hostSet := envMap["DENIED_HOST"]
+	_, portSet := envMap["DENIED_PORT"]
+	assert.False(t, hostSet, "DENIED_HOST must be unset so kubelet's KUBERNETES_SERVICE_HOST flows through")
+	assert.False(t, portSet, "DENIED_PORT must be unset so kubelet's KUBERNETES_SERVICE_PORT flows through")
 	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
 }

--- a/packages/controller/pkg/reconciler/np_gate_init_test.go
+++ b/packages/controller/pkg/reconciler/np_gate_init_test.go
@@ -51,13 +51,11 @@ func TestBuildNPGateInitContainer_NoCapsUnprivileged(t *testing.T) {
 	assert.Empty(t, ic.SecurityContext.Capabilities.Add, "no capabilities — pure TCP probe")
 }
 
-func TestBuildNPGateInitContainer_ProbeShapeWithOverride(t *testing.T) {
+func TestBuildNPGateInitContainer_ProbeShape(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{
 		Enabled:        true,
 		Image:          "busybox:1.36",
-		DeniedHost:     "10.0.0.1",
-		DeniedPort:     443,
 		TimeoutSeconds: 30,
 	}
 
@@ -66,45 +64,24 @@ func TestBuildNPGateInitContainer_ProbeShapeWithOverride(t *testing.T) {
 	require.GreaterOrEqual(t, len(ic.Command), 3)
 	script := ic.Command[2]
 
-	// Probe shape: nc against denied host expected to FAIL, against
-	// gateway expected to SUCCEED. Both must hold before exit 0.
-	assert.Contains(t, script, `nc -w 2 -z "${DENIED_HOST}" "${DENIED_PORT}"`, "TCP probe against canary denied destination")
+	// Probe shape: nc against kube-apiserver (must FAIL — NP denies),
+	// and against gateway (must SUCCEED). Both must hold before exit 0.
+	assert.Contains(t, script, `nc -w 2 -z "${KUBERNETES_SERVICE_HOST}" "${KUBERNETES_SERVICE_PORT}"`,
+		"negative probe against kube-apiserver (kubelet-injected env)")
 	assert.Contains(t, script, `nc -w 2 -z "${GATEWAY_IP}" "${ENVOY_PORT}"`, "positive probe against the paired gateway")
 	assert.Contains(t, script, "exit 1", "fail-closed on timeout — NP didn't converge")
 	assert.Contains(t, script, "exit 0", "release the workload when both probes match expectation")
-	// Shell fallback to kubelet env vars when operator doesn't override.
-	assert.Contains(t, script, `DENIED_HOST="${DENIED_HOST:-${KUBERNETES_SERVICE_HOST}}"`,
-		"DENIED_HOST falls back to KUBERNETES_SERVICE_HOST")
-	assert.Contains(t, script, `DENIED_PORT="${DENIED_PORT:-${KUBERNETES_SERVICE_PORT}}"`,
-		"DENIED_PORT falls back to KUBERNETES_SERVICE_PORT")
 
 	envMap := map[string]string{}
 	for _, e := range ic.Env {
 		envMap[e.Name] = e.Value
 	}
 	assert.Equal(t, "10.96.42.42", envMap["GATEWAY_IP"])
-	assert.Equal(t, "10.0.0.1", envMap["DENIED_HOST"], "operator override sets the env var")
-	assert.Equal(t, "443", envMap["DENIED_PORT"])
 	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
 	assert.NotEmpty(t, envMap["ENVOY_PORT"])
-}
-
-// Default config must NOT set DENIED_HOST / DENIED_PORT — empty env
-// vars would mask kubelet's KUBERNETES_SERVICE_HOST/PORT injection,
-// which the shell fallback relies on. Absence is load-bearing.
-func TestBuildNPGateInitContainer_DefaultsUseKubeAPIServer(t *testing.T) {
-	cfg := *testConfig
-	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}
-
-	ic := buildNPGateInitContainer(&cfg, "10.96.42.42")
-	require.NotNil(t, ic)
-	envMap := map[string]string{}
-	for _, e := range ic.Env {
-		envMap[e.Name] = e.Value
-	}
-	_, hostSet := envMap["DENIED_HOST"]
-	_, portSet := envMap["DENIED_PORT"]
-	assert.False(t, hostSet, "DENIED_HOST must be unset so kubelet's KUBERNETES_SERVICE_HOST flows through")
-	assert.False(t, portSet, "DENIED_PORT must be unset so kubelet's KUBERNETES_SERVICE_PORT flows through")
-	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
+	// kube-apiserver isn't plumbed via our env block — kubelet does it.
+	_, kubeHostSet := envMap["KUBERNETES_SERVICE_HOST"]
+	_, kubePortSet := envMap["KUBERNETES_SERVICE_PORT"]
+	assert.False(t, kubeHostSet, "KUBERNETES_SERVICE_HOST comes from kubelet, not the controller")
+	assert.False(t, kubePortSet, "KUBERNETES_SERVICE_PORT comes from kubelet, not the controller")
 }

--- a/packages/controller/pkg/reconciler/np_gate_init_test.go
+++ b/packages/controller/pkg/reconciler/np_gate_init_test.go
@@ -25,9 +25,8 @@ func TestBuildNPGateInitContainer_EmptyImageReturnsNil(t *testing.T) {
 	assert.Nil(t, buildNPGateInitContainer(&cfg, "10.96.42.42"), "missing image must not crash; chart enforces non-empty")
 }
 
-// Without a gateway ClusterIP the positive-probe target is unknown — the
-// init can't tell "NP applied" from "everything broken." Skip until the
-// next reconcile picks up the assigned IP (caller's needsGatewayIP gate).
+// Without a gateway ClusterIP the positive-probe target is unknown.
+// Skip — the reconciler requeues until the IP is assigned.
 func TestBuildNPGateInitContainer_NoGatewayIPReturnsNil(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}
@@ -90,11 +89,9 @@ func TestBuildNPGateInitContainer_ProbeShapeWithOverride(t *testing.T) {
 	assert.NotEmpty(t, envMap["ENVOY_PORT"])
 }
 
-// Default config (no operator override) must NOT set DENIED_HOST /
-// DENIED_PORT env vars — that lets kubelet's auto-injected
-// KUBERNETES_SERVICE_HOST / KUBERNETES_SERVICE_PORT flow through the
-// shell fallback. Setting empty-valued env vars would mask kubelet's
-// values, so the absence is load-bearing.
+// Default config must NOT set DENIED_HOST / DENIED_PORT — empty env
+// vars would mask kubelet's KUBERNETES_SERVICE_HOST/PORT injection,
+// which the shell fallback relies on. Absence is load-bearing.
 func TestBuildNPGateInitContainer_DefaultsUseKubeAPIServer(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.NPGateInit = &config.AgentNPGateInit{Enabled: true, Image: "busybox:1.36"}

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -44,11 +44,9 @@ const (
 	RoleGateway   = "gateway"
 )
 
-// agentProxyAddr is the agent's HTTPS_PROXY value: the paired gateway's
-// ClusterIP literal. IP-direct so the proxy URL has zero DNS dependency
-// — the egress NetworkPolicy denies port 53 outright. Callers gate pod
-// render on `gatewayClusterIP != ""` (see needsGatewayIP in
-// instance.go / fork.go), so this never sees an empty IP in practice.
+// agentProxyAddr is the agent's HTTPS_PROXY value — IP-direct, no DNS.
+// The instance/fork reconcilers requeue until the gateway ClusterIP is
+// assigned, so this never sees an empty IP at steady state.
 func agentProxyAddr(cfg *config.Config, gatewayClusterIP string) string {
 	return fmt.Sprintf("http://%s:%d", gatewayClusterIP, cfg.EnvoyPort)
 }
@@ -61,10 +59,9 @@ func agentProxyAddr(cfg *config.Config, gatewayClusterIP string) string {
 // surfaced as an env var and pod annotation; no Secret material is mounted
 // into the agent pod.
 //
-// `gatewayClusterIP` is the paired gateway Service's assigned ClusterIP.
-// HTTPS_PROXY is set to `http://<ip>:<port>` so there's no DNS dependency
-// — the egress NetworkPolicy denies port 53. The caller (instance.go /
-// fork.go) requeues when the IP isn't yet assigned.
+// `gatewayClusterIP` is the paired gateway Service's assigned ClusterIP,
+// used directly as the HTTPS_PROXY target. The caller requeues when
+// it's not yet assigned.
 func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec *types.AgentSpec, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret, gatewayClusterIP string) *appsv1.StatefulSet {
 	base := cfg.AgentBase
 	defaults := cfg.AgentTemplateDefaults

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -44,10 +44,13 @@ const (
 	RoleGateway   = "gateway"
 )
 
-// agentProxyAddr is the agent's HTTPS_PROXY value: the paired gateway pod's
-// Service DNS. Service-form is stable across gateway pod restarts (ADR-038).
-func agentProxyAddr(instanceName string, cfg *config.Config) string {
-	return fmt.Sprintf("http://%s:%d", GatewayName(instanceName), cfg.EnvoyPort)
+// agentProxyAddr is the agent's HTTPS_PROXY value: the paired gateway's
+// ClusterIP literal. IP-direct so the proxy URL has zero DNS dependency
+// — the egress NetworkPolicy denies port 53 outright. Callers gate pod
+// render on `gatewayClusterIP != ""` (see needsGatewayIP in
+// instance.go / fork.go), so this never sees an empty IP in practice.
+func agentProxyAddr(cfg *config.Config, gatewayClusterIP string) string {
+	return fmt.Sprintf("http://%s:%d", gatewayClusterIP, cfg.EnvoyPort)
 }
 
 // BuildAgentStatefulSet renders the agent half of the paired pod set
@@ -58,10 +61,10 @@ func agentProxyAddr(instanceName string, cfg *config.Config) string {
 // surfaced as an env var and pod annotation; no Secret material is mounted
 // into the agent pod.
 //
-// `gatewayClusterIP` is injected into `hostAliases` when `DisableDNS` is on,
-// so `HTTPS_PROXY=http://<pair>-gateway:<port>` resolves without DNS. Empty
-// when the controller doesn't have the IP yet — caller is expected to
-// fail-closed in that case.
+// `gatewayClusterIP` is the paired gateway Service's assigned ClusterIP.
+// HTTPS_PROXY is set to `http://<ip>:<port>` so there's no DNS dependency
+// — the egress NetworkPolicy denies port 53. The caller (instance.go /
+// fork.go) requeues when the IP isn't yet assigned.
 func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec *types.AgentSpec, cfg *config.Config, ownerCM *corev1.ConfigMap, credentialSecrets []corev1.Secret, gatewayClusterIP string) *appsv1.StatefulSet {
 	base := cfg.AgentBase
 	defaults := cfg.AgentTemplateDefaults
@@ -114,7 +117,7 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 
 	caCertPath := "/etc/platform/ca/ca.crt"
 
-	proxyAddr := agentProxyAddr(name, cfg)
+	proxyAddr := agentProxyAddr(cfg, gatewayClusterIP)
 
 	// The agent container holds zero platform credentials. Inbound calls to
 	// agent-runtime's tRPC are gated by the api-server's mesh
@@ -263,8 +266,16 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	}
 	var initContainers []corev1.Container
 	// Egress-lockdown runs before the user init so the allow-list is in
-	// place by the time anything dials the network.
+	// place by the time anything dials the network. Two flavors: the
+	// kernel-level iptables init (works on plain OCI runtimes; needs
+	// netfilter modules in the guest, which Kata/CoCo strips) and the
+	// userspace NP-readiness gate (works everywhere — no caps, no
+	// kernel modules; verifies the NetworkPolicy is in force before
+	// releasing the workload). Whichever the chart enables fires here.
 	if ic := buildIptablesInitContainer(cfg, gatewayClusterIP); ic != nil {
+		initContainers = append(initContainers, *ic)
+	}
+	if ic := buildNPGateInitContainer(cfg, gatewayClusterIP); ic != nil {
 		initContainers = append(initContainers, *ic)
 	}
 	if initScript != "" {
@@ -364,11 +375,6 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 	}
 	applyAgentBaseMeta(&podMeta, base)
 
-	var hostAliases []corev1.HostAlias
-	if base.DisableDNS && gatewayClusterIP != "" {
-		hostAliases = append(hostAliases, buildGatewayHostAlias(name, gatewayClusterIP))
-	}
-
 	podSpec := corev1.PodSpec{
 		// Agent pod opts out of ambient mesh
 		// (`istio.io/dataplane-mode: none` pod label above); it has no
@@ -385,7 +391,6 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 		ShareProcessNamespace:         shareProcessNS,
 		Containers:                    containers,
 		Volumes:                       volumes,
-		HostAliases:                   hostAliases,
 	}
 	applyAgentBaseScheduling(&podSpec, base)
 

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -85,7 +85,7 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 		Env:          []types.EnvVar{{Name: "GITHUB_ORG", Value: "alpha"}},
 		SecretRef:    "my-secrets",
 	}
-	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "")
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "10.96.42.42")
 
 	require.NotNil(t, ss)
 	assert.Equal(t, "my-instance", ss.Name)
@@ -121,9 +121,10 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	assert.Equal(t, int32(120), c.StartupProbe.FailureThreshold)
 
 	envMap := envToMap(c.Env)
-	// HTTPS_PROXY now points at the paired gateway Service DNS, not loopback.
-	assert.Equal(t, "http://my-instance-gateway:10000", envMap["HTTPS_PROXY"])
-	assert.Equal(t, "http://my-instance-gateway:10000", envMap["HTTP_PROXY"])
+	// HTTPS_PROXY is IP-direct — the gateway's ClusterIP literal so
+	// there's no DNS dependency (egress NP denies port 53).
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTPS_PROXY"])
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTP_PROXY"])
 
 	for _, e := range c.Env {
 		assert.NotEqual(t, "AGENT_RUNTIME_TOKEN", e.Name)
@@ -350,6 +351,20 @@ func TestBuildAgentStatefulSet_PodHardening(t *testing.T) {
 	assert.False(t, *ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	require.NotNil(t, ss.Spec.Template.Spec.ShareProcessNamespace)
 	assert.False(t, *ss.Spec.Template.Spec.ShareProcessNamespace)
+}
+
+// When the controller knows the gateway ClusterIP, HTTPS_PROXY must use
+// the IP literal — no DNS dependency, so the egress NetworkPolicy can
+// deny port 53 entirely. Falls back to the Service DNS name only when
+// the IP isn't known yet (first reconcile race).
+func TestBuildAgentStatefulSet_ProxyURLUsesIPDirectly(t *testing.T) {
+	instance := &types.InstanceSpec{DesiredState: "running"}
+	ss := BuildAgentStatefulSet("my-instance", instance, testAgent, testConfig, testOwnerCM, nil, "10.96.42.42")
+	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTPS_PROXY"], "must be IP-direct when gateway IP is known")
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTP_PROXY"])
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["https_proxy"])
+	assert.Equal(t, "http://10.96.42.42:10000", envMap["http_proxy"])
 }
 
 // --- Envoy bootstrap rendering (still produces the same YAML, just bound on 0.0.0.0 now) ---


### PR DESCRIPTION
## Summary

Reworks the agent egress lockdown to work on OpenShift Sandboxed Containers where the Kata/CoCo guest kernel strips netfilter modules (see #234) — the existing privileged `iptables-init` container can't program in-pod rules there. Two clean modes now, picked by a single chart value each:

- **`iptablesInit.enabled: true`** — plain OCI runtime, kernel-level in-pod allow-list (existing, unchanged)
- **`npGateInit.enabled: true`** — Kata / OpenShift Sandboxed Containers, unprivileged userspace TCP probe gates the agent's main container on NetworkPolicy being verifiably enforced

Egress posture changes (apply to both modes):

- `HTTPS_PROXY` uses the gateway ClusterIP literal — no DNS dependency
- Chart-rendered namespace-scope `agent-egress-deny-all` NetworkPolicy gives default-deny baseline; per-pair NP layers the gateway allow on top
- Per-pair NP no longer admits DNS ports (was conditional on `disableDns`, now structural — proxy is IP-direct so DNS is unneeded)
- `hostAliases` removed (was the DNS workaround, no longer relevant)
- `disableDns` config field removed — DNS is always denied

The `np-gate` init container probes a known-denied destination (default `1.1.1.1:443`) until the connect times out **and** probes the paired gateway until it succeeds. Both conditions must hold before releasing the agent's main container. Fail-closes on timeout. Pure userspace TCP probe — no caps, works inside CoCo guests with no netfilter.

`needsGatewayIP` simplifies to "always required" — the controller requeues when the gateway Service hasn't been assigned a ClusterIP yet. Tests use a fake-client reactor to stamp a stable IP on Service creation.

Context from the investigation that led here: docs/notes/ has the rundown of why iptables-in-guest is impossible on this OSC build (sealed rootfs, no netfilter modules, `KataConfig` CRD doesn't expose kernel customization, vanilla vs CoCo flavor isn't selectable on this cluster).

## Test plan

- [x] `mise run controller:test` — all green
- [x] `mise run controller:check` — `go vet` + build clean
- [x] `mise run helm:check:lint` + `helm:check:render` — chart + kubeconform pass
- [ ] Deploy to `dam-dev-sandboxed` with `iptablesInit.enabled: false` + `npGateInit.enabled: true`; verify agent pod reaches `Init:Running` → `np-gate: NetworkPolicy enforced (...)` log → main container starts
- [ ] Verify `agent-egress-deny-all` NetworkPolicy is rendered and applies to agent pods
- [ ] Verify HTTPS_PROXY env var resolves to an IP literal in the running pod