### PR TITLE
fix(keycloak-theme): style CLI device-flow login pages

### DIFF
--- a/packages/keycloak-theme/src/login/KcPage.tsx
+++ b/packages/keycloak-theme/src/login/KcPage.tsx
@@ -9,6 +9,10 @@ import Template from "./Template.js";
 const Login = lazy(() => import("./pages/Login.js"));
 const Error = lazy(() => import("./pages/Error.js"));
 const Info = lazy(() => import("./pages/Info.js"));
+const LoginOauth2DeviceVerifyUserCode = lazy(
+  () => import("./pages/LoginOauth2DeviceVerifyUserCode.js"),
+);
+const LoginOauthGrant = lazy(() => import("./pages/LoginOauthGrant.js"));
 
 const doMakeUserConfirmPassword = true;
 
@@ -40,6 +44,24 @@ export default function KcPage({ kcContext }: { kcContext: KcContext }) {
           case "info.ftl":
             return (
               <Info
+                kcContext={kcContext}
+                i18n={i18n}
+                doUseDefaultCss={false}
+                Template={Template}
+              />
+            );
+          case "login-oauth2-device-verify-user-code.ftl":
+            return (
+              <LoginOauth2DeviceVerifyUserCode
+                kcContext={kcContext}
+                i18n={i18n}
+                doUseDefaultCss={false}
+                Template={Template}
+              />
+            );
+          case "login-oauth-grant.ftl":
+            return (
+              <LoginOauthGrant
                 kcContext={kcContext}
                 i18n={i18n}
                 doUseDefaultCss={false}

--- a/packages/keycloak-theme/src/login/pages/LoginOauth2DeviceVerifyUserCode.tsx
+++ b/packages/keycloak-theme/src/login/pages/LoginOauth2DeviceVerifyUserCode.tsx
@@ -1,0 +1,64 @@
+import type { PageProps } from "keycloakify/login/pages/PageProps";
+import { useState } from "react";
+
+import { Button } from "../../components/button.js";
+import { Input } from "../../components/input.js";
+import { Label } from "../../components/label.js";
+import type { I18n } from "../i18n.js";
+import type { KcContext } from "../KcContext.js";
+
+export default function LoginOauth2DeviceVerifyUserCode(
+  props: PageProps<
+    Extract<KcContext, { pageId: "login-oauth2-device-verify-user-code.ftl" }>,
+    I18n
+  >,
+) {
+  const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
+  const { url } = kcContext;
+  const { msg, msgStr } = i18n;
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  return (
+    <Template
+      kcContext={kcContext}
+      i18n={i18n}
+      doUseDefaultCss={doUseDefaultCss}
+      classes={classes}
+      headerNode={msg("oauth2DeviceVerificationTitle")}
+    >
+      <form
+        id="kc-user-verify-device-user-code-form"
+        className="space-y-4"
+        onSubmit={() => {
+          setIsSubmitting(true);
+          return true;
+        }}
+        action={url.oauth2DeviceVerificationAction}
+        method="post"
+      >
+        <div className="space-y-2">
+          <Label htmlFor="device-user-code">
+            {msg("verifyOAuth2DeviceUserCode")}
+          </Label>
+          <Input
+            id="device-user-code"
+            name="device_user_code"
+            type="text"
+            autoComplete="off"
+            autoFocus
+          />
+        </div>
+
+        <Button
+          type="submit"
+          size="lg"
+          className="w-full"
+          disabled={isSubmitting}
+        >
+          {msgStr("doSubmit")}
+        </Button>
+      </form>
+    </Template>
+  );
+}

--- a/packages/keycloak-theme/src/login/pages/LoginOauthGrant.tsx
+++ b/packages/keycloak-theme/src/login/pages/LoginOauthGrant.tsx
@@ -1,0 +1,135 @@
+import type { PageProps } from "keycloakify/login/pages/PageProps";
+import { useState } from "react";
+
+import { Button } from "../../components/button.js";
+import type { I18n } from "../i18n.js";
+import type { KcContext } from "../KcContext.js";
+
+export default function LoginOauthGrant(
+  props: PageProps<
+    Extract<KcContext, { pageId: "login-oauth-grant.ftl" }>,
+    I18n
+  >,
+) {
+  const { kcContext, i18n, doUseDefaultCss, Template, classes } = props;
+  const { url, oauth, client } = kcContext;
+  const { msg, msgStr, advancedMsg, advancedMsgStr } = i18n;
+
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const clientName = client.name
+    ? advancedMsgStr(client.name)
+    : client.clientId;
+  const hasInfo = Boolean(
+    client.attributes.tosUri || client.attributes.policyUri,
+  );
+
+  return (
+    <Template
+      kcContext={kcContext}
+      i18n={i18n}
+      doUseDefaultCss={doUseDefaultCss}
+      classes={classes}
+      headerNode={
+        <span className="flex items-center gap-3">
+          {client.attributes.logoUri && (
+            <img src={client.attributes.logoUri} alt="" className="h-8 w-8" />
+          )}
+          {msg("oauthGrantTitle", clientName)}
+        </span>
+      }
+    >
+      <div id="kc-oauth" className="space-y-6">
+        <div className="space-y-3">
+          <h3 className="text-foreground text-sm font-medium">
+            {msg("oauthGrantRequest")}
+          </h3>
+          <ul className="space-y-2">
+            {oauth.clientScopesRequested.map((clientScope) => (
+              <li
+                key={clientScope.consentScreenText}
+                className="border-input bg-muted/40 text-foreground rounded-md border px-3 py-2 text-sm"
+              >
+                <span>
+                  {advancedMsg(clientScope.consentScreenText)}
+                  {clientScope.dynamicScopeParameter && (
+                    <>
+                      : <b>{clientScope.dynamicScopeParameter}</b>
+                    </>
+                  )}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </div>
+
+        {hasInfo && (
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            {msg("oauthGrantInformation", clientName)}
+            {client.attributes.tosUri && (
+              <>
+                {" "}
+                {msg("oauthGrantReview")}{" "}
+                <a
+                  href={client.attributes.tosUri}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline underline-offset-2"
+                >
+                  {msg("oauthGrantTos")}
+                </a>
+              </>
+            )}
+            {client.attributes.policyUri && (
+              <>
+                {" "}
+                {msg("oauthGrantReview")}{" "}
+                <a
+                  href={client.attributes.policyUri}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-primary underline underline-offset-2"
+                >
+                  {msg("oauthGrantPolicy")}
+                </a>
+              </>
+            )}
+          </p>
+        )}
+
+        <form
+          className="flex gap-3"
+          action={url.oauthAction}
+          method="POST"
+          onSubmit={() => {
+            setIsSubmitting(true);
+            return true;
+          }}
+        >
+          <input type="hidden" name="code" value={oauth.code} />
+          <Button
+            type="submit"
+            name="accept"
+            id="kc-login"
+            size="lg"
+            className="flex-1"
+            disabled={isSubmitting}
+          >
+            {msgStr("doYes")}
+          </Button>
+          <Button
+            type="submit"
+            name="cancel"
+            id="kc-cancel"
+            variant="outline"
+            size="lg"
+            className="flex-1"
+            disabled={isSubmitting}
+          >
+            {msgStr("doNo")}
+          </Button>
+        </form>
+      </div>
+    </Template>
+  );
+}


### PR DESCRIPTION
## What

Adds branded keycloakify page components for the two Keycloak pages the `dam` CLI device-flow login walks through, which previously fell back to the stock PatternFly theme:

- **`login-oauth2-device-verify-user-code.ftl`** — the "Device Login" code-entry page.
- **`login-oauth-grant.ftl`** — the "Grant Access to platform-cli" consent page.

Both now reuse the shared `Template` (Aurora backdrop + marketing panel) and the branded `Button` / `Input` / `Label` primitives, matching `Login.tsx` / `Info.tsx`. They're wired into `KcPage.tsx`.

## Why

`dam auth login` opens Keycloak's `verification_uri_complete` in the browser. The flow went: branded sign-in (`login.ftl`) → **stock-themed consent** → branded success (`info.ftl`), and the bare `/device` code-entry page was likewise unstyled. The mid-flow theme flip looked broken. `user_code` handling itself is correct and unchanged.

Closes #453

## Testing

- `mise run keycloak-theme:check` — format, tsc, lint all pass.
- Built the theme (`mise run cluster:build-keycloak`) and verified the **Device Login** code-entry page renders with the branded theme in a real browser.
- Grant page verified by walking the device flow and signing in (see issue for repro commands).

### Screenshots

_Device Login (after):_ branded Aurora layout, IBM Plex, card styling — matches the sign-in page.
