### PR TITLE
fix(api-server): deliver built-in platform connection at agent creation

### DIFF
--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -577,6 +577,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       readTemplateSpec,
       presetSeeder,
       cleanupHooks: agentCleanupHooks,
+      runtimeMutator,
     });
     const { schedules, isOwnedSchedule } = composeSchedulesForOwner({
       boot: schedulesBoot,

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -155,6 +155,29 @@ const userDirectory = createKeycloakUserDirectory({
   clientSecret: config.keycloakApiClientSecret,
 });
 
+if (!config.redisUrl)
+  throw new Error(
+    "REDIS_URL is required (Redis is a platform primitive — see ADR-036)",
+  );
+const redisBus = createRedisBus(config.redisUrl, {
+  password: config.redisPassword ?? undefined,
+});
+
+const bullConnection = createBullConnection(
+  config.redisUrl,
+  config.redisPassword ?? undefined,
+);
+
+// Composed before the system-agents reader so runtimeMutator is a required agents dep (#421).
+const runtimeDelivery = composeRuntimeDelivery({
+  db,
+  namespace: config.namespace,
+  bullConnection,
+  agentRunningPort: { isRunning: () => true },
+  harnessServerUrl: config.harnessServerUrl,
+});
+runtimeDelivery.sweep.start();
+
 const { agents: systemAgents } = composeAgentsModule({
   api,
   namespace: config.namespace,
@@ -163,6 +186,7 @@ const { agents: systemAgents } = composeAgentsModule({
   userDirectory,
   channelSecretStore,
   readTemplateSpec: async () => null,
+  runtimeMutator: runtimeDelivery.runtimeMutator,
 });
 const persistSession = upsertSession(db);
 const persistSlackSession = (
@@ -284,19 +308,6 @@ const channelManager = createChannelManager({
   channelSecretStore,
 });
 
-if (!config.redisUrl)
-  throw new Error(
-    "REDIS_URL is required (Redis is a platform primitive — see ADR-036)",
-  );
-const redisBus = createRedisBus(config.redisUrl, {
-  password: config.redisPassword ?? undefined,
-});
-
-const bullConnection = createBullConnection(
-  config.redisUrl,
-  config.redisPassword ?? undefined,
-);
-
 // Seed list for the `trusted` egress preset (ADR-035).
 // Read once at boot; the helm ConfigMap is the operator-editable source.
 const trustedHosts = loadTrustedHosts(config.trustedHostsPath);
@@ -371,15 +382,6 @@ const agentArtifactsSweeper = createAgentArtifactsSweeper({
   batchSize: 200,
 });
 agentArtifactsSweeper.start();
-
-const runtimeDelivery = composeRuntimeDelivery({
-  db,
-  namespace: config.namespace,
-  bullConnection,
-  agentRunningPort: { isRunning: () => true },
-  harnessServerUrl: config.harnessServerUrl,
-});
-runtimeDelivery.sweep.start();
 
 const schedulesBoot = composeSchedulesAtBoot({
   db,

--- a/packages/api-server/src/modules/agents/compose.ts
+++ b/packages/api-server/src/modules/agents/compose.ts
@@ -30,6 +30,7 @@ import {
 } from "./infrastructure/allowed-users-repository.js";
 import type { KeycloakUserDirectory } from "./infrastructure/keycloak-user-directory.js";
 import type { ReadTemplateSpec } from "../templates/index.js";
+import type { RuntimeMutator } from "../runtime-delivery/index.js";
 
 export type {
   AgentCleanupHook,
@@ -48,6 +49,7 @@ export function composeAgentsModule(deps: {
   readTemplateSpec: ReadTemplateSpec;
   presetSeeder?: PresetSeeder;
   cleanupHooks?: readonly AgentCleanupHook[];
+  runtimeMutator: RuntimeMutator;
 }): {
   agents: AgentsService;
   repo: AgentsRepository;
@@ -66,6 +68,7 @@ export function composeAgentsModule(deps: {
       readTemplateSpec: deps.readTemplateSpec,
       presetSeeder: deps.presetSeeder,
       cleanupHooks: deps.cleanupHooks,
+      runtimeMutator: deps.runtimeMutator,
       listChannelsByOwner: listChannelsByOwner(deps.db, owner),
       listChannelsByAgent: listChannelsByAgent(deps.db, owner),
       upsertChannel: upsertChannel(deps.db, owner),

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -22,6 +22,7 @@ import {
 import type { KeycloakUserDirectory } from "../infrastructure/keycloak-user-directory.js";
 import { isSlackChannelUniqueViolation } from "../infrastructure/channel-bindings-repository.js";
 import type { ChannelSecretStore } from "../../channels/infrastructure/channel-secret-store.js";
+import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 import { ok, err } from "../../../core/result.js";
 import type { UnitOfWork, Tx } from "../../../core/unit-of-work.js";
 import { emit, EventType } from "../../../events.js";
@@ -71,6 +72,7 @@ export function createAgentsService(deps: {
   /** Run after a successful K8s delete. Each module that owns per-agent
    *  Postgres state contributes one hook. */
   cleanupHooks?: readonly AgentCleanupHook[];
+  runtimeMutator: RuntimeMutator;
   // --- Runtime / channels / allowed-users dependencies (formerly Instance) ---
   listChannelsByOwner: () => Promise<Map<string, ChannelConfig[]>>;
   listChannelsByAgent: (agentId: string) => Promise<ChannelConfig[]>;
@@ -218,6 +220,9 @@ export function createAgentsService(deps: {
           owner,
         );
       }
+
+      // Bump so the built-in platform connection ships from creation (#421).
+      await deps.runtimeMutator.bump(infra.id, []);
 
       const agent = assembleAgent(infra, [], emails);
       emit({


### PR DESCRIPTION
## Problem

Closes #421.

A freshly created agent never received its built-in platform connection — the `platform-outbound` MCP entry it uses to call back into the platform — until some *unrelated* connection was granted. Until then the built-in was silently missing, so a new agent couldn't use its platform-provided tools out of the box.

## Root cause

The built-in contribution is computed on the fly in `stateBuilder.build()`, but both delivery paths short-circuit before that runs unless the agent already has a `runtime_state_outbox` row with version > 0:

- `hello-handler.ts` — `if (!row || row.version === 0) return { events: [] }`
- `worker-handler.ts` — `if (!row) return`

A brand-new agent has no outbox row (it's first created by a grant's version bump in `contribution-fanout`). So neither path delivers the built-in until the first grant — exactly the "until another connection is granted" symptom.

## Fix

Bump the agent's runtime version once at creation. That single `runtimeMutator.bump(infra.id, [])` makes the outbox row exist at v1, which is all the delivery machinery needs:

- On boot the agent calls `hello`; `row.version = 1 > 0`, so it returns the full desired state — including the built-in — immediately. **This is the actual delivery path.**
- The cron sweep is the backstop: the still-unacked row is re-enqueued, the worker (now holding the capabilities recorded by that first `hello`) dispatches `applyState`, the agent acks, and the row settles.

No create-time enqueue: the pod hasn't sent `hello` yet, so the worker would defer on missing capabilities — it can't deliver anything at that moment.

`runtimeMutator` is now a **required** dependency of every agents composition (runtime-delivery is composed before the system-agents reader in boot), so the bump can't be silently dropped — closing the same silent-no-op failure class as the bug itself. It reuses the existing public `RuntimeMutator` port, the same way connections/skills/schedules already consume it — no new abstraction.

## Changes (4 files, all api-server)

- `modules/agents/services/agents-service.ts` — `create()` bumps the runtime version after the preset-seeder block; `runtimeMutator` added as a required dep.
- `modules/agents/compose.ts` — threads `runtimeMutator` through `composeAgentsModule`.
- `index.ts` — composes runtime-delivery before the system-agents reader so it can supply `runtimeMutator`.
- `apps/api-server/app.ts` — passes the in-scope `runtimeMutator` to `composeAgentsModule`.

No DB schema, ADR, or architecture-doc change.

## Verification

- `mise run check` — green.
- `mise run test` — all api-server tests pass (166). The one `cli` integration-test failure requires a live k3s/Keycloak cluster and fails identically on a clean tree — unrelated to this change.
- Manual cluster e2e not yet run: create a fresh agent and confirm it receives `platform-outbound` with no other connection granted.