### PR TITLE
chore(skill): react-ui-engineering — no code comments

### DIFF
--- a/.agents/skills/react-ui-engineering/SKILL.md
+++ b/.agents/skills/react-ui-engineering/SKILL.md
@@ -15,7 +15,7 @@ This skill is the rulebook Claude applies when touching React+TS UI code. It is 
 2. **Separation by lineage** — state is classified by where its source of truth lives (server, UI, local, URL). Each has a designated home. Mixing lineages is the single biggest driver of drift.
 3. **Small surface, small files** — a component or hook that can't be held in working memory is a bug report waiting to happen. Split aggressively along responsibilities.
 4. **Meaningful names** — variables, functions, components, hooks, and types carry intent in their names. `selectedAgentId` over `sel`; `hasUnsavedChanges` over `flag`; `calculateMonthlyTotal` over `calc`; `useFilteredAgents` over `useData`. A well-named identifier removes the need for a comment. Naming is the cheapest documentation you can write.
-5. **No unnecessary comments** — code explains *what* through clear names and structure. Comments explain *why* only when the reason isn't obvious from the code itself: a subtle invariant, a non-obvious constraint, a workaround tied to a specific bug. Keep them brief — one line, usually. If you can rename a variable or restructure a block to remove the need for a comment, do that instead. Never narrate what the next line already says.
+5. **No code comments** — code explains itself through clear names and structure. If you reach for a comment, rename or restructure until you don't need it. The only acceptable exceptions are linter escape hatches (`@ts-expect-error`, `eslint-disable-next-line`) where the directive itself is a comment — those carry the minimum reason needed for the disable to make sense and nothing more.
 6. **Types at boundaries, not assertions** — `any`, `as`, and untyped fetch responses are how large codebases rot. Prefer Zod inference and type guards.
 
 ---
@@ -55,8 +55,7 @@ Each of these is expanded in a reference file. Severity in brackets.
 
 ### Code style (applies everywhere)
 - [HIGH] Names carry intent. Variables, functions, types, and components are named for what they represent, not for their type, position, or abbreviation (`selectedAgentId` not `sel`, `handleSubmit` not `h`, `Agent` not `Data`, `hasPendingChanges` not `dirty`). If you're reaching for a comment to explain a name, rename it.
-- [HIGH] Comments explain *why*, not *what*. Add a brief comment only when code contains something a future reader couldn't infer: a subtle invariant, a workaround for a specific bug, a constraint from an external system. Delete comments that restate the code.
-- [MODERATE] One line is enough for most comments. Multi-paragraph docstrings and block comments are almost always a sign that the code itself should be clearer.
+- [CRITICAL] No code comments. Rename, restructure, or extract until the code reads on its own. The only acceptable exceptions are linter escape hatches (`@ts-expect-error`, `eslint-disable-next-line`) — the directive's reason is the minimum needed to interpret the disable, not narration.
 - [MODERATE] Destructure when a path repeats in a scope. `schedule.status.lastRun`, `schedule.status.nextRun`, `schedule.status.lastResult` → `const { lastRun, nextRun, lastResult } = status;` (after the guard that narrows `status`). Single-use access stays inline — don't destructure for its own sake. See `references/components.md`.
 
 ### Structure & files
@@ -95,7 +94,7 @@ Each of these is expanded in a reference file. Severity in brackets.
 
 ### Types
 - [CRITICAL] No `any` at module boundaries. Use `unknown` + narrowing or proper types. See `references/types.md`.
-- [HIGH] `as` only when a type guard cannot express the narrowing. When you must use `as`, a one-line comment explains why.
+- [HIGH] `as` only when a type guard cannot express the narrowing. If you reach for `as`, try narrowing first; refactor the call site to make the guard expressible. No comment justifying the assertion — if it's the right call, it's the right call without prose.
 - [HIGH] Export types inferred from Zod schemas (`export type Agent = z.infer<typeof agentSchema>`) — single source of truth.
 
 ### Styling

--- a/.agents/skills/react-ui-engineering/references/async-data.md
+++ b/.agents/skills/react-ui-engineering/references/async-data.md
@@ -181,7 +181,7 @@ const createAgent = useCreateAgent({ onSuccess: () => closeDialog() });
 
 **[CRITICAL] Use `meta.invalidates`.** Do not call `queryClient.invalidateQueries()` by hand inside `onSuccess` — the MutationCache handler does it centrally for every mutation.
 
-If a mutation needs to invalidate something that depends on its *response* (e.g., an id returned by the server), the handler supports functions too — extend the MutationCache `onSuccess` to accept a function form (`invalidates: (data) => [...]`). Or call `queryClient.invalidateQueries` in the mutation's own `onSuccess` when truly dynamic — exception documented with a one-line comment.
+If a mutation needs to invalidate something that depends on its *response* (e.g., an id returned by the server), the handler supports functions too — extend the MutationCache `onSuccess` to accept a function form (`invalidates: (data) => [...]`). Or call `queryClient.invalidateQueries` in the mutation's own `onSuccess` when truly dynamic.
 
 ### Optimistic updates
 

--- a/.agents/skills/react-ui-engineering/references/hooks.md
+++ b/.agents/skills/react-ui-engineering/references/hooks.md
@@ -115,7 +115,7 @@ export function useFilteredAgents(filter: string) {
 
 ## Dependencies
 
-**[CRITICAL] Declare exhaustive dependency arrays** (`react-hooks/exhaustive-deps` lint, once ESLint is set up). When you genuinely need to omit a dep, leave a one-line comment explaining why — not a `// eslint-disable` alone.
+**[CRITICAL] Declare exhaustive dependency arrays** (`react-hooks/exhaustive-deps` lint, once ESLint is set up). If you think you need to omit a dep, the dependency is wrong — restructure (destructure the stable field, lift the value, extract a hook) until exhaustive-deps is satisfied without disabling the rule. Never `// eslint-disable` exhaustive-deps.
 
 **Stable references** for callbacks passed to children: wrap in `useCallback` only when the callback is in a dependency array of a child hook/memo, or the child is memoized. Wrapping every handler is cargo-culted noise.
 

--- a/.agents/skills/react-ui-engineering/references/types.md
+++ b/.agents/skills/react-ui-engineering/references/types.md
@@ -91,12 +91,12 @@ For errors:
 1. **Type guards** (`isAgent(x)` returns `x is Agent`).
 2. **Zod parsing** at boundaries (`agentSchema.parse(raw)`).
 3. **Discriminated unions** with `match` / `switch` on a `type` field.
-4. **Only then** `as`, with a comment explaining why.
+4. **Only then** `as`.
 
 Allowed `as` patterns:
 - **`as const`** for literal-type narrowing — totally fine.
 - **`as CSSProperties`** when React's type for `style` is stricter than CSS custom properties allow. Fine.
-- **Narrowing after an `if` you can't express in TS** — acceptable with a comment.
+- **Narrowing after an `if` you can't express in TS** — acceptable, but reach for a type guard first.
 
 ```ts
 ✅ const tuple = ["hello", 42] as const;
@@ -180,10 +180,10 @@ See `references/api-layer.md` for the end-to-end error contract.
 
 ## Anti-patterns
 
-- **`any` anywhere except in a temporary migration comment with a `TODO` deadline.**
+- **`any` anywhere.** If you can't type it now, leave it `unknown` and narrow.
 - **`as` used to "shut up the compiler"** — the compiler is telling you something is off.
 - **Non-null assertions (`x!`, `undefined!`)** — same smell as `as`, just narrower. If the value really can't be null, prove it with a guard or refactor the API; if it can, handle it.
-- **`@ts-ignore` / `@ts-expect-error`** without a comment explaining why — if it's needed, it's needed *and* explained.
+- **`@ts-ignore` / `@ts-expect-error`** without the minimum reason in the directive — if it's needed, the reason rides on the disable itself and stays short.
 - **Redundant annotations** (`const name: string = getName()` when `getName` is typed).
 - **Missing types on exported function parameters** — always annotate the public surface.
 - **`type Props = {}`** (empty props) — omit the parameter.


### PR DESCRIPTION
## Summary

Closes the "brief why-comments are fine" loophole in the react-ui-engineering skill. The old wording let a brief why-comment slip into PR #378's UI changes; this aligns the skill with the no-comments policy used elsewhere.

Changes:
- `SKILL.md` principle #5 + the matching top-level rule → **[CRITICAL] No code comments.** Rename / restructure / extract instead. Linter escape hatches (`@ts-expect-error`, `eslint-disable-next-line`) remain the sole exception because the directive itself is a comment by syntax.
- `SKILL.md` `as` rule: drop "with a comment explaining why".
- `references/async-data.md`: drop "exception documented with a one-line comment" for the dynamic-invalidation case.
- `references/hooks.md`: never `eslint-disable` exhaustive-deps; restructure (destructure the stable field, extract a hook, lift the value) until the rule is satisfied.
- `references/types.md`: drop "with a comment" allowance for `as`; for `@ts-ignore` / `@ts-expect-error` the reason rides the directive, not separate narration.

## Test plan
- [ ] Re-read `SKILL.md` lines 17–18 and 56–58 — no remaining "brief why-comment" carve-outs
- [ ] `grep -rn "comment" .agents/skills/react-ui-engineering/` shows only references that push *away* from comments