### PR TITLE
feat: in-pod editor attach prototype (SSH-over-WS)

### DIFF
--- a/docs/adrs/DRAFT-in-pod-editor-attach.md
+++ b/docs/adrs/DRAFT-in-pod-editor-attach.md
@@ -1,0 +1,34 @@
+# ADR-NNN: In-pod editor attach via SSH-over-WebSocket
+
+**Date:** 2026-05-20
+**Status:** Proposed
+**Owner:** @tomkis
+
+## Context
+
+Users want to drive an agent pod from their local editor — edit files Claude Code is working on, open multiple terminals, run language servers and extensions — while the agent itself keeps running. Today the only inbound channel into a pod is the chat/terminal relay, a single-PTY pipe to one hardcoded TUI. It can't carry the multiplexed traffic an editor needs (file sync, language server, parallel shells), and it gives no way to ship an editor's remote backend into the pod.
+
+## Decision
+
+For the in-pod editor prototype, agent pods optionally run an SSH daemon, and SSH bytes are tunneled to the user's machine through the api-server's existing WebSocket auth route. Any SSH-capable editor (VSCode Remote-SSH, JetBrains Gateway, Zed, Cursor, plain `ssh` + terminal editors) attaches the same way; the prototype ships VSCode as the reference client because it has the broadest install base, but the pod-side and transport are editor-agnostic. The api-server's JWT auth is the only access gate.
+
+The daemon is opt-in per instance, activated by a flag at instance creation. The user's keypair is generated locally at that moment, the public key rides into the pod through the existing env-var plumbing, and the private key never leaves the user's machine. No state about the editor lives in the api-server or DB.
+
+Environment that the agent process relies on (credential proxy variables, gateway CA trust) is snapshotted at pod start so SSH sessions inherit it. Without that, anything launched from the editor's terminal can't reach the credential gateway.
+
+## Alternatives Considered
+
+- **VSCode Remote Tunnels** — requires every user to authenticate `code tunnel` against a Microsoft or GitHub account per session, and routes editor traffic through Microsoft's relay infrastructure instead of our own auth.
+- **code-server / openvscode-server in a browser tab** — drops local VSCode entirely; loses Microsoft-marketplace extensions including any official editor integration, and gives no path to reuse the user's local settings.
+- **`kubectl port-forward` to the pod's SSH port** — requires distributing a kubeconfig with pod/portforward rights to every CLI user, sidestepping the JWT auth and ownership checks the api-server already enforces.
+- **Reuse the chat/terminal relay** — its frame protocol is a single PTY channel; SSH needs concurrent multiplexed channels (sftp + shell + port-forward + extension host) and a standards-compliant transport so VSCode's installer and rsync work.
+
+## Consequences
+
+- **Easier:** A fourth attach mode can be added as one regex branch in the WS-upgrade handler — auth, ownership, and ingress routing are already shared with the chat and ACP relays.
+- **Easier:** Users keep their local editor, its marketplace, and their personal settings; this is the only path among the alternatives that preserves all three.
+- **Easier:** Editor portability is free — JetBrains Gateway, Zed remote, plain SSH, etc., reach the same pod with no server-side change. The choice of editor stays with the user, not with the platform.
+- **Harder:** Adds an SSH daemon to the claude-code image and a long-lived listener inside the agent pod. Threat model is now "anyone with a valid user JWT for this instance can run arbitrary commands as the agent user" — same blast radius as `dam chat`, but reachable in more ways.
+- **Harder:** SSH sessions do not inherit the container environment by default, so credential-proxy variables must be re-injected via a startup snapshot. Anything the agent process picks up after pod start (rotated tokens, runtime-set env) will be stale in editor shells.
+- **Harder:** First attach uploads the editor's remote backend (~150 MB for vscode-server, similar order for JetBrains) into the pod's $HOME and persists it on the workspace volume across restarts. Re-attaches are fast; cold attaches on freshly-built images aren't.
+- **Committed-to:** The api-server's `/api/instances/:id/<channel>` WS-upgrade handler as the single auth front door for any future pod-attached protocol. Adding a fifth port would mean another branch here, not another auth gate elsewhere.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -56,3 +56,4 @@ This directory contains ADRs for the Platform project.
 |-------|-------|-------|
 | [DRAFT](DRAFT-multi-agent.md) | Multi-agent collaboration — isolated instances with shared artifacts | @tomkis |
 | [DRAFT](044-file-import.md) | File import — bundled, atomic, one-shot | @janjeliga |
+| [DRAFT](DRAFT-in-pod-editor-attach.md) | In-pod editor attach via SSH-over-WebSocket | @tomkis |

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -3,10 +3,18 @@ FROM ${BASE_IMAGE}
 
 USER root
 
+RUN dnf install -y openssh-server openssh-clients && dnf clean all \
+    && echo "agent:x:65532:0::/home/agent:/bin/bash" >> /etc/passwd
+
 RUN npm install @agentclientprotocol/claude-agent-acp \
     && npm install -g @anthropic-ai/claude-code \
     && chown -R 65532:0 /app
 
+COPY --chown=65532:0 entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
 USER 65532
+
+ENTRYPOINT ["/app/entrypoint.sh"]
+CMD ["node", "/app/dist/server.js"]

--- a/packages/agents/claude-code/entrypoint.sh
+++ b/packages/agents/claude-code/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -e
+
+if [ "$PLATFORM_EDITOR" = "1" ] && [ -n "$PLATFORM_EDITOR_PUBKEY" ]; then
+  echo "[editor] starting sshd on :2222"
+  SSHD_DIR=/tmp/sshd
+  mkdir -p "$SSHD_DIR"
+  ssh-keygen -t ed25519 -f "$SSHD_DIR/host_ed25519" -N "" -q
+  printf '%s\n' "$PLATFORM_EDITOR_PUBKEY" > "$SSHD_DIR/authorized_keys"
+  chmod 600 "$SSHD_DIR/authorized_keys"
+
+  mkdir -p /home/agent/.ssh
+  chmod 700 /home/agent/.ssh
+  ENV_OUT=/home/agent/.ssh/environment
+  : > "$ENV_OUT"
+  while IFS= read -r -d '' line; do
+    key="${line%%=*}"
+    case "$key" in
+      ''|PS1|PWD|OLDPWD|SHLVL|_|TERM|SHELL|HOSTNAME|HOME|USER|LOGNAME) ;;
+      *) printf '%s\n' "$line" >> "$ENV_OUT" ;;
+    esac
+  done < /proc/self/environ
+  chmod 600 "$ENV_OUT"
+
+  cat > "$SSHD_DIR/sshd_config" <<EOF
+Port 2222
+ListenAddress 0.0.0.0
+HostKey $SSHD_DIR/host_ed25519
+AuthorizedKeysFile $SSHD_DIR/authorized_keys
+PidFile $SSHD_DIR/sshd.pid
+PasswordAuthentication no
+PubkeyAuthentication yes
+PermitRootLogin no
+UsePAM no
+StrictModes no
+UsePrivilegeSeparation no
+PermitUserEnvironment yes
+Subsystem sftp /usr/libexec/openssh/sftp-server
+EOF
+  /usr/sbin/sshd -f "$SSHD_DIR/sshd_config" -D -e &
+fi
+
+exec "$@"

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -35,6 +35,7 @@ import {
 } from "../../modules/channels/infrastructure/telegram-threads-repository.js";
 import { createAcpRelay } from "./acp-relay.js";
 import { createTerminalRelay } from "./terminal-relay.js";
+import { createEditorRelay } from "./editor-relay.js";
 import { getSessionMode } from "../../modules/sessions/infrastructure/sessions-repository.js";
 import { createOAuthRoutes } from "./oauth.js";
 import { mountBrandIconRoutes } from "./brand-icon.js";
@@ -631,6 +632,8 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     getSessionMode: getSessionMode(db),
   });
 
+  const editorRelay = createEditorRelay(config.namespace, instancesRepo);
+
   const server = serve({ fetch: app.fetch, port: config.port }, () => {
     process.stderr.write(
       `api-server listening on http://localhost:${config.port}\n`,
@@ -665,7 +668,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   server.on("upgrade", async (req, socket, head) => {
     const url = new URL(req.url!, `http://${req.headers.host}`);
     const match = url.pathname.match(
-      /^\/api\/instances\/([^/]+)\/(acp|terminal)$/,
+      /^\/api\/instances\/([^/]+)\/(acp|terminal|editor)$/,
     );
     if (!match) {
       socket.destroy();
@@ -674,6 +677,9 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
 
     const token = url.searchParams.get("token");
     if (!token) {
+      process.stderr.write(
+        `[ws-upgrade] 401 no-token path=${url.pathname}\n`,
+      );
       socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
       socket.destroy();
       return;
@@ -685,6 +691,9 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     } catch (err) {
       const status =
         err instanceof ForbiddenError ? "403 Forbidden" : "401 Unauthorized";
+      process.stderr.write(
+        `[ws-upgrade] ${status} path=${url.pathname} reason=${err instanceof Error ? err.message : String(err)}\n`,
+      );
       socket.write(`HTTP/1.1 ${status}\r\n\r\n`);
       socket.destroy();
       return;
@@ -697,7 +706,12 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       return;
     }
 
-    const relay = match[2] === "acp" ? acpRelay : terminalRelay;
+    const relay =
+      match[2] === "acp"
+        ? acpRelay
+        : match[2] === "terminal"
+          ? terminalRelay
+          : editorRelay;
     relay.handleUpgrade(req, socket, head, instanceId);
   });
 

--- a/packages/api-server/src/apps/api-server/editor-relay.ts
+++ b/packages/api-server/src/apps/api-server/editor-relay.ts
@@ -1,0 +1,110 @@
+import { WebSocketServer, WebSocket } from "ws";
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import net from "node:net";
+import type { InstancesRepository } from "../../modules/instances/infrastructure/instances-repository.js";
+
+const EDITOR_PORT = 2222;
+
+export interface EditorRelay {
+  handleUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    instanceId: string,
+  ): void;
+}
+
+export function createEditorRelay(
+  namespace: string,
+  repo: InstancesRepository,
+): EditorRelay {
+  const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
+
+  function handleUpgrade(
+    req: IncomingMessage,
+    socket: Duplex,
+    head: Buffer,
+    instanceId: string,
+  ) {
+    wss.handleUpgrade(req, socket, head, (client) => {
+      client.on("error", () => {
+        try {
+          client.terminate();
+        } catch {}
+      });
+
+      const pending: Buffer[] = [];
+      const buffer = (data: Buffer) => {
+        pending.push(data);
+      };
+      client.on("message", buffer);
+
+      repo
+        .ensureReady(instanceId)
+        .then(
+          () =>
+            new Promise<net.Socket>((resolve, reject) => {
+              const host = `${instanceId}-0.${instanceId}.${namespace}.svc`;
+              const tcp = net.createConnection(
+                { host, port: EDITOR_PORT },
+                () => resolve(tcp),
+              );
+              tcp.once("error", (err) => reject(err));
+            }),
+        )
+        .then((upstream) => {
+          client.off("message", buffer);
+          for (const data of pending) upstream.write(data);
+
+          client.on("message", (data) => {
+            if (!upstream.writable) return;
+            upstream.write(data as Buffer);
+          });
+
+          upstream.on("data", (data) => {
+            if (client.readyState === WebSocket.OPEN)
+              client.send(data, { binary: true });
+          });
+
+          upstream.on("close", () => {
+            if (client.readyState === WebSocket.OPEN) {
+              try {
+                client.close(1000, "upstream closed");
+              } catch {
+                client.terminate();
+              }
+            }
+          });
+
+          upstream.on("error", () => {
+            if (client.readyState === WebSocket.OPEN) {
+              try {
+                client.close(1011, "upstream error");
+              } catch {
+                client.terminate();
+              }
+            }
+          });
+
+          client.on("close", () => {
+            try {
+              upstream.destroy();
+            } catch {}
+          });
+        })
+        .catch((err) => {
+          process.stderr.write(
+            `[editor-relay] failed to connect: ${err?.message ?? err}\n`,
+          );
+          try {
+            client.close(1011, "failed to connect to editor");
+          } catch {
+            client.terminate();
+          }
+        });
+    });
+  }
+
+  return { handleUpgrade };
+}

--- a/packages/cli/src/compose.ts
+++ b/packages/cli/src/compose.ts
@@ -3,6 +3,7 @@ import { composeAgentModule } from "./modules/agent/compose.js";
 import { composeAuthModule } from "./modules/auth/compose.js";
 import { composeChatModule } from "./modules/chat/compose.js";
 import { composeCliModule } from "./modules/cli/compose.js";
+import { composeEditorModule } from "./modules/editor/compose.js";
 import { composeImportModule } from "./modules/import/compose.js";
 import { composeInstanceModule } from "./modules/instance/compose.js";
 import { composeTemplateModule } from "./modules/template/compose.js";
@@ -75,6 +76,13 @@ export function compose(opts: ComposeOptions = {}): Command {
     serverEnvVar: "DAM_SERVER",
   });
 
+  const editor = composeEditorModule({
+    compatService: cli.services.compatService,
+    configService: cli.services.configService,
+    tokenProvider,
+    createInstanceService: instance.exports.createService,
+  });
+
   const program = new Command();
   program
     .name("dam")
@@ -88,6 +96,7 @@ export function compose(opts: ComposeOptions = {}): Command {
   for (const command of chat.commands) program.addCommand(command);
   for (const command of agent.commands) program.addCommand(command);
   for (const command of importModule.commands) program.addCommand(command);
+  for (const command of editor.commands) program.addCommand(command);
 
   return program;
 }

--- a/packages/cli/src/modules/editor/commands/editor.ts
+++ b/packages/cli/src/modules/editor/commands/editor.ts
@@ -1,0 +1,190 @@
+import { Command } from "commander";
+import net from "node:net";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import WebSocket from "ws";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import type { TokenProvider } from "../../auth/index.js";
+import type { InstanceService } from "../../instance/index.js";
+import { createInstanceResolver } from "../../instance/index.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import {
+  EXIT_INSTANCE_BELOW_FLOOR,
+  EXIT_INSTANCE_INVALID_INPUT,
+  EXIT_INSTANCE_RUNTIME_FAILURE,
+} from "../../instance/commands/exit-codes.js";
+import { editorKeyPath } from "../../instance/infrastructure/editor-keys.js";
+
+export function buildEditorCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  tokenProvider: TokenProvider;
+  createInstanceService: (host: string) => InstanceService;
+}): Command {
+  return new Command("editor")
+    .description(
+      "[PROTOTYPE] Open a local SSH tunnel to an instance's in-pod editor (VSCode Remote-SSH)",
+    )
+    .argument("<instance>", "Instance name or id (created with --with-editor)")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option(
+      "--port <port>",
+      "local TCP port to bind (default: random ephemeral)",
+    )
+    .action(
+      async (
+        ref: string,
+        opts: { server?: string; port?: string },
+      ): Promise<void> => {
+        await runEditor(ref, opts, deps);
+      },
+    );
+}
+
+async function runEditor(
+  ref: string,
+  opts: { server?: string; port?: string },
+  deps: {
+    compatService: CompatService;
+    configService: ConfigService;
+    tokenProvider: TokenProvider;
+    createInstanceService: (host: string) => InstanceService;
+  },
+): Promise<void> {
+  const localPort = opts.port ? Number.parseInt(opts.port, 10) : 0;
+  if (opts.port && (Number.isNaN(localPort) || localPort < 0)) {
+    process.stderr.write(`error: invalid --port \`${opts.port}\`\n`);
+    process.exit(EXIT_INSTANCE_INVALID_INPUT);
+  }
+
+  const host = await resolveActiveHost(deps, {
+    flag: opts.server ? { server: opts.server } : undefined,
+    exitCodes: {
+      runtimeFailure: EXIT_INSTANCE_RUNTIME_FAILURE,
+      belowFloor: EXIT_INSTANCE_BELOW_FLOOR,
+    },
+  });
+
+  const tokRes = await deps.tokenProvider.getValidAccessToken(host);
+  if (!tokRes.ok) {
+    process.stderr.write(
+      `error: not authenticated (${tokRes.error.kind}); run \`dam auth login\` first\n`,
+    );
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  const token = tokRes.value;
+
+  const svc = deps.createInstanceService(host);
+  const resolver = createInstanceResolver({ instanceService: svc });
+  const resolved = await resolver.resolve(ref);
+  if (!resolved.ok) {
+    process.stderr.write(
+      `error: ${JSON.stringify(resolved.error)} for \`${ref}\`\n`,
+    );
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+  const instance = resolved.value;
+
+  const keyPath = editorKeyPath(instance.name);
+  if (!existsSync(keyPath)) {
+    process.stderr.write(
+      `error: editor key not found at ${keyPath}\nhint: create the instance with \`dam instance create ${instance.name} --template … --with-editor\`\n`,
+    );
+    process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+  }
+
+  const proto = host.startsWith("https://") ? "wss:" : "ws:";
+  const base = host.replace(/^https?:\/\//, "");
+  const wsUrl = `${proto}//${base}/api/instances/${encodeURIComponent(instance.id)}/editor?token=${encodeURIComponent(token)}`;
+
+  const server = net.createServer((conn) => {
+    conn.pause();
+    const ws = new WebSocket(wsUrl);
+    let opened = false;
+    const pending: Buffer[] = [];
+    conn.on("data", (data) => {
+      const buf = typeof data === "string" ? Buffer.from(data) : data;
+      if (opened && ws.readyState === WebSocket.OPEN) ws.send(buf);
+      else pending.push(buf);
+    });
+    conn.on("close", () => {
+      if (
+        ws.readyState === WebSocket.OPEN ||
+        ws.readyState === WebSocket.CONNECTING
+      )
+        ws.close();
+    });
+    conn.on("error", () => {
+      try {
+        ws.close();
+      } catch {}
+    });
+    ws.on("open", () => {
+      opened = true;
+      for (const b of pending) ws.send(b);
+      pending.length = 0;
+      conn.resume();
+    });
+    ws.on("message", (data) => {
+      conn.write(data as Buffer);
+    });
+    ws.on("close", () => conn.end());
+    ws.on("error", (e) => {
+      process.stderr.write(`[editor] upstream error: ${e.message}\n`);
+      try {
+        conn.destroy();
+      } catch {}
+    });
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(localPort, "127.0.0.1", () => resolve());
+  });
+
+  const boundPort = (server.address() as net.AddressInfo).port;
+  const alias = `dam-editor-${instance.name}`;
+  const sshConfigPath = writeSshConfig(alias, boundPort, keyPath);
+
+  process.stdout.write(
+    [
+      `✓ Tunnel ready on 127.0.0.1:${boundPort}`,
+      `  ssh config: ${sshConfigPath}`,
+      `  attach VSCode:`,
+      `    code --folder-uri 'vscode-remote://ssh-remote+${alias}/home/agent/work'`,
+      `  one-time setup (if not done): add to your ~/.ssh/config:`,
+      `    Include ${sshConfigPath}`,
+      ``,
+      `Press Ctrl+C to close the tunnel.`,
+      ``,
+    ].join("\n"),
+  );
+
+  await new Promise<void>(() => {});
+}
+
+function writeSshConfig(alias: string, port: number, keyPath: string): string {
+  const dir =
+    process.env.XDG_STATE_HOME && process.env.XDG_STATE_HOME.length > 0
+      ? join(process.env.XDG_STATE_HOME, "dam", "editor-ssh")
+      : join(homedir(), ".local", "state", "dam", "editor-ssh");
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const path = join(dir, `${alias}.conf`);
+  const block = [
+    `Host ${alias}`,
+    `  HostName 127.0.0.1`,
+    `  Port ${port}`,
+    `  User agent`,
+    `  IdentityFile ${keyPath}`,
+    `  IdentitiesOnly yes`,
+    `  StrictHostKeyChecking no`,
+    `  UserKnownHostsFile /dev/null`,
+    ``,
+  ].join("\n");
+  writeFileSync(path, block, { mode: 0o600 });
+  return path;
+}

--- a/packages/cli/src/modules/editor/compose.ts
+++ b/packages/cli/src/modules/editor/compose.ts
@@ -1,0 +1,28 @@
+import { Command } from "commander";
+import type { CompatService, ConfigService } from "../cli/index.js";
+import type { TokenProvider } from "../auth/index.js";
+import type { InstanceService } from "../instance/index.js";
+import { buildEditorCommand } from "./commands/editor.js";
+
+export function composeEditorModule({
+  compatService,
+  configService,
+  tokenProvider,
+  createInstanceService,
+}: {
+  compatService: CompatService;
+  configService: ConfigService;
+  tokenProvider: TokenProvider;
+  createInstanceService: (host: string) => InstanceService;
+}): { commands: ReadonlyArray<Command> } {
+  return {
+    commands: [
+      buildEditorCommand({
+        compatService,
+        configService,
+        tokenProvider,
+        createInstanceService,
+      }),
+    ],
+  };
+}

--- a/packages/cli/src/modules/instance/commands/create.ts
+++ b/packages/cli/src/modules/instance/commands/create.ts
@@ -11,6 +11,7 @@ import { fetchOrFallback } from "../services/fetch-or-fallback.js";
 import { waitForRunning } from "../services/wait-for-state.js";
 import { formatTransportError, printServiceError } from "./errors.js";
 import { parseEnvFlag, validateInstanceName } from "./create-helpers.js";
+import { generateEditorKey } from "../infrastructure/editor-keys.js";
 import {
   EXIT_INSTANCE_BELOW_FLOOR,
   EXIT_INSTANCE_INVALID_INPUT,
@@ -58,6 +59,10 @@ export function buildCreateCommand(deps: {
       (val: string, prev: string[]) => [...prev, val],
       [] as string[],
     )
+    .option(
+      "--with-editor",
+      "enable VSCode Remote-SSH editor attach via `dam editor <name>` (PROTOTYPE)",
+    )
     .option("--wait", "poll until state == `running` (or terminal error)")
     .option(
       "--timeout <seconds>",
@@ -83,6 +88,7 @@ export function buildCreateCommand(deps: {
           template?: string;
           description?: string;
           env?: string[];
+          withEditor?: boolean;
           wait?: boolean;
           timeout?: string;
           json?: boolean;
@@ -102,6 +108,7 @@ async function runCreate(
     template?: string;
     description?: string;
     env?: string[];
+    withEditor?: boolean;
     wait?: boolean;
     timeout?: string;
     json?: boolean;
@@ -146,6 +153,21 @@ async function runCreate(
     process.stderr.write(
       `warning: \`--env ${dup}=…\` was provided multiple times; using the last value\n`,
     );
+  }
+
+  let editorPrivateKeyPath: string | undefined;
+  if (opts.withEditor) {
+    try {
+      const key = await generateEditorKey(name);
+      env.push({ name: "PLATFORM_EDITOR", value: "1" });
+      env.push({ name: "PLATFORM_EDITOR_PUBKEY", value: key.publicKey });
+      editorPrivateKeyPath = key.privateKeyPath;
+    } catch (e) {
+      process.stderr.write(
+        `error: failed to generate editor keypair: ${e instanceof Error ? e.message : String(e)}\n`,
+      );
+      process.exit(EXIT_INSTANCE_RUNTIME_FAILURE);
+    }
   }
 
   const timeoutSeconds = parseTimeout(opts.timeout, DEFAULT_TIMEOUT_SECONDS);
@@ -274,6 +296,11 @@ async function runCreate(
     process.stdout.write(
       `✓ Created instance "${finalInstance.name}" (${finalInstance.id}). State: ${finalInstance.state}.\n`,
     );
+    if (editorPrivateKeyPath) {
+      process.stdout.write(
+        `  editor key: ${editorPrivateKeyPath}\n  attach: dam editor ${finalInstance.name}\n`,
+      );
+    }
   }
   process.exit(EXIT_INSTANCE_SUCCESS);
 }

--- a/packages/cli/src/modules/instance/infrastructure/editor-keys.ts
+++ b/packages/cli/src/modules/instance/infrastructure/editor-keys.ts
@@ -1,0 +1,61 @@
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+import { mkdir, readFile, chmod, rm } from "node:fs/promises";
+import { spawn } from "node:child_process";
+
+export function defaultEditorKeysDir(
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const xdg = env.XDG_STATE_HOME;
+  if (xdg && xdg.length > 0) return join(xdg, "dam", "editor-keys");
+  return join(homedir(), ".local", "state", "dam", "editor-keys");
+}
+
+export function editorKeyPath(
+  instanceName: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  return join(defaultEditorKeysDir(env), `${instanceName}.pem`);
+}
+
+export async function generateEditorKey(
+  instanceName: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ privateKeyPath: string; publicKey: string }> {
+  const privateKeyPath = editorKeyPath(instanceName, env);
+  const publicKeyPath = `${privateKeyPath}.pub`;
+  await mkdir(dirname(privateKeyPath), { recursive: true, mode: 0o700 });
+  await rm(privateKeyPath, { force: true });
+  await rm(publicKeyPath, { force: true });
+
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      "ssh-keygen",
+      [
+        "-t",
+        "ed25519",
+        "-f",
+        privateKeyPath,
+        "-N",
+        "",
+        "-q",
+        "-C",
+        `dam-editor-${instanceName}`,
+      ],
+      { stdio: ["ignore", "ignore", "pipe"] },
+    );
+    let err = "";
+    child.stderr.on("data", (b) => {
+      err += b.toString();
+    });
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`ssh-keygen exited ${code}: ${err}`));
+    });
+  });
+
+  await chmod(privateKeyPath, 0o600);
+  const publicKey = (await readFile(publicKeyPath, "utf8")).trim();
+  return { privateKeyPath, publicKey };
+}

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -340,9 +340,10 @@ func BuildAgentStatefulSet(name string, instance *types.InstanceSpec, agentSpec 
 		Name:            "agent",
 		Image:           agentSpec.Image,
 		ImagePullPolicy: corev1.PullPolicy(pullPolicy),
-		Ports: []corev1.ContainerPort{{
-			Name: "acp", ContainerPort: 8080,
-		}},
+		Ports: []corev1.ContainerPort{
+			{Name: "acp", ContainerPort: 8080},
+			{Name: "editor", ContainerPort: 2222},
+		},
 		Env:             env,
 		EnvFrom:         envFrom,
 		StartupProbe:    startupProbe,
@@ -430,9 +431,10 @@ func BuildAgentService(name string, cfg *config.Config, ownerCM *corev1.ConfigMa
 		Spec: corev1.ServiceSpec{
 			ClusterIP: corev1.ClusterIPNone,
 			Selector:  selector,
-			Ports: []corev1.ServicePort{{
-				Name: "acp", Port: 8080, TargetPort: intstr.FromString("acp"),
-			}},
+			Ports: []corev1.ServicePort{
+				{Name: "acp", Port: 8080, TargetPort: intstr.FromString("acp")},
+				{Name: "editor", Port: 2222, TargetPort: intstr.FromString("editor")},
+			},
 		},
 	}
 }


### PR DESCRIPTION
## Summary

- Throwaway prototype for attaching a local editor (VSCode Remote-SSH, JetBrains Gateway, Zed, plain ssh) to an agent's pod
- New `dam editor <instance>` opens a local SSH tunnel; `--with-editor` flag on `dam instance create` opts the instance in
- Decision shape: [DRAFT-in-pod-editor-attach.md](docs/adrs/DRAFT-in-pod-editor-attach.md)
- Feature ticket: #303

**Not for merge** — this is to extract learnings before deciding the production shape. Marking draft so it stays clearly out of the merge queue.

## Test plan

- [x] `mise run check` and `mise run test` green on the branch
- [x] Local smoke: create instance with `--with-editor`, attach via VSCode Remote-SSH, open shell, see `/home/agent/work`
- [x] Env propagation: `claude` runs in the editor's terminal and reaches the credential gateway
- [ ] Decide which learnings are worth keeping before reshaping into a production PR