### PR TITLE
fix(ui): adding a close-race for selected acp request methods to prevent hangs

### DIFF
--- a/packages/ui/src/modules/acp/acp.ts
+++ b/packages/ui/src/modules/acp/acp.ts
@@ -12,6 +12,7 @@ import {
 
 import { getAccessToken } from "../../auth.js";
 import { type PermissionOutcome, useStore } from "../../store.js";
+import { withCloseRace } from "./close-race.js";
 import type { UpdateHandler } from "./types.js";
 
 const WS_CONNECT_TIMEOUT_MS = 120_000;
@@ -100,7 +101,7 @@ export async function openConnection(
   onUpdate: UpdateHandler,
 ): Promise<{ connection: ClientSideConnection; ws: WebSocket }> {
   const { stream, ws } = await wsStream(await wsUrl(agentId));
-  const connection = new ClientSideConnection(
+  const raw = new ClientSideConnection(
     () => ({
       async requestPermission(params: RequestPermissionRequest) {
         return awaitPermission(params);
@@ -148,5 +149,5 @@ export async function openConnection(
     }),
     stream,
   );
-  return { connection, ws };
+  return { connection: withCloseRace(raw), ws };
 }

--- a/packages/ui/src/modules/acp/close-race.ts
+++ b/packages/ui/src/modules/acp/close-race.ts
@@ -1,0 +1,54 @@
+import type { ClientSideConnection } from "@agentclientprotocol/sdk/dist/acp.js";
+
+export class ConnectionClosedError extends Error {
+  readonly name = "ConnectionClosedError";
+  constructor() {
+    super("Connection closed while request was in flight");
+  }
+}
+
+// SDK methods that issue a JSON-RPC request via `Connection.sendRequest`. The
+// SDK's receive loop never rejects `#pendingResponses` on stream close, so
+// these calls hang indefinitely when the WebSocket dies mid-flight. Listed by
+// name so adding a new SDK method is a deliberate decision rather than a
+// silent leak through an unwrapped path.
+const REQUEST_METHODS = new Set<string>([
+  "initialize",
+  "authenticate",
+  "logout",
+  "newSession",
+  "loadSession",
+  "forkSession",
+  "listSessions",
+  "unstable_resumeSession",
+  "closeSession",
+  "setSessionMode",
+  "setSessionModel",
+  "setSessionConfigOption",
+  "prompt",
+  "cancel",
+]);
+
+/**
+ * Wrap a `ClientSideConnection` so every request-style method races against
+ * the connection's `closed` promise. On close, in-flight calls reject with
+ * `ConnectionClosedError` so consumer catch-paths can surface a real error
+ * instead of awaiting a promise that will never settle.
+ */
+export function withCloseRace(
+  conn: ClientSideConnection,
+): ClientSideConnection {
+  const closedThrows = conn.closed.then(() => {
+    throw new ConnectionClosedError();
+  });
+  return new Proxy(conn, {
+    get(target, prop, receiver) {
+      const value = Reflect.get(target, prop, receiver);
+      if (typeof value !== "function") return value;
+      if (!REQUEST_METHODS.has(prop as string)) return value.bind(target);
+      const fn = value as (...args: unknown[]) => Promise<unknown>;
+      return (...args: unknown[]) =>
+        Promise.race([fn.apply(target, args), closedThrows]);
+    },
+  });
+}

--- a/packages/ui/src/modules/acp/close-race.ts
+++ b/packages/ui/src/modules/acp/close-race.ts
@@ -7,33 +7,17 @@ export class ConnectionClosedError extends Error {
   }
 }
 
-// SDK methods that issue a JSON-RPC request via `Connection.sendRequest`. The
-// SDK's receive loop never rejects `#pendingResponses` on stream close, so
-// these calls hang indefinitely when the WebSocket dies mid-flight. Listed by
-// name so adding a new SDK method is a deliberate decision rather than a
-// silent leak through an unwrapped path.
-const REQUEST_METHODS = new Set<string>([
-  "initialize",
-  "authenticate",
-  "logout",
-  "newSession",
-  "loadSession",
-  "forkSession",
-  "listSessions",
-  "unstable_resumeSession",
-  "closeSession",
-  "setSessionMode",
-  "setSessionModel",
-  "setSessionConfigOption",
-  "prompt",
-  "cancel",
-]);
-
 /**
- * Wrap a `ClientSideConnection` so every request-style method races against
+ * Wrap a `ClientSideConnection` so every Promise-returning call races against
  * the connection's `closed` promise. On close, in-flight calls reject with
  * `ConnectionClosedError` so consumer catch-paths can surface a real error
  * instead of awaiting a promise that will never settle.
+ *
+ * Implementation detects requests dynamically — every public method on
+ * `ClientSideConnection` returns a Promise, non-method members are getters
+ * (`closed`, `signal`). This avoids a hand-maintained allowlist that would
+ * silently disable the race for typos, new SDK methods, or future renames
+ * (e.g. the `unstable_*` prefix dance).
  */
 export function withCloseRace(
   conn: ClientSideConnection,
@@ -45,10 +29,13 @@ export function withCloseRace(
     get(target, prop, receiver) {
       const value = Reflect.get(target, prop, receiver);
       if (typeof value !== "function") return value;
-      if (!REQUEST_METHODS.has(prop as string)) return value.bind(target);
-      const fn = value as (...args: unknown[]) => Promise<unknown>;
-      return (...args: unknown[]) =>
-        Promise.race([fn.apply(target, args), closedThrows]);
+      const fn = value as (...args: unknown[]) => unknown;
+      return (...args: unknown[]) => {
+        const result = fn.apply(target, args);
+        return result instanceof Promise
+          ? Promise.race([result, closedThrows])
+          : result;
+      };
     },
   });
 }


### PR DESCRIPTION
The ACP SDK's `Connection` never rejects pending JSON-RPC requests when its
stream closes — the `#receive` loop just exits and the `#pendingResponses`
map is leaked. Every `ClientSideConnection.*` call that issues a request can
therefore hang forever if the WS dies mid-flight.

Most visible symptom (#363): pod rolls during the user's first prompt → WS
dies → `conn.prompt(...)` hangs → empty assistant bubble, no error, no
recovery. Less visible but worse: same wedge on `initialize`,
`unstable_resumeSession`, `loadSession`, `setSessionMode`, etc. — the
reconnect path itself silently dead-ends.

Fix: a thin Proxy at `openConnection` races each request-style SDK method
against the public `conn.closed` promise and rejects with a
`ConnectionClosedError`. Consumer catch-paths (e.g. sendPrompt's existing
SendErrorCard + Retry) surface the error normally.

Scope: UI only. Does not change when or why pods restart — that's parked.

Closes #363