### PR TITLE
chore(slack): add app manifest

### DIFF
--- a/deploy/slack-app-manifest.yaml
+++ b/deploy/slack-app-manifest.yaml
@@ -1,0 +1,38 @@
+# After creating the app from this manifest, generate an app-level token in the
+# Slack UI: Basic Information -> App-Level Tokens -> Generate Token and Scopes.
+# Required scope: connections:write (socket mode). Add authorizations:read if
+# you need to list installations.
+
+display_information:
+  name: DAM
+  description: Deploy Agents MASSIVELY
+  background_color: "#2c2d30"
+  long_description: >
+    Platform runs isolated AI agent harnesses on Kubernetes. This Slack app lets
+    you trigger agent sessions, receive run updates, and chat with agents
+    directly from channels and DMs.
+
+features:
+  bot_user:
+    display_name: DAM
+    always_online: true
+  slash_commands:
+    - command: /dam
+      description: Login or logout of DAM
+      usage_hint: "login | logout"
+      should_escape: false
+
+oauth_config:
+  scopes:
+    bot:
+      - commands
+      - chat:write
+      - users:read
+      - users:read.email
+
+settings:
+  interactivity:
+    is_enabled: true
+  org_deploy_enabled: false
+  socket_mode_enabled: true
+  token_rotation_enabled: false


### PR DESCRIPTION
## Summary
- Slack app manifest for DAM, socket-mode only with `/dam login|logout` slash command.
- Minimal bot scopes: `commands`, `chat:write`, `users:read`, `users:read.email`.

## Notes
- App-level token (`xapp-…`, scope `connections:write`) must be generated in the Slack UI after creating the app — it's not declarable in the manifest.
- Reinstall to workspace after applying so the slash command takes effect.

## Test plan
- [ ] Create app from manifest at api.slack.com/apps
- [ ] Generate app-level token with `connections:write`
- [ ] Install to workspace and verify `/dam` autocompletes
- [ ] Run `/dam login` and `/dam logout` against api-server