### PR TITLE
fix(ui): show agent name in chat header instead of instance id

### DIFF
--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -42,6 +42,8 @@ export function ChatView() {
   const selectedInstance = useStore((s) => s.selectedInstance);
   const { data: instancesData } = useInstances();
   const instances = instancesData?.list ?? [];
+  const selectedInstanceName =
+    instances.find((i) => i.id === selectedInstance)?.name ?? selectedInstance;
   const sessionId = useStore((s) => s.sessionId);
   const sessionMode = useStore((s) => s.sessionMode);
   const setSessionMode = useStore((s) => s.setSessionMode);
@@ -356,7 +358,7 @@ export function ChatView() {
           </button>
           <span className="w-px h-4 bg-border-light" />
           <h1 className="text-[14px] font-bold text-text truncate">
-            {selectedInstance}
+            {selectedInstanceName}
           </h1>
           <div className="flex h-7 rounded-md border border-border-light overflow-hidden">
             <button


### PR DESCRIPTION
## Summary
- The chat header was rendering the instance id (a random-looking string), making it hard to tell which agent the user was talking to.
- Now resolves the instance from the loaded list and renders its `name`, falling back to the id if the list hasn't loaded yet.

Closes #210

## Test plan
- [ ] Open a chat for an agent — header shows the agent's name, not its id.
- [ ] Reload mid-fetch — falls back to id until `useInstances()` resolves, then swaps to the name.