### PR TITLE
feat(agents): default Claude Code to auto permission mode

### DIFF
--- a/packages/platform-base/harness-terminal.sh
+++ b/packages/platform-base/harness-terminal.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
+CLAUDE_OPTS="--permission-mode auto --allow-dangerously-skip-permissions"
 if find "$HOME/.claude/projects" -name "$HARNESS_SESSION_ID.jsonl" -type f -print -quit 2>/dev/null | grep -q .; then
-  exec claude --resume "$HARNESS_SESSION_ID" "$@"
+  exec claude $CLAUDE_OPTS --resume "$HARNESS_SESSION_ID" "$@"
 else
-  exec claude --session-id "$HARNESS_SESSION_ID" "$@"
+  exec claude $CLAUDE_OPTS --session-id "$HARNESS_SESSION_ID" "$@"
 fi

--- a/packages/platform-base/working-dir/.claude/settings.json
+++ b/packages/platform-base/working-dir/.claude/settings.json
@@ -1,4 +1,7 @@
 {
   "theme": "dark",
-  "enableAllProjectMcpServers": true
+  "enableAllProjectMcpServers": true,
+  "permissions": {
+    "defaultMode": "auto"
+  }
 }


### PR DESCRIPTION
## Summary

- Set `permissions.defaultMode` to `"auto"` in the project settings baked into the platform-base image — the ACP wrapper (`claude-agent-acp`) reads this via `SettingsManager` and resolves it into the session's initial permission mode
- Pass `--permission-mode auto` in `harness-terminal.sh` since the terminal path invokes the `claude` CLI directly (bypasses ACP settings)
- Users can still switch to any mode (default, plan, bypassPermissions, etc.) via the session config popover — this only changes the default

`bypassPermissions` (yolo) mode is already available in the mode picker for non-root agents (our pods run as UID 65532), so no additional work needed to "expose" it.

Closes #38

## Test plan

- [ ] Create a new Claude Code agent and start a session — verify the mode picker shows "Auto" as the active mode
- [ ] In a terminal session, verify Claude Code starts in auto mode (accepts tool calls without prompting)
- [ ] Switch to "Default" mode from the picker — verify prompts resume
- [ ] Verify bypassPermissions mode is available in the picker and works when selected
- [ ] Verify scheduled/headless sessions still auto-approve (no regression from server-side `acp-client.ts`)