### PR TITLE
fix(ui): add delivery watchdog for unresponsive agent prompts

### DIFF
--- a/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
@@ -1,5 +1,5 @@
 import type { ClientSideConnection } from "@agentclientprotocol/sdk/dist/acp.js";
-import { useCallback } from "react";
+import { useCallback, useRef } from "react";
 
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
@@ -10,6 +10,8 @@ import {
 } from "../../acp/session-projection.js";
 import { buildPromptBlocks, extractErrorMessage } from "../../acp/utils.js";
 import { acpSessionsKeys } from "../api/queries.js";
+
+const DELIVERY_TIMEOUT_MS = 60_000;
 
 interface LiveConnection {
   connection: ClientSideConnection;
@@ -44,6 +46,7 @@ export function useAcpPrompt(
 } {
   const setMessages = useStore((s) => s.setMessages);
   const addLog = useStore((s) => s.addLog);
+  const watchdogRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const sendPrompt = useCallback(
     async (text: string, attachments?: Attachment[]) => {
@@ -92,6 +95,32 @@ export function useAcpPrompt(
       ]);
       addLog("prompt", { text });
 
+      if (watchdogRef.current) clearTimeout(watchdogRef.current);
+      watchdogRef.current = setTimeout(() => {
+        const msgs = useStore.getState().messages;
+        const bubble = msgs.find((m) => m.id === aId);
+        if (bubble?.streaming && bubble.parts.length === 0) {
+          addLog("error", { message: "Delivery watchdog fired" });
+          setMessages((p) =>
+            p.map((m) =>
+              m.id === aId
+                ? {
+                    ...m,
+                    streaming: false,
+                    queued: false,
+                    parts: [],
+                    error: {
+                      message: "Couldn't deliver — the agent didn't respond.",
+                      retryWith: { text, attachments },
+                    },
+                  }
+                : m,
+            ),
+          );
+        }
+        watchdogRef.current = null;
+      }, DELIVERY_TIMEOUT_MS);
+
       try {
         const conn = await ensureConnection();
         if (!conn) throw new Error("Failed to establish connection");
@@ -131,6 +160,10 @@ export function useAcpPrompt(
           ),
         );
       } finally {
+        if (watchdogRef.current) {
+          clearTimeout(watchdogRef.current);
+          watchdogRef.current = null;
+        }
         queryClient.invalidateQueries({ queryKey: acpSessionsKeys.all });
         textareaRef.current?.focus();
       }


### PR DESCRIPTION
## Summary

- Adds a 60-second client-side watchdog timer to the prompt hook
- If the agent produces no content within 60s after a prompt is sent, the assistant bubble shows "Couldn't deliver — the agent didn't respond." with a Retry button
- Timer is cancelled when the prompt resolves normally (success or caught error)
- Reuses the existing `error.retryWith` pattern — Retry works identically to other error cases

Closes #133

## Test plan

- [ ] `mise run check` passes
- [ ] `mise run test` passes
- [ ] Manual: send a prompt to an agent, verify normal flow works (timer doesn't fire)
- [ ] Manual: simulate an unresponsive agent (e.g. disconnect network), verify "Couldn't deliver" appears after ~60s with a Retry button