### PR TITLE
feat(cli): manage network access rules from the CLI

### DIFF
--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-Last verified: 2026-06-01
+Last verified: 2026-06-02
 
 ## Motivated by
 
@@ -9,6 +9,7 @@ Last verified: 2026-06-01
 - [#73 — Import local project context into agent workspace](https://github.com/dam-agents/dam/issues/73) — the `dam import` verb that uploads local files and folders into an Agent.
 - [#254 — Granular file ops over the agent-runtime proxy](https://github.com/dam-agents/dam/issues/254) — the `dam file` group (`get`, `put`, `list`) for single-file workspace operations.
 - [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — the CLI addresses Agents (not Instances); a single `dam agent` group covers the lifecycle.
+- [ADR-035 — Unified HITL UX](../adrs/035-unified-hitl-ux.md) — the per-Agent egress pre-approvals that the `dam egress` group lists and mutates ([#345](https://github.com/dam-agents/dam/issues/345), a P0 sub-issue of [#329](https://github.com/dam-agents/dam/issues/329)).
 
 ## Overview
 

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -12,7 +12,7 @@ Last verified: 2026-06-01
 
 ## Overview
 
-The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam agent` group (`list` [default], `get`, `create`, `create-interactive`, `delete`, `restart`); `dam chat`; `dam session list`; `dam template list`; `dam import`; and the `dam file` group (`get`, `put`, `list`). Command groups are singular to align with `gh`, `git`, and `docker` conventions.
+The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam agent` group (`list` [default], `get`, `create`, `create-interactive`, `delete`, `restart`); `dam chat`; `dam session list`; `dam template list`; `dam import`; the `dam file` group (`get`, `put`, `list`); and the `dam egress` group (`list`, `create`, `update`, `revoke`, `preset`, `apply-preset`, `trusted-hosts`). Command groups are singular to align with `gh`, `git`, and `docker` conventions.
 
 The CLI shares types directly with the api-server via a shared contract package, so server-side type changes reach the CLI without codegen or manual mirroring. Most routes are reached through plain HTTP calls against the api-server's tRPC endpoints; the `dam chat` verb additionally opens a WebSocket to the terminal relay for the interactive PTY session. The auth probes (`/api/auth/config`, OIDC discovery) stay as raw `fetch` because they are not tRPC.
 
@@ -143,3 +143,26 @@ The chat module composes a per-host `SessionsPort` backed by a small ACP client 
 - **Caps and exclusions** — the per-file size cap is enforced server-side in `agent-runtime`'s `FilesService` and surfaces on both `read` and `upload` as `PAYLOAD_TOO_LARGE` (single source of truth — the CLI doesn't duplicate the constant). Excluded basenames (`.git`, `.npm`, `.triggers`, `.claude.json`, `.initialized`, `node_modules`, `.DS_Store`) are invisible in `list` and refused on `put`. Symmetric to `dam import`'s exclusions.
 - **No service layer** — each verb is one tRPC call; the action handler classifies inline rather than introducing a port, mirroring `dam import`.
 - **Out of scope (v1)** — recursive directory download (combine `dam file list | xargs dam file get`), streaming for files > 10 MB, `dam file rm` / `mv` / `mkdir`, globs in `<remote-path>`. Each lands when a concrete use case appears.
+
+## Egress
+
+`dam egress` manages per-Agent outbound-host rules — the pre-approvals that let an Agent reach external services without round-tripping the inbox ([ADR-035](../adrs/035-unified-hitl-ux.md)). The CLI is a thin wrapper around the `egressRules.*` tRPC procedures, at parity with the per-agent network access editor in the UI.
+
+Seven commands, agent-scoped ones positional-first on the agent ref to match the existing verb convention:
+
+- `dam egress list <agent>` — six-column table sorted by `(host, method, pathPattern)`; `--json` emits `EgressRuleView[]`.
+- `dam egress preset <agent>` — current effective preset (`none` / `trusted` / `all`).
+- `dam egress create <agent> --host <h> [--method] [--path] [--verdict]` — adds a manual rule. `--method` and `--path` default to `*` (the L4 host-only rule); `--verdict` defaults to `allow`.
+- `dam egress update <rule-id> [--method] [--path] [--verdict]` — partial update; at least one flag is required. Flips `source` to `manual` server-side.
+- `dam egress revoke <rule-id>` — deletes the rule. Idempotent — unknown IDs exit 0.
+- `dam egress apply-preset <agent> --preset <name>` — bulk-seeds; replaces existing `preset:*` rows; preserves `manual` and `connection:*` rows.
+- `dam egress trusted-hosts` — the platform-wide hosts seeded by the `trusted` preset.
+
+Two pieces of non-obvious behavior the CLI surfaces:
+
+- **Path/method-specific rules require L7 enforcement.** When `create` or `update` produces a rule with non-wildcard method or path, the gateway has to re-MITM the host, which rolls the Agent pod (~5–15s). The CLI prompts on TTY; `--yes` bypasses; non-TTY without `--yes` exits `EXIT_INVALID_INPUT` (2). The check fires on user-passed flags only — false positives for already-L7 rules are accepted in preference to fetching the existing row.
+- **Preset `all` is a development escape hatch.** `apply-preset --preset all` confirms before applying (mirrors the UI's `window.confirm`). Every preset apply prints an explanatory line to stderr that manual and connection-derived rules are preserved.
+
+`update` against an unknown rule ID exits `EXIT_RULE_NOT_FOUND` (6) — the contract change in `egress-rules-service.ts` converts the plain `Error("egress rule not found")` to `TRPCError({ code: "NOT_FOUND" })` so the CLI can classify the error via `data.code`.
+
+The `source` field is rendered via the shared `formatEgressRuleSource` helper in [packages/api-server-api/src/modules/egress-rules/format.ts](../../packages/api-server-api/src/modules/egress-rules/format.ts) so the CLI and UI use identical labels.

--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -9,11 +9,11 @@ Last verified: 2026-06-02
 - [#73 — Import local project context into agent workspace](https://github.com/dam-agents/dam/issues/73) — the `dam import` verb that uploads local files and folders into an Agent.
 - [#254 — Granular file ops over the agent-runtime proxy](https://github.com/dam-agents/dam/issues/254) — the `dam file` group (`get`, `put`, `list`) for single-file workspace operations.
 - [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — the CLI addresses Agents (not Instances); a single `dam agent` group covers the lifecycle.
-- [ADR-035 — Unified HITL UX](../adrs/035-unified-hitl-ux.md) — the per-Agent egress pre-approvals that the `dam egress` group lists and mutates ([#345](https://github.com/dam-agents/dam/issues/345), a P0 sub-issue of [#329](https://github.com/dam-agents/dam/issues/329)).
+- [ADR-035 — Unified HITL UX](../adrs/035-unified-hitl-ux.md) — the per-Agent network access pre-approvals that the `dam network` group lists and mutates ([#345](https://github.com/dam-agents/dam/issues/345), a P0 sub-issue of [#329](https://github.com/dam-agents/dam/issues/329)).
 
 ## Overview
 
-The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam agent` group (`list` [default], `get`, `create`, `create-interactive`, `delete`, `restart`); `dam chat`; `dam session list`; `dam template list`; `dam import`; the `dam file` group (`get`, `put`, `list`); and the `dam egress` group (`list`, `create`, `update`, `revoke`, `preset`, `apply-preset`, `trusted-hosts`). Command groups are singular to align with `gh`, `git`, and `docker` conventions.
+The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam agent` group (`list` [default], `get`, `create`, `create-interactive`, `delete`, `restart`); `dam chat`; `dam session list`; `dam template list`; `dam import`; the `dam file` group (`get`, `put`, `list`); and the `dam network` group (`list`, `create`, `update`, `revoke`, `preset`, `apply-preset`, `trusted-hosts`). Command groups are singular to align with `gh`, `git`, and `docker` conventions.
 
 The CLI shares types directly with the api-server via a shared contract package, so server-side type changes reach the CLI without codegen or manual mirroring. Most routes are reached through plain HTTP calls against the api-server's tRPC endpoints; the `dam chat` verb additionally opens a WebSocket to the terminal relay for the interactive PTY session. The auth probes (`/api/auth/config`, OIDC discovery) stay as raw `fetch` because they are not tRPC.
 
@@ -145,19 +145,19 @@ The chat module composes a per-host `SessionsPort` backed by a small ACP client 
 - **No service layer** — each verb is one tRPC call; the action handler classifies inline rather than introducing a port, mirroring `dam import`.
 - **Out of scope (v1)** — recursive directory download (combine `dam file list | xargs dam file get`), streaming for files > 10 MB, `dam file rm` / `mv` / `mkdir`, globs in `<remote-path>`. Each lands when a concrete use case appears.
 
-## Egress
+## Network access
 
-`dam egress` manages per-Agent outbound-host rules — the pre-approvals that let an Agent reach external services without round-tripping the inbox ([ADR-035](../adrs/035-unified-hitl-ux.md)). The CLI is a thin wrapper around the `egressRules.*` tRPC procedures, at parity with the per-agent network access editor in the UI.
+`dam network` manages per-Agent outbound-host rules — the pre-approvals that let an Agent reach external services without round-tripping the inbox ([ADR-035](../adrs/035-unified-hitl-ux.md)). The CLI is a thin wrapper around the `egressRules.*` tRPC procedures, at parity with the per-agent network access editor in the UI.
 
 Seven commands, agent-scoped ones positional-first on the agent ref to match the existing verb convention:
 
-- `dam egress list <agent>` — six-column table sorted by `(host, method, pathPattern)`; `--json` emits `EgressRuleView[]`.
-- `dam egress preset <agent>` — current effective preset (`none` / `trusted` / `all`).
-- `dam egress create <agent> --host <h> [--method] [--path] [--verdict]` — adds a manual rule. `--method` and `--path` default to `*` (the L4 host-only rule); `--verdict` defaults to `allow`.
-- `dam egress update <rule-id> [--method] [--path] [--verdict]` — partial update; at least one flag is required. Flips `source` to `manual` server-side.
-- `dam egress revoke <rule-id>` — deletes the rule. Idempotent — unknown IDs exit 0.
-- `dam egress apply-preset <agent> --preset <name>` — bulk-seeds; replaces existing `preset:*` rows; preserves `manual` and `connection:*` rows.
-- `dam egress trusted-hosts` — the platform-wide hosts seeded by the `trusted` preset.
+- `dam network list <agent>` — six-column table sorted by `(host, method, pathPattern)`; `--json` emits `EgressRuleView[]`.
+- `dam network preset <agent>` — current effective preset (`none` / `trusted` / `all`).
+- `dam network create <agent> --host <h> [--method] [--path] [--verdict]` — adds a manual rule. `--method` and `--path` default to `*` (the L4 host-only rule); `--verdict` defaults to `allow`.
+- `dam network update <rule-id> [--method] [--path] [--verdict]` — partial update; at least one flag is required. Flips `source` to `manual` server-side.
+- `dam network revoke <rule-id>` — deletes the rule. Idempotent — unknown IDs exit 0.
+- `dam network apply-preset <agent> --preset <name>` — bulk-seeds; replaces existing `preset:*` rows; preserves `manual` and `connection:*` rows.
+- `dam network trusted-hosts` — the platform-wide hosts seeded by the `trusted` preset.
 
 Two pieces of non-obvious behavior the CLI surfaces:
 

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -280,6 +280,10 @@ export {
   egressRuleUpdateInputSchema,
   ruleVerdictSchema,
 } from "./modules/egress-rules/schemas.js";
+export {
+  formatEgressRuleInline,
+  formatEgressRuleSource,
+} from "./modules/egress-rules/format.js";
 
 // ACP platform/* synthetic notifications
 export {

--- a/packages/api-server-api/src/modules/egress-rules/format.ts
+++ b/packages/api-server-api/src/modules/egress-rules/format.ts
@@ -1,0 +1,35 @@
+import type { EgressRuleSource, EgressRuleView } from "./types.js";
+
+/**
+ * Non-null for every variant — callers that want to hide manual rows check
+ * `source === "manual"` explicitly.
+ */
+export function formatEgressRuleSource(source: EgressRuleSource): string {
+  if (source === "manual") return "manual";
+  if (source === "inbox") return "from inbox";
+  if (source === "preset:trusted") return "preset: trusted";
+  if (source === "preset:all") return "preset: all";
+  if (source.startsWith("connection:")) {
+    return `from ${source.slice("connection:".length)}`;
+  }
+  return source;
+}
+
+/** `<verdict> [<method>] <host>[<path>]` — wildcard method/path suppressed. */
+export function formatEgressRuleInline(
+  rule: Pick<EgressRuleView, "verdict" | "method" | "host" | "pathPattern">,
+): string {
+  const parts: string[] = [rule.verdict];
+  if (rule.method !== "*") parts.push(rule.method);
+  parts.push(joinHostPath(rule.host, rule.pathPattern));
+  return parts.join(" ");
+}
+
+function joinHostPath(host: string, pathPattern: string): string {
+  const normalizedHost = host.replace(/\/+$/, "");
+  if (pathPattern === "*") return normalizedHost;
+  const normalizedPath = pathPattern.startsWith("/")
+    ? pathPattern
+    : `/${pathPattern}`;
+  return `${normalizedHost}${normalizedPath}`;
+}

--- a/packages/api-server-api/src/modules/egress-rules/schemas.ts
+++ b/packages/api-server-api/src/modules/egress-rules/schemas.ts
@@ -19,16 +19,16 @@ export const egressRuleCurrentPresetInputSchema = z.object({
 export const egressRuleCreateInputSchema = z.object({
   agentId: z.string().min(1),
   host: z.string().min(1),
-  method: z.string().min(1),
-  pathPattern: z.string().min(1),
+  method: z.string().min(1).default("*"),
+  pathPattern: z.string().min(1).default("*"),
   verdict: ruleVerdictSchema,
 });
 
 export const egressRuleUpdateInputSchema = z.object({
   id: z.string().min(1),
-  method: z.string().min(1),
-  pathPattern: z.string().min(1),
-  verdict: ruleVerdictSchema,
+  method: z.string().min(1).optional(),
+  pathPattern: z.string().min(1).optional(),
+  verdict: ruleVerdictSchema.optional(),
 });
 
 export const egressRuleRevokeInputSchema = z.object({

--- a/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
+++ b/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { TRPCError } from "@trpc/server";
 import type {
   EgressPreset,
   EgressRuleCreateInput,
@@ -79,7 +80,7 @@ export function createEgressRulesService(
           reason: "not-owner",
           detail: { surface: "egress-rule.create" },
         });
-        throw new Error("agent not found");
+        throw new TRPCError({ code: "NOT_FOUND", message: "agent not found" });
       }
       const row = await deps.repo.insert({
         id: randomUUID(),
@@ -137,16 +138,27 @@ export function createEgressRulesService(
             detail: { surface: "egress-rule.update", ruleId: input.id },
           });
         }
-        throw new Error("egress rule not found");
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "egress rule not found",
+        });
       }
+      const method = input.method ?? rule.method;
+      const pathPattern = input.pathPattern ?? rule.pathPattern;
+      const verdict = input.verdict ?? rule.verdict;
       const updated = await deps.repo.updatePromoteToManual({
         id: input.id,
-        method: input.method,
-        pathPattern: input.pathPattern,
-        verdict: input.verdict,
+        method,
+        pathPattern,
+        verdict,
         decidedBy: deps.ownerSub,
       });
-      if (!updated) throw new Error("egress rule not found");
+      if (!updated) {
+        throw new TRPCError({
+          code: "NOT_FOUND",
+          message: "egress rule not found",
+        });
+      }
       securityLog("info", "egress_rule.update", {
         category: "authz-list",
         actor: deps.ownerSub,
@@ -164,10 +176,7 @@ export function createEgressRulesService(
       // The user may have just narrowed `(host, *, *)` to `(host, GET, /v1/x)`,
       // which promotes the host to L7 if it wasn't already. Same idempotent
       // ensure as create.
-      if (
-        needsL7Promotion(input.method, input.pathPattern) &&
-        deps.allowOnlySecrets
-      ) {
+      if (needsL7Promotion(method, pathPattern) && deps.allowOnlySecrets) {
         await deps.allowOnlySecrets.ensure(deps.ownerSub, updated.host);
       }
       return toView(updated);
@@ -203,7 +212,7 @@ export function createEgressRulesService(
           reason: "not-owner",
           detail: { surface: "egress-rule.preset" },
         });
-        throw new Error("agent not found");
+        throw new TRPCError({ code: "NOT_FOUND", message: "agent not found" });
       }
       if (!deps.presetSeeder) return;
       // The seeder sweeps prior `preset:*` rows before inserting the new

--- a/packages/cli/src/compose.ts
+++ b/packages/cli/src/compose.ts
@@ -3,6 +3,7 @@ import { composeAgentModule } from "./modules/agent/compose.js";
 import { composeAuthModule } from "./modules/auth/compose.js";
 import { composeChatModule } from "./modules/chat/compose.js";
 import { composeCliModule } from "./modules/cli/compose.js";
+import { composeEgressModule } from "./modules/egress/compose.js";
 import { composeFileModule } from "./modules/file/compose.js";
 import { composeImportModule } from "./modules/import/compose.js";
 import { composeTemplateModule } from "./modules/template/compose.js";
@@ -74,6 +75,13 @@ export function compose(opts: ComposeOptions = {}): Command {
     createAgentService: agent.exports.createService,
   });
 
+  const egress = composeEgressModule({
+    tokenProvider: auth.exports.tokenProvider,
+    configService: cli.services.configService,
+    compatService: cli.services.compatService,
+    createAgentService: agent.exports.createService,
+  });
+
   const program = new Command();
   program
     .name("dam")
@@ -87,6 +95,7 @@ export function compose(opts: ComposeOptions = {}): Command {
   for (const command of agent.commands) program.addCommand(command);
   for (const command of importModule.commands) program.addCommand(command);
   for (const command of fileModule.commands) program.addCommand(command);
+  for (const command of egress.commands) program.addCommand(command);
 
   return program;
 }

--- a/packages/cli/src/modules/agent/commands/delete.ts
+++ b/packages/cli/src/modules/agent/commands/delete.ts
@@ -8,7 +8,7 @@ import {
   printResolveError,
   printServiceError,
 } from "./errors.js";
-import { confirm } from "../../shared/prompt.js";
+import { confirm, exitCancelled } from "../../shared/prompt.js";
 import {
   EXIT_BELOW_FLOOR,
   EXIT_INVALID_INPUT,
@@ -81,14 +81,7 @@ async function runDelete(
     const proceed = await confirm(
       `Delete agent "${agent.name}"? This destroys all persistent data and cannot be undone.`,
     );
-    if (!proceed) {
-      if (opts.json) {
-        process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
-      } else {
-        process.stdout.write("Cancelled.\n");
-      }
-      process.exit(EXIT_SUCCESS);
-    }
+    if (!proceed) exitCancelled(opts);
   }
 
   // Per ADR-046, Agent is the single resource — no separate Instance to

--- a/packages/cli/src/modules/egress/commands/apply-preset.ts
+++ b/packages/cli/src/modules/egress/commands/apply-preset.ts
@@ -15,7 +15,7 @@ import {
   EXIT_SUCCESS,
 } from "../../shared/exit-codes.js";
 import { resolveActiveHost } from "../../shared/preflight.js";
-import { confirm } from "../../shared/prompt.js";
+import { confirm, exitCancelled } from "../../shared/prompt.js";
 import type { EgressService } from "../services/egress-service.js";
 
 export function buildApplyPresetCommand(deps: {
@@ -87,14 +87,7 @@ export function buildApplyPresetCommand(deps: {
           process.stderr.write(
             "Preset 'all' allows the agent to reach any host — this is a development escape hatch and bypasses the inbox entirely.\n",
           );
-          if (!(await confirm("Continue?"))) {
-            if (opts.json) {
-              process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
-            } else {
-              process.stdout.write("Cancelled.\n");
-            }
-            process.exit(EXIT_SUCCESS);
-          }
+          if (!(await confirm("Continue?"))) exitCancelled(opts);
         }
 
         const result = await deps

--- a/packages/cli/src/modules/egress/commands/apply-preset.ts
+++ b/packages/cli/src/modules/egress/commands/apply-preset.ts
@@ -43,8 +43,8 @@ export function buildApplyPresetCommand(deps: {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  dam egress apply-preset my-agent --preset trusted\n" +
-        "  dam egress apply-preset my-agent --preset all --yes\n",
+        "  dam network apply-preset my-agent --preset trusted\n" +
+        "  dam network apply-preset my-agent --preset all --yes\n",
     )
     .action(
       async (
@@ -108,7 +108,7 @@ export function buildApplyPresetCommand(deps: {
           );
         } else {
           process.stdout.write(
-            `✓ Applied preset '${opts.preset}' to ${ref}. Run \`dam egress list ${ref}\` to see the resulting rules.\n`,
+            `✓ Applied preset '${opts.preset}' to ${ref}. Run \`dam network list ${ref}\` to see the resulting rules.\n`,
           );
         }
         process.exit(EXIT_SUCCESS);

--- a/packages/cli/src/modules/egress/commands/apply-preset.ts
+++ b/packages/cli/src/modules/egress/commands/apply-preset.ts
@@ -1,0 +1,120 @@
+import { Command, Option } from "commander";
+import type { EgressPreset } from "api-server-api";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_INVALID_INPUT,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { confirm } from "../../shared/prompt.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildApplyPresetCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("apply-preset")
+    .description(
+      "Replace existing preset rules on the Agent. Manual and connection-derived rules are preserved.",
+    )
+    .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
+    .addOption(
+      new Option("--preset <name>", "preset to apply")
+        .choices(["none", "trusted", "all"])
+        .makeOptionMandatory(),
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("-y, --yes", "skip the 'all' preset confirmation")
+    .option("--json", "emit { ok, agentId, preset } as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  dam egress apply-preset my-agent --preset trusted\n" +
+        "  dam egress apply-preset my-agent --preset all --yes\n",
+    )
+    .action(
+      async (
+        ref: string,
+        opts: {
+          preset: EgressPreset;
+          server?: string;
+          yes?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+
+        const resolver = createAgentResolver({
+          agentService: deps.createAgentService(host),
+        });
+        const resolved = await resolver.resolve(ref);
+        if (!resolved.ok) {
+          printResolveError(resolved.error, host);
+          process.exit(exitCodeForResolveError(resolved.error));
+        }
+
+        process.stderr.write(
+          `Applying preset '${opts.preset}' will replace existing preset rules. Manual and connection-derived rules are preserved.\n`,
+        );
+
+        if (opts.preset === "all" && !opts.yes) {
+          if (!process.stdin.isTTY) {
+            process.stderr.write(
+              "error: --preset all requires --yes on non-interactive stdin\n",
+            );
+            process.exit(EXIT_INVALID_INPUT);
+          }
+          process.stderr.write(
+            "Preset 'all' allows the agent to reach any host — this is a development escape hatch and bypasses the inbox entirely.\n",
+          );
+          if (!(await confirm("Continue?"))) {
+            process.stderr.write("Cancelled.\n");
+            process.exit(EXIT_SUCCESS);
+          }
+        }
+
+        const result = await deps
+          .createEgressService(host)
+          .applyPreset(resolved.value.id, opts.preset);
+        if (!result.ok) {
+          printServiceError(result.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (opts.json) {
+          process.stdout.write(
+            `${JSON.stringify({
+              ok: true,
+              agentId: resolved.value.id,
+              preset: opts.preset,
+            })}\n`,
+          );
+        } else {
+          process.stdout.write(
+            `✓ Applied preset '${opts.preset}' to ${ref}. Run \`dam egress list ${ref}\` to see the resulting rules.\n`,
+          );
+        }
+        process.exit(EXIT_SUCCESS);
+      },
+    );
+}

--- a/packages/cli/src/modules/egress/commands/apply-preset.ts
+++ b/packages/cli/src/modules/egress/commands/apply-preset.ts
@@ -88,7 +88,11 @@ export function buildApplyPresetCommand(deps: {
             "Preset 'all' allows the agent to reach any host — this is a development escape hatch and bypasses the inbox entirely.\n",
           );
           if (!(await confirm("Continue?"))) {
-            process.stderr.write("Cancelled.\n");
+            if (opts.json) {
+              process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
+            } else {
+              process.stdout.write("Cancelled.\n");
+            }
             process.exit(EXIT_SUCCESS);
           }
         }

--- a/packages/cli/src/modules/egress/commands/create.ts
+++ b/packages/cli/src/modules/egress/commands/create.ts
@@ -89,7 +89,11 @@ export function buildCreateCommand(deps: {
             "This rule requires path-level enforcement (non-wildcard method/path) and will restart the agent (~5–15s).\n",
           );
           if (!(await confirm("Continue?"))) {
-            process.stderr.write("Cancelled.\n");
+            if (opts.json) {
+              process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
+            } else {
+              process.stdout.write("Cancelled.\n");
+            }
             process.exit(EXIT_SUCCESS);
           }
         }

--- a/packages/cli/src/modules/egress/commands/create.ts
+++ b/packages/cli/src/modules/egress/commands/create.ts
@@ -25,7 +25,7 @@ export function buildCreateCommand(deps: {
   createEgressService: (host: string) => EgressService;
 }): Command {
   return new Command("create")
-    .description("Add an egress rule to an Agent")
+    .description("Add a network access rule to an Agent")
     .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
     .requiredOption("--host <h>", "host the rule applies to")
     .option("--method <m>", "HTTP method; default '*'", "*")
@@ -44,8 +44,8 @@ export function buildCreateCommand(deps: {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  dam egress create my-agent --host api.example.com\n" +
-        "  dam egress create my-agent --host api.example.com --method GET --path /v1/* --yes\n",
+        "  dam network create my-agent --host api.example.com\n" +
+        "  dam network create my-agent --host api.example.com --method GET --path /v1/* --yes\n",
     )
     .action(
       async (

--- a/packages/cli/src/modules/egress/commands/create.ts
+++ b/packages/cli/src/modules/egress/commands/create.ts
@@ -1,0 +1,119 @@
+import { Command, Option } from "commander";
+import { formatEgressRuleInline } from "api-server-api";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_INVALID_INPUT,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { confirm } from "../../shared/prompt.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildCreateCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("create")
+    .description("Add an egress rule to an Agent")
+    .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
+    .requiredOption("--host <h>", "host the rule applies to")
+    .option("--method <m>", "HTTP method; default '*'", "*")
+    .option("--path <p>", "path pattern; default '*'", "*")
+    .addOption(
+      new Option("--verdict <v>", "allow or deny; default 'allow'")
+        .choices(["allow", "deny"])
+        .default("allow"),
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("-y, --yes", "skip the path-level restart confirmation")
+    .option("--json", "emit the created rule as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  dam egress create my-agent --host api.example.com\n" +
+        "  dam egress create my-agent --host api.example.com --method GET --path /v1/* --yes\n",
+    )
+    .action(
+      async (
+        ref: string,
+        opts: {
+          host: string;
+          method: string;
+          path: string;
+          verdict: "allow" | "deny";
+          server?: string;
+          yes?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+
+        const resolver = createAgentResolver({
+          agentService: deps.createAgentService(host),
+        });
+        const resolved = await resolver.resolve(ref);
+        if (!resolved.ok) {
+          printResolveError(resolved.error, host);
+          process.exit(exitCodeForResolveError(resolved.error));
+        }
+
+        const requiresRestart = opts.method !== "*" || opts.path !== "*";
+        if (requiresRestart && !opts.yes) {
+          if (!process.stdin.isTTY) {
+            process.stderr.write(
+              "error: path-level rules require --yes on non-interactive stdin\n",
+            );
+            process.exit(EXIT_INVALID_INPUT);
+          }
+          process.stderr.write(
+            "This rule requires path-level enforcement (non-wildcard method/path) and will restart the agent (~5–15s).\n",
+          );
+          if (!(await confirm("Continue?"))) {
+            process.stderr.write("Cancelled.\n");
+            process.exit(EXIT_SUCCESS);
+          }
+        }
+
+        const result = await deps.createEgressService(host).create({
+          agentId: resolved.value.id,
+          host: opts.host,
+          method: opts.method,
+          pathPattern: opts.path,
+          verdict: opts.verdict,
+        });
+        if (!result.ok) {
+          printServiceError(result.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(result.value)}\n`);
+        } else {
+          process.stdout.write(
+            `✓ Created rule ${result.value.id} (${formatEgressRuleInline(result.value)}) on ${ref}.\n`,
+          );
+        }
+        process.exit(EXIT_SUCCESS);
+      },
+    );
+}

--- a/packages/cli/src/modules/egress/commands/create.ts
+++ b/packages/cli/src/modules/egress/commands/create.ts
@@ -15,7 +15,7 @@ import {
   EXIT_SUCCESS,
 } from "../../shared/exit-codes.js";
 import { resolveActiveHost } from "../../shared/preflight.js";
-import { confirm } from "../../shared/prompt.js";
+import { confirm, exitCancelled } from "../../shared/prompt.js";
 import type { EgressService } from "../services/egress-service.js";
 
 export function buildCreateCommand(deps: {
@@ -88,14 +88,7 @@ export function buildCreateCommand(deps: {
           process.stderr.write(
             "This rule requires path-level enforcement (non-wildcard method/path) and will restart the agent (~5–15s).\n",
           );
-          if (!(await confirm("Continue?"))) {
-            if (opts.json) {
-              process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
-            } else {
-              process.stdout.write("Cancelled.\n");
-            }
-            process.exit(EXIT_SUCCESS);
-          }
+          if (!(await confirm("Continue?"))) exitCancelled(opts);
         }
 
         const result = await deps.createEgressService(host).create({

--- a/packages/cli/src/modules/egress/commands/list.ts
+++ b/packages/cli/src/modules/egress/commands/list.ts
@@ -1,0 +1,98 @@
+import { Command } from "commander";
+import { formatEgressRuleSource } from "api-server-api";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { renderTable } from "../../shared/render-table.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildListCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("list")
+    .description("List egress rules for an Agent")
+    .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit raw JSON instead of the default table")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  dam egress list my-agent\n  dam egress list agent-abc123 --json\n",
+    )
+    .action(async (ref: string, opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+
+      const resolver = createAgentResolver({
+        agentService: deps.createAgentService(host),
+      });
+      const resolved = await resolver.resolve(ref);
+      if (!resolved.ok) {
+        printResolveError(resolved.error, host);
+        process.exit(exitCodeForResolveError(resolved.error));
+      }
+
+      const result = await deps
+        .createEgressService(host)
+        .listForAgent(resolved.value.id);
+      if (!result.ok) {
+        printServiceError(result.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(result.value)}\n`);
+        process.exit(EXIT_SUCCESS);
+      }
+
+      if (result.value.length === 0) {
+        process.stderr.write(
+          `No egress rules. Add one with \`dam egress create ${ref} --host <h>\` or apply a preset with \`dam egress apply-preset ${ref} --preset trusted\`.\n`,
+        );
+        process.exit(EXIT_SUCCESS);
+      }
+
+      const sorted = [...result.value].sort((a, b) => {
+        const h = a.host.localeCompare(b.host);
+        if (h !== 0) return h;
+        const m = a.method.localeCompare(b.method);
+        if (m !== 0) return m;
+        return a.pathPattern.localeCompare(b.pathPattern);
+      });
+      process.stdout.write(
+        renderTable([
+          ["ID", "VERDICT", "METHOD", "HOST", "PATH", "SOURCE"],
+          ...sorted.map((r) => [
+            r.id,
+            r.verdict,
+            r.method,
+            r.host,
+            r.pathPattern,
+            formatEgressRuleSource(r.source),
+          ]),
+        ]),
+      );
+      process.exit(EXIT_SUCCESS);
+    });
+}

--- a/packages/cli/src/modules/egress/commands/list.ts
+++ b/packages/cli/src/modules/egress/commands/list.ts
@@ -24,7 +24,7 @@ export function buildListCommand(deps: {
   createEgressService: (host: string) => EgressService;
 }): Command {
   return new Command("list")
-    .description("List egress rules for an Agent")
+    .description("List network access rules for an Agent")
     .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
     .option(
       "--server <url>",
@@ -33,7 +33,7 @@ export function buildListCommand(deps: {
     .option("--json", "emit raw JSON instead of the default table")
     .addHelpText(
       "after",
-      "\nExamples:\n  dam egress list my-agent\n  dam egress list agent-abc123 --json\n",
+      "\nExamples:\n  dam network list my-agent\n  dam network list agent-abc123 --json\n",
     )
     .action(async (ref: string, opts: { server?: string; json?: boolean }) => {
       const host = await resolveActiveHost(deps, {
@@ -68,7 +68,7 @@ export function buildListCommand(deps: {
 
       if (result.value.length === 0) {
         process.stderr.write(
-          `No egress rules. Add one with \`dam egress create ${ref} --host <h>\` or apply a preset with \`dam egress apply-preset ${ref} --preset trusted\`.\n`,
+          `No network access rules. Add one with \`dam network create ${ref} --host <h>\` or apply a preset with \`dam network apply-preset ${ref} --preset trusted\`.\n`,
         );
         process.exit(EXIT_SUCCESS);
       }

--- a/packages/cli/src/modules/egress/commands/preset.ts
+++ b/packages/cli/src/modules/egress/commands/preset.ts
@@ -1,0 +1,69 @@
+import { Command } from "commander";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildPresetCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("preset")
+    .description("Show the Agent's current effective egress preset")
+    .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit JSON `{ preset }` instead of a bare string")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  dam egress preset my-agent\n  dam egress preset my-agent --json\n",
+    )
+    .action(async (ref: string, opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+
+      const resolver = createAgentResolver({
+        agentService: deps.createAgentService(host),
+      });
+      const resolved = await resolver.resolve(ref);
+      if (!resolved.ok) {
+        printResolveError(resolved.error, host);
+        process.exit(exitCodeForResolveError(resolved.error));
+      }
+
+      const result = await deps
+        .createEgressService(host)
+        .currentPreset(resolved.value.id);
+      if (!result.ok) {
+        printServiceError(result.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify({ preset: result.value })}\n`);
+      } else {
+        process.stdout.write(`${result.value}\n`);
+      }
+      process.exit(EXIT_SUCCESS);
+    });
+}

--- a/packages/cli/src/modules/egress/commands/preset.ts
+++ b/packages/cli/src/modules/egress/commands/preset.ts
@@ -22,7 +22,7 @@ export function buildPresetCommand(deps: {
   createEgressService: (host: string) => EgressService;
 }): Command {
   return new Command("preset")
-    .description("Show the Agent's current effective egress preset")
+    .description("Show the Agent's current effective network access preset")
     .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
     .option(
       "--server <url>",
@@ -31,7 +31,7 @@ export function buildPresetCommand(deps: {
     .option("--json", "emit JSON `{ preset }` instead of a bare string")
     .addHelpText(
       "after",
-      "\nExamples:\n  dam egress preset my-agent\n  dam egress preset my-agent --json\n",
+      "\nExamples:\n  dam network preset my-agent\n  dam network preset my-agent --json\n",
     )
     .action(async (ref: string, opts: { server?: string; json?: boolean }) => {
       const host = await resolveActiveHost(deps, {

--- a/packages/cli/src/modules/egress/commands/revoke.ts
+++ b/packages/cli/src/modules/egress/commands/revoke.ts
@@ -15,8 +15,10 @@ export function buildRevokeCommand(deps: {
   createEgressService: (host: string) => EgressService;
 }): Command {
   return new Command("revoke")
-    .description("Delete an egress rule. Idempotent — unknown IDs exit 0.")
-    .argument("<rule-id>", "Rule UUID (copy from `dam egress list`)")
+    .description(
+      "Delete a network access rule. Idempotent — unknown IDs exit 0.",
+    )
+    .argument("<rule-id>", "Rule UUID (copy from `dam network list`)")
     .option(
       "--server <url>",
       "override the configured server URL for this call",
@@ -24,7 +26,7 @@ export function buildRevokeCommand(deps: {
     .option("--json", "emit { ok, id } as JSON")
     .addHelpText(
       "after",
-      "\nExamples:\n  dam egress revoke 3f2a8c0e-2b91-4d6a-9c1b-7e8a1f0a2b3c\n",
+      "\nExamples:\n  dam network revoke 3f2a8c0e-2b91-4d6a-9c1b-7e8a1f0a2b3c\n",
     )
     .action(async (id: string, opts: { server?: string; json?: boolean }) => {
       const host = await resolveActiveHost(deps, {

--- a/packages/cli/src/modules/egress/commands/revoke.ts
+++ b/packages/cli/src/modules/egress/commands/revoke.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+import { printServiceError } from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildRevokeCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("revoke")
+    .description("Delete an egress rule. Idempotent — unknown IDs exit 0.")
+    .argument("<rule-id>", "Rule UUID (copy from `dam egress list`)")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit { ok, id } as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  dam egress revoke 3f2a8c0e-2b91-4d6a-9c1b-7e8a1f0a2b3c\n",
+    )
+    .action(async (id: string, opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+
+      const result = await deps.createEgressService(host).revoke(id);
+      if (!result.ok) {
+        printServiceError(result.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify({ ok: true, id })}\n`);
+      } else {
+        process.stdout.write(`✓ Revoked rule ${id}.\n`);
+      }
+      process.exit(EXIT_SUCCESS);
+    });
+}

--- a/packages/cli/src/modules/egress/commands/trusted-hosts.ts
+++ b/packages/cli/src/modules/egress/commands/trusted-hosts.ts
@@ -1,0 +1,50 @@
+import { Command } from "commander";
+import { printServiceError } from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildTrustedHostsCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("trusted-hosts")
+    .description("List the platform-wide hosts seeded by the `trusted` preset")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit raw JSON instead of one host per line")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  dam egress trusted-hosts\n  dam egress trusted-hosts --json\n",
+    )
+    .action(async (opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+
+      const result = await deps.createEgressService(host).trustedHosts();
+      if (!result.ok) {
+        printServiceError(result.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify(result.value)}\n`);
+      } else if (result.value.length > 0) {
+        process.stdout.write(`${result.value.join("\n")}\n`);
+      }
+      process.exit(EXIT_SUCCESS);
+    });
+}

--- a/packages/cli/src/modules/egress/commands/trusted-hosts.ts
+++ b/packages/cli/src/modules/egress/commands/trusted-hosts.ts
@@ -23,7 +23,7 @@ export function buildTrustedHostsCommand(deps: {
     .option("--json", "emit raw JSON instead of one host per line")
     .addHelpText(
       "after",
-      "\nExamples:\n  dam egress trusted-hosts\n  dam egress trusted-hosts --json\n",
+      "\nExamples:\n  dam network trusted-hosts\n  dam network trusted-hosts --json\n",
     )
     .action(async (opts: { server?: string; json?: boolean }) => {
       const host = await resolveActiveHost(deps, {

--- a/packages/cli/src/modules/egress/commands/update.ts
+++ b/packages/cli/src/modules/egress/commands/update.ts
@@ -88,7 +88,11 @@ export function buildUpdateCommand(deps: {
             "This rule requires path-level enforcement (non-wildcard method/path) and will restart the agent (~5–15s).\n",
           );
           if (!(await confirm("Continue?"))) {
-            process.stderr.write("Cancelled.\n");
+            if (opts.json) {
+              process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
+            } else {
+              process.stdout.write("Cancelled.\n");
+            }
             process.exit(EXIT_SUCCESS);
           }
         }

--- a/packages/cli/src/modules/egress/commands/update.ts
+++ b/packages/cli/src/modules/egress/commands/update.ts
@@ -10,7 +10,7 @@ import {
   EXIT_SUCCESS,
 } from "../../shared/exit-codes.js";
 import { resolveActiveHost } from "../../shared/preflight.js";
-import { confirm } from "../../shared/prompt.js";
+import { confirm, exitCancelled } from "../../shared/prompt.js";
 import type { EgressService } from "../services/egress-service.js";
 
 export function buildUpdateCommand(deps: {
@@ -87,14 +87,7 @@ export function buildUpdateCommand(deps: {
           process.stderr.write(
             "This rule requires path-level enforcement (non-wildcard method/path) and will restart the agent (~5–15s).\n",
           );
-          if (!(await confirm("Continue?"))) {
-            if (opts.json) {
-              process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
-            } else {
-              process.stdout.write("Cancelled.\n");
-            }
-            process.exit(EXIT_SUCCESS);
-          }
+          if (!(await confirm("Continue?"))) exitCancelled(opts);
         }
 
         const result = await deps.createEgressService(host).update({

--- a/packages/cli/src/modules/egress/commands/update.ts
+++ b/packages/cli/src/modules/egress/commands/update.ts
@@ -20,9 +20,9 @@ export function buildUpdateCommand(deps: {
 }): Command {
   return new Command("update")
     .description(
-      "Update an egress rule; flips source to 'manual'. Partial — pass only the fields you want to change.",
+      "Update a network access rule; flips source to 'manual'. Partial — pass only the fields you want to change.",
     )
-    .argument("<rule-id>", "Rule UUID (copy from `dam egress list`)")
+    .argument("<rule-id>", "Rule UUID (copy from `dam network list`)")
     .option("--method <m>", "new HTTP method")
     .option("--path <p>", "new path pattern")
     .addOption(
@@ -37,8 +37,8 @@ export function buildUpdateCommand(deps: {
     .addHelpText(
       "after",
       "\nExamples:\n" +
-        "  dam egress update 3f2a8c0e-... --verdict deny\n" +
-        "  dam egress update 3f2a8c0e-... --method GET --path /v1/* --yes\n",
+        "  dam network update 3f2a8c0e-... --verdict deny\n" +
+        "  dam network update 3f2a8c0e-... --method GET --path /v1/* --yes\n",
     )
     .action(
       async (
@@ -99,7 +99,7 @@ export function buildUpdateCommand(deps: {
         if (!result.ok) {
           if (result.error.kind === "rule-not-found") {
             process.stderr.write(
-              `error: egress rule not found: ${result.error.id}\n`,
+              `error: network access rule not found: ${result.error.id}\n`,
             );
             process.exit(EXIT_RULE_NOT_FOUND);
           }

--- a/packages/cli/src/modules/egress/commands/update.ts
+++ b/packages/cli/src/modules/egress/commands/update.ts
@@ -1,0 +1,123 @@
+import { Command, Option } from "commander";
+import { formatEgressRuleInline, formatEgressRuleSource } from "api-server-api";
+import { printServiceError } from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_INVALID_INPUT,
+  EXIT_RULE_NOT_FOUND,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { confirm } from "../../shared/prompt.js";
+import type { EgressService } from "../services/egress-service.js";
+
+export function buildUpdateCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createEgressService: (host: string) => EgressService;
+}): Command {
+  return new Command("update")
+    .description(
+      "Update an egress rule; flips source to 'manual'. Partial — pass only the fields you want to change.",
+    )
+    .argument("<rule-id>", "Rule UUID (copy from `dam egress list`)")
+    .option("--method <m>", "new HTTP method")
+    .option("--path <p>", "new path pattern")
+    .addOption(
+      new Option("--verdict <v>", "new verdict").choices(["allow", "deny"]),
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("-y, --yes", "skip the path-level restart confirmation")
+    .option("--json", "emit the updated rule as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  dam egress update 3f2a8c0e-... --verdict deny\n" +
+        "  dam egress update 3f2a8c0e-... --method GET --path /v1/* --yes\n",
+    )
+    .action(
+      async (
+        id: string,
+        opts: {
+          method?: string;
+          path?: string;
+          verdict?: "allow" | "deny";
+          server?: string;
+          yes?: boolean;
+          json?: boolean;
+        },
+      ) => {
+        if (
+          opts.method === undefined &&
+          opts.path === undefined &&
+          opts.verdict === undefined
+        ) {
+          process.stderr.write(
+            "error: at least one of --method, --path, --verdict must be provided\n",
+          );
+          process.exit(EXIT_INVALID_INPUT);
+        }
+
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+
+        // Restart check uses only user-passed flags — accept false positives
+        // for rules already on the L7 chain rather than fetch to compute the
+        // merged effective shape.
+        const requiresRestart =
+          (opts.method !== undefined && opts.method !== "*") ||
+          (opts.path !== undefined && opts.path !== "*");
+        if (requiresRestart && !opts.yes) {
+          if (!process.stdin.isTTY) {
+            process.stderr.write(
+              "error: path-level rules require --yes on non-interactive stdin\n",
+            );
+            process.exit(EXIT_INVALID_INPUT);
+          }
+          process.stderr.write(
+            "This rule requires path-level enforcement (non-wildcard method/path) and will restart the agent (~5–15s).\n",
+          );
+          if (!(await confirm("Continue?"))) {
+            process.stderr.write("Cancelled.\n");
+            process.exit(EXIT_SUCCESS);
+          }
+        }
+
+        const result = await deps.createEgressService(host).update({
+          id,
+          method: opts.method,
+          pathPattern: opts.path,
+          verdict: opts.verdict,
+        });
+        if (!result.ok) {
+          if (result.error.kind === "rule-not-found") {
+            process.stderr.write(
+              `error: egress rule not found: ${result.error.id}\n`,
+            );
+            process.exit(EXIT_RULE_NOT_FOUND);
+          }
+          printServiceError(result.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(result.value)}\n`);
+        } else {
+          process.stdout.write(
+            `✓ Updated rule ${result.value.id} (${formatEgressRuleInline(result.value)}). Source: ${formatEgressRuleSource(result.value.source)}.\n`,
+          );
+        }
+        process.exit(EXIT_SUCCESS);
+      },
+    );
+}

--- a/packages/cli/src/modules/egress/compose.ts
+++ b/packages/cli/src/modules/egress/compose.ts
@@ -6,9 +6,13 @@ import {
   createTrpcClient,
   type TrpcClient,
 } from "../shared/trpc/trpc-client.js";
+import { buildApplyPresetCommand } from "./commands/apply-preset.js";
+import { buildCreateCommand } from "./commands/create.js";
 import { buildListCommand } from "./commands/list.js";
 import { buildPresetCommand } from "./commands/preset.js";
+import { buildRevokeCommand } from "./commands/revoke.js";
 import { buildTrustedHostsCommand } from "./commands/trusted-hosts.js";
+import { buildUpdateCommand } from "./commands/update.js";
 import {
   createEgressService,
   type EgressService,
@@ -34,26 +38,28 @@ export function composeEgressModule(opts: EgressModuleOptions): EgressModule {
   const createService = (host: string): EgressService =>
     createEgressService({ trpc: buildTrpc(host) });
 
-  const shared = {
+  const agentScoped = {
     compatService: opts.compatService,
     configService: opts.configService,
     createAgentService: opts.createAgentService,
+    createEgressService: createService,
+  };
+  const idScoped = {
+    compatService: opts.compatService,
+    configService: opts.configService,
     createEgressService: createService,
   };
 
   const parent = new Command("egress").description(
     "Manage per-Agent egress rules (the pre-approvals that let an Agent reach external hosts)",
   );
-  parent.addCommand(buildListCommand(shared));
-  parent.addCommand(buildPresetCommand(shared));
-  // Mutation commands (create / update / revoke / apply-preset) land in sub-issue 04.
-  parent.addCommand(
-    buildTrustedHostsCommand({
-      compatService: opts.compatService,
-      configService: opts.configService,
-      createEgressService: createService,
-    }),
-  );
+  parent.addCommand(buildListCommand(agentScoped));
+  parent.addCommand(buildCreateCommand(agentScoped));
+  parent.addCommand(buildUpdateCommand(idScoped));
+  parent.addCommand(buildRevokeCommand(idScoped));
+  parent.addCommand(buildPresetCommand(agentScoped));
+  parent.addCommand(buildApplyPresetCommand(agentScoped));
+  parent.addCommand(buildTrustedHostsCommand(idScoped));
 
   return { commands: [parent], exports: { createService } };
 }

--- a/packages/cli/src/modules/egress/compose.ts
+++ b/packages/cli/src/modules/egress/compose.ts
@@ -50,8 +50,8 @@ export function composeEgressModule(opts: EgressModuleOptions): EgressModule {
     createEgressService: createService,
   };
 
-  const parent = new Command("egress").description(
-    "Manage per-Agent egress rules (the pre-approvals that let an Agent reach external hosts)",
+  const parent = new Command("network").description(
+    "Manage per-Agent network access rules (the pre-approvals that let an Agent reach external hosts)",
   );
   parent.addCommand(buildListCommand(agentScoped));
   parent.addCommand(buildCreateCommand(agentScoped));

--- a/packages/cli/src/modules/egress/compose.ts
+++ b/packages/cli/src/modules/egress/compose.ts
@@ -1,0 +1,59 @@
+import { Command } from "commander";
+import type { AgentService } from "../agent/index.js";
+import type { TokenProvider } from "../auth/index.js";
+import type { CompatService, ConfigService } from "../cli/index.js";
+import {
+  createTrpcClient,
+  type TrpcClient,
+} from "../shared/trpc/trpc-client.js";
+import { buildListCommand } from "./commands/list.js";
+import { buildPresetCommand } from "./commands/preset.js";
+import { buildTrustedHostsCommand } from "./commands/trusted-hosts.js";
+import {
+  createEgressService,
+  type EgressService,
+} from "./services/egress-service.js";
+
+export interface EgressModuleOptions {
+  tokenProvider: TokenProvider;
+  configService: ConfigService;
+  compatService: CompatService;
+  /** Per-host factory the resolver inside agent-scoped commands consumes. */
+  createAgentService: (host: string) => AgentService;
+}
+
+export interface EgressModule {
+  commands: ReadonlyArray<Command>;
+  exports: { createService: (host: string) => EgressService };
+}
+
+export function composeEgressModule(opts: EgressModuleOptions): EgressModule {
+  const buildTrpc = (host: string): TrpcClient =>
+    createTrpcClient({ host, tokenProvider: opts.tokenProvider });
+
+  const createService = (host: string): EgressService =>
+    createEgressService({ trpc: buildTrpc(host) });
+
+  const shared = {
+    compatService: opts.compatService,
+    configService: opts.configService,
+    createAgentService: opts.createAgentService,
+    createEgressService: createService,
+  };
+
+  const parent = new Command("egress").description(
+    "Manage per-Agent egress rules (the pre-approvals that let an Agent reach external hosts)",
+  );
+  parent.addCommand(buildListCommand(shared));
+  parent.addCommand(buildPresetCommand(shared));
+  // Mutation commands (create / update / revoke / apply-preset) land in sub-issue 04.
+  parent.addCommand(
+    buildTrustedHostsCommand({
+      compatService: opts.compatService,
+      configService: opts.configService,
+      createEgressService: createService,
+    }),
+  );
+
+  return { commands: [parent], exports: { createService } };
+}

--- a/packages/cli/src/modules/egress/domain/errors.ts
+++ b/packages/cli/src/modules/egress/domain/errors.ts
@@ -1,0 +1,6 @@
+export type { TransportError, AuthRequiredError } from "../../shared/errors.js";
+
+export interface RuleNotFoundError {
+  kind: "rule-not-found";
+  id: string;
+}

--- a/packages/cli/src/modules/egress/index.ts
+++ b/packages/cli/src/modules/egress/index.ts
@@ -1,0 +1,7 @@
+export type { EgressService } from "./services/egress-service.js";
+export { createEgressService } from "./services/egress-service.js";
+export type {
+  TransportError,
+  AuthRequiredError,
+  RuleNotFoundError,
+} from "./domain/errors.js";

--- a/packages/cli/src/modules/egress/services/egress-service.ts
+++ b/packages/cli/src/modules/egress/services/egress-service.ts
@@ -1,0 +1,89 @@
+import type {
+  EgressPreset,
+  EgressRuleCreateInput,
+  EgressRuleUpdateInput,
+  EgressRuleView,
+} from "api-server-api";
+import { err, type Result } from "../../../result.js";
+import { trpcCall } from "../../shared/trpc/classify.js";
+import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
+import type {
+  AuthRequiredError,
+  RuleNotFoundError,
+  TransportError,
+} from "../domain/errors.js";
+
+export interface EgressService {
+  listForAgent(
+    agentId: string,
+  ): Promise<
+    Result<readonly EgressRuleView[], TransportError | AuthRequiredError>
+  >;
+  currentPreset(
+    agentId: string,
+  ): Promise<Result<EgressPreset, TransportError | AuthRequiredError>>;
+  trustedHosts(): Promise<
+    Result<readonly string[], TransportError | AuthRequiredError>
+  >;
+  create(
+    input: EgressRuleCreateInput,
+  ): Promise<Result<EgressRuleView, TransportError | AuthRequiredError>>;
+  update(
+    input: EgressRuleUpdateInput,
+  ): Promise<
+    Result<
+      EgressRuleView,
+      TransportError | AuthRequiredError | RuleNotFoundError
+    >
+  >;
+  revoke(
+    id: string,
+  ): Promise<
+    Result<void, TransportError | AuthRequiredError | RuleNotFoundError>
+  >;
+  applyPreset(
+    agentId: string,
+    preset: EgressPreset,
+  ): Promise<Result<void, TransportError | AuthRequiredError>>;
+}
+
+export function createEgressService(deps: { trpc: TrpcClient }): EgressService {
+  return {
+    async listForAgent(agentId) {
+      return trpcCall(
+        () =>
+          deps.trpc.egressRules.listForAgent.query({ agentId }) as Promise<
+            readonly EgressRuleView[]
+          >,
+      );
+    },
+    async currentPreset(agentId) {
+      return trpcCall(
+        () =>
+          deps.trpc.egressRules.currentPreset.query({
+            agentId,
+          }) as Promise<EgressPreset>,
+      );
+    },
+    async trustedHosts() {
+      return trpcCall(
+        () =>
+          deps.trpc.egressRules.trustedHosts.query() as Promise<
+            readonly string[]
+          >,
+      );
+    },
+    async create(_input) {
+      return err({ kind: "transport", reason: "not implemented" });
+    },
+    async update(_input) {
+      return err({ kind: "transport", reason: "not implemented" });
+    },
+    async revoke(_id) {
+      return err({ kind: "transport", reason: "not implemented" });
+    },
+    async applyPreset(_agentId, _preset) {
+      return err({ kind: "transport", reason: "not implemented" });
+    },
+  };
+}

--- a/packages/cli/src/modules/egress/services/egress-service.ts
+++ b/packages/cli/src/modules/egress/services/egress-service.ts
@@ -4,8 +4,8 @@ import type {
   EgressRuleUpdateInput,
   EgressRuleView,
 } from "api-server-api";
-import { err, type Result } from "../../../result.js";
-import { trpcCall } from "../../shared/trpc/classify.js";
+import { err, ok, type Result } from "../../../result.js";
+import { classifyTrpcError, trpcCall } from "../../shared/trpc/classify.js";
 import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
 import type {
   AuthRequiredError,
@@ -36,11 +36,7 @@ export interface EgressService {
       TransportError | AuthRequiredError | RuleNotFoundError
     >
   >;
-  revoke(
-    id: string,
-  ): Promise<
-    Result<void, TransportError | AuthRequiredError | RuleNotFoundError>
-  >;
+  revoke(id: string): Promise<Result<void, TransportError | AuthRequiredError>>;
   applyPreset(
     agentId: string,
     preset: EgressPreset,
@@ -73,17 +69,35 @@ export function createEgressService(deps: { trpc: TrpcClient }): EgressService {
           >,
       );
     },
-    async create(_input) {
-      return err({ kind: "transport", reason: "not implemented" });
+    async create(input) {
+      return trpcCall(
+        () =>
+          deps.trpc.egressRules.create.mutate(input) as Promise<EgressRuleView>,
+      );
     },
-    async update(_input) {
-      return err({ kind: "transport", reason: "not implemented" });
+    async update(input) {
+      try {
+        const view = (await deps.trpc.egressRules.update.mutate(
+          input,
+        )) as EgressRuleView;
+        return ok(view);
+      } catch (e) {
+        if ((e as { data?: { code?: string } })?.data?.code === "NOT_FOUND") {
+          return err({ kind: "rule-not-found", id: input.id });
+        }
+        return classifyTrpcError(e);
+      }
     },
-    async revoke(_id) {
-      return err({ kind: "transport", reason: "not implemented" });
+    async revoke(id) {
+      // Server is idempotent on revoke — unknown IDs return without throwing.
+      return trpcCall(async () => {
+        await deps.trpc.egressRules.revoke.mutate({ id });
+      });
     },
-    async applyPreset(_agentId, _preset) {
-      return err({ kind: "transport", reason: "not implemented" });
+    async applyPreset(agentId, preset) {
+      return trpcCall(async () => {
+        await deps.trpc.egressRules.applyPreset.mutate({ agentId, preset });
+      });
     },
   };
 }

--- a/packages/cli/src/modules/shared/exit-codes.ts
+++ b/packages/cli/src/modules/shared/exit-codes.ts
@@ -16,7 +16,7 @@ export const EXIT_AUTH_STATUS_NO_VALID = 4;
 /** Agent ref didn't resolve — zero matches or ambiguous. */
 export const EXIT_AGENT_NOT_RESOLVED = 5;
 
-/** `dam egress update` / `revoke` against an unknown rule ID. */
+/** `dam egress update` against an unknown rule ID (revoke is idempotent — exits 0). */
 export const EXIT_RULE_NOT_FOUND = 6;
 
 /** POSIX convention: 128 + SIGINT(2). Emitted on Ctrl+C during bundle pack/upload. */

--- a/packages/cli/src/modules/shared/exit-codes.ts
+++ b/packages/cli/src/modules/shared/exit-codes.ts
@@ -16,5 +16,8 @@ export const EXIT_AUTH_STATUS_NO_VALID = 4;
 /** Agent ref didn't resolve — zero matches or ambiguous. */
 export const EXIT_AGENT_NOT_RESOLVED = 5;
 
+/** `dam egress update` / `revoke` against an unknown rule ID. */
+export const EXIT_RULE_NOT_FOUND = 6;
+
 /** POSIX convention: 128 + SIGINT(2). Emitted on Ctrl+C during bundle pack/upload. */
 export const EXIT_SIGINT = 130;

--- a/packages/cli/src/modules/shared/exit-codes.ts
+++ b/packages/cli/src/modules/shared/exit-codes.ts
@@ -16,7 +16,7 @@ export const EXIT_AUTH_STATUS_NO_VALID = 4;
 /** Agent ref didn't resolve — zero matches or ambiguous. */
 export const EXIT_AGENT_NOT_RESOLVED = 5;
 
-/** `dam egress update` against an unknown rule ID (revoke is idempotent — exits 0). */
+/** `dam network update` against an unknown rule ID (revoke is idempotent — exits 0). */
 export const EXIT_RULE_NOT_FOUND = 6;
 
 /** POSIX convention: 128 + SIGINT(2). Emitted on Ctrl+C during bundle pack/upload. */

--- a/packages/cli/src/modules/shared/prompt.ts
+++ b/packages/cli/src/modules/shared/prompt.ts
@@ -1,4 +1,5 @@
 import { createInterface } from "node:readline/promises";
+import { EXIT_SUCCESS } from "./exit-codes.js";
 
 /** Default idle window before a hanging confirm prompt aborts to No. */
 const DEFAULT_PROMPT_TIMEOUT_MS = 30_000;
@@ -45,4 +46,19 @@ export async function confirm(
     clearTimeout(timer);
     rl.close();
   }
+}
+
+/**
+ * Common exit path for verbs that confirm before mutating: writes
+ * `{"cancelled":true}` (under `--json`) or `Cancelled.` to stdout, then
+ * exits 0. Stdout — not stderr — so scripts can branch on it without
+ * a separate stream redirect.
+ */
+export function exitCancelled(opts: { json?: boolean }): never {
+  if (opts.json) {
+    process.stdout.write(`${JSON.stringify({ cancelled: true })}\n`);
+  } else {
+    process.stdout.write("Cancelled.\n");
+  }
+  process.exit(EXIT_SUCCESS);
 }

--- a/packages/ui/src/modules/egress-rules/api/mutations.ts
+++ b/packages/ui/src/modules/egress-rules/api/mutations.ts
@@ -17,18 +17,6 @@ export function useCreateEgressRule() {
   });
 }
 
-export function useUpdateEgressRule() {
-  return useMutation({
-    ...trpc.egressRules.update.mutationOptions(),
-    meta: {
-      // Editing flips source to 'manual'; refetch so the row's badge
-      // reflects user-owned state and connection revoke won't touch it.
-      invalidates: [egressRulesKeys.all],
-      errorToast: "Couldn't update egress rule",
-    },
-  });
-}
-
 export function useRevokeEgressRule() {
   return useMutation({
     ...trpc.egressRules.revoke.mutationOptions(),

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -3,7 +3,11 @@ import {
   RotateCounterclockwise as RotateCcw,
   TrashCan as Trash2,
 } from "@carbon/icons-react";
-import type { EgressPreset, EgressRuleView } from "api-server-api";
+import {
+  type EgressPreset,
+  type EgressRuleView,
+  formatEgressRuleSource,
+} from "api-server-api";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -473,7 +477,9 @@ function RuleRow({
     rule.verdict === "allow"
       ? "text-primary border-primary/40"
       : "text-destructive border-destructive/40";
-  const sourceLabel = sourceLabelOverride ?? formatSource(rule.source);
+  const sourceLabel =
+    sourceLabelOverride ??
+    (rule.source === "manual" ? null : formatEgressRuleSource(rule.source));
   const dim = pendingDelete ? "opacity-40 line-through" : "";
   return (
     <li
@@ -631,14 +637,4 @@ function PreviewPresetRow({ row }: { row: PreviewRow }) {
           selection or cancel the dialog to drop the preview. */}
     </li>
   );
-}
-
-function formatSource(source: EgressRuleView["source"]): string | null {
-  if (source === "manual") return null;
-  if (source === "inbox") return "from inbox";
-  if (source === "preset:trusted") return "preset: trusted";
-  if (source === "preset:all") return "preset: all";
-  if (source.startsWith("connection:"))
-    return `from ${source.slice("connection:".length)}`;
-  return source;
 }


### PR DESCRIPTION
Closes #345 (P0 sub-issue of #329).

## Summary

Brings CLI parity with the per-agent network access editor in the UI. A new `dam network` group lets users list, inspect, and mutate the network access rules that pre-approve which external hosts an Agent can reach (ADR-035).

> **Naming:** the command group is `dam network` (originally drafted as `dam egress`, renamed per review). This matches what the UI already calls the feature — the "Network access" tab — so users see one consistent term. Internal naming keeps the precise domain term (`egress` module, `EgressService`, the `egressRules.*` tRPC procedures, `EgressRuleView`), mirroring the UI's existing code-vs-label split.

Seven commands:

- `dam network list <agent>` — table; `--json` for `EgressRuleView[]`
- `dam network preset <agent>` — current effective preset (`none` / `trusted` / `all`)
- `dam network create <agent> --host <h> [...]` — add a manual rule
- `dam network update <rule-id> [...]` — partial update; flips source to manual
- `dam network revoke <rule-id>` — delete; idempotent
- `dam network apply-preset <agent> --preset <name>` — bulk reseed; preserves manual and connection-derived rules
- `dam network trusted-hosts` — the platform-wide trusted host list

`create` / `update` prompt before producing path-level-enforced rules (which roll the Agent pod ~5–15s). `apply-preset all` prompts before bypassing the inbox. `--yes` skips the prompt; non-TTY without `--yes` exits 2.

Architecture page [docs/architecture/cli.md](../tree/feat/cli-egress/docs/architecture/cli.md) has a new Network access section covering the two pieces of non-obvious behavior the CLI surfaces.

## Test plan

- [x] `mise run check` green
- [x] `mise run test` green (all 526 tests still pass; no new tests added per project convention)
- [x] `mise run cli:build` green
- [x] Smoke-tested end-to-end against a live cluster: read commands, create (L4 / L7), partial update, NOT_FOUND classification, revoke idempotency, apply-preset (`trusted` / `all` / non-TTY), JSON output shapes, cancel-on-decline behavior — all 35 scenarios pass
- [x] Re-smoke-tested the renamed `dam network` surface end-to-end against a live cluster (all 7 subcommands, table + `--json`, create/update/revoke, idempotent revoke, NOT_FOUND → exit 6, non-TTY guards → exit 2, apply-preset `trusted`/`all`); no user-facing output contains "egress"; agent state restored to baseline
- [ ] Reviewer spot-check the [Network access section](../tree/feat/cli-egress/docs/architecture/cli.md) reads correctly
