### PR TITLE
refactor(cli): simplify tsup noExternal to bundle-everything

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -15,24 +15,16 @@ export default defineConfig({
   platform: "node",
   splitting: false,
   clean: true,
-  // Ship a self-contained dist/bin.js. Node-builtins stay external; runtime
-  // deps fold into the bundle so `node dist/bin.js` works from anywhere.
-  noExternal: [
-    "@agentclientprotocol/sdk",
-    "@clack/prompts",
-    "@trpc/client",
-    "@trpc/server",
-    "api-server-api",
-    "commander",
-    "open",
-    "smol-toml",
-    "tar-stream",
-    "ws",
-    "zod",
-  ],
-  // CJS deps (commander) use dynamic `require()` of node builtins; ESM
-  // doesn't expose `require` by default, so synthesize one at the top of
-  // the bundle. Without this, `node dist/bin.js` throws on first call.
+  // Ship a self-contained dist/bin.js: the contract packages (api-server-api,
+  // agent-runtime-api) are private and never published, so everything except
+  // Node builtins must fold into the bundle. Bundle-everything is more robust
+  // than a hand-maintained list, which silently relied on each dep sitting in
+  // devDependencies (tsup externalizes only `dependencies`/`peerDependencies`).
+  noExternal: [/.*/],
+  // commander is bundled as CJS and calls `require()` at runtime; ESM output
+  // has no `require`, so synthesize one. Without this, `node dist/bin.js`
+  // throws "Dynamic require of 'events'" on first call. (This also lets ws's
+  // optional native-addon requires fail gracefully into its JS fallback.)
   banner: {
     js: "import { createRequire as __createRequire } from 'node:module'; const require = __createRequire(import.meta.url);",
   },


### PR DESCRIPTION
## What

Replace the hand-maintained `noExternal` package list in `packages/cli/tsup.config.ts` with `noExternal: [/.*/]`.

## Why

The explicit list was **inert**. Every runtime dep is in `devDependencies`, and tsup bundles those by default — it externalizes only `dependencies`/`peerDependencies`, of which the CLI has none. The list also already omitted `agent-runtime-api` (type-only import) and "worked" purely by the devDep convention.

`noExternal: [/.*/]` states the real intent — *ship a standalone `dist/bin.js`* — and is robust to a dep later being misfiled as a `dependency`. Bundle-everything isn't optional here: the contract packages (`api-server-api`, `agent-runtime-api`) are `private: true` and never published, so they can't be resolved as runtime deps and **must** be bundled.

The `createRequire` banner is kept — `commander@14` is bundled as CJS and calls `require('events')` at runtime; ESM output has no `require` without it (verified: the bundle crashes with `Dynamic require of "events" is not supported` if removed).

## Verification

- Build succeeds; external imports are **Node builtins only** — byte-equivalent to before.
- Ran the bundle: `--version`, `--help`, subcommand helps, `config set` (smol-toml write), `ping` (trpc/fetch error path) all work; `ws`/`open` module init clean.