### PR TITLE
feat(terms): acceptance gate across UI/CLI/Slack/Telegram

### DIFF
--- a/deploy/helm/platform/templates/_validators.tpl
+++ b/deploy/helm/platform/templates/_validators.tpl
@@ -11,6 +11,7 @@ add it to the include list in `platform.validate`.
 {{- define "platform.validate" -}}
 {{- include "platform.validate.anyuidCapNetRequiresAgentNamespace" . -}}
 {{- include "platform.validate.egressLockdownModeExclusive" . -}}
+{{- include "platform.validate.termsRequired" . -}}
 {{- end -}}
 
 {{/*
@@ -35,5 +36,20 @@ comment.
 {{- $base := .Values.controller.agent.base -}}
 {{- if and $base.iptablesInit $base.iptablesInit.enabled $base.npGateInit $base.npGateInit.enabled -}}
 {{- fail "controller.agent.base.iptablesInit.enabled and npGateInit.enabled are mutually exclusive — enable exactly one. See values.yaml for the two-mode comment." -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Terms of Use are non-optional — the api-server gate refuses every
+authenticated route until each user has accepted the current version.
+A missing text or version would lock out every account at first request.
+See ADR-047.
+*/}}
+{{- define "platform.validate.termsRequired" -}}
+{{- if not (.Values.terms.text | default "" | trim) -}}
+{{- fail "terms.text is required. Supply via `helm install --set-file terms.text=./TERMS.md`. See ADR-047." -}}
+{{- end -}}
+{{- if not (.Values.terms.version | default "" | trim) -}}
+{{- fail "terms.version is required. Bump on material text changes to re-prompt every user. See ADR-047." -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -249,8 +249,6 @@ spec:
             - name: BRAND_ICON_SVG
               value: {{ .Values.brand.icon | quote }}
             {{- end }}
-            # Terms of Use — see ADR-047. Required; chart validation fails
-            # the install when either value is unset.
             - name: TERMS_VERSION
               value: {{ .Values.terms.version | quote }}
             - name: TERMS_TEXT

--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -249,6 +249,12 @@ spec:
             - name: BRAND_ICON_SVG
               value: {{ .Values.brand.icon | quote }}
             {{- end }}
+            # Terms of Use — see ADR-047. Required; chart validation fails
+            # the install when either value is unset.
+            - name: TERMS_VERSION
+              value: {{ .Values.terms.version | quote }}
+            - name: TERMS_TEXT
+              value: {{ .Values.terms.text | quote }}
           volumeMounts:
             - name: trusted-hosts
               mountPath: /etc/platform/trusted-hosts

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -30,6 +30,19 @@ brand:
   # for the easiest override workflow.
   icon: ""
 
+# -- Terms of Use shown at the api-server acceptance gate. Both fields are
+# required; the chart refuses to install when either is unset. Bump
+# `terms.version` on every material change to re-prompt every user; the
+# server records `sha256(text)` on each Acceptance row as proof binding.
+# See ADR-047.
+terms:
+  # Markdown content rendered at /terms and on the login page. Supply via
+  # `helm install --set-file terms.text=./TERMS.md`.
+  text: ""
+  # Free-form re-prompt trigger (e.g. "2026-05-25", "v1"). Operator
+  # judgment — whitespace edits don't bump this.
+  version: ""
+
 # -- Base domain for the app. UI and API share this host; the ingress
 # splits `/api/*` to the api-server and everything else to the UI. Keycloak
 # lives at `keycloak.{domain}`.

--- a/deploy/helm/tasks.toml
+++ b/deploy/helm/tasks.toml
@@ -8,7 +8,7 @@ sources = ["**/*.yaml", "**/*.yml", "**/*.tpl"]
 
 ["helm:check:render"]
 dir = "{{config_root}}/deploy/helm/platform"
-run = "helm template platform . | kubeconform -strict -summary -skip Certificate,Issuer,ClusterIssuer,AuthorizationPolicy,Gateway,SecurityContextConstraints"
+run = "helm template platform . --set terms.version=test --set terms.text='Test Terms' | kubeconform -strict -summary -skip Certificate,Issuer,ClusterIssuer,AuthorizationPolicy,Gateway,SecurityContextConstraints"
 sources = ["**/*.yaml", "**/*.yml", "**/*.tpl"]
 
 ["helm:setup"]

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -374,7 +374,11 @@ rm -f "$tar"
 
 # 4. Helm install or upgrade
 # Dev-cluster defaults (overridable via --set)
-DEV_DEFAULTS=(--set keycloak.admin.password=admin)
+DEV_DEFAULTS=(
+  --set keycloak.admin.password=admin
+  --set terms.version=dev
+  --set "terms.text=Dev placeholder Terms of Use. See ADR-047."
+)
 
 # Detect btrfs-backed clusters (Fedora hosts default to btrfs) and bypass
 # the bundled nfs-ganesha provisioner — it returns EREMOTEIO on every write

--- a/packages/api-server-api/src/context.ts
+++ b/packages/api-server-api/src/context.ts
@@ -9,6 +9,7 @@ import type { SecretsService } from "./modules/secrets/types.js";
 import type { SessionsService } from "./modules/sessions/types.js";
 import type { SkillsService } from "./modules/skills/types.js";
 import type { TemplatesService } from "./modules/templates/types.js";
+import type { TermsService } from "./modules/terms/types.js";
 
 export interface UserIdentity {
   sub: string;
@@ -27,5 +28,6 @@ export interface ApiContext {
   approvals: ApprovalsService;
   egressRules: EgressRulesService;
   files: FilesService;
+  terms: TermsService;
   user: UserIdentity;
 }

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -314,6 +314,22 @@ export type {
 export { brandSchema } from "./modules/brand/types.js";
 export type { Brand } from "./modules/brand/types.js";
 
+// Terms
+export type {
+  TermsCurrent,
+  TermsDocument,
+  StaleAcceptance,
+  AcceptedAcceptance,
+  TermsService,
+} from "./modules/terms/types.js";
+export {
+  staleAcceptanceSchema,
+  termsAcceptInputSchema,
+  termsCurrentSchema,
+  termsDocumentSchema,
+  termsLatestAcceptanceSchema,
+} from "./modules/terms/schemas.js";
+
 // Auth config
 export { authConfigSchema } from "./modules/auth/types.js";
 export type { AuthConfig } from "./modules/auth/types.js";

--- a/packages/api-server-api/src/modules/terms/router.ts
+++ b/packages/api-server-api/src/modules/terms/router.ts
@@ -1,0 +1,31 @@
+import { TRPCError } from "@trpc/server";
+import { t } from "../../trpc.js";
+import { termsAcceptInputSchema } from "./schemas.js";
+import type { StaleAcceptance } from "./types.js";
+
+export const termsRouter = t.router({
+  current: t.procedure.query(({ ctx }) => ctx.terms.current()),
+
+  latestAcceptance: t.procedure.query(({ ctx }) =>
+    ctx.terms.latestAcceptance(ctx.user.sub),
+  ),
+
+  accept: t.procedure
+    .input(termsAcceptInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const current = ctx.terms.current();
+      if (input.version !== current.version) {
+        const stale: StaleAcceptance = {
+          error: "terms_stale",
+          currentVersion: current.version,
+          currentHash: current.hash,
+        };
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "terms_stale",
+          cause: stale,
+        });
+      }
+      await ctx.terms.accept(ctx.user.sub, input.version);
+    }),
+});

--- a/packages/api-server-api/src/modules/terms/schemas.ts
+++ b/packages/api-server-api/src/modules/terms/schemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+export const termsCurrentSchema = z.object({
+  version: z.string().min(1),
+  hash: z.string().min(1),
+});
+
+export const termsDocumentSchema = z.object({
+  version: z.string().min(1),
+  text: z.string(),
+  hash: z.string().min(1),
+});
+
+export const termsAcceptInputSchema = z.object({
+  version: z.string().min(1),
+});
+
+export const staleAcceptanceSchema = z.object({
+  error: z.literal("terms_stale"),
+  currentVersion: z.string().min(1),
+  currentHash: z.string().min(1),
+});
+
+export const termsLatestAcceptanceSchema = z
+  .object({
+    version: z.string().min(1),
+    hash: z.string().min(1),
+    acceptedAt: z.date(),
+  })
+  .nullable();

--- a/packages/api-server-api/src/modules/terms/types.ts
+++ b/packages/api-server-api/src/modules/terms/types.ts
@@ -1,0 +1,30 @@
+export interface TermsCurrent {
+  version: string;
+  hash: string;
+}
+
+export interface TermsDocument {
+  version: string;
+  text: string;
+  hash: string;
+}
+
+export interface StaleAcceptance {
+  error: "terms_stale";
+  currentVersion: string;
+  currentHash: string;
+}
+
+export interface AcceptedAcceptance {
+  version: string;
+  hash: string;
+  acceptedAt: Date;
+}
+
+export interface TermsService {
+  current(): TermsCurrent;
+  document(): TermsDocument;
+  accept(sub: string, version: string): Promise<void>;
+  latestAcceptance(sub: string): Promise<AcceptedAcceptance | null>;
+  isAccepted(sub: string): Promise<boolean>;
+}

--- a/packages/api-server-api/src/router.ts
+++ b/packages/api-server-api/src/router.ts
@@ -10,6 +10,7 @@ import { secretsRouter } from "./modules/secrets/router.js";
 import { sessionsRouter } from "./modules/sessions/router.js";
 import { skillsRouter } from "./modules/skills/router.js";
 import { templatesRouter } from "./modules/templates/router.js";
+import { termsRouter } from "./modules/terms/router.js";
 
 export const appRouter = t.router({
   templates: templatesRouter,
@@ -23,6 +24,7 @@ export const appRouter = t.router({
   approvals: approvalsRouter,
   egressRules: egressRulesRouter,
   files: filesRouter,
+  terms: termsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/api-server/src/__tests__/helpers/test-cluster.ts
+++ b/packages/api-server/src/__tests__/helpers/test-cluster.ts
@@ -1,5 +1,7 @@
 import { execSync } from "node:child_process";
 import type { TestProject } from "vitest/node";
+import { createTRPCClient, httpBatchLink } from "@trpc/client";
+import type { AppRouter } from "api-server-api";
 import { waitForKeycloak, getToken } from "./auth.js";
 
 const API_URL = "http://localtest.me:5555";
@@ -16,6 +18,19 @@ async function waitForReady(url: string, timeoutMs = 120_000) {
   throw new Error(`API server not ready after ${timeoutMs}ms`);
 }
 
+async function acceptCurrentTerms(token: string) {
+  const client = createTRPCClient<AppRouter>({
+    links: [
+      httpBatchLink({
+        url: `${API_URL}/api/trpc`,
+        headers: { Authorization: `Bearer ${token}` },
+      }),
+    ],
+  });
+  const current = await client.terms.current.query();
+  await client.terms.accept.mutate({ version: current.version });
+}
+
 export async function setup(project: TestProject) {
   console.log("Waiting for Keycloak realm to be ready...");
   await waitForKeycloak();
@@ -25,8 +40,10 @@ export async function setup(project: TestProject) {
 
   console.log("Getting auth token...");
   const token = await getToken();
-  // Provide the token to test workers (globalSetup runs in a separate
-  // process from test files, so module-level state can't be shared).
+
+  console.log("Accepting terms of use...");
+  await acceptCurrentTerms(token);
+
   project.provide("authToken", token);
 
   console.log("Test cluster ready.");

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -221,9 +221,6 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   // of brand truth; all UI components read from here, never from build-time
   // constants.
   app.get("/api/brand", (c) => c.json(config.brand satisfies Brand));
-  // Public — Terms of Use document. Hit by the login page and the /terms
-  // route. Ships text only on this read; the gate response carries
-  // version+hash only. See ADR-047.
   app.get("/api/terms", (c) => c.json(terms.document()));
   // Public — PWA manifest (replaces the build-time bundled one). Served
   // dynamically so the installed-PWA name follows brand without a UI rebuild.

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -8,6 +8,7 @@ import type {
   ApiContext,
   AuthConfig,
   Brand,
+  TermsService,
   UserIdentity,
 } from "api-server-api";
 import { buildPlatformSessionModeChangedNotification } from "api-server-api";
@@ -41,6 +42,7 @@ import {
   authorizeThread,
   revokeThread,
   listAuthorizedThreads,
+  getAuthorizedBy,
 } from "../../modules/channels/infrastructure/telegram-threads-repository.js";
 import { createAcpRelay } from "./acp-relay.js";
 import { createTerminalRelay } from "./terminal-relay.js";
@@ -49,6 +51,8 @@ import { createOAuthRoutes } from "./oauth.js";
 import { mountBrandIconRoutes } from "./brand-icon.js";
 import type { Config } from "../../config.js";
 import { createAuth, ForbiddenError } from "./auth.js";
+import { createTermsGate } from "./terms-gate.js";
+import type { IsAcceptedPort } from "../../modules/terms/compose.js";
 import { createK8sSecretsPort } from "./../../modules/secrets/infrastructure/k8s-secrets-port.js";
 import { createSecretsService } from "./../../modules/secrets/services/secrets-service.js";
 import {
@@ -106,6 +110,8 @@ export interface ApiServerAppDeps {
   mountUsageRoutes: (
     app: Hono<{ Variables: { user: UserIdentity; roles: string[] } }>,
   ) => void;
+  terms: TermsService;
+  isTermsAccepted: IsAcceptedPort;
 }
 
 export function startApiServerApp(deps: ApiServerAppDeps) {
@@ -128,6 +134,8 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     secretStores,
     runtimeMutator,
     schedulesBoot,
+    terms,
+    isTermsAccepted,
   } = deps;
 
   const k8sClient = createK8sClient(api, config.namespace);
@@ -213,6 +221,10 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   // of brand truth; all UI components read from here, never from build-time
   // constants.
   app.get("/api/brand", (c) => c.json(config.brand satisfies Brand));
+  // Public — Terms of Use document. Hit by the login page and the /terms
+  // route. Ships text only on this read; the gate response carries
+  // version+hash only. See ADR-047.
+  app.get("/api/terms", (c) => c.json(terms.document()));
   // Public — PWA manifest (replaces the build-time bundled one). Served
   // dynamically so the installed-PWA name follows brand without a UI rebuild.
   app.get("/api/brand/manifest.webmanifest", (c) => {
@@ -253,6 +265,8 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   mountBrandIconRoutes(app);
 
   app.use("/api/*", auth.middleware);
+  const termsGate = createTermsGate({ terms });
+  app.use("/api/*", termsGate.middleware);
 
   app.route(
     "/",
@@ -295,6 +309,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
           authorize: authorizeThread(db),
           list: listAuthorizedThreads(db),
           revoke: revokeThread(db),
+          getAuthorizedBy: getAuthorizedBy(db),
         },
         isAgentOwner: (agentId, sub) => agentsRepo.isOwnedBy(agentId, sub),
         oauthConfig: {
@@ -649,6 +664,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
         approvals,
         egressRules,
         files,
+        terms,
         user,
       }),
     });
@@ -740,6 +756,12 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     const agentId = decodeURIComponent(match[1]);
     if (!(await verifyOwner(agentId, user.sub))) {
       socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
+      socket.destroy();
+      return;
+    }
+
+    if (!(await isTermsAccepted(user.sub))) {
+      socket.write("HTTP/1.1 412 Precondition Failed\r\n\r\n");
       socket.destroy();
       return;
     }

--- a/packages/api-server/src/apps/api-server/auth.ts
+++ b/packages/api-server/src/apps/api-server/auth.ts
@@ -34,6 +34,7 @@ const PUBLIC_PATHS = new Set([
   "/api/oauth/callback",
   "/api/slack/oauth/callback",
   "/api/telegram/oauth/callback",
+  "/api/terms",
 ]);
 
 const PUBLIC_PATH_PREFIXES = ["/api/brand/"];

--- a/packages/api-server/src/apps/api-server/terms-gate.ts
+++ b/packages/api-server/src/apps/api-server/terms-gate.ts
@@ -1,0 +1,32 @@
+import type { MiddlewareHandler } from "hono";
+import type {
+  TermsService,
+  UserIdentity,
+  StaleAcceptance,
+} from "api-server-api";
+
+export interface TermsGateConfig {
+  terms: TermsService;
+}
+
+const TRPC_TERMS_PREFIX = "/api/trpc/terms.";
+
+export function createTermsGate(config: TermsGateConfig) {
+  const middleware: MiddlewareHandler<{
+    Variables: { user: UserIdentity };
+  }> = async (c, next) => {
+    if (c.req.path.startsWith(TRPC_TERMS_PREFIX)) return next();
+    const user = c.get("user");
+    if (!user) return next();
+    const accepted = await config.terms.isAccepted(user.sub);
+    if (accepted) return next();
+    const current = config.terms.current();
+    const body: StaleAcceptance = {
+      error: "terms_stale",
+      currentVersion: current.version,
+      currentHash: current.hash,
+    };
+    return c.json(body, 412);
+  };
+  return { middleware };
+}

--- a/packages/api-server/src/apps/api-server/terms-gate.ts
+++ b/packages/api-server/src/apps/api-server/terms-gate.ts
@@ -9,13 +9,19 @@ export interface TermsGateConfig {
   terms: TermsService;
 }
 
-const TRPC_TERMS_PREFIX = "/api/trpc/terms.";
+const TRPC_PREFIX = "/api/trpc/";
+
+function isTermsOnlyTrpcCall(path: string): boolean {
+  if (!path.startsWith(TRPC_PREFIX)) return false;
+  const procs = path.slice(TRPC_PREFIX.length).split(",");
+  return procs.length > 0 && procs.every((p) => p.startsWith("terms."));
+}
 
 export function createTermsGate(config: TermsGateConfig) {
   const middleware: MiddlewareHandler<{
     Variables: { user: UserIdentity };
   }> = async (c, next) => {
-    if (c.req.path.startsWith(TRPC_TERMS_PREFIX)) return next();
+    if (isTermsOnlyTrpcCall(c.req.path)) return next();
     const user = c.get("user");
     if (!user) return next();
     const accepted = await config.terms.isAccepted(user.sub);

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -119,6 +119,14 @@ const configSchema = z.object({
    *  env-var input-prep block below — not in the schema — so a malformed
    *  server response cannot silently coerce on the UI side. */
   brand: brandSchema,
+  /** Terms of Use shown at the acceptance gate. Required Helm values
+   *  (`terms.text`, `terms.version`) — chart refuses install when unset.
+   *  Text is markdown; `version` is operator-bumped on material changes
+   *  to re-prompt every user. See ADR-047. */
+  terms: z.object({
+    version: z.string().min(1, "terms.version must be set"),
+    text: z.string().min(1, "terms.text must be set"),
+  }),
 });
 
 export type Config = z.infer<typeof configSchema>;
@@ -182,6 +190,10 @@ export function loadConfig(): Config {
           accentLight: process.env.BRAND_THEME_DARK_ACCENT_LIGHT ?? "#0f1f3a",
         },
       },
+    },
+    terms: {
+      version: process.env.TERMS_VERSION,
+      text: process.env.TERMS_TEXT,
     },
   });
 }

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -119,10 +119,6 @@ const configSchema = z.object({
    *  env-var input-prep block below — not in the schema — so a malformed
    *  server response cannot silently coerce on the UI side. */
   brand: brandSchema,
-  /** Terms of Use shown at the acceptance gate. Required Helm values
-   *  (`terms.text`, `terms.version`) — chart refuses install when unset.
-   *  Text is markdown; `version` is operator-bumped on material changes
-   *  to re-prompt every user. See ADR-047. */
   terms: z.object({
     version: z.string().min(1, "terms.version must be set"),
     text: z.string().min(1, "terms.text must be set"),

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -52,6 +52,7 @@ import {
   revokeThread,
   listAuthorizedThreads,
   deleteThreadsByAgent,
+  getAuthorizedBy,
 } from "./modules/channels/infrastructure/telegram-threads-repository.js";
 import {
   composeRuntimeDelivery,
@@ -69,6 +70,7 @@ import {
 } from "./modules/forks/index.js";
 import { composeUsageModule } from "./modules/usage/compose.js";
 import { createK8sForkOrchestrator } from "./modules/forks/infrastructure/k8s-fork-orchestrator.js";
+import { composeTermsModule } from "./modules/terms/index.js";
 import { loadConfig } from "./config.js";
 import { startApiServerApp } from "./apps/api-server/app.js";
 import { startHarnessApiServerApp } from "./apps/harness-api-server/app.js";
@@ -105,6 +107,13 @@ const subPseudonymizer = createSubPseudonymizer(config.activityHmacKey);
 
 const secretStores = createSecretStoreRegistry();
 secretStores.register(createKubernetesSecretStore({ k8s: k8sClient }));
+
+const { service: termsService, isAcceptedPort: isTermsAccepted } =
+  composeTermsModule({
+    db,
+    version: config.terms.version,
+    text: config.terms.text,
+  });
 
 const k8sCleanupSub = startK8sCleanupSaga(k8sClient, channelSecretStore);
 const channelCleanupSub = startChannelCleanupSaga(
@@ -233,6 +242,8 @@ const slackWorker =
         (agentId) => agentsRepo.getOwner(agentId),
         channelRegistry,
         config.brand.short,
+        isTermsAccepted,
+        config.uiBaseUrl,
       )
     : undefined;
 
@@ -248,6 +259,7 @@ const telegramWorker =
           authorize: authorizeThread(db),
           list: listAuthorizedThreads(db),
           revoke: revokeThread(db),
+          getAuthorizedBy: getAuthorizedBy(db),
         },
         {
           keycloakExternalUrl: config.keycloakExternalUrl,
@@ -261,6 +273,8 @@ const telegramWorker =
           find: findByInstanceAndThreadTs(db),
           touch: touchSession(db),
         },
+        isTermsAccepted,
+        config.uiBaseUrl,
       )
     : undefined;
 
@@ -397,6 +411,8 @@ const { server: apiServer } = startApiServerApp({
   runtimeMutator: runtimeDelivery.runtimeMutator,
   schedulesBoot,
   mountUsageRoutes: usage.mount,
+  terms: termsService,
+  isTermsAccepted,
 });
 
 const { server: harnessApiServer } = startHarnessApiServerApp({

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -115,6 +115,8 @@ export function createSlackWorker(
   /** Lowercase brand identifier used as the Slack slash command name (e.g.
    *  brandShort="name" → /name login). Sourced from BRAND_SHORT env var. */
   brandShort: string,
+  isTermsAccepted: (sub: string) => Promise<boolean>,
+  uiBaseUrl: string,
   emit: (event: DomainEvent) => void = defaultEmit,
 ): SlackWorker {
   let app: BoltApp | null = null;
@@ -534,6 +536,15 @@ export function createSlackWorker(
         channel: args.channel,
         user: args.slackUserId,
         text: "You don't have access to this instance. Contact the instance owner to be added to the allowed users list.",
+      });
+      return;
+    }
+
+    if (!(await isTermsAccepted(args.keycloakSub))) {
+      await app.client.chat.postEphemeral({
+        channel: args.channel,
+        user: args.slackUserId,
+        text: `Open ${uiBaseUrl} to accept the Terms of Use before sending messages.`,
       });
       return;
     }

--- a/packages/api-server/src/modules/channels/infrastructure/telegram-threads-repository.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/telegram-threads-repository.ts
@@ -56,6 +56,22 @@ export function revokeThread(db: Db) {
   };
 }
 
+export function getAuthorizedBy(db: Db) {
+  return async (agentId: string, threadId: string): Promise<string | null> => {
+    const rows = await db
+      .select({ authorizedBy: telegramThreads.authorizedBy })
+      .from(telegramThreads)
+      .where(
+        and(
+          eq(telegramThreads.agentId, agentId),
+          eq(telegramThreads.threadId, threadId),
+        ),
+      )
+      .limit(1);
+    return rows[0]?.authorizedBy ?? null;
+  };
+}
+
 export function deleteThreadsByAgent(db: Db) {
   return async (agentId: string): Promise<void> => {
     await db

--- a/packages/api-server/src/modules/channels/infrastructure/telegram.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/telegram.ts
@@ -39,6 +39,10 @@ export interface TelegramThreadsRepo {
   ) => Promise<void>;
   list: (agentId: string) => Promise<string[]>;
   revoke: (agentId: string, threadId: string) => Promise<void>;
+  getAuthorizedBy: (
+    agentId: string,
+    threadId: string,
+  ) => Promise<string | null>;
 }
 
 export interface ChannelConversation {
@@ -132,6 +136,8 @@ export function createTelegramWorker(
     ) => Promise<{ sessionId: string } | null>;
     touch: (sessionId: string) => Promise<void>;
   },
+  isTermsAccepted: (sub: string) => Promise<boolean>,
+  uiBaseUrl: string,
   emit: (event: DomainEvent) => void = defaultEmit,
 ): TelegramWorker {
   const bots = new Map<string, InstanceBot>();
@@ -319,6 +325,18 @@ export function createTelegramWorker(
         if (thread.isDM) {
           await thread.post(
             "This conversation isn't authorized. An admin needs to send /login.",
+          );
+        }
+        return;
+      }
+      const authorizedBy = await threads.getAuthorizedBy(
+        instanceName,
+        thread.id,
+      );
+      if (authorizedBy && !(await isTermsAccepted(authorizedBy))) {
+        if (thread.isDM) {
+          await thread.post(
+            `Open ${uiBaseUrl} to accept the Terms of Use before continuing.`,
           );
         }
         return;

--- a/packages/api-server/src/modules/terms/compose.ts
+++ b/packages/api-server/src/modules/terms/compose.ts
@@ -1,0 +1,27 @@
+import { createHash } from "node:crypto";
+import type { Db } from "db";
+import type { TermsService } from "api-server-api";
+import { createTermsAcceptancesRepository } from "./infrastructure/terms-acceptances-repository.js";
+import { createTermsService } from "./services/terms-service.js";
+
+export type IsAcceptedPort = (sub: string) => Promise<boolean>;
+
+export function composeTermsModule(deps: {
+  db: Db;
+  version: string;
+  text: string;
+}): {
+  service: TermsService;
+  isAcceptedPort: IsAcceptedPort;
+} {
+  const hash = createHash("sha256").update(deps.text).digest("hex");
+  const repo = createTermsAcceptancesRepository(deps.db);
+  const service = createTermsService({
+    current: { version: deps.version, text: deps.text, hash },
+    repo,
+  });
+  return {
+    service,
+    isAcceptedPort: (sub) => service.isAccepted(sub),
+  };
+}

--- a/packages/api-server/src/modules/terms/domain/terms.ts
+++ b/packages/api-server/src/modules/terms/domain/terms.ts
@@ -1,0 +1,11 @@
+import type { TermsCurrent, TermsDocument } from "api-server-api";
+
+export type CurrentTerms = TermsDocument;
+
+export function buildCurrent(terms: CurrentTerms): TermsCurrent {
+  return { version: terms.version, hash: terms.hash };
+}
+
+export function buildDocument(terms: CurrentTerms): TermsDocument {
+  return { version: terms.version, text: terms.text, hash: terms.hash };
+}

--- a/packages/api-server/src/modules/terms/index.ts
+++ b/packages/api-server/src/modules/terms/index.ts
@@ -1,0 +1,1 @@
+export { composeTermsModule, type IsAcceptedPort } from "./compose.js";

--- a/packages/api-server/src/modules/terms/infrastructure/terms-acceptances-repository.ts
+++ b/packages/api-server/src/modules/terms/infrastructure/terms-acceptances-repository.ts
@@ -1,0 +1,63 @@
+import type { Db } from "db";
+import { termsAcceptances, eq, and, desc } from "db";
+import type { AcceptedAcceptance } from "api-server-api";
+
+export interface TermsAcceptancesRepository {
+  recordAcceptance(sub: string, version: string, hash: string): Promise<void>;
+  findLatest(sub: string): Promise<AcceptedAcceptance | null>;
+  findForVersion(
+    sub: string,
+    version: string,
+  ): Promise<AcceptedAcceptance | null>;
+}
+
+export function createTermsAcceptancesRepository(
+  db: Db,
+): TermsAcceptancesRepository {
+  return {
+    async recordAcceptance(sub, version, hash) {
+      await db
+        .insert(termsAcceptances)
+        .values({ sub, version, hash })
+        .onConflictDoNothing({
+          target: [termsAcceptances.sub, termsAcceptances.version],
+        });
+    },
+
+    async findLatest(sub) {
+      const rows = await db
+        .select()
+        .from(termsAcceptances)
+        .where(eq(termsAcceptances.sub, sub))
+        .orderBy(desc(termsAcceptances.acceptedAt))
+        .limit(1);
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        version: row.version,
+        hash: row.hash,
+        acceptedAt: row.acceptedAt,
+      };
+    },
+
+    async findForVersion(sub, version) {
+      const rows = await db
+        .select()
+        .from(termsAcceptances)
+        .where(
+          and(
+            eq(termsAcceptances.sub, sub),
+            eq(termsAcceptances.version, version),
+          ),
+        )
+        .limit(1);
+      const row = rows[0];
+      if (!row) return null;
+      return {
+        version: row.version,
+        hash: row.hash,
+        acceptedAt: row.acceptedAt,
+      };
+    },
+  };
+}

--- a/packages/api-server/src/modules/terms/services/terms-service.ts
+++ b/packages/api-server/src/modules/terms/services/terms-service.ts
@@ -1,0 +1,26 @@
+import type { TermsService } from "api-server-api";
+import {
+  buildCurrent,
+  buildDocument,
+  type CurrentTerms,
+} from "../domain/terms.js";
+import type { TermsAcceptancesRepository } from "../infrastructure/terms-acceptances-repository.js";
+
+export function createTermsService(deps: {
+  current: CurrentTerms;
+  repo: TermsAcceptancesRepository;
+}): TermsService {
+  const { current, repo } = deps;
+  return {
+    current: () => buildCurrent(current),
+    document: () => buildDocument(current),
+    accept: async (sub, version) => {
+      await repo.recordAcceptance(sub, version, current.hash);
+    },
+    latestAcceptance: (sub) => repo.findLatest(sub),
+    isAccepted: async (sub) => {
+      const row = await repo.findForVersion(sub, current.version);
+      return row !== null;
+    },
+  };
+}

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -1,5 +1,16 @@
 #!/usr/bin/env node
 import { compose } from "./compose.js";
+import { TermsStaleAtTransportError } from "./modules/shared/trpc/trpc-client.js";
 
 const program = compose();
-await program.parseAsync(process.argv);
+try {
+  await program.parseAsync(process.argv);
+} catch (err) {
+  if (err instanceof TermsStaleAtTransportError) {
+    process.stderr.write(
+      `error: Terms of Use acceptance required\nhint: open ${err.host} to accept\n`,
+    );
+    process.exit(1);
+  }
+  throw err;
+}

--- a/packages/cli/src/modules/shared/trpc/classify.ts
+++ b/packages/cli/src/modules/shared/trpc/classify.ts
@@ -1,12 +1,16 @@
 import { err, ok, type Result } from "../../../result.js";
 import type { AuthRequiredError, TransportError } from "../errors.js";
-import { AuthRequiredAtTransportError } from "./trpc-client.js";
+import {
+  AuthRequiredAtTransportError,
+  TermsStaleAtTransportError,
+} from "./trpc-client.js";
 
 export function classifyTrpcError(
   e: unknown,
 ): Result<never, TransportError | AuthRequiredError> {
   let cursor: unknown = e;
   for (let depth = 0; cursor && depth < 8; depth++) {
+    if (cursor instanceof TermsStaleAtTransportError) throw cursor;
     if (cursor instanceof AuthRequiredAtTransportError)
       return err({ kind: "auth-required", reason: cursor.message });
     cursor = (cursor as { cause?: unknown }).cause;

--- a/packages/cli/src/modules/shared/trpc/trpc-client.ts
+++ b/packages/cli/src/modules/shared/trpc/trpc-client.ts
@@ -14,6 +14,14 @@ export class AuthRequiredAtTransportError extends Error {
   }
 }
 
+export class TermsStaleAtTransportError extends Error {
+  readonly kind = "terms-stale" as const;
+  constructor(public readonly host: string) {
+    super(`Terms of Use acceptance required at ${host}`);
+    this.name = "TermsStaleAtTransportError";
+  }
+}
+
 function buildAuthHeaders(deps: {
   host: string;
   tokenProvider: TokenProvider;
@@ -41,6 +49,29 @@ function buildAuthHeaders(deps: {
   };
 }
 
+function wrapFetchWithTermsGate(
+  host: string,
+  baseFetch?: typeof fetch,
+): typeof fetch {
+  const inner = baseFetch ?? fetch;
+  return (async (input, init) => {
+    const response = await inner(input, init);
+    if (response.status === 412) {
+      const clone = response.clone();
+      try {
+        const body = (await clone.json()) as { error?: string };
+        if (body.error === "terms_stale") {
+          throw new TermsStaleAtTransportError(host);
+        }
+      } catch (err) {
+        if (err instanceof TermsStaleAtTransportError) throw err;
+        // non-JSON 412 — let it bubble normally
+      }
+    }
+    return response;
+  }) as typeof fetch;
+}
+
 export function createTrpcClient(deps: {
   host: string;
   tokenProvider: TokenProvider;
@@ -50,7 +81,7 @@ export function createTrpcClient(deps: {
     links: [
       httpBatchLink({
         url: `${deps.host.replace(/\/+$/, "")}/api/trpc`,
-        fetch: deps.fetch,
+        fetch: wrapFetchWithTermsGate(deps.host, deps.fetch),
         headers: buildAuthHeaders(deps),
       }),
     ],
@@ -68,7 +99,7 @@ export function createAgentTrpcClient(deps: {
     links: [
       httpBatchLink({
         url: base,
-        fetch: deps.fetch,
+        fetch: wrapFetchWithTermsGate(deps.host, deps.fetch),
         headers: buildAuthHeaders(deps),
       }),
     ],

--- a/packages/cli/src/modules/shared/trpc/trpc-client.ts
+++ b/packages/cli/src/modules/shared/trpc/trpc-client.ts
@@ -65,7 +65,6 @@ function wrapFetchWithTermsGate(
         }
       } catch (err) {
         if (err instanceof TermsStaleAtTransportError) throw err;
-        // non-JSON 412 — let it bubble normally
       }
     }
     return response;

--- a/packages/db/drizzle/0018_terms_acceptances.sql
+++ b/packages/db/drizzle/0018_terms_acceptances.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "terms_acceptances" (
+	"sub" text NOT NULL,
+	"version" text NOT NULL,
+	"hash" text NOT NULL,
+	"accepted_at" timestamp with time zone DEFAULT now() NOT NULL,
+	CONSTRAINT "terms_acceptances_sub_version_pk" PRIMARY KEY("sub","version")
+);

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1779926400000,
       "tag": "0017_schedules",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1780531200000,
+      "tag": "0018_terms_acceptances",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -19,6 +19,7 @@ export {
   schedules,
   activityEvents,
   actorRoles,
+  termsAcceptances,
 } from "./schema.js";
 export {
   eq,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -284,6 +284,19 @@ export const agents = pgTable(
   (table) => [index("agents_owner_idx").on(table.ownerSub)],
 );
 
+export const termsAcceptances = pgTable(
+  "terms_acceptances",
+  {
+    sub: text("sub").notNull(),
+    version: text("version").notNull(),
+    hash: text("hash").notNull(),
+    acceptedAt: timestamp("accepted_at", { withTimezone: true })
+      .defaultNow()
+      .notNull(),
+  },
+  (table) => [primaryKey({ columns: [table.sub, table.version] })],
+);
+
 export const agentSkillPublishes = pgTable(
   "agent_skill_publishes",
   {

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -20,9 +20,7 @@ export const api = createTRPCClient<AppRouter>({
             try {
               const body = (await clone.json()) as { error?: string };
               if (body.error === "terms_stale") onTermsStale();
-            } catch {
-              // non-JSON 412 — leave the response to bubble up.
-            }
+            } catch {}
           }
           return response;
         } catch (error) {

--- a/packages/ui/src/api.ts
+++ b/packages/ui/src/api.ts
@@ -3,6 +3,7 @@ import type { AppRouter } from "api-server-api";
 
 import { getAccessToken } from "./auth.js";
 import { onFetchError, onFetchSuccess } from "./lib/api-health.js";
+import { onTermsStale } from "./modules/terms/lib/on-terms-stale.js";
 
 export const api = createTRPCClient<AppRouter>({
   links: [
@@ -14,6 +15,15 @@ export const api = createTRPCClient<AppRouter>({
           if (response.ok) onFetchSuccess();
           else if (response.status === 502 || response.status === 503)
             onFetchError();
+          else if (response.status === 412) {
+            const clone = response.clone();
+            try {
+              const body = (await clone.json()) as { error?: string };
+              if (body.error === "terms_stale") onTermsStale();
+            } catch {
+              // non-JSON 412 — leave the response to bubble up.
+            }
+          }
           return response;
         } catch (error) {
           onFetchError();

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -101,6 +101,18 @@ export default function App() {
       </>
     );
 
+  // Terms view is full-screen and standalone — no sidebar, no other
+  // queries firing. Until the user accepts, every other authenticated
+  // surface gets 412'd by the gate; mounting the shell would spam
+  // failing queries.
+  if (view === "terms")
+    return (
+      <>
+        <TermsView />
+        <ToastOverlay />
+      </>
+    );
+
   // All non-chat views share the sidebar shell
   return (
     <div className="flex h-dvh bg-bg relative overflow-hidden">
@@ -123,8 +135,6 @@ export default function App() {
             <InboxView />
           ) : view === "agent-egress" ? (
             <AgentEgressView />
-          ) : view === "terms" ? (
-            <TermsView />
           ) : (
             <ListView />
           )}

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -101,10 +101,6 @@ export default function App() {
       </>
     );
 
-  // Terms view is full-screen and standalone — no sidebar, no other
-  // queries firing. Until the user accepts, every other authenticated
-  // surface gets 412'd by the gate; mounting the shell would spam
-  // failing queries.
   if (view === "terms")
     return (
       <>

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -13,6 +13,7 @@ import { AgentEgressView } from "./modules/egress-rules/views/agent-egress-view.
 import { ChatView } from "./modules/sessions/views/chat-view.js";
 import { ProvidersView } from "./modules/settings/views/providers-view.js";
 import { SettingsView } from "./modules/settings/views/settings-view.js";
+import { TermsView } from "./modules/terms/views/terms-view.js";
 import { useStore } from "./store.js";
 
 export default function App() {
@@ -74,6 +75,7 @@ export default function App() {
         useStore.setState({ view: "connections" });
       else if (path === "/settings") useStore.setState({ view: "settings" });
       else if (path === "/inbox") useStore.setState({ view: "inbox" });
+      else if (path === "/terms") useStore.setState({ view: "terms" });
       else if (path.startsWith("/agents/") && path.endsWith("/egress")) {
         const id = decodeURIComponent(
           path.slice("/agents/".length, -"/egress".length),
@@ -121,6 +123,8 @@ export default function App() {
             <InboxView />
           ) : view === "agent-egress" ? (
             <AgentEgressView />
+          ) : view === "terms" ? (
+            <TermsView />
           ) : (
             <ListView />
           )}

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -5,27 +5,10 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
-import { api } from "./api.js";
 import { initAuth } from "./auth.js";
 import { applyBrand, loadBrand } from "./brand.js";
+import { preflightTermsGate } from "./modules/terms/lib/preflight.js";
 import { queryClient } from "./query-client.js";
-
-async function preflightTermsGate(): Promise<boolean> {
-  if (window.location.pathname === "/terms") return true;
-  try {
-    const [current, latest] = await Promise.all([
-      api.terms.current.query(),
-      api.terms.latestAcceptance.query(),
-    ]);
-    if (!latest || latest.version !== current.version) {
-      window.location.replace("/terms");
-      return false;
-    }
-    return true;
-  } catch {
-    return true;
-  }
-}
 
 async function main() {
   // Brand fetch is unauthenticated and runs in parallel with auth init so the

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -5,9 +5,27 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 
+import { api } from "./api.js";
 import { initAuth } from "./auth.js";
 import { applyBrand, loadBrand } from "./brand.js";
 import { queryClient } from "./query-client.js";
+
+async function preflightTermsGate(): Promise<boolean> {
+  if (window.location.pathname === "/terms") return true;
+  try {
+    const [current, latest] = await Promise.all([
+      api.terms.current.query(),
+      api.terms.latestAcceptance.query(),
+    ]);
+    if (!latest || latest.version !== current.version) {
+      window.location.replace("/terms");
+      return false;
+    }
+    return true;
+  } catch {
+    return true;
+  }
+}
 
 async function main() {
   // Brand fetch is unauthenticated and runs in parallel with auth init so the
@@ -15,6 +33,8 @@ async function main() {
   // fetch falls back to the bundled defaults — login still works.
   const [user] = await Promise.all([initAuth(), loadBrand().then(applyBrand)]);
   if (!user) return; // Redirecting to Keycloak, don't render
+
+  if (!(await preflightTermsGate())) return;
 
   const { default: App } = await import("./app.js");
   createRoot(document.getElementById("root")!).render(

--- a/packages/ui/src/modules/platform/lib/routes.ts
+++ b/packages/ui/src/modules/platform/lib/routes.ts
@@ -8,6 +8,7 @@ export const viewSchema = z.enum([
   "settings",
   "inbox",
   "agent-egress",
+  "terms",
 ]);
 export type View = z.infer<typeof viewSchema>;
 
@@ -23,6 +24,7 @@ export function viewToPath(
   if (view === "inbox") return "/inbox";
   if (view === "agent-egress" && agentId)
     return `/agents/${encodeURIComponent(agentId)}/egress`;
+  if (view === "terms") return "/terms";
   return "/";
 }
 
@@ -37,6 +39,7 @@ export function pathToState(path: string): {
   if (path === "/connections") return { view: "connections" };
   if (path === "/settings") return { view: "settings" };
   if (path === "/inbox") return { view: "inbox" };
+  if (path === "/terms") return { view: "terms" };
   const egressMatch = path.match(/^\/agents\/([^/]+)\/egress$/);
   if (egressMatch)
     return {

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -36,6 +36,7 @@ export function SettingsView() {
   const [activeTab, setActiveTab] = useState<Tab>("account");
   const theme = useStore((s) => s.theme);
   const setTheme = useStore((s) => s.setTheme);
+  const setView = useStore((s) => s.setView);
   const user = getUser();
 
   return (
@@ -121,6 +122,15 @@ export function SettingsView() {
               >
                 <LogOut size={14} />
                 Log out
+              </button>
+            </div>
+
+            <div className="mt-6">
+              <button
+                onClick={() => setView("terms")}
+                className="text-[13px] font-medium text-text-secondary hover:text-text underline underline-offset-2"
+              >
+                View Terms of Use
               </button>
             </div>
           </div>

--- a/packages/ui/src/modules/terms/api/fetch-terms.ts
+++ b/packages/ui/src/modules/terms/api/fetch-terms.ts
@@ -1,0 +1,30 @@
+import type { TermsDocument } from "api-server-api";
+
+import { getAccessToken } from "../../../auth.js";
+
+export async function fetchTermsDocument(): Promise<TermsDocument> {
+  const res = await fetch("/api/terms");
+  if (!res.ok) throw new Error(`Failed to fetch terms (${res.status})`);
+  return (await res.json()) as TermsDocument;
+}
+
+export async function fetchLatestAcceptance(): Promise<{
+  version: string;
+  hash: string;
+  acceptedAt: string;
+} | null> {
+  const res = await fetch("/api/trpc/terms.latestAcceptance", {
+    headers: { Authorization: `Bearer ${await getAccessToken()}` },
+  });
+  if (!res.ok) return null;
+  const body = (await res.json()) as {
+    result?: {
+      data?: {
+        version: string;
+        hash: string;
+        acceptedAt: string;
+      } | null;
+    };
+  };
+  return body.result?.data ?? null;
+}

--- a/packages/ui/src/modules/terms/api/fetch-terms.ts
+++ b/packages/ui/src/modules/terms/api/fetch-terms.ts
@@ -1,30 +1,7 @@
 import type { TermsDocument } from "api-server-api";
 
-import { getAccessToken } from "../../../auth.js";
-
 export async function fetchTermsDocument(): Promise<TermsDocument> {
   const res = await fetch("/api/terms");
   if (!res.ok) throw new Error(`Failed to fetch terms (${res.status})`);
   return (await res.json()) as TermsDocument;
-}
-
-export async function fetchLatestAcceptance(): Promise<{
-  version: string;
-  hash: string;
-  acceptedAt: string;
-} | null> {
-  const res = await fetch("/api/trpc/terms.latestAcceptance", {
-    headers: { Authorization: `Bearer ${await getAccessToken()}` },
-  });
-  if (!res.ok) return null;
-  const body = (await res.json()) as {
-    result?: {
-      data?: {
-        version: string;
-        hash: string;
-        acceptedAt: string;
-      } | null;
-    };
-  };
-  return body.result?.data ?? null;
 }

--- a/packages/ui/src/modules/terms/api/fetch-terms.ts
+++ b/packages/ui/src/modules/terms/api/fetch-terms.ts
@@ -1,7 +1,0 @@
-import type { TermsDocument } from "api-server-api";
-
-export async function fetchTermsDocument(): Promise<TermsDocument> {
-  const res = await fetch("/api/terms");
-  if (!res.ok) throw new Error(`Failed to fetch terms (${res.status})`);
-  return (await res.json()) as TermsDocument;
-}

--- a/packages/ui/src/modules/terms/api/mutations.ts
+++ b/packages/ui/src/modules/terms/api/mutations.ts
@@ -1,0 +1,13 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { trpc } from "../../../trpc.js";
+
+export function useAcceptTerms() {
+  return useMutation({
+    ...trpc.terms.accept.mutationOptions(),
+    meta: {
+      invalidates: [trpc.terms.latestAcceptance.queryKey()],
+      errorToast: "Couldn't accept Terms of Use",
+    },
+  });
+}

--- a/packages/ui/src/modules/terms/api/queries.ts
+++ b/packages/ui/src/modules/terms/api/queries.ts
@@ -1,0 +1,26 @@
+import { useQuery } from "@tanstack/react-query";
+import { termsDocumentSchema } from "api-server-api";
+
+import { trpc } from "../../../trpc.js";
+
+export const termsKeys = {
+  all: () => ["terms"] as const,
+  document: () => [...termsKeys.all(), "document"] as const,
+};
+
+export function useTermsDocument() {
+  return useQuery({
+    queryKey: termsKeys.document(),
+    queryFn: async () => {
+      const res = await fetch("/api/terms");
+      if (!res.ok) throw new Error(`Failed to fetch terms (${res.status})`);
+      return termsDocumentSchema.parse(await res.json());
+    },
+    staleTime: Infinity,
+    meta: { errorToast: "Couldn't load Terms of Use" },
+  });
+}
+
+export function useLatestAcceptance() {
+  return useQuery(trpc.terms.latestAcceptance.queryOptions());
+}

--- a/packages/ui/src/modules/terms/lib/on-terms-stale.ts
+++ b/packages/ui/src/modules/terms/lib/on-terms-stale.ts
@@ -1,0 +1,6 @@
+import { useStore } from "../../../store.js";
+
+export function onTermsStale() {
+  if (useStore.getState().view === "terms") return;
+  useStore.getState().setView("terms");
+}

--- a/packages/ui/src/modules/terms/lib/on-terms-stale.ts
+++ b/packages/ui/src/modules/terms/lib/on-terms-stale.ts
@@ -1,6 +1,8 @@
-import { useStore } from "../../../store.js";
+let redirecting = false;
 
 export function onTermsStale() {
-  if (useStore.getState().view === "terms") return;
-  useStore.getState().setView("terms");
+  if (redirecting) return;
+  if (window.location.pathname === "/terms") return;
+  redirecting = true;
+  window.location.assign("/terms");
 }

--- a/packages/ui/src/modules/terms/lib/preflight.ts
+++ b/packages/ui/src/modules/terms/lib/preflight.ts
@@ -1,0 +1,18 @@
+import { api } from "../../../api.js";
+
+export async function preflightTermsGate(): Promise<boolean> {
+  if (window.location.pathname === "/terms") return true;
+  try {
+    const [current, latest] = await Promise.all([
+      api.terms.current.query(),
+      api.terms.latestAcceptance.query(),
+    ]);
+    if (!latest || latest.version !== current.version) {
+      window.location.replace("/terms");
+      return false;
+    }
+    return true;
+  } catch {
+    return true;
+  }
+}

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -4,20 +4,15 @@ import { useEffect, useState } from "react";
 import { api } from "../../../api.js";
 import { Markdown } from "../../../components/markdown.js";
 import { useStore } from "../../../store.js";
-import {
-  fetchLatestAcceptance,
-  fetchTermsDocument,
-} from "../api/fetch-terms.js";
+import { fetchTermsDocument } from "../api/fetch-terms.js";
 
-type LatestAcceptance = {
-  version: string;
-  hash: string;
-  acceptedAt: string;
-};
+type LatestAcceptance = Awaited<
+  ReturnType<typeof api.terms.latestAcceptance.query>
+>;
 
 export function TermsView() {
   const [doc, setDoc] = useState<TermsDocument | null>(null);
-  const [latest, setLatest] = useState<LatestAcceptance | null>(null);
+  const [latest, setLatest] = useState<LatestAcceptance>(null);
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const setView = useStore((s) => s.setView);
@@ -28,7 +23,7 @@ export function TermsView() {
       try {
         const [d, l] = await Promise.all([
           fetchTermsDocument(),
-          fetchLatestAcceptance(),
+          api.terms.latestAcceptance.query(),
         ]);
         setDoc(d);
         setLatest(l);
@@ -62,7 +57,7 @@ export function TermsView() {
     setSubmitting(true);
     try {
       await api.terms.accept.mutate({ version: doc.version });
-      const refreshed = await fetchLatestAcceptance();
+      const refreshed = await api.terms.latestAcceptance.query();
       setLatest(refreshed);
       showToast({ kind: "success", message: "Terms accepted." });
       setView("list");

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -1,116 +1,115 @@
-import type { TermsDocument } from "api-server-api";
-import { useEffect, useState } from "react";
-
-import { api } from "../../../api.js";
 import { Markdown } from "../../../components/markdown.js";
-import { useStore } from "../../../store.js";
-import { fetchTermsDocument } from "../api/fetch-terms.js";
+import { useAcceptTerms } from "../api/mutations.js";
+import { useLatestAcceptance, useTermsDocument } from "../api/queries.js";
 
-type LatestAcceptance = Awaited<
-  ReturnType<typeof api.terms.latestAcceptance.query>
+type LatestAcceptance = NonNullable<
+  ReturnType<typeof useLatestAcceptance>["data"]
 >;
 
 export function TermsView() {
-  const [doc, setDoc] = useState<TermsDocument | null>(null);
-  const [latest, setLatest] = useState<LatestAcceptance>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [submitting, setSubmitting] = useState(false);
-  const setView = useStore((s) => s.setView);
-  const showToast = useStore((s) => s.showToast);
+  const document = useTermsDocument();
+  const latest = useLatestAcceptance();
+  const accept = useAcceptTerms();
 
-  useEffect(() => {
-    void (async () => {
-      try {
-        const [d, l] = await Promise.all([
-          fetchTermsDocument(),
-          api.terms.latestAcceptance.query(),
-        ]);
-        setDoc(d);
-        setLatest(l);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : "Failed to load terms");
-      }
-    })();
-  }, []);
-
-  if (error) {
+  if (document.isLoading || latest.isLoading) {
+    return <CenteredMessage>Loading…</CenteredMessage>;
+  }
+  if (document.error || !document.data) {
     return (
-      <div className="mx-auto w-full max-w-[800px] px-4 py-10">
-        <div className="text-red-600">{error}</div>
-      </div>
+      <CenteredMessage tone="error">Failed to load Terms.</CenteredMessage>
     );
   }
 
-  if (!doc) {
-    return (
-      <div className="mx-auto w-full max-w-[800px] px-4 py-10">
-        <div className="text-muted">Loading…</div>
-      </div>
-    );
-  }
-
-  const acceptedCurrent = latest !== null && latest.version === doc.version;
-  const blocking = !acceptedCurrent;
-
-  async function onAccept() {
-    if (!doc) return;
-    setSubmitting(true);
-    try {
-      await api.terms.accept.mutate({ version: doc.version });
-      const refreshed = await api.terms.latestAcceptance.query();
-      setLatest(refreshed);
-      showToast({ kind: "success", message: "Terms accepted." });
-      setView("list");
-    } catch (err) {
-      const message =
-        err instanceof Error ? err.message : "Failed to accept terms";
-      if (message.toLowerCase().includes("terms_stale")) {
-        const fresh = await fetchTermsDocument();
-        setDoc(fresh);
-        showToast({
-          kind: "error",
-          message: "Terms changed while you were reading. Please re-read.",
-        });
-      } else {
-        showToast({ kind: "error", message });
-      }
-    } finally {
-      setSubmitting(false);
-    }
-  }
+  const doc = document.data;
+  const acceptedCurrent = latest.data?.version === doc.version;
 
   return (
-    <div className="mx-auto w-full max-w-[800px] px-4 py-10">
+    <div className="mx-auto w-full max-w-200 px-4 py-10">
       <h1 className="text-2xl font-semibold mb-2">Terms of Use</h1>
-      <div className="text-sm text-muted mb-6">
-        Version <code>{doc.version}</code>
-        {acceptedCurrent && latest && (
-          <>
-            {" · "}Accepted on{" "}
-            {new Date(latest.acceptedAt).toLocaleDateString()}
-          </>
-        )}
-      </div>
+      <TermsMeta version={doc.version} accepted={latest.data} />
       <Markdown>{doc.text}</Markdown>
       <div className="mt-8 flex gap-3 items-center">
-        {blocking ? (
-          <button
-            type="button"
-            disabled={submitting}
-            onClick={() => void onAccept()}
-            className="bg-accent text-white px-4 py-2 rounded disabled:opacity-50"
-          >
-            {submitting ? "Accepting…" : "I accept the Terms of Use"}
-          </button>
+        {acceptedCurrent ? (
+          <BackButton />
         ) : (
-          <button
-            type="button"
-            onClick={() => setView("list")}
-            className="bg-accent text-white px-4 py-2 rounded"
-          >
-            Back
-          </button>
+          <AcceptButton
+            pending={accept.isPending}
+            onClick={() =>
+              accept.mutate(
+                { version: doc.version },
+                { onSuccess: () => window.location.assign("/") },
+              )
+            }
+          />
         )}
+      </div>
+    </div>
+  );
+}
+
+function TermsMeta({
+  version,
+  accepted,
+}: {
+  version: string;
+  accepted: LatestAcceptance | null | undefined;
+}) {
+  const isCurrent = accepted?.version === version;
+  return (
+    <div className="text-sm text-muted mb-6">
+      Version <code>{version}</code>
+      {isCurrent && accepted && (
+        <>
+          {" · "}Accepted on{" "}
+          {new Date(accepted.acceptedAt).toLocaleDateString()}
+        </>
+      )}
+    </div>
+  );
+}
+
+function AcceptButton({
+  pending,
+  onClick,
+}: {
+  pending: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={pending}
+      onClick={onClick}
+      className="bg-accent text-white px-4 py-2 rounded disabled:opacity-50"
+    >
+      {pending ? "Accepting…" : "I accept the Terms of Use"}
+    </button>
+  );
+}
+
+function BackButton() {
+  return (
+    <button
+      type="button"
+      onClick={() => window.location.assign("/")}
+      className="bg-accent text-white px-4 py-2 rounded"
+    >
+      Back
+    </button>
+  );
+}
+
+function CenteredMessage({
+  children,
+  tone = "muted",
+}: {
+  children: React.ReactNode;
+  tone?: "muted" | "error";
+}) {
+  return (
+    <div className="mx-auto w-full max-w-200 px-4 py-10">
+      <div className={tone === "error" ? "text-red-600" : "text-muted"}>
+        {children}
       </div>
     </div>
   );

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -1,0 +1,122 @@
+import type { TermsDocument } from "api-server-api";
+import { useEffect, useState } from "react";
+
+import { api } from "../../../api.js";
+import { Markdown } from "../../../components/markdown.js";
+import { useStore } from "../../../store.js";
+import {
+  fetchLatestAcceptance,
+  fetchTermsDocument,
+} from "../api/fetch-terms.js";
+
+type LatestAcceptance = {
+  version: string;
+  hash: string;
+  acceptedAt: string;
+};
+
+export function TermsView() {
+  const [doc, setDoc] = useState<TermsDocument | null>(null);
+  const [latest, setLatest] = useState<LatestAcceptance | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const setView = useStore((s) => s.setView);
+  const showToast = useStore((s) => s.showToast);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const [d, l] = await Promise.all([
+          fetchTermsDocument(),
+          fetchLatestAcceptance(),
+        ]);
+        setDoc(d);
+        setLatest(l);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Failed to load terms");
+      }
+    })();
+  }, []);
+
+  if (error) {
+    return (
+      <div className="mx-auto w-full max-w-[800px] px-4 py-10">
+        <div className="text-red-600">{error}</div>
+      </div>
+    );
+  }
+
+  if (!doc) {
+    return (
+      <div className="mx-auto w-full max-w-[800px] px-4 py-10">
+        <div className="text-muted">Loading…</div>
+      </div>
+    );
+  }
+
+  const acceptedCurrent = latest !== null && latest.version === doc.version;
+  const blocking = !acceptedCurrent;
+
+  async function onAccept() {
+    if (!doc) return;
+    setSubmitting(true);
+    try {
+      await api.terms.accept.mutate({ version: doc.version });
+      const refreshed = await fetchLatestAcceptance();
+      setLatest(refreshed);
+      showToast({ kind: "success", message: "Terms accepted." });
+      setView("list");
+    } catch (err) {
+      const message =
+        err instanceof Error ? err.message : "Failed to accept terms";
+      if (message.toLowerCase().includes("terms_stale")) {
+        const fresh = await fetchTermsDocument();
+        setDoc(fresh);
+        showToast({
+          kind: "error",
+          message: "Terms changed while you were reading. Please re-read.",
+        });
+      } else {
+        showToast({ kind: "error", message });
+      }
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-[800px] px-4 py-10">
+      <h1 className="text-2xl font-semibold mb-2">Terms of Use</h1>
+      <div className="text-sm text-muted mb-6">
+        Version <code>{doc.version}</code>
+        {acceptedCurrent && latest && (
+          <>
+            {" · "}Accepted on{" "}
+            {new Date(latest.acceptedAt).toLocaleDateString()}
+          </>
+        )}
+      </div>
+      <Markdown>{doc.text}</Markdown>
+      <div className="mt-8 flex gap-3 items-center">
+        {blocking ? (
+          <button
+            type="button"
+            disabled={submitting}
+            onClick={() => void onAccept()}
+            className="bg-accent text-white px-4 py-2 rounded disabled:opacity-50"
+          >
+            {submitting ? "Accepting…" : "I accept the Terms of Use"}
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setView("list")}
+            className="bg-accent text-white px-4 py-2 rounded"
+          >
+            Back
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Implements ADR-047 (#374). Hash-as-proof Terms of Use acceptance gate over every authenticated surface.

- New `terms` module: contract (tRPC `terms.current` / `terms.accept`), server (drizzle `terms_acceptances` PK `(sub, version)`, sha256 hash recorded per row), domain/services/infrastructure split per TS engineering conventions.
- Hono middleware on `/api/*` after auth returns 412 with `{ error: 'terms_stale', currentVersion, currentHash }`; exempts `/api/trpc/terms.*` and bootstrap paths; WS upgrade gated at upgrade only (live ACP/terminal survive bumps).
- `isAcceptedPort` injected into Slack worker (checks replier `keycloakSub`) and Telegram worker (checks thread `authorizedBy`) via composition root — no cross-module imports.
- UI tRPC client routes 412+`terms_stale` to `/terms`; dual-mode view (accept blocking / read-only with date). "View Terms of Use" link in Settings → Account.
- CLI throws `TermsStaleAtTransportError` from fetch wrapper; bin handler prints `Open <host> to accept` and exits 1.
- Helm `terms.{version,text}` required; chart validator fails fast when unset; dev `cluster:install` ships placeholder defaults.

## Test plan

- [x] `mise run check` clean (lint + typecheck across all packages)
- [x] `mise run test` green (api-server, cli, ui)
- [x] `mise run helm:check:lint` + `mise run helm:check:render` pass
- [x] Chart validator: `helm template platform .` without `terms.*` fails with the ADR-047 pointer
- [x] First login: UI lands on `/terms`, accept clears the gate, normal flow resumes
- [x] Bump `terms.version`: every existing user re-prompted; live WS sessions keep running
- [x] CLI: any tRPC call from a stale user exits 1 with `open <host> to accept`
- [x] Slack: foreign reply by a stale user gets ephemeral bounce, no fork spawned
- [x] Telegram DM: stale `authorizedBy` gets ephemeral bounce; groups stay silent