### PR TITLE
feat(cli): add connection management commands

### DIFF
--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-Last verified: 2026-06-02
+Last verified: 2026-06-03
 
 ## Motivated by
 
@@ -10,10 +10,11 @@ Last verified: 2026-06-02
 - [#254 — Granular file ops over the agent-runtime proxy](https://github.com/dam-agents/dam/issues/254) — the `dam file` group (`get`, `put`, `list`) for single-file workspace operations.
 - [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — the CLI addresses Agents (not Instances); a single `dam agent` group covers the lifecycle.
 - [ADR-035 — Unified HITL UX](../adrs/035-unified-hitl-ux.md) — the per-Agent network access pre-approvals that the `dam network` group lists and mutates ([#345](https://github.com/dam-agents/dam/issues/345), a P0 sub-issue of [#329](https://github.com/dam-agents/dam/issues/329)).
+- [#344 — Manage OAuth connections from the CLI](https://github.com/dam-agents/dam/issues/344) — the `dam connection` group that lists, grants, revokes, and disconnects Connections (OAuth apps and MCP servers) for an Agent (a P0 sub-issue of [#329](https://github.com/dam-agents/dam/issues/329)); the connection/contribution model is [ADR-051](../adrs/051-connections-and-contributions.md), credential injection is [ADR-033](../adrs/033-envoy-credential-gateway.md).
 
 ## Overview
 
-The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam agent` group (`list` [default], `get`, `create`, `create-interactive`, `delete`, `restart`); `dam chat`; `dam session list`; `dam template list`; `dam import`; the `dam file` group (`get`, `put`, `list`); and the `dam network` group (`list`, `create`, `update`, `revoke`, `preset`, `apply-preset`, `trusted-hosts`). Command groups are singular to align with `gh`, `git`, and `docker` conventions.
+The `dam` CLI is a TypeScript Node package that users install on their own machine and point at a configured Platform deployment. It never runs inside the cluster. The current surface: `dam --version`, `dam --help` (built-in flags); `dam config set`; `dam ping`; `dam version`; the `dam auth` group (`login`, `logout`, `status`); the `dam agent` group (`list` [default], `get`, `create`, `create-interactive`, `delete`, `restart`); `dam chat`; `dam session list`; `dam template list`; `dam import`; the `dam file` group (`get`, `put`, `list`); the `dam network` group (`list`, `create`, `update`, `revoke`, `preset`, `apply-preset`, `trusted-hosts`); and the `dam connection` group (`list`, `disconnect`, `grant`, `revoke`). Command groups are singular to align with `gh`, `git`, and `docker` conventions.
 
 The CLI shares types directly with the api-server via a shared contract package, so server-side type changes reach the CLI without codegen or manual mirroring. Most routes are reached through plain HTTP calls against the api-server's tRPC endpoints; the `dam chat` verb additionally opens a WebSocket to the terminal relay for the interactive PTY session. The auth probes (`/api/auth/config`, OIDC discovery) stay as raw `fetch` because they are not tRPC.
 
@@ -167,3 +168,19 @@ Two pieces of non-obvious behavior the CLI surfaces:
 `update` against an unknown rule ID exits `EXIT_RULE_NOT_FOUND` (6) — the contract change in `egress-rules-service.ts` converts the plain `Error("egress rule not found")` to `TRPCError({ code: "NOT_FOUND" })` so the CLI can classify the error via `data.code`.
 
 The `source` field is rendered via the shared `formatEgressRuleSource` helper in [packages/api-server-api/src/modules/egress-rules/format.ts](../../packages/api-server-api/src/modules/egress-rules/format.ts) so the CLI and UI use identical labels.
+
+## Connections
+
+`dam connection` brings the CLI to parity with the UI for managing **Connections** — the stored credentials and contributions an Agent uses to reach authenticated external APIs and MCP servers (the concept is owned by [connections.md](connections.md) / [ADR-051](../adrs/051-connections-and-contributions.md); credential injection is [ADR-033](../adrs/033-envoy-credential-gateway.md)). The CLI is a thin client over the `connections.*` tRPC procedures. Four commands:
+
+- `dam connection list [<agent>]` — without an Agent, a five-column table (`ID NAME CATEGORY STATUS HOSTS`) of every team connection — apps and MCP servers alike — sorted by `(category, name, id)`; with an Agent, only that Agent's granted connections. `--json` emits the raw `ConnectionView[]`.
+- `dam connection grant <agent> --connection <id>…` — grant one or more connections to an Agent. Additive.
+- `dam connection revoke <agent> --connection <id>…` — revoke one or more connections from an Agent. Idempotent.
+- `dam connection disconnect <id>` — delete a team connection and its stored credential.
+
+Everything is tRPC (`connections.list`, `getAgentConnections`, `setAgentConnections`, `delete`) — there is no REST surface and no service state beyond the per-host client. Two pieces of non-obvious behavior:
+
+- **Grant/revoke are read-merge-set.** `connections.setAgentConnections` is a full replace, so the CLI reads the Agent's current grants (`getAgentConnections`), unions in (grant) or subtracts out (revoke) the requested ids, and writes the whole set back — letting the server re-fan-out each connection's contributions (env vars + egress injection) for the correct final set. `grant` rejects ids absent from the team list up front (`EXIT_INVALID_INPUT`) so a dead grant is never stored; `revoke` skips that check because removing an ungranted id is a harmless no-op. `disconnect` is idempotent server-side — deleting an unknown id still succeeds.
+- **Stale grants are surfaced, not hidden.** `list <agent>` intersects the Agent's granted ids with the team list; any granted id that no longer resolves to a live connection is reported on stderr rather than rendered as a fabricated row.
+
+Creating connections (`connect` / the OAuth authorization flow) is out of scope for the CLI today — it needs a browser round-trip and per-template input forms with no completion signal the CLI can poll; deferred to a follow-up. Listing, granting, revoking, and disconnecting connections created in the web UI is fully supported.

--- a/packages/cli/src/compose.ts
+++ b/packages/cli/src/compose.ts
@@ -3,6 +3,7 @@ import { composeAgentModule } from "./modules/agent/compose.js";
 import { composeAuthModule } from "./modules/auth/compose.js";
 import { composeChatModule } from "./modules/chat/compose.js";
 import { composeCliModule } from "./modules/cli/compose.js";
+import { composeConnectionModule } from "./modules/connection/compose.js";
 import { composeEgressModule } from "./modules/egress/compose.js";
 import { composeFileModule } from "./modules/file/compose.js";
 import { composeImportModule } from "./modules/import/compose.js";
@@ -82,6 +83,13 @@ export function compose(opts: ComposeOptions = {}): Command {
     createAgentService: agent.exports.createService,
   });
 
+  const connection = composeConnectionModule({
+    tokenProvider: auth.exports.tokenProvider,
+    configService: cli.services.configService,
+    compatService: cli.services.compatService,
+    createAgentService: agent.exports.createService,
+  });
+
   const program = new Command();
   program
     .name("dam")
@@ -96,6 +104,7 @@ export function compose(opts: ComposeOptions = {}): Command {
   for (const command of importModule.commands) program.addCommand(command);
   for (const command of fileModule.commands) program.addCommand(command);
   for (const command of egress.commands) program.addCommand(command);
+  for (const command of connection.commands) program.addCommand(command);
 
   return program;
 }

--- a/packages/cli/src/modules/connection/commands/disconnect.ts
+++ b/packages/cli/src/modules/connection/commands/disconnect.ts
@@ -1,0 +1,51 @@
+import { Command } from "commander";
+import { printServiceError } from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import type { ConnectionService } from "../services/connection-service.js";
+
+export function buildDisconnectCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createConnectionService: (host: string) => ConnectionService;
+}): Command {
+  return new Command("disconnect")
+    .description("Remove a team connection (deletes the stored credential)")
+    .argument("<id>", "Connection id (copy from `dam connection list`)")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit { ok, id } as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n  dam connection disconnect conn-61cc7b9137b0\n",
+    )
+    .action(async (id: string, opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+
+      const result = await deps.createConnectionService(host).disconnect(id);
+      if (!result.ok) {
+        printServiceError(result.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      if (opts.json) {
+        process.stdout.write(`${JSON.stringify({ ok: true, id })}\n`);
+      } else {
+        process.stdout.write(`✓ Disconnected ${id}.\n`);
+      }
+      process.exit(EXIT_SUCCESS);
+    });
+}

--- a/packages/cli/src/modules/connection/commands/grant.ts
+++ b/packages/cli/src/modules/connection/commands/grant.ts
@@ -1,0 +1,114 @@
+import { Command } from "commander";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_INVALID_INPUT,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import type { ConnectionService } from "../services/connection-service.js";
+
+const collect = (v: string, acc: string[]): string[] => [...acc, v];
+
+export function buildGrantCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createConnectionService: (host: string) => ConnectionService;
+}): Command {
+  return new Command("grant")
+    .description("Grant one or more connections to an Agent")
+    .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
+    .option(
+      "--connection <id>",
+      "connection id to grant (repeatable)",
+      collect,
+      [] as string[],
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit { ok, agentId, connectionIds } as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  dam connection grant my-agent --connection github\n" +
+        "  dam connection grant my-agent --connection github --connection spotify\n",
+    )
+    .action(
+      async (
+        ref: string,
+        opts: { connection: string[]; server?: string; json?: boolean },
+      ) => {
+        const requested = opts.connection;
+        if (requested.length === 0) {
+          process.stderr.write("error: pass at least one --connection <id>\n");
+          process.exit(EXIT_INVALID_INPUT);
+        }
+
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+
+        const resolver = createAgentResolver({
+          agentService: deps.createAgentService(host),
+        });
+        const resolved = await resolver.resolve(ref);
+        if (!resolved.ok) {
+          printResolveError(resolved.error, host);
+          process.exit(exitCodeForResolveError(resolved.error));
+        }
+
+        const svc = deps.createConnectionService(host);
+
+        // Reject unknown ids up front — a dead grant the server can't turn
+        // into an egress rule would otherwise be stored silently.
+        const allRes = await svc.list();
+        if (!allRes.ok) {
+          printServiceError(allRes.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+        const known = new Set(allRes.value.map((c) => c.id));
+        const unknown = requested.filter((id) => !known.has(id));
+        if (unknown.length > 0) {
+          process.stderr.write(
+            `error: unknown connection id(s): ${unknown.join(", ")}\n`,
+          );
+          process.stderr.write(
+            "hint: run `dam connection list` to see valid ids\n",
+          );
+          process.exit(EXIT_INVALID_INPUT);
+        }
+
+        const res = await svc.grant(resolved.value.id, requested);
+        if (!res.ok) {
+          printServiceError(res.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (opts.json) {
+          process.stdout.write(
+            `${JSON.stringify({ ok: true, agentId: resolved.value.id, connectionIds: res.value })}\n`,
+          );
+        } else {
+          process.stdout.write(
+            `✓ Granted to ${resolved.value.name}. Agent now has ${res.value.length} connection(s).\n`,
+          );
+        }
+        process.exit(EXIT_SUCCESS);
+      },
+    );
+}

--- a/packages/cli/src/modules/connection/commands/list.ts
+++ b/packages/cli/src/modules/connection/commands/list.ts
@@ -1,0 +1,159 @@
+import { Command } from "commander";
+import type { ConnectionView } from "api-server-api";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { renderTable } from "../../shared/render-table.js";
+import type { ConnectionService } from "../services/connection-service.js";
+
+const HEADER = ["ID", "NAME", "CATEGORY", "STATUS", "HOSTS"];
+
+function sortViews(
+  views: readonly ConnectionView[],
+): readonly ConnectionView[] {
+  return [...views].sort((a, b) => {
+    const c = a.category.localeCompare(b.category);
+    if (c !== 0) return c;
+    const n = a.name.localeCompare(b.name);
+    if (n !== 0) return n;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+function tableFor(views: readonly ConnectionView[]): string {
+  return renderTable([
+    HEADER,
+    ...sortViews(views).map((c) => [
+      c.id,
+      c.name,
+      c.category,
+      c.status,
+      c.hosts.join(","),
+    ]),
+  ]);
+}
+
+export function buildListCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createConnectionService: (host: string) => ConnectionService;
+}): Command {
+  return new Command("list")
+    .description(
+      "List team connections, or the connections granted to one Agent",
+    )
+    .argument("[agent]", "Agent Ref — name or 'agent-…' ID (optional)")
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit raw JSON instead of the default table")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  dam connection list\n" +
+        "  dam connection list my-agent\n" +
+        "  dam connection list --json\n",
+    )
+    .action(
+      async (
+        ref: string | undefined,
+        opts: { server?: string; json?: boolean },
+      ) => {
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+        const svc = deps.createConnectionService(host);
+
+        if (ref === undefined) {
+          const result = await svc.list();
+          if (!result.ok) {
+            printServiceError(result.error, host);
+            process.exit(EXIT_RUNTIME_FAILURE);
+          }
+          if (opts.json) {
+            process.stdout.write(`${JSON.stringify(result.value)}\n`);
+            process.exit(EXIT_SUCCESS);
+          }
+          if (result.value.length === 0) {
+            process.stderr.write(
+              "No connections. Create one in the web UI (CLI connect is not yet supported).\n",
+            );
+            process.exit(EXIT_SUCCESS);
+          }
+          process.stdout.write(tableFor(result.value));
+          process.exit(EXIT_SUCCESS);
+        }
+
+        // Agent-scoped: resolve the ref, read its grants, intersect with the
+        // team list. Granted ids absent from the team list (stale grants) are
+        // surfaced on stderr rather than rendered as fabricated rows.
+        const resolver = createAgentResolver({
+          agentService: deps.createAgentService(host),
+        });
+        const resolved = await resolver.resolve(ref);
+        if (!resolved.ok) {
+          printResolveError(resolved.error, host);
+          process.exit(exitCodeForResolveError(resolved.error));
+        }
+
+        // Independent reads — fetch the agent's grants and the team list
+        // concurrently; the intersection below needs both.
+        const [idsRes, allRes] = await Promise.all([
+          svc.agentConnectionIds(resolved.value.id),
+          svc.list(),
+        ]);
+        if (!idsRes.ok) {
+          printServiceError(idsRes.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+        if (!allRes.ok) {
+          printServiceError(allRes.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        const byId = new Map(allRes.value.map((c) => [c.id, c]));
+        const matched: ConnectionView[] = [];
+        const missing: string[] = [];
+        for (const id of idsRes.value) {
+          const view = byId.get(id);
+          if (view) matched.push(view);
+          else missing.push(id);
+        }
+
+        if (opts.json) {
+          process.stdout.write(`${JSON.stringify(matched)}\n`);
+          process.exit(EXIT_SUCCESS);
+        }
+        if (matched.length === 0 && missing.length === 0) {
+          process.stderr.write(
+            `Agent ${ref} has no connections. Grant one with \`dam connection grant ${ref} --connection <id>\`.\n`,
+          );
+          process.exit(EXIT_SUCCESS);
+        }
+        if (matched.length > 0) process.stdout.write(tableFor(matched));
+        if (missing.length > 0) {
+          process.stderr.write(
+            `note: ${missing.length} granted connection(s) no longer exist: ${missing.join(", ")}\n`,
+          );
+        }
+        process.exit(EXIT_SUCCESS);
+      },
+    );
+}

--- a/packages/cli/src/modules/connection/commands/revoke.ts
+++ b/packages/cli/src/modules/connection/commands/revoke.ts
@@ -1,0 +1,97 @@
+import { Command } from "commander";
+import type { AgentService } from "../../agent/index.js";
+import { createAgentResolver } from "../../agent/index.js";
+import {
+  exitCodeForResolveError,
+  printResolveError,
+  printServiceError,
+} from "../../agent/commands/errors.js";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_INVALID_INPUT,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import type { ConnectionService } from "../services/connection-service.js";
+
+const collect = (v: string, acc: string[]): string[] => [...acc, v];
+
+export function buildRevokeCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createAgentService: (host: string) => AgentService;
+  createConnectionService: (host: string) => ConnectionService;
+}): Command {
+  return new Command("revoke")
+    .description(
+      "Revoke one or more connections from an Agent. Idempotent — revoking an ungranted id exits 0.",
+    )
+    .argument("<agent>", "Agent Ref — name or 'agent-…' ID")
+    .option(
+      "--connection <id>",
+      "connection id to revoke (repeatable)",
+      collect,
+      [] as string[],
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit { ok, agentId, connectionIds } as JSON")
+    .addHelpText(
+      "after",
+      "\nExamples:\n" +
+        "  dam connection revoke my-agent --connection github\n" +
+        "  dam connection revoke my-agent --connection github --connection spotify\n",
+    )
+    .action(
+      async (
+        ref: string,
+        opts: { connection: string[]; server?: string; json?: boolean },
+      ) => {
+        const requested = opts.connection;
+        if (requested.length === 0) {
+          process.stderr.write("error: pass at least one --connection <id>\n");
+          process.exit(EXIT_INVALID_INPUT);
+        }
+
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+
+        const resolver = createAgentResolver({
+          agentService: deps.createAgentService(host),
+        });
+        const resolved = await resolver.resolve(ref);
+        if (!resolved.ok) {
+          printResolveError(resolved.error, host);
+          process.exit(exitCodeForResolveError(resolved.error));
+        }
+
+        const res = await deps
+          .createConnectionService(host)
+          .revoke(resolved.value.id, requested);
+        if (!res.ok) {
+          printServiceError(res.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (opts.json) {
+          process.stdout.write(
+            `${JSON.stringify({ ok: true, agentId: resolved.value.id, connectionIds: res.value })}\n`,
+          );
+        } else {
+          process.stdout.write(
+            `✓ Revoked connection(s) from ${resolved.value.name}. Agent now has ${res.value.length}.\n`,
+          );
+        }
+        process.exit(EXIT_SUCCESS);
+      },
+    );
+}

--- a/packages/cli/src/modules/connection/compose.ts
+++ b/packages/cli/src/modules/connection/compose.ts
@@ -1,0 +1,62 @@
+import { Command } from "commander";
+import type { AgentService } from "../agent/index.js";
+import type { TokenProvider } from "../auth/index.js";
+import type { CompatService, ConfigService } from "../cli/index.js";
+import {
+  createTrpcClient,
+  type TrpcClient,
+} from "../shared/trpc/trpc-client.js";
+import { buildDisconnectCommand } from "./commands/disconnect.js";
+import { buildGrantCommand } from "./commands/grant.js";
+import { buildListCommand } from "./commands/list.js";
+import { buildRevokeCommand } from "./commands/revoke.js";
+import {
+  createConnectionService,
+  type ConnectionService,
+} from "./services/connection-service.js";
+
+export interface ConnectionModuleOptions {
+  tokenProvider: TokenProvider;
+  configService: ConfigService;
+  compatService: CompatService;
+  /** Per-host factory the resolver inside agent-scoped commands consumes. */
+  createAgentService: (host: string) => AgentService;
+}
+
+export interface ConnectionModule {
+  commands: ReadonlyArray<Command>;
+  exports: { createService: (host: string) => ConnectionService };
+}
+
+export function composeConnectionModule(
+  opts: ConnectionModuleOptions,
+): ConnectionModule {
+  const buildTrpc = (host: string): TrpcClient =>
+    createTrpcClient({ host, tokenProvider: opts.tokenProvider });
+
+  const createService = (host: string): ConnectionService =>
+    createConnectionService({ trpc: buildTrpc(host) });
+
+  const agentScoped = {
+    compatService: opts.compatService,
+    configService: opts.configService,
+    createAgentService: opts.createAgentService,
+    createConnectionService: createService,
+  };
+
+  const parent = new Command("connection").description(
+    "Manage OAuth connections and agent connection grants",
+  );
+  parent.addCommand(buildListCommand(agentScoped));
+  parent.addCommand(
+    buildDisconnectCommand({
+      compatService: opts.compatService,
+      configService: opts.configService,
+      createConnectionService: createService,
+    }),
+  );
+  parent.addCommand(buildGrantCommand(agentScoped));
+  parent.addCommand(buildRevokeCommand(agentScoped));
+
+  return { commands: [parent], exports: { createService } };
+}

--- a/packages/cli/src/modules/connection/domain/errors.ts
+++ b/packages/cli/src/modules/connection/domain/errors.ts
@@ -1,0 +1,1 @@
+export type { TransportError, AuthRequiredError } from "../../shared/errors.js";

--- a/packages/cli/src/modules/connection/index.ts
+++ b/packages/cli/src/modules/connection/index.ts
@@ -1,0 +1,3 @@
+export type { ConnectionService } from "./services/connection-service.js";
+export { createConnectionService } from "./services/connection-service.js";
+export type { TransportError, AuthRequiredError } from "./domain/errors.js";

--- a/packages/cli/src/modules/connection/services/connection-service.ts
+++ b/packages/cli/src/modules/connection/services/connection-service.ts
@@ -1,0 +1,86 @@
+import type { ConnectionView } from "api-server-api";
+import type { Result } from "../../../result.js";
+import { trpcCall } from "../../shared/trpc/classify.js";
+import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
+import type { AuthRequiredError, TransportError } from "../domain/errors.js";
+
+export interface ConnectionService {
+  /** All of the owner's connections (apps + MCP), as stored on the server. */
+  list(): Promise<
+    Result<readonly ConnectionView[], TransportError | AuthRequiredError>
+  >;
+  /** Connection ids currently granted to an agent. */
+  agentConnectionIds(
+    agentId: string,
+  ): Promise<Result<readonly string[], TransportError | AuthRequiredError>>;
+  /** Read current grants, union in `add`, write the full set back. Returns the resulting set. */
+  grant(
+    agentId: string,
+    add: readonly string[],
+  ): Promise<Result<readonly string[], TransportError | AuthRequiredError>>;
+  /** Read current grants, remove `remove`, write the full set back. Returns the resulting set. Idempotent. */
+  revoke(
+    agentId: string,
+    remove: readonly string[],
+  ): Promise<Result<readonly string[], TransportError | AuthRequiredError>>;
+  /** Delete a connection (the stored credential) by id. */
+  disconnect(
+    id: string,
+  ): Promise<Result<void, TransportError | AuthRequiredError>>;
+}
+
+export function createConnectionService(deps: {
+  trpc: TrpcClient;
+}): ConnectionService {
+  const readIds = async (agentId: string): Promise<readonly string[]> => {
+    const res = await deps.trpc.connections.getAgentConnections.query({
+      agentId,
+    });
+    return res.connections.map((c) => c.connectionId);
+  };
+
+  return {
+    async list() {
+      return trpcCall(
+        () =>
+          deps.trpc.connections.list.query() as Promise<
+            readonly ConnectionView[]
+          >,
+      );
+    },
+    async agentConnectionIds(agentId) {
+      return trpcCall(() => readIds(agentId));
+    },
+    async grant(agentId, add) {
+      // `setAgentConnections` is a full replace — read current grants, union
+      // in the additions, and write the whole set back so the server's
+      // contribution/egress resync sees the correct final state.
+      return trpcCall(async () => {
+        const current = await readIds(agentId);
+        const next = Array.from(new Set([...current, ...add]));
+        await deps.trpc.connections.setAgentConnections.mutate({
+          agentId,
+          connectionIds: next,
+        });
+        return next as readonly string[];
+      });
+    },
+    async revoke(agentId, remove) {
+      return trpcCall(async () => {
+        const drop = new Set(remove);
+        const current = await readIds(agentId);
+        const next = current.filter((id) => !drop.has(id));
+        await deps.trpc.connections.setAgentConnections.mutate({
+          agentId,
+          connectionIds: next,
+        });
+        return next as readonly string[];
+      });
+    },
+    async disconnect(id) {
+      return trpcCall(async () => {
+        await deps.trpc.connections.delete.mutate({ id });
+      });
+    },
+  };
+}


### PR DESCRIPTION
Brings the `dam` CLI to parity with the web UI for managing connections.

A new `dam connection` group lets you:

- **list** — all team connections (OAuth apps and MCP servers), or the ones granted to a specific agent
- **grant** / **revoke** — manage which connections an agent can use
- **disconnect** — remove a connection

Part of #329. Closes #344.

---
> Stacked on `feat/cli-egress` — retarget the base to `main` once that PR merges.