### PR TITLE
fix(ui): update Bob Shell placeholder to new opaque key format

### DIFF
--- a/packages/ui/src/modules/settings/components/bob/form.tsx
+++ b/packages/ui/src/modules/settings/components/bob/form.tsx
@@ -1,5 +1,5 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ChevronDown, ChevronRight, X } from "lucide-react";
+import { ChevronDown, ChevronRight, ExternalLink, X } from "lucide-react";
 import { useState } from "react";
 import { useForm, type UseFormRegisterReturn } from "react-hook-form";
 import { z } from "zod";
@@ -118,7 +118,15 @@ export function BobForm({
           <div className="text-[12px] text-text-muted">
             {isEdit
               ? "Paste a new token to replace the existing one. Advanced settings are passed to Bob as CLI flags / env."
-              : "IBM's AI shell assistant. Paste your Bob API key to get started."}
+              : "IBM's AI shell assistant. Paste a Bob API key of type Inference to get started."}{" "}
+            <a
+              href="https://bob.ibm.com/admin/apikeys"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent hover:underline inline-flex items-center gap-1"
+            >
+              Manage keys <ExternalLink size={11} />
+            </a>
           </div>
         </div>
         {onCancel && (

--- a/packages/ui/src/modules/settings/components/bob/modes.ts
+++ b/packages/ui/src/modules/settings/components/bob/modes.ts
@@ -1,12 +1,12 @@
-/** Bob Shell is single-mode (Bearer API token). Length-1 shape kept for
- *  symmetry with `anthropic/modes.ts` and `ibm-litellm/modes.ts`. */
+/** Bob Shell is single-mode (Apikey scheme on api.us-east). Length-1 shape
+ *  kept for symmetry with `anthropic/modes.ts` and `ibm-litellm/modes.ts`. */
 export const MODE_KEYS = ["api-key"] as const;
 export type Mode = (typeof MODE_KEYS)[number];
 
 export const MODES = {
   "api-key": {
     label: "API Key",
-    placeholder: "sk-…",
+    placeholder: "bob_prod_bob-apikey_…",
   },
 } as const satisfies Record<Mode, { label: string; placeholder: string }>;
 


### PR DESCRIPTION
Bob's new api-key format (`bob_prod_bob-apikey_...`) replaces the legacy `sk-`/`pk-` prefix scheme. Update the API-key input placeholder so the hint matches what users actually paste; also refresh the doc comment ("Bearer API token" → "Apikey scheme on api.us-east") to reflect the provider preset's current wire shape.