### PR TITLE
feat(logging): structured logging for the api-server + security audit trail

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -112,6 +112,8 @@ spec:
               value: {{ include "platform.fullname" . | quote }}
             - name: PORT
               value: {{ .Values.apiServer.port | quote }}
+            - name: LOG_LEVEL
+              value: {{ .Values.apiServer.logLevel | quote }}
             - name: MCP_PORT
               value: {{ .Values.apiServer.harnessServerPort | quote }}
             - name: PLATFORM_HARNESS_SERVER_URL

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -335,6 +335,13 @@ apiServer:
     pullPolicy: IfNotPresent
   port: 4000
   harnessServerPort: 4001
+  # -- Minimum severity emitted by the structured logger
+  # (`error`|`warn`|`info`|`debug`). The security audit trail is logged at
+  # common levels (denials → warn, allowed/successful actions → info), so the
+  # default `info` keeps the full trail on; raise to `warn` to keep only
+  # denials/failures, or `error` to silence the trail. There is no separate
+  # audit on/off switch — visibility is governed here as usual.
+  logLevel: info
   # -- ext_authz gRPC listener for the Envoy sidecar's HITL gate
   # (ADR-035). Single endpoint: Envoy's HTTP filter (L7,
   # TLS-terminated chains) and network filter (L4, catch-all chain) both

--- a/docs/adrs/057-structured-logging.md
+++ b/docs/adrs/057-structured-logging.md
@@ -1,0 +1,32 @@
+# ADR-057: Structured logging for the api-server
+
+**Date:** 2026-05-29
+**Status:** Accepted
+**Owner:** @pilartomas
+
+## Context
+
+The api-server has no logging abstraction. Diagnostics are ad-hoc writes to stderr, and the only durable structured signal is the in-process domain event bus, which the usage subsystem turns into HMAC-pseudonymized rows in Postgres for operator analytics. Reconstructing *who did what, and whether it was allowed* after a security incident is impossible: the auth edge records nothing on a rejected token, the credentialed-egress gate records no allow/deny decision, and credential and authorization-list mutations are largely silent. Producing a forensic trail first requires a logging primitive — there is nothing today that emits attributable, parseable records to the platform's log pipeline.
+
+## Decision
+
+The api-server emits structured logs through Pino: one JSON record per line on stdout, the common severity levels (`error`/`warn`/`info`/`debug`), and visibility governed by the standard configured level — there is no per-feature on/off switch. One process-wide logger is configured once at startup.
+
+The first consumer is a **security audit trail**. Security-relevant actions and decisions are ordinary log records at mapped common levels — denied/failed at `warn`, allowed/successful at `info`, internal failures on a security path at `error` — and carry the **real, un-pseudonymized actor identity** plus a coarse `category` so the log pipeline can isolate the trail. Because Kubernetes merges stdout and stderr into one pod log, consumers discriminate on that field, not on the stream. Records never carry secret values, tokens, or raw prompts.
+
+This deliberately diverges from the usage subsystem: that store is pseudonymized analytics ([ADR-048](048-usage-tracking.md)); this trail is real-identity forensics. They stay separate.
+
+## Alternatives Considered
+
+- **A dedicated audit on/off flag or a custom "audit" log level** — rejected: visibility belongs to the standard level configuration; a separate switch is one more control to misconfigure and silently lose the trail.
+- **Reuse the pseudonymized activity-events path** — rejected: HMAC-pseudonymized subjects defeat the attribution forensics needs, and Postgres is not the platform's incident-log surface.
+- **Hand-rolled JSON logger** — rejected: leveling, redaction, and safe serialization of circular structures are already solved by an established library.
+
+## Consequences
+
+- **Easier:** any security decision point emits an attributable record in one call, collected from stdout with no new infrastructure — the api-server already runs as a stdout-logged pod, so the trail rides the existing pipeline.
+- **Easier:** rejected and denied actions now leave a trace. Previously the auth edge emitted nothing on 401/403 and the egress gate logged no allow/deny/hold decision; these are the highest-value forensic signals and were entirely dark.
+- **Harder:** the trail carries real Keycloak subjects, so it is PII and must be access-controlled and retained as such at the log sink — GDPR treats the subject identifier as personal data, which is exactly why the analytics path pseudonymizes.
+- **Harder:** logging every credentialed-egress decision adds a write to a path that runs on the proxy's request-blocking hop, so the writer must stay non-blocking and the allow-volume must be tolerable to the sink.
+- **Committed-to:** the logger is a process-wide singleton configured once at startup; records emitted before configuration use the default level.
+- **Committed-to:** raising the configured level above `info` drops the audit trail by design — operators own that trade-off.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -61,6 +61,7 @@ This directory contains ADRs for the Platform project.
 | [054](054-keycloak-theme.md)                  | Branded Keycloak login via Keycloakify-built custom image | @kapetr |
 | [055](055-agent-owned-session-metadata.md)    | Agent-owned session metadata via ACP `_meta`; server sessions become a Redis cache | @jezekra1 |
 | [056](056-browser-driven-e2e.md)              | Browser-driven E2E tracer with values-gated test affordances | @tomkis |
+| [057](057-structured-logging.md)              | Structured logging for the api-server — Pino, JSON to stdout, security audit trail as first consumer | @pilartomas |
 
 ## Drafts
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -64,6 +64,7 @@ Each page describes how the accepted ADRs are realized in the current system. AD
 - [skills](architecture/skills.md) — connectable git-based skill sources, install onto the per-Agent PVC, REST-only publish back as a PR, Envoy sidecar credential injection for GitHub.
 - [connections](architecture/connections.md) — unified Connection / Contribution model, runtime channel between api-server and agent-runtime, transactional outbox + worker delivery, agent-side driver model.
 - [usage-tracking](architecture/usage-tracking.md) — append-only activity log in Postgres, SQL views as the read interface, HMAC-pseudonymized identifiers, inspector-role gating.
+- [logging](architecture/logging.md) — Pino structured logging to stdout, and the real-identity security audit trail built on it (the forensic counterpart to pseudonymized usage-tracking).
 - [security-scanning](architecture/security-scanning.md) — Quay image scanning with auto-filed issues, CodeQL SAST, Dependabot, and the remediation flow.
 
 ## Strategy

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -1,0 +1,54 @@
+# Logging
+
+Last verified: 2026-05-29
+
+## Motivated by
+
+- [ADR-057 — Structured logging for the api-server](../adrs/057-structured-logging.md) — Pino, one JSON record per line on stdout, common levels, security audit trail as the first consumer
+- [ADR-048 — Usage tracking](../adrs/048-usage-tracking.md) — the pseudonymized analytics store the audit trail is deliberately kept separate from
+
+## Overview
+
+The api-server logs through a single process-wide **Pino** logger ([`packages/api-server/src/core/logger.ts`](../../packages/api-server/src/core/logger.ts)), configured once at startup from the `info`-default log level. Output is one JSON object per line on stdout; the common levels `error/warn/info/debug` are the only knob — there is no per-feature toggle. Visibility is the operator's level choice, governed the usual way.
+
+The logger's first and primary consumer is a **security audit trail**: a structured record at every security-relevant decision point, so a forensic investigation can reconstruct *who did what, to what, and whether it was allowed*. The trail is the orthogonal counterpart to [usage-tracking](usage-tracking.md): usage is **pseudonymized analytics** in Postgres (a database leak yields opaque hashes); the audit trail is **real-identity forensics** on stdout (an investigator can attribute directly). The two never share actor handling.
+
+## The audit record
+
+`securityLog(level, event, fields)` ([`core/security-log.ts`](../../packages/api-server/src/core/security-log.ts)) is a thin, typed wrapper over the Pino logger — not a new level or stream. The dotted `event` (e.g. `egress.decision`, `secret.create`, `authn.deny`) is the log message; the fields are merged into the line:
+
+- **`category`** — the coarse class (`authn`, `authz`, `egress`, `approval`, `authz-list`, `credential`, `channel`, `resource`, `privileged`). Kubernetes merges stdout and stderr into one pod log, so a shipper isolates the trail by **filtering on this field**, not on the stream.
+- **`actor` / `actorKind`** — the raw (un-pseudonymized) Keycloak `sub`, an agent id, `system:<component>`, or `null`; tagged `user | agent | system | external`.
+- **`result`** (`success | failure`) and **`decision`** (`allow | deny | hold | expired`) are **separate axes** — an execution failure is not a policy deny, so the canonical "show me every deny" query stays unambiguous.
+- **`correlationId`** ties a multi-site flow together. A credentialed-egress hold (`egress.hold`), the human verdict (`approval.verdict`), and the resolved decision (`egress.decision`) all carry the same pending-approval id.
+- **`agentId`, `target`, `sourceIp`, `reason`, `detail`** round out the line. `detail` is shallow and value-free.
+
+**Level mapping:** deny/fail → `warn`, allow/success/mutation → `info`, internal failure on a security path → `error`.
+
+**Redaction is the caller's contract.** Records never carry token/secret/PAT values, refresh tokens, raw JWTs, or raw prompts — only metadata (`hasRefresh`, `secretId`, env key *names*, byte counts, a resolved file path). The bus saga projects explicit fields per event rather than spreading a domain event (which would leak `ForeignReplyReceived.prompt`). The logger also censors a few well-known credential keys as defense-in-depth, and the WS edge strips `?token=` before logging a path.
+
+## How the trail is produced
+
+Two disjoint mechanisms feed the one logger:
+
+- **Bus saga** ([`modules/audit`](../../packages/api-server/src/modules/audit)) — subscribes the in-process domain event bus for the success/observation events that already carry a real actor: `UserAuthenticated`, `ChannelTurnRelayed`, `ScheduleFired`, `FilesImported`, `ForeignReplyReceived` (cross-identity turn, prompt omitted), and the `Fork*` events. It mirrors the usage `persist-activity` saga shape.
+- **Direct calls** at every decision/denial/mutation site not on the bus — the majority, and all denials. Each site logs at the application/service layer or the transport edge, where the actor is in scope; never in the pure domain layer.
+
+## Coverage
+
+| Surface | Representative events |
+|---|---|
+| Auth edge | `authn.deny` (bad/missing token), `authz.deny` (missing role) |
+| HTTP / WS edge | `authz.owner_mismatch` (cross-tenant agent access), `ws.authn_deny` / `ws.owner_mismatch` / `ws.terms_block`, `relay.attach` (terminal/ACP attach to a credentialed pod) |
+| Credentialed egress (HITL) | `egress.decision` (every allow/deny/expired), `egress.hold`; identity-unresolved and ext-authz transport denials |
+| Approvals | `approval.verdict` (approve/deny once/permanent/host) |
+| Authorization lists | `agent.allowed_users_set` (with added/removed diff), `egress_rule.create|update|revoke|preset`, `secret.grants_set`, `connection.grants_set` |
+| Credentials | `secret.create|update|delete`, `oauth.token_mint`, `connection.create|delete`, `secret.orphan_cleanup_failed` |
+| Channels | `channel.authz` / `channel.authz_deny` (Slack unlinked + allowed-users gate; Telegram group-admin + unauthorized thread), `identity.link`, `channel.outbound` (agent post, incl. resolved attachment path), `channel.thread_revoked` |
+| Privileged | `skill.install` / `skill.uninstall` / `skill.publish`, `schedule.create|toggle|delete` (incl. agent-driven), `usage.inspect` / `usage.inspect.deny`, `agent.create|update|delete|restart|wake` |
+
+## Invariants
+
+- **Single process, single stdout.** The public API, harness, and ext-authz gRPC apps run in one process, so one logger configuration and one stream cover the whole api-server.
+- **Once per replica.** The domain bus is in-process; each replica's saga logs only its own events. Moving domain events onto the cross-replica Redis bus would require dedup, or every replica would duplicate every line. The api-server runs single-replica today.
+- **Non-blocking.** The egress gate logs on the proxy's request-blocking hop; the writer must never block or throw into a request path.

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Last verified: 2026-05-29
+Last verified: 2026-06-01
 
 ## Motivated by
 
@@ -31,14 +31,14 @@ The logger's first and primary consumer is a **security audit trail**: a structu
 
 Two disjoint mechanisms feed the one logger:
 
-- **Bus saga** ([`modules/audit`](../../packages/api-server/src/modules/audit)) — subscribes the in-process domain event bus for the success/observation events that already carry a real actor: `UserAuthenticated`, `ChannelTurnRelayed`, `ScheduleFired`, `FilesImported`, `ForeignReplyReceived` (cross-identity turn, prompt omitted), and the `Fork*` events. It mirrors the usage `persist-activity` saga shape.
+- **Bus saga** ([`modules/audit`](../../packages/api-server/src/modules/audit)) — subscribes the in-process domain event bus for the discrete success/observation events that already carry a real actor: `ChannelTurnRelayed`, `ScheduleFired`, `FilesImported`, `ForeignReplyReceived` (cross-identity turn, prompt omitted), and the `Fork*` events. It mirrors the usage `persist-activity` saga shape, but only for events that occur at most once per action — it deliberately does **not** subscribe `UserAuthenticated`, which fires on every authenticated request (the usage saga consumes that one, collapsing it to a single row per day).
 - **Direct calls** at every decision/denial/mutation site not on the bus — the majority, and all denials. Each site logs at the application/service layer or the transport edge, where the actor is in scope; never in the pure domain layer.
 
 ## Coverage
 
 | Surface | Representative events |
 |---|---|
-| Auth edge | `authn.deny` (bad/missing token), `authz.deny` (missing role) |
+| Auth edge | `authn.deny` (bad/missing token), `authz.deny` (missing role). Successful logins are not logged here — the api-server only ever sees already-issued tokens on per-request verification; Keycloak's authentication-event log is the authoritative record of logins. |
 | HTTP / WS edge | `authz.owner_mismatch` (cross-tenant agent access), `ws.authn_deny` / `ws.owner_mismatch` / `ws.terms_block`, `relay.attach` (terminal/ACP attach to a credentialed pod) |
 | Credentialed egress (HITL) | `egress.decision` (every allow/deny/expired), `egress.hold`; identity-unresolved and ext-authz transport denials |
 | Approvals | `approval.verdict` (approve/deny once/permanent/host) |

--- a/packages/api-server/package.json
+++ b/packages/api-server/package.json
@@ -35,6 +35,7 @@
     "jose": "^6.0.11",
     "js-yaml": "^4.1.0",
     "mock-agent-api": "workspace:*",
+    "pino": "~9.11.0",
     "rrule": "^2.8.1",
     "rxjs": "^7.8.2",
     "sharp": "^0.34.5",

--- a/packages/api-server/src/__tests__/unit/audit-log-saga.test.ts
+++ b/packages/api-server/src/__tests__/unit/audit-log-saga.test.ts
@@ -78,7 +78,7 @@ describe("audit-log saga", () => {
     expect(rec.result).toBe("failure");
   });
 
-  it("normalizes an unexpected auth surface to 'other'", () => {
+  it("does not log auth.login: per-request UserAuthenticated is intentionally ignored", () => {
     const h = harness();
     active = h.sub;
     emit({
@@ -87,10 +87,9 @@ describe("audit-log saga", () => {
       surface: "other",
       isCore: false,
     });
-    const rec = h.records()[0]!;
-    expect(rec.msg).toBe("auth.login");
-    expect(rec.surface).toBe("other");
-    expect(rec.actor).toBe("kc-2");
+    // The usage saga consumes this per-request event; the audit trail must not,
+    // or an open UI's polling would flood it. Real logins live in Keycloak.
+    expect(h.records()).toHaveLength(0);
   });
 
   it("flags a credential-mint fork failure as a credential event", () => {

--- a/packages/api-server/src/__tests__/unit/audit-log-saga.test.ts
+++ b/packages/api-server/src/__tests__/unit/audit-log-saga.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, afterEach } from "vitest";
+import type { Subscription } from "rxjs";
+import { configureLogger } from "../../core/logger.js";
+import { startAuditLogSaga } from "../../modules/audit/sagas/audit-log.js";
+import { emit, EventType } from "../../events.js";
+
+function harness() {
+  const lines: string[] = [];
+  configureLogger({ level: "info", write: (l) => lines.push(l) });
+  const sub = startAuditLogSaga();
+  return {
+    sub,
+    records: () => lines.map((l) => JSON.parse(l)),
+    raw: () => lines.join(""),
+  };
+}
+
+let active: Subscription | null = null;
+afterEach(() => {
+  active?.unsubscribe();
+  active = null;
+});
+
+describe("audit-log saga", () => {
+  it("logs a foreign-reply turn WITHOUT leaking the prompt", () => {
+    const h = harness();
+    active = h.sub;
+    emit({
+      type: EventType.ForeignReplyReceived,
+      replyId: "reply-1",
+      agentId: "agent-1",
+      foreignSub: "kc-foreign",
+      threadTs: "1700000000.0001",
+      prompt: "SUPER-SECRET-PROMPT-do-not-log",
+      slackContext: { channelId: "C123", userSlackId: "U999" },
+    });
+    const rec = h.records()[0]!;
+    expect(rec.msg).toBe("channel.foreign_turn.begin");
+    expect(rec.category).toBe("channel");
+    expect(rec.actor).toBe("kc-foreign");
+    expect(rec.agentId).toBe("agent-1");
+    expect(rec.correlationId).toBe("reply-1");
+    // The raw prompt must never appear anywhere on the audit stream.
+    expect(h.raw()).not.toContain("SUPER-SECRET-PROMPT");
+    expect(JSON.stringify(rec)).not.toContain("prompt");
+  });
+
+  it("attributes a Telegram turn (no Keycloak sub) as an external actor", () => {
+    const h = harness();
+    active = h.sub;
+    emit({
+      type: EventType.ChannelTurnRelayed,
+      channel: "telegram",
+      agentId: "agent-2",
+      actorSub: null,
+      outcome: "success",
+    });
+    const rec = h.records()[0]!;
+    expect(rec.msg).toBe("channel.turn");
+    expect(rec.actor).toBe(null);
+    expect(rec.actorKind).toBe("external");
+    expect(rec.surface).toBe("telegram");
+    expect(rec.level).toBe("info");
+  });
+
+  it("logs a failed channel turn at warn", () => {
+    const h = harness();
+    active = h.sub;
+    emit({
+      type: EventType.ChannelTurnRelayed,
+      channel: "slack",
+      agentId: "agent-3",
+      actorSub: "kc-1",
+      outcome: "failure",
+    });
+    const rec = h.records()[0]!;
+    expect(rec.level).toBe("warn");
+    expect(rec.result).toBe("failure");
+  });
+
+  it("normalizes an unexpected auth surface to 'other'", () => {
+    const h = harness();
+    active = h.sub;
+    emit({
+      type: EventType.UserAuthenticated,
+      userSub: "kc-2",
+      surface: "other",
+      isCore: false,
+    });
+    const rec = h.records()[0]!;
+    expect(rec.msg).toBe("auth.login");
+    expect(rec.surface).toBe("other");
+    expect(rec.actor).toBe("kc-2");
+  });
+
+  it("flags a credential-mint fork failure as a credential event", () => {
+    const h = harness();
+    active = h.sub;
+    emit({
+      type: EventType.ForkFailed,
+      forkId: "fork-1",
+      replyId: "reply-9",
+      reason: "CredentialMintFailed",
+    });
+    const rec = h.records()[0]!;
+    expect(rec.msg).toBe("fork.failed");
+    expect(rec.category).toBe("credential");
+    expect(rec.level).toBe("warn");
+    expect(rec.reason).toBe("CredentialMintFailed");
+  });
+});

--- a/packages/api-server/src/__tests__/unit/auth-audit.test.ts
+++ b/packages/api-server/src/__tests__/unit/auth-audit.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Stub jose so the middleware can be exercised without a real Keycloak/JWKS.
+vi.mock("jose", () => ({
+  createRemoteJWKSet: () => () => ({}),
+  jwtVerify: vi.fn(),
+}));
+
+import { jwtVerify } from "jose";
+import { createAuth } from "../../apps/api-server/auth.js";
+import { configureLogger } from "../../core/logger.js";
+
+const verifyMock = jwtVerify as unknown as ReturnType<typeof vi.fn>;
+
+function capture() {
+  const lines: string[] = [];
+  configureLogger({ level: "info", write: (l) => lines.push(l) });
+  return { records: () => lines.map((l) => JSON.parse(l)) };
+}
+
+/** Minimal Hono-context stub covering what the auth middleware touches. */
+function fakeCtx(headers: Record<string, string>, path = "/api/trpc/x") {
+  const responses: { body: unknown; status: number }[] = [];
+  const c = {
+    req: { path, header: (n: string) => headers[n.toLowerCase()] },
+    set: () => {},
+    json: (body: unknown, status: number) => {
+      responses.push({ body, status });
+      return { body, status };
+    },
+  };
+  return { c, responses };
+}
+
+const auth = createAuth({
+  issuerUrl: "http://kc/realms/platform",
+  jwksUrl: "http://kc/jwks",
+  audience: "platform-api",
+  requiredRole: "platform-access",
+  uiClientId: "platform-ui",
+  cliClientId: "platform-cli",
+});
+
+const next = async () => "NEXT" as never;
+
+beforeEach(() => verifyMock.mockReset());
+
+describe("auth middleware audit", () => {
+  it("logs authn.deny with reason=missing-bearer and no token when the header is absent", async () => {
+    const cap = capture();
+    const { c, responses } = fakeCtx({});
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(401);
+    const rec = cap.records().find((r) => r.msg === "authn.deny")!;
+    expect(rec.category).toBe("authn");
+    expect(rec.reason).toBe("missing-bearer");
+    expect(rec.target).toBe("/api/trpc/x");
+  });
+
+  it("logs authn.deny with the verify-error class (never the token) on a bad JWT", async () => {
+    const cap = capture();
+    const err = new Error("expired");
+    err.name = "JWTExpired";
+    verifyMock.mockRejectedValueOnce(err);
+    const { c, responses } = fakeCtx({
+      authorization: "Bearer SECRET.JWT.VAL",
+    });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(401);
+    const rec = cap.records().find((r) => r.msg === "authn.deny")!;
+    expect(rec.reason).toBe("JWTExpired");
+    expect(JSON.stringify(cap.records())).not.toContain("SECRET.JWT.VAL");
+  });
+
+  it("logs authz.deny against the decoded sub when the required role is missing", async () => {
+    const cap = capture();
+    verifyMock.mockResolvedValueOnce({
+      payload: {
+        sub: "kc-denied",
+        azp: "platform-ui",
+        preferred_username: "u",
+        realm_access: { roles: ["some-other-role"] },
+      },
+    });
+    const { c, responses } = fakeCtx({ authorization: "Bearer x" });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(403);
+    const rec = cap.records().find((r) => r.msg === "authz.deny")!;
+    expect(rec.category).toBe("authz");
+    expect(rec.actor).toBe("kc-denied");
+    expect(rec.detail.requiredRole).toBe("platform-access");
+  });
+
+  it("does not emit a deny line on a valid, authorized token", async () => {
+    const cap = capture();
+    verifyMock.mockResolvedValueOnce({
+      payload: {
+        sub: "kc-ok",
+        azp: "platform-ui",
+        preferred_username: "u",
+        realm_access: { roles: ["platform-access"] },
+      },
+    });
+    const { c } = fakeCtx({ authorization: "Bearer x" });
+    const result = await auth.middleware(c as any, next as any);
+    expect(result).toBe("NEXT");
+    expect(cap.records().some((r) => String(r.msg).endsWith(".deny"))).toBe(
+      false,
+    );
+  });
+});

--- a/packages/api-server/src/__tests__/unit/logger.test.ts
+++ b/packages/api-server/src/__tests__/unit/logger.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import { configureLogger, getLogger } from "../../core/logger.js";
+import { securityLog } from "../../core/security-log.js";
+
+/** Capture sink — each test installs a fresh Pino instance writing here, with
+ *  an explicit level so singleton state doesn't leak between cases. */
+function capture(level: "error" | "warn" | "info" | "debug" = "info") {
+  const lines: string[] = [];
+  configureLogger({ level, write: (line) => lines.push(line) });
+  return {
+    lines,
+    records: () => lines.map((l) => JSON.parse(l)),
+    raw: () => lines.join(""),
+  };
+}
+
+describe("logger (pino-backed)", () => {
+  it("emits one JSON object per call with string level, ISO time, and the event as msg", () => {
+    const cap = capture("info");
+    securityLog("info", "egress.decision", {
+      category: "egress",
+      actor: "kc-1",
+      actorKind: "agent",
+      decision: "allow",
+    });
+    expect(cap.lines).toHaveLength(1);
+    const rec = cap.records()[0]!;
+    expect(rec.level).toBe("info");
+    expect(rec.msg).toBe("egress.decision");
+    expect(rec.category).toBe("egress");
+    expect(rec.decision).toBe("allow");
+    expect(typeof rec.time).toBe("string");
+    expect(() => new Date(rec.time).toISOString()).not.toThrow();
+  });
+
+  it("gates by configured level — debug suppressed at info; warn/error always emit", () => {
+    const cap = capture("info");
+    getLogger().debug("noisy");
+    getLogger().info("kept");
+    getLogger().warn("kept-warn");
+    getLogger().error("kept-error");
+    expect(cap.records().map((r) => r.msg)).toEqual([
+      "kept",
+      "kept-warn",
+      "kept-error",
+    ]);
+  });
+
+  it("raising the level to warn drops info/debug (the audit-trail dial)", () => {
+    const cap = capture("warn");
+    securityLog("info", "authz.allow", {
+      category: "authz",
+      actor: "kc-1",
+      actorKind: "user",
+    });
+    securityLog("warn", "authn.deny", {
+      category: "authn",
+      actor: null,
+      actorKind: "external",
+    });
+    expect(cap.records().map((r) => r.msg)).toEqual(["authn.deny"]);
+  });
+
+  it("does not throw on unserializable (circular) fields", () => {
+    const cap = capture("info");
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() =>
+      securityLog("info", "secret.create", {
+        category: "credential",
+        actor: "kc-1",
+        actorKind: "user",
+        detail: circular,
+      }),
+    ).not.toThrow();
+    expect(cap.records()[0]!.msg).toBe("secret.create");
+  });
+
+  it("censors well-known credential keys as defense-in-depth", () => {
+    const cap = capture("info");
+    getLogger().info({ token: "xoxb-leak", note: "ok" }, "oops");
+    expect(cap.raw()).not.toContain("xoxb-leak");
+    expect(cap.raw()).toContain("[REDACTED]");
+  });
+});
+
+describe("securityLog", () => {
+  it("writes at the given common level and always carries category", () => {
+    const cap = capture("info");
+    securityLog("warn", "authn.deny", {
+      category: "authn",
+      actor: null,
+      actorKind: "external",
+      result: "failure",
+      reason: "JWTExpired",
+    });
+    const rec = cap.records()[0]!;
+    expect(rec.level).toBe("warn");
+    expect(rec.msg).toBe("authn.deny");
+    expect(rec.category).toBe("authn");
+    expect(rec.actor).toBe(null);
+    expect(rec.reason).toBe("JWTExpired");
+  });
+});

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -51,7 +51,8 @@ import { getSessionMode } from "../../modules/sessions/infrastructure/sessions-r
 import { createOAuthRoutes } from "./oauth.js";
 import { mountBrandIconRoutes } from "./brand-icon.js";
 import type { Config } from "../../config.js";
-import { createAuth, ForbiddenError } from "./auth.js";
+import { createAuth, ForbiddenError, clientIp } from "./auth.js";
+import { securityLog } from "../../core/security-log.js";
 import { createTermsGate } from "./terms-gate.js";
 import type { IsAcceptedPort } from "../../modules/terms/compose.js";
 import { createK8sSecretsPort } from "./../../modules/secrets/infrastructure/k8s-secrets-port.js";
@@ -331,6 +332,18 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     const user = c.get("user");
     const agentId = c.req.param("id")!;
     if (!(await verifyOwner(agentId, user.sub))) {
+      // The 404 is otherwise indistinguishable from a genuinely missing
+      // agent — log the cross-tenant access attempt.
+      securityLog("warn", "authz.owner_mismatch", {
+        category: "authz",
+        actor: user.sub,
+        actorKind: "user",
+        agentId,
+        decision: "deny",
+        reason: "not-owner",
+        sourceIp: clientIp(c),
+        detail: { surface: "trpc-proxy" },
+      });
       return c.json({ error: "not found" }, 404);
     }
 
@@ -402,6 +415,16 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     const user = c.get("user");
     const agentId = c.req.param("id")!;
     if (!(await verifyOwner(agentId, user.sub))) {
+      securityLog("warn", "authz.owner_mismatch", {
+        category: "authz",
+        actor: user.sub,
+        actorKind: "user",
+        agentId,
+        decision: "deny",
+        reason: "not-owner",
+        sourceIp: clientIp(c),
+        detail: { surface: "import" },
+      });
       return c.json({ error: "not found" }, 404);
     }
     // Hard byte ceiling at the proxy boundary. Requires Content-Length so
@@ -738,8 +761,30 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       return;
     }
 
+    // `relayKind` and `agentId` identify the target credentialed pod; the
+    // token rides in the query string and must NEVER be logged (only the
+    // pathname, which carries no secret).
+    const relayKind = match[2]!; // "acp" | "terminal"
+    const agentId = decodeURIComponent(match[1]!);
+    const fwd = req.headers["x-forwarded-for"];
+    const sourceIp =
+      (typeof fwd === "string" ? fwd.split(",")[0]!.trim() : undefined) ??
+      req.socket.remoteAddress ??
+      undefined;
+
     const token = url.searchParams.get("token");
     if (!token) {
+      securityLog("warn", "ws.authn_deny", {
+        category: "authn",
+        actor: null,
+        actorKind: "external",
+        surface: "ws",
+        agentId,
+        decision: "deny",
+        reason: "missing-token",
+        sourceIp,
+        detail: { relay: relayKind },
+      });
       socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
       socket.destroy();
       return;
@@ -749,27 +794,77 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     try {
       user = (await auth.verify(token)).user;
     } catch (err) {
-      const status =
-        err instanceof ForbiddenError ? "403 Forbidden" : "401 Unauthorized";
-      socket.write(`HTTP/1.1 ${status}\r\n\r\n`);
+      const forbidden = err instanceof ForbiddenError;
+      securityLog("warn", forbidden ? "ws.authz_deny" : "ws.authn_deny", {
+        category: forbidden ? "authz" : "authn",
+        actor: forbidden ? err.sub : null,
+        actorKind: forbidden ? "user" : "external",
+        surface: "ws",
+        agentId,
+        decision: "deny",
+        reason: forbidden
+          ? "missing-required-role"
+          : err instanceof Error
+            ? err.name
+            : "verify-failed",
+        sourceIp,
+        detail: { relay: relayKind },
+      });
+      socket.write(
+        `HTTP/1.1 ${forbidden ? "403 Forbidden" : "401 Unauthorized"}\r\n\r\n`,
+      );
       socket.destroy();
       return;
     }
 
-    const agentId = decodeURIComponent(match[1]);
     if (!(await verifyOwner(agentId, user.sub))) {
+      securityLog("warn", "ws.owner_mismatch", {
+        category: "authz",
+        actor: user.sub,
+        actorKind: "user",
+        surface: "ws",
+        agentId,
+        decision: "deny",
+        reason: "not-owner",
+        sourceIp,
+        detail: { relay: relayKind },
+      });
       socket.write("HTTP/1.1 404 Not Found\r\n\r\n");
       socket.destroy();
       return;
     }
 
     if (!(await isTermsAccepted(user.sub))) {
+      securityLog("warn", "ws.terms_block", {
+        category: "authz",
+        actor: user.sub,
+        actorKind: "user",
+        surface: "ws",
+        agentId,
+        decision: "deny",
+        reason: "terms-not-accepted",
+        sourceIp,
+        detail: { relay: relayKind },
+      });
       socket.write("HTTP/1.1 412 Precondition Failed\r\n\r\n");
       socket.destroy();
       return;
     }
 
-    const relay = match[2] === "acp" ? acpRelay : terminalRelay;
+    // Success: a human (or token-bearer) is attaching to a credentialed pod —
+    // an interactive shell (terminal) or prompt channel (acp). High-value
+    // forensic event in its own right.
+    securityLog("info", "relay.attach", {
+      category: "privileged",
+      actor: user.sub,
+      actorKind: "user",
+      surface: "ws",
+      agentId,
+      result: "success",
+      sourceIp,
+      detail: { relay: relayKind },
+    });
+    const relay = relayKind === "acp" ? acpRelay : terminalRelay;
     relay.handleUpgrade(req, socket, head, agentId);
   });
 

--- a/packages/api-server/src/apps/api-server/auth.ts
+++ b/packages/api-server/src/apps/api-server/auth.ts
@@ -1,12 +1,25 @@
 import { createRemoteJWKSet, jwtVerify } from "jose";
-import type { MiddlewareHandler } from "hono";
+import type { Context, MiddlewareHandler } from "hono";
 import type { UserIdentity } from "api-server-api";
 import { emit, EventType } from "../../events.js";
+import { securityLog } from "../../core/security-log.js";
 
 export class ForbiddenError extends Error {
-  constructor(public readonly requiredRole: string) {
+  constructor(
+    public readonly requiredRole: string,
+    /** Decoded subject of the rejected token — carried so the 403 can be
+     *  audited against a known principal. */
+    public readonly sub: string,
+  ) {
     super(`Missing required role: ${requiredRole}`);
   }
+}
+
+/** Best-effort client IP behind Traefik/Istio (first `X-Forwarded-For` hop). */
+export function clientIp(c: Context): string | undefined {
+  const fwd = c.req.header("x-forwarded-for");
+  if (fwd) return fwd.split(",")[0]!.trim();
+  return c.req.header("x-real-ip") ?? undefined;
 }
 
 export interface AuthConfig {
@@ -56,7 +69,7 @@ export function createAuth(config: AuthConfig) {
     const roles = realmAccess?.roles ?? [];
 
     if (config.requiredRole && !roles.includes(config.requiredRole)) {
-      throw new ForbiddenError(config.requiredRole);
+      throw new ForbiddenError(config.requiredRole, payload.sub!);
     }
 
     return {
@@ -79,6 +92,15 @@ export function createAuth(config: AuthConfig) {
 
     const authHeader = c.req.header("authorization");
     if (!authHeader?.startsWith("Bearer ")) {
+      securityLog("warn", "authn.deny", {
+        category: "authn",
+        actor: null,
+        actorKind: "external",
+        result: "failure",
+        reason: "missing-bearer",
+        target: c.req.path,
+        sourceIp: clientIp(c),
+      });
       return c.json({ error: "unauthorized" }, 401);
     }
 
@@ -103,6 +125,18 @@ export function createAuth(config: AuthConfig) {
       return next();
     } catch (err) {
       if (err instanceof ForbiddenError) {
+        // Known principal denied for lack of a required role — the most
+        // forensically interesting authz event.
+        securityLog("warn", "authz.deny", {
+          category: "authz",
+          actor: err.sub,
+          actorKind: "user",
+          result: "failure",
+          reason: "missing-required-role",
+          target: c.req.path,
+          sourceIp: clientIp(c),
+          detail: { requiredRole: err.requiredRole },
+        });
         return c.json(
           {
             error: "forbidden",
@@ -111,6 +145,18 @@ export function createAuth(config: AuthConfig) {
           403,
         );
       }
+      // Token present but invalid — log the verify-error class (never the
+      // token itself): expired/bad-signature/wrong-audience are replay and
+      // tampering signals.
+      securityLog("warn", "authn.deny", {
+        category: "authn",
+        actor: null,
+        actorKind: "external",
+        result: "failure",
+        reason: err instanceof Error ? err.name : "verify-failed",
+        target: c.req.path,
+        sourceIp: clientIp(c),
+      });
       return c.json({ error: "unauthorized" }, 401);
     }
   };

--- a/packages/api-server/src/apps/ext-authz/grpc.ts
+++ b/packages/api-server/src/apps/ext-authz/grpc.ts
@@ -1,5 +1,6 @@
 import * as grpc from "@grpc/grpc-js";
 import type { ExtAuthzGate } from "../../modules/approvals/compose.js";
+import { securityLog } from "../../core/security-log.js";
 import {
   AuthorizationService,
   type AuthorizationServer,
@@ -69,9 +70,15 @@ export async function startExtAuthzGrpcApp(
         const authority = call.getHost();
         const agentId = parseInstanceFromAuthority(authority, expectedPrefix);
         if (!agentId) {
-          process.stderr.write(
-            `[ext-authz] denied: unparsable :authority='${authority}'\n`,
-          );
+          securityLog("warn", "egress.decision", {
+            category: "egress",
+            actor: null,
+            actorKind: "agent",
+            surface: "ext-authz",
+            decision: "deny",
+            reason: "unparsable-authority",
+            detail: { authority },
+          });
           callback(
             null,
             denied(`unable to derive instance from :authority='${authority}'`),
@@ -88,6 +95,15 @@ export async function startExtAuthzGrpcApp(
         const rawHost = httpReq?.host || sni;
         const host = rawHost ? stripPort(rawHost) : null;
         if (!host) {
+          securityLog("warn", "egress.decision", {
+            category: "egress",
+            actor: null,
+            actorKind: "agent",
+            surface: "ext-authz",
+            agentId,
+            decision: "deny",
+            reason: "missing-host",
+          });
           callback(null, denied("missing host/sni"));
           return;
         }
@@ -100,6 +116,18 @@ export async function startExtAuthzGrpcApp(
         });
         callback(null, verdict === "allow" ? ok() : denied("policy denied"));
       } catch (err) {
+        // Fail closed AND surface — this catch otherwise hides identity-
+        // resolution / rule-lookup exceptions behind a generic gRPC deny.
+        securityLog("error", "egress.decision", {
+          category: "egress",
+          actor: null,
+          actorKind: "agent",
+          surface: "ext-authz",
+          decision: "deny",
+          result: "failure",
+          reason: "internal-error",
+          detail: { error: err instanceof Error ? err.message : "unknown" },
+        });
         callback(
           null,
           denied(err instanceof Error ? err.message : "internal error"),

--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -18,6 +18,7 @@ import type {
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
 import { podBaseUrl } from "../../modules/agents/infrastructure/k8s.js";
 import { resolveAgent } from "./agent-auth.js";
+import { securityLog } from "../../core/security-log.js";
 
 const SESSION_TTL_MS = 30 * 60 * 1000;
 
@@ -165,6 +166,7 @@ export function createMcpSession(
     },
     async ({ channel, text, chatId, attachment }) => {
       let resolved: ChannelAttachment | undefined;
+      let attachmentAudit: Record<string, unknown> | undefined;
       if (attachment) {
         const resolvedPath = resolveWorkspacePath(attachment.path, agentHome);
         let file: { content: string; binary: boolean; mimeType?: string };
@@ -198,6 +200,14 @@ export function createMcpSession(
             : {}),
           ...(attachment.title ? { title: attachment.title } : {}),
         };
+        // Capture the requested (possibly absolute) and resolved source path
+        // so file-exfil-via-channel is investigable — an agent can attach an
+        // absolute pod path, not just a workspace file.
+        attachmentAudit = {
+          requestedPath: attachment.path,
+          resolvedPath,
+          bytes: data.length,
+        };
       }
       const result = await deps.channelManager.postMessage(
         agentId,
@@ -208,6 +218,23 @@ export function createMcpSession(
           ...(resolved ? { attachment: resolved } : {}),
         },
       );
+      const failed = "error" in result;
+      // Autonomous egress to an external channel under the agent identity, no
+      // human in the loop. Never log the message text.
+      securityLog(failed ? "warn" : "info", "channel.outbound", {
+        category: "channel",
+        actor: agentId,
+        actorKind: "agent",
+        surface: channel,
+        agentId,
+        result: failed ? "failure" : "success",
+        detail: {
+          ...(chatId ? { conversationId: chatId } : {}),
+          hasAttachment: attachmentAudit !== undefined,
+          ...(attachmentAudit ? { attachment: attachmentAudit } : {}),
+          textLength: text.length,
+        },
+      });
       if ("error" in result) return errorResult(result.error);
       return textResult("Message sent");
     },
@@ -477,6 +504,17 @@ export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
     // resolve is just a label lookup for owner / agentId.
     const verified = await resolveAgent(deps.k8s, agentId);
     if (!verified) {
+      // Backstop for the waypoint guarantee: an agent id that resolves to no
+      // K8s agent means the mesh principal and cluster state diverged.
+      securityLog("warn", "mcp.resolve_fail", {
+        category: "authn",
+        actor: agentId,
+        actorKind: "agent",
+        surface: "mcp",
+        agentId,
+        decision: "deny",
+        reason: "agent-unresolved",
+      });
       return c.json({ error: "not found" }, 404);
     }
 
@@ -485,6 +523,18 @@ export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
     if (sessionId && sessions.has(sessionId)) {
       const session = sessions.get(sessionId)!;
       if (session.agentId !== agentId) {
+        // A session id minted for one agent reused against another — a
+        // session-hijack signal.
+        securityLog("warn", "mcp.session_mismatch", {
+          category: "authn",
+          actor: agentId,
+          actorKind: "agent",
+          surface: "mcp",
+          agentId,
+          decision: "deny",
+          reason: "session-agent-mismatch",
+          detail: { sessionAgentId: session.agentId },
+        });
         return c.json({ error: "not found" }, 404);
       }
       session.lastActivity = Date.now();

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -29,6 +29,12 @@ const configSchema = z.object({
    *  request would fail closed with no obvious cause — fail-fast at
    *  startup is the diagnosable shape. */
   releaseName: z.string().min(1, "PLATFORM_RELEASE_NAME must be set"),
+  /** Minimum severity emitted by the structured logger (`src/core/logger.ts`).
+   *  Governs the security audit trail "as usual" — it is logged at common
+   *  levels (deny/fail → warn, allow/success → info), so a default of `info`
+   *  keeps the trail on; raising the level reduces it. No separate audit
+   *  toggle. */
+  logLevel: z.enum(["error", "warn", "info", "debug"]).default("info"),
   port: z.coerce.number().default(4000),
   harnessServerPort: z.coerce.number().default(4001),
   harnessServerUrl: z.string().url(),
@@ -134,6 +140,7 @@ export function loadConfig(): Config {
     serverVersion: pkg.version,
     namespace: process.env.NAMESPACE,
     releaseName: process.env.PLATFORM_RELEASE_NAME,
+    logLevel: process.env.LOG_LEVEL,
     port: process.env.PORT,
     harnessServerPort: process.env.MCP_PORT,
     harnessServerUrl: process.env.PLATFORM_HARNESS_SERVER_URL,

--- a/packages/api-server/src/core/logger.ts
+++ b/packages/api-server/src/core/logger.ts
@@ -1,0 +1,67 @@
+/** The api-server's structured logger.
+ *
+ *  Backed by Pino — a single process-wide instance configured once at startup
+ *  (index.ts), imported via `getLogger()` so it need not be threaded through
+ *  every service factory (the same singleton shape as `emit()`/`events$()` in
+ *  `events.ts`). Pino emits one JSON object per line on STDOUT; visibility is
+ *  governed by the configured level (the common `error|warn|info|debug`),
+ *  with no bespoke per-feature toggles. It is the substrate the security audit
+ *  trail (`security-log.ts`) is built on, but it is a general logger — any
+ *  component may use it.
+ *
+ *  In Kubernetes stdout and stderr are merged into one pod log, so consumers
+ *  discriminate on fields (the audit trail's `category`), not on stream. */
+
+import pino, { type Logger, type LoggerOptions } from "pino";
+
+export type { Logger };
+export type LogLevel = "error" | "warn" | "info" | "debug";
+
+function options(level: LogLevel): LoggerOptions {
+  return {
+    level,
+    // String level labels and an ISO `time` — readable, parseable, and
+    // independent of Pino's numeric defaults.
+    formatters: { level: (label: string) => ({ level: label }) },
+    timestamp: pino.stdTimeFunctions.isoTime,
+    // Drop pid/hostname noise — the log pipeline annotates pod identity.
+    base: undefined,
+    // Defense-in-depth: even though call sites must never pass secret values,
+    // censor a few well-known credential keys (top-level and one nesting deep)
+    // so a careless field can't leak a token onto the forensic stream.
+    redact: {
+      paths: [
+        "token",
+        "*.token",
+        "authorization",
+        "*.authorization",
+        "password",
+        "*.password",
+        "secret",
+        "*.secret",
+        "refreshToken",
+        "*.refreshToken",
+      ],
+      censor: "[REDACTED]",
+    },
+  };
+}
+
+let instance: Logger = pino(options("info"));
+
+/** Configure the process-wide logger. Call once at startup. `write` swaps the
+ *  destination (tests capture lines); otherwise output goes to STDOUT. */
+export function configureLogger(opts: {
+  level?: LogLevel;
+  write?: (line: string) => void;
+}): void {
+  const level = opts.level ?? (instance.level as LogLevel);
+  instance = opts.write
+    ? pino(options(level), { write: opts.write })
+    : pino(options(level));
+}
+
+/** The current Pino instance. Read at call time so reconfiguration applies. */
+export function getLogger(): Logger {
+  return instance;
+}

--- a/packages/api-server/src/core/security-log.ts
+++ b/packages/api-server/src/core/security-log.ts
@@ -1,0 +1,85 @@
+/** Security audit trail — the structured-field convention layered on the
+ *  general `logger` (logger.ts) so a security incident can be reconstructed
+ *  from STDOUT: *who did what, to what, and whether it was allowed*.
+ *
+ *  This is a thin, typed wrapper over `logger[level]` — NOT a new log level
+ *  or a separate stream. Every line carries `category`, which is what a log
+ *  shipper filters on to isolate the audit trail from operational noise.
+ *
+ *  Level mapping (the common levels, used as usual):
+ *    - `warn`  — a denied / blocked / failed security decision
+ *    - `info`  — an allowed / successful security-relevant action or mutation
+ *    - `error` — an internal failure on a security path
+ *
+ *  Actor is the raw (un-pseudonymized) Keycloak `sub`: forensics needs direct
+ *  attribution, which is the deliberate difference from the usage subsystem's
+ *  HMAC-pseudonymized `activity_events` (those protect analytics-at-rest; this
+ *  protects an investigation). The audit stream is therefore PII and is
+ *  governed at the log sink. See dam-ops#13.
+ *
+ *  Redaction is the caller's responsibility: never pass token/secret/PAT
+ *  values, raw JWTs, or raw prompts. Pass metadata only (`hasRefresh`,
+ *  `secretId`, env key *names*, byte counts). Never spread a whole domain
+ *  event into `detail` — project explicit fields. */
+
+import { getLogger, type LogLevel } from "./logger.js";
+
+export type SecurityCategory =
+  | "authn" // authentication (who you are)
+  | "authz" // authorization (what you may do)
+  | "egress" // credentialed egress / ext_authz decisions
+  | "approval" // HITL verdicts
+  | "authz-list" // allow-list mutations (allowedUsers, egress rules, grants)
+  | "credential" // secret / token / connection lifecycle
+  | "channel" // messenger inbound/outbound + identity linking
+  | "resource" // agent / schedule lifecycle
+  | "privileged"; // privileged reads / admin-surface actions
+
+export type ActorKind = "user" | "agent" | "system" | "external";
+
+export type SecuritySurface =
+  | "ui"
+  | "cli"
+  | "other" // an OIDC client that is neither the UI nor the CLI
+  | "slack"
+  | "telegram"
+  | "scheduler"
+  | "ext-authz"
+  | "mcp"
+  | "ws";
+
+export interface SecurityFields {
+  /** Coarse class — the field a log shipper filters the audit trail on. */
+  category: SecurityCategory;
+  /** Raw Keycloak `sub`, `"system:<component>"`, an external id, or null. */
+  actor: string | null;
+  actorKind: ActorKind;
+  surface?: SecuritySurface;
+  /** Execution outcome — distinct from `decision` so "what failed" and "what
+   *  was denied" stay separable. */
+  result?: "success" | "failure";
+  /** Policy outcome for gated actions. */
+  decision?: "allow" | "deny" | "hold" | "expired";
+  agentId?: string;
+  /** What was acted on — host / connectionKey / secretId / resource id. */
+  target?: string;
+  /** Client IP at the HTTP edge (strip any `?token=` before passing a URL). */
+  sourceIp?: string;
+  /** Ties a multi-site flow together (e.g. ext_authz hold → verdict). */
+  correlationId?: string;
+  /** Denial cause / failure reason. */
+  reason?: string;
+  /** Shallow, value-free extras (added/removed subs, changed env key names,
+   *  matched rule, byte counts). Never raw secrets/prompts. */
+  detail?: Record<string, unknown>;
+}
+
+/** Emit one security audit line at the given common level. The dotted `event`
+ *  name is the log message; `fields` are merged into the JSON line. */
+export function securityLog(
+  level: LogLevel,
+  event: string,
+  fields: SecurityFields,
+): void {
+  getLogger()[level](fields, event);
+}

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -69,10 +69,12 @@ import {
   startOnChannelTurnRelayedSaga,
 } from "./modules/forks/index.js";
 import { composeUsageModule } from "./modules/usage/compose.js";
+import { composeAuditModule } from "./modules/audit/index.js";
 import { createK8sForkOrchestrator } from "./modules/forks/infrastructure/k8s-fork-orchestrator.js";
 import { composeE2eModule } from "./modules/e2e/compose.js";
 import { composeTermsModule } from "./modules/terms/index.js";
 import { loadConfig } from "./config.js";
+import { configureLogger } from "./core/logger.js";
 import { startApiServerApp } from "./apps/api-server/app.js";
 import { startHarnessApiServerApp } from "./apps/harness-api-server/app.js";
 import { startExtAuthzGrpcApp } from "./apps/ext-authz/grpc.js";
@@ -96,6 +98,7 @@ import { createSubPseudonymizer } from "./core/sub-pseudonymizer.js";
 import { podBaseUrl } from "./modules/agents/infrastructure/k8s.js";
 
 const config = loadConfig();
+configureLogger({ level: config.logLevel });
 
 const { api } = createApi(config.namespace);
 await runMigrations(config.databaseUrl, config.migrationsPath);
@@ -152,6 +155,12 @@ const usage = composeUsageModule({
   },
 });
 usage.start();
+
+// Security audit trail (bus-driven half). Denials and call-site-only
+// mutations log directly at their sites; this covers the actor-bearing
+// success/observation events on the domain bus.
+const audit = composeAuditModule();
+audit.start();
 
 const userDirectory = createKeycloakUserDirectory({
   keycloakUrl: config.keycloakUrl,
@@ -465,6 +474,7 @@ async function shutdown() {
   onForeignReplySub.unsubscribe();
   onChannelTurnRelayedSub.unsubscribe();
   usage.stop();
+  audit.stop();
   await deliverySweeper.stop();
   await agentArtifactsSweeper.stop();
   await channelManager.stopAll();

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -26,6 +26,7 @@ import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 import { ok, err } from "../../../core/result.js";
 import type { UnitOfWork, Tx } from "../../../core/unit-of-work.js";
 import { emit, EventType } from "../../../events.js";
+import { securityLog } from "../../../core/security-log.js";
 
 /**
  * Port consumed by `create()` to seed `egress_rules` for a brand-new agent
@@ -140,6 +141,14 @@ export function createAgentsService(deps: {
       ];
       const orphans = psqlAgentIds.filter((id) => !infraIds.has(id));
       if (orphans.length > 0) {
+        // Clearing an authorization list as a side-effect of a read — flag it
+        // so a transient K8s read returning empty can't silently mass-purge.
+        securityLog("warn", "agent.allowed_users.orphan_purge", {
+          category: "authz-list",
+          actor: deps.owner ?? null,
+          actorKind: "user",
+          detail: { agentIds: orphans },
+        });
         await Promise.all([
           deps.deleteChannelsByAgentIds(orphans),
           deps.deleteAllowedUsersByAgentIds(orphans),
@@ -208,6 +217,14 @@ export function createAgentsService(deps: {
       if (emails.length > 0) {
         const subs = await emailsToSubs(emails);
         await deps.setAllowedUsers(infra.id, subs);
+        securityLog("info", "agent.allowed_users_set", {
+          category: "authz-list",
+          actor: owner || null,
+          actorKind: "user",
+          agentId: infra.id,
+          result: "success",
+          detail: { added: subs, removed: [], resultUnrestricted: false },
+        });
       }
 
       // Bulk-seed the requested preset (default `trusted`). `none` is a
@@ -225,6 +242,22 @@ export function createAgentsService(deps: {
       await deps.runtimeMutator.bump(infra.id, []);
 
       const agent = assembleAgent(infra, [], emails);
+      // Records the agent's initial security posture (preset, secret ref,
+      // allow-list size, env key names — never env values).
+      securityLog("info", "agent.create", {
+        category: "resource",
+        actor: owner || null,
+        actorKind: "user",
+        agentId: agent.id,
+        result: "success",
+        detail: {
+          ...(templateId ? { templateId } : {}),
+          egressPreset: input.egressPreset ?? "trusted",
+          allowedUserCount: emails.length,
+          secretRefSet: input.secretRef !== undefined,
+          envKeys: (input.env ?? []).map((e) => e.name),
+        },
+      });
       emit({
         type: EventType.AgentCreated,
         agentId: agent.id,
@@ -248,9 +281,42 @@ export function createAgentsService(deps: {
       const infra = await deps.repo.updateSpec(input.id, deps.owner, patch);
       if (!infra) return null;
 
+      if (input.env !== undefined || input.secretRef !== undefined) {
+        // Env and secretRef control what credentials the pod receives — log
+        // key names only, never values.
+        securityLog("info", "agent.update", {
+          category: "resource",
+          actor: deps.owner ?? null,
+          actorKind: "user",
+          agentId: input.id,
+          result: "success",
+          detail: {
+            secretRefChanged: input.secretRef !== undefined,
+            ...(env !== undefined ? { envKeys: env.map((e) => e.name) } : {}),
+          },
+        });
+      }
+
       if (input.allowedUserEmails !== undefined) {
+        // Diff against the prior list so an attacker silently inserting their
+        // own sub (or emptying the list to make it unrestricted) is visible.
+        const prior = await deps.listAllowedUsersByAgent(input.id);
         const subs = await emailsToSubs(input.allowedUserEmails);
+        const priorSet = new Set(prior);
+        const nextSet = new Set(subs);
         await deps.setAllowedUsers(input.id, subs);
+        securityLog("info", "agent.allowed_users_set", {
+          category: "authz-list",
+          actor: deps.owner ?? null,
+          actorKind: "user",
+          agentId: input.id,
+          result: "success",
+          detail: {
+            added: subs.filter((s) => !priorSet.has(s)),
+            removed: prior.filter((s) => !nextSet.has(s)),
+            resultUnrestricted: subs.length === 0,
+          },
+        });
       }
 
       emit({ type: EventType.AgentUpdated, agentId: input.id });
@@ -268,28 +334,66 @@ export function createAgentsService(deps: {
         try {
           await hook(id);
         } catch (err) {
-          process.stderr.write(
-            `agents.delete cleanup hook failed for ${id}: ${err instanceof Error ? err.message : err}\n`,
-          );
+          securityLog("warn", "agent.delete.cleanup_failed", {
+            category: "resource",
+            actor: deps.owner ?? null,
+            actorKind: "user",
+            agentId: id,
+            result: "failure",
+            reason: err instanceof Error ? err.message : "unknown",
+          });
         }
       }
+      // Destructive (cascades PVC/secret/egress-rule cleanup); the actor is
+      // absent from the AgentDeleted event, so log it here.
+      securityLog("info", "agent.delete", {
+        category: "resource",
+        actor: deps.owner ?? null,
+        actorKind: "user",
+        agentId: id,
+        result: "success",
+      });
       emit({ type: EventType.AgentDeleted, agentId: id });
     },
 
     async restart(id) {
       const restarted = await deps.repo.restart(id, deps.owner);
       if (restarted) {
+        securityLog("info", "agent.restart", {
+          category: "privileged",
+          actor: deps.owner ?? null,
+          actorKind: "user",
+          agentId: id,
+          result: "success",
+        });
         emit({ type: EventType.AgentRestarted, agentId: id });
       }
       return restarted;
     },
 
     async wake(id) {
-      if (deps.owner && !(await deps.repo.isOwnedBy(id, deps.owner)))
+      if (deps.owner && !(await deps.repo.isOwnedBy(id, deps.owner))) {
+        securityLog("warn", "authz.owner_mismatch", {
+          category: "authz",
+          actor: deps.owner,
+          actorKind: "user",
+          agentId: id,
+          decision: "deny",
+          reason: "not-owner",
+          detail: { surface: "agent.wake" },
+        });
         return null;
+      }
       const infra = await deps.repo.wake(id);
       if (!infra) return null;
       if (infra.desiredState === "running") {
+        securityLog("info", "agent.wake", {
+          category: "privileged",
+          actor: deps.owner ?? null,
+          actorKind: "user",
+          agentId: id,
+          result: "success",
+        });
         emit({ type: EventType.AgentWoken, agentId: id });
       }
       return project(infra);

--- a/packages/api-server/src/modules/approvals/services/approvals-service.ts
+++ b/packages/api-server/src/modules/approvals/services/approvals-service.ts
@@ -11,6 +11,7 @@ import {
   buildAcpPermissionResponse,
   pickOptionId,
 } from "../infrastructure/wrapper-response-frames.js";
+import { securityLog } from "../../../core/security-log.js";
 
 /** Notifier for cross-replica wake-up of held ext_authz calls. Publishes to
  *  `approval:<id>` on Redis; consumers read the verdict from Postgres. The
@@ -73,8 +74,43 @@ async function loadOwned(
   id: string,
 ): Promise<PendingApprovalRow | null> {
   const row = await deps.repo.getPending(id);
-  if (!row || row.ownerSub !== deps.ownerSub) return null;
+  if (!row) return null;
+  if (row.ownerSub !== deps.ownerSub) {
+    // A caller acting on an approval that isn't theirs — cross-tenant
+    // approval-tampering attempt.
+    securityLog("warn", "authz.owner_mismatch", {
+      category: "authz",
+      actor: deps.ownerSub,
+      actorKind: "user",
+      agentId: row.agentId,
+      decision: "deny",
+      reason: "not-owner",
+      correlationId: id,
+      detail: { surface: "approval.verdict" },
+    });
+    return null;
+  }
   return row;
+}
+
+/** One audit line per HITL verdict. correlationId === the pending-approval id,
+ *  which is the same id the ext_authz gate logs on hold-open / hold-resolve —
+ *  so the held request and the human decision join on it. */
+function auditVerdict(
+  deps: CreateApprovalsServiceDeps,
+  row: PendingApprovalRow,
+  decision: "allow" | "deny",
+  detail: Record<string, unknown>,
+): void {
+  securityLog("info", "approval.verdict", {
+    category: "approval",
+    actor: deps.ownerSub,
+    actorKind: "user",
+    agentId: row.agentId,
+    decision,
+    correlationId: row.id,
+    detail,
+  });
 }
 
 export function createApprovalsService(
@@ -100,6 +136,10 @@ export function createApprovalsService(
       if (row.type === "ext_authz") {
         await deps.repo.resolvePending(id, "allow_once", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
+        auditVerdict(deps, row, "allow", {
+          verdict: "allow_once",
+          ruleWritten: false,
+        });
         return;
       }
       await resolveAndDeliverAcpNative(deps, row, "allow_once");
@@ -124,6 +164,13 @@ export function createApprovalsService(
         // approve-permanent flow: rule is written, future retries match.
         await deps.repo.resolvePending(id, "allow", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
+        auditVerdict(deps, row, "allow", {
+          verdict: "allow",
+          ruleWritten: true,
+          host: row.payload.host,
+          method: row.payload.method,
+          pathPattern: row.payload.path,
+        });
         return;
       }
       // ACP-native: persistence ("allow_always") is the harness's own
@@ -153,6 +200,14 @@ export function createApprovalsService(
         });
         await deps.repo.resolvePending(id, "allow", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
+        // Host-wide allow (method:*/path:*) — a broad widening of the
+        // allow-list; flag it.
+        auditVerdict(deps, row, "allow", {
+          verdict: "allow",
+          ruleWritten: true,
+          host: row.payload.host,
+          hostWide: true,
+        });
         return;
       }
       await resolveAndDeliverAcpNative(deps, row, "allow");
@@ -174,6 +229,13 @@ export function createApprovalsService(
         });
         await deps.repo.resolvePending(id, "deny", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
+        auditVerdict(deps, row, "deny", {
+          verdict: "deny",
+          ruleWritten: true,
+          host: row.payload.host,
+          method: row.payload.method,
+          pathPattern: row.payload.path,
+        });
         return;
       }
       await resolveAndDeliverAcpNative(deps, row, "deny");
@@ -187,6 +249,10 @@ export function createApprovalsService(
       if (row.type === "ext_authz") {
         await deps.repo.resolvePending(id, "deny_once", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
+        auditVerdict(deps, row, "deny", {
+          verdict: "deny_once",
+          ruleWritten: false,
+        });
         return;
       }
       await resolveAndDeliverAcpNative(deps, row, "deny_once");
@@ -209,6 +275,10 @@ async function resolveAndDeliverAcpNative(
 ): Promise<void> {
   if (row.payload.kind !== "acp_native") return;
   await deps.repo.resolvePending(row.id, verdict, deps.ownerSub);
+  auditVerdict(deps, row, verdict.startsWith("allow") ? "allow" : "deny", {
+    verdict,
+    native: true,
+  });
   const rpcId = row.payload.rpcId;
   if (rpcId === undefined || rpcId === null) return;
   const optionId = pickOptionId(row.payload.options ?? [], verdict);

--- a/packages/api-server/src/modules/approvals/services/ext-authz-gate.ts
+++ b/packages/api-server/src/modules/approvals/services/ext-authz-gate.ts
@@ -5,6 +5,9 @@ import {
   buildExtAuthzSynthFrame,
   injectChannelOf,
 } from "../infrastructure/acp-frames.js";
+import { securityLog } from "../../../core/security-log.js";
+import { getLogger } from "../../../core/logger.js";
+import { formatError } from "../../../core/format-error.js";
 
 export type ExtAuthzVerdict = "allow" | "deny";
 
@@ -59,7 +62,22 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
   return {
     async gateRequest({ agentId, host, method, path }) {
       const identity = await deps.identityResolver.resolve(agentId);
-      if (!identity) return "deny";
+      if (!identity) {
+        // A caller presenting an agent id that resolves to no owner is the
+        // spoof / stale-caller signal an investigator wants — fail closed.
+        securityLog("warn", "egress.decision", {
+          category: "egress",
+          actor: null,
+          actorKind: "agent",
+          surface: "ext-authz",
+          agentId,
+          target: host,
+          decision: "deny",
+          reason: "identity-unresolved",
+          detail: { method, path },
+        });
+        return "deny";
+      }
 
       const matched = await deps.ruleMatcher.match(
         identity.agentId,
@@ -67,7 +85,23 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
         method,
         path,
       );
-      if (matched) return matched.verdict;
+      if (matched) {
+        securityLog(
+          matched.verdict === "deny" ? "warn" : "info",
+          "egress.decision",
+          {
+            category: "egress",
+            actor: identity.ownerSub,
+            actorKind: "agent",
+            surface: "ext-authz",
+            agentId: identity.agentId,
+            target: host,
+            decision: matched.verdict,
+            detail: { method, path, basis: "rule" },
+          },
+        );
+        return matched.verdict;
+      }
 
       // Dedupe retried holds: when the agent's CLI retries (Envoy timeout,
       // network blip, api-server restart mid-hold) we want one inbox row
@@ -99,44 +133,83 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
           path,
         });
         void deps.bus.publish(injectChannelOf(agentId), frame);
+        // Agent egress blocked awaiting a human verdict. correlationId ties
+        // this to the verdict line written when the hold settles (and to the
+        // approval.verdict line in approvals-service).
+        securityLog("warn", "egress.hold", {
+          category: "egress",
+          actor: identity.ownerSub,
+          actorKind: "agent",
+          surface: "ext-authz",
+          agentId: identity.agentId,
+          target: host,
+          decision: "hold",
+          correlationId: pendingId,
+          detail: { method, path },
+        });
       }
 
-      return waitForVerdict(deps, pendingId);
+      const { verdict, reason } = await waitForVerdict(deps, pendingId);
+      securityLog(verdict === "deny" ? "warn" : "info", "egress.decision", {
+        category: "egress",
+        actor: identity.ownerSub,
+        actorKind: "agent",
+        surface: "ext-authz",
+        agentId: identity.agentId,
+        target: host,
+        decision: reason === "hold-expired" ? "expired" : verdict,
+        correlationId: pendingId,
+        reason,
+        detail: { method, path, basis: "hold" },
+      });
+      return verdict;
     },
   };
+}
+
+interface SettledVerdict {
+  verdict: ExtAuthzVerdict;
+  reason: "hold-resolved" | "hold-expired";
 }
 
 async function waitForVerdict(
   deps: CreateExtAuthzGateDeps,
   id: string,
-): Promise<ExtAuthzVerdict> {
+): Promise<SettledVerdict> {
   // Re-read the row up front: a verdict written between INSERT and
   // SUBSCRIBE would otherwise be missed. Postgres is the truth path.
   const initial = await deps.repo.getPending(id);
   if (initial && initial.status === "resolved")
-    return verdictOf(initial.verdict);
+    return { verdict: verdictOf(initial.verdict), reason: "hold-resolved" };
 
-  return new Promise<ExtAuthzVerdict>((resolve) => {
+  return new Promise<SettledVerdict>((resolve) => {
     let settled = false;
-    const settle = (v: ExtAuthzVerdict) => {
+    const settle = (s: SettledVerdict) => {
       if (settled) return;
       settled = true;
       cleanup();
-      resolve(v);
+      resolve(s);
     };
 
     const unsubscribe = deps.bus.subscribe(`approval:${id}`, async () => {
       const row = await deps.repo.getPending(id);
       if (!row || row.status !== "resolved") return;
-      settle(verdictOf(row.verdict));
+      settle({ verdict: verdictOf(row.verdict), reason: "hold-resolved" });
     });
 
     const timeout = setTimeout(async () => {
       // Mark expired so the inbox shows the row's terminal state. The
       // egress rules path is unaffected — a future approve-permanent still
       // writes a rule that the agent's next retry consumes.
-      await deps.repo.expirePending(id).catch(() => {});
-      settle("deny");
+      await deps.repo.expirePending(id).catch((err) => {
+        // Surface rather than swallow: a failure here means the inbox row is
+        // stuck non-terminal even though the hold fail-closed denied.
+        getLogger().error(
+          { pendingId: id, reason: formatError(err) },
+          "egress.hold_expire_error",
+        );
+      });
+      settle({ verdict: "deny", reason: "hold-expired" });
     }, deps.holdSeconds * 1000);
     timeout.unref();
 

--- a/packages/api-server/src/modules/audit/compose.ts
+++ b/packages/api-server/src/modules/audit/compose.ts
@@ -1,0 +1,31 @@
+import type { Subscription } from "rxjs";
+import { startAuditLogSaga } from "./sagas/audit-log.js";
+
+export interface AuditModule {
+  /** Subscribes the domain bus and starts emitting audit lines. */
+  start(): void;
+  /** Unsubscribes (test/teardown). */
+  stop(): void;
+}
+
+/**
+ * Security audit-trail module. A bus-driven sink (mirrors the usage module
+ * shape) with no domain operations of its own: it subscribes the event bus
+ * and writes forensic audit lines via the shared logger. It needs no deps —
+ * the logger and the event bus are both process-wide singletons.
+ *
+ * The trail is governed by the configured log level (no separate toggle); the
+ * saga always subscribes, and whether a line is emitted is the logger's call.
+ */
+export function composeAuditModule(): AuditModule {
+  let sub: Subscription | null = null;
+  return {
+    start() {
+      sub ??= startAuditLogSaga();
+    },
+    stop() {
+      sub?.unsubscribe();
+      sub = null;
+    },
+  };
+}

--- a/packages/api-server/src/modules/audit/index.ts
+++ b/packages/api-server/src/modules/audit/index.ts
@@ -1,0 +1,1 @@
+export { composeAuditModule, type AuditModule } from "./compose.js";

--- a/packages/api-server/src/modules/audit/sagas/audit-log.ts
+++ b/packages/api-server/src/modules/audit/sagas/audit-log.ts
@@ -4,7 +4,6 @@ import {
   ofType,
   EventType,
   type DomainEvent,
-  type UserAuthenticated,
   type ChannelTurnRelayed,
   type ScheduleFired,
   type FilesImported,
@@ -56,15 +55,13 @@ export function startAuditLogSaga(): Subscription {
     );
   }
 
-  on<UserAuthenticated>(EventType.UserAuthenticated, (e) =>
-    securityLog("info", "auth.login", {
-      category: "authn",
-      actor: e.userSub,
-      actorKind: "user",
-      surface: e.surface === "ui" || e.surface === "cli" ? e.surface : "other",
-      result: "success",
-    }),
-  );
+  // NB: `UserAuthenticated` is deliberately NOT logged here. It fires on every
+  // authenticated `/api/*` request (auth.ts middleware), not once per login —
+  // the usage saga subscribes it precisely because it wants that per-request
+  // signal, and collapses it to one row/day. A successful login is recorded
+  // authoritatively by Keycloak's own authentication-event log; mirroring it
+  // per-request here only floods the trail. Denied auth still surfaces here as
+  // `authn.deny` / `authz.deny`, logged directly at the edge in auth.ts.
 
   on<ChannelTurnRelayed>(EventType.ChannelTurnRelayed, (e) =>
     securityLog(e.outcome === "failure" ? "warn" : "info", "channel.turn", {

--- a/packages/api-server/src/modules/audit/sagas/audit-log.ts
+++ b/packages/api-server/src/modules/audit/sagas/audit-log.ts
@@ -1,0 +1,165 @@
+import { Subscription } from "rxjs";
+import {
+  events$,
+  ofType,
+  EventType,
+  type DomainEvent,
+  type UserAuthenticated,
+  type ChannelTurnRelayed,
+  type ScheduleFired,
+  type FilesImported,
+  type ForeignReplyReceived,
+  type ForkReady,
+  type ForkFailed,
+  type ForkCompleted,
+} from "../../../events.js";
+import { getLogger } from "../../../core/logger.js";
+import { securityLog } from "../../../core/security-log.js";
+import { formatError } from "../../../core/format-error.js";
+
+/**
+ * Security-event saga: subscribes the in-process domain bus and writes a
+ * forensic audit line for the success/observation events that already carry a
+ * real actor. It is the bus-driven half of the audit trail; denials and the
+ * mutations whose actor is only known at the call site are logged directly
+ * there (so this saga and those call sites stay disjoint — no double-logging).
+ *
+ * Each handler PROJECTS explicit fields — never spread a whole event onto the
+ * line, because some events (ForeignReplyReceived) carry the raw user prompt,
+ * which must never reach the audit stream.
+ *
+ * Single-process, single-subscriber: one line per replica that handles the
+ * event. Domain events must not be moved onto the cross-replica Redis bus
+ * without dedup, or every replica's saga would duplicate every line.
+ */
+export function startAuditLogSaga(): Subscription {
+  const sub = new Subscription();
+
+  function on<T extends DomainEvent>(
+    type: T["type"],
+    handler: (event: T) => void,
+  ): void {
+    sub.add(
+      events$()
+        .pipe(ofType<T>(type))
+        .subscribe((event) => {
+          try {
+            handler(event);
+          } catch (err) {
+            // A projection bug must never tear down the subscription.
+            getLogger().error(
+              { sourceEvent: type, reason: formatError(err) },
+              "audit.saga_error",
+            );
+          }
+        }),
+    );
+  }
+
+  on<UserAuthenticated>(EventType.UserAuthenticated, (e) =>
+    securityLog("info", "auth.login", {
+      category: "authn",
+      actor: e.userSub,
+      actorKind: "user",
+      surface: e.surface === "ui" || e.surface === "cli" ? e.surface : "other",
+      result: "success",
+    }),
+  );
+
+  on<ChannelTurnRelayed>(EventType.ChannelTurnRelayed, (e) =>
+    securityLog(e.outcome === "failure" ? "warn" : "info", "channel.turn", {
+      category: "channel",
+      actor: e.actorSub,
+      // Telegram relays have no Keycloak identity (actorSub null) — the
+      // driver is an external messenger user.
+      actorKind: e.actorSub ? "user" : "external",
+      surface: e.channel,
+      agentId: e.agentId,
+      result: e.outcome,
+      ...(e.forkId ? { detail: { forkId: e.forkId } } : {}),
+    }),
+  );
+
+  on<ScheduleFired>(EventType.ScheduleFired, (e) =>
+    securityLog(e.outcome === "failure" ? "warn" : "info", "schedule.fired", {
+      category: "resource",
+      // Unattended run on the owner's behalf — system-initiated, owner-owned.
+      actor: e.ownerSub,
+      actorKind: "system",
+      surface: "scheduler",
+      agentId: e.agentId,
+      result: e.outcome,
+      detail: {
+        scheduleId: e.scheduleId,
+        mode: e.mode,
+        sessionId: e.sessionId,
+      },
+    }),
+  );
+
+  on<FilesImported>(EventType.FilesImported, (e) =>
+    securityLog(e.outcome === "failure" ? "warn" : "info", "files.import", {
+      category: "resource",
+      actor: e.actorSub,
+      actorKind: "user",
+      agentId: e.agentId,
+      result: e.outcome,
+      detail: { bytes: e.bytes },
+    }),
+  );
+
+  on<ForeignReplyReceived>(EventType.ForeignReplyReceived, (e) =>
+    // The single most security-relevant channel action: a NON-owner driving
+    // someone else's agent under their own credentials (ADR-027). Project
+    // fields explicitly — e.prompt MUST NOT be logged.
+    securityLog("info", "channel.foreign_turn.begin", {
+      category: "channel",
+      actor: e.foreignSub,
+      actorKind: "user",
+      surface: "slack",
+      agentId: e.agentId,
+      correlationId: e.replyId,
+      detail: {
+        threadTs: e.threadTs,
+        channelId: e.slackContext.channelId,
+        userSlackId: e.slackContext.userSlackId,
+        ...(e.sessionId ? { sessionId: e.sessionId } : {}),
+      },
+    }),
+  );
+
+  on<ForkReady>(EventType.ForkReady, (e) =>
+    securityLog("info", "fork.ready", {
+      category: "resource",
+      actor: null,
+      actorKind: "system",
+      correlationId: e.replyId,
+      detail: { forkId: e.forkId },
+    }),
+  );
+
+  on<ForkFailed>(EventType.ForkFailed, (e) =>
+    securityLog("warn", "fork.failed", {
+      // A credential-mint failure is a credential-path event, not just a
+      // resource lifecycle blip — surface it as such.
+      category: e.reason === "CredentialMintFailed" ? "credential" : "resource",
+      actor: null,
+      actorKind: "system",
+      result: "failure",
+      reason: e.reason,
+      correlationId: e.replyId,
+      detail: { forkId: e.forkId, ...(e.detail ? { detail: e.detail } : {}) },
+    }),
+  );
+
+  on<ForkCompleted>(EventType.ForkCompleted, (e) =>
+    securityLog("info", "fork.completed", {
+      category: "resource",
+      actor: null,
+      actorKind: "system",
+      correlationId: e.forkId,
+    }),
+  );
+
+  return sub;
+}

--- a/packages/api-server/src/modules/channels/infrastructure/slack-oauth.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack-oauth.ts
@@ -5,6 +5,7 @@ import {
   exchangeCodeForTokens,
   type KeycloakOAuthConfig,
 } from "./identity-oauth.js";
+import { securityLog } from "../../../core/security-log.js";
 
 const FLOW_TTL_MS = 10 * 60 * 1000;
 
@@ -33,6 +34,15 @@ export function createSlackOAuthRoutes(deps: {
 
     const pending = deps.pendingFlows.get(state);
     if (!pending) {
+      // Invalid/replayed state on a public callback — a CSRF/replay probe.
+      securityLog("warn", "identity.link.denied", {
+        category: "channel",
+        actor: null,
+        actorKind: "external",
+        surface: "slack",
+        decision: "deny",
+        reason: "invalid-state",
+      });
       return c.text("Invalid or expired state", 400);
     }
 
@@ -65,6 +75,18 @@ export function createSlackOAuthRoutes(deps: {
       result.keycloakSub,
       result.refreshToken,
     );
+    // The primary "who got bound to which Keycloak account" record.
+    securityLog("info", "identity.link", {
+      category: "channel",
+      actor: result.keycloakSub,
+      actorKind: "user",
+      surface: "slack",
+      result: "success",
+      detail: {
+        externalUserId: pending.slackUserId,
+        hasRefresh: Boolean(result.refreshToken),
+      },
+    });
 
     return c.html(
       "<html><body><h2>Account linked!</h2><p>You can close this window and return to Slack.</p></body></html>",

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -31,6 +31,7 @@ import {
   type KeycloakOAuthConfig,
 } from "./identity-oauth.js";
 import { formatError } from "../../../core/format-error.js";
+import { securityLog } from "../../../core/security-log.js";
 
 type BoltApp = InstanceType<typeof App>;
 
@@ -640,6 +641,16 @@ export function createSlackWorker(
 
     const keycloakSub = await identityLinks.resolve("slack", slackUserId);
     if (!keycloakSub) {
+      // An unlinked (unauthenticated) Slack user probing to drive an agent.
+      securityLog("warn", "channel.authz_deny", {
+        category: "channel",
+        actor: null,
+        actorKind: "external",
+        surface: "slack",
+        decision: "deny",
+        reason: "unlinked",
+        detail: { slackUserId, channelId: event.channel },
+      });
       await app.client.chat.postEphemeral({
         channel: event.channel,
         user: slackUserId,
@@ -718,6 +729,18 @@ export function createSlackWorker(
     ]);
     const isOwner = ownerSub !== null && ownerSub === args.keycloakSub;
     if (!isOwner && !isAllowed) {
+      // A linked user who is neither owner nor on the allow-list tried to
+      // drive the agent.
+      securityLog("warn", "channel.authz_deny", {
+        category: "channel",
+        actor: args.keycloakSub,
+        actorKind: "user",
+        surface: "slack",
+        agentId: args.instanceName,
+        decision: "deny",
+        reason: "not-allowed",
+        detail: { slackUserId: args.slackUserId, channelId: args.channel },
+      });
       await app.client.chat.postEphemeral({
         channel: args.channel,
         user: args.slackUserId,
@@ -725,6 +748,16 @@ export function createSlackWorker(
       });
       return;
     }
+    // Authorized to drive — record who and on what basis.
+    securityLog("info", "channel.authz", {
+      category: "channel",
+      actor: args.keycloakSub,
+      actorKind: "user",
+      surface: "slack",
+      agentId: args.instanceName,
+      decision: "allow",
+      detail: { basis: isOwner ? "owner" : "allowlist" },
+    });
 
     if (!(await isTermsAccepted(args.keycloakSub))) {
       await app.client.chat.postEphemeral({

--- a/packages/api-server/src/modules/channels/infrastructure/telegram.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/telegram.ts
@@ -10,6 +10,7 @@ import type {
 } from "../stored-channel.js";
 import type { PostMessageOptions } from "../services/channel-manager.js";
 import { createAcpClient } from "../../../core/acp-client.js";
+import { securityLog } from "../../../core/security-log.js";
 import {
   buildAuthorizeUrl,
   generatePkce,
@@ -230,6 +231,16 @@ export function createTelegramWorker(
           telegramUserId,
         );
         if (!isAdmin) {
+          securityLog("warn", "channel.authz_deny", {
+            category: "channel",
+            actor: null,
+            actorKind: "external",
+            surface: "telegram",
+            agentId: instanceName,
+            decision: "deny",
+            reason: "not-group-admin",
+            detail: { telegramUserId, threadId: thread.id, command: "login" },
+          });
           await thread.post("Only group admins can /login.");
           return;
         }
@@ -269,6 +280,16 @@ export function createTelegramWorker(
           telegramUserId,
         );
         if (!isAdmin) {
+          securityLog("warn", "channel.authz_deny", {
+            category: "channel",
+            actor: null,
+            actorKind: "external",
+            surface: "telegram",
+            agentId: instanceName,
+            decision: "deny",
+            reason: "not-group-admin",
+            detail: { telegramUserId, threadId: thread.id, command: "logout" },
+          });
           await thread.post("Only group admins can /logout.");
           return;
         }
@@ -280,6 +301,15 @@ export function createTelegramWorker(
         return;
       }
       await threads.revoke(instanceName, thread.id);
+      securityLog("info", "channel.thread_revoked", {
+        category: "authz-list",
+        actor: null,
+        actorKind: "external",
+        surface: "telegram",
+        agentId: instanceName,
+        result: "success",
+        detail: { threadId: thread.id, byTelegramUserId: telegramUserId },
+      });
       await thread.post(
         "Conversation revoked. Send /login to authorize again.",
       );
@@ -320,6 +350,22 @@ export function createTelegramWorker(
 
       const authorized = await threads.isAuthorized(instanceName, thread.id);
       if (!authorized) {
+        // An unauthorized conversation attempting to drive the agent. Repeated
+        // hits from the same thread are the probing signal.
+        securityLog("warn", "channel.inbound.unauthorized", {
+          category: "channel",
+          actor: null,
+          actorKind: "external",
+          surface: "telegram",
+          agentId: instanceName,
+          decision: "deny",
+          reason: "thread-not-authorized",
+          detail: {
+            telegramUserId: message.author.userId,
+            threadId: thread.id,
+            isDM: thread.isDM,
+          },
+        });
         // Only prompt for /login in DMs. Staying silent in groups avoids
         // spamming unauthorized group chats that the bot happens to be in.
         if (thread.isDM) {

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -21,6 +21,7 @@ import { discoverMcpAuth } from "../infrastructure/mcp-discovery.js";
 import type { ContributionFanOut } from "./contribution-fanout.js";
 import type { OAuthFlowService } from "./oauth-flow.js";
 import { emit, EventType } from "../../../events.js";
+import { securityLog } from "../../../core/security-log.js";
 
 export function createConnectionsService(deps: {
   ownerId: string;
@@ -126,6 +127,19 @@ export function createConnectionsService(deps: {
       }
 
       const template = deps.templates.get(conn.templateId);
+      securityLog("info", "connection.delete", {
+        category: "credential",
+        actor: deps.ownerId,
+        actorKind: "user",
+        target: conn.id,
+        result: "success",
+        detail: {
+          templateId: conn.templateId,
+          authKind: conn.auth.kind,
+          secretsDeleted: paths.size,
+          affectedAgents: affectedAgents.length,
+        },
+      });
       emit({
         type: EventType.ConnectionRemoved,
         actorSub: deps.ownerId,
@@ -155,6 +169,16 @@ export function createConnectionsService(deps: {
       const ownedById = new Map(owned.map((c) => [c.id, c]));
       for (const id of deduped) {
         if (!ownedById.has(id)) {
+          securityLog("warn", "authz.owner_mismatch", {
+            category: "authz",
+            actor: deps.ownerId,
+            actorKind: "user",
+            agentId,
+            decision: "deny",
+            reason: "connection-not-owned",
+            target: id,
+            detail: { surface: "connection.grants_set" },
+          });
           throw new Error(`connection ${id} not owned by caller`);
         }
       }
@@ -170,6 +194,18 @@ export function createConnectionsService(deps: {
 
       for (const id of toGrant) await deps.repo.grant(id, agentId);
       for (const id of toRevoke) await deps.repo.revoke(id, agentId);
+
+      if (toGrant.length > 0 || toRevoke.length > 0) {
+        // Links "credential granted" to "agent that may inject it".
+        securityLog("info", "connection.grants_set", {
+          category: "authz-list",
+          actor: deps.ownerId,
+          actorKind: "user",
+          agentId,
+          result: "success",
+          detail: { granted: toGrant, revoked: toRevoke },
+        });
+      }
 
       const grantedConnections = deduped
         .map((id) => ownedById.get(id))
@@ -241,6 +277,16 @@ export function createConnectionsService(deps: {
         }
         throw err;
       }
+      // Header-auth connections store a credential at rest here with no
+      // ConnectionCreated event (that fires only on OAuth-callback completion).
+      securityLog("info", "connection.create", {
+        category: "credential",
+        actor: deps.ownerId,
+        actorKind: "user",
+        target: id,
+        result: "success",
+        detail: { templateId: template.id, authKind: built.auth.kind },
+      });
       return id;
     },
 

--- a/packages/api-server/src/modules/connections/services/oauth-flow.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-flow.ts
@@ -12,6 +12,7 @@ import type { ConnectionTemplateRegistry } from "../domain/connection-template.j
 import { buildConnectionSdsFields } from "../domain/connection-sds.js";
 import type { SecretStore } from "../../secret-store/index.js";
 import { emit, EventType } from "../../../events.js";
+import { securityLog } from "../../../core/security-log.js";
 
 export interface OAuthFlowService {
   startOAuth(connectionId: string): Promise<{ authUrl: string }>;
@@ -97,6 +98,21 @@ export function createOAuthFlowService(deps: {
       }
 
       const template = deps.templates.get(conn.templateId);
+      // Long-lived credentials minted via the public, unauthenticated callback
+      // — record the mint (never the tokens).
+      securityLog("info", "oauth.token_mint", {
+        category: "credential",
+        actor: pending.ctx.ownerId,
+        actorKind: "user",
+        target: conn.id,
+        result: "success",
+        detail: {
+          templateId: conn.templateId,
+          hasRefresh: Boolean(
+            tokens.refreshToken && pending.ctx.refreshTokenRef,
+          ),
+        },
+      });
       emit({
         type: EventType.ConnectionCreated,
         actorSub: pending.ctx.ownerId,

--- a/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
+++ b/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
@@ -10,6 +10,7 @@ import type { EgressRulesRepository } from "../infrastructure/egress-rules-repos
 import type { EgressRuleRow } from "../domain/types.js";
 import type { K8sAllowOnlySecretsPort } from "../infrastructure/k8s-allow-only-secrets-port.js";
 import type { PresetSeeder } from "./preset-seeder.js";
+import { securityLog } from "../../../core/security-log.js";
 
 export interface CreateEgressRulesServiceDeps {
   repo: EgressRulesRepository;
@@ -69,6 +70,15 @@ export function createEgressRulesService(
 
     async create(input: EgressRuleCreateInput) {
       if (!(await deps.isAgentOwnedBy(input.agentId, deps.ownerSub))) {
+        securityLog("warn", "authz.owner_mismatch", {
+          category: "authz",
+          actor: deps.ownerSub,
+          actorKind: "user",
+          agentId: input.agentId,
+          decision: "deny",
+          reason: "not-owner",
+          detail: { surface: "egress-rule.create" },
+        });
         throw new Error("agent not found");
       }
       const row = await deps.repo.insert({
@@ -80,6 +90,25 @@ export function createEgressRulesService(
         verdict: input.verdict,
         decidedBy: deps.ownerSub,
         source: "manual",
+      });
+      securityLog("info", "egress_rule.create", {
+        category: "authz-list",
+        actor: deps.ownerSub,
+        actorKind: "user",
+        agentId: input.agentId,
+        target: input.host,
+        decision: input.verdict,
+        detail: {
+          method: input.method,
+          pathPattern: input.pathPattern,
+          ruleId: row.id,
+          source: "manual",
+          ...(input.host === "*" &&
+          input.method === "*" &&
+          input.pathPattern === "*"
+            ? { unrestricted: true }
+            : {}),
+        },
       });
       // Path-specific rules need MITM so the L7 ext_authz handler can see
       // method/path. The allow-only Secret is the controller's signal to
@@ -97,6 +126,17 @@ export function createEgressRulesService(
     async update(input: EgressRuleUpdateInput) {
       const rule = await deps.repo.getById(input.id);
       if (!rule || !(await deps.isAgentOwnedBy(rule.agentId, deps.ownerSub))) {
+        if (rule) {
+          securityLog("warn", "authz.owner_mismatch", {
+            category: "authz",
+            actor: deps.ownerSub,
+            actorKind: "user",
+            agentId: rule.agentId,
+            decision: "deny",
+            reason: "not-owner",
+            detail: { surface: "egress-rule.update", ruleId: input.id },
+          });
+        }
         throw new Error("egress rule not found");
       }
       const updated = await deps.repo.updatePromoteToManual({
@@ -107,6 +147,20 @@ export function createEgressRulesService(
         decidedBy: deps.ownerSub,
       });
       if (!updated) throw new Error("egress rule not found");
+      securityLog("info", "egress_rule.update", {
+        category: "authz-list",
+        actor: deps.ownerSub,
+        actorKind: "user",
+        agentId: updated.agentId,
+        target: updated.host,
+        decision: input.verdict,
+        detail: {
+          ruleId: input.id,
+          method: input.method,
+          pathPattern: input.pathPattern,
+          priorVerdict: rule.verdict,
+        },
+      });
       // The user may have just narrowed `(host, *, *)` to `(host, GET, /v1/x)`,
       // which promotes the host to L7 if it wasn't already. Same idempotent
       // ensure as create.
@@ -124,10 +178,31 @@ export function createEgressRulesService(
       if (!rule || !(await deps.isAgentOwnedBy(rule.agentId, deps.ownerSub)))
         return;
       await deps.repo.revoke(id);
+      securityLog("info", "egress_rule.revoke", {
+        category: "authz-list",
+        actor: deps.ownerSub,
+        actorKind: "user",
+        agentId: rule.agentId,
+        target: rule.host,
+        detail: {
+          ruleId: id,
+          method: rule.method,
+          pathPattern: rule.pathPattern,
+        },
+      });
     },
 
     async applyPreset(agentId: string, preset: EgressPreset) {
       if (!(await deps.isAgentOwnedBy(agentId, deps.ownerSub))) {
+        securityLog("warn", "authz.owner_mismatch", {
+          category: "authz",
+          actor: deps.ownerSub,
+          actorKind: "user",
+          agentId,
+          decision: "deny",
+          reason: "not-owner",
+          detail: { surface: "egress-rule.preset" },
+        });
         throw new Error("agent not found");
       }
       if (!deps.presetSeeder) return;
@@ -135,6 +210,15 @@ export function createEgressRulesService(
       // ones, so switching presets replaces rather than piles up. Manual
       // and connection-derived rows are untouched.
       await deps.presetSeeder.seed(agentId, preset, deps.ownerSub);
+      // The `all` preset seeds host:* method:* path:* — a single row that
+      // removes every egress restriction; flag it explicitly.
+      securityLog("info", "egress_rule.preset", {
+        category: "authz-list",
+        actor: deps.ownerSub,
+        actorKind: "user",
+        agentId,
+        detail: { preset, ...(preset === "all" ? { unrestricted: true } : {}) },
+      });
     },
   };
 }

--- a/packages/api-server/src/modules/schedules/services/schedules-service.ts
+++ b/packages/api-server/src/modules/schedules/services/schedules-service.ts
@@ -14,6 +14,7 @@ import {
   validateRRule,
   validateTimezone,
 } from "../domain/recurrences.js";
+import { securityLog } from "../../../core/security-log.js";
 
 export function createSchedulesService(deps: {
   repo: SchedulesRepository;
@@ -50,6 +51,22 @@ export function createSchedulesService(deps: {
         spec,
       });
       await deps.runner.sync(schedule.id);
+      // An agent self-scheduling recurring executions (createdBy='agent') is
+      // especially notable.
+      securityLog("info", "schedule.create", {
+        category: "privileged",
+        actor: deps.owner,
+        actorKind: createdBy === "agent" ? "agent" : "user",
+        agentId: input.agentId,
+        target: schedule.id,
+        result: "success",
+        detail: {
+          createdBy,
+          type: "cron",
+          cron: input.cron,
+          ...(input.sessionMode ? { sessionMode: input.sessionMode } : {}),
+        },
+      });
       return schedule;
     },
 
@@ -78,6 +95,19 @@ export function createSchedulesService(deps: {
         spec,
       });
       await deps.runner.sync(schedule.id);
+      securityLog("info", "schedule.create", {
+        category: "privileged",
+        actor: deps.owner,
+        actorKind: "user",
+        agentId: input.agentId,
+        target: schedule.id,
+        result: "success",
+        detail: {
+          createdBy: "user",
+          type: "rrule",
+          ...(input.sessionMode ? { sessionMode: input.sessionMode } : {}),
+        },
+      });
       return schedule;
     },
 
@@ -105,6 +135,13 @@ export function createSchedulesService(deps: {
     async delete(id) {
       await deps.runner.cancel(id);
       await deps.repo.delete(id, deps.owner);
+      securityLog("info", "schedule.delete", {
+        category: "privileged",
+        actor: deps.owner,
+        actorKind: "user",
+        target: id,
+        result: "success",
+      });
     },
 
     async toggle(id) {
@@ -115,6 +152,15 @@ export function createSchedulesService(deps: {
       } else {
         await deps.runner.cancel(id);
       }
+      securityLog("info", "schedule.toggle", {
+        category: "privileged",
+        actor: deps.owner,
+        actorKind: "user",
+        agentId: next.agentId,
+        target: id,
+        result: "success",
+        detail: { enabled: next.spec.enabled },
+      });
       return next;
     },
   };

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -26,6 +26,7 @@ import type {
 } from "./../infrastructure/k8s-secrets-port.js";
 import type { AgentGrantsPort } from "../../agents/infrastructure/agent-grants-port.js";
 import { hostPatternFor, pathPatternFor } from "../domain/types.js";
+import { securityLog } from "../../../core/security-log.js";
 
 interface InternalSecretCreate {
   type: SecretType;
@@ -261,19 +262,30 @@ export function createSecretsService(deps: {
         try {
           await deps.k8sPort.deleteSecret(twinId);
         } catch (cleanupErr) {
-          console.warn(
-            `secrets-service: orphan twin K8s Secret ${twinId} (primary ${id}, type ${input.type}) — manual cleanup required:`,
-            cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
-          );
+          securityLog("error", "secret.orphan_cleanup_failed", {
+            category: "credential",
+            actor: deps.ownerSub ?? null,
+            actorKind: "user",
+            target: twinId,
+            result: "failure",
+            reason:
+              cleanupErr instanceof Error ? cleanupErr.message : "unknown",
+            detail: { primarySecretId: id, type: input.type, role: "twin" },
+          });
         }
       }
       try {
         await deps.k8sPort.deleteSecret(id);
       } catch (cleanupErr) {
-        console.warn(
-          `secrets-service: orphan primary K8s Secret ${id} (type ${input.type}) — manual cleanup required:`,
-          cleanupErr instanceof Error ? cleanupErr.message : cleanupErr,
-        );
+        securityLog("error", "secret.orphan_cleanup_failed", {
+          category: "credential",
+          actor: deps.ownerSub ?? null,
+          actorKind: "user",
+          target: id,
+          result: "failure",
+          reason: cleanupErr instanceof Error ? cleanupErr.message : "unknown",
+          detail: { type: input.type, role: "primary" },
+        });
       }
       throw err;
     }
@@ -289,6 +301,20 @@ export function createSecretsService(deps: {
       view.injectionConfig = input.injectionConfig;
     }
     if (envMappings?.length) view.envMappings = envMappings;
+    // A credential stored at rest — record who, what kind, and where it
+    // injects. NEVER the value.
+    securityLog("info", "secret.create", {
+      category: "credential",
+      actor: deps.ownerSub ?? null,
+      actorKind: "user",
+      target: id,
+      result: "success",
+      detail: {
+        type: input.type,
+        hostPattern,
+        twins: createdTwinIds.length,
+      },
+    });
     return view;
   }
 
@@ -406,10 +432,34 @@ export function createSecretsService(deps: {
             : {}),
         ...(rotation ? { authMode: rotation.authMode } : {}),
       });
-      if (!result) throw new TRPCError({ code: "NOT_FOUND" });
+      if (!result) {
+        securityLog("warn", "secret.update_notfound", {
+          category: "credential",
+          actor: deps.ownerSub ?? null,
+          actorKind: "user",
+          target: id,
+          result: "failure",
+          reason: "not-found",
+        });
+        throw new TRPCError({ code: "NOT_FOUND" });
+      }
       const { before, after } = result;
 
       const valueChanged = patch.value !== undefined;
+      // Rotation/timestamp forensics most wants after a suspected leak — log
+      // metadata only (what changed), never the value.
+      securityLog("info", "secret.update", {
+        category: "credential",
+        actor: deps.ownerSub ?? null,
+        actorKind: "user",
+        target: id,
+        result: "success",
+        detail: {
+          valueChanged,
+          nameChanged: patch.name !== undefined,
+          authModeRotated: rotation !== null,
+        },
+      });
       const envChanged = envMappingsChanged(before, after);
       if (valueChanged) {
         const allSecretsForTwins = await deps.k8sPort.listSecrets();
@@ -449,6 +499,15 @@ export function createSecretsService(deps: {
         await deps.k8sPort.deleteSecret(twinId);
       }
       await deps.k8sPort.deleteSecret(id);
+      // Proves when a credential was revoked/destroyed.
+      securityLog("info", "secret.delete", {
+        category: "credential",
+        actor: deps.ownerSub ?? null,
+        actorKind: "user",
+        target: id,
+        result: "success",
+        detail: { twins: twinIds.length },
+      });
     },
 
     async getAgentAccess(agentId: string) {
@@ -480,6 +539,15 @@ export function createSecretsService(deps: {
         ...primaries.flatMap((id) => twinsByPrimary.get(id) ?? []),
       ];
       await deps.grants.setSecretGrants(agentId, expanded);
+      // Central to "which agent could use credential X at time T".
+      securityLog("info", "secret.grants_set", {
+        category: "authz-list",
+        actor: deps.ownerSub ?? null,
+        actorKind: "user",
+        agentId,
+        result: "success",
+        detail: { primarySecretIds: primaries, expandedCount: expanded.length },
+      });
 
       if (deps.connectionRules && deps.ownerSub) {
         const ownedSourceIds = new Set(allSecrets.map((s) => s.id));

--- a/packages/api-server/src/modules/skills/services/publish-service.ts
+++ b/packages/api-server/src/modules/skills/services/publish-service.ts
@@ -13,6 +13,7 @@ import {
 } from "../infrastructure/agent-runtime-client.js";
 import { detectHost } from "../infrastructure/git-host.js";
 import { upstreamToTrpc } from "../infrastructure/upstream-to-trpc.js";
+import { securityLog } from "../../../core/security-log.js";
 
 const DEFAULT_SKILL_PATHS = ["/home/agent/.agents/skills/"];
 
@@ -105,6 +106,22 @@ export async function publishSkill(
     publishedAt: new Date().toISOString(),
   };
   await deps.agentSkills.appendPublish(input.agentId, record);
+
+  // Credential-backed external write: the agent's injected GitHub PAT opens a
+  // PR upstream on the owner's behalf.
+  securityLog("info", "skill.publish", {
+    category: "privileged",
+    actor: deps.owner,
+    actorKind: "user",
+    agentId: input.agentId,
+    target: source.gitUrl,
+    result: "success",
+    detail: {
+      skill: input.name,
+      repo: `${host.owner}/${host.repo}`,
+      prUrl: result.prUrl,
+    },
+  });
 
   return result;
 }

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -22,6 +22,7 @@ import {
 import type { AgentSkillsRepository } from "../infrastructure/agent-skills-repository.js";
 import type { SkillSourceSeed } from "../infrastructure/seed-sources.js";
 import { seedToSkillSource } from "../infrastructure/seed-sources.js";
+import { securityLog } from "../../../core/security-log.js";
 import {
   AgentRuntimeUpstreamError,
   type AgentRuntimeSkillsClient,
@@ -377,6 +378,18 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       await deps.agentSkillsRepo.upsertSkill(input.agentId, ref);
       await deps.runtimeMutator.bump(input.agentId, []);
       await deps.runtimeMutator.enqueueAfterCommit(input.agentId);
+      // Supply-chain: code fetched from an arbitrary git URL onto the agent's
+      // PV (often agent-driven via MCP). "what did this agent install, from
+      // where" must be answerable post-incident.
+      securityLog("info", "skill.install", {
+        category: "privileged",
+        actor: deps.owner,
+        actorKind: "user",
+        agentId: input.agentId,
+        target: input.source,
+        result: "success",
+        detail: { name: input.name, version: input.version },
+      });
       const current = await deps.agentSkillsRepo.listSkills(input.agentId);
       return upsertSkillRef(
         current.filter(
@@ -395,6 +408,15 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       });
       await deps.runtimeMutator.bump(input.agentId, []);
       await deps.runtimeMutator.enqueueAfterCommit(input.agentId);
+      securityLog("info", "skill.uninstall", {
+        category: "privileged",
+        actor: deps.owner,
+        actorKind: "user",
+        agentId: input.agentId,
+        target: input.source,
+        result: "success",
+        detail: { name: input.name },
+      });
       const current = await deps.agentSkillsRepo.listSkills(input.agentId);
       return removeSkillRef(current, {
         source: input.source,

--- a/packages/api-server/src/modules/usage/routes.ts
+++ b/packages/api-server/src/modules/usage/routes.ts
@@ -10,6 +10,7 @@ import {
   type ViewName,
 } from "./services/report-service.js";
 import { renderHtmlReport, type ViewResult } from "./html-report.js";
+import { securityLog } from "../../core/security-log.js";
 
 export type UsageRoutesDeps = {
   service: ReportService;
@@ -28,9 +29,29 @@ export function createUsageRoutes(deps: UsageRoutesDeps) {
   const inspectorOnly = async (c: Context<AppEnv>, next: Next) => {
     const roles = c.get("roles") ?? [];
     if (!roles.includes(deps.inspectorRole)) {
+      // Attempt to read the most privileged cross-tenant surface without the
+      // role.
+      securityLog("warn", "usage.inspect.deny", {
+        category: "privileged",
+        actor: c.get("user")?.sub ?? null,
+        actorKind: "user",
+        decision: "deny",
+        reason: "missing-inspector-role",
+        target: c.req.path,
+      });
       if (c.req.path === "/api/usage/report") return c.text("forbidden", 403);
       return c.json({ error: "forbidden" }, 403);
     }
+    // Successful privileged read of cross-tenant activity — recorded on STDOUT,
+    // distinct from the pseudonymized activity_events it reads.
+    securityLog("info", "usage.inspect", {
+      category: "privileged",
+      actor: c.get("user")?.sub ?? null,
+      actorKind: "user",
+      result: "success",
+      target: c.req.path,
+      ...(c.req.query("view") ? { detail: { view: c.req.query("view") } } : {}),
+    });
     await next();
   };
   routes.use("/api/usage", inspectorOnly);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,6 +211,9 @@ importers:
       mock-agent-api:
         specifier: workspace:*
         version: link:../e2e/agents/mock-api
+      pino:
+        specifier: ~9.11.0
+        version: 9.11.0
       rrule:
         specifier: ^2.8.1
         version: 2.8.1
@@ -2929,6 +2932,10 @@ packages:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
@@ -3641,6 +3648,10 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-redact@3.5.0:
+    resolution: {integrity: sha512-dwsoQlS7h9hMeYUq1W++23NDcBLV4KqONnITDV9DjfS3q1SgDGVrBdvvTLUotWtPSD7asWDV9/CmsZPy8Hf70A==}
+    engines: {node: '>=6'}
 
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
@@ -4679,6 +4690,10 @@ packages:
     resolution: {integrity: sha512-l2q8l9CTCTOlbX+AnK4p3M+4CEpKpyQhle6blQkdFhm0IsBqsxm15bYaSa11G7pWdsYr6epdsRZxJpCyCRbT8A==}
     engines: {node: '>=18'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   on-finished@2.4.1:
     resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
     engines: {node: '>= 0.8'}
@@ -4820,6 +4835,16 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.11.0:
+    resolution: {integrity: sha512-+YIodBB9sxcWeR8PrXC2K3gEDyfkUuVEITOcbqrfcj+z5QW4ioIcqZfYFbrLTYLsmAwunbS7nfU/dpBB6PZc1g==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -4922,6 +4947,9 @@ packages:
     resolution: {integrity: sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ==}
     engines: {node: ^14.13.1 || >=16.0.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   proper-lockfile@4.1.2:
     resolution: {integrity: sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==}
 
@@ -4950,6 +4978,9 @@ packages:
   qs@6.15.2:
     resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4987,6 +5018,10 @@ packages:
   readdirp@4.1.2:
     resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
     engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   redis-errors@1.2.0:
     resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
@@ -5114,6 +5149,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -5221,6 +5260,9 @@ packages:
   socks@2.8.7:
     resolution: {integrity: sha512-HLpt+uLy/pxB+bum/9DzAgiKS8CX1EvbWxI4zlmgGCExImLdiad2iCwXT5Z4c9c3Eq8rP2318mPW2c+QbtjK8A==}
     engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -5390,6 +5432,9 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -8469,6 +8514,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   available-typed-arrays@1.0.7:
     dependencies:
       possible-typed-array-names: 1.1.0
@@ -9205,6 +9252,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-redact@3.5.0: {}
 
   fast-string-truncated-width@3.0.3: {}
 
@@ -10432,6 +10481,8 @@ snapshots:
     dependencies:
       jwt-decode: 4.0.0
 
+  on-exit-leak-free@2.1.2: {}
+
   on-finished@2.4.1:
     dependencies:
       ee-first: 1.1.1
@@ -10572,6 +10623,26 @@ snapshots:
 
   picomatch@4.0.4: {}
 
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.11.0:
+    dependencies:
+      atomic-sleep: 1.0.0
+      fast-redact: 3.5.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
+
   pirates@4.0.7: {}
 
   pkce-challenge@5.0.1: {}
@@ -10639,6 +10710,8 @@ snapshots:
 
   pretty-bytes@6.1.1: {}
 
+  process-warning@5.0.0: {}
+
   proper-lockfile@4.1.2:
     dependencies:
       graceful-fs: 4.2.11
@@ -10679,6 +10752,8 @@ snapshots:
   qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
+
+  quick-format-unescaped@4.0.4: {}
 
   range-parser@1.2.1: {}
 
@@ -10724,6 +10799,8 @@ snapshots:
       loose-envify: 1.4.0
 
   readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
 
   redis-errors@1.2.0: {}
 
@@ -10915,6 +10992,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-stable-stringify@2.5.0: {}
+
   safer-buffer@2.1.2: {}
 
   scheduler@0.23.2:
@@ -11069,6 +11148,10 @@ snapshots:
     dependencies:
       ip-address: 10.2.0
       smart-buffer: 4.2.0
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -11282,6 +11365,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## What & why

The api-server had **no logging abstraction** — diagnostics were ad-hoc `process.stderr` writes, and the only structured signal was the domain event bus, which lands HMAC-pseudonymized rows in Postgres for operator analytics. There was no way to reconstruct **who did what, to what, and whether it was allowed** after a security incident: the auth edge logged nothing on a rejected token, the credentialed-egress gate logged no allow/deny decision, and credential / authorization-list mutations were largely silent.

This introduces structured logging as a general primitive and builds a real-identity **security audit trail** on top of it.

## The primitive — `ADR-056`

- **Pino** singleton (`core/logger.ts`), configured once at startup. One JSON record per line on stdout.
- Common levels `error/warn/info/debug`; visibility governed by `LOG_LEVEL` (default `info`). **No bespoke per-feature toggle** — it's the standard level config.
- Because k8s merges stdout+stderr into one pod log, consumers filter the audit trail on a `category` field, not on the stream.

## The audit trail — `core/security-log.ts`

`securityLog(level, event, fields)` — a thin typed wrapper over the logger. Level mapping: deny/fail → `warn`, allow/success → `info`, internal security-path errors → `error`. Two axes kept separate (`result` = success/failure vs `decision` = allow/deny/hold/expired) so "show me every deny" stays unambiguous. A `correlationId` joins multi-site flows (e.g. egress hold → human verdict → resolved decision).

The actor is the **raw Keycloak sub** — forensics needs direct attribution, which is the deliberate difference from the pseudonymized usage analytics store; the two never share actor handling. Records carry **no** token/secret/PAT values, raw JWTs, or raw prompts (only metadata); the logger also censors well-known credential keys and the WS edge strips `?token=`.

Two disjoint mechanisms feed the logger (no double-logging):
- a **bus saga** (`modules/audit`) for actor-bearing success events (login, channel turns, schedule fires, file imports, foreign-reply, forks);
- **direct calls** at every denial/mutation site not on the bus.

## Coverage

| Surface | Events |
|---|---|
| Auth / edge | `authn.deny` (401), `authz.deny` (403), `authz.owner_mismatch`, WS-ladder denials, `relay.attach` |
| Credentialed egress (HITL) | every `egress.decision` (allow/deny/expired), `egress.hold`, identity-unresolved + transport denials |
| Approvals | `approval.verdict` (correlated to the egress hold) |
| Authorization lists | `agent.allowed_users_set` (added/removed diff), `egress_rule.*`, `secret.grants_set`, `connection.grants_set` |
| Credentials | `secret.create/update/delete`, `oauth.token_mint`, `connection.create/delete`, orphan-cleanup failures |
| Channels | Slack/Telegram authz allow+deny, `identity.link`, `channel.outbound` (incl. resolved attachment path) |
| Privileged | `skill.install/uninstall/publish`, `schedule.create/toggle/delete` (incl. agent-driven), `usage.inspect(.deny)`, `agent.create/update/delete/restart/wake` |

## Testing

- `mise run check` (all packages): clean (one pre-existing, unrelated UI hook-deps warning).
- `mise run api-server:test`: **181/181** — incl. new tests for logger level-gating/redaction, saga field-projection + no-prompt-leak, and the auth 401/403 path.
- `mise run helm:check:render`: valid; `LOG_LEVEL` renders into the api-server deployment.

## Notes

- Draft. Manual cluster e2e (drive an egress HITL / channel mention / `allowedUsers` change, then grep pod logs for `"category"` lines) not yet run.
- Deferred follow-ups (same pattern, lower value): OAuth refresh re-mint, public OAuth-callback failure lines, connection-rules-sync / allow-only-MITM materialization, Slack `/login`-`/logout` initiate, terminal session-mode 409.
- Pino pinned to `~9.11.0`: the repo's `trustPolicy: no-downgrade` rejects 9.14.0 / `slow-redact@0.3.2`; 9.11 still uses the trusted `fast-redact`.
