### PR TITLE
chore(lima): bump dev VM disk to 200 GiB

### DIFF
--- a/deploy/lima-k3s.yaml
+++ b/deploy/lima-k3s.yaml
@@ -16,7 +16,7 @@ cpus: 4
 # from a 4 GiB VM must reprovision:
 #   mise run cluster:delete && mise run cluster:install
 memory: 8GiB
-disk: 100GiB
+disk: 200GiB
 
 containerd:
   system: false


### PR DESCRIPTION
## Summary
- 100 GiB fills up after a few `cluster:install` cycles; running into `No space left on device` mid-build was a recurring papercut
- 200 GiB gives headroom for image churn + containerd build cache between `cluster:reclaim` runs

Only affects newly created VMs (same caveat as the existing `memory:` comment in the file). Existing devs keep their 100 GiB VM until they reprovision.

## Test plan
- [ ] `mise run cluster:delete && mise run cluster:install` on a fresh VM
- [ ] Confirm guest reports 200 GiB: `limactl shell platform-k3s df -h /`