### PR TITLE
feat(e2e): mise run e2e task + spec hardening

### DIFF
--- a/deploy/helm/platform/values-e2e.yaml
+++ b/deploy/helm/platform/values-e2e.yaml
@@ -1,8 +1,23 @@
 # E2E test cluster overlay (ADR-055). Layered on top of values-local.yaml
 # by `mise run e2e`. Flips the e2e.enabled gate so the api-server registers
 # its control tRPC namespace and the mock harness becomes drivable from
-# Playwright. values-local.yaml already enables `keycloak.testUser` (dev/dev)
-# and the mock Agent Template, so nothing else is needed here.
+# Playwright. values-local.yaml already enables `keycloak.testUser` (dev/dev).
 
 e2e:
   enabled: true
+
+# Helm replaces lists wholesale — narrow values-local.yaml's agentTemplates
+# down to just `mock`. The e2e task builds only platform-base + mock images,
+# so registering claude-code / codex / pi-agent / bob / google-workspace would
+# leave the chart pointing at images that aren't loaded in the test cluster.
+agentTemplates:
+  - name: mock
+    enabled: true
+    description: "Scripted mock agent (E2E test fixture)"
+    image:
+      repository: platform-mock
+      tag: latest
+    storageSize: "1Gi"
+    env:
+      - name: MOCK_DEFAULT_REPLY
+        value: "Hello from the mock agent."

--- a/deploy/lima-k3s-test.yaml
+++ b/deploy/lima-k3s-test.yaml
@@ -5,7 +5,13 @@ images:
     arch: x86_64
 
 cpus: 4
-memory: 4GiB
+# Matches lima-k3s.yaml: Istio ambient (istiod + istio-cni + ztunnel +
+# waypoint) adds ~1 GiB on top of the platform stack. On 4 GiB the keycloak
+# JVM boot exceeds the 2-min keycloak-config-cli retry deadline because
+# every pod is fighting for memory. Bumping here doesn't resize an existing
+# VM — `mise run e2e` always nukes the prior VM first, so this takes effect
+# on the next run.
+memory: 8GiB
 disk: 20GiB
 
 # Skip lima's default rootless containerd + buildkit + stargz setup —

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -72,13 +72,17 @@ docker build -f packages/ui/Dockerfile -t platform-ui:latest .
 '''
 
 ["image:agent"]
-description = "Build agent Docker images (platform-base + claude-code + codex + google-workspace + pi-agent + bob + mock)"
+description = "Build agent Docker images (platform-base + claude-code + codex + google-workspace + pi-agent + bob + mock). E2E_MOCK_ONLY=1 builds platform-base + mock only."
 dir = "{{config_root}}"
 run = '''
 #!/usr/bin/env bash
 set -eo pipefail
 [ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
 docker build -f packages/platform-base/Dockerfile -t platform-base .
+if [ -n "${E2E_MOCK_ONLY:-}" ]; then
+  docker build -f packages/e2e/agents/mock/Dockerfile -t platform-mock:latest .
+  exit 0
+fi
 docker build -t platform-claude-code:latest packages/agents/claude-code
 docker build -t platform-codex:latest packages/agents/codex
 docker build -t platform-google-workspace-agent:latest packages/agents/google-workspace
@@ -369,7 +373,13 @@ if [ -n "${SKIP_IMAGE_BUILD:-}" ]; then
 else
   echo "Loading images into k3s..."
   tar="/tmp/platform-images.tar"
-  docker save -o "$tar" platform-controller:latest platform-api-server:latest platform-ui:latest platform-claude-code:latest platform-codex:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest platform-mock:latest
+  IMAGES_TO_LOAD=(platform-controller:latest platform-api-server:latest platform-ui:latest)
+  if [ -n "${E2E_MOCK_ONLY:-}" ]; then
+    IMAGES_TO_LOAD+=(platform-mock:latest)
+  else
+    IMAGES_TO_LOAD+=(platform-claude-code:latest platform-codex:latest platform-google-workspace-agent:latest platform-pi-agent:latest platform-bob:latest platform-mock:latest)
+  fi
+  docker save -o "$tar" "${IMAGES_TO_LOAD[@]}"
   if [ -n "${IS_SANDBOX:-}" ]; then
     [ -z "${CI:-}" ] && docker image prune --all --force >/dev/null 2>&1 || true
     sudo k3s ctr images import "$tar"

--- a/packages/e2e/playwright/src/tests/01-auth.spec.ts
+++ b/packages/e2e/playwright/src/tests/01-auth.spec.ts
@@ -12,14 +12,22 @@ test("login via Keycloak and accept terms", async ({ page }) => {
   await page.locator("#password").fill(testUser.password);
   await page.locator("#kc-login").click();
 
-  await page.waitForURL((url) => url.origin === baseUrl);
-  if (page.url() === `${baseUrl}/terms`) {
-    await page
-      .getByRole("button", { name: /I accept the Terms of Use/ })
-      .click();
+  await page.waitForURL(
+    (url) => url.origin === baseUrl && !url.pathname.startsWith("/auth/callback"),
+  );
+
+  const termsButton = page.getByRole("button", {
+    name: /I accept the Terms of Use/,
+  });
+  const appSidebar = page.getByTestId("app-sidebar");
+
+  await expect(termsButton.or(appSidebar)).toBeVisible();
+
+  if (await termsButton.isVisible()) {
+    await termsButton.click();
     await page.waitForURL(`${baseUrl}/`);
   }
-  await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  await expect(appSidebar).toBeVisible();
 
   await page.context().storageState({ path: storageStatePath });
 });

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,13 @@ trustPolicyExclude:
   # maintainer (paulmillr), GitHub tag matches, restored in 5.0.0 via
   # `trustedPublisher: github`. Benign publisher-side workflow change.
   - 'chokidar@4.0.3'
+  # tinyexec@1.2.2 downgraded from trusted-publisher (1.1.1) to provenance-
+  # attestation. Same upstream (tinylibs), no open advisories. Pulled in
+  # transitively by vitest. Only surfaces in `pnpm deploy --legacy` paths
+  # (platform-base Dockerfile) because legacy deploy bypasses the lockfile
+  # and re-resolves to latest. Normal pnpm install pins 1.1.1 via the
+  # lockfile and is unaffected.
+  - 'tinyexec@1.2.2'
   # @mariozechner/clipboard 0.3.6 (2026-05-16) dropped OIDC provenance that
   # 0.3.0–0.3.5 had — same upstream (mariozechner), benign publisher-side
   # workflow change. Pulled in transitively by @earendil-works/pi-coding-agent

--- a/tasks.toml
+++ b/tasks.toml
@@ -13,7 +13,114 @@ depends = ["*:fix"]
 depends = ["*:test"]
 
 ["e2e"]
-depends = ["*:e2e"]
+description = "Run Playwright e2e: spin up fresh test cluster, run specs, tear down. Options: --headed"
+dir = "{{config_root}}"
+raw = true
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+PLAYWRIGHT_TASK="e2e-playwright:run"
+for arg in "$@"; do
+  case "$arg" in
+    --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
+  esac
+done
+
+VM_NAME="platform-k3s-test"
+if [ -n "${IS_SANDBOX:-}" ]; then
+  KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+else
+  KUBECONFIG="$HOME/.lima/$VM_NAME/copied-from-guest/kubeconfig.yaml"
+fi
+
+export E2E_MOCK_ONLY=1
+
+cleanup() {
+  local exit_code=$?
+  if [ $exit_code -ne 0 ] && [ -f "$KUBECONFIG" ]; then
+    echo ""
+    echo "=== FAILURE: dumping cluster diagnostics ==="
+    echo ""
+    echo "--- Nodes ---"
+    kubectl --kubeconfig="$KUBECONFIG" get nodes -o wide 2>&1 || true
+    echo ""
+    echo "--- Pods (all namespaces) ---"
+    kubectl --kubeconfig="$KUBECONFIG" get pods -A -o wide 2>&1 || true
+    echo ""
+    echo "--- Events (recent, all namespaces) ---"
+    kubectl --kubeconfig="$KUBECONFIG" get events -A --sort-by=.lastTimestamp 2>&1 | tail -50 || true
+    echo ""
+    echo "--- Describe not-ready pods ---"
+    kubectl --kubeconfig="$KUBECONFIG" get pods -A -o json 2>/dev/null \
+      | jq -r '.items[] | select(.status.phase != "Running" or ([.status.containerStatuses[]?.ready] | all | not)) | "\(.metadata.namespace) \(.metadata.name)"' \
+      | while read -r ns name; do
+          echo "### $ns/$name ###"
+          kubectl --kubeconfig="$KUBECONFIG" describe pod -n "$ns" "$name" 2>&1 || true
+          echo ""
+        done
+    echo ""
+    echo "--- Logs from Platform pods ---"
+    for ns in default platform-agents; do
+      for pod in $(kubectl --kubeconfig="$KUBECONFIG" get pods -n "$ns" -o name 2>/dev/null); do
+        echo "### $ns/$pod (current) ###"
+        kubectl --kubeconfig="$KUBECONFIG" logs -n "$ns" "$pod" --all-containers --tail=200 2>&1 || true
+        echo "### $ns/$pod (previous) ###"
+        kubectl --kubeconfig="$KUBECONFIG" logs -n "$ns" "$pod" --all-containers --tail=200 --previous 2>&1 || true
+        echo ""
+      done
+    done
+    echo "=== End diagnostics ==="
+  fi
+
+  echo ""
+  echo "=== Tearing down test cluster ==="
+  mise run cluster:delete -- --vm-name="$VM_NAME" --force || true
+
+  exit $exit_code
+}
+trap cleanup EXIT
+
+# Skip pre-nuke in sandbox/CI — the runner starts clean. Locally, a prior
+# run may have died before teardown fired, leaving a half-provisioned VM.
+if [ -z "${IS_SANDBOX:-}" ]; then
+  echo "Nuking any pre-existing test cluster..."
+  mise run cluster:delete -- --vm-name="$VM_NAME" --force
+fi
+
+INSTALL_ARGS=(
+  --lima-template=deploy/lima-k3s-test.yaml
+  --helm-values=deploy/helm/platform/values-e2e.yaml
+  --set=domain=localhost
+  --set=port=5555
+  --set=controller.agent.templateDefaults.storageSize=1Gi
+  --no-restart
+)
+# domain=localhost (NOT localtest.me): Chromium treats *.localhost as a
+# secure context per the URL spec, so window.crypto.subtle is available
+# and oidc-client-ts can generate PKCE state in signinRedirect(). On
+# *.localtest.me the page is NOT secure-context, crypto.subtle is undefined,
+# the OIDC redirect throws silently, and the SPA hangs on a blank screen.
+if [ -z "${IS_SANDBOX:-}" ]; then
+  INSTALL_ARGS+=(--vm-name="$VM_NAME")
+fi
+mise run cluster:install -- "${INSTALL_ARGS[@]}"
+
+# Targeted apiserver rollout: on a fresh cluster the apiserver pod starts in
+# parallel with postgres and loses a race against postgres's init-databases.sh
+# (creates keycloak + platform DBs, then restarts postgres). The Drizzle
+# migration's CREATE SCHEMA dies with ECONNRESET and the pod crash-loops.
+# Bouncing just apiserver after postgres is settled lets the second pod
+# generation migrate cleanly. UI/controller don't share this race, and
+# restarting the UI introduces a transient Traefik-endpoint 502 window that
+# breaks Playwright's first asset fetch — leave them alone.
+mise run cluster:kubectl -- rollout restart deployment platform-apiserver
+mise run cluster:kubectl -- rollout status deployment platform-apiserver --timeout=5m
+
+PLATFORM_BASE_URL="http://localhost:5555" \
+PLATFORM_KEYCLOAK_URL="http://keycloak.localhost:5555" \
+  mise run "$PLAYWRIGHT_TASK"
+'''
 
 # -- Git hooks --
 


### PR DESCRIPTION
Stacks on #407. Closes item 6 of #404. Supersedes #428 (rebased onto the squash-merged base of #417).

## Summary

- New `mise run e2e` task. Owns the full test-cluster lifecycle: nuke prior VM, provision fresh with `values-e2e.yaml` overlay, run Playwright, tear down in trap regardless of outcome. Supports `--headed`. Replaces `mise run api-server:e2e`.
- Test cluster uses `domain=localhost`, port 5555. `*.localhost` is a secure-context origin in Chromium so `crypto.subtle` is available and oidc-client-ts can generate PKCE.
- `E2E_MOCK_ONLY=1` narrows `image:agent` and the docker-save tarball to platform-base + mock. `values-e2e.yaml` drops the other agentTemplates so the chart matches what's loaded.
- After helm install, targeted `rollout restart` of `platform-apiserver` only. Bouncing UI/controller introduces a transient Traefik-endpoint 502 window that breaks Playwright's first asset fetch; just api-server needs the bounce to dodge the postgres init-databases.sh race.
- Test VM bumped to 8GiB to match the dev VM's istio-ambient sizing.

Also folds in two pre-existing fixes uncovered while shaking this down:
- `01-auth` spec waited for `origin === baseUrl` which resolved at `/auth/callback?code=...` before the SPA finished its post-callback redirect. Now waits past `/auth/callback` and settles on terms button or app sidebar.
- `tinyexec@1.2.2` added to `trustPolicyExclude` so `pnpm deploy --legacy` in the platform-base Dockerfile doesn't trip on a publisher-side trust regression.

## Test plan

- [x] `mise run e2e` passes locally (2 specs in 31s, fresh VM, clean teardown)
- [x] `mise run e2e -- --headed` runs with visible browser
- [ ] CI run pending