### PR TITLE
fix(agent-runtime): bump claude-agent-acp to fix claude.exe SIGSEGV

### DIFF
--- a/packages/agent-runtime/package.json
+++ b/packages/agent-runtime/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@agentclientprotocol/claude-agent-acp": "^0.24.2",
+    "@agentclientprotocol/claude-agent-acp": "^0.33.1",
     "@trpc/server": "^11.16.0",
     "@xterm/addon-serialize": "0.14.0",
     "@xterm/headless": "5.5.0",

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN npm install @agentclientprotocol/claude-agent-acp @anthropic-ai/claude-agent-sdk \
+RUN npm install @agentclientprotocol/claude-agent-acp \
     && npm install -g @anthropic-ai/claude-code \
     && chown -R 65532:0 /app
 

--- a/packages/agents/code-guardian/Dockerfile
+++ b/packages/agents/code-guardian/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN npm install @agentclientprotocol/claude-agent-acp @anthropic-ai/claude-agent-sdk \
+RUN npm install @agentclientprotocol/claude-agent-acp \
     && npm install -g @anthropic-ai/claude-code \
     && chown -R 65532:0 /app
 

--- a/packages/agents/google-workspace/Dockerfile
+++ b/packages/agents/google-workspace/Dockerfile
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN npm install @agentclientprotocol/claude-agent-acp @anthropic-ai/claude-agent-sdk \
+RUN npm install @agentclientprotocol/claude-agent-acp \
     && npm install -g @anthropic-ai/claude-code @googleworkspace/cli@0.22.5 \
     && chown -R 65532:0 /app
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
   packages/agent-runtime:
     dependencies:
       '@agentclientprotocol/claude-agent-acp':
-        specifier: ^0.24.2
-        version: 0.24.2
+        specifier: ^0.33.1
+        version: 0.33.1
       '@lydell/node-pty':
         specifier: 1.1.0
         version: 1.1.0
@@ -440,25 +440,78 @@ importers:
 
 packages:
 
-  '@agentclientprotocol/claude-agent-acp@0.24.2':
-    resolution: {integrity: sha512-/qRaecc/Hj0nL1jPIaYwCtVOIOZ6z7YBNf8uG4TGesI9YjGXixgo+xT1iAH4Gz0tyo3Q8+LmIv37oQlzOxI1/w==}
+  '@agentclientprotocol/claude-agent-acp@0.33.1':
+    resolution: {integrity: sha512-k4wCNTqrjk/d9RRafWa/51Y08heeONYLpJB/7k7WgxueoKwwHzCBl9kBYQgu2SzllamyUUEbSQ/cVa1MC7jQEg==}
     hasBin: true
-
-  '@agentclientprotocol/sdk@0.17.0':
-    resolution: {integrity: sha512-inBMYAEd9t4E+ULZK2os9kmLG5jbPvMLbPvY71XDDem1YteW/uDwkahg6OwsGR3tvvgVhYbRJ9mJCp2VXqG4xQ==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   '@agentclientprotocol/sdk@0.17.1':
     resolution: {integrity: sha512-yjyIn8POL18IOXioLySYiL0G44kZ/IZctAls7vS3AC3X+qLhFXbWmzABSZehwRnWFShMXT+ODa/HJG1+mGXZ1A==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
-  '@anthropic-ai/claude-agent-sdk@0.2.84':
-    resolution: {integrity: sha512-rvp3kZJM4IgDBE1zwj30H3N0bI3pYRF28tDJoyAVuWTLiWls7diNVCyFz7GeXZEAYYD87lCBE3vnQplLLluNHg==}
+  '@agentclientprotocol/sdk@0.21.0':
+    resolution: {integrity: sha512-ONj+Q8qOdNQp5XbH5jnMwzT9IKZJsSN0p0lkceS4GtUtNOPVLpNzSS8gqQdGMKfBvA0ESbkL8BTaSN1Rc9miEw==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.132':
+    resolution: {integrity: sha512-wrGxeqsnhw3JSU25v78FSw85guN0FGqLA7LuAzLe+KVZqJElJvhtae1ceCvgF8e8Bc/RUrniNxRrTur+8vIZYQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.132':
+    resolution: {integrity: sha512-qiutRtM+cz6FPA2AX2fKaINkLpMO9W48d3s4CTcWPT014uJTRxZZRb5TBxnjdxRLIt6njsqvvvh0XzQLGpblBA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.132':
+    resolution: {integrity: sha512-Gu4JCAkXA/XChcrTixtnurSn445O/1EHt2TAlX/rq2gP/wCijKU3eQyZ+YWx2UMud0f9e+E4W/CHhwtCVzgqgw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.132':
+    resolution: {integrity: sha512-fWyjKRg+qfThhY9iI5GJRNtBW7qBoV20yn8kJ9RoKG4c6yn3Q+QJX+ybkfgXM45RyrO4SPmdhDeTCTG9LJSN3w==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.132':
+    resolution: {integrity: sha512-Ri7RQkbjOVox0TXTN4g04oiO5bU8WLCH9SdChxaZtS/K76Yu1vV6fYyB/wRoYWuvRLHjOANWUFIGs6O/wK5s0w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.132':
+    resolution: {integrity: sha512-AAThetjWjCRWQ7IcDTjXLltUB9DJS4S4HpPmTpCOM8muOFWOwpgTmOHe1DJc9uVXbAgFO/WEASDbD4qrsdn0rw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.132':
+    resolution: {integrity: sha512-8m5L6MlMqIzvx2V/J1gJwhXt9iMfXFvLOmtm1nhzyslc7czJWZQtHUQ8Tr/1rW32t2oEpXqrDhbjrlHgGp9xBQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.132':
+    resolution: {integrity: sha512-NNbAHtl/Bew6HUvOW8R27r/pwwctZbScGAKAxt/p4GiYa0oLKvxq/CGLv+wscRVlebeI0hA6DwC0DtnB0KnA1Q==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-agent-sdk@0.2.132':
+    resolution: {integrity: sha512-3hCkfbHi6d73QcNqgrjU9zXGdNs3BrwWnxV90p+DDFARtnwbszkkEm4nz9c80af3nzGBRVvKNZPVCqVaBrkO0g==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/sdk@0.81.0':
+    resolution: {integrity: sha512-D4K5PvEV6wPiRtVlVsJHIUhHAmOZ6IT/I9rKlTf84gR7GyyAurPJK7z9BOf/AZqC5d1DhYQGJNKRmV+q8dGhgw==}
+    hasBin: true
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    peerDependenciesMeta:
+      zod:
+        optional: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -6078,33 +6131,70 @@ packages:
 
 snapshots:
 
-  '@agentclientprotocol/claude-agent-acp@0.24.2':
+  '@agentclientprotocol/claude-agent-acp@0.33.1':
     dependencies:
-      '@agentclientprotocol/sdk': 0.17.0(zod@4.4.3)
-      '@anthropic-ai/claude-agent-sdk': 0.2.84(zod@4.4.3)
+      '@agentclientprotocol/sdk': 0.21.0(zod@4.4.3)
+      '@anthropic-ai/claude-agent-sdk': 0.2.132(zod@4.4.3)
       zod: 4.4.3
-
-  '@agentclientprotocol/sdk@0.17.0(zod@4.4.3)':
-    dependencies:
-      zod: 4.4.3
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
 
   '@agentclientprotocol/sdk@0.17.1(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
 
-  '@anthropic-ai/claude-agent-sdk@0.2.84(zod@4.4.3)':
+  '@agentclientprotocol/sdk@0.21.0(zod@4.4.3)':
     dependencies:
       zod: 4.4.3
+
+  '@anthropic-ai/claude-agent-sdk-darwin-arm64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-darwin-x64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64-musl@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-arm64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64-musl@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-linux-x64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-arm64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk-win32-x64@0.2.132':
+    optional: true
+
+  '@anthropic-ai/claude-agent-sdk@0.2.132(zod@4.4.3)':
+    dependencies:
+      '@anthropic-ai/sdk': 0.81.0(zod@4.4.3)
+      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
+      zod: 4.4.3
     optionalDependencies:
-      '@img/sharp-darwin-arm64': 0.34.5
-      '@img/sharp-darwin-x64': 0.34.5
-      '@img/sharp-linux-arm': 0.34.5
-      '@img/sharp-linux-arm64': 0.34.5
-      '@img/sharp-linux-x64': 0.34.5
-      '@img/sharp-linuxmusl-arm64': 0.34.5
-      '@img/sharp-linuxmusl-x64': 0.34.5
-      '@img/sharp-win32-arm64': 0.34.5
-      '@img/sharp-win32-x64': 0.34.5
+      '@anthropic-ai/claude-agent-sdk-darwin-arm64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-darwin-x64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-arm64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-arm64-musl': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-x64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-linux-x64-musl': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-win32-arm64': 0.2.132
+      '@anthropic-ai/claude-agent-sdk-win32-x64': 0.2.132
+    transitivePeerDependencies:
+      - '@cfworker/json-schema'
+      - supports-color
+
+  '@anthropic-ai/sdk@0.81.0(zod@4.4.3)':
+    dependencies:
+      json-schema-to-ts: 3.1.1
+    optionalDependencies:
+      zod: 4.4.3
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- Bump `@agentclientprotocol/claude-agent-acp` 0.24.2 → 0.33.1.
- Drop the explicit `@anthropic-ai/claude-agent-sdk` install from the three agent Dockerfiles (claude-code, code-guardian, google-workspace).

Both changes are load-bearing — see below.

## Why

Long-lived sessions died with:

```
No onPostToolUseHook found for tool use ID: toolu_...
Session ...: Claude Agent process died: Claude Code process terminated by signal SIGSEGV
```

Root cause is a JS-protocol-layer / native-binary version mismatch inside the agent pod:

- The Dockerfile ran `npm install @agentclientprotocol/claude-agent-acp @anthropic-ai/claude-agent-sdk` on top of the pnpm-installed `/app` from platform-base. The unversioned `@anthropic-ai/claude-agent-sdk` install pulled the latest SDK (0.3.144) into the **top level** of `/app/node_modules`, dragging in its paired native binary `claude-agent-sdk-linux-arm64@0.3.144` — the actual `claude` executable.
- `claude-agent-acp@0.24.2` bundles its own nested `@anthropic-ai/claude-agent-sdk@0.2.84`. That nested copy has no nested native-binary subpackage, so when the 0.2.84 JS layer went to spawn `claude`, Node's module resolution walked **up** to the top-level `claude-agent-sdk-linux-arm64@0.3.144`.
- Net result inside the pod: **JS protocol layer at 0.2.84 talking to a native binary at 0.3.144** — different control-protocol dialects. The CLI tolerated mismatched frames for a while, eventually segfaulted on a hook callback it didn't understand. The `No onPostToolUseHook found` log was the dialect-mismatch symptom; the SIGSEGV was the binary crashing.

The fix aligns JS layer and native binary:

1. Bumping `claude-agent-acp` to 0.33.1 ships JS SDK 0.2.132.
2. Removing the explicit SDK install lets the umbrella's transitive resolution decide the top-level version; the paired native binary lands at the matching 0.2.132.

Verified in the rebuilt pod:

```
/app/node_modules/@anthropic-ai/claude-agent-sdk           → 0.2.132
/app/node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64 → 0.2.132
```

Either change alone would not fix it: bumping acp without dropping the explicit install would re-introduce the mismatch on every rebuild; dropping the install without bumping acp would leave us on the 0.2.84 line.

`0.33.1` is the newest version of `claude-agent-acp` that satisfies the repo's 7-day `minimumReleaseAge` policy. `0.35.0+` moves the SDK to the 0.3.x line (paired with newer CLI builds) and would be a more aggressive fix; holding it in reserve in case 0.2.132 ↔ 2.1.144 turns out to have its own quirks.

## What I tried first (and removed)

Initial hypothesis was a race between our `unstable_closeSession` call and post-turn teardown in the CLI. Shipped a 30s grace-period delay before idle-close; the SIGSEGV still reproduced. Timestamped logs showed the crash firing 36s after the deferred close, and in some runs with no close logged at all — proving our close call wasn't the trigger. Those commits were dropped from this PR.

## Test plan

- [x] `mise run check` — typecheck + lint clean.
- [x] `mise run test` — full suite passes.
- [x] `mise run cluster:build-agent` — all three agent images build with the bumped dep, no ERESOLVE.
- [x] Manual cluster verification — same scenario that previously crashed now runs without SIGSEGV.