### PR TITLE
feat(agents): add OpenAI Codex agent support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       - name: Build agent images
         run: |
           docker build -t platform-claude-code:latest packages/agents/claude-code
+          docker build -t platform-codex:latest packages/agents/codex
           docker build -t platform-google-workspace-agent:latest packages/agents/google-workspace
           docker build -t platform-pi-agent:latest packages/agents/pi-agent
           docker build -t platform-bob:latest packages/agents/bob

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -42,6 +42,14 @@ agentTemplates:
     skillPaths:
       - $HOME/.claude/skills/
 
+  - name: codex
+    enabled: true
+    description: "OpenAI Codex coding agent"
+    image:
+      repository: platform-codex
+      tag: latest
+    storageSize: "5Gi"
+
   - name: google-workspace
     enabled: true
     description: "Google Workspace agent with Drive and Gmail via gws CLI"

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -592,6 +592,14 @@ agentTemplates:
     skillPaths:
       - $HOME/.claude/skills/
 
+  - name: codex
+    enabled: true
+    description: "OpenAI Codex coding agent"
+    image:
+      repository: quay.io/dam-agents/codex
+      tag: ""
+    storageSize: "5Gi"
+
   - name: bob
     enabled: true
     description: "Bob shell agent"

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -72,7 +72,7 @@ docker build -f packages/ui/Dockerfile -t platform-ui:latest .
 '''
 
 ["image:agent"]
-description = "Build agent Docker images (platform-base + claude-code + google-workspace + pi-agent + bob)"
+description = "Build agent Docker images (platform-base + claude-code + codex + google-workspace + pi-agent + bob)"
 dir = "{{config_root}}"
 run = '''
 #!/usr/bin/env bash
@@ -80,6 +80,7 @@ set -eo pipefail
 [ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
 docker build -f packages/platform-base/Dockerfile -t platform-base .
 docker build -t platform-claude-code:latest packages/agents/claude-code
+docker build -t platform-codex:latest packages/agents/codex
 docker build -t platform-google-workspace-agent:latest packages/agents/google-workspace
 docker build -t platform-pi-agent:latest packages/agents/pi-agent
 docker build -t platform-bob:latest packages/agents/bob
@@ -361,7 +362,7 @@ kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mo
 # 3. Load images into k3s (built by depends: image:*)
 echo "Loading images into k3s..."
 tar="/tmp/platform-images.tar"
-docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest
+docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-codex:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest
 if [ -n "${IS_SANDBOX:-}" ]; then
   [ -z "${CI:-}" ] && docker image prune --all --force >/dev/null 2>&1 || true
   sudo k3s ctr images import "$tar"
@@ -524,7 +525,7 @@ set -eo pipefail
 
 echo "Loading into k3s..."
 tar="/tmp/platform-agent-images.tar"
-docker save platform-claude-code:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest -o "$tar"
+docker save platform-claude-code:latest platform-codex:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest -o "$tar"
 
 if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"

--- a/docs/adrs/023-harness-agnostic-base-image.md
+++ b/docs/adrs/023-harness-agnostic-base-image.md
@@ -56,6 +56,7 @@ The platform contract is two executables at fixed paths ([ADR-037](037-remote-te
 |---|---|---|
 | `example-agent` | Claude Code ACP (default) | `claude` (default) |
 | `google-workspace` | Claude Code ACP (default) | `claude` (default) |
+| `codex` | `codex-acp` | `codex` / `codex resume $HARNESS_SESSION_ID` |
 | `pi-agent` | `pi-acp` | `pi --session $HARNESS_SESSION_ID` |
 
 See `packages/agents/pi-agent/README.md` for pi-specific config (memory scopes, system-prompt conventions, workspace layout).

--- a/docs/adrs/023-harness-agnostic-base-image.md
+++ b/docs/adrs/023-harness-agnostic-base-image.md
@@ -56,7 +56,7 @@ The platform contract is two executables at fixed paths ([ADR-037](037-remote-te
 |---|---|---|
 | `example-agent` | Claude Code ACP (default) | `claude` (default) |
 | `google-workspace` | Claude Code ACP (default) | `claude` (default) |
-| `codex` | `codex-acp` | `codex` / `codex resume $HARNESS_SESSION_ID` |
+| `codex` | `codex-acp` | `codex` / `codex resume --last` |
 | `pi-agent` | `pi-acp` | `pi --session $HARNESS_SESSION_ID` |
 
 See `packages/agents/pi-agent/README.md` for pi-specific config (memory scopes, system-prompt conventions, workspace layout).

--- a/package.json
+++ b/package.json
@@ -34,8 +34,5 @@
     "prettier": "^3.8.3",
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.3"
-  },
-  "dependencies": {
-    "@anthropic-ai/claude-code": "2.1.140"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,5 +34,8 @@
     "prettier": "^3.8.3",
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.3"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-code": "2.1.140"
   }
 }

--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -3,7 +3,9 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-RUN npm install -g @zed-industries/codex-acp @openai/codex \
+COPY package.json package-lock.json /opt/codex/
+RUN --mount=type=cache,target=/root/.npm \
+    cd /opt/codex && npm ci \
     && chown -R 65532:0 /app
 
 COPY harness-chat.sh /usr/local/bin/harness-chat
@@ -16,5 +18,6 @@ COPY --chown=65532:0 workspace/ /app/working-dir/
 # by the Envoy sidecar on the wire. This placeholder satisfies the CLI's
 # startup check.
 ENV OPENAI_API_KEY=dummy-placeholder
+ENV PATH="/opt/codex/node_modules/.bin:$PATH"
 
 USER 65532

--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -1,0 +1,20 @@
+ARG BASE_IMAGE=platform-base
+FROM ${BASE_IMAGE}
+
+USER root
+
+RUN npm install -g @zed-industries/codex-acp @openai/codex \
+    && chown -R 65532:0 /app
+
+COPY harness-chat.sh /usr/local/bin/harness-chat
+COPY harness-terminal.sh /usr/local/bin/harness-terminal
+RUN chmod +x /usr/local/bin/harness-chat /usr/local/bin/harness-terminal
+
+COPY --chown=65532:0 workspace/ /app/working-dir/
+
+# Codex needs OPENAI_API_KEY to be present; the real credential is injected
+# by the Envoy sidecar on the wire. This placeholder satisfies the CLI's
+# startup check.
+ENV OPENAI_API_KEY=dummy-placeholder
+
+USER 65532

--- a/packages/agents/codex/README.md
+++ b/packages/agents/codex/README.md
@@ -1,0 +1,51 @@
+# Codex Agent
+
+Platform agent running [OpenAI Codex CLI](https://github.com/openai/codex) via the [codex-acp](https://github.com/zed-industries/codex-acp) ACP adapter.
+
+## Stack
+
+| Component | Package | Purpose |
+|---|---|---|
+| ACP bridge | `@zed-industries/codex-acp` | Translates ACP <> Codex protocol for chat sessions |
+| Terminal CLI | `@openai/codex` | Interactive TUI for terminal sessions |
+
+## Authentication
+
+Codex requires an OpenAI API key. On the platform, the actual credential is never stored in the pod -- the Envoy sidecar injects it on the wire (see [ADR-033](../../../docs/adrs/033-envoy-credential-gateway.md)).
+
+Create a **generic secret** on the platform with:
+- `hostPattern`: `api.openai.com`
+- env-mapping: `OPENAI_API_KEY`
+
+The Dockerfile sets `OPENAI_API_KEY=dummy-placeholder` so the CLI's startup check passes before a real credential is attached.
+
+### Custom OpenAI-compatible endpoints
+
+To point Codex at an OpenAI-compatible proxy or self-hosted endpoint, add `OPENAI_BASE_URL` to the secret's env-mappings:
+
+```json
+[
+  { "envName": "OPENAI_API_KEY", "placeholder": "dummy-placeholder" },
+  { "envName": "OPENAI_BASE_URL", "placeholder": "https://my-proxy.example.com/v1" }
+]
+```
+
+The harness scripts translate `OPENAI_BASE_URL` into Codex's `-c openai_base_url=...` config override. Update the secret's `hostPattern` to match the proxy host so the Envoy sidecar injects the credential on the right outbound requests.
+
+## Harness scripts
+
+| Script | Runs | Purpose |
+|---|---|---|
+| `harness-chat.sh` | `codex-acp` | ACP subprocess for chat-mode sessions (UI) |
+| `harness-terminal.sh` | `codex` / `codex resume` | Interactive TUI for terminal-mode sessions |
+
+Terminal sessions use `--dangerously-bypass-approvals-and-sandbox` since the pod itself is the sandbox (network isolation + Envoy credential injection).
+
+## Usage
+
+```sh
+mise run cluster:install        # first time
+mise run cluster:build-agent    # rebuild after changes
+```
+
+Create an agent from the **codex** template in the Platform UI, attach an OpenAI credential, and open a session.

--- a/packages/agents/codex/harness-chat.sh
+++ b/packages/agents/codex/harness-chat.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+CODEX_ARGS='-c model_provider="openai-platform"'
+if [ -n "$OPENAI_BASE_URL" ]; then
+  CODEX_ARGS="$CODEX_ARGS -c model_providers.openai-platform.base_url=\"$OPENAI_BASE_URL\""
+fi
+if [ -n "$OPENAI_MODEL" ]; then
+  CODEX_ARGS="$CODEX_ARGS -c model=\"$OPENAI_MODEL\""
+fi
+exec codex-acp $CODEX_ARGS "$@"

--- a/packages/agents/codex/harness-chat.sh
+++ b/packages/agents/codex/harness-chat.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-CODEX_ARGS='-c model_provider="openai-platform"'
+set -- -c 'model_provider="openai-platform"'
 if [ -n "$OPENAI_BASE_URL" ]; then
-  CODEX_ARGS="$CODEX_ARGS -c model_providers.openai-platform.base_url=\"$OPENAI_BASE_URL\""
+  set -- "$@" -c "model_providers.openai-platform.base_url=\"$OPENAI_BASE_URL\""
 fi
 if [ -n "$OPENAI_MODEL" ]; then
-  CODEX_ARGS="$CODEX_ARGS -c model=\"$OPENAI_MODEL\""
+  set -- "$@" -c "model=\"$OPENAI_MODEL\""
 fi
-exec codex-acp $CODEX_ARGS "$@"
+exec codex-acp "$@"

--- a/packages/agents/codex/harness-terminal.sh
+++ b/packages/agents/codex/harness-terminal.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+CODEX_OPTS='--dangerously-bypass-approvals-and-sandbox -c model_provider="openai-platform"'
+if [ -n "$OPENAI_BASE_URL" ]; then
+  CODEX_OPTS="$CODEX_OPTS -c model_providers.openai-platform.base_url=\"$OPENAI_BASE_URL\""
+fi
+if [ -n "$OPENAI_MODEL" ]; then
+  CODEX_OPTS="$CODEX_OPTS -c model=\"$OPENAI_MODEL\""
+fi
+
+# Codex manages its own session IDs internally (no external --session-id
+# flag). Since each agent pod is single-tenant, resume the most recent
+# session if one exists; otherwise start fresh.
+SESSION_MARKER="$HOME/.codex/.session-started"
+mkdir -p "$HOME/.codex" >/dev/null 2>&1
+
+if [ -f "$SESSION_MARKER" ]; then
+  exec codex resume --last $CODEX_OPTS "$@"
+else
+  touch "$SESSION_MARKER"
+  exec codex $CODEX_OPTS "$@"
+fi

--- a/packages/agents/codex/harness-terminal.sh
+++ b/packages/agents/codex/harness-terminal.sh
@@ -1,21 +1,18 @@
 #!/bin/sh
-CODEX_OPTS='--dangerously-bypass-approvals-and-sandbox -c model_provider="openai-platform"'
+set -- --dangerously-bypass-approvals-and-sandbox -c 'model_provider="openai-platform"'
 if [ -n "$OPENAI_BASE_URL" ]; then
-  CODEX_OPTS="$CODEX_OPTS -c model_providers.openai-platform.base_url=\"$OPENAI_BASE_URL\""
+  set -- "$@" -c "model_providers.openai-platform.base_url=\"$OPENAI_BASE_URL\""
 fi
 if [ -n "$OPENAI_MODEL" ]; then
-  CODEX_OPTS="$CODEX_OPTS -c model=\"$OPENAI_MODEL\""
+  set -- "$@" -c "model=\"$OPENAI_MODEL\""
 fi
 
-# Codex manages its own session IDs internally (no external --session-id
-# flag). Since each agent pod is single-tenant, resume the most recent
-# session if one exists; otherwise start fresh.
 SESSION_MARKER="$HOME/.codex/.session-started"
 mkdir -p "$HOME/.codex" >/dev/null 2>&1
 
 if [ -f "$SESSION_MARKER" ]; then
-  exec codex resume --last $CODEX_OPTS "$@"
+  exec codex resume --last "$@"
 else
   touch "$SESSION_MARKER"
-  exec codex $CODEX_OPTS "$@"
+  exec codex "$@"
 fi

--- a/packages/agents/codex/package-lock.json
+++ b/packages/agents/codex/package-lock.json
@@ -1,0 +1,249 @@
+{
+  "name": "platform-codex",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "platform-codex",
+      "dependencies": {
+        "@openai/codex": "0.133.0",
+        "@zed-industries/codex-acp": "0.14.0"
+      }
+    },
+    "node_modules/@openai/codex": {
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0.tgz",
+      "integrity": "sha512-Gh42kLLBo/6gpnHmDzUWDVvyS57ekCB1+1Dz0RG2oIl3Lhk1uwrjSj/PwaJWWh4Rw/rUp1RqkwrMugFfFEOlqQ==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex": "bin/codex.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "@openai/codex-darwin-arm64": "npm:@openai/codex@0.133.0-darwin-arm64",
+        "@openai/codex-darwin-x64": "npm:@openai/codex@0.133.0-darwin-x64",
+        "@openai/codex-linux-arm64": "npm:@openai/codex@0.133.0-linux-arm64",
+        "@openai/codex-linux-x64": "npm:@openai/codex@0.133.0-linux-x64",
+        "@openai/codex-win32-arm64": "npm:@openai/codex@0.133.0-win32-arm64",
+        "@openai/codex-win32-x64": "npm:@openai/codex@0.133.0-win32-x64"
+      }
+    },
+    "node_modules/@openai/codex-darwin-arm64": {
+      "name": "@openai/codex",
+      "version": "0.133.0-darwin-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0-darwin-arm64.tgz",
+      "integrity": "sha512-W7f8+DckLujnqGlptKCzgJU+ooeHKMuk6KYgMFP6A9asn7YUsGUgJqjiBaX8oNcXO6w/pTbKGRARx1kCNS8lIg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-darwin-x64": {
+      "name": "@openai/codex",
+      "version": "0.133.0-darwin-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0-darwin-x64.tgz",
+      "integrity": "sha512-Ek8ikvLOiXZ8emcIJVBXxK6fm8ratBy0kaEt3JNisTNszxGshUHf/R4xxDxIyKNcUkYYXjW7A/rMwW3iu3OFlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-arm64": {
+      "name": "@openai/codex",
+      "version": "0.133.0-linux-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0-linux-arm64.tgz",
+      "integrity": "sha512-uKXYYSJ3mY16sp4hcG/4BMNRjva/ZS4oARiI1+7k8+NiuoAhdCGWNe5u4KJ3sMuL3tp/IXcmc6B56EFX1+WDBQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-linux-x64": {
+      "name": "@openai/codex",
+      "version": "0.133.0-linux-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0-linux-x64.tgz",
+      "integrity": "sha512-9YfyqrfUj/UZ2+aXE4zBz47t6RXbVni95ZorGsNh857vxYK/asVpUtR2cymo9lB3JaI4mQaKFfV/t7IRItqkuA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-arm64": {
+      "name": "@openai/codex",
+      "version": "0.133.0-win32-arm64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0-win32-arm64.tgz",
+      "integrity": "sha512-mRzND0PSGHRoLk0X41GTSoc3tFjZSF4HgDlfjU5fiQcWVi0/kLb7Ku6/tPFT/X2hOLa3YdJkbIcHC0Hc9ni80g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@openai/codex-win32-x64": {
+      "name": "@openai/codex",
+      "version": "0.133.0-win32-x64",
+      "resolved": "https://registry.npmjs.org/@openai/codex/-/codex-0.133.0-win32-x64.tgz",
+      "integrity": "sha512-u3ji78DIPZCGJeELuovsAnaZH+vK9gsA4F6M1y+Uy2s80Sz7/i1S0KL81qGReYji3urSjgBpkQuNP47GXOqxrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp/-/codex-acp-0.14.0.tgz",
+      "integrity": "sha512-IT9Zh9YDsRfXnc+RN9T00OCBFZrvQxzsWARWL9C1f0do4xB67eCZGildkJCHjoXmGAyYn1V7rIdRR6/+PzDdmw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "codex-acp": "bin/codex-acp.js"
+      },
+      "optionalDependencies": {
+        "@zed-industries/codex-acp-darwin-arm64": "0.14.0",
+        "@zed-industries/codex-acp-darwin-x64": "0.14.0",
+        "@zed-industries/codex-acp-linux-arm64": "0.14.0",
+        "@zed-industries/codex-acp-linux-x64": "0.14.0",
+        "@zed-industries/codex-acp-win32-arm64": "0.14.0",
+        "@zed-industries/codex-acp-win32-x64": "0.14.0"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-darwin-arm64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-arm64/-/codex-acp-darwin-arm64-0.14.0.tgz",
+      "integrity": "sha512-FWjHKlNJTZmXWM/2/GAQAg0WJEjPlfxEQJgvfxuzK1xZh81CDg9U6uSgZ1ggBkkN2bOoCnOupvGAPOmBoL5m2Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "codex-acp-darwin-arm64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-darwin-x64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-darwin-x64/-/codex-acp-darwin-x64-0.14.0.tgz",
+      "integrity": "sha512-KgC92J5wxOJM2N0VMNX7UQSGHVKa7xQCFsniWcxClsLWleJGlUdGlde5Aefd/yoU0J86ii6HCK8RfalUC76Inw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "bin": {
+        "codex-acp-darwin-x64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-linux-arm64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-arm64/-/codex-acp-linux-arm64-0.14.0.tgz",
+      "integrity": "sha512-KGfQq0/tdY31XBsdLe5nsKiV97pcsCruW28UDw7sgHUjPq8NPh9IiDdVj+xr1L4opihnswGelcoVvya+Vng8jQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "codex-acp-linux-arm64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-linux-x64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-linux-x64/-/codex-acp-linux-x64-0.14.0.tgz",
+      "integrity": "sha512-y1wrDOTJ/OYjYNRVmrf9Jti2571DjSp1xe5lSiZ9pBohA4oUQk9YIhlnv7NzeI0PYWyrjLd6QpQ09wTfxZFC8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "bin": {
+        "codex-acp-linux-x64": "bin/codex-acp"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-win32-arm64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-arm64/-/codex-acp-win32-arm64-0.14.0.tgz",
+      "integrity": "sha512-mUNZYfcpkM9YSs0tFzH7j2NHlxpjScFz2lpyJKiMl8wcTHLU8HYzeJZ7xodHzsIJrb5YMKxZ44zkBM3FBGAVaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "codex-acp-win32-arm64": "bin/codex-acp.exe"
+      }
+    },
+    "node_modules/@zed-industries/codex-acp-win32-x64": {
+      "version": "0.14.0",
+      "resolved": "https://registry.npmjs.org/@zed-industries/codex-acp-win32-x64/-/codex-acp-win32-x64-0.14.0.tgz",
+      "integrity": "sha512-KYckY87//om8Vsnb3fMUOkex76z2MF+e3H/n91tXnBep9ecnDT0rtEuoTvr4gP7evAf210YoSSGi0BB4ljse4w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "bin": {
+        "codex-acp-win32-x64": "bin/codex-acp.exe"
+      }
+    }
+  }
+}

--- a/packages/agents/codex/package.json
+++ b/packages/agents/codex/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "platform-codex",
+  "private": true,
+  "dependencies": {
+    "@zed-industries/codex-acp": "0.14.0",
+    "@openai/codex": "0.133.0"
+  }
+}

--- a/packages/agents/codex/workspace/.codex/config.toml
+++ b/packages/agents/codex/workspace/.codex/config.toml
@@ -1,0 +1,20 @@
+# Platform defaults — agent pod is the sandbox; auth comes from env.
+forced_login_method = "api"
+
+# Override the built-in openai provider to disable WebSocket transport.
+# The Envoy MITM proxy can't relay WSS upgrades, so Codex would hang on
+# the WSS handshake then fall back to HTTP. Disabling WSS skips the delay.
+[model_providers.openai-platform]
+name = "OpenAI"
+env_key = "OPENAI_API_KEY"
+supports_websockets = false
+
+# Trust the agent working directory so Codex doesn't prompt on startup.
+[projects."/home/agent/work"]
+trust_level = "trusted"
+
+# Clear the built-in model catalog so the Platform UI doesn't show a
+# model picker with irrelevant OpenAI model names. The active model is
+# controlled by the OPENAI_MODEL env var injected via credential config.
+[model_catalog]
+models = []

--- a/packages/agents/codex/workspace/.codex/config.toml
+++ b/packages/agents/codex/workspace/.codex/config.toml
@@ -12,9 +12,3 @@ supports_websockets = false
 # Trust the agent working directory so Codex doesn't prompt on startup.
 [projects."/home/agent/work"]
 trust_level = "trusted"
-
-# Clear the built-in model catalog so the Platform UI doesn't show a
-# model picker with irrelevant OpenAI model names. The active model is
-# controlled by the OPENAI_MODEL env var injected via credential config.
-[model_catalog]
-models = []

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -109,9 +109,9 @@ const IBM_LITELLM_BASE_URL = `https://${IBM_LITELLM_HOST}`;
  * advanced disclosure; the default bundle (with `IBM_LITELLM_DEFAULT_MODEL_PINS`)
  * is what the registry stores.
  *
- * 13 entries: 1 credential placeholder, 1 endpoint pin, 2 behavior flags,
- * 5 Claude Code model pins, 4 pi-agent `openai-proxy` SPECS overrides
- * (`pi-dynamic-providers/index.ts`).
+ * 16 entries: 1 credential placeholder, 1 endpoint pin, 2 behavior flags,
+ * 5 Claude Code model pins, 4 pi-agent `openai-proxy` overrides
+ * (`pi-dynamic-providers/index.ts`), 3 Codex/OpenAI-compatible env vars.
  */
 export function ibmLitellmEnvMappings(
   pins: IbmLitellmModelPins = IBM_LITELLM_DEFAULT_MODEL_PINS,
@@ -130,6 +130,9 @@ export function ibmLitellmEnvMappings(
     { envName: "OPENAI_PROXY_MODEL", placeholder: pins.opus },
     { envName: "OPENAI_PROXY_CONTEXT_WINDOW", placeholder: "200000" },
     { envName: "OPENAI_PROXY_MAX_TOKENS", placeholder: "8192" },
+    { envName: "OPENAI_API_KEY", placeholder: "sk-dummy" },
+    { envName: "OPENAI_BASE_URL", placeholder: IBM_LITELLM_BASE_URL },
+    { envName: "OPENAI_MODEL", placeholder: "gpt-5.5" },
   ];
 }
 

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -90,6 +90,8 @@ export interface IbmLitellmModelPins {
   subagent: string;
   /** `ANTHROPIC_MODEL` — fallback when no `ANTHROPIC_DEFAULT_*_MODEL` matches. */
   default: string;
+  /** `OPENAI_MODEL` — model ID for Codex and other OpenAI-compatible agents. */
+  openaiModel: string;
 }
 
 export const IBM_LITELLM_DEFAULT_MODEL_PINS: IbmLitellmModelPins = {
@@ -98,6 +100,7 @@ export const IBM_LITELLM_DEFAULT_MODEL_PINS: IbmLitellmModelPins = {
   haiku: "aws/claude-haiku-4-5",
   subagent: "aws/claude-opus-4-6",
   default: "aws/claude-opus-4-6",
+  openaiModel: "gpt-5.5",
 };
 
 const IBM_LITELLM_HOST = "ete-litellm.ai-models.vpc-int.res.ibm.com";
@@ -130,9 +133,9 @@ export function ibmLitellmEnvMappings(
     { envName: "OPENAI_PROXY_MODEL", placeholder: pins.opus },
     { envName: "OPENAI_PROXY_CONTEXT_WINDOW", placeholder: "200000" },
     { envName: "OPENAI_PROXY_MAX_TOKENS", placeholder: "8192" },
-    { envName: "OPENAI_API_KEY", placeholder: "sk-dummy" },
+    { envName: "OPENAI_API_KEY", placeholder: DEFAULT_ENV_PLACEHOLDER },
     { envName: "OPENAI_BASE_URL", placeholder: IBM_LITELLM_BASE_URL },
-    { envName: "OPENAI_MODEL", placeholder: "gpt-5.5" },
+    { envName: "OPENAI_MODEL", placeholder: pins.openaiModel },
   ];
 }
 
@@ -161,6 +164,8 @@ export function ibmLitellmPinsFromEnvMappings(
       IBM_LITELLM_DEFAULT_MODEL_PINS.subagent,
     default:
       lookup("ANTHROPIC_MODEL") ?? IBM_LITELLM_DEFAULT_MODEL_PINS.default,
+    openaiModel:
+      lookup("OPENAI_MODEL") ?? IBM_LITELLM_DEFAULT_MODEL_PINS.openaiModel,
   };
 }
 

--- a/packages/ui/src/modules/settings/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/settings/components/ibm-litellm/form.tsx
@@ -20,6 +20,7 @@ const ibmLitellmCredentialSchema = z
     modelHaiku: z.string().min(1, "Required"),
     modelSubagent: z.string().min(1, "Required"),
     modelDefault: z.string().min(1, "Required"),
+    modelOpenai: z.string().min(1, "Required"),
   })
   .superRefine((data, ctx) => {
     // Strip whitespace before checking emptiness (Q11=B): paste-from-terminal
@@ -61,6 +62,7 @@ export function IbmLitellmForm({
       modelHaiku: pins.haiku,
       modelSubagent: pins.subagent,
       modelDefault: pins.default,
+      modelOpenai: pins.openaiModel,
     },
   });
   const { errors, isSubmitting, isValid } = formState;
@@ -79,6 +81,7 @@ export function IbmLitellmForm({
         haiku: values.modelHaiku,
         subagent: values.modelSubagent,
         default: values.modelDefault,
+        openaiModel: values.modelOpenai,
       },
     });
   });
@@ -179,6 +182,12 @@ export function IbmLitellmForm({
             hint="ANTHROPIC_MODEL — fallback when no DEFAULT_*_MODEL matches."
             error={errors.modelDefault?.message}
             register={register("modelDefault")}
+          />
+          <ModelField
+            label="OpenAI model"
+            hint="OPENAI_MODEL — model ID for Codex and other OpenAI-compatible agents."
+            error={errors.modelOpenai?.message}
+            register={register("modelOpenai")}
           />
         </div>
       )}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@anthropic-ai/claude-code':
+        specifier: 2.1.140
+        version: 2.1.140
     devDependencies:
       eslint:
         specifier: ^10.2.0
@@ -543,6 +547,55 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
+
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.140':
+    resolution: {integrity: sha512-S6LYafRHImb1+cia05kPx1F/yhhRzivWjHw70JDn8A+I6w6uKntm7FA1tQy27gGLMn8g99ccOpRYaq+09vR0XA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-code-darwin-x64@2.1.140':
+    resolution: {integrity: sha512-019VzhPmgTOBof00SiscTRbTk0vpljs/T/CylRd2Cbu00sQfwmm3WexmWEPUhS58dqrO2Sw44CUL8MD13zIlew==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.140':
+    resolution: {integrity: sha512-rB5LSSDuFp5fQWFKm4OIWLIJFYJnhqnrs1fv+wm+Vij6jmz4ECw3+aGxONHqAeCh9C2yeNlEJq/+ZON/3L5N0Q==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-code-linux-arm64@2.1.140':
+    resolution: {integrity: sha512-iV4RFk15jRyK5SIYXjqwW5UgCNZfe0AQsIVWAT6Sar0bkOdOeKCn/xqyr57XQqy8Im5CgrhW89rq6NBA5SCRUQ==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.140':
+    resolution: {integrity: sha512-c8+5bYoc033l6c6XwWCCke+VtPOIIVbOGaaOMqOJ1Lx2v+CWA+ECQ9CAJXS3TS78GGp617Lg9xSjDM9CcQty+w==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@anthropic-ai/claude-code-linux-x64@2.1.140':
+    resolution: {integrity: sha512-6fIEtDVmYcuBxnhPhHNDQ7dK9i3HuB/Fl286mmLL6qlQ8egd6NL7zZLDEYQiJP3MDf+mU8aA2Cu84bwBi/KSHA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@anthropic-ai/claude-code-win32-arm64@2.1.140':
+    resolution: {integrity: sha512-Yvr2OTd3gNawgz9dms19Kc5j8F4fh9tlFlV9QfBCLtzpTtjwJAX0UCKQUsDvRKv+ysBKtvGNtwm7/i1xfY7xqA==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@anthropic-ai/claude-code-win32-x64@2.1.140':
+    resolution: {integrity: sha512-j/3VzKNVjS588xikQc5ncUh3apstBbgxCqkIW/FJLpXMa+WAHhPMoM0lT3zjZWLnVfBQq0/OCYHCyjVHFWKEsw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@anthropic-ai/claude-code@2.1.140':
+    resolution: {integrity: sha512-R7cEIvTww28I4m7MKTGsS7yvb6BR85ub+ev2uCVZvZF8veKBz4VLRqda7H9hoFGXBt1t5cN1LC3f/c3PBfjFKA==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -6116,6 +6169,41 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
+
+  '@anthropic-ai/claude-code-darwin-arm64@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-darwin-x64@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-arm64@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-x64-musl@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-linux-x64@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-win32-arm64@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code-win32-x64@2.1.140':
+    optional: true
+
+  '@anthropic-ai/claude-code@2.1.140':
+    optionalDependencies:
+      '@anthropic-ai/claude-code-darwin-arm64': 2.1.140
+      '@anthropic-ai/claude-code-darwin-x64': 2.1.140
+      '@anthropic-ai/claude-code-linux-arm64': 2.1.140
+      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.140
+      '@anthropic-ai/claude-code-linux-x64': 2.1.140
+      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.140
+      '@anthropic-ai/claude-code-win32-arm64': 2.1.140
+      '@anthropic-ai/claude-code-win32-x64': 2.1.140
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,10 +15,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      '@anthropic-ai/claude-code':
-        specifier: 2.1.140
-        version: 2.1.140
     devDependencies:
       eslint:
         specifier: ^10.2.0
@@ -547,55 +543,6 @@ packages:
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^4.0.0
-
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.140':
-    resolution: {integrity: sha512-S6LYafRHImb1+cia05kPx1F/yhhRzivWjHw70JDn8A+I6w6uKntm7FA1tQy27gGLMn8g99ccOpRYaq+09vR0XA==}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-code-darwin-x64@2.1.140':
-    resolution: {integrity: sha512-019VzhPmgTOBof00SiscTRbTk0vpljs/T/CylRd2Cbu00sQfwmm3WexmWEPUhS58dqrO2Sw44CUL8MD13zIlew==}
-    cpu: [x64]
-    os: [darwin]
-
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.140':
-    resolution: {integrity: sha512-rB5LSSDuFp5fQWFKm4OIWLIJFYJnhqnrs1fv+wm+Vij6jmz4ECw3+aGxONHqAeCh9C2yeNlEJq/+ZON/3L5N0Q==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@anthropic-ai/claude-code-linux-arm64@2.1.140':
-    resolution: {integrity: sha512-iV4RFk15jRyK5SIYXjqwW5UgCNZfe0AQsIVWAT6Sar0bkOdOeKCn/xqyr57XQqy8Im5CgrhW89rq6NBA5SCRUQ==}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.140':
-    resolution: {integrity: sha512-c8+5bYoc033l6c6XwWCCke+VtPOIIVbOGaaOMqOJ1Lx2v+CWA+ECQ9CAJXS3TS78GGp617Lg9xSjDM9CcQty+w==}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@anthropic-ai/claude-code-linux-x64@2.1.140':
-    resolution: {integrity: sha512-6fIEtDVmYcuBxnhPhHNDQ7dK9i3HuB/Fl286mmLL6qlQ8egd6NL7zZLDEYQiJP3MDf+mU8aA2Cu84bwBi/KSHA==}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@anthropic-ai/claude-code-win32-arm64@2.1.140':
-    resolution: {integrity: sha512-Yvr2OTd3gNawgz9dms19Kc5j8F4fh9tlFlV9QfBCLtzpTtjwJAX0UCKQUsDvRKv+ysBKtvGNtwm7/i1xfY7xqA==}
-    cpu: [arm64]
-    os: [win32]
-
-  '@anthropic-ai/claude-code-win32-x64@2.1.140':
-    resolution: {integrity: sha512-j/3VzKNVjS588xikQc5ncUh3apstBbgxCqkIW/FJLpXMa+WAHhPMoM0lT3zjZWLnVfBQq0/OCYHCyjVHFWKEsw==}
-    cpu: [x64]
-    os: [win32]
-
-  '@anthropic-ai/claude-code@2.1.140':
-    resolution: {integrity: sha512-R7cEIvTww28I4m7MKTGsS7yvb6BR85ub+ev2uCVZvZF8veKBz4VLRqda7H9hoFGXBt1t5cN1LC3f/c3PBfjFKA==}
-    engines: {node: '>=18.0.0'}
-    hasBin: true
 
   '@anthropic-ai/sdk@0.91.1':
     resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
@@ -6169,41 +6116,6 @@ snapshots:
     transitivePeerDependencies:
       - '@cfworker/json-schema'
       - supports-color
-
-  '@anthropic-ai/claude-code-darwin-arm64@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-darwin-x64@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-arm64-musl@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-arm64@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-x64-musl@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-linux-x64@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-win32-arm64@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code-win32-x64@2.1.140':
-    optional: true
-
-  '@anthropic-ai/claude-code@2.1.140':
-    optionalDependencies:
-      '@anthropic-ai/claude-code-darwin-arm64': 2.1.140
-      '@anthropic-ai/claude-code-darwin-x64': 2.1.140
-      '@anthropic-ai/claude-code-linux-arm64': 2.1.140
-      '@anthropic-ai/claude-code-linux-arm64-musl': 2.1.140
-      '@anthropic-ai/claude-code-linux-x64': 2.1.140
-      '@anthropic-ai/claude-code-linux-x64-musl': 2.1.140
-      '@anthropic-ai/claude-code-win32-arm64': 2.1.140
-      '@anthropic-ai/claude-code-win32-x64': 2.1.140
 
   '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds Codex (OpenAI coding agent) as a new harness, using `codex-acp` for ACP chat and the `codex` CLI for terminal sessions
- Agent image extends `platform-base`, installs both binaries via npm, and ships harness scripts that bridge `OPENAI_BASE_URL` / `OPENAI_MODEL` env vars to Codex `-c` config overrides
- Seed config (`workspace/.codex/config.toml`) disables WSS transport (Envoy can't relay upgrades), suppresses auth prompts, trusts the working directory, and clears the built-in model catalog so the Platform UI doesn't show irrelevant OpenAI model names
- Extends the IBM LiteLLM credential preset with `OPENAI_API_KEY`, `OPENAI_BASE_URL`, and `OPENAI_MODEL` env mappings so Codex works through the LiteLLM proxy out of the box
- Helm chart, build pipeline, and ADR-023 updated accordingly

## Test plan

- [x] Built and deployed to local k3s cluster
- [x] Verified terminal session starts without auth/trust prompts
- [x] Verified chat (ACP) session works via codex-acp
- [x] Verified custom OPENAI_BASE_URL and OPENAI_MODEL are respected
- [x] Verified WSS is skipped (no hanging on WebSocket handshake)
- [x] Verified model picker is suppressed with `[model_catalog] models = []`
- [ ] Verify Helm lint/render passes (`mise run helm:check:lint && mise run helm:check:render`)
- [ ] Verify `mise run check` passes