### PR TITLE
fix(helm): point values-local at locally-built agent images

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -46,7 +46,7 @@ agentTemplates:
     enabled: true
     description: "Google Workspace agent with Drive and Gmail via gws CLI"
     image:
-      repository: quay.io/dam-agents/google-workspace-agent
+      repository: platform-google-workspace
       tag: latest
     storageSize: "2Gi"
     skillPaths:
@@ -56,7 +56,7 @@ agentTemplates:
     enabled: true
     description: "Pi coding agent with multi-LLM support"
     image:
-      repository: quay.io/dam-agents/pi-agent
+      repository: platform-pi-agent
       tag: latest
     storageSize: "2Gi"
     skillPaths:
@@ -66,7 +66,7 @@ agentTemplates:
     enabled: true
     description: "PR code review agent (gh + Claude Code)"
     image:
-      repository: quay.io/dam-agents/code-guardian
+      repository: platform-code-guardian
       tag: latest
     storageSize: "10Gi"             # larger — clones real repos
     skillPaths:


### PR DESCRIPTION
## Summary
- Three agent templates in `deploy/helm/platform/values-local.yaml` (`google-workspace`, `pi-agent`, `code-guardian`) referenced `quay.io/dam-agents/*` images, but local clusters set `imagePullPolicy: Never`. New agent pods immediately failed with `ErrImageNeverPull` because those images are never loaded into k3s — `mise run image:agent` produces `platform-*` repositories instead.
- Repointed all three to the locally-built `platform-*` images, matching the existing `claude-code` and `bob` entries.

## Test plan
- [ ] `mise run cluster:build-agent`
- [ ] Create a fresh `google-workspace`, `pi-agent`, and `code-guardian` agent instance — pod reaches `Running` instead of `Init:ErrImageNeverPull`
- [ ] `mise run helm:check:lint` / `mise run helm:check:render`