### PR TITLE
feat(cluster): add cluster:helm task for chart-only redeploys

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -360,17 +360,24 @@ YAML
 kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mode=ambient --overwrite
 
 # 3. Load images into k3s (built by depends: image:*)
-echo "Loading images into k3s..."
-tar="/tmp/platform-images.tar"
-docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-codex:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest
-if [ -n "${IS_SANDBOX:-}" ]; then
-  [ -z "${CI:-}" ] && docker image prune --all --force >/dev/null 2>&1 || true
-  sudo k3s ctr images import "$tar"
+# SKIP_IMAGE_BUILD also skips the load: image:* tasks already no-op'd, so
+# there's nothing new in docker to ship. Pods keep running their pinned SHAs.
+if [ -n "${SKIP_IMAGE_BUILD:-}" ]; then
+  echo "Skipping image load (SKIP_IMAGE_BUILD set)"
+  NO_RESTART=true
 else
-  limactl copy "$tar" "$LIMA_INSTANCE":"$tar"
-  limactl shell "$LIMA_INSTANCE" sudo k3s ctr images import "$tar"
+  echo "Loading images into k3s..."
+  tar="/tmp/platform-images.tar"
+  docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-codex:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest
+  if [ -n "${IS_SANDBOX:-}" ]; then
+    [ -z "${CI:-}" ] && docker image prune --all --force >/dev/null 2>&1 || true
+    sudo k3s ctr images import "$tar"
+  else
+    limactl copy "$tar" "$LIMA_INSTANCE":"$tar"
+    limactl shell "$LIMA_INSTANCE" sudo k3s ctr images import "$tar"
+  fi
+  rm -f "$tar"
 fi
-rm -f "$tar"
 
 # 4. Helm install or upgrade
 # Dev-cluster defaults (overridable via --set)
@@ -439,6 +446,15 @@ echo "=== Cluster ready ==="
 echo "KUBECONFIG=$KUBECONFIG"
 echo ""
 kubectl --kubeconfig="$KUBECONFIG" get pods
+'''
+
+["cluster:helm"]
+description = "Redeploy chart only (no image rebuild, no image load, no pod restart). Use for values/template/secret changes. Forwards extra args to cluster:install."
+dir = "{{config_root}}"
+raw = true
+run = '''
+#!/usr/bin/env bash
+exec env SKIP_IMAGE_BUILD=1 mise run cluster:install "$@"
 '''
 
 ["cluster:build-apiserver"]


### PR DESCRIPTION
## Summary
- Adds `mise run cluster:helm` for redeploying the chart without rebuilding images or running the multi-GB `docker save` → `limactl copy` → `k3s ctr import` roundtrip.
- `SKIP_IMAGE_BUILD` now also gates the image-load block in `cluster:install` and implies `--no-restart` (pointless to bounce pods if `:latest` digests didn't move).
- Use case: iterating on Helm values, templates, or secrets without paying the image pipeline cost.

## Test plan
- [x] `mise run cluster:helm` on an already-installed cluster completes and skips image rebuild + load
- [x] `mise run cluster:install` still does the full rebuild + load + restart