### PR TITLE
feat: allow sending images through slack

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Users can also author skills in the Files panel and publish them upstream as pul
 
 Platform runs a single Slack app (Socket Mode) for the entire installation. Multiple instances can share a channel — the bot routes messages per thread.
 
-1. [Create a Slack app](https://api.slack.com/apps) with Socket Mode enabled and bot/user token scopes: `app_mentions:read`, `channels:history`, `chat:write`, `files:write`, `reactions:write`, `commands`, `users:read`. (`files:write` powers outbound file attachments via the `send_channel_message` MCP tool — existing installations must add it and have admins re-approve.)
+1. [Create a Slack app](https://api.slack.com/apps) with Socket Mode enabled and bot/user token scopes: `app_mentions:read`, `channels:history`, `chat:write`, `files:read`, `files:write`, `reactions:write`, `commands`, `users:read`. (`files:write` powers outbound file attachments via the `send_channel_message` MCP tool; `files:read` lets the worker download user-attached images so the agent can see them. Existing installations must add both and have admins re-approve.)
 2. Add slash command `/platform` pointing to your app.
 3. Generate an app-level token (`xapp-...`) with `connections:write` scope. Deploy with both tokens:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ Users can also author skills in the Files panel and publish them upstream as pul
 
 Platform runs a single Slack app (Socket Mode) for the entire installation. Multiple instances can share a channel — the bot routes messages per thread.
 
-1. [Create a Slack app](https://api.slack.com/apps) with Socket Mode enabled and bot/user token scopes: `app_mentions:read`, `channels:history`, `chat:write`, `files:read`, `files:write`, `reactions:write`, `commands`, `users:read`. (`files:write` powers outbound file attachments via the `send_channel_message` MCP tool; `files:read` lets the worker download user-attached images so the agent can see them. Existing installations must add both and have admins re-approve.)
+1. [Create a Slack app](https://api.slack.com/apps) with Socket Mode enabled and bot/user token scopes: `app_mentions:read`, `channels:history`, `chat:write`, `files:read`, `files:write`, `reactions:write`, `commands`, `users:read`.
 2. Add slash command `/platform` pointing to your app.
 3. Generate an app-level token (`xapp-...`) with `connections:write` scope. Deploy with both tokens:
 

--- a/packages/api-server/src/core/acp-client.ts
+++ b/packages/api-server/src/core/acp-client.ts
@@ -2,6 +2,10 @@ import { WebSocket } from "ws";
 import { ClientSideConnection } from "@agentclientprotocol/sdk/dist/acp.js";
 import type { Stream } from "@agentclientprotocol/sdk/dist/stream.js";
 import type { AnyMessage } from "@agentclientprotocol/sdk/dist/jsonrpc.js";
+import type {
+  ContentBlock,
+  InitializeResponse,
+} from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { podBaseUrl } from "../modules/agents/infrastructure/k8s.js";
 
 const TIMEOUT_MS = 120_000;
@@ -58,7 +62,10 @@ type SessionAttach =
   | { resumeSessionId: string }
   | { onSessionCreated: (sessionId: string) => Promise<void> };
 
-export type SendPromptOpts = SessionAttach;
+export type SendPromptOpts = SessionAttach & {
+  /** Called when image blocks are stripped because the agent lacks image support. */
+  onImagesDropped?: () => Promise<void> | void;
+};
 
 export type TriggerSessionOpts = {
   prompt: string;
@@ -67,7 +74,10 @@ export type TriggerSessionOpts = {
 
 export interface AcpClient {
   listSessions(): Promise<AcpSessionInfo[]>;
-  sendPrompt(prompt: string, opts: SendPromptOpts): Promise<string>;
+  sendPrompt(
+    prompt: string | ContentBlock[],
+    opts: SendPromptOpts,
+  ): Promise<string>;
   triggerSession(opts: TriggerSessionOpts): Promise<TriggerSessionResult>;
 }
 
@@ -75,7 +85,10 @@ async function withAcpConnection<T>(
   url: string,
   clientName: string,
   handlers: { sessionUpdate?: (params: any) => Promise<void> },
-  fn: (connection: ClientSideConnection) => Promise<T>,
+  fn: (
+    connection: ClientSideConnection,
+    init: InitializeResponse,
+  ) => Promise<T>,
 ): Promise<T> {
   const { stream, ws } = await wsStream(url);
 
@@ -122,13 +135,13 @@ async function withAcpConnection<T>(
 
   try {
     ac.signal.addEventListener("abort", cleanup, { once: true });
-    await connection.initialize({
+    const init = await connection.initialize({
       protocolVersion: 1,
       clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
       clientInfo: { name: clientName, version: "1.0.0" },
     });
     return await Promise.race([
-      fn(connection),
+      fn(connection, init),
       new Promise<never>((_, reject) => {
         if (ac.signal.aborted) {
           reject(
@@ -218,7 +231,7 @@ function createAcpClientForUrl(url: string): AcpClient {
     },
 
     async sendPrompt(
-      prompt: string,
+      prompt: string | ContentBlock[],
       sendOpts: SendPromptOpts,
     ): Promise<string> {
       const responseChunks: string[] = [];
@@ -236,7 +249,7 @@ function createAcpClientForUrl(url: string): AcpClient {
             }
           },
         },
-        async (connection) => {
+        async (connection, init) => {
           let sessionId: string;
           if ("resumeSessionId" in sendOpts) {
             // loadSession (not unstable_resumeSession) survives the agent-runtime's
@@ -256,10 +269,23 @@ function createAcpClientForUrl(url: string): AcpClient {
             sessionId = s.sessionId;
             await sendOpts.onSessionCreated(sessionId);
           }
-          await connection.prompt({
-            sessionId,
-            prompt: [{ type: "text", text: prompt }],
-          });
+
+          const blocks: ContentBlock[] =
+            typeof prompt === "string"
+              ? [{ type: "text", text: prompt }]
+              : prompt;
+          const supportsImages =
+            init.agentCapabilities?.promptCapabilities?.image === true;
+          const hasImages = blocks.some((b) => b.type === "image");
+          const finalBlocks =
+            hasImages && !supportsImages
+              ? blocks.filter((b) => b.type !== "image")
+              : blocks;
+          if (hasImages && !supportsImages) {
+            await sendOpts.onImagesDropped?.();
+          }
+
+          await connection.prompt({ sessionId, prompt: finalBlocks });
         },
       );
 
@@ -273,7 +299,7 @@ function createAcpClientForUrl(url: string): AcpClient {
         url,
         "platform-trigger",
         {},
-        async (connection) => {
+        async (connection, _init) => {
           let sessionId: string;
           const mcpServers = (triggerOpts.mcpServers ?? []) as any[];
 

--- a/packages/api-server/src/events.ts
+++ b/packages/api-server/src/events.ts
@@ -1,5 +1,6 @@
 import { Subject, type Observable } from "rxjs";
 import { filter } from "rxjs/operators";
+import type { ContentBlock } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 
 // ---------------------------------------------------------------------------
 // Domain events — write-side only
@@ -119,7 +120,7 @@ export type ForeignReplyReceived = {
   foreignSub: string;
   threadTs: string;
   sessionId?: string;
-  prompt: string;
+  prompt: string | ContentBlock[];
   slackContext: {
     channelId: string;
     userSlackId: string;

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -175,7 +175,9 @@ export function createSlackWorker(
     try {
       await app.client.chat.postEphemeral({ channel, user, text });
     } catch (err) {
-      process.stderr.write(`[slack] postEphemeral failed: ${formatError(err)}\n`);
+      process.stderr.write(
+        `[slack] postEphemeral failed: ${formatError(err)}\n`,
+      );
     }
   }
 
@@ -257,7 +259,9 @@ export function createSlackWorker(
       );
       outcome = "success";
     } catch (err) {
-      process.stderr.write(`[${instanceName}] ACP error: ${formatError(err)}\n`);
+      process.stderr.write(
+        `[${instanceName}] ACP error: ${formatError(err)}\n`,
+      );
       await app.client.chat.postMessage({
         channel: ctx.channel,
         thread_ts: ctx.threadTs,
@@ -514,10 +518,7 @@ export function createSlackWorker(
     const text = parts.join("\n\n");
 
     if (ctx.images.length === 0) return text;
-    return [
-      { type: "text", text },
-      ...ctx.images.map((i) => i.block),
-    ];
+    return [{ type: "text", text }, ...ctx.images.map((i) => i.block)];
   }
 
   async function handleCommand({ command, ack }: SlackCommandMiddlewareArgs) {

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -9,6 +9,7 @@ import { match, P } from "ts-pattern";
 import { ChannelType, SessionType, type AgentsService } from "api-server-api";
 import type { StoredChannelConfig } from "../stored-channel.js";
 import type { PostMessageOptions } from "../services/channel-manager.js";
+import type { ContentBlock } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import {
   createAcpClient,
   createForkAcpClient,
@@ -34,6 +35,54 @@ import { formatError } from "../../../core/format-error.js";
 type BoltApp = InstanceType<typeof App>;
 
 const FORK_OUTCOME_TIMEOUT_MS = 2 * 60_000;
+
+type SlackImageFile = {
+  id: string;
+  name: string;
+  mimetype: string;
+  url_private: string;
+  size: number;
+};
+
+export type FetchedImage = {
+  block: ContentBlock;
+  meta: { name: string; size: number };
+};
+
+type FetchedFailure = { name: string; reason: string };
+
+async function fetchSlackImages(
+  botToken: string,
+  files: SlackImageFile[] | undefined,
+): Promise<{ images: FetchedImage[]; failures: FetchedFailure[] }> {
+  const images: FetchedImage[] = [];
+  const failures: FetchedFailure[] = [];
+  for (const f of files ?? []) {
+    if (!f.mimetype?.startsWith("image/")) continue;
+    try {
+      const res = await fetch(f.url_private, {
+        headers: { Authorization: `Bearer ${botToken}` },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = Buffer.from(await res.arrayBuffer()).toString("base64");
+      images.push({
+        block: { type: "image", data, mimeType: f.mimetype },
+        meta: { name: f.name, size: f.size },
+      });
+    } catch (err) {
+      failures.push({ name: f.name, reason: formatError(err) });
+    }
+  }
+  return { images, failures };
+}
+
+function renderTurnFiles(images: FetchedImage[]): string {
+  if (images.length === 0) return "";
+  const list = images
+    .map((i) => `${i.meta.name} (${(i.meta.size / 1_000_000).toFixed(1)} MB)`)
+    .join(", ");
+  return `\nTurn included: ${list}.`;
+}
 
 async function getContextMessages(
   app: BoltApp,
@@ -121,6 +170,15 @@ export function createSlackWorker(
 ): SlackWorker {
   let app: BoltApp | null = null;
 
+  async function ephemeral(channel: string, user: string, text: string) {
+    if (!app) return;
+    try {
+      await app.client.chat.postEphemeral({ channel, user, text });
+    } catch (err) {
+      process.stderr.write(`[slack] postEphemeral failed: ${formatError(err)}\n`);
+    }
+  }
+
   async function relayOwnerTurn(ctx: {
     instanceName: string;
     channel: string;
@@ -129,6 +187,8 @@ export function createSlackWorker(
     text: string;
     hasThread: boolean;
     actorSub: string;
+    slackUserId: string;
+    images: FetchedImage[];
   }) {
     if (!app) return;
     const { instanceName } = ctx;
@@ -140,6 +200,12 @@ export function createSlackWorker(
     });
 
     let outcome: TurnOutcome = "failure";
+    const onImagesDropped = () =>
+      ephemeral(
+        ctx.channel,
+        ctx.slackUserId,
+        "This agent can't process images yet — answering text only.",
+      );
     try {
       await agents().ensureReady(instanceName);
       const acp = createAcpClient({ namespace, instanceName });
@@ -153,20 +219,34 @@ export function createSlackWorker(
 
       let response: string;
       const existing = await threadSessions.find(instanceName, ctx.threadTs);
+      const resumePrompt: string | ContentBlock[] =
+        ctx.images.length === 0
+          ? ctx.text
+          : [
+              { type: "text", text: ctx.text },
+              ...ctx.images.map((i) => i.block),
+            ];
 
       if (existing) {
         try {
-          response = await acp.sendPrompt(ctx.text, {
+          response = await acp.sendPrompt(resumePrompt, {
             resumeSessionId: existing.sessionId,
+            onImagesDropped,
           });
           await threadSessions.touch(existing.sessionId);
         } catch {
           const prompt = await buildThreadPrompt(app, ctx);
-          response = await acp.sendPrompt(prompt, { onSessionCreated });
+          response = await acp.sendPrompt(prompt, {
+            onSessionCreated,
+            onImagesDropped,
+          });
         }
       } else {
         const prompt = await buildThreadPrompt(app, ctx);
-        response = await acp.sendPrompt(prompt, { onSessionCreated });
+        response = await acp.sendPrompt(prompt, {
+          onSessionCreated,
+          onImagesDropped,
+        });
       }
 
       await postAssistantMessage(
@@ -177,11 +257,11 @@ export function createSlackWorker(
       );
       outcome = "success";
     } catch (err) {
-      process.stderr.write(`[${instanceName}] ACP error: ${err}\n`);
+      process.stderr.write(`[${instanceName}] ACP error: ${formatError(err)}\n`);
       await app.client.chat.postMessage({
         channel: ctx.channel,
         thread_ts: ctx.threadTs,
-        text: `Error: ${formatError(err)}`,
+        text: `Error: ${formatError(err)}.${renderTurnFiles(ctx.images)}`,
       });
     } finally {
       emit({
@@ -224,6 +304,7 @@ export function createSlackWorker(
     instanceName: string;
     text: string;
     hasThread: boolean;
+    images: FetchedImage[];
   }) {
     if (!app) return;
 
@@ -239,6 +320,7 @@ export function createSlackWorker(
       eventTs: args.eventTs,
       text: args.text,
       hasThread: args.hasThread,
+      images: args.images,
     });
     const existing = await threadSessions.find(
       args.instanceName,
@@ -266,6 +348,7 @@ export function createSlackWorker(
             slackUserId: args.slackUserId,
             actorSub: args.keycloakSub,
             prompt,
+            images: args.images,
             existingSessionId,
           }).catch((err) => {
             process.stderr.write(
@@ -316,7 +399,8 @@ export function createSlackWorker(
       instanceName: string;
       slackUserId: string;
       actorSub: string;
-      prompt: string;
+      prompt: string | ContentBlock[];
+      images: FetchedImage[];
       existingSessionId: string | undefined;
     },
   ) {
@@ -326,11 +410,18 @@ export function createSlackWorker(
     await match(outcome)
       .with({ type: EventType.ForkReady }, async (event) => {
         let turnOutcome: TurnOutcome = "failure";
+        const onImagesDropped = () =>
+          ephemeral(
+            ctx.channel,
+            ctx.slackUserId,
+            "This agent can't process images yet — answering text only.",
+          );
         try {
           const acp = createForkAcpClient({ podIP: event.podIP });
           const response = ctx.existingSessionId
             ? await acp.sendPrompt(ctx.prompt, {
                 resumeSessionId: ctx.existingSessionId,
+                onImagesDropped,
               })
             : await acp.sendPrompt(ctx.prompt, {
                 onSessionCreated: (sid) =>
@@ -340,6 +431,7 @@ export function createSlackWorker(
                     SessionType.ChannelSlack,
                     ctx.threadTs,
                   ),
+                onImagesDropped,
               });
           if (ctx.existingSessionId)
             await threadSessions.touch(ctx.existingSessionId);
@@ -352,12 +444,12 @@ export function createSlackWorker(
           turnOutcome = "success";
         } catch (err) {
           process.stderr.write(
-            `[slack/fork ${event.forkId}] ACP error: ${err}\n`,
+            `[slack/fork ${event.forkId}] ACP error: ${formatError(err)}\n`,
           );
           await bolt.client.chat.postMessage({
             channel: ctx.channel,
             thread_ts: ctx.threadTs,
-            text: `Error: ${formatError(err)}`,
+            text: `Error: ${formatError(err)}.${renderTurnFiles(ctx.images)}`,
           });
         } finally {
           emit({
@@ -405,8 +497,9 @@ export function createSlackWorker(
       eventTs: string;
       text: string;
       hasThread: boolean;
+      images: FetchedImage[];
     },
-  ): Promise<string> {
+  ): Promise<string | ContentBlock[]> {
     const contextMessages = await getContextMessages(
       boltApp,
       ctx.channel,
@@ -418,7 +511,13 @@ export function createSlackWorker(
       parts.push(`<context>\n${contextMessages.join("\n")}\n</context>`);
     }
     parts.push(ctx.text);
-    return parts.join("\n\n");
+    const text = parts.join("\n\n");
+
+    if (ctx.images.length === 0) return text;
+    return [
+      { type: "text", text },
+      ...ctx.images.map((i) => i.block),
+    ];
   }
 
   async function handleCommand({ command, ack }: SlackCommandMiddlewareArgs) {
@@ -502,6 +601,18 @@ export function createSlackWorker(
       return;
     }
 
+    const { images, failures } = await fetchSlackImages(
+      botToken,
+      (event as { files?: SlackImageFile[] }).files,
+    );
+    for (const f of failures) {
+      await ephemeral(
+        event.channel,
+        slackUserId,
+        `Couldn't fetch attached image '${f.name}': ${f.reason}. Try resending.`,
+      );
+    }
+
     await routeReply({
       channel: event.channel,
       threadTs,
@@ -511,6 +622,7 @@ export function createSlackWorker(
       slackUserId,
       keycloakSub,
       instanceName,
+      images,
     });
   }
 
@@ -523,6 +635,7 @@ export function createSlackWorker(
     slackUserId: string;
     keycloakSub: string;
     instanceName: string;
+    images: FetchedImage[];
   }) {
     if (!app) return;
 
@@ -562,6 +675,8 @@ export function createSlackWorker(
       text: args.text,
       hasThread: args.hasThread,
       actorSub: args.keycloakSub,
+      slackUserId: args.slackUserId,
+      images: args.images,
     });
   }
 

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -51,29 +51,69 @@ export type FetchedImage = {
 
 type FetchedFailure = { name: string; reason: string };
 
+type FetchImagesResult =
+  | { kind: "ok"; images: FetchedImage[]; failures: FetchedFailure[] }
+  | { kind: "cap_exceeded"; totalBytes: number; count: number };
+
+const TOTAL_IMAGE_BYTES_CAP = 30 * 1_000_000;
+const CONCURRENT_IMAGE_FETCH_LIMIT = 10;
+
+function createSemaphore(max: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  return {
+    async acquire(): Promise<() => void> {
+      if (active < max) active++;
+      else await new Promise<void>((r) => queue.push(r));
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        const next = queue.shift();
+        if (next) next();
+        else active--;
+      };
+    },
+  };
+}
+
+const imageFetchSemaphore = createSemaphore(CONCURRENT_IMAGE_FETCH_LIMIT);
+
 async function fetchSlackImages(
   botToken: string,
   files: SlackImageFile[] | undefined,
-): Promise<{ images: FetchedImage[]; failures: FetchedFailure[] }> {
-  const images: FetchedImage[] = [];
-  const failures: FetchedFailure[] = [];
-  for (const f of files ?? []) {
-    if (!f.mimetype?.startsWith("image/")) continue;
-    try {
-      const res = await fetch(f.url_private, {
-        headers: { Authorization: `Bearer ${botToken}` },
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      const data = Buffer.from(await res.arrayBuffer()).toString("base64");
-      images.push({
-        block: { type: "image", data, mimeType: f.mimetype },
-        meta: { name: f.name, size: f.size },
-      });
-    } catch (err) {
-      failures.push({ name: f.name, reason: formatError(err) });
-    }
+): Promise<FetchImagesResult> {
+  const imageFiles = (files ?? []).filter((f) =>
+    f.mimetype?.startsWith("image/"),
+  );
+  const totalBytes = imageFiles.reduce((sum, f) => sum + (f.size ?? 0), 0);
+  if (totalBytes > TOTAL_IMAGE_BYTES_CAP) {
+    return { kind: "cap_exceeded", totalBytes, count: imageFiles.length };
   }
-  return { images, failures };
+
+  const release = await imageFetchSemaphore.acquire();
+  try {
+    const images: FetchedImage[] = [];
+    const failures: FetchedFailure[] = [];
+    for (const f of imageFiles) {
+      try {
+        const res = await fetch(f.url_private, {
+          headers: { Authorization: `Bearer ${botToken}` },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = Buffer.from(await res.arrayBuffer()).toString("base64");
+        images.push({
+          block: { type: "image", data, mimeType: f.mimetype },
+          meta: { name: f.name, size: f.size },
+        });
+      } catch (err) {
+        failures.push({ name: f.name, reason: formatError(err) });
+      }
+    }
+    return { kind: "ok", images, failures };
+  } finally {
+    release();
+  }
 }
 
 function renderTurnFiles(images: FetchedImage[]): string {
@@ -170,10 +210,25 @@ export function createSlackWorker(
 ): SlackWorker {
   let app: BoltApp | null = null;
 
-  async function ephemeral(channel: string, user: string, text: string) {
-    if (!app) return;
+  async function ephemeral(
+    channel: string,
+    user: string,
+    threadTs: string | undefined,
+    text: string,
+  ) {
+    if (!app) {
+      process.stderr.write(
+        `[slack] ephemeral skipped (app not started): ${text}\n`,
+      );
+      return;
+    }
     try {
-      await app.client.chat.postEphemeral({ channel, user, text });
+      await app.client.chat.postEphemeral({
+        channel,
+        user,
+        ...(threadTs ? { thread_ts: threadTs } : {}),
+        text,
+      });
     } catch (err) {
       process.stderr.write(
         `[slack] postEphemeral failed: ${formatError(err)}\n`,
@@ -206,6 +261,7 @@ export function createSlackWorker(
       ephemeral(
         ctx.channel,
         ctx.slackUserId,
+        ctx.hasThread ? ctx.threadTs : undefined,
         "This agent can't process images yet — answering text only.",
       );
     try {
@@ -348,6 +404,7 @@ export function createSlackWorker(
           handleForkOutcome(outcome, {
             channel: args.channel,
             threadTs: args.threadTs,
+            hasThread: args.hasThread,
             instanceName: args.instanceName,
             slackUserId: args.slackUserId,
             actorSub: args.keycloakSub,
@@ -400,6 +457,7 @@ export function createSlackWorker(
     ctx: {
       channel: string;
       threadTs: string;
+      hasThread: boolean;
       instanceName: string;
       slackUserId: string;
       actorSub: string;
@@ -418,6 +476,7 @@ export function createSlackWorker(
           ephemeral(
             ctx.channel,
             ctx.slackUserId,
+            ctx.hasThread ? ctx.threadTs : undefined,
             "This agent can't process images yet — answering text only.",
           );
         try {
@@ -602,14 +661,27 @@ export function createSlackWorker(
       return;
     }
 
-    const { images, failures } = await fetchSlackImages(
+    const fetchResult = await fetchSlackImages(
       botToken,
       (event as { files?: SlackImageFile[] }).files,
     );
+    if (fetchResult.kind === "cap_exceeded") {
+      const mb = (fetchResult.totalBytes / 1_000_000).toFixed(1);
+      const capMb = (TOTAL_IMAGE_BYTES_CAP / 1_000_000).toFixed(0);
+      await ephemeral(
+        event.channel,
+        slackUserId,
+        event.thread_ts,
+        `Attached images total ${mb} MB, over the ${capMb} MB per-message cap. Send smaller images or fewer at once.`,
+      );
+      return;
+    }
+    const { images, failures } = fetchResult;
     for (const f of failures) {
       await ephemeral(
         event.channel,
         slackUserId,
+        event.thread_ts,
         `Couldn't fetch attached image '${f.name}': ${f.reason}. Try resending.`,
       );
     }


### PR DESCRIPTION
Extending the api-server functionality such that sending images through slack is now possible for agents that support such functionality through ACP.
The only guard on the api-server side is the agents capability, otherwise all images are relayed unconditionally and errors are reported to the user.
The necessary adjustments on the slack bot side are documented.

Closes #306 

Note:
Not tested for any other agent than CC as I do not have access

<img width="371" height="357" alt="image" src="https://github.com/user-attachments/assets/2d9c89c0-7be3-4a43-9428-c8385d423bbd" />
