### PR TITLE
chore(skills): source react-ui-engineering from dam-agents/skills

### DIFF
--- a/skills-lock.json
+++ b/skills-lock.json
@@ -41,6 +41,12 @@
       "sourceType": "github",
       "computedHash": "c75f3ffd7f894ff4c0911a5240d9dd00b15fc5b40bf5372f6afadd47ff56b9f3"
     },
+    "react-ui-engineering": {
+      "source": "dam-agents/skills",
+      "sourceType": "github",
+      "skillPath": "skills/react-ui-engineering/SKILL.md",
+      "computedHash": "b84c8dd313729a13c098067539bf08e60773adcba6479b5cac77a29861478e74"
+    },
     "review": {
       "source": "tomkis/typescript-engineering",
       "sourceType": "github",


### PR DESCRIPTION
## Summary

- Re-point `react-ui-engineering` at `dam-agents/skills` in `skills-lock.json` so the skill is maintained in the shared catalog and other harnesses (code-guardian) can install from the same source.
- Local files in `.agents/skills/` and `.claude/skills/` stay committed, matching the existing `typescript-engineering` convention (idiomatic `vercel-labs/skills` flow — `npx skills add` then commit; lock is bookkeeping).

Closes #280.

## Findings on the unresolved question

The issue asked: install as system source (default-on) or opt-in per instance?

**`dam-agents/skills` is currently private.** That changes the calculus:

- **System source** ([`skills.skillSources` in helm](deploy/helm/platform/values.yaml)) bakes the source into every Platform deployment. For a private repo, the catalog UI's public-archive scan 404s and falls back to the agent-runtime path, which needs a running instance + connected GitHub OAuth + org access. Anyone deploying Platform outside the DAM org gets a permanently-broken, undeletable Platform-badged source.
- **Opt-in per instance** is the same pattern `typescript-engineering` uses today (no helm wiring; users add the source via UI). Clean for outsiders; per-owner scoping is the table's design.

**Recommendation:** opt-in for now. Promote to system source if/when `dam-agents/skills` goes public, or via a DAM-internal helm overlay.

## Test plan

- [x] `mise run check` — passes (one pre-existing UI warning unrelated to this change).
- [x] `npx skills list` shows `react-ui-engineering` sourced from `dam-agents/skills`.
- [x] `.agents/skills/react-ui-engineering/SKILL.md` hash matches the remote (clean lift-and-shift).
- [ ] **Not verified end-to-end:** connecting `dam-agents/skills` to a code-guardian Platform instance with a personal OAuth App. GitHub rejected the request because the `dam-agents` org has OAuth App access restrictions enabled. Approving the personal OAuth App in the org settings would unblock the test. This adds weight to making `dam-agents/skills` public so private-source friction (OAuth App approvals, private-repo catalog UX) is out of the loop.