### PR TITLE
ci(e2e): run browser e2e on every PR, upload report on failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
           SKIP_IMAGE_BUILD: "1"
 
       - name: Upload Playwright report
-        if: failure()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,33 +8,12 @@ on:
 
 permissions:
   contents: read
-  pull-requests: read
 
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  paths:
-    runs-on: ubuntu-latest
-    outputs:
-      e2e: ${{ github.event_name == 'workflow_dispatch' || steps.filter.outputs.e2e == 'true' }}
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
-        id: filter
-        with:
-          filters: |
-            e2e:
-              - 'packages/api-server/**'
-              - 'packages/api-server-api/**'
-              - 'packages/db/**'
-              - 'packages/controller/**'
-              - 'packages/agent-runtime/**'
-              - 'packages/agent-runtime-api/**'
-              - 'packages/platform-base/**'
-              - 'deploy/helm/**'
-
   check:
     name: mise check
     runs-on: ubuntu-latest
@@ -57,8 +36,6 @@ jobs:
 
   e2e:
     name: mise e2e
-    needs: [paths]
-    if: needs.paths.outputs.e2e == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
@@ -131,3 +108,14 @@ jobs:
       - run: mise run e2e
         env:
           SKIP_IMAGE_BUILD: "1"
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: playwright-report
+          path: |
+            packages/e2e/playwright/playwright-report/
+            packages/e2e/playwright/test-results/
+          retention-days: 7
+          if-no-files-found: ignore

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -364,11 +364,13 @@ YAML
 # chart's validate-istio.yaml asserts this label is present).
 kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mode=ambient --overwrite
 
-# 3. Load images into k3s (built by depends: image:*)
-# SKIP_IMAGE_BUILD also skips the load: image:* tasks already no-op'd, so
-# there's nothing new in docker to ship. Pods keep running their pinned SHAs.
-if [ -n "${SKIP_IMAGE_BUILD:-}" ]; then
-  echo "Skipping image load (SKIP_IMAGE_BUILD set)"
+# 3. Load images into k3s (built by depends: image:*, or out-of-band in CI).
+# SKIP_IMAGE_LOAD skips the containerd import — cluster:helm reuses the SHAs
+# already loaded, so pods keep their pinned images. SKIP_IMAGE_BUILD alone (CI)
+# does NOT skip the load: buildx built the images out-of-band into the docker
+# daemon, and they still have to be imported into k3s's separate containerd.
+if [ -n "${SKIP_IMAGE_LOAD:-}" ]; then
+  echo "Skipping image load (SKIP_IMAGE_LOAD set)"
   NO_RESTART=true
 else
   echo "Loading images into k3s..."
@@ -469,7 +471,7 @@ dir = "{{config_root}}"
 raw = true
 run = '''
 #!/usr/bin/env bash
-exec env SKIP_IMAGE_BUILD=1 mise run cluster:install "$@"
+exec env SKIP_IMAGE_BUILD=1 SKIP_IMAGE_LOAD=1 mise run cluster:install "$@"
 '''
 
 ["cluster:build-apiserver"]

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -12,9 +12,9 @@ export default defineConfig({
   reporter: [["list"], ["html", { open: "never" }]],
   use: {
     baseURL,
-    trace: "retain-on-failure",
+    trace: "on",
     screenshot: "only-on-failure",
-    video: "retain-on-failure",
+    video: "on",
   },
   projects: [
     {

--- a/packages/e2e/playwright/src/tests/01-auth.spec.ts
+++ b/packages/e2e/playwright/src/tests/01-auth.spec.ts
@@ -13,7 +13,8 @@ test("login via Keycloak and accept terms", async ({ page }) => {
   await page.locator("#kc-login").click();
 
   await page.waitForURL(
-    (url) => url.origin === baseUrl && !url.pathname.startsWith("/auth/callback"),
+    (url) =>
+      url.origin === baseUrl && !url.pathname.startsWith("/auth/callback"),
   );
 
   const termsButton = page.getByRole("button", {

--- a/packages/e2e/playwright/tasks.toml
+++ b/packages/e2e/playwright/tasks.toml
@@ -1,18 +1,32 @@
-["e2e-playwright:run"]
+["e2e-playwright:install-browsers"]
+description = "Download the Chromium binary Playwright drives (+ OS libs on Linux)"
 dir = "{{config_root}}/packages/e2e/playwright"
 depends = ["common:setup:pnpm"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ "$(uname)" = "Linux" ]; then
+  pnpm exec playwright install --with-deps chromium
+else
+  pnpm exec playwright install chromium
+fi
+'''
+
+["e2e-playwright:run"]
+dir = "{{config_root}}/packages/e2e/playwright"
+depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
 run = "pnpm exec playwright test"
 
 ["e2e-playwright:run-headed"]
 description = "Run Playwright with a visible browser window"
 dir = "{{config_root}}/packages/e2e/playwright"
-depends = ["common:setup:pnpm"]
+depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
 run = "pnpm exec playwright test --headed"
 
 ["e2e-playwright:run-ui"]
 description = "Open Playwright UI mode (time-travel debugger, watch mode)"
 dir = "{{config_root}}/packages/e2e/playwright"
-depends = ["common:setup:pnpm"]
+depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
 run = "pnpm exec playwright test --ui"
 
 ["e2e-playwright:check"]


### PR DESCRIPTION
Item 7 of #404.

The `e2e` CI job already installed mise and ran `mise run e2e` (legacy from ADR-014). This finishes the wiring for the browser-driven tracer:

- **Every PR runs e2e.** Dropped the `paths`/`dorny/paths-filter` gate and the e2e job's `needs`/`if`. ADR-055 says the workflow runs on every PR push; path-filtered gating is a documented follow-up. Also removed the now-unused `pull-requests: read` permission.
- **Artifacts on failure.** `actions/upload-artifact` (SHA-pinned v7.0.1) uploads `playwright-report/` + `test-results/` on `failure()`, `if-no-files-found: ignore`. Playwright already captures traces/screenshots/video retain-on-failure, so the HTML report is browsable from the artifact.

Advisory at start needs no YAML: it just means not adding `mise e2e` to required status checks until 10 clean merges.