### PR TITLE
refactor: strip clutter comments from PR #398

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -114,11 +114,6 @@ spec:
               value: {{ .Values.apiServer.port | quote }}
             - name: MCP_PORT
               value: {{ .Values.apiServer.harnessServerPort | quote }}
-            # Used by runtime-delivery's builtin-contributions to render
-            # the per-agent `platform-outbound` MCP entry. Must match the
-            # `:authority` the paired gateway pod's Envoy is configured
-            # to passthrough (envoy.go HarnessAuthority). Same env name
-            # the controller already consumes — single source of truth.
             - name: PLATFORM_HARNESS_SERVER_URL
               value: "http://{{ include "platform.fullname" . }}-apiserver-harness.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.apiServer.harnessServerPort }}"
             - name: EXT_AUTHZ_PORT

--- a/packages/agent-runtime/src/modules/runtime-channel/dispatcher.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/dispatcher.ts
@@ -17,10 +17,6 @@ export interface ContextEnv {
 }
 
 export interface Dispatcher {
-  /** Returns per-kind failures so the caller can report them up the wire.
-   *  An empty array means every handler ran cleanly. Handlers that
-   *  partially succeed (e.g. installed 1 of 2 skills) report their own
-   *  details via `ctx.log`; only thrown errors land here. */
   apply(contributions: Contribution[]): Promise<DriverFailure[]>;
 }
 

--- a/packages/agent-runtime/src/modules/runtime-channel/infrastructure/file-ops.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/infrastructure/file-ops.ts
@@ -60,13 +60,6 @@ export function createFileOps(): FileOps {
 
         const existed = existsSync(target);
         let existing = existed ? readFileSync(target, "utf8") : "";
-        // Self-heal a corrupted file. For parse-required merge modes
-        // (key-targeted is the main one — it has to read the structure
-        // to know which keys to replace), an unparseable on-disk file
-        // would otherwise jam every future apply for this path until
-        // someone deletes it by hand. Move the bad content aside for
-        // forensics and treat existing as empty so the platform's
-        // contributions can land.
         if (existing && needsParse(fragments)) {
           const parseErr = probeParse(fragments[0]!.format, existing);
           if (parseErr) {
@@ -143,15 +136,6 @@ function mergeKeyTargeted(
   format: FileFormat,
   fragments: FileDesired[],
 ): string {
-  // Ownership semantics:
-  //   - With keyPath: the platform owns everything under that path
-  //     authoritatively. Replace the subtree with the fragment content
-  //     rather than deep-merging, so a shrink (fewer entries on the next
-  //     apply) actually deletes the missing keys. Anything OUTSIDE the
-  //     keyPath in the existing file is preserved.
-  //   - Without keyPath: the platform owns each top-level key it emits.
-  //     `Object.assign` re-writes those keys; anything not in the
-  //     fragment is preserved.
   const base = (existing ? parse(format, existing) : {}) as Record<
     string,
     unknown
@@ -231,8 +215,6 @@ function parse(format: FileFormat, content: string): unknown {
   }
 }
 
-/** True when at least one fragment uses a merge mode that needs to
- *  read the existing file's structure. Drives the self-heal probe. */
 function needsParse(fragments: FileDesired[]): boolean {
   return fragments.some(
     (f) =>
@@ -240,10 +222,6 @@ function needsParse(fragments: FileDesired[]): boolean {
   );
 }
 
-/** Returns the parser's error message if `content` doesn't parse as
- *  `format`, or null on success. Used as a non-throwing pre-flight so
- *  the caller can decide to recover (move-aside + treat as empty)
- *  rather than fail the whole apply. */
 function probeParse(format: FileFormat, content: string): string | null {
   try {
     parse(format, content);

--- a/packages/agent-runtime/src/modules/runtime-channel/service.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/service.ts
@@ -44,13 +44,6 @@ export function createRuntimeChannelService(
         );
         const failures = await deps.dispatcher.apply(input.state.contributions);
         if (failures.length > 0) {
-          // Fail loud: do NOT advance state-store or return success.
-          // The agent's `lastAppliedVersion` stays at the previous value
-          // so the *next* applyState (sweep re-enqueue or fresh state
-          // change) re-runs the dispatcher with the same payload. The
-          // worker on the server side catches this and refuses to stamp
-          // ack, so the outbox row also keeps re-enqueueing until the
-          // failure clears.
           const summary = failures
             .map((f) => `${f.kind}: ${f.message}`)
             .join("; ");

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -21,11 +21,6 @@ export const connectionSetAgentConnectionsInputSchema = z.object({
   connectionIds: z.array(z.string().min(1)),
 });
 
-/** Connection name doubles as the agent-visible MCP server slug
- *  (e.g. `mcp__<name>__tool`), so it must be a valid identifier:
- *  lowercase ASCII alphanumerics + single hyphens, 1–63 chars, no
- *  leading/trailing/consecutive hyphens. Required — uniqueness is
- *  enforced per-owner at the DB level (see migration 0019). */
 export const connectionNameSchema = z
   .string()
   .min(1, "name is required")

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -31,12 +31,6 @@ const configSchema = z.object({
   releaseName: z.string().min(1, "PLATFORM_RELEASE_NAME must be set"),
   port: z.coerce.number().default(4000),
   harnessServerPort: z.coerce.number().default(4001),
-  /** URL of the api-server's harness Service as the paired gateway
-   *  pod's Envoy sees it (e.g.
-   *  `http://<rel>-apiserver-harness.<rel-ns>.svc.cluster.local:4001`).
-   *  Used to render the `platform-outbound` builtin MCP entry pushed to
-   *  every agent via the runtime channel. Same env (`PLATFORM_HARNESS_SERVER_URL`)
-   *  and shape the controller consumes — one name across the platform. */
   harnessServerUrl: z.string().url(),
   /** gRPC ext_authz listener — serves both Envoy's HTTP filter (L7,
    *  TLS-terminated chains) and network filter (L4, catch-all). */

--- a/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
@@ -41,9 +41,6 @@ export interface ConnectionsRepository {
     agentId: string,
   ): Promise<{ connectionId: string; grantedAt: Date }[]>;
   listConnectionsForAgent(agentId: string): Promise<Connection[]>;
-  /** Agents that currently have this connection granted. Used by
-   *  deleteConnection to fan-out the removal to each affected agent
-   *  before the grant rows cascade away. */
   listAgentsForConnection(connectionId: string): Promise<string[]>;
 }
 

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -88,10 +88,6 @@ export function createConnectionsService(deps: {
       const conn = await deps.repo.get(id, deps.ownerId);
       if (!conn) return;
 
-      // Capture the agents that had this granted BEFORE the cascade so
-      // we can fan-out the removal afterward — otherwise the deletion
-      // doesn't reach the agent and stale entries (e.g. an mcp-entry)
-      // are left behind in `.mcp.json`.
       const affectedAgents = await deps.repo.listAgentsForConnection(id);
 
       const paths = new Set<string>();
@@ -114,9 +110,6 @@ export function createConnectionsService(deps: {
 
       await deps.repo.delete(id, deps.ownerId);
 
-      // Re-run fan-out per affected agent with the post-delete grant
-      // set. Drives the runtime channel (drops the mcp-entry from
-      // `.mcp.json`), egress rules, and secrets-rev updates.
       if (affectedAgents.length > 0) {
         const ownerConnsAfter = await deps.repo.listByOwner(deps.ownerId);
         const allOwnerConnectionIds = new Set(ownerConnsAfter.map((c) => c.id));
@@ -203,12 +196,6 @@ export function createConnectionsService(deps: {
       );
 
       const id = newConnectionId();
-      // The agent's mcp-entry plugin keys `.mcp.json` by contribution
-      // `name` (last write wins). Template-declared and code-pushed
-      // mcp-entry contributions default to `template.id`, so two
-      // Connections from the same template would collide. Re-stamp the
-      // name per-Connection using the user-given (slug-validated, DB-
-      // unique-per-owner) connection name — that's the keyspace.
       const contributions = built.contributions.map(
         (c): Contribution =>
           c.kind === "mcp-entry" ? { ...c, name: input.name } : c,
@@ -246,11 +233,6 @@ export function createConnectionsService(deps: {
           contributions,
         });
       } catch (err) {
-        // Postgres unique-violation on `connections_owner_name_unique_idx`
-        // — surface a clean CONFLICT so the UI can show "pick a different
-        // name" instead of a 500. SQLSTATE 23505 is the unique-violation
-        // class; matching on it (not on the message) survives library
-        // wording changes.
         if (isUniqueViolation(err)) {
           throw new TRPCError({
             code: "CONFLICT",

--- a/packages/api-server/src/modules/connections/services/contribution-fanout.ts
+++ b/packages/api-server/src/modules/connections/services/contribution-fanout.ts
@@ -75,13 +75,6 @@ export function createContributionFanOut(deps: {
         await deps.port.bumpSecretsRev(agentId);
       }
 
-      // Bump the outbox unconditionally on every fan-out. Gating on "the
-      // post-change set still has runtime-channel contributions" would
-      // skip the bump on a shrink-to-empty change (e.g. disconnecting the
-      // only MCP-bearing Connection), leaving the agent's .mcp.json /
-      // installed files / env stale with no way back. The agent-side
-      // hash-dedupe in `applyState` already short-circuits no-op
-      // deliveries, so over-bumping is cheap and the conservative choice.
       await deps.runtimeMutator.bump(agentId, []);
       await deps.runtimeMutator.enqueueAfterCommit(agentId);
     },

--- a/packages/api-server/src/modules/runtime-delivery/compose.ts
+++ b/packages/api-server/src/modules/runtime-delivery/compose.ts
@@ -50,10 +50,6 @@ export interface ComposeRuntimeDeliveryOpts {
   namespace: string;
   bullConnection: ConnectionOptions;
   agentRunningPort: IsAgentRunning;
-  /** URL of the api-server harness Service used to render the
-   *  `platform-outbound` builtin MCP entry (e.g.
-   *  `http://<rel>-apiserver-harness.<rel-ns>.svc.cluster.local:4001`).
-   *  Sourced from `PLATFORM_HARNESS_SERVER_URL`, matching the controller. */
   harnessServerUrl: string;
   log?: (msg: string) => void;
 }

--- a/packages/api-server/src/modules/runtime-delivery/services/builtin-contributions.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/builtin-contributions.ts
@@ -5,22 +5,9 @@ export interface BuiltinContributions {
 }
 
 export interface BuiltinContributionsOpts {
-  /** URL of the api-server harness Service that the paired gateway
-   *  pod's Envoy is configured to passthrough. Used to render the
-   *  per-agent `platform-outbound` MCP entry. Sourced from
-   *  `PLATFORM_HARNESS_SERVER_URL`, matching the controller. */
   harnessServerUrl: string;
 }
 
-/**
- * Always-on contributions injected into every applyState payload, on top
- * of user-granted Connection contributions and installed Skills.
- *
- * Today: a single `platform-outbound` MCP server pointing at the agent's
- * own harness MCP endpoint. No Authorization header — harness traffic
- * rides the paired gateway pod's mesh identity (ADR-041), and the
- * waypoint AuthorizationPolicy enforces principal == URL :id.
- */
 export function createBuiltinContributions(
   opts: BuiltinContributionsOpts,
 ): BuiltinContributions {

--- a/packages/api-server/src/modules/runtime-delivery/services/runtime-mutator.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/runtime-mutator.ts
@@ -6,12 +6,6 @@ import type {
 import type { StateQueue } from "../infrastructure/state-queue.js";
 
 export interface RuntimeMutator {
-  /** Bump the outbox version after a state change. `events` is required
-   *  to force every caller to make an explicit choice: pass `[]` for
-   *  the common "I changed state, nothing to attach" case, or a list
-   *  of events (today: scheduler triggers) that must ride the same
-   *  version atomically. Returns the new version. Pair with
-   *  `enqueueAfterCommit` so the worker picks the change up. */
   bump(
     agentId: string,
     events: Omit<PendingEventRow, "agentId" | "version">[],
@@ -27,13 +21,9 @@ export function createRuntimeMutator(deps: {
 }): RuntimeMutator {
   return {
     async bump(agentId, events): Promise<number> {
-      // No events → single statement, no transaction ceremony.
       if (events.length === 0) {
         return deps.outboxRepo.bumpVersion(agentId);
       }
-      // Events present → bump + inserts must land atomically so the
-      // agent sees them on the same applyState payload as the version
-      // they're keyed to.
       return deps.db.transaction(async (tx) => {
         const version = await deps.outboxRepo.bumpVersion(agentId, tx);
         for (const e of events) {

--- a/packages/api-server/src/modules/runtime-delivery/services/worker-handler.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/worker-handler.ts
@@ -72,10 +72,6 @@ export function createWorkerHandler(deps: WorkerHandlerDeps): WorkerHandler {
         return;
       }
       if (msg.includes("apply failed for")) {
-        // Agent dispatcher had one or more driver failures. The agent
-        // refused to advance its state, so we MUST NOT stampAck — let
-        // BullMQ retry the job and the sweep re-enqueue. Re-throw so
-        // both mechanisms kick in.
         deps.log(
           `[runtime-worker] ${agentId}: driver failure on v=${row.version} — not acking, will retry: ${msg}`,
         );

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -9,9 +9,4 @@ export function createDb(url: string) {
 
 export type Db = ReturnType<typeof createDb>["db"];
 
-/** The handle Drizzle passes to a `db.transaction(cb)` callback. Shares
- *  the same query surface as `Db` (insert/select/update/delete/execute)
- *  but is nominally a different type. Repo methods that need to run
- *  inside a caller-owned transaction accept `Db | DbTx` so the call
- *  site doesn't need an `as unknown as Db` cast. */
 export type DbTx = Parameters<Parameters<Db["transaction"]>[0]>[0];

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -333,11 +333,6 @@ export const connections = pgTable(
   },
   (table) => [
     index("connections_owner_idx").on(table.owner),
-    // The connection `name` doubles as the user-facing label AND the
-    // `mcp-entry` key the agent writes into `.mcp.json` (and the slug
-    // tools surface as `mcp__<name>__<tool>`). Two connections with
-    // the same name per owner would silently clobber each other in the
-    // agent's file, so the keyspace is enforced at the DB.
     uniqueIndex("connections_owner_name_unique_idx").on(
       table.owner,
       table.name,

--- a/packages/ui/src/modules/connections/forms/template-create-form.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form.tsx
@@ -29,10 +29,6 @@ export function TemplateCreateForm({
 }) {
   const create = useCreateConnection();
 
-  // Suggest a slug from the template name (e.g. "GitHub" → "github").
-  // User can override; if they create a second connection from the same
-  // template they'll hit the unique constraint and get a CONFLICT error
-  // pointing them at the collision.
   const [name, setName] = useState(() => slugifyTemplateName(template.name));
   const [fields, setFields] = useState<Record<string, string>>({});
   const [overrides, setOverrides] = useState<Record<string, boolean>>({});
@@ -335,8 +331,6 @@ function LabeledInput({
   );
 }
 
-/** Runs the same Zod schema the server uses, so the form surfaces the
- *  same error string the API would return — no drift to keep in sync. */
 function validateConnectionName(name: string): string | null {
   const result = connectionNameSchema.safeParse(name);
   return result.success
@@ -344,11 +338,6 @@ function validateConnectionName(name: string): string | null {
     : (result.error.issues[0]?.message ?? "Invalid name");
 }
 
-/** Turn the template's display name into a connection-name suggestion
- *  that satisfies `connectionNameSchema` ("GitHub" → "github",
- *  "GitHub Enterprise" → "github-enterprise"). Returns empty string if
- *  the template name has nothing usable — the user-facing required
- *  validation will then prompt for a name. */
 function slugifyTemplateName(name: string): string {
   return name
     .toLowerCase()


### PR DESCRIPTION
Removes 129 lines of JSDoc and inline narration introduced during #398 across 16 files.

Per CLAUDE.md guidance, comments only earn their place when the WHY is non-obvious. The stripped comments restated what the code already says by structure, naming, or surrounding context. No code changes — pure deletion.

## Test plan

- [x] \`mise run check\` clean
- [x] \`mise run test\` — all suites pass