### PR TITLE
ci(security): add Mend SCA dependency scan to daily workflow

### DIFF
--- a/.github/workflows/daily.yml
+++ b/.github/workflows/daily.yml
@@ -10,6 +10,91 @@ permissions:
   issues: write
 
 jobs:
+  mend-sca:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      MEND_URL: https://ibmets.whitesourcesoftware.com
+      MEND_EMAIL: eal_apm0047897service_user@ibm.com
+      MEND_USER_KEY: ${{ secrets.MEND_USER_KEY }}
+      MEND_ORGNAME: Enterprise Applications
+      MEND_PRODUCTNAME: EAL_APM0047897
+      MEND_PROJECTNAME: platform-sca
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Mend CLI
+        run: |
+          curl -fsSL https://downloads.mend.io/cli/linux_amd64/mend -o /usr/local/bin/mend
+          chmod +x /usr/local/bin/mend
+
+      - name: Run SCA scan and file issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          results=$(mend dep --dir . \
+            --scope "${MEND_ORGNAME}//${MEND_PRODUCTNAME}//${MEND_PROJECTNAME}" \
+            --update --format json --non-interactive)
+
+          mapfile -t findings < <(echo "$results" | jq -c '
+            [.. | objects | select(.vulnerabilities) |
+              .name as $lib | .vulnerabilities[] |
+              { cve: .name, severity: .severity, score: .cvss3_score,
+                description: .description, url: .url,
+                library: $lib, fix: (.topFix.fixResolution // "—") }]
+            | unique_by(.cve + "|" + .library)
+            | .[]')
+
+          if [ "${#findings[@]}" -eq 0 ]; then
+            echo "::notice::Mend SCA: no vulnerabilities detected"
+            exit 0
+          fi
+
+          for finding in "${findings[@]}"; do
+            cve=$(echo "$finding" | jq -r '.cve')
+            severity=$(echo "$finding" | jq -r '.severity')
+            score=$(echo "$finding" | jq -r '.score')
+            description=$(echo "$finding" | jq -r '.description')
+            url=$(echo "$finding" | jq -r '.url')
+            library=$(echo "$finding" | jq -r '.library')
+            fix=$(echo "$finding" | jq -r '.fix')
+
+            title="[${cve}] ${severity} vulnerability in ${library} (SCA)"
+
+            existing=$(gh issue list \
+              --repo "${GITHUB_REPOSITORY}" \
+              --state open \
+              --search "in:title \"${cve}\" \"${library}\"" \
+              --json number \
+              --jq '.[0].number // empty')
+
+            if [ -n "$existing" ]; then
+              gh issue comment "$existing" \
+                --repo "${GITHUB_REPOSITORY}" \
+                --body "Still present. Library: \`${library}\`. Fix: \`${fix}\`."
+              continue
+            fi
+
+            issue_body=$(printf '%s\n' \
+              "**Source:** Mend SCA" \
+              "**CVE:** [\`${cve}\`](${url}) (${severity}, CVSS ${score})" \
+              "**Library:** \`${library}\`" \
+              "**Fix:** \`${fix}\`" \
+              "" \
+              "${description}" \
+              "" \
+              "---" \
+              "See [docs/architecture/security-scanning.md](../blob/main/docs/architecture/security-scanning.md) for the remediation flow.")
+
+            gh issue create \
+              --repo "${GITHUB_REPOSITORY}" \
+              --title "$title" \
+              --body "$issue_body" \
+              --label "security,vulnerability"
+          done
+
   quay-vulnerabilities:
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
## Summary

- Adds a `mend-sca` job to the daily workflow that scans monorepo dependencies using the Mend CLI against the IBM Mend platform (`ibmets.whitesourcesoftware.com`)
- Parses JSON output and creates/updates GitHub issues per CVE, following the same dedup pattern as the existing `quay-vulnerabilities` job
- Uploads scan results to the Mend platform for centralized tracking under `Enterprise Applications // EAL_APM0047897 // platform-sca`

## Prerequisites

Set the repository secret before merging:

```bash
gh secret set MEND_USER_KEY --repo dam-agents/dam --body "<service-user-key>"
```

## Test plan

- [x] Set `MEND_USER_KEY` secret on the repo
- [ ] Trigger the workflow manually via `workflow_dispatch`
- [ ] Verify the `mend-sca` job completes and issues are filed for detected CVEs
- [ ] Verify re-run comments on existing issues instead of creating duplicates