### PR TITLE
fix(api): make brand icon PNG routes publicly reachable

### DIFF
--- a/packages/api-server/src/__tests__/auth.test.ts
+++ b/packages/api-server/src/__tests__/auth.test.ts
@@ -11,6 +11,12 @@ describe("auth: public endpoints", () => {
     expect(await res.json()).toEqual({ status: "ok" });
   });
 
+  it("/api/brand/icon-192.png returns 200 without token", async () => {
+    const res = await fetch(`${API_BASE}/api/brand/icon-192.png`);
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toBe("image/png");
+  });
+
   it("/api/auth/config returns issuer, clientId and cliClientId without token", async () => {
     const res = await fetch(`${API_BASE}/api/auth/config`);
     expect(res.status).toBe(200);

--- a/packages/api-server/src/apps/api-server/auth.ts
+++ b/packages/api-server/src/apps/api-server/auth.ts
@@ -28,6 +28,8 @@ const PUBLIC_PATHS = new Set([
   "/api/telegram/oauth/callback",
 ]);
 
+const PUBLIC_PATH_PREFIXES = ["/api/brand/"];
+
 export function createAuth(config: AuthConfig) {
   const JWKS = createRemoteJWKSet(new URL(config.jwksUrl));
 
@@ -56,7 +58,11 @@ export function createAuth(config: AuthConfig) {
   }
 
   const middleware: MiddlewareHandler = async (c, next) => {
-    if (PUBLIC_PATHS.has(c.req.path)) return next();
+    if (
+      PUBLIC_PATHS.has(c.req.path) ||
+      PUBLIC_PATH_PREFIXES.some((p) => c.req.path.startsWith(p))
+    )
+      return next();
 
     const authHeader = c.req.header("authorization");
     if (!authHeader?.startsWith("Bearer ")) {

--- a/packages/ui/index.html
+++ b/packages/ui/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1D6BE1" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <link rel="icon" type="image/svg+xml" href="/api/brand/icon.svg" />
     <link rel="apple-touch-icon" href="/api/brand/icon-180.png" />


### PR DESCRIPTION
## Summary

- Add `PUBLIC_PATH_PREFIXES` check in auth middleware so all `/api/brand/` routes bypass auth — fixes Hono's `RegExpRouter` dispatching wildcard middleware before parameterized route handlers (`icon-:size.png`) regardless of registration order
- Add standardized `<meta name="mobile-web-app-capable">` tag alongside the apple-prefixed one in `index.html`
- Add regression test verifying `/api/brand/icon-192.png` returns 200 without a token

Closes #221

## Test plan

- [ ] `mise run check` passes (lint + type-check)
- [ ] `mise run test` passes (all 576 tests)
- [ ] Verify `curl -s -o /dev/null -w '%{http_code}' http://localhost:4444/api/brand/icon-192.png` returns `200` on a running cluster
- [ ] Verify PWA manifest icons load without console errors
- [ ] Verify no `apple-mobile-web-app-capable` deprecation warning in Chromium console