### PR TITLE
fix(ci): restore docker→k3s image load when SKIP_IMAGE_BUILD is set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,11 @@ jobs:
               - 'packages/agent-runtime/**'
               - 'packages/agent-runtime-api/**'
               - 'packages/platform-base/**'
+              - 'packages/keycloak-theme/**'
               - 'deploy/helm/**'
+              - 'deploy/tasks.toml'
+              - 'deploy/lima-k3s-test.yaml'
+              - '.github/workflows/ci.yml'
 
   check:
     name: mise check
@@ -127,6 +131,10 @@ jobs:
 
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - run: mise run setup
+      # Keycloak image bakes the Keycloakify theme JAR — build it via mise
+      # so the keycloak-theme:build:jar dep runs first, then docker build
+      # lands platform-keycloak:latest in the daemon for cluster:install.
+      - run: mise run image:keycloak
       - run: mise run e2e
         env:
           SKIP_IMAGE_BUILD: "1"

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -371,10 +371,11 @@ YAML
 kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mode=ambient --overwrite
 
 # 3. Load images into k3s (built by depends: image:*)
-# SKIP_IMAGE_BUILD also skips the load: image:* tasks already no-op'd, so
-# there's nothing new in docker to ship. Pods keep running their pinned SHAs.
-if [ -n "${SKIP_IMAGE_BUILD:-}" ]; then
-  echo "Skipping image load (SKIP_IMAGE_BUILD set)"
+# SKIP_IMAGE_LOAD skips the docker→containerd transfer. cluster:helm sets it
+# (no fresh images in docker); CI sets SKIP_IMAGE_BUILD only (buildx pre-loaded
+# the runner's docker daemon, but k3s containerd is still empty).
+if [ -n "${SKIP_IMAGE_LOAD:-}" ]; then
+  echo "Skipping image load (SKIP_IMAGE_LOAD set)"
   NO_RESTART=true
 else
   echo "Loading images into k3s..."
@@ -469,7 +470,7 @@ dir = "{{config_root}}"
 raw = true
 run = '''
 #!/usr/bin/env bash
-exec env SKIP_IMAGE_BUILD=1 mise run cluster:install "$@"
+exec env SKIP_IMAGE_BUILD=1 SKIP_IMAGE_LOAD=1 mise run cluster:install "$@"
 '''
 
 ["cluster:build-apiserver"]


### PR DESCRIPTION
## Summary
- The e2e job has been failing on `ErrImageNeverPull` for `platform-api-server`, `platform-controller`, and `platform-ui` since PR #382 merged.
- Root cause: PR #382 widened `SKIP_IMAGE_BUILD` to also gate the `docker save → k3s ctr images import` step in [`cluster:install`](deploy/tasks.toml). That's correct for the new `cluster:helm` task (nothing fresh in docker) but breaks CI, which sets `SKIP_IMAGE_BUILD=1` precisely *because* `docker/build-push-action` with `load: true` already populated the runner's docker daemon — those images still need to reach k3s containerd.
- Fix: split the two concerns. `SKIP_IMAGE_LOAD` now gates the docker→containerd transfer. `cluster:helm` sets both flags; CI keeps `SKIP_IMAGE_BUILD` only, and the load step runs again.

Closes #408.

## Test plan
- [x] CI e2e job goes green on this PR
- [x] `mise run cluster:helm` on an already-installed cluster still skips both rebuild and load (no behaviour change for the original use case)
- [x] `mise run cluster:install` still does the full rebuild + load + restart locally