### PR TITLE
feat(helm): enable pi-agent template by default

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -600,6 +600,16 @@ agentTemplates:
       tag: ""
     storageSize: "5Gi"
 
+  - name: pi-agent
+    enabled: true
+    description: "Pi coding agent with multi-LLM support"
+    image:
+      repository: quay.io/dam-agents/pi-agent
+      tag: ""
+    storageSize: "5Gi"
+    skillPaths:
+      - $HOME/.pi/agent/skills/
+
   - name: bob
     enabled: true
     description: "Bob shell agent"


### PR DESCRIPTION
## Summary

- Add `pi-agent` to the default `agentTemplates` in `deploy/helm/platform/values.yaml` so staging (and any consumer of the chart defaults) renders a `pi-agent` agent-template ConfigMap.
- The image is already built and pushed by `.github/workflows/cd.yml` (`quay.io/dam-agents/pi-agent`); only the template entry was missing, which is why pi-agent never showed up in staging deployments.
- Mirrors the shape of the existing `claude-code` / `codex` entries (empty `tag` falls back to chart `appVersion`, `5Gi` storage) and carries over the `$HOME/.pi/agent/skills/` skill path from `values-local.yaml`.

## Test plan

- [ ] `mise run helm:check:lint`
- [ ] `mise run helm:check:render` — confirm a `platform-pi-agent` AgentTemplate ConfigMap is rendered with defaults
- [ ] Staging deploy: verify the `pi-agent` template appears in `agentNamespace` and can spawn an agent
- [ ] Confirm staging has `OPENAI_API_KEY` / `OPENAI_BASE_URL` secrets seeded before users launch pi-agent (needed for its LiteLLM-routed multi-LLM support)