### PR TITLE
fix(ci): add explicit permissions to e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds top-level `permissions: contents: read` to `e2e.yml`
- Resolves code scanning alerts #150 and #151 (`actions/missing-workflow-permissions`)
- Other workflows (`main.yml`, `publish.yml`, `quay-vuln-issue.yml`) already have this

## Test plan

- [x] Workflow syntax is valid (same pattern as other workflows)