### PR TITLE
feat(keycloak): record authentication and admin events

### DIFF
--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -82,10 +82,12 @@ spec:
                   key: KEYCLOAK_ADMIN_PASSWORD
             - name: KC_HEALTH_ENABLED
               value: "true"
-            - name: KC_LOG
-              value: "console"
-            - name: KC_LOG_LEVEL
-              value: {{ .Values.keycloak.events.logLevel | quote }}
+            - name: KC_LOG_CONSOLE_OUTPUT
+              value: {{ .Values.keycloak.log.consoleOutput | quote }}
+            - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL
+              value: {{ .Values.keycloak.events.successLevel | quote }}
+            - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_ERROR_LEVEL
+              value: {{ .Values.keycloak.events.errorLevel | quote }}
             - name: KC_HTTP_PORT
               value: {{ .Values.keycloak.port | quote }}
             - name: KC_HOSTNAME

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -82,6 +82,10 @@ spec:
                   key: KEYCLOAK_ADMIN_PASSWORD
             - name: KC_HEALTH_ENABLED
               value: "true"
+            - name: KC_LOG
+              value: "console"
+            - name: KC_LOG_LEVEL
+              value: {{ .Values.keycloak.events.logLevel | quote }}
             - name: KC_HTTP_PORT
               value: {{ .Values.keycloak.port | quote }}
             - name: KC_HOSTNAME

--- a/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
+++ b/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
@@ -21,6 +21,12 @@ data:
       "resetPasswordAllowed": false,
       "editUsernameAllowed": false,
       "bruteForceProtected": true,
+      "eventsEnabled": true,
+      "eventsListeners": ["jboss-logging"],
+      "enabledEventTypes": [],
+      "eventsExpiration": {{ .Values.keycloak.events.expirationSeconds }},
+      "adminEventsEnabled": true,
+      "adminEventsDetailsEnabled": true,
       "clients": [
         {
           "clientId": {{ .Values.keycloak.clientId | quote }},

--- a/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
+++ b/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
@@ -21,10 +21,9 @@ data:
       "resetPasswordAllowed": false,
       "editUsernameAllowed": false,
       "bruteForceProtected": true,
-      "eventsEnabled": true,
+      "eventsEnabled": false,
       "eventsListeners": ["jboss-logging"],
       "enabledEventTypes": [],
-      "eventsExpiration": {{ .Values.keycloak.events.expirationSeconds }},
       "adminEventsEnabled": true,
       "adminEventsDetailsEnabled": true,
       "clients": [

--- a/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
+++ b/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
@@ -25,7 +25,7 @@ data:
       "eventsListeners": ["jboss-logging"],
       "enabledEventTypes": [],
       "adminEventsEnabled": true,
-      "adminEventsDetailsEnabled": true,
+      "adminEventsDetailsEnabled": false,
       "clients": [
         {
           "clientId": {{ .Values.keycloak.clientId | quote }},

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -101,3 +101,6 @@ keycloak:
     - "*"
   extraWebOrigins:
     - "*"
+  # Human-readable Keycloak logs for `mise run cluster:logs` during dev.
+  log:
+    consoleOutput: "default"

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -205,20 +205,21 @@ keycloak:
 
   # -- Event logging. Login events (LOGIN, LOGIN_ERROR, LOGOUT, REGISTER,
   # …) and admin events (any change made via the admin REST API / console)
-  # are persisted to the Keycloak DB and emitted to stdout via the
-  # `jboss-logging` event listener. Stdout events ride the cluster log
-  # pipeline; DB-backed events are queryable from the admin console under
-  # `Events → Login events` / `Admin events`.
+  # are emitted to stdout via the `jboss-logging` event listener so they
+  # ride the cluster log pipeline to whatever external log service is
+  # collecting pod logs.
+  #
+  # Login events are NOT persisted to the Keycloak DB — pod logs are the
+  # source of truth. Admin events ARE persisted (low volume, useful as a
+  # break-glass surface in the Keycloak admin console under `Events →
+  # Admin events`); set `adminEventsEnabled: false` in the realm import if
+  # you want to drop that too.
   #
   # The jboss-logging listener emits successful events at DEBUG and errors
   # at WARN. `logLevel` raises the `org.keycloak.events` category to DEBUG
   # so successful logins / admin actions appear in the pod log without
   # making the rest of Keycloak chatty.
   events:
-    # -- TTL (seconds) for stored events in Postgres. Older events are
-    # pruned automatically. Default: 7 days for login events; admin
-    # events follow the same retention (Keycloak shares the field).
-    expirationSeconds: 604800
     # -- Root logger plus per-category overrides, in the comma-separated
     # form Keycloak's quarkus-logging parser expects.
     logLevel: "INFO,org.keycloak.events:debug"

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -208,10 +208,13 @@ keycloak:
   # pipeline to whatever external log service is collecting pod logs.
   #
   # Login events are NOT persisted to the Keycloak DB (eventsEnabled: false
-  # in the realm import) — pod logs are the source of truth. Admin events
-  # ARE persisted (low volume, useful as a break-glass audit surface in
-  # the admin console under `Events → Admin events`); set
-  # `adminEventsEnabled: false` in the realm import to drop that too.
+  # in the realm import) — pod logs are the source of truth. Admin-event
+  # metadata IS persisted (low volume), but request-body detail is NOT
+  # (adminEventsDetailsEnabled: false in the realm import): those bodies can
+  # carry plaintext credentials on user-create/update and Keycloak keeps
+  # them indefinitely (no built-in expiration), while the log pipeline is
+  # the audit source of truth regardless. Set `adminEventsEnabled: false`
+  # in the realm import to stop admin events firing on the listener too.
   #
   # The listener emits successes at `debug` and errors at `warn` by
   # default. We raise success-level to `info` so successful logins appear
@@ -226,10 +229,12 @@ keycloak:
 
   # -- Keycloak logging output.
   log:
-    # -- Console output format. `default` is human-readable plain text;
-    # `json` is structured one-record-per-line, friendlier for external
-    # log aggregators (Loki / ELK / Datadog). Local dev overrides this
-    # to `default` in `values-local.yaml` for readable `kubectl logs`.
+    # -- Console output format. Only `default` and `json` are valid;
+    # Keycloak rejects any other value at startup. `default` is
+    # human-readable plain text; `json` is structured one-record-per-line,
+    # friendlier for external log aggregators (Loki / ELK / Datadog).
+    # Local dev overrides this to `default` in `values-local.yaml` for
+    # readable `kubectl logs`.
     consoleOutput: "json"
 
   # -- Test user bootstrapped via realm import.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -203,26 +203,34 @@ keycloak:
   extraRedirectUris: []
   extraWebOrigins: []
 
-  # -- Event logging. Login events (LOGIN, LOGIN_ERROR, LOGOUT, REGISTER,
-  # …) and admin events (any change made via the admin REST API / console)
-  # are emitted to stdout via the `jboss-logging` event listener so they
-  # ride the cluster log pipeline to whatever external log service is
-  # collecting pod logs.
+  # -- Event logging. Login + admin events are emitted to stdout via the
+  # built-in `jboss-logging` event listener so they ride the cluster log
+  # pipeline to whatever external log service is collecting pod logs.
   #
-  # Login events are NOT persisted to the Keycloak DB — pod logs are the
-  # source of truth. Admin events ARE persisted (low volume, useful as a
-  # break-glass surface in the Keycloak admin console under `Events →
-  # Admin events`); set `adminEventsEnabled: false` in the realm import if
-  # you want to drop that too.
+  # Login events are NOT persisted to the Keycloak DB (eventsEnabled: false
+  # in the realm import) — pod logs are the source of truth. Admin events
+  # ARE persisted (low volume, useful as a break-glass audit surface in
+  # the admin console under `Events → Admin events`); set
+  # `adminEventsEnabled: false` in the realm import to drop that too.
   #
-  # The jboss-logging listener emits successful events at DEBUG and errors
-  # at WARN. `logLevel` raises the `org.keycloak.events` category to DEBUG
-  # so successful logins / admin actions appear in the pod log without
-  # making the rest of Keycloak chatty.
+  # The listener emits successes at `debug` and errors at `warn` by
+  # default. We raise success-level to `info` so successful logins appear
+  # under the default root log level without touching log categories.
+  # See https://www.keycloak.org/server/all-provider-config (search for
+  # `spi-events-listener-jboss-logging`).
   events:
-    # -- Root logger plus per-category overrides, in the comma-separated
-    # form Keycloak's quarkus-logging parser expects.
-    logLevel: "INFO,org.keycloak.events:debug"
+    # -- Log level for successful auth / admin events.
+    successLevel: "info"
+    # -- Log level for error events (LOGIN_ERROR, etc.).
+    errorLevel: "warn"
+
+  # -- Keycloak logging output.
+  log:
+    # -- Console output format. `default` is human-readable plain text;
+    # `json` is structured one-record-per-line, friendlier for external
+    # log aggregators (Loki / ELK / Datadog). Local dev overrides this
+    # to `default` in `values-local.yaml` for readable `kubectl logs`.
+    consoleOutput: "json"
 
   # -- Test user bootstrapped via realm import.
   # DISABLED by default — production deployments must not ship a known credential.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -203,6 +203,26 @@ keycloak:
   extraRedirectUris: []
   extraWebOrigins: []
 
+  # -- Event logging. Login events (LOGIN, LOGIN_ERROR, LOGOUT, REGISTER,
+  # …) and admin events (any change made via the admin REST API / console)
+  # are persisted to the Keycloak DB and emitted to stdout via the
+  # `jboss-logging` event listener. Stdout events ride the cluster log
+  # pipeline; DB-backed events are queryable from the admin console under
+  # `Events → Login events` / `Admin events`.
+  #
+  # The jboss-logging listener emits successful events at DEBUG and errors
+  # at WARN. `logLevel` raises the `org.keycloak.events` category to DEBUG
+  # so successful logins / admin actions appear in the pod log without
+  # making the rest of Keycloak chatty.
+  events:
+    # -- TTL (seconds) for stored events in Postgres. Older events are
+    # pruned automatically. Default: 7 days for login events; admin
+    # events follow the same retention (Keycloak shares the field).
+    expirationSeconds: 604800
+    # -- Root logger plus per-category overrides, in the comma-separated
+    # form Keycloak's quarkus-logging parser expects.
+    logLevel: "INFO,org.keycloak.events:debug"
+
   # -- Test user bootstrapped via realm import.
   # DISABLED by default — production deployments must not ship a known credential.
   # Local dev and e2e tests (via values-local.yaml) enable it.

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-21
+Last verified: 2026-05-29
 
 ## Motivated by
 
@@ -132,6 +132,40 @@ user agent flow:
 There is no token exchange — credential storage is K8s-native and label-
 scoped, so the api-server enforces ownership directly when reading and
 writing.
+
+## Keycloak event logging
+
+Keycloak is also an audit event source. It emits login and admin events
+to pod stdout via its built-in `jboss-logging` event listener, so they
+ride the same cluster log pipeline as every other pod log out to the
+external log service. The listener's level is set through Keycloak's
+per-listener SPI knobs rather than a broad `org.keycloak` log-category
+override: successes surface at `info`, errors at `warn`. Production pods
+emit structured JSON; local dev overrides the console format to plain
+text for a readable `cluster:logs`.
+
+Persistence is split by event class:
+
+- **Login events** (LOGIN, LOGOUT, LOGIN_ERROR, token refresh, account
+  changes, …) are *not* written to the Keycloak database. The listener
+  fires independently of DB-store gating, so the events still reach
+  stdout; the external log service is the source of truth for the
+  authentication audit trail, and Postgres is spared the high-volume
+  write.
+- **Admin events** (any change made through the admin REST API or
+  console) fire on the same listener, so their metadata — who acted, on
+  which resource, from where — reaches stdout and the external log
+  service alongside login events. That metadata is also recorded to
+  Postgres (low volume), but the full request body is *not*
+  (`adminEventsDetailsEnabled` is off): stored bodies would otherwise
+  capture sensitive payloads — plaintext credentials on user-create /
+  user-update flows — and Keycloak retains admin events indefinitely with
+  no built-in expiration. The log line never carries the request body, so
+  the external log pipeline, not the Keycloak database, is the audit
+  source of truth.
+
+The event knobs, log format, and realm import live in the Keycloak Helm
+values under [`deploy/helm/platform/`](../../deploy/helm/platform/).
 
 ## Resource ownership
 


### PR DESCRIPTION
## Summary
- Emit Keycloak login and admin events to stdout via the built-in `jboss-logging` event listener so the external log collector picks them up as part of the normal pod-log pipeline. Login events (LOGIN, LOGIN_ERROR, LOGOUT, REGISTER, token refresh, account changes, …) and admin events (any change made via the admin REST API / console) both fire on the listener.
- Use Keycloak's documented `success-level` / `error-level` SPI knobs on the `jboss-logging` listener (`KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL=info`, `KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_ERROR_LEVEL=warn`) so successful events surface under the default INFO root logger. No log-category override, no DEBUG noise.
- Switch Keycloak console output to structured JSON (`KC_LOG_CONSOLE_OUTPUT=json`) so the external log service sees proper fields. `values-local.yaml` overrides to `default` (plain text) for human-readable `mise run cluster:logs` during dev.
- **Login events are not persisted** to the Keycloak DB — `eventsEnabled: false`. The `jboss-logging` listener fires independently of DB-store gating, so events still reach stdout; the external log service is the source of truth and we avoid the redundant Postgres write + table growth.
- **Admin events: metadata only.** `adminEventsEnabled: true` keeps admin-event metadata flowing to stdout (and to Postgres — low volume) so *who did what to which resource* is auditable, but `adminEventsDetailsEnabled: false` — the full request **body is not stored**. Those bodies can carry plaintext credentials on user-create/update flows and Keycloak retains admin events indefinitely with no built-in expiration; the log pipeline is the audit source of truth, so persisting the bodies buys nothing and adds risk.

## Why these defaults
The `jboss-logging` listener defaults are `success-level=debug` / `error-level=warn`, so out-of-the-box only auth *failures* reach the pod log under the default root level — useless as an audit trail. Keycloak documents the per-listener knobs as the supported way to flip that, rather than touching log categories. See https://www.keycloak.org/server/all-provider-config (search `spi-events-listener-jboss-logging`).

JSON console output is the Keycloak docs' recommended production K8s default; it costs nothing in pod log volume and saves the log shipper from string parsing.

## Docs
`docs/architecture/security-and-credentials.md` gains a **Keycloak event logging** section: the split-persistence model (login events to logs only; admin metadata to logs + Postgres, no request body), the jboss-logging SPI level knobs, and the production-JSON / dev-plaintext console split.

## Test plan
- [x] `mise run helm:check:lint` passes
- [x] `mise run helm:check:render` passes
- [ ] After `mise run cluster:install`, a fresh login produces a `type=LOGIN` line in the Keycloak pod log:
      `mise run cluster:kubectl -- logs deploy/platform-keycloak | grep 'type=LOGIN'`
- [ ] An admin-console change (e.g. toggling a user) produces an admin event (metadata, no request body) in the pod log
