### PR TITLE
fix(pi-agent): hide built-in openai provider when proxied

### DIFF
--- a/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-dynamic-providers/index.ts
+++ b/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-dynamic-providers/index.ts
@@ -13,11 +13,21 @@ declare const process: { env: Record<string, string | undefined> };
 type ProviderSpec = {
 	name: string;
 	envPrefix: string;
+	// If this spec activates and ${envPrefix}_URL matches the shadow's urlEnv,
+	// hide the named provider as a duplicate alias. apiKeyEnv is unset so
+	// built-in providers (whose auth is discovered via pi-ai env-api-keys) are
+	// filtered out of getAvailable() — pi.unregisterProvider() alone only
+	// affects dynamically-registered providers.
+	shadows?: { name: string; urlEnv: string; apiKeyEnv?: string }[];
 };
 
 const SPECS: ProviderSpec[] = [
 	{ name: "rits", envPrefix: "RITS" },
-	{ name: "openai-proxy", envPrefix: "OPENAI_PROXY" },
+	{
+		name: "openai-proxy",
+		envPrefix: "OPENAI_PROXY",
+		shadows: [{ name: "openai", urlEnv: "OPENAI_BASE_URL", apiKeyEnv: "OPENAI_API_KEY" }],
+	},
 ];
 
 export default function register(pi: ExtensionAPI): void {
@@ -93,6 +103,15 @@ export default function register(pi: ExtensionAPI): void {
 		modelsFile.providers[spec.name] = provider;
 		authFile[spec.name] = { type: "api_key", key: apiKey };
 		lastActivated = { name: spec.name, model };
+
+		for (const shadow of spec.shadows ?? []) {
+			const shadowUrl = env(shadow.urlEnv)?.replace(/\/+$/, "");
+			if (!shadowUrl || shadowUrl !== url) continue;
+			pi.unregisterProvider(shadow.name);
+			delete modelsFile.providers[shadow.name];
+			delete authFile[shadow.name];
+			if (shadow.apiKeyEnv) delete process.env[shadow.apiKeyEnv];
+		}
 	}
 
 	if (!lastActivated) return;


### PR DESCRIPTION
## Summary

When `OPENAI_PROXY_URL` points at the same endpoint as `OPENAI_BASE_URL`, the pi-agent UI listed the entire built-in OpenAI model catalog as duplicates of the single `openai-proxy` model. Filtering them out turned out to be more than a `pi.unregisterProvider()` call:

- `pi.unregisterProvider()` only affects **dynamically-registered** providers, so it can't remove the built-in `openai` provider that ships in `@mariozechner/pi-ai`.
- Those built-in models stay "available" because `ModelRegistry.getAvailable()` filters on `hasConfiguredAuth()`, which discovers `OPENAI_API_KEY` via pi-ai's `env-api-keys` lookup — regardless of what's in `models.json`/`auth.json`.

## Changes

- Add a generic per-spec `shadows` list to the dynamic-providers extension. When an activated spec's URL matches a shadow's `urlEnv`, the extension:
  - calls `pi.unregisterProvider(shadow.name)`,
  - drops the shadow from the mirrored `models.json` / `auth.json`,
  - unsets the shadow's `apiKeyEnv` so the built-in provider falls out of `getAvailable()`.
- Wire up `openai` as a shadow of `openai-proxy` (`urlEnv: OPENAI_BASE_URL`, `apiKeyEnv: OPENAI_API_KEY`).

## Test plan

- [x] `mise run check` passes
- [x] Rebuilt the agent image (`mise run cluster:build-agent`) and verified in-pod: `pi --list-models` and the `--mode rpc` `get_available_models` path both return only `openai-proxy` (no built-in OpenAI models)
- [x] Confirmed in the UI that the duplicate OpenAI models no longer appear