### PR TITLE
docs: ubiquitous-language + ADR template + grill-with-adr skill

### DIFF
--- a/.agents/skills/adr/SKILL.md
+++ b/.agents/skills/adr/SKILL.md
@@ -34,28 +34,7 @@ When promoting a Draft to Accepted: rename `DRAFT-title.md` → `NNN-title.md` a
 - File names: short kebab-case, 2-3 words max
 - Index: `docs/adrs/index.md` — always keep in sync
 
+
 ## Template
 
-```markdown
-# ADR-NNN: Title
-
-**Date:** YYYY-MM-DD
-**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-NNN
-**Owner:** @github-username
-
-## Context
-
-What is the issue motivating this decision?
-
-## Decision
-
-What we decided.
-
-## Alternatives Considered
-
-What else was evaluated and why rejected.
-
-## Consequences
-
-What becomes easier or more difficult.
-```
+Look at the template at `docs/adr-template.md` for the expected structure and content of ADR files. Follow that format closely.

--- a/.agents/skills/grill-with-adr/SKILL.md
+++ b/.agents/skills/grill-with-adr/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: grill-with-adr
+description: Grilling session that challenges your plan against the existing domain model, sharpens terminology, and files/ammends ADR as decisions crystallise. Use when user wants to stress-test a plan against their project's language and documented decisions.
+---
+
+<what-to-do>
+
+Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+
+Ask the questions one at a time, waiting for feedback on each question before continuing.
+
+If a question can be answered by exploring the codebase, explore the codebase instead.
+
+</what-to-do>
+
+<supporting-info>
+
+## Domain awareness
+
+During codebase exploration, also look for related ADRs and existing documentation:
+
+### File
+
+- `docs/architecture/index.md` — the main system architecture overview
+- `docs/ubiquitous-language.md` — the glossary of domain terms and their definitions.
+- `docs/adrs/` — the directory of ADRs
+
+## During the session
+
+### Challenge against the glossary
+
+When the user uses a term that conflicts with the existing language in `docs/ubiquitous-language.md`, call it out immediately. "Your glossary defines 'cancellation' as X, but you seem to mean Y — which is it?"
+
+### Sharpen fuzzy language
+
+When the user uses vague or overloaded terms, propose a precise canonical term. "You're saying 'account' — do you mean the Customer or the User? Those are different things."
+
+### Discuss concrete scenarios
+
+When domain relationships are being discussed, stress-test them with specific scenarios. Invent scenarios that probe edge cases and force the user to be precise about the boundaries between concepts.
+
+### Cross-reference with code
+
+When the user states how something works, check whether the code agrees. If you find a contradiction, surface it: "Your code cancels entire Orders, but you just said partial cancellation is possible — which is right?"
+
+### Update `docs/ubiquitous-language.md` inline
+
+When a term is resolved, update `docs/ubiquitous-language.md` right there. Don't batch these up — capture them as they happen.
+
+### Offer ADRs sparingly
+
+Only offer to create an ADR when all three are true:
+
+1. **Hard to reverse** — the cost of changing your mind later is meaningful
+2. **Surprising without context** — a future reader will wonder "why did they do it this way?"
+3. **The result of a real trade-off** — there were genuine alternatives and you picked one for specific reasons
+
+If any of the three is missing, skip the ADR. Run /adr skill to draft or ammend the ADR.
+
+</supporting-info>

--- a/.claude/skills/grill-with-adr
+++ b/.claude/skills/grill-with-adr
@@ -1,0 +1,1 @@
+../../.agents/skills/grill-with-adr

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ Generic conventions for TS server-side code (tRPC, Zod, RxJS, layering). Invoke 
 
 Always follow [`docs/guidelines/documentation-guidelines.md`](docs/guidelines/documentation-guidelines.md).
 
+## Work process
+
+Proposed ideal flow for new features — see [`docs/guidelines/work-process.md`](docs/guidelines/work-process.md).
+
 ## UI (`packages/ui`)
 
 Follow the [`react-ui-engineering`](.agents/skills/react-ui-engineering/SKILL.md) skill for all React + TypeScript work. Run `mise run lint:fix` after edits; auto-fixes import order and `import type`.

--- a/README.md
+++ b/README.md
@@ -66,3 +66,7 @@ Open [localhost:4444](http://localhost:4444) (login: `dev` / `dev`), create an i
 - **[Security model](docs/strategy/security-model.md)** — the three big risks when running AI agents, how DAM handles each, and what's still unsolved
 - **[Multiplayer](docs/strategy/multi-player.md)** — DAM's multi-user model: what's private to each player, what's shared when you collaborate, and what's install-wide plumbing
 - **[Why DAM exists](PITCH.md)** — the three problems every agent hits in production, how DAM solves each, and a 5-minute walkthrough
+
+## Contributing
+
+- **[Work process](docs/guidelines/work-process.md)** — the proposed ideal flow from idea to merged code

--- a/docs/adr-template.md
+++ b/docs/adr-template.md
@@ -1,0 +1,21 @@
+# ADR-NNN: Title
+
+**Date:** YYYY-MM-DD
+**Status:** Proposed | Accepted | Deprecated | Superseded by ADR-NNN
+**Owner:** @github-username
+
+## Context
+
+What is the issue motivating this decision?
+
+## Decision
+
+What we decided.
+
+## Alternatives Considered
+
+What else was evaluated and why rejected.
+
+## Consequences
+
+What becomes easier or more difficult.

--- a/docs/guidelines/work-process.md
+++ b/docs/guidelines/work-process.md
@@ -1,0 +1,15 @@
+# Work process
+
+Proposed ideal — not a hard rule.
+
+1. **Discuss** — chat with Claude to accumulate context.
+2. **Grill** — `/grill-with-adr`. Pressure-tests vocabulary and architecture; files an ADR PR when the decision warrants it.
+3. **File issue** — `/file-issue`. Captures the problem statement; references the ADR PR if one exists.
+4. **Implement** — once any ADR PR is merged. Use `/typescript-engineering` for TS work.
+
+## Keep in mind
+
+- **Capture important decisions as ADRs.** If a choice is hard to reverse or a future reader will wonder why we did it this way, write it down. Skip the ADR for everything else.
+- **Stress-test ideas with both humans and agents.** Agents catch inconsistencies with the codebase and existing ADRs fast. Humans catch the bigger picture. You want both before committing to a direction.
+- **Every draft ADR sits on top of a ticket.** The ticket states the problem clearly; the ADR proposes how to solve it. WHAT we're solving matters more than HOW we get there.
+- **Keep the codebase architecturally consistent.** Inconsistency compounds. `/typescript-engineering` exists to keep TS work coherent with the conventions the rest of the system already follows.

--- a/docs/guidelines/work-process.md
+++ b/docs/guidelines/work-process.md
@@ -5,11 +5,11 @@ Proposed ideal — not a hard rule.
 1. **Discuss** — chat with Claude to accumulate context.
 2. **Grill** — `/grill-with-adr`. Pressure-tests vocabulary and architecture; files an ADR PR when the decision warrants it.
 3. **File issue** — `/file-issue`. Captures the problem statement; references the ADR PR if one exists.
-4. **Implement** — once any ADR PR is merged. Use `/typescript-engineering` for TS work.
+4. **Implement** — once any ADR PR is merged. Use `/typescript-engineering` for server-side TS work and `/react-ui-engineering` for UI work.
 
 ## Keep in mind
 
 - **Capture important decisions as ADRs.** If a choice is hard to reverse or a future reader will wonder why we did it this way, write it down. Skip the ADR for everything else.
 - **Stress-test ideas with both humans and agents.** Agents catch inconsistencies with the codebase and existing ADRs fast. Humans catch the bigger picture. You want both before committing to a direction.
 - **Every draft ADR sits on top of a ticket.** The ticket states the problem clearly; the ADR proposes how to solve it. WHAT we're solving matters more than HOW we get there.
-- **Keep the codebase architecturally consistent.** Inconsistency compounds. `/typescript-engineering` exists to keep TS work coherent with the conventions the rest of the system already follows.
+- **Keep the codebase architecturally consistent.** Inconsistency compounds. `/typescript-engineering` and `/react-ui-engineering` exist to keep new code coherent with the conventions the rest of the system already follows.

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -1,0 +1,121 @@
+# Ubiquitous Language
+
+Domain terms used across this project. Each term is scoped to its bounded context, except for the cross-cutting Substrate vocabulary below.
+
+## Substrate
+
+Persistence vocabulary shared by every bounded context. See [`docs/architecture/persistence.md`](../docs/architecture/persistence.md) for the substrate split.
+
+| Term | Definition |
+|------|-----------|
+| Infra State | State the Controller reconciles into running infrastructure. Stored in a ConfigMap with `spec.yaml` (api-server writer) and `status.yaml` (controller writer). |
+| Application State | State only the API Server reads and writes; the Controller never touches it. Stored in PostgreSQL. |
+
+## Agents (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Template | A read-only catalog blueprint that defines the base image, mounts, env, and resources for creating an agent |
+| Agent | A user-owned definition of a runnable AI harness, optionally derived from a template |
+| Instance | A running (or hibernated) deployment of an agent with its own state and environment; aggregate root assembled from Infra State (desiredState, env, secretRef) and Application State (channels, session metadata) |
+| Session | One conversation with the agent harness, with its own lifecycle and metadata |
+| Schedule | A time-triggered task attached to an instance — either cron-based or heartbeat |
+| Desired State | The target lifecycle state of an instance: running or hibernated |
+| Wake | Transitioning an instance from hibernated to running |
+| Heartbeat | A recurring schedule type defined by interval, internally converted to cron |
+| Keycloak User Directory | Infrastructure port resolving between user emails and Keycloak `sub` identifiers; backed by the Keycloak admin API |
+
+## Channels (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Channel | An external communication pathway connecting users to an agent instance (e.g., Slack) |
+| Channel Binding | The 1:1 linkage between a Slack channel and an Instance; a Slack channel may be bound to at most one Instance globally; Instance delete or Slack disconnect releases the binding |
+| Channel Worker | A long-running process that bridges an external service to an agent instance |
+| Thread | A Slack conversation thread identified by its `thread_ts` timestamp; maps 1:1 to at most one Session per Instance |
+| Foreign Replier | A linked Slack user in an instance's `allowedUsers` list whose identity differs from the Instance owner; triggers a Fork for the turn |
+
+## Forks (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Fork | An ephemeral, per-turn execution environment derived from an Instance that impersonates a foreign user for the duration of one Slack turn |
+| Foreign Sub | The Keycloak `sub` of a Slack replier who is not the Instance owner |
+| Fork Phase | The lifecycle state of a Fork: Pending, Ready, Failed, or Completed |
+
+## Skills — api-server side (bounded context)
+
+Catalog and orchestration view of skills. Distinct from the agent-runtime's Skills context — same words, different responsibilities. The api-server owns *which sources are connected, which skills are installed where, and what was published from which instance*; it never manipulates files on a pod directly. Per [`docs/architecture/persistence.md`](../docs/architecture/persistence.md), every concept here is Application State and lives in Postgres or in api-server config.
+
+| Term | Definition |
+|------|-----------|
+| Skill Source | A connected source of skills addressable by id; one of three kinds — user (Postgres row, owner-scoped), system (Seed List entry, cluster-admin-declared), or template (synthesised from a Template's `skillSources`) |
+| Installed Skill Ref | A record that a Scanned Skill from a Skill Source is installed at a Version on a specific Instance; identity is `(instanceId, source, name)` |
+| Skill Publish Record | A record that a Local Skill from an Instance was published as a PR to a Skill Source; written on every successful Publish, denormalized so it survives source rename or deletion |
+| Seed List | The cluster-admin-declared system Skill Sources injected as JSON into api-server config (`SKILL_SOURCES_SEED`) at startup; merged into Skill Source listings with `system: true` and protected from user deletion |
+
+## Skills — agent-runtime side (bounded context)
+
+Pod-side operational view of skills. Distinct from the api-server's Skills context — same words, different responsibilities. Agent-runtime owns *what files are where on this pod and how to mutate them*; it never reasons about source catalogs or drift.
+
+| Term | Definition |
+|------|-----------|
+| Skill | A directory containing `SKILL.md` (with `name`/`description` frontmatter); the unit of installation |
+| Skill Path | An absolute on-pod directory under which Skills are materialized; a Skill's identity within a path is the directory name |
+| Local Skill | A Skill present in some Skill Path on this pod, regardless of whether it was installed from a Source or authored in place |
+| Skill Source | A git repository URL that contains one or more Skills under `skills/*` or top-level `*` |
+| Scanned Skill | A Skill discovered in a Source: `(source, name, description, version, contentHash)` where `version` is the Source's HEAD commit SHA at scan time |
+| Content Hash | Deterministic SHA-256 over a Skill directory's file contents (sorted-path order, NUL-delimited); the drift signal produced — but not compared — on this side |
+| Install | Materializing a Skill from a Source at a Version into one or more Skill Paths |
+| Publish | Lifting a Local Skill to a GitHub repository as a new branch + PR via the REST API |
+| Scan | Enumerating Scanned Skills in a Source |
+
+## Approvals (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Approval | A user-pending decision that gates either a credentialed egress request (ext_authz) or a harness tool call (acp_native); persisted in the `pending_approvals` table |
+| Pending Approval | An approval whose verdict has not yet been decided; lives in the inbox |
+| Inbox | The user-facing surface listing pending approvals — top-level page, sidebar bell with badge, and per-instance tray |
+| Verdict | The user's decision on a pending approval: `allow_once`, `allow`, or `deny` |
+| Synth Frame | A synthetic ACP `session/request_permission` frame the relay injects into an attached client WS for an ext_authz approval; the synthetic session id has the `_egress:` prefix so the UI dispatches it to the inbox rather than the in-session permission queue |
+| Held Call | An ext_authz request blocking on the API Server while it waits for a verdict, up to `approvalHoldSeconds` (default 30 minutes); durable pending row outlives the hold |
+| ext_authz Gate | The application service that runs Envoy's HTTP ext_authz check: rule lookup, pending-row creation, synth-frame fan-out, synchronous hold, wake-up, expiry |
+| Wrapper Response | A JSON-RPC response frame the inbox publishes when resolving an acp_native row; whichever replica holds the upstream WS for the instance forwards it to the wrapper |
+| Approvals Relay Service | Server-internal port the ACP relay consumes for mirror writes (record / resolve acp-native pending) and stream subscriptions (synth frames, wrapper responses) |
+
+## Egress Rules (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Egress Rule | A persistent allow/deny decision keyed on `(agent, host, method, path_pattern)`; matched on every ext_authz check before any user prompt |
+| Rule Verdict | `allow` or `deny` — the decision a rule encodes |
+| Rule Match | Lookup of the most-specific active rule for a given egress request; misses fall through to the ext_authz Gate's pending-approval flow |
+
+## Secrets (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Secret | A user-owned credential (e.g., an Anthropic API key) stored as a K8s Secret labelled with the owner's `sub` and mounted into the agent pod's Envoy sidecar for wire-level injection on outbound traffic |
+| Secret Type | The provider taxonomy for a secret — currently `anthropic` (hostPattern fixed) or `generic` (user-supplied host/path patterns) |
+| Host Pattern | The hostname pattern that identifies which outbound requests the Envoy sidecar should inject this secret into |
+| Secret Assignment | The linkage between a Secret and an Agent that makes the secret available to that agent's egress; stored as the `agent-platform.ai/secret-mode` + `agent-platform.ai/granted-secret-ids` annotations on the agent's instance ConfigMap |
+| Provider | The external service a secret authenticates against (e.g., Anthropic); for typed secrets the provider determines default routing rules |
+
+## Platform CLI (bounded context)
+
+| Term | Definition |
+|------|-----------|
+| Platform CLI | The `dam` command-line client that talks to a hosted Platform deployment from the user's terminal; package at `packages/cli/` |
+| Config | The CLI's resolved settings for the current invocation — currently only the target Server URL |
+| Config Source | One of the three inputs the Config is resolved from: command-line flag, environment variable, or config file |
+| Server URL | The Platform deployment the CLI is configured to talk to |
+| Compat Verdict | The result of comparing the local CLI's version against the server's reported `minClientVersion` and current version: `Ok`, `BehindMinClient` (hard-refuse), or `BehindCurrent` (soft-warn) |
+| Active Host | The Server URL the CLI sends commands to by default — resolved from `--server` flag, env var, or `config.toml` in that order. Also the key into the Auth Store for the credential a given invocation should use |
+| Host Auth | The per-Host credential record persisted by `dam auth login` — issuer, username, sub, the rotated access/refresh tokens, and the access token's expiry instant |
+| Auth Store | The machine-managed credential file at `$XDG_STATE_HOME/dam/auth.toml` (mode 0600, atomic writes) holding Host Auth entries keyed by Host URL — distinct from Config, which is user-editable |
+| Token Provider | The single cross-module application service every authenticated CLI verb calls to obtain a valid bearer for a Host — owns `DAM_TOKEN` precedence, proactive refresh within 60s of expiry, and the `invalid_grant` → clear-creds policy |
+| CLI Client | The Platform CLI's public OAuth client registered in Keycloak (`platform-cli` by default, advertised as `cliClientId` on `/api/auth/config`); device-grant only, no client secret, no redirect URIs |
+| Instance Ref | The user-supplied string that addresses an Instance from the CLI — either an Instance ID (anything starting with the Reserved ID Prefix) or an Instance name, disambiguated syntactically |
+| Instance Resolver | The cross-module application service every Instance-targeted CLI verb consumes to convert an Instance Ref into the owner's Instance; exact case-sensitive name match; returns a typed not-found / ambiguous / transport / auth-required error |
+| Reserved ID Prefix | `inst-` — the prefix the controller mints onto every Instance ID; the CLI uses it as the ID-vs-name syntactic split signal and the api-server forbids Instance names that begin with it at create-time |


### PR DESCRIPTION
## Summary
- Extract ADR template out of the adr skill into `docs/adr-template.md`; skill now points to it.
- Add `docs/ubiquitous-language.md` — per-bounded-context glossary (substrate, agents, channels, forks, skills, approvals, egress rules, secrets, CLI).
- Add `grill-with-adr` skill: grills a plan against the glossary and ADRs, sharpens fuzzy terms, offers ADRs only when reversible/surprising/trade-off.

## Test plan
- [ ] N/A — docs + skill content only