### PR TITLE
fix(api): reject wildcard host patterns in credentials

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -93,7 +93,10 @@ export {
   bobPinsFromEnvMappings,
   BOB_CHAT_MODES,
 } from "./modules/secrets/types.js";
-export { updateSecretInputSchema } from "./modules/secrets/schemas.js";
+export {
+  hostPatternSchema,
+  updateSecretInputSchema,
+} from "./modules/secrets/schemas.js";
 
 export type { ChannelsService } from "./modules/channels/types.js";
 

--- a/packages/api-server-api/src/modules/secrets/router.ts
+++ b/packages/api-server-api/src/modules/secrets/router.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 import { t } from "../../trpc.js";
 import {
   envMappingsSchema,
+  hostPatternSchema,
   injectionConfigSchema,
   secretTypeSchema,
   updateSecretInputSchema,
@@ -32,7 +33,7 @@ export const secretsRouter = t.router({
           type: secretTypeSchema,
           name: z.string().min(1).max(100),
           value: z.string().min(1),
-          hostPattern: z.string().min(1).max(253).optional(),
+          hostPattern: hostPatternSchema.optional(),
           pathPattern: z.string().min(1).max(1000).optional(),
           injectionConfig: injectionConfigSchema.optional(),
           envMappings: envMappingsSchema.optional(),

--- a/packages/api-server-api/src/modules/secrets/schemas.ts
+++ b/packages/api-server-api/src/modules/secrets/schemas.ts
@@ -13,6 +13,19 @@ export const secretTypeSchema = z.enum([
   "generic",
 ]);
 
+/**
+ * Reusable hostPattern field. Rejects wildcard patterns (`*`) because the
+ * agent network gateway (Envoy) cannot route them and the pod would crash-loop.
+ */
+export const hostPatternSchema = z
+  .string()
+  .min(1)
+  .max(253)
+  .refine((v) => !v.includes("*"), {
+    message:
+      "Wildcard host patterns are not supported. Please specify exact hostnames.",
+  });
+
 export const envMappingSchema = z.object({
   envName: z
     .string()
@@ -46,7 +59,7 @@ export const updateSecretInputSchema = z
     id: z.string().min(1),
     name: z.string().min(1).max(100).optional(),
     value: z.string().min(1).optional(),
-    hostPattern: z.string().min(1).max(253).optional(),
+    hostPattern: hostPatternSchema.optional(),
     pathPattern: z.string().max(1000).nullable().optional(),
     injectionConfig: injectionConfigSchema.nullable().optional(),
     envMappings: envMappingsSchema.optional(),

--- a/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/k8s-secrets-port.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import type * as k8s from "@kubernetes/client-node";
-import { updateSecretInputSchema } from "api-server-api";
+import { hostPatternSchema, updateSecretInputSchema } from "api-server-api";
 
 import {
   createK8sSecretsPort,
@@ -656,5 +656,50 @@ describe("updateSecretInputSchema", () => {
     if (!r.success) {
       expect(r.error.issues[0]!.path).toEqual(["value"]);
     }
+  });
+
+  it("rejects a wildcard hostPattern on update", () => {
+    const r = updateSecretInputSchema.safeParse({
+      id: "abc",
+      hostPattern: "*.vercel.com",
+    });
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.message).toMatch(/wildcard/i);
+    }
+  });
+});
+
+describe("hostPatternSchema", () => {
+  it("accepts an exact hostname", () => {
+    expect(hostPatternSchema.safeParse("api.example.com").success).toBe(true);
+  });
+
+  it("rejects a leading wildcard", () => {
+    const r = hostPatternSchema.safeParse("*.example.com");
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.message).toMatch(/wildcard/i);
+    }
+  });
+
+  it("rejects a bare wildcard", () => {
+    const r = hostPatternSchema.safeParse("*");
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.message).toMatch(/wildcard/i);
+    }
+  });
+
+  it("rejects a wildcard embedded in the hostname", () => {
+    const r = hostPatternSchema.safeParse("api.*.example.com");
+    expect(r.success).toBe(false);
+    if (!r.success) {
+      expect(r.error.issues[0]!.message).toMatch(/wildcard/i);
+    }
+  });
+
+  it("rejects an empty string", () => {
+    expect(hostPatternSchema.safeParse("").success).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `hostPatternSchema` Zod validation that rejects host patterns containing `*` with a clear error message
- Applied to both create and update input schemas in the secrets router
- Exported from `api-server-api` for client-side reuse
- 6 new tests covering leading wildcards, bare `*`, embedded wildcards, and empty strings

Previously, wildcard hosts like `*.vercel.com` were silently accepted at credential creation but crashed the agent's network gateway (Envoy) at pod startup.

Closes #175

## Test plan

- [x] `mise run check` passes
- [x] `mise run test` passes (261 api-server tests)