### PR TITLE
fix(cluster): self-heal istio ambient SVID rotation on dev cluster

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,8 @@ Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` i
 
 Activate cluster environment for interactive use: `export KUBECONFIG="$(mise run cluster:kubeconfig)"`.
 
+If the UI suddenly can't log in or `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, suspect expired Istio ambient workload SVIDs (issue #283). The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` within ~10 min when it sees the expired-cert signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait.
+
 ## System Architecture (what this system is)
 
 Platform-specific. **Always** start from [`docs/architecture.md`](docs/architecture.md) to understand the system. Before changing behavior in any subsystem, you **must** read its architecture page and the ADRs it links. Do not infer the architecture from the code alone — the docs are the source of truth for *why* the system is shaped the way it is.

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -230,7 +230,16 @@ istio_install_if_missing() {
 }
 
 istio_install_if_missing istio-base istio/base
-istio_install_if_missing istiod istio/istiod --set profile=ambient
+# Pin workload SVID TTL to 30d (issue #283). The default 24h races
+# against lima VM suspend/resume on a sleeping host laptop — when the
+# rotation window slips past expiry, every mesh hop dies until ztunnel
+# is bounced. Bumping the TTL well past a typical dev-cluster lifetime
+# (and well under Istio's 90d MAX_WORKLOAD_CERT_TTL default) takes the
+# rotation race off the critical path for normal dev work; the
+# ztunnel-cert-watchdog CronJob below covers the residual.
+istio_install_if_missing istiod istio/istiod \
+  --set profile=ambient \
+  --set pilot.env.DEFAULT_WORKLOAD_CERT_TTL=720h
 # k3s places CNI dirs at non-upstream paths (/var/lib/rancher/k3s/...).
 # Without these overrides istio-cni-node loops "no networks found in
 # /host/etc/cni/net.d" and ambient redirection never engages.
@@ -241,6 +250,94 @@ istio_install_if_missing istio-cni istio/cni \
 istio_install_if_missing ztunnel istio/ztunnel
 kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout status ds/ztunnel --timeout=120s
 kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout status ds/istio-cni-node --timeout=120s
+
+# Watchdog: every 10 min, scan ztunnel pod logs for the expired-SVID
+# markers (issue #283) and roll ds/ztunnel if any are present. Belt-and-
+# suspenders against any rotation failure that slips past the 30d
+# DEFAULT_WORKLOAD_CERT_TTL pinned on istiod above (e.g. a cluster left
+# running past TTL, an upstream istio bug). Apply is idempotent on
+# re-runs of cluster:install.
+kubectl --kubeconfig="$KUBECONFIG" apply -f - <<'YAML'
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ztunnel-cert-watchdog
+  namespace: istio-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: ztunnel-cert-watchdog
+  namespace: istio-system
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["daemonsets"]
+    # list+watch needed by `rollout status` (it watches the ds);
+    # patch is what `rollout restart` does (pod-template annotation).
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: ztunnel-cert-watchdog
+  namespace: istio-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: ztunnel-cert-watchdog
+subjects:
+  - kind: ServiceAccount
+    name: ztunnel-cert-watchdog
+    namespace: istio-system
+---
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: ztunnel-cert-watchdog
+  namespace: istio-system
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 1
+  jobTemplate:
+    spec:
+      backoffLimit: 0
+      ttlSecondsAfterFinished: 600
+      template:
+        spec:
+          serviceAccountName: ztunnel-cert-watchdog
+          restartPolicy: Never
+          containers:
+            - name: watchdog
+              image: alpine/k8s:1.30.4
+              command:
+                - sh
+                - -c
+                - |
+                  set -eu
+                  TRIGGERED=0
+                  for pod in $(kubectl -n istio-system get pods -l app=ztunnel -o name); do
+                    if kubectl -n istio-system logs --since=15m "$pod" 2>/dev/null \
+                        | grep -qiE 'certificate expired|AlertReceived\(CertificateExpired\)'; then
+                      echo "watchdog: $pod reported expired SVID — rolling ds/ztunnel"
+                      TRIGGERED=1
+                      break
+                    fi
+                  done
+                  if [ "$TRIGGERED" = 1 ]; then
+                    kubectl -n istio-system rollout restart ds/ztunnel
+                    kubectl -n istio-system rollout status ds/ztunnel --timeout=120s
+                  else
+                    echo "watchdog: ztunnel SVIDs healthy"
+                  fi
+YAML
 
 # Release namespace must be ambient so the api-server pod and the
 # Istio-synthesised waypoint Pod participate in mesh mTLS. The helm

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-19
+Last verified: 2026-05-21
 
 ## Motivated by
 
@@ -332,3 +332,18 @@ to api-server endpoints. Each pod's gate matches its threat model:
 the agent runs untrusted code and is held at the kernel layer; the
 gateway is platform-controlled and its identity flows through the
 mesh.
+
+## Dev cluster: SVID rotation resilience
+
+A dev-cluster constraint, not an architectural property. The local
+k3s/lima `cluster:install` ([`deploy/tasks.toml`](../../deploy/tasks.toml))
+pins `DEFAULT_WORKLOAD_CERT_TTL=720h` on istiod so workload SVIDs
+outlive a typical dev cluster's lifetime, and installs a
+`ztunnel-cert-watchdog` CronJob in `istio-system` that scans recent
+ztunnel logs every 10 min and rolls `ds/ztunnel` if it sees
+`certificate expired` / `AlertReceived(CertificateExpired)`. Together
+these absorb the race where lima VM suspend/resume on a sleeping host
+laptop slips past the default 24h rotation window and stalls every
+mesh hop — see [issue #283](https://github.com/dam-agents/dam/issues/283).
+Production deployments configure mesh PKI separately and don't get
+either knob.


### PR DESCRIPTION
## Summary

- Pin `DEFAULT_WORKLOAD_CERT_TTL=720h` on istiod so workload SVIDs outlive a typical dev-cluster lifetime; closes the race against lima suspend/resume that stalled every mesh hop after ~24h (misleading `Connection reset` from anything talking to keycloak).
- Install a `ztunnel-cert-watchdog` CronJob in `istio-system` (SA + Role + RoleBinding + CronJob applied directly from `cluster:install`) that scans recent ztunnel logs every 10 min and rolls `ds/ztunnel` if the expired-SVID signature shows up — belt-and-suspenders for any rotation failure that slips past the long TTL.
- Both changes are install-only in `cluster:install`; no `helm upgrade` for istiod and no platform helm chart changes.

## Test plan

- [x] `mise run helm:check:lint && mise run helm:check:render` — green
- [x] `mise run check` — green (only a pre-existing unrelated React-hooks warning)
- [x] Watchdog YAML validated standalone via `kubeconform` (4 resources, 0 invalid)
- [ ] Fresh install: `mise run cluster:delete --force && mise run cluster:install`, then verify `DEFAULT_WORKLOAD_CERT_TTL=720h` on the istiod deploy and that `cronjob/ztunnel-cert-watchdog` + its RBAC exist in `istio-system`.
- [ ] Force-run the watchdog on a healthy cluster: `kubectl create job --from=cronjob/ztunnel-cert-watchdog watchdog-test -n istio-system && kubectl logs job/watchdog-test -n istio-system` — expect `watchdog: ztunnel SVIDs healthy`.
- [ ] Confirm watchdog triggers and rolls cleanly on the failure mode (smoke-tested live during PR development: the watchdog detected an in-flight expired SVID and rolled `ds/ztunnel`; the original `rollout status` exit-1 led to the RBAC fix in this PR, with `list`/`watch` added to the daemonsets rule).

Closes #283