### PR TITLE
fix(agent-runtime): invalidate cache on idle session close so resume rehydrates

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
@@ -1053,6 +1053,184 @@ describe("createAcpRuntime", () => {
     ).toHaveLength(0);
   });
 
+  it("after closing an idle session, the next session/resume falls into cold-bootstrap (not hot-path from stale cache)", () => {
+    // Regression: maybeCloseIdleSession used to leave log.metadata intact
+    // after sending session/close. A reconnecting viewer's session/resume
+    // then hit the hot path and was served synthetically from cache — the
+    // agent was never told to rehydrate, and the subsequent session/prompt
+    // was forwarded to an agent that no longer had the session, producing
+    // "Session not found" with no recovery.
+    const fa = makeFakeAgent();
+    const runtime = createAcpRuntime({
+      spawnAgent: () => fa.agent,
+      workingDir: "/tmp",
+    });
+
+    // Tab A creates the session and populates log.metadata.
+    const a = makeFakeChannel();
+    runtime.attach(a.channel);
+    a.pushMessage(newSessionRequest(1));
+    const newOut = outboundId(fa.sent[0]);
+    fa.pushLine(newSessionResponse(newOut, SID));
+
+    // Tab A leaves → session is idle → runtime sends session/close.
+    a.remoteClose();
+    expect(
+      fa.sent.filter((f: any) => f.method === "session/close"),
+    ).toHaveLength(1);
+
+    // A fresh viewer resumes. With the fix, this MUST cold-bootstrap a
+    // session/load to rehydrate the agent — not serve from cache.
+    const agentSentBefore = fa.sent.length;
+    const b = makeFakeChannel();
+    runtime.attach(b.channel);
+    b.pushMessage(resumeSessionRequest(7));
+
+    const newForwards = fa.sent.slice(agentSentBefore);
+    const loadForwards = newForwards.filter(
+      (f: any) => f.method === "session/load",
+    );
+    expect(loadForwards).toHaveLength(1);
+    expect((loadForwards[0] as any).params.sessionId).toBe(SID);
+    // No synthetic resume response yet — waiter is parked on bootstrap.
+    expect(b.sent.some((f) => JSON.parse(f).id === 7)).toBe(false);
+
+    // Agent succeeds → resume waiter served.
+    completeResumeBootstrap(fa, SID);
+    expect(b.sent.some((f) => JSON.parse(f).id === 7)).toBe(true);
+  });
+
+  it("after closing an idle session, cold revival does not double the log on the agent's history replay", () => {
+    // Without resetting log.entries in maybeCloseIdleSession, the agent's
+    // replaySessionHistory events on a post-close cold load would append on
+    // top of the pre-close history — the log would double in size and a
+    // later hot-path session/load would replay duplicated entries.
+    const fa = makeFakeAgent();
+    const runtime = createAcpRuntime({
+      spawnAgent: () => fa.agent,
+      workingDir: "/tmp",
+    });
+
+    // Tab A: cold-load, populates log with one history entry + metadata.
+    const a = makeFakeChannel();
+    runtime.attach(a.channel);
+    a.pushMessage(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "session/load",
+        params: { sessionId: SID, cwd: "." },
+      }),
+    );
+    const aLoadOut = outboundId(fa.sent[0]);
+    const histA = JSON.stringify({
+      method: "session/update",
+      params: {
+        sessionId: SID,
+        update: {
+          sessionUpdate: "agent_message_chunk",
+          content: { type: "text", text: "old" },
+        },
+      },
+    });
+    fa.pushLine(histA);
+    fa.pushLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: aLoadOut,
+        result: { sessionId: SID, modes: {}, models: {}, configOptions: [] },
+      }),
+    );
+
+    // A leaves → session/close → log reset.
+    a.remoteClose();
+
+    // B resumes → cold bootstrap → agent replays the same history.
+    const b = makeFakeChannel();
+    runtime.attach(b.channel);
+    b.pushMessage(resumeSessionRequest(2));
+    fa.pushLine(histA);
+    completeResumeBootstrap(fa, SID);
+
+    // C joins via session/load → hot-path serves from cache. C should see
+    // exactly ONE copy of the history update, not two.
+    const c = makeFakeChannel();
+    runtime.attach(c.channel);
+    c.pushMessage(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "session/load",
+        params: { sessionId: SID, cwd: "." },
+      }),
+    );
+    const histCount = c.sent.filter((f) => f === histA).length;
+    expect(histCount).toBe(1);
+  });
+
+  it("after closing an idle session, a failed cold session/load relays the agent's error to the resume waiter and does not poison the cache", () => {
+    // If the agent's on-disk store doesn't have the session (lost, corrupted,
+    // wrong cwd), the cold load returns an error response. The runtime must
+    // relay that error to the parked resume waiter under the waiter's
+    // original id, and must NOT cache phantom { sessionId } metadata — or a
+    // retry would hit the hot path and serve from poisoned cache.
+    const fa = makeFakeAgent();
+    const runtime = createAcpRuntime({
+      spawnAgent: () => fa.agent,
+      workingDir: "/tmp",
+    });
+
+    // Set up cached metadata via session/new, then reap.
+    const a = makeFakeChannel();
+    runtime.attach(a.channel);
+    a.pushMessage(newSessionRequest(1));
+    const newOut = outboundId(fa.sent[0]);
+    fa.pushLine(newSessionResponse(newOut, SID));
+    a.remoteClose();
+
+    // Fresh viewer resumes → cold path → runtime issues session/load.
+    const b = makeFakeChannel();
+    runtime.attach(b.channel);
+    b.pushMessage(resumeSessionRequest(42));
+
+    const loadFrame = fa.sent.find(
+      (f: any) => f.method === "session/load" && f.params.sessionId === SID,
+    );
+    expect(loadFrame).toBeDefined();
+    const loadOut = outboundId(loadFrame);
+
+    // Agent errors — session not on disk.
+    fa.pushLine(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        id: loadOut,
+        error: {
+          code: -32603,
+          message: "Internal error",
+          data: { details: "Session not found" },
+        },
+      }),
+    );
+
+    // B receives the error under its own id, not a synthetic success.
+    const bResp = b.sent.map((f) => JSON.parse(f)).find((p) => p.id === 42);
+    expect(bResp).toBeDefined();
+    expect(bResp.error).toBeDefined();
+    expect(bResp.result).toBeUndefined();
+
+    // A retry from another channel must also cold-bootstrap, not hit a
+    // poisoned hot-path cache.
+    const agentSentBefore = fa.sent.length;
+    const c = makeFakeChannel();
+    runtime.attach(c.channel);
+    c.pushMessage(resumeSessionRequest(99));
+    const newForwards = fa.sent.slice(agentSentBefore);
+    expect(
+      newForwards.filter((f: any) => f.method === "session/load"),
+    ).toHaveLength(1);
+    expect(c.sent.some((f) => JSON.parse(f).id === 99)).toBe(false);
+  });
+
   it("serves subsequent session/load from the in-memory log instead of forwarding to the agent", () => {
     // Viewer A cold-bootstraps the session: forwards session/load to the
     // agent, receives history + response, engages live. Viewer B opens a

--- a/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
@@ -1098,6 +1098,24 @@ describe("createAcpRuntime", () => {
     // Agent succeeds → resume waiter served.
     completeResumeBootstrap(fa, SID);
     expect(b.sent.some((f) => JSON.parse(f).id === 7)).toBe(true);
+
+    // End-to-end proof of rehydration: a session/prompt issued by B after
+    // the resume must reach the agent under a real outbound id, and the
+    // agent's response must flow back to B under its original id. Before
+    // the fix this was the failing step — the resume would be served from
+    // stale cache, the agent had no record of the session, and the prompt
+    // came back with "Session not found".
+    const promptBefore = fa.sent.length;
+    b.pushMessage(promptRequest(8, SID));
+    const promptForwards = fa.sent
+      .slice(promptBefore)
+      .filter((f: any) => f.method === "session/prompt");
+    expect(promptForwards).toHaveLength(1);
+    const promptOut = outboundId(promptForwards[0]);
+    fa.pushLine(agentPromptResponse(promptOut));
+    const promptResp = b.sent.map((f) => JSON.parse(f)).find((p) => p.id === 8);
+    expect(promptResp).toBeDefined();
+    expect(promptResp.result).toBeDefined();
   });
 
   it("after closing an idle session, cold revival does not double the log on the agent's history replay", () => {

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -136,7 +136,17 @@ interface SessionLog {
    * and our log mirrors what it would replay." When `maybeCloseIdleSession`
    * tears the session down inside the agent, it MUST reset `metadata` to
    * null AND clear `entries`, so the next access goes through cold-bootstrap
-   * and rehydrates both sides from disk. */
+   * and rehydrates both sides from disk.
+   *
+   * `null` represents two states: (a) the session was never bootstrapped, or
+   * (b) the most recent cold `session/load` failed — the cache-population
+   * guard in `handleAgentLine` skips writes when the agent's response has
+   * `result === undefined` (i.e. an error frame), so an error leaves
+   * `metadata` null. The bootstrap completion handler relies on exactly
+   * this to detect cold-load failure (`loadFailed = log.metadata === null`)
+   * and relay the agent's error to parked waiters. A future discriminated
+   * union (`{ status: "loaded"; data: unknown } | null`) would let the
+   * type system encode this directly. */
   metadata: unknown | null;
 }
 
@@ -793,6 +803,9 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
           const boot = bootstrapBySession.get(sid);
           if (boot) {
             bootstrapBySession.delete(sid);
+            // Error responses leave metadata null (cache-population guard
+            // above requires `result !== undefined`); see SessionLog.metadata
+            // invariant for the full coupling.
             const loadFailed = log.metadata === null;
             for (const waiter of boot.waiters) {
               if (!waiter.channel.isOpen()) continue;

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -130,7 +130,13 @@ interface SessionLog {
   truncated: boolean;
   /** Cached `session/load` response metadata, captured from the first
    * (cold) bootstrap response. Used to synthesize responses to subsequent
-   * `session/load` requests without forwarding to the agent. */
+   * `session/load` requests without forwarding to the agent.
+   *
+   * Invariant: `metadata !== null` means "the agent has this session live
+   * and our log mirrors what it would replay." When `maybeCloseIdleSession`
+   * tears the session down inside the agent, it MUST reset `metadata` to
+   * null AND clear `entries`, so the next access goes through cold-bootstrap
+   * and rehydrates both sides from disk. */
   metadata: unknown | null;
 }
 
@@ -587,6 +593,23 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       method: "session/close",
       params: { sessionId },
     });
+    // Invalidate the cache so the next session/resume or session/load goes
+    // through cold-bootstrap (the agent will rehydrate from disk and the
+    // log will repopulate from the replay events). Without this reset,
+    // hot-path resume would serve from stale cache, the next session/prompt
+    // would be forwarded to an agent that no longer has the session, and
+    // the harness would respond with "Session not found". Resetting entries
+    // too prevents the replay on revival from doubling the log on top of
+    // pre-close history. Safe because we only get here when no channel is
+    // engaged (see hasEngagedChannel check above).
+    const log = sessionLogs.get(sessionId);
+    if (log) {
+      log.entries = [];
+      log.nextSeq = 1;
+      log.totalBytes = 0;
+      log.truncated = false;
+      log.metadata = null;
+    }
     deps.log?.(`closing idle session ${sessionId}`);
   }
 
@@ -748,12 +771,11 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
             mapping.method === "session/new" ||
             mapping.method === "session/fork" ||
             mapping.method === "session/load";
-          if (cacheable) {
+          const result = (frame as { result?: unknown }).result;
+          if (cacheable && result !== undefined) {
             const log = getOrCreateLog(sidForChannel);
             if (log.metadata === null) {
-              log.metadata = (frame as { result?: unknown }).result ?? {
-                sessionId: sidForChannel,
-              };
+              log.metadata = result;
             }
           }
         }
@@ -771,8 +793,20 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
           const boot = bootstrapBySession.get(sid);
           if (boot) {
             bootstrapBySession.delete(sid);
+            const loadFailed = log.metadata === null;
             for (const waiter of boot.waiters) {
               if (!waiter.channel.isOpen()) continue;
+              if (loadFailed) {
+                // Relay the agent's error to the waiter under its own id
+                // — we have no cached metadata to synthesize a response,
+                // and a thrown error here would leave the waiter hanging.
+                const out = JSON.stringify({
+                  ...(frame as object),
+                  id: waiter.originalId,
+                });
+                waiter.channel.send(rewriteAuthError(out));
+                continue;
+              }
               if (waiter.kind === "load") {
                 serveLoadFromLog(waiter.channel, waiter.originalId, sid, log);
               } else {

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -566,24 +566,40 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   }
 
   /**
-   * Close an SDK session when nothing is keeping it alive. Each open session
-   * pins a `claude` CLI subprocess (~300MB RSS) inside the agent pod; leaving
-   * them open after viewers leave accumulates until the pod OOMs.
+   * Tear a session down on both sides of the relay: send `session/close` to
+   * the agent (if it supports it) and drop the runtime's cache + per-channel
+   * cursors. The two halves MUST happen together — otherwise the cache lies
+   * to the UI about a session the agent has forgotten, and the next
+   * `session/prompt` comes back with "Session not found".
    *
-   * "Idle" means: no channel engaged with the session, no active or queued
-   * prompts, no agent→client requests still pending (permission prompts).
-   * The SDK respawns the subprocess on the next resume/load, so closing is
-   * safe — we just trade memory for a brief cold-start when a viewer returns.
+   * Fire-and-forget on the agent side: we don't register the outbound id, so
+   * the agent's response is silently dropped by `handleAgentLine`.
+   */
+  function tearDownSession(sessionId: string): void {
+    if (agent && !agentExited && sessionCloseSupported) {
+      agent.send({
+        jsonrpc: "2.0",
+        id: nextOutboundId++,
+        method: "session/close",
+        params: { sessionId },
+      });
+    }
+    sessionLogs.delete(sessionId);
+    for (const cursors of channelCursors.values()) cursors.delete(sessionId);
+  }
+
+  /**
+   * Refcount-driven reap: when no channel is engaged with the session and no
+   * work is in flight, tear it down to free the ~300MB CLI subprocess the
+   * SDK pins per session. The cold-bootstrap path rehydrates from disk on
+   * the next viewer's `session/resume`.
    *
-   * Fire-and-forget: we don't register the outbound id, so the agent's
-   * response is silently dropped by `handleAgentLine`.
+   * Skipped entirely when the agent doesn't advertise
+   * `sessionCapabilities.close`: we can't tell the agent to drop the session,
+   * so we also keep the cache so future resumes can still serve from memory.
    */
   function maybeCloseIdleSession(sessionId: string): void {
     if (!agent || agentExited) return;
-    // Skip if the agent didn't advertise `sessionCapabilities.close` in its
-    // initialize response. The session lives on inside the agent — keep the
-    // local log + cursors so a future session/resume can serve from cache
-    // without forcing a cold re-bootstrap the agent likely can't satisfy.
     if (!sessionCloseSupported) return;
     if (hasEngagedChannel(sessionId)) return;
     if (activePromptBySession.has(sessionId)) return;
@@ -596,30 +612,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       if (req.sessionId === sessionId) return;
     }
 
-    const id = nextOutboundId++;
-    agent.send({
-      jsonrpc: "2.0",
-      id,
-      method: "session/close",
-      params: { sessionId },
-    });
-    // Invalidate the cache so the next session/resume or session/load goes
-    // through cold-bootstrap (the agent will rehydrate from disk and the
-    // log will repopulate from the replay events). Without this reset,
-    // hot-path resume would serve from stale cache, the next session/prompt
-    // would be forwarded to an agent that no longer has the session, and
-    // the harness would respond with "Session not found". Resetting entries
-    // too prevents the replay on revival from doubling the log on top of
-    // pre-close history. Safe because we only get here when no channel is
-    // engaged (see hasEngagedChannel check above).
-    const log = sessionLogs.get(sessionId);
-    if (log) {
-      log.entries = [];
-      log.nextSeq = 1;
-      log.totalBytes = 0;
-      log.truncated = false;
-      log.metadata = null;
-    }
+    tearDownSession(sessionId);
     deps.log?.(`closing idle session ${sessionId}`);
   }
 
@@ -1118,17 +1111,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
     },
 
     resetSession(sessionId) {
-      if (agent && !agentExited && sessionCloseSupported) {
-        agent.send({
-          jsonrpc: "2.0",
-          id: nextOutboundId++,
-          method: "session/close",
-          params: { sessionId },
-        });
-      }
-      // Always clear client-side state even if the agent didn't accept the close.
-      sessionLogs.delete(sessionId);
-      for (const cursors of channelCursors.values()) cursors.delete(sessionId);
+      tearDownSession(sessionId);
       deps.log?.(`reset session ${sessionId}`);
     },
 


### PR DESCRIPTION
## Summary

- After `maybeCloseIdleSession` sent `session/close` to the agent, the runtime kept the cached log + metadata. A reconnecting viewer's `session/resume` then hit the hot path and was served synthetically — the agent never rehydrated. The next `session/prompt` was forwarded to an agent that no longer had the session, producing `Session not found` with no recovery.
- Fix the divergence with a single invariant: `metadata !== null` ⇔ the agent has this session live and our log mirrors what it would replay. `maybeCloseIdleSession` now resets entries / counters and nulls metadata atomically with the close send, so hot-path resume / load short-circuit naturally fall through to cold-bootstrap and the agent re-hydrates from disk.
- Also stop caching phantom `{ sessionId }` metadata from error responses to a cold `session/load`. Bootstrap waiters get the agent's error relayed under their original ids instead of `serveLoadFromLog` throwing on null metadata, so a session lost on disk surfaces as a clean error in the UI.

## How

- `packages/agent-runtime/src/modules/acp/services/acp-runtime.ts`
  - Reset `entries` / `nextSeq` / `totalBytes` / `truncated` / `metadata` inside `maybeCloseIdleSession`.
  - Guard cache population on `frame.result !== undefined` so error responses don't poison the cache.
  - Relay the agent's error frame to all parked bootstrap waiters under each waiter's `originalId` when a cold `session/load` fails.

## Test plan

- [x] `mise run test` — full suite green.
- [x] `mise run check` — lint / format / type-check green.
- [x] New unit tests in `packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts`:
  - Resume after idle close falls into cold-bootstrap, not hot-path-from-stale-cache.
  - Cold revival does not double the log on the agent's history replay.
  - Failed cold `session/load` relays the agent's error to the resume waiter and does not poison the cache.
- [x] Verified in local k3s: live agent that was producing `Session not found` after a transient outage recovered the on-disk session on the very next UI resume.

## Notes for reviewers

- Single-invariant design supersedes an earlier `closedInAgent` flag draft that carried two pieces of state — review feedback caught two bugs in that shape (stale `loadFailed` derivation, doubled replay log). Both are intrinsically prevented by the single-invariant approach.
- Trade-off: an idle close drops the cached log, so the next viewer pays one round-trip to the agent for `session/load`. That matches the original comment's intent ("brief cold-start when a viewer returns") and was effectively the design before this regression was introduced.
- Not addressed here (separate concern): if the agent returns an error for the runtime-issued `session/close`, the runtime now thinks the session is gone but the agent might still have it. The runtime will cold-load on next access; most SDK implementations make that idempotent. Worth a follow-up if we see misbehavior in the field.