### PR TITLE
fix(platform-base): honor the lockfile in the agent-runtime deploy

### DIFF
--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -27,8 +27,30 @@ COPY packages/agent-runtime/ packages/agent-runtime/
 
 RUN pnpm --filter agent-runtime build
 
-# Materialize a flat, prod-only runtime tree from agent-runtime/package.json; strip devDeps so downstream `npm install` doesn't choke on workspace:* specifiers.
-RUN pnpm --filter agent-runtime deploy --legacy --prod --node-linker=hoisted /deploy \
+# Materialize a flat, prod-only runtime tree for agent-runtime. The contract
+# packages (agent-runtime-api, api-server-api) are inlined into dist by tsup
+# (noExternal) and live in devDependencies, so --prod omits them from node_modules.
+#
+# Honor the lockfile: the `--legacy` deploy implementation re-resolves the graph
+# WITHOUT the lockfile, drifting to the latest published versions on every build
+# (non-reproducible, and it trips the repo's `no-downgrade` trust policy when a
+# transitive dep's publisher signal changes). pnpm 10's modern deploy uses the
+# lockfile but guards against non-injected workspaces — satisfy that guard with
+# a command-scoped `inject-workspace-packages=true` (no prod workspace deps are
+# actually injected here) rather than flipping the global config, which would
+# turn workspace symlinks into copies for everyone's dev install.
+#
+# Use the authored manifest, not pnpm's: modern deploy rewrites package.json
+# dependency versions to pnpm's peer-resolved form (e.g.
+# `@trpc/server: 11.16.0(typescript@6.0.2)`), which is invalid npm syntax and
+# breaks the plain `npm install` in derived agent images (claude-code,
+# google-workspace) with EINVALIDTAGNAME. agent-runtime's own package.json
+# already carries clean semver ranges, so overwrite the deployed manifest with
+# it and drop devDependencies — keeping deploy's lockfile-pinned node_modules
+# but an npm-consumable manifest.
+RUN npm_config_inject_workspace_packages=true \
+    pnpm --filter agent-runtime deploy --frozen-lockfile --prod --node-linker=hoisted /deploy \
+    && cp packages/agent-runtime/package.json /deploy/package.json \
     && (cd /deploy && pnpm pkg delete devDependencies)
 
 # -builder base: agent images extending this need dnf+npm install at build time.


### PR DESCRIPTION
## Problem

The agent image build fails. First the `platform-base` builder stage:

```
ERR_PNPM_TRUST_DOWNGRADE  High-risk trust downgrade for "tinyexec@1.2.2"
  This error happened while installing the dependencies of vitest@4.1.7
```

Root cause: `pnpm --filter agent-runtime deploy --legacy`. The **legacy** deploy re-resolves the dependency graph **without the lockfile** ("the current configuration prohibits to read or write a lockfile"), so every build drifts to the latest published versions. That's non-reproducible, and it trips the repo's `no-downgrade` trust policy the moment a transitive dep's publisher signal changes — a freshly-resolved `vitest@4.1.7` pulls `tinyexec@1.2.2`, which switched from trusted-publisher to provenance-attestation. The committed lockfile pins the trusted `vitest@4.1.3` / `tinyexec@1.1.1`, but legacy deploy ignores it.

## Fix

Use pnpm 10's **modern** deploy, which honors the lockfile. Two wrinkles, both handled without touching global config or post-processing pnpm's output:

1. Modern deploy guards against non-injected workspaces (`ERR_PNPM_DEPLOY_NONINJECTED_WORKSPACE`). Satisfied with a **command-scoped** `inject-workspace-packages=true` — not the global config, which would turn workspace symlinks into copies for every dev install. `--frozen-lockfile` makes reproducibility explicit.
2. Modern deploy rewrites `package.json` dependency versions into pnpm's peer-resolved syntax (`@trpc/server: 11.16.0(typescript@6.0.2)`) — valid for pnpm, **invalid for npm**, which is what the derived agent images (`claude-code`, `google-workspace`) use. That caused a follow-on `EINVALIDTAGNAME`. Rather than mangle pnpm's output, use the **authored** `agent-runtime/package.json` (already clean semver ranges) for the runner manifest; its only non-npm specs are `workspace:*`/build deps, which live in devDependencies and get dropped.

```diff
-RUN pnpm --filter agent-runtime deploy --legacy --prod --node-linker=hoisted /deploy \
+RUN npm_config_inject_workspace_packages=true \
+    pnpm --filter agent-runtime deploy --frozen-lockfile --prod --node-linker=hoisted /deploy \
+    && cp packages/agent-runtime/package.json /deploy/package.json \
     && (cd /deploy && pnpm pkg delete devDependencies)
```

Net: deploy's **lockfile-pinned `node_modules`** + the **human-authored, npm-consumable manifest**. Output tree shape is unchanged (hoisted, prod-only; contract packages stay inlined into `dist` by tsup `noExternal`).

## Verification

Built end to end with `docker build`:

- `platform-base`: the deploy step reuses packages **straight from the lockfile store** (`resolved 0, downloaded 0`) — no re-resolution, no trust error; `/deploy` has 0 devDeps, no `vitest`/`tinyexec`, and prod deps resolve.
- `platform-claude-code` (the image that was failing): the `npm install @agentclientprotocol/claude-agent-acp && npm install -g @anthropic-ai/claude-code` step now succeeds (`added … packages`, no `EINVALIDTAGNAME`).

## Notes

- Independent of the audit-logging PR (#413) — that one only touches `packages/api-server`, helm, and docs.
- The same `--legacy` deploy pattern in any other image would share the lockfile-bypass; none other uses it today.
