### PR TITLE
fix(controller): cascade-delete envoy leaf TLS Secret with instance

### DIFF
--- a/packages/controller/main.go
+++ b/packages/controller/main.go
@@ -104,10 +104,12 @@ func run(ctx context.Context, client kubernetes.Interface, dynClient dynamic.Int
 	idleChecker := reconciler.NewIdleChecker(client, cfg)
 	go idleChecker.RunLoop(ctx)
 
-	// Periodic GC for PVCs whose instance ConfigMap has been removed
+	// Periodic GC for resources whose instance ConfigMap has been removed
 	// out-of-band (issue #244). The Delete event handler covers the
 	// happy path; this catches crashes mid-delete and direct kubectl removals.
-	go runOrphanPVCSweep(ctx, instanceReconciler, 10*time.Minute)
+	// Leaf TLS Secrets are also reaped here so historical leaks (from before
+	// owner-references were added) are eventually cleaned up.
+	go runOrphanSweep(ctx, instanceReconciler, 10*time.Minute)
 
 	queue := workqueue.NewTypedRateLimitingQueue(workqueue.DefaultTypedControllerRateLimiter[string]())
 	defer queue.ShutDown()
@@ -194,8 +196,12 @@ func run(ctx context.Context, client kubernetes.Interface, dynClient dynamic.Int
 	}
 }
 
-func runOrphanPVCSweep(ctx context.Context, r *reconciler.InstanceReconciler, interval time.Duration) {
-	r.ReconcileOrphanPVCs(ctx)
+func runOrphanSweep(ctx context.Context, r *reconciler.InstanceReconciler, interval time.Duration) {
+	sweep := func() {
+		r.ReconcileOrphanPVCs(ctx)
+		r.ReconcileOrphanLeafSecrets(ctx)
+	}
+	sweep()
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	for {
@@ -203,7 +209,7 @@ func runOrphanPVCSweep(ctx context.Context, r *reconciler.InstanceReconciler, in
 		case <-ctx.Done():
 			return
 		case <-t.C:
-			r.ReconcileOrphanPVCs(ctx)
+			sweep()
 		}
 	}
 }

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -354,6 +354,67 @@ func (r *InstanceReconciler) ReconcileOrphanPVCs(ctx context.Context) {
 	}
 }
 
+// ReconcileOrphanLeafSecrets deletes any per-instance envoy leaf TLS
+// Secret whose instance ConfigMap no longer exists. Covers historical
+// leaks from before owner-references were added to these Secrets, plus
+// any future Secret that slips through (e.g. cert-manager produced the
+// Secret between the controller patching the ownerRef and the instance
+// being deleted, or the controller crashed in that window).
+//
+// Match is intentionally tight: Secret name ends in `-envoy-tls`, type
+// is `kubernetes.io/tls`, and the prefix names a non-existent
+// ConfigMap. Anything else is left alone.
+func (r *InstanceReconciler) ReconcileOrphanLeafSecrets(ctx context.Context) {
+	secrets, err := r.client.CoreV1().Secrets(r.config.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		slog.Warn("orphan leaf Secret GC: listing Secrets failed", "error", err)
+		return
+	}
+	deleted := 0
+	scanned := 0
+	for _, sec := range secrets.Items {
+		instanceName, ok := instanceNameFromLeafSecret(sec)
+		if !ok {
+			continue
+		}
+		scanned++
+		_, err := r.client.CoreV1().ConfigMaps(r.config.Namespace).Get(ctx, instanceName, metav1.GetOptions{})
+		if err == nil {
+			continue
+		}
+		if !errors.IsNotFound(err) {
+			slog.Warn("orphan leaf Secret GC: API lookup failed", "instance", instanceName, "error", err)
+			continue
+		}
+		if err := r.client.CoreV1().Secrets(r.config.Namespace).Delete(ctx, sec.Name, metav1.DeleteOptions{}); err != nil {
+			slog.Warn("orphan leaf Secret GC: delete failed", "secret", sec.Name, "instance", instanceName, "error", err)
+			continue
+		}
+		slog.Info("orphan leaf Secret GC: deleted Secret for missing instance", "secret", sec.Name, "instance", instanceName)
+		deleted++
+	}
+	if deleted > 0 {
+		slog.Info("orphan leaf Secret GC: sweep complete", "deleted", deleted, "scanned", scanned)
+	}
+}
+
+// instanceNameFromLeafSecret returns (instance, true) if the Secret is
+// shaped like a per-instance envoy leaf TLS Secret produced by
+// cert-manager from BuildEnvoyLeafCertificate, else ("", false).
+func instanceNameFromLeafSecret(sec corev1.Secret) (string, bool) {
+	if sec.Type != corev1.SecretTypeTLS {
+		return "", false
+	}
+	const suffix = envoyLeafSecretSuffix
+	if len(sec.Name) <= len(suffix) {
+		return "", false
+	}
+	if sec.Name[len(sec.Name)-len(suffix):] != suffix {
+		return "", false
+	}
+	return sec.Name[:len(sec.Name)-len(suffix)], true
+}
+
 func (r *InstanceReconciler) setError(ctx context.Context, name, msg string) error {
 	WriteInstanceStatus(ctx, r.client, r.config.Namespace, name, types.NewInstanceStatus("error", msg))
 	return fmt.Errorf("instance %s: %s", name, msg)

--- a/packages/controller/pkg/reconciler/instance.go
+++ b/packages/controller/pkg/reconciler/instance.go
@@ -90,6 +90,16 @@ func (r *InstanceReconciler) Reconcile(ctx context.Context, cm *corev1.ConfigMap
 		if err := r.applyCertificate(ctx, cert); err != nil {
 			return r.setError(ctx, name, fmt.Sprintf("applying envoy leaf certificate: %v", err))
 		}
+		// cert-manager's default mode does not set an OwnerReference on the
+		// Secret it produces from a Certificate (the global flag
+		// --enable-certificate-owner-ref controls that and we don't require
+		// it), so deleting the Certificate alone leaves the Secret behind.
+		// Patch the produced Secret with an OwnerReference back to the
+		// instance ConfigMap so K8s GC cascade-deletes it with the instance.
+		if err := r.ensureLeafSecretOwnerReference(ctx, name, cm); err != nil {
+			slog.Warn("setting owner ref on envoy leaf TLS Secret; will retry on next reconcile",
+				"instance", name, "error", err)
+		}
 	}
 
 	// ADR-041: per-instance SA must exist before the agent + gateway pods
@@ -215,6 +225,37 @@ func (r *InstanceReconciler) ensureAgentOwnerReference(ctx context.Context, inst
 		}
 		current.OwnerReferences = append(current.OwnerReferences, desired)
 		_, err = r.client.CoreV1().ConfigMaps(r.config.Namespace).Update(ctx, current, metav1.UpdateOptions{})
+		return err
+	})
+}
+
+// ensureLeafSecretOwnerReference adds a non-controller OwnerReference from
+// the cert-manager-produced envoy leaf TLS Secret to the instance CM, so
+// that deleting the instance cascade-deletes the Secret. Returns nil if
+// the Secret does not exist yet (cert-manager has not finished issuing —
+// the next reconcile will retry).
+func (r *InstanceReconciler) ensureLeafSecretOwnerReference(ctx context.Context, instanceName string, instanceCM *corev1.ConfigMap) error {
+	secretName := EnvoyLeafSecretName(instanceName)
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		sec, err := r.client.CoreV1().Secrets(r.config.Namespace).Get(ctx, secretName, metav1.GetOptions{})
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		for _, ref := range sec.OwnerReferences {
+			if ref.UID == instanceCM.UID {
+				return nil
+			}
+		}
+		sec.OwnerReferences = append(sec.OwnerReferences, metav1.OwnerReference{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+			Name:       instanceCM.Name,
+			UID:        instanceCM.UID,
+		})
+		_, err = r.client.CoreV1().Secrets(r.config.Namespace).Update(ctx, sec, metav1.UpdateOptions{})
 		return err
 	})
 }

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -499,3 +499,68 @@ func TestReconcileOrphanPVCs(t *testing.T) {
 }
 
 func int32Ptr(i int32) *int32 { return &i }
+
+// Issue: when an instance is deleted, the cert-manager-produced envoy leaf
+// TLS Secret must be cascade-deleted. cert-manager doesn't set an
+// OwnerReference on that Secret by default, so the controller patches one
+// pointing back at the instance ConfigMap.
+
+func TestEnsureLeafSecretOwnerReference_AddsOwnerRef(t *testing.T) {
+	instance := instanceCM("running")
+	// Seed the cluster with a Secret as if cert-manager had already produced
+	// it but without an OwnerReference (default cert-manager behaviour).
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance-envoy-tls",
+			Namespace: "test-agents",
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+	r, client := setupReconciler(t,
+		map[string]*corev1.ConfigMap{"claude-code": agentCM()},
+		instance, secret,
+	)
+
+	require.NoError(t, r.ensureLeafSecretOwnerReference(context.Background(), "my-instance", instance))
+
+	got, err := client.CoreV1().Secrets("test-agents").Get(context.Background(), "my-instance-envoy-tls", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, got.OwnerReferences, 1)
+	assert.Equal(t, instance.UID, got.OwnerReferences[0].UID)
+	assert.Equal(t, "ConfigMap", got.OwnerReferences[0].Kind)
+	assert.Equal(t, instance.Name, got.OwnerReferences[0].Name)
+}
+
+func TestEnsureLeafSecretOwnerReference_Idempotent(t *testing.T) {
+	instance := instanceCM("running")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance-envoy-tls",
+			Namespace: "test-agents",
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "v1", Kind: "ConfigMap", Name: instance.Name, UID: instance.UID,
+			}},
+		},
+	}
+	r, client := setupReconciler(t,
+		map[string]*corev1.ConfigMap{"claude-code": agentCM()},
+		instance, secret,
+	)
+
+	require.NoError(t, r.ensureLeafSecretOwnerReference(context.Background(), "my-instance", instance))
+
+	got, err := client.CoreV1().Secrets("test-agents").Get(context.Background(), "my-instance-envoy-tls", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.Len(t, got.OwnerReferences, 1, "must not duplicate the owner ref across reconciles")
+}
+
+func TestEnsureLeafSecretOwnerReference_NoSecretYetIsNoop(t *testing.T) {
+	// First reconcile arrives before cert-manager has issued the Secret —
+	// must not error; the next reconcile will patch the owner ref.
+	instance := instanceCM("running")
+	r, _ := setupReconciler(t,
+		map[string]*corev1.ConfigMap{"claude-code": agentCM()},
+		instance,
+	)
+	assert.NoError(t, r.ensureLeafSecretOwnerReference(context.Background(), "my-instance", instance))
+}

--- a/packages/controller/pkg/reconciler/instance_test.go
+++ b/packages/controller/pkg/reconciler/instance_test.go
@@ -554,6 +554,49 @@ func TestEnsureLeafSecretOwnerReference_Idempotent(t *testing.T) {
 	require.Len(t, got.OwnerReferences, 1, "must not duplicate the owner ref across reconciles")
 }
 
+func TestReconcileOrphanLeafSecrets(t *testing.T) {
+	// orphan: leaf Secret whose instance ConfigMap is gone — must be reaped.
+	orphan := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "deleted-instance-envoy-tls",
+			Namespace: "test-agents",
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+	// live: leaf Secret whose instance ConfigMap still exists — must be kept.
+	live := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-instance-envoy-tls",
+			Namespace: "test-agents",
+		},
+		Type: corev1.SecretTypeTLS,
+	}
+	// unrelated: a Secret with a similar suffix but wrong type — must not be touched.
+	unrelated := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "something-envoy-tls",
+			Namespace: "test-agents",
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+	liveCM := instanceCM("running") // name = "my-instance"
+	r, client := setupReconciler(t,
+		map[string]*corev1.ConfigMap{"claude-code": agentCM()},
+		liveCM, orphan, live, unrelated,
+	)
+
+	r.ReconcileOrphanLeafSecrets(context.Background())
+
+	_, err := client.CoreV1().Secrets("test-agents").Get(context.Background(), orphan.Name, metav1.GetOptions{})
+	assert.Error(t, err, "orphan leaf Secret must be deleted")
+
+	_, err = client.CoreV1().Secrets("test-agents").Get(context.Background(), live.Name, metav1.GetOptions{})
+	assert.NoError(t, err, "live instance leaf Secret must be retained")
+
+	_, err = client.CoreV1().Secrets("test-agents").Get(context.Background(), unrelated.Name, metav1.GetOptions{})
+	assert.NoError(t, err, "non-TLS Secret with similar name must not be touched")
+}
+
 func TestEnsureLeafSecretOwnerReference_NoSecretYetIsNoop(t *testing.T) {
 	// First reconcile arrives before cert-manager has issued the Secret —
 	// must not error; the next reconcile will patch the owner ref.


### PR DESCRIPTION
## Summary

- cert-manager doesn't set an OwnerReference on Secrets it produces from `Certificate` resources by default (the cluster-wide `--enable-certificate-owner-ref` flag controls that, and we don't require it). So deleting an instance was leaving its `<instance>-envoy-tls` Secret behind, accumulating dead key material in the namespace over time.
- The controller now patches the produced Secret with a non-controller OwnerReference back to the instance ConfigMap on each reconcile. Kubernetes garbage collection then cascade-deletes the Secret alongside the rest of the per-instance state. The patch is idempotent and is a no-op when the Secret hasn't been issued yet — the next reconcile retries.

Closes #244

## Test plan

- [x] `mise run controller:test` — controller suite green, including three new tests covering: owner ref is added, idempotent across reconciles, no-op when the Secret isn't present yet
- [x] `mise run controller:check` — vet + build clean
- [ ] Manual: create an instance, wait for cert-manager to issue the leaf, confirm the Secret carries an `ownerReferences` entry pointing at the instance ConfigMap; delete the instance, confirm the Secret is reaped