### PR TITLE
Fix for Unused variable, import, function or class

### DIFF
--- a/packages/api-server/src/__tests__/schedules.test.ts
+++ b/packages/api-server/src/__tests__/schedules.test.ts
@@ -12,7 +12,6 @@ import {
   describeConfigMap,
   getEvents,
 } from "./helpers/kubectl.js";
-import yaml from "js-yaml";
 
 let AGENT_ID: string;
 


### PR DESCRIPTION
Remove the unused `js-yaml` import from `packages/api-server/src/__tests__/schedules.test.ts`.

Best fix without changing functionality:
- Delete line 15 (`import yaml from "js-yaml";`) only.
- Do not alter test logic, variables, or other imports.
- No additional methods, definitions, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._