### PR TITLE
fix(ui): surface MCP OAuth start errors

### DIFF
--- a/packages/ui/src/__tests__/unit/connections-fetchers.test.ts
+++ b/packages/ui/src/__tests__/unit/connections-fetchers.test.ts
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { authFetch } from "../../auth.js";
+import { startMcpOAuth } from "../../modules/connections/api/fetchers.js";
+
+vi.mock("../../auth.js", () => ({
+  authFetch: vi.fn(),
+}));
+
+const mockedAuthFetch = vi.mocked(authFetch);
+
+describe("connection fetchers", () => {
+  beforeEach(() => {
+    mockedAuthFetch.mockReset();
+  });
+
+  describe("startMcpOAuth", () => {
+    it("surfaces backend MCP OAuth validation errors", async () => {
+      mockedAuthFetch.mockResolvedValue(
+        Response.json(
+          { error: "MCP server does not support OAuth discovery" },
+          { status: 400 },
+        ),
+      );
+
+      await expect(startMcpOAuth("https://example.com/mcp")).rejects.toThrow(
+        "MCP server does not support OAuth discovery",
+      );
+    });
+
+    it("falls back to the status code when the error body is not JSON", async () => {
+      mockedAuthFetch.mockResolvedValue(
+        new Response("not json", {
+          status: 502,
+          headers: { "Content-Type": "text/plain" },
+        }),
+      );
+
+      await expect(startMcpOAuth("https://example.com/mcp")).rejects.toThrow(
+        "OAuth start failed (502)",
+      );
+    });
+  });
+});

--- a/packages/ui/src/modules/connections/api/fetchers.ts
+++ b/packages/ui/src/modules/connections/api/fetchers.ts
@@ -23,13 +23,36 @@ const startOAuthResponseSchema = z.object({
   error: z.string().optional(),
 });
 
+const oauthErrorResponseSchema = z.object({
+  error: z.string().optional(),
+});
+
+async function parseOAuthErrorDetail(
+  res: Response,
+  fallback: string,
+): Promise<string> {
+  try {
+    const body = oauthErrorResponseSchema.safeParse(await res.json());
+    return body.success && body.data.error ? body.data.error : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
 export async function startMcpOAuth(mcpServerUrl: string) {
   const res = await authFetch("/api/oauth/start", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ mcpServerUrl }),
   });
-  if (!res.ok) throw new Error(`OAuth start failed (${res.status})`);
+  if (!res.ok) {
+    // Surface backend validation messages, e.g. non-OAuth MCP servers.
+    const detail = await parseOAuthErrorDetail(
+      res,
+      `OAuth start failed (${res.status})`,
+    );
+    throw new Error(detail);
+  }
   return startOAuthResponseSchema.parse(await res.json());
 }
 
@@ -146,13 +169,10 @@ export async function startAppOAuth(args: {
   if (!res.ok) {
     // Surface the server's validation message if present (4xx body is a JSON
     // `{ error }` shape; tolerate non-JSON failure modes).
-    let detail = `OAuth start failed (${res.status})`;
-    try {
-      const body = (await res.json()) as { error?: string };
-      if (body.error) detail = body.error;
-    } catch {
-      /* ignore */
-    }
+    const detail = await parseOAuthErrorDetail(
+      res,
+      `OAuth start failed (${res.status})`,
+    );
     throw new Error(detail);
   }
   return startOAuthResponseSchema.parse(await res.json());


### PR DESCRIPTION
## Summary
- surface the backend `{ error }` message when MCP OAuth start fails
- keep the current status-code fallback for non-JSON failures
- add UI unit coverage for both paths

## Why
Refs #360. Today a non-OAuth MCP server reaches the backend's explicit `MCP server does not support OAuth discovery` branch, but the UI collapses it to `OAuth start failed (400)`. This does not add transport-only/no-auth MCP support by itself; it makes the current limitation visible so users and support can distinguish non-OAuth servers from generic OAuth start failures.

A full fix for #360 likely needs a separate transport-only MCP connection path, because the current MCP picker is backed by `__mcp:<host>` credential Secrets and the connection storage path is OAuth token/SDS oriented.

## Verification
- `corepack pnpm --filter platform-ui test -- src/__tests__/unit/connections-fetchers.test.ts`
- `corepack pnpm --filter platform-ui typecheck`
- `corepack pnpm exec prettier --check packages/ui/src/modules/connections/api/fetchers.ts packages/ui/src/__tests__/unit/connections-fetchers.test.ts`

Prepared by an AI agent/operator; scoped to the observable UI error loss in #360.
