### PR TITLE
fix(deps): patch CVE-2026-45740, CVE-2026-45736, CVE-2026-45149

### DIFF
--- a/docs/architecture/security-scanning.md
+++ b/docs/architecture/security-scanning.md
@@ -3,29 +3,27 @@
 Last verified: 2026-05-19
 
 Motivated by: operational policy, not an architectural decision — no ADR.
-Image scanning, source SAST, and dependency advisory follow industry-standard
-shapes; the choices here are off-the-shelf integrations, not load-bearing
-decisions worth a separate record.
 
 ## Overview
 
-Three scanners cover three different surfaces of the same supply chain:
+Two scanners find vulnerabilities, one poller turns them into GitHub issues,
+and two more tools cover source-level and direct-dependency gaps:
 
-| Layer         | Scanner                | What it catches                                                                  | Where alerts surface                                          | Triage owner       |
-|---------------|------------------------|----------------------------------------------------------------------------------|---------------------------------------------------------------|--------------------|
-| Built images  | Quay.io Clair          | CVEs in OS packages and language deps baked into the image (apt, pip, npm, etc.) | Auto-filed GitHub issue (`security`, `vulnerability` labels)  | Security oncall    |
-| Our source    | CodeQL                 | SAST findings in our Go and TypeScript code                                      | GitHub **Security → Code scanning** tab                       | PR author / review |
-| Declared deps | Dependabot             | Vulnerable npm / Go / GitHub Actions / Docker base versions                      | Auto-filed PR; alert in **Security → Dependabot** tab         | PR author          |
+| Scanner       | What it scans                                                                 | Where alerts surface                                         |
+|---------------|-------------------------------------------------------------------------------|--------------------------------------------------------------|
+| Quay.io Clair | Built container images — OS packages, language deps, Red Hat base layer CVEs  | GitHub issue via `daily.yml` (`security` + `vulnerability`)  |
+| Mend SCA      | Repo lockfiles — npm and Go transitive dependency CVEs                        | GitHub issue (auto-filed by Mend App, same labels)           |
+| CodeQL        | Our Go and TypeScript source (SAST)                                           | GitHub **Security → Code scanning** tab                      |
+| Dependabot    | Direct dependency advisories (mostly redundant to Mend, kept as safety net)   | GitHub **Security → Dependabot** tab; auto-filed PRs         |
 
-GitHub **secret scanning** is auto-enabled on public repos and complements the
-above by blocking accidental credential commits at push time. No config in this
-repo; alerts surface in the Security tab.
+GitHub **secret scanning** complements the above by blocking credential commits
+at push time.
 
 ## Pipeline
 
 ```mermaid
 flowchart LR
-  subgraph build["GitHub Actions"]
+  subgraph ci["GitHub Actions"]
     cd[cd.yml]
     poll[daily.yml<br/>daily cron]
   end
@@ -36,6 +34,8 @@ flowchart LR
     api[security API]
   end
 
+  mend[Mend SCA<br/>GitHub App]
+
   subgraph github["GitHub"]
     issue[issue]
   end
@@ -45,74 +45,95 @@ flowchart LR
   clair --> api
   poll -->|GET /security| api
   poll -->|gh issue create / comment| issue
+  mend -->|scan lockfiles| issue
 ```
 
-We poll instead of receiving a webhook because Quay's webhook notifications
-have a body template but no header field, so they can't carry the bearer
-token GitHub's `repository_dispatch` requires. Polling keeps the auth shape
-one-way (CI → Quay) and removes the need for a fine-grained PAT stored in
-Quay's UI.
+### Quay Clair + daily.yml
 
-Quay rescans existing images whenever its CVE database updates, so a CVE
-disclosed *after* a release still produces a finding — which is the whole
-reason for moving off ghcr.io ([free Clair scanning is the killer feature][quay-scan]).
-The poll runs daily, so there's up to ~24h between Clair finding a CVE and
-an issue being filed. Tune the `cron:` line in
-[`daily.yml`](../../.github/workflows/daily.yml) if that window is too wide.
+[`cd.yml`](../../.github/workflows/cd.yml) pushes images to Quay on every
+`main` push and `v*` tag. Quay's built-in Clair scanner runs automatically and
+rescans whenever its CVE database updates — so a CVE disclosed *after* a
+release still produces a finding. Images use hardened Red Hat base layers, so
+Clair also catches CVEs in OS-level packages from upstream.
 
-## Workflows in this repo
+[`daily.yml`](../../.github/workflows/daily.yml) polls Quay once a day and
+turns findings into GitHub issues. One matrix job per image repository:
 
-- [`.github/workflows/cd.yml`](../../.github/workflows/cd.yml) — builds and pushes images to `quay.io/dam-agents/<component>` on every push to `main` and on `v*` tags.
-- [`.github/workflows/daily.yml`](../../.github/workflows/daily.yml) — daily poller; for each image's `latest` tag, hits Quay's security API, dedupes by `(repository, CVE, package)`, opens new issues or comments existing ones.
+1. Resolves the `latest` tag to a manifest digest via Quay's tag API.
+2. Fetches the Clair scan for that manifest. Exits with a notice if the scan
+   isn't ready yet.
+3. Flattens findings into `(CVE, package, version, severity, fixed_by)`
+   tuples, deduped by `(CVE, package)`. No severity filter — everything
+   surfaces.
+4. For each finding, searches open issues for the same CVE + repo name. Adds
+   a "still present" comment to existing issues; creates new ones with
+   `security` + `vulnerability` labels.
 
-CodeQL runs from GitHub's **default setup** (configured in repo Settings, no
-workflow file) — it picks Go and JavaScript/TypeScript automatically, runs on
-push and PR to default + protected branches, and weekly. Findings show up
-under **Security → Code scanning** the same way they would with a workflow.
+We poll instead of receiving a Quay webhook because Quay's webhook body
+template has no header field, so it can't carry the bearer token
+`repository_dispatch` requires. Polling keeps auth one-way (CI → Quay).
 
-There is no `dependabot.yml`. Dependabot alerts and security PRs are repo-level
-toggles (Settings → Code security), not config-file driven; non-security
-version bumps are explicitly opted out of so the repo doesn't drown in churn.
+### Mend SCA
 
-## Manual one-time setup
+Mend runs as a GitHub App, configured via
+[`renovate.json`](../../renovate.json): all routine package updates are
+disabled, only `vulnerabilityAlerts` is enabled. Mend scans the full
+transitive dependency tree in lockfiles and auto-files GitHub issues for CVEs
+it finds.
 
-The pipeline needs only two pieces of state outside the repo:
+## Dependency remediation
 
-1. **Quay org `dam-agents`** — public-tier (free Clair scanning). One repo per image, all public:
-   `api-server`, `claude-code`, `code-guardian`, `controller`, `google-workspace-agent`,
-   `pi-agent`, `platform-base`, `ui` (plus `charts` for the Helm OCI chart, no scan needed).
-2. **Robot account** with Write across the org. Credentials stored as repo secrets:
+When a scanner flags a transitive npm dependency, the fix is typically a
+`pnpm.overrides` entry (the vulnerable package isn't in our `package.json`).
+Scope the override to the vulnerable range so it self-expires:
+
+```jsonc
+"pnpm": {
+  "overrides": {
+    "protobufjs@<7.5.8": "7.5.8"
+  }
+}
+```
+
+When multiple major versions of the same package exist in the tree (e.g.
+`brace-expansion` 2.x and 5.x), use an exact version selector to avoid
+overriding the wrong line.
+
+`minimumReleaseAge` in `pnpm-workspace.yaml` rejects packages published within
+7 days as a supply-chain defence. Security fixes sometimes land inside that
+window — add those to `minimumReleaseAgeExclude`. The `common:check:lockfile-age`
+mise task enforces the same constraint independently and reads the same
+exclusion list.
+
+## Remediation flow
+
+1. Issue lands in the inbox.
+2. Identify the source: base image (rebuild), dependency (bump / override), or our code (patch).
+3. Merge the fix; the next scan + poll cycle stops commenting on the issue.
+4. Close the issue once a poll cycle goes quiet. Closed issues don't dedupe — if the CVE reappears, a fresh issue is opened.
+5. **No fix available?** Document risk acceptance in the issue, apply `accepted-risk`, leave open until upstream patches.
+
+## Setup
+
+External state the pipeline needs:
+
+1. **Quay org `dam-agents`** — public-tier (free Clair). One repo per image, all public.
+2. **Robot account** with Write across the org:
    ```sh
    gh secret set QUAY_USERNAME --body 'dam-agents+platform_ci'
    gh secret set QUAY_PASSWORD < ~/quay-robot-token.txt
    ```
+3. **Mend Renovate** GitHub App — installed on the repo; no credentials to store.
 
-The poller uses the default `GITHUB_TOKEN` for issue writes — no PAT, no
-Quay webhook, no header config. (We tried; Quay webhooks don't expose a
-header field, which made `repository_dispatch` infeasible.)
-
-Repo-level toggles to flip in **Settings → Code security**:
-
-- Dependabot alerts: **on**
-- Dependabot security updates: **on**
-- Secret scanning + push protection: **on**
-- CodeQL default setup: **on** (Go + JavaScript/TypeScript).
-
-## Remediation flow
-
-1. Issue or PR lands in the inbox.
-2. The owner identifies the source: a base image (rebuild), a dependency (bump), or our own code (patch).
-3. Merge the fix; the next image build's Quay scan reports the CVE gone, and the next daily poll stops commenting on the open issue.
-4. Close the issue once a poll cycle goes quiet. If the same CVE reappears later (regression, or new image with the old base), the next poll opens a fresh issue — closed issues don't dedupe.
-5. **No fix available?** Document the risk acceptance in the issue: which versions are affected, why an immediate workaround isn't possible, and what monitoring catches exploitation. Apply the `accepted-risk` label and leave open until upstream ships a patch.
+Repo-level toggles in **Settings → Code security**: Dependabot alerts **on**,
+Dependabot security updates **on**, secret scanning + push protection **on**,
+CodeQL default setup **on** (Go + JavaScript/TypeScript).
 
 ## What this does NOT cover
 
-Out of scope today, listed so the gap is visible:
-
-- **Runtime container scanning** (Falco, kube-bench at the cluster level). Catches drift after deploy; we rely on the image scan being the authoritative source pre-deploy.
-- **Kubernetes manifest hardening** (kubesec, polaris). Helm chart linting in CI is a `mise run helm:check:lint` away but doesn't include SAST-style policy.
-- **Supply-chain provenance** (cosign signing, SLSA attestations, SBOM). Quay supports cosign verification but we don't sign yet. Tracked in the security model as future work.
-- **Agent workspace contents.** Per the [persistence security note](persistence.md), workspace residue is adversarial input on the next turn — the scanners here cover the platform, not user-generated content inside an instance.
+- **Runtime container scanning** (Falco, kube-bench). We rely on image scans pre-deploy.
+- **Kubernetes manifest hardening** (kubesec, polaris). Helm linting in CI doesn't include SAST-style policy.
+- **Supply-chain provenance** (cosign, SLSA, SBOM). Tracked as future work.
+- **Agent workspace contents.** Per the [persistence security note](persistence.md), workspace residue is adversarial input — scanners cover the platform, not user-generated content.
 
 [quay-scan]: https://docs.projectquay.io/use_quay.html#security-scanning

--- a/package.json
+++ b/package.json
@@ -19,8 +19,11 @@
   "pnpm": {
     "overrides": {
       "@anthropic-ai/sdk@<0.91.1": "0.91.1",
+      "brace-expansion@5.0.5": "5.0.6",
       "esbuild@<0.25.0": "0.25.12",
-      "serialize-javascript@<7.0.5": "7.0.5"
+      "protobufjs@<7.5.8": "7.5.8",
+      "serialize-javascript@<7.0.5": "7.0.5",
+      "ws@8.20.0": "8.20.1"
     }
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,8 +6,11 @@ settings:
 
 overrides:
   '@anthropic-ai/sdk@<0.91.1': 0.91.1
+  brace-expansion@5.0.5: 5.0.6
   esbuild@<0.25.0: 0.25.12
+  protobufjs@<7.5.8: 7.5.8
   serialize-javascript@<7.0.5: 7.0.5
+  ws@8.20.0: 8.20.1
 
 importers:
 
@@ -71,8 +74,8 @@ importers:
         specifier: ^7.5.13
         version: 7.5.13
       ws:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: 8.20.1
+        version: 8.20.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -125,7 +128,7 @@ importers:
     devDependencies:
       '@mariozechner/pi-coding-agent':
         specifier: ^0.71.0
-        version: 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+        version: 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.17
@@ -208,8 +211,8 @@ importers:
         specifier: ^5.9.0
         version: 5.9.0
       ws:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: 8.20.1
+        version: 8.20.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -297,8 +300,8 @@ importers:
         specifier: ^4.1.3
         version: 4.1.3(@types/node@25.5.0)(vite@6.4.2(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.47.1)(tsx@4.21.0)(yaml@2.8.3))
       ws:
-        specifier: ^8.20.0
-        version: 8.20.0
+        specifier: 8.20.1
+        version: 8.20.1
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -3056,8 +3059,8 @@ packages:
   brace-expansion@2.1.0:
     resolution: {integrity: sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==}
 
-  brace-expansion@5.0.5:
-    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -4209,7 +4212,7 @@ packages:
   isomorphic-ws@5.0.0:
     resolution: {integrity: sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==}
     peerDependencies:
-      ws: '*'
+      ws: 8.20.1
 
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
@@ -4754,7 +4757,7 @@ packages:
     resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
     hasBin: true
     peerDependencies:
-      ws: ^8.18.0
+      ws: 8.20.1
       zod: ^3.25 || ^4.0
     peerDependenciesMeta:
       ws:
@@ -4998,8 +5001,8 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  protobufjs@7.5.6:
-    resolution: {integrity: sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==}
+  protobufjs@7.5.8:
+    resolution: {integrity: sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==}
     engines: {node: '>=12.0.0'}
 
   proxy-addr@2.0.7:
@@ -5918,8 +5921,8 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.0:
-    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+  ws@8.20.1:
+    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -7519,8 +7522,8 @@ snapshots:
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
-      protobufjs: 7.5.6
-      ws: 8.20.0
+      protobufjs: 7.5.8
+      ws: 8.20.1
     optionalDependencies:
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
     transitivePeerDependencies:
@@ -7537,7 +7540,7 @@ snapshots:
     dependencies:
       lodash.camelcase: 4.3.0
       long: 5.3.2
-      protobufjs: 7.5.6
+      protobufjs: 7.5.8
       yargs: 17.7.2
 
   '@hono/node-server@1.19.14(hono@4.12.18)':
@@ -7706,7 +7709,7 @@ snapshots:
       '@types/stream-buffers': 3.0.8
       form-data: 4.0.5
       hpagent: 1.2.0
-      isomorphic-ws: 5.0.0(ws@8.20.0)
+      isomorphic-ws: 5.0.0(ws@8.20.1)
       js-yaml: 4.1.1
       jsonpath-plus: 10.4.0
       node-fetch: 2.7.0
@@ -7715,7 +7718,7 @@ snapshots:
       socks-proxy-agent: 8.0.5
       stream-buffers: 3.0.3
       tar-fs: 3.1.2
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -7861,9 +7864,9 @@ snapshots:
       std-env: 3.10.0
       yoctocolors: 2.1.2
 
-  '@mariozechner/pi-agent-core@0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
+  '@mariozechner/pi-agent-core@0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
-      '@mariozechner/pi-ai': 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      '@mariozechner/pi-ai': 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       typebox: 1.1.34
     transitivePeerDependencies:
       - '@modelcontextprotocol/sdk'
@@ -7874,14 +7877,14 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-ai@0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
+  '@mariozechner/pi-ai@0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1038.0
       '@google/genai': 1.50.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@mistralai/mistralai': 2.2.1
       chalk: 5.6.2
-      openai: 6.26.0(ws@8.20.0)(zod@4.4.3)
+      openai: 6.26.0(ws@8.20.1)(zod@4.4.3)
       partial-json: 0.1.7
       proxy-agent: 6.5.0
       typebox: 1.1.34
@@ -7896,11 +7899,11 @@ snapshots:
       - ws
       - zod
 
-  '@mariozechner/pi-coding-agent@0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)':
+  '@mariozechner/pi-coding-agent@0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
     dependencies:
       '@mariozechner/jiti': 2.6.5
-      '@mariozechner/pi-agent-core': 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
-      '@mariozechner/pi-ai': 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.0)(zod@4.4.3)
+      '@mariozechner/pi-agent-core': 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
+      '@mariozechner/pi-ai': 0.71.1(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
       '@mariozechner/pi-tui': 0.71.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
@@ -7942,7 +7945,7 @@ snapshots:
 
   '@mistralai/mistralai@2.2.1':
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
       zod-to-json-schema: 3.25.2(zod@4.4.3)
     transitivePeerDependencies:
@@ -8165,7 +8168,7 @@ snapshots:
       '@types/node': 25.5.0
       '@types/ws': 8.18.1
       eventemitter3: 5.0.4
-      ws: 8.20.0
+      ws: 8.20.1
     transitivePeerDependencies:
       - bufferutil
       - debug
@@ -9129,7 +9132,7 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.5:
+  brace-expansion@5.0.6:
     dependencies:
       balanced-match: 4.0.4
 
@@ -10356,9 +10359,9 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  isomorphic-ws@5.0.0(ws@8.20.0):
+  isomorphic-ws@5.0.0(ws@8.20.1):
     dependencies:
-      ws: 8.20.0
+      ws: 8.20.1
 
   jackspeak@4.2.3:
     dependencies:
@@ -10950,7 +10953,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.5
+      brace-expansion: 5.0.6
 
   minimatch@5.1.9:
     dependencies:
@@ -11043,9 +11046,9 @@ snapshots:
       powershell-utils: 0.1.0
       wsl-utils: 0.3.1
 
-  openai@6.26.0(ws@8.20.0)(zod@4.4.3):
+  openai@6.26.0(ws@8.20.1)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.0
+      ws: 8.20.1
       zod: 4.4.3
 
   openid-client@6.8.2:
@@ -11261,7 +11264,7 @@ snapshots:
 
   property-information@7.1.0: {}
 
-  protobufjs@7.5.6:
+  protobufjs@7.5.8:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/base64': 1.1.2
@@ -11273,7 +11276,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.1
-      '@types/node': 25.5.0
+      '@types/node': 25.6.2
       long: 5.3.2
 
   proxy-addr@2.0.7:
@@ -12472,7 +12475,7 @@ snapshots:
 
   wrappy@1.0.2: {}
 
-  ws@8.20.0: {}
+  ws@8.20.1: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -21,6 +21,9 @@ trustPolicyExclude:
   # maintainer (paulmillr), GitHub tag matches, restored in 5.0.0 via
   # `trustedPublisher: github`. Benign publisher-side workflow change.
   - 'chokidar@4.0.3'
+minimumReleaseAgeExclude:
+  # CVE-2026-45736 security fix — released 2026-05-12, inside the 7-day window
+  - 'ws@8.20.1'
 allowBuilds:
   # grpc-tools downloads the protoc binary in a postinstall step; needed
   # by `mise run api-server:gen:proto` (ts-proto codegen for ext_authz).

--- a/tasks.toml
+++ b/tasks.toml
@@ -84,7 +84,7 @@ depends = ["common:check:*"]
 ["common:check:lockfile-age"]
 description = "Verify no lockfile dependency is newer than 7 days"
 dir = "{{config_root}}"
-sources = ["pnpm-lock.yaml"]
+sources = ["pnpm-lock.yaml", "pnpm-workspace.yaml"]
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
@@ -96,6 +96,13 @@ else
 fi
 export LOCKFILE_ENTRIES=$(mktemp); trap 'rm -f "$LOCKFILE_ENTRIES"' EXIT
 yq '.packages | keys | .[]' pnpm-lock.yaml | sed 's/\(.*\)@/\1\t/' > "$LOCKFILE_ENTRIES"
+# Honour pnpm minimumReleaseAgeExclude — same packages pnpm itself skips
+while IFS= read -r excl; do
+  [[ -z "$excl" ]] && continue
+  excl_name="${excl%@*}"; excl_ver="${excl##*@}"
+  tmp=$(mktemp)
+  awk -F'\t' -v n="$excl_name" -v v="$excl_ver" '!(n==$1 && v==$2)' "$LOCKFILE_ENTRIES" > "$tmp" && mv "$tmp" "$LOCKFILE_ENTRIES"
+done < <(yq '.minimumReleaseAgeExclude // [] | .[]' pnpm-workspace.yaml 2>/dev/null)
 check_pkg() {
   export PKG_NAME="$1" PKG_VERSIONS=$(awk -F'\t' -v n="$1" '$1==n{printf(c++?",":"[")"\""$2"\""}END{print"]"}' "$LOCKFILE_ENTRIES")
   curl -sf --max-time 10 -H 'Accept: application/json' \


### PR DESCRIPTION
## Summary

- Override `protobufjs` 7.5.6 → 7.5.8 (CVE-2026-45740: stack exhaustion via deeply nested JSON descriptors)
- Override `ws` 8.20.0 → 8.20.1 (CVE-2026-45736: uninitialized memory disclosure in `close()`)
- Override `brace-expansion` 5.0.5 → 5.0.6 (CVE-2026-45149: excessive allocation in numeric ranges)
- Add `minimumReleaseAgeExclude` for `ws@8.20.1` (released <7d ago, security fix)
- Teach `common:check:lockfile-age` to honour `minimumReleaseAgeExclude` from `pnpm-workspace.yaml`

Closes #298, closes #299, closes #300.

**Re #297 (`@babel/runtime@7.29.2`):** CVE-2025-27789 says fixed in 7.26.10; installed 7.29.2 is well past that. Mend's fix database only lists `8.0.0-alpha.17` for the `@babel/runtime` npm package — this is a scanner mapping gap, not a real vulnerability. Commented on the issue.

## Test plan

- [x] `pnpm why -r protobufjs` → 7.5.8
- [x] `pnpm why -r ws` → 8.20.1
- [x] `pnpm why -r brace-expansion` → 5.0.6
- [x] `mise run check` passes
- [x] `mise run test` passes (534 tests)