### PR TITLE
chore(agents/bob): switch installer to bob.ibm.com

### DIFF
--- a/packages/agents/bob/Dockerfile
+++ b/packages/agents/bob/Dockerfile
@@ -4,9 +4,9 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-# Bob installer — bobshell isn't on npmjs.org; the S3 bucket is the
-# only distribution channel. `--pm npm` skips pnpm/yarn detection.
-RUN curl -fsSL https://s3.us-south.cloud-object-storage.appdomain.cloud/bobshell/install-bobshell.sh \
+# Bob installer — bobshell isn't on npmjs.org; bob.ibm.com is the
+# official distribution channel. `--pm npm` skips pnpm/yarn detection.
+RUN curl -fsSL https://bob.ibm.com/download/bobshell.sh \
     | bash -s -- --pm npm \
     && chown -R 65532:0 /app
 

--- a/packages/agents/bob/README.md
+++ b/packages/agents/bob/README.md
@@ -6,7 +6,7 @@ Platform agent running [Bob Shell](https://internal.bob.ibm.com/docs/shell) — 
 
 | Component | Source | Purpose |
 |---|---|---|
-| Harness | `bobshell` (IBM internal S3 distribution) | Bob CLI in `--experimental-acp` mode + native TUI |
+| Harness | `bobshell` (installed from `bob.ibm.com/download/bobshell.sh`) | Bob CLI in `--experimental-acp` mode + native TUI |
 | ACP bridge | `bob-acp-shim.mjs` (verbatim from upstream Bob) | Translates Bob's session/update events into the shape the platform UI expects; auto-approves `session/request_permission` (Bob's ACP doesn't actually issue per-tool HITL requests for built-in tools — see autonomy posture below) |
 | Storage | `/home/agent` PVC (ADR-027) | Bob's session index lives under `~/.bob/`; survives pod restarts |
 


### PR DESCRIPTION
The bobshell installer is now distributed from bob.ibm.com/download instead of the S3 bucket. `--pm npm` flag is preserved so harness- terminal.sh still finds bob.js at /usr/local/lib/node_modules/bobshell/.