### PR TITLE
test(e2e): agent lifecycle spec + mock create-file-on-prompt

### DIFF
--- a/packages/api-server-api/src/modules/e2e/schemas.ts
+++ b/packages/api-server-api/src/modules/e2e/schemas.ts
@@ -7,9 +7,17 @@ export const scriptEntrySchema = z
   })
   .strict();
 
+export const scriptFileSchema = z
+  .object({
+    path: z.string().min(1),
+    content: z.string(),
+  })
+  .strict();
+
 export const setScriptInputSchema = z
   .object({
     entries: z.array(scriptEntrySchema),
+    files: z.array(scriptFileSchema).optional(),
     stopReason: z.string().default("end_turn"),
   })
   .strict();

--- a/packages/e2e/agents/mock-api/src/index.ts
+++ b/packages/e2e/agents/mock-api/src/index.ts
@@ -6,6 +6,7 @@ export {
   receivedPromptSchema,
   resetResultSchema,
   scriptEntrySchema,
+  scriptFileSchema,
   setScriptInputSchema,
 } from "./modules/scripted-mock/schemas.js";
 export type {
@@ -14,5 +15,6 @@ export type {
   ResetResult,
   ScriptEntry,
   ScriptedMockService,
+  ScriptFile,
   SetScriptInput,
 } from "./modules/scripted-mock/types.js";

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/schemas.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/schemas.ts
@@ -7,9 +7,17 @@ export const scriptEntrySchema = z
   })
   .strict();
 
+export const scriptFileSchema = z
+  .object({
+    path: z.string().min(1),
+    content: z.string(),
+  })
+  .strict();
+
 export const setScriptInputSchema = z
   .object({
     entries: z.array(scriptEntrySchema),
+    files: z.array(scriptFileSchema).optional(),
     stopReason: z.string().default("end_turn"),
   })
   .strict();

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/types.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/types.ts
@@ -4,10 +4,12 @@ import type {
   receivedPromptSchema,
   resetResultSchema,
   scriptEntrySchema,
+  scriptFileSchema,
   setScriptInputSchema,
 } from "./schemas.js";
 
 export type ScriptEntry = z.infer<typeof scriptEntrySchema>;
+export type ScriptFile = z.infer<typeof scriptFileSchema>;
 export type SetScriptInput = z.infer<typeof setScriptInputSchema>;
 export type ReceivedPrompt = z.infer<typeof receivedPromptSchema>;
 export type GetReceivedPromptsResult = z.infer<

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
@@ -5,6 +5,7 @@ import { startAcpService } from "./services/acp-service.js";
 import { createTrpcDispatch } from "./services/trpc-dispatch.js";
 import type { AcpChannel } from "./services/ports.js";
 import { createStdioChannel } from "./infrastructure/stdio-channel.js";
+import { createWorkspaceWriter } from "./infrastructure/workspace-writer.js";
 
 export interface ScriptedMockComposition {
   scriptedMock: ScriptedMockService;
@@ -33,7 +34,11 @@ export function composeScriptedMock(): ScriptedMockComposition {
     },
   };
 
-  startAcpService({ channel: acpChannel, state });
+  startAcpService({
+    channel: acpChannel,
+    state,
+    workspace: createWorkspaceWriter(process.cwd()),
+  });
 
   return { scriptedMock };
 }

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/domain/state.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/domain/state.ts
@@ -1,8 +1,9 @@
-import type { ReceivedPrompt, ScriptEntry } from "mock-agent-api";
+import type { ReceivedPrompt, ScriptEntry, ScriptFile } from "mock-agent-api";
 
 export interface MockState {
   scriptEntries: ScriptEntry[];
   scriptStopReason: string;
+  scriptFiles: ScriptFile[];
   receivedPrompts: ReceivedPrompt[];
 }
 
@@ -10,6 +11,7 @@ export function createInitialState(): MockState {
   return {
     scriptEntries: [],
     scriptStopReason: "end_turn",
+    scriptFiles: [],
     receivedPrompts: [],
   };
 }

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/infrastructure/workspace-writer.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/infrastructure/workspace-writer.ts
@@ -1,0 +1,17 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, resolve, sep } from "node:path";
+import type { WorkspaceWriter } from "../services/ports.js";
+
+export function createWorkspaceWriter(baseDir: string): WorkspaceWriter {
+  const root = resolve(baseDir);
+  return {
+    async writeFile(relPath, content) {
+      const abs = resolve(root, relPath);
+      if (abs !== root && !abs.startsWith(root + sep)) {
+        throw new Error(`refusing to write outside workspace: ${relPath}`);
+      }
+      await mkdir(dirname(abs), { recursive: true });
+      await writeFile(abs, content, "utf8");
+    },
+  };
+}

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/acp-service.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/acp-service.ts
@@ -2,11 +2,12 @@ import { randomUUID } from "node:crypto";
 import { isRequest, parseFrame, type JsonRpcId } from "../domain/frames.js";
 import type { MockState } from "../domain/state.js";
 import { recordPrompt } from "./control-service.js";
-import type { AcpChannel } from "./ports.js";
+import type { AcpChannel, WorkspaceWriter } from "./ports.js";
 
 export interface AcpServiceDeps {
   channel: AcpChannel;
   state: MockState;
+  workspace: WorkspaceWriter;
   now?: () => Date;
   sleep?: (ms: number) => Promise<void>;
   newSessionId?: () => string;
@@ -83,6 +84,10 @@ export function startAcpService(deps: AcpServiceDeps): void {
       receivedAt: now().toISOString(),
       prompt: promptPayload,
     });
+
+    for (const file of deps.state.scriptFiles) {
+      await deps.workspace.writeFile(file.path, file.content);
+    }
 
     for (const entry of deps.state.scriptEntries) {
       if (entry.delayMs && entry.delayMs > 0) await sleep(entry.delayMs);

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/control-service.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/control-service.ts
@@ -13,6 +13,7 @@ export function createScriptedMockService(
     setScript(input: SetScriptInput) {
       state.scriptEntries = input.entries;
       state.scriptStopReason = input.stopReason;
+      state.scriptFiles = input.files ?? [];
       return { ok: true as const };
     },
     getReceivedPrompts(): GetReceivedPromptsResult {
@@ -21,6 +22,7 @@ export function createScriptedMockService(
     reset() {
       state.scriptEntries = [];
       state.scriptStopReason = "end_turn";
+      state.scriptFiles = [];
       state.receivedPrompts = [];
       return { ok: true as const };
     },

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/ports.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/ports.ts
@@ -4,3 +4,7 @@ export interface AcpChannel {
   send(frame: JsonRpcFrame): void;
   onLine(handler: (line: string) => void): void;
 }
+
+export interface WorkspaceWriter {
+  writeFile(relPath: string, content: string): Promise<void>;
+}

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -28,5 +28,11 @@ export default defineConfig({
       dependencies: ["auth"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
+    {
+      name: "lifecycle",
+      testMatch: /03-.*\.spec\.ts$/,
+      dependencies: ["agent"],
+      use: { ...devices["Desktop Chrome"], storageState },
+    },
   ],
 });

--- a/packages/e2e/playwright/src/lib/agents.ts
+++ b/packages/e2e/playwright/src/lib/agents.ts
@@ -1,4 +1,4 @@
-import { expect, type Page } from "@playwright/test";
+import { expect, type Locator, type Page } from "@playwright/test";
 
 import type { ApiClient } from "./api-client.js";
 
@@ -83,4 +83,41 @@ export async function setMockAgentReply(
       stopReason: "end_turn",
     },
   });
+}
+
+export async function setMockReplyWithFiles(
+  api: ApiClient,
+  agentId: string,
+  reply: string,
+  files: { path: string; content: string }[],
+): Promise<void> {
+  await api.e2e.setScript.mutate({
+    agentId,
+    script: {
+      entries: [
+        {
+          sessionUpdate: {
+            sessionUpdate: "agent_message_chunk",
+            content: { type: "text", text: reply },
+          },
+        },
+      ],
+      files,
+      stopReason: "end_turn",
+    },
+  });
+}
+
+export function agentNameHeading(page: Page, agentName: string): Locator {
+  return page.getByRole("heading", { name: agentName, exact: true });
+}
+
+export function agentCardStatus(
+  page: Page,
+  agentName: string,
+  label: string,
+): Locator {
+  return agentNameHeading(page, agentName)
+    .locator("..")
+    .getByText(label, { exact: true });
 }

--- a/packages/e2e/playwright/src/tests/03-lifecycle.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-lifecycle.spec.ts
@@ -82,7 +82,7 @@ test("agent is not openable until ready, then chats and writes files", async ({
     );
 
     // File browser is empty for the freshly-created file before the prompt.
-    await page.getByRole("button", { name: "files" }).click();
+    await page.getByRole("button", { name: "files", exact: true }).click();
     await page.getByText("work", { exact: true }).click();
     await expect(page.getByText(createdFile, { exact: true })).toHaveCount(0);
 

--- a/packages/e2e/playwright/src/tests/03-lifecycle.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-lifecycle.spec.ts
@@ -1,0 +1,107 @@
+import { expect, test } from "@playwright/test";
+
+import { baseUrl } from "../config.js";
+import {
+  agentCardStatus,
+  agentNameHeading,
+  sendMessageToAgent,
+  setMockReplyWithFiles,
+  waitForAgentRunning,
+} from "../lib/agents.js";
+import { createApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+
+const harnessName = "mock";
+const agentName = "e2e-lifecycle";
+const scriptedReply = "scripted-reply-from-lifecycle";
+const userPrompt = "hello-from-lifecycle";
+const createdFile = "lifecycle-output.md";
+const createdFileContent = "written by the lifecycle mock on prompt";
+
+// Red spec for issue #168: gate opening on readiness. Documents the desired
+// not-ready -> ready -> interactive flow, all without a page reload. Expected
+// to fail until the gating behavior ships; the sleeping/offline lock is a
+// separate flow and out of scope here.
+test("agent is not openable until ready, then chats and writes files", async ({
+  page,
+}) => {
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+
+  await test.step("assert clean slate", async () => {
+    const existing = (await api.agents.list.query()).find(
+      (a) => a.name === agentName,
+    );
+    expect(
+      existing,
+      `agent ${agentName} already exists - expected clean slate`,
+    ).toBeUndefined();
+  });
+
+  await test.step("open app", async () => {
+    await page.goto(baseUrl);
+    await expect(page.getByTestId("app-sidebar")).toBeVisible();
+  });
+
+  await test.step("create mock agent", async () => {
+    await page.getByRole("button", { name: /add agent/i }).click();
+    await page.getByText(harnessName, { exact: true }).click();
+
+    await page.getByPlaceholder("my-agent").fill(agentName);
+    await page.getByRole("button", { name: /create agent/i }).click();
+  });
+
+  await test.step("agent is not openable while starting", async () => {
+    // Appears in the list on its own, no reload.
+    await expect(agentNameHeading(page, agentName)).toBeVisible({
+      timeout: 30_000,
+    });
+    await expect(agentCardStatus(page, agentName, "Starting")).toBeVisible();
+
+    // Clicking a starting agent is a no-op: it must not reach the detail view.
+    await agentNameHeading(page, agentName).click();
+    await expect(page).not.toHaveURL(/\/chat\//);
+  });
+
+  await test.step("agent becomes openable once running, without reload", async () => {
+    await expect(agentCardStatus(page, agentName, "Running")).toBeVisible({
+      timeout: 180_000,
+    });
+  });
+
+  const agentId = await waitForAgentRunning(api, agentName);
+
+  await test.step("open agent and exchange a message", async () => {
+    await setMockReplyWithFiles(api, agentId, scriptedReply, [
+      { path: createdFile, content: createdFileContent },
+    ]);
+
+    await agentNameHeading(page, agentName).click();
+    await expect(page).toHaveURL(
+      new RegExp(`/chat/${encodeURIComponent(agentId)}`),
+    );
+
+    // File browser is empty for the freshly-created file before the prompt.
+    await page.getByRole("button", { name: "files" }).click();
+    await page.getByText("work", { exact: true }).click();
+    await expect(page.getByText(createdFile, { exact: true })).toHaveCount(0);
+
+    await sendMessageToAgent(page, userPrompt);
+
+    await expect(page.getByText(scriptedReply)).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The prompt made the mock write the file into its working dir; it now
+    // shows up in the tree (already-expanded `work`) on the next poll.
+    await expect(page.getByText(createdFile, { exact: true })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    const { prompts } = await api.e2e.getReceivedPrompts.query({ agentId });
+    expect(prompts.length).toBeGreaterThan(0);
+    expect(JSON.stringify(prompts)).toContain(userPrompt);
+  });
+
+  // No teardown: leave the agent in place.
+});

--- a/tasks.toml
+++ b/tasks.toml
@@ -114,8 +114,8 @@ mise run cluster:install -- "${INSTALL_ARGS[@]}"
 # generation migrate cleanly. UI/controller don't share this race, and
 # restarting the UI introduces a transient Traefik-endpoint 502 window that
 # breaks Playwright's first asset fetch — leave them alone.
-mise run cluster:kubectl -- rollout restart deployment platform-apiserver
-mise run cluster:kubectl -- rollout status deployment platform-apiserver --timeout=5m
+kubectl --kubeconfig="$KUBECONFIG" rollout restart deployment platform-apiserver
+kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-apiserver --timeout=5m
 
 PLATFORM_BASE_URL="http://localhost:5555" \
 PLATFORM_KEYCLOAK_URL="http://keycloak.localhost:5555" \


### PR DESCRIPTION
Builds the plan from #168 (the agent creation lifecycle spec).

## Mock agent: create-file-on-prompt
- `setScript` accepts an optional `files` array; the mock writes them into its working dir on each prompt, before emitting the scripted reply.
- File writing sits behind a `WorkspaceWriter` port + node-fs adapter (refuses paths escaping the workspace root).
- `files` mirrored through the api-server e2e contract so the call forwards unchanged.

## Lifecycle spec (03)
New `lifecycle` Playwright project, runs after `agent` (02), reusing the auth session. The spec:
- creates a mock agent through the UI
- asserts it's not openable while starting (click is a no-op)
- asserts it becomes openable once running, without a reload
- opens it, does a chat round-trip
- asserts the created file is absent in the tree before the prompt, then appears under `work/` after

## Notes
- The spec is currently active and expected to fail until the readiness-gating / no-reload behavior ships. Re-skip if it should not gate CI.
- The file tree is rooted at `/home/agent` while the harness runs in `/home/agent/work`, so mock-written files surface under `work/`.

Refs #168