### PR TITLE
fix(helm): correct google-workspace image name in values-local

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -46,7 +46,7 @@ agentTemplates:
     enabled: true
     description: "Google Workspace agent with Drive and Gmail via gws CLI"
     image:
-      repository: platform-google-workspace
+      repository: platform-google-workspace-agent
       tag: latest
     storageSize: "2Gi"
     skillPaths:


### PR DESCRIPTION
## Summary
- Follow-up to #242: the image built by `mise run image:agent` is `platform-google-workspace-agent:latest` (see `deploy/tasks.toml:70`), not `platform-google-workspace`. With `imagePullPolicy: Never`, the off-by-suffix name still produced `ErrImageNeverPull` on agent pod start.
- Adds the missing `-agent` suffix so the local image actually resolves.

## Test plan
- [ ] `mise run cluster:build-agent`
- [ ] Create a fresh google-workspace agent instance — pod reaches `Running` instead of `Init:ErrImageNeverPull`