### PR TITLE
feat(e2e): auth spec — Keycloak login + T&C accept

### DIFF
--- a/packages/e2e/playwright/src/tests/01-auth.spec.ts
+++ b/packages/e2e/playwright/src/tests/01-auth.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+import { baseUrl, testUser } from "../config.js";
+
+const storageStatePath = "./.auth/user.json";
+
+test("login via Keycloak and accept terms", async ({ page }) => {
+  await page.goto(baseUrl);
+
+  await page.waitForURL(/\/realms\/platform\/protocol\/openid-connect\/auth/);
+  await page.locator("#username").fill(testUser.username);
+  await page.locator("#password").fill(testUser.password);
+  await page.locator("#kc-login").click();
+
+  await page.waitForURL((url) => url.origin === baseUrl);
+  if (page.url() === `${baseUrl}/terms`) {
+    await page
+      .getByRole("button", { name: /I accept the Terms of Use/ })
+      .click();
+    await page.waitForURL(`${baseUrl}/`);
+  }
+  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+  await page.context().storageState({ path: storageStatePath });
+});

--- a/packages/e2e/playwright/tasks.toml
+++ b/packages/e2e/playwright/tasks.toml
@@ -1,3 +1,8 @@
+["e2e-playwright:run"]
+dir = "{{config_root}}/packages/e2e/playwright"
+depends = ["common:setup:pnpm"]
+run = "pnpm exec playwright test"
+
 ["e2e-playwright:check"]
 depends = ["e2e-playwright:check:*"]
 

--- a/packages/ui/src/components/sidebar.tsx
+++ b/packages/ui/src/components/sidebar.tsx
@@ -35,6 +35,7 @@ export function Sidebar() {
 
   return (
     <nav
+      data-testid="app-sidebar"
       className={`hidden md:flex flex-col h-dvh bg-surface border-r border-border-light shrink-0 transition-[width] duration-200 ${collapsed ? "w-[52px]" : "w-[200px]"}`}
     >
       {/* Logo */}


### PR DESCRIPTION
Part of #404 (point 5). Stacks on #407.

## Summary

- `01-auth.spec.ts` logs in via the dev/dev Keycloak user, accepts T&C if shown, saves storage state to `./.auth/user.json` for spec 02 to reuse
- Adds `data-testid="app-sidebar"` to disambiguate the sidebar from the onboarding-progress nav
- New mise task `e2e-playwright:run`; supports headed via `-- --headed`

Idempotent against the local cluster — re-runs skip T&C if already accepted. CI runs against a fresh cluster (point 6) so the branch is unused there.

## Test plan

- [ ] `mise run e2e-playwright:check` clean
- [ ] `mise run e2e-playwright:run` green headless
- [ ] `mise run e2e-playwright:run -- --headed` green watching the browser
- [ ] `packages/e2e/playwright/.auth/user.json` contains Keycloak cookies + UI localStorage