### PR TITLE
fix(ui): use model name directly instead of parsing description text

### DIFF
--- a/packages/ui/src/modules/sessions/components/session-config-popover.tsx
+++ b/packages/ui/src/modules/sessions/components/session-config-popover.tsx
@@ -43,18 +43,6 @@ export function getSavedPreferences(instanceId: string): {
   };
 }
 
-/** Extract short model name from description (e.g. "Sonnet 4.6 · Best for..." → "Sonnet 4.6") */
-function shortModelLabel(model: {
-  name: string;
-  description?: string | null;
-}): string {
-  if (model.description) {
-    const before = model.description.split("·")[0]?.trim();
-    if (before && before !== model.name) return before;
-  }
-  return model.name;
-}
-
 /**
  * Inline session config controls: mode label + popover for modes, config options, and model.
  * All dynamically driven from ACP session state — renders nothing if the agent doesn't report capabilities.
@@ -231,7 +219,7 @@ export function SessionConfigBar({
           <span className="text-text-muted">Loading...</span>
         ) : (
           <span className="truncate max-w-[250px]">
-            {[currentModel && shortModelLabel(currentModel), currentMode?.name]
+            {[currentModel?.name, currentMode?.name]
               .filter(Boolean)
               .join(" · ") || "Config"}
           </span>


### PR DESCRIPTION
## Summary

- Remove `shortModelLabel()` which derived a short label by splitting the model description on `·` — this broke when harnesses prefixed descriptions with arbitrary text like "New version available"
- Use `model.name` directly in the config bar, which is always a reliable short identifier

Closes #246

## Test plan

- [ ] Open a session with a harness whose model description starts with non-model text (e.g. "New version available · ...")
- [ ] Verify the config bar shows the model's actual name, not the description prefix
- [ ] Verify normal models still show their name correctly