### PR TITLE
docs: tune ADR skill for shorter sharper records

### DIFF
--- a/.agents/skills/adr/SKILL.md
+++ b/.agents/skills/adr/SKILL.md
@@ -11,6 +11,31 @@ argument-hint: "[what you'd like to do]"
 
 Manage Architecture Decision Records in `docs/adrs/`. Interpret `$ARGUMENTS` as natural language.
 
+## What an ADR is, and what it isn't
+
+An ADR is a **decision**, not a design document. It captures *what was decided* and *why*, so a future reader can recover the reasoning without rereading the surrounding code. It is not the place to explain how the decision is implemented.
+
+A good ADR is short. Aim for under ~100 lines of body content. If a record is growing past one screen of prose, you're writing a design doc — the parts you'd cut to fit the shorter shape aren't worth keeping.
+
+## Writing rules
+
+- **Lead with the thesis.** The first one or two sentences of `Decision` must state what was decided. A reader who stops there should already have the answer.
+- **Name the decision, not the mechanism.** Don't name anything that could plausibly be renamed during implementation without changing the decision. Type names, function signatures, library version pins, env var names, struct fields, internal file paths — out. Interface-level names that the decision is *about* (a destination directory contract, a protocol identifier) are fine.
+- **Consequences are non-optional, and balanced.** Every ADR ends with `Easier / Harder / Committed-to`. Both pros and cons must appear — a Consequences section with only upsides is a sales pitch, not a decision record. Drop labels that don't apply; add a fourth only when it captures something the three don't. This is the part future readers come back for.
+- **Consequences must be objective.** Each bullet is backed by concrete evidence: a measurement, a prior incident, a constraint from a contract or platform, a count, a deadline. Subjective claims ("feels cleaner", "more elegant", "easier to reason about") don't belong — if you can't point at the evidence, the consequence isn't real enough to record.
+- **One-line alternatives.** Each rejected option is `**Name** — reason`. If the reasoning needs a paragraph, the `Decision` section is under-stating something; fix that instead.
+- **No code blocks except trivial inline.** Flow diagrams, schemas, and pseudo-code belong in design docs and the code, not the ADR.
+- **No re-statement.** If `Consequences` repeats what `Decision` already said, cut it. Each section earns its words.
+
+## Drafting protocol
+
+When creating or updating an ADR:
+
+1. Draft the `Decision` thesis (one or two sentences) before anything else. Show it to the user. If it doesn't survive that read, the rest is wasted work.
+2. Fill in `Context` only enough to motivate the thesis. Stop when the reader has enough.
+3. Write `Consequences` before `Alternatives Considered`. Knowing the cost makes the alternative comparisons honest.
+4. Read the whole thing top to bottom and cut. Remove any sentence that doesn't change the decision or its cost. If two sentences say the same thing, keep the shorter one.
+
 ## Creating an ADR
 
 Ask the user for any missing information. You need at minimum: title, context, decision, and owner (@github-username).
@@ -34,7 +59,6 @@ When promoting a Draft to Accepted: rename `DRAFT-title.md` → `NNN-title.md` a
 - File names: short kebab-case, 2-3 words max
 - Index: `docs/adrs/index.md` — always keep in sync
 
-
 ## Template
 
-Look at the template at `docs/adr-template.md` for the expected structure and content of ADR files. Follow that format closely.
+See [`docs/adr-template.md`](../../docs/adr-template.md) for the section skeleton.

--- a/.agents/skills/adr/SKILL.md
+++ b/.agents/skills/adr/SKILL.md
@@ -61,4 +61,4 @@ When promoting a Draft to Accepted: rename `DRAFT-title.md` → `NNN-title.md` a
 
 ## Template
 
-See [`docs/adr-template.md`](../../docs/adr-template.md) for the section skeleton.
+See [`docs/adr-template.md`](../../../docs/adr-template.md) for the section skeleton.

--- a/docs/adr-template.md
+++ b/docs/adr-template.md
@@ -6,16 +6,21 @@
 
 ## Context
 
-What is the issue motivating this decision?
+What changed, or what gap surfaced, that forces a decision now. One short paragraph. Stop when the reader has enough to understand *why now*.
 
 ## Decision
 
-What we decided.
+Open with one or two sentences naming what was decided. A reader who stops here should already have the answer. The rest of the section names the rules and boundaries of the decision — not the mechanism that implements it.
 
 ## Alternatives Considered
 
-What else was evaluated and why rejected.
+- **Name** — why rejected, one line.
+- **Name** — why rejected, one line.
 
 ## Consequences
 
-What becomes easier or more difficult.
+Pros and cons, both stated, each backed by concrete evidence — a measurement, a prior incident, a constraint, a contract. No "feels cleaner," no "more elegant."
+
+- **Easier:** what now becomes cheap, possible, or obvious — and the evidence that it does.
+- **Harder:** what now costs more, or what future work has to work around — and the evidence that it does.
+- **Committed-to:** what's now load-bearing — the thing a future reader would ask "do we still need this?" about.


### PR DESCRIPTION
Closes #23

## Summary

- Reshape the ADR skill so records come out short and decision-shaped: thesis-first Decision, name the decision not the mechanism, ~100-line target
- Make Consequences non-optional, balanced (pros AND cons), and objective (concrete evidence — no "feels cleaner")
- Bake `Easier / Harder / Committed-to` into the template skeleton

## Test plan

- [ ] Skim updated template — section skeleton reads as a decision, not a design doc
- [ ] Run `/adr` for a real decision and confirm the skill steers toward the short shape