### PR TITLE
test(e2e): fast warm-cluster loop + fix traefik CRD ownership

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,16 +30,32 @@ mise run ui:run             # start UI dev server
 ### Cluster lifecycle (k3s via lima)
 
 ```sh
-mise run cluster:install      # create k3s VM, build images, install cert-manager + Platform chart (or upgrade if already installed)
-mise run cluster:build-agent  # rebuild agent image only, restart agent pods
-mise run cluster:status       # show pods and cluster state
-mise run cluster:logs         # show api-server pod logs
-mise run cluster:stop         # stop k3s VM (preserves data)
-mise run cluster:uninstall    # helm uninstall + cleanup PVCs
-mise run cluster:delete       # destroy k3s VM entirely
+mise run cluster:install         # create k3s VM, build images, install cert-manager + Platform chart (or upgrade if already installed)
+mise run cluster:build-apiserver # rebuild api-server image only, restart apiserver pod
+mise run cluster:build-ui        # rebuild UI image only, restart UI pod
+mise run cluster:build-controller# rebuild controller image only, restart controller pod
+mise run cluster:build-agent     # rebuild agent image only, restart agent pods
+mise run cluster:build-keycloak  # rebuild keycloak image only, restart keycloak pod
+mise run cluster:status          # show pods and cluster state
+mise run cluster:logs            # show api-server pod logs
+mise run cluster:stop            # stop k3s VM (preserves data)
+mise run cluster:uninstall       # helm uninstall + cleanup PVCs
+mise run cluster:delete          # destroy k3s VM entirely
 ```
 
+The `cluster:build-*` tasks honor a `LIMA_INSTANCE` env var (default `platform-k3s`); set it to target a different VM (e.g. the e2e cluster).
+
 Services are available at `*.localhost:4444` automatically (Traefik on port 4444, auto-forwarded by lima). `*.localtest.me:4444` also works as an alias.
+
+### E2E tests (Playwright)
+
+```sh
+mise run e2e          # full from-scratch run: nuke test VM, install fresh cluster, run specs, tear down (CI path)
+mise run e2e:loop     # fast rerun against a warm test cluster: bootstrap once if missing, optionally rebuild components, wipe data, run specs. Options: --headed --rebuild=apiserver,ui,controller,keycloak,mock-agent
+mise run e2e:reset    # data wipe only: drop+recreate platform DB, delete agents (CMs/sts/pods/PVCs), clear stored Playwright auth. Leaves the cluster running
+```
+
+`e2e:loop` runs on a dedicated persistent `platform-k3s-test` VM that it never deletes, so reruns skip VM/Istio/cert-manager/Keycloak provisioning. Running `mise run e2e` nukes that VM (shared name); the next `e2e:loop` bootstraps a fresh one. `e2e:loop` does not heal a wedged cluster — if the warm cluster is broken, it fails loud; use `mise run e2e` or `cluster:fix-certs`. Use `e2e:loop` for iteration, `e2e` after helm/realm/infra changes.
 
 ### Cluster debugging (pre-approved in .claude/settings.json)
 

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -238,6 +238,24 @@ else
   echo "Gateway API CRDs already installed"
 fi
 
+# k3s bundles Traefik (chart v39+), whose `traefik-crd` chart also ships the
+# Gateway API CRDs. We install those out-of-band above (for Istio) via plain
+# `kubectl apply`, so they carry no Helm ownership metadata — and the
+# `traefik-crd` Helm job then dies with "invalid ownership metadata" and
+# Traefik never installs, leaving nothing on the ingress port. Stamp the
+# ownership the `traefik-crd` release expects so it adopts them on its next
+# reconcile. Idempotent, and covers both install orders (whichever of the k3s
+# Traefik bootstrap vs. this CRD apply wins the race).
+echo "Stamping Helm ownership on Gateway API CRDs (so k3s traefik-crd can adopt them)..."
+for crd in gatewayclasses gateways grpcroutes httproutes referencegrants; do
+  kubectl --kubeconfig="$KUBECONFIG" label crd "$crd.gateway.networking.k8s.io" \
+    app.kubernetes.io/managed-by=Helm --overwrite >/dev/null 2>&1 || true
+  kubectl --kubeconfig="$KUBECONFIG" annotate crd "$crd.gateway.networking.k8s.io" \
+    meta.helm.sh/release-name=traefik-crd --overwrite >/dev/null 2>&1 || true
+  kubectl --kubeconfig="$KUBECONFIG" annotate crd "$crd.gateway.networking.k8s.io" \
+    meta.helm.sh/release-namespace=kube-system --overwrite >/dev/null 2>&1 || true
+done
+
 echo "Ensuring Istio ambient mesh ($ISTIO_VERSION)..."
 helm repo add istio https://istio-release.storage.googleapis.com/charts >/dev/null 2>&1 || true
 helm repo update istio >/dev/null
@@ -517,7 +535,7 @@ if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
   sudo k3s ctr images import "$tar"
 else
-  LIMA_INSTANCE="platform-k3s"
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
   KUBECONFIG="$HOME/.lima/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
   limactl copy "$tar" "$LIMA_INSTANCE":"$tar"
   limactl shell "$LIMA_INSTANCE" sudo k3s ctr images import "$tar"
@@ -527,6 +545,43 @@ rm -f "$tar"
 echo "Restarting apiserver pod..."
 kubectl --kubeconfig="$KUBECONFIG" rollout restart deployment platform-apiserver
 kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-apiserver --timeout=60s
+
+PRUNE_DANGLING='sudo k3s crictl images 2>/dev/null | sed -nE "s/^<none>[[:space:]]+<none>[[:space:]]+([^[:space:]]+).*/\\1/p" | xargs -r sudo k3s crictl rmi >/dev/null 2>&1 || true'
+if [ -n "${IS_SANDBOX:-}" ]; then
+  bash -c "$PRUNE_DANGLING"
+else
+  limactl shell "$LIMA_INSTANCE" bash -c "$PRUNE_DANGLING"
+fi
+
+echo "Done."
+'''
+
+["cluster:build-controller"]
+description = "Build and load controller image into k3s, restart controller pod"
+depends = ["image:controller"]
+dir = "{{config_root}}"
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+echo "Loading into k3s..."
+tar="/tmp/platform-controller.tar"
+docker save platform-controller:latest -o "$tar"
+
+if [ -n "${IS_SANDBOX:-}" ]; then
+  KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+  sudo k3s ctr images import "$tar"
+else
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
+  KUBECONFIG="$HOME/.lima/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
+  limactl copy "$tar" "$LIMA_INSTANCE":"$tar"
+  limactl shell "$LIMA_INSTANCE" sudo k3s ctr images import "$tar"
+fi
+rm -f "$tar"
+
+echo "Restarting controller pod..."
+kubectl --kubeconfig="$KUBECONFIG" rollout restart deployment platform-controller
+kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-controller --timeout=60s
 
 PRUNE_DANGLING='sudo k3s crictl images 2>/dev/null | sed -nE "s/^<none>[[:space:]]+<none>[[:space:]]+([^[:space:]]+).*/\\1/p" | xargs -r sudo k3s crictl rmi >/dev/null 2>&1 || true'
 if [ -n "${IS_SANDBOX:-}" ]; then
@@ -554,7 +609,7 @@ if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
   sudo k3s ctr images import "$tar"
 else
-  LIMA_INSTANCE="platform-k3s"
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
   KUBECONFIG="$HOME/.lima/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
   limactl copy "$tar" "$LIMA_INSTANCE":"$tar"
   limactl shell "$LIMA_INSTANCE" sudo k3s ctr images import "$tar"
@@ -585,7 +640,7 @@ set -eo pipefail
 if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 else
-  LIMA_INSTANCE="platform-k3s"
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
   KUBECONFIG="$HOME/.lima/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
 fi
 
@@ -660,7 +715,7 @@ if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
   sudo k3s ctr images import "$tar"
 else
-  LIMA_INSTANCE="platform-k3s"
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
   KUBECONFIG="$HOME/.lima/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
   limactl copy "$tar" "$LIMA_INSTANCE":"$tar"
   limactl shell "$LIMA_INSTANCE" sudo k3s ctr images import "$tar"
@@ -804,7 +859,7 @@ if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
   RUN_IN_VM="sudo"
 else
-  LIMA_INSTANCE="platform-k3s"
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
   KUBECONFIG="$HOME/.lima/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
   RUN_IN_VM="limactl shell $LIMA_INSTANCE sudo"
 fi

--- a/tasks.toml
+++ b/tasks.toml
@@ -34,8 +34,6 @@ else
   KUBECONFIG="$HOME/.lima/$VM_NAME/copied-from-guest/kubeconfig.yaml"
 fi
 
-export E2E_MOCK_ONLY=1
-
 cleanup() {
   local exit_code=$?
   if [ $exit_code -ne 0 ] && [ -f "$KUBECONFIG" ]; then
@@ -88,6 +86,33 @@ if [ -z "${IS_SANDBOX:-}" ]; then
   mise run cluster:delete -- --vm-name="$VM_NAME" --force
 fi
 
+# Provision a fresh e2e cluster. Install args + the apiserver race-fix live in
+# e2e:install, shared with e2e:loop so the two never drift.
+E2E_VM_NAME="$VM_NAME" mise run e2e:install
+
+PLATFORM_BASE_URL="http://localhost:5555" \
+PLATFORM_KEYCLOAK_URL="http://keycloak.localhost:5555" \
+  mise run "$PLAYWRIGHT_TASK"
+'''
+
+["e2e:install"]
+hide = true
+description = "Provision/upgrade the e2e test cluster (mock-only agents, e2e control API on). Shared by `e2e` and `e2e:loop`. VM via E2E_VM_NAME (default platform-k3s-test)."
+dir = "{{config_root}}"
+raw = true
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+VM_NAME="${E2E_VM_NAME:-platform-k3s-test}"
+if [ -n "${IS_SANDBOX:-}" ]; then
+  KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+else
+  KUBECONFIG="$HOME/.lima/$VM_NAME/copied-from-guest/kubeconfig.yaml"
+fi
+
+export E2E_MOCK_ONLY=1
+
 INSTALL_ARGS=(
   --lima-template=deploy/lima-k3s-test.yaml
   --helm-values=deploy/helm/platform/values-e2e.yaml
@@ -116,7 +141,145 @@ mise run cluster:install -- "${INSTALL_ARGS[@]}"
 # breaks Playwright's first asset fetch — leave them alone.
 kubectl --kubeconfig="$KUBECONFIG" rollout restart deployment platform-apiserver
 kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-apiserver --timeout=5m
+'''
 
+["e2e:reset"]
+description = "Wipe e2e cluster data without reinstalling: drop+recreate the platform DB, delete agents (ConfigMaps/StatefulSets/pods/PVCs), clear stored Playwright auth. Leaves the cluster running. VM via E2E_VM_NAME (default platform-k3s-test)."
+dir = "{{config_root}}"
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+VM_NAME="${E2E_VM_NAME:-platform-k3s-test}"
+if [ -n "${IS_SANDBOX:-}" ]; then
+  KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+else
+  KUBECONFIG="$HOME/.lima/$VM_NAME/copied-from-guest/kubeconfig.yaml"
+fi
+KCTL=(kubectl --kubeconfig="$KUBECONFIG")
+
+# 1. Delete agents. Drop the durable ConfigMaps first so the controller stops
+# reconciling them, then sweep the StatefulSets/pods it owns plus the PVCs k8s
+# retains (StatefulSet volumeClaimTemplates are never GC'd with their owner).
+# Templates (agent-template) are helm-managed — leave them.
+echo "Deleting agents in platform-agents..."
+"${KCTL[@]}" -n platform-agents delete configmap \
+  -l 'agent-platform.ai/type in (agent,agent-fork,agent-schedule,channel-secret)' \
+  --ignore-not-found
+"${KCTL[@]}" -n platform-agents delete statefulset --all --ignore-not-found --wait=true --timeout=60s
+"${KCTL[@]}" -n platform-agents delete pod --all --ignore-not-found --force --grace-period=0 2>/dev/null || true
+"${KCTL[@]}" -n platform-agents delete pvc --all --ignore-not-found --wait=true --timeout=60s
+
+# 2. Drop + recreate the platform DB. apiserver must be disconnected first
+# (DROP DATABASE refuses while a session is attached); scale it to 0, drop with
+# FORCE to evict any stragglers, recreate empty, then scale back. The new pod
+# reruns the Drizzle migrations from zero on boot. Postgres stays up the whole
+# time, so the fresh-cluster apiserver-vs-init race never applies here.
+echo "Dropping + recreating the platform database..."
+"${KCTL[@]}" scale deployment platform-apiserver --replicas=0
+"${KCTL[@]}" wait --for=delete pod -l app.kubernetes.io/component=apiserver --timeout=60s 2>/dev/null || true
+"${KCTL[@]}" exec platform-postgres-0 -- bash -c \
+  'PGPASSWORD="$POSTGRES_PASSWORD" psql -U "$POSTGRES_USER" -d postgres -v ON_ERROR_STOP=1 \
+     -c "DROP DATABASE IF EXISTS platform WITH (FORCE);" \
+     -c "CREATE DATABASE platform;"'
+"${KCTL[@]}" scale deployment platform-apiserver --replicas=1
+"${KCTL[@]}" wait --for=condition=Available deployment/platform-apiserver --timeout=120s
+
+# 3. Clear stored Playwright auth so 01-auth re-runs the login + terms flow
+# (terms acceptance lived in the platform DB we just dropped; a fresh browser
+# context with no cookie makes Keycloak prompt for credentials again).
+echo "Clearing stored Playwright auth..."
+rm -f packages/e2e/playwright/.auth/user.json
+
+echo "e2e data reset complete."
+'''
+
+["e2e:loop"]
+description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run specs. Options: --headed --rebuild=apiserver,ui,controller,keycloak,mock-agent"
+dir = "{{config_root}}"
+raw = true
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+VM_NAME="platform-k3s-test"
+export E2E_VM_NAME="$VM_NAME"
+if [ -n "${IS_SANDBOX:-}" ]; then
+  KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+else
+  KUBECONFIG="$HOME/.lima/$VM_NAME/copied-from-guest/kubeconfig.yaml"
+fi
+
+PLAYWRIGHT_TASK="e2e-playwright:run"
+REBUILD=""
+REBUILD_SET=false
+for arg in "$@"; do
+  case "$arg" in
+    --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
+    --rebuild=*) REBUILD="${arg#--rebuild=}"; REBUILD_SET=true ;;
+  esac
+done
+
+# 1. Ensure a warm cluster exists. Bootstrap once if it's missing; never try to
+# heal a broken one — fail loud and let the operator decide.
+NEEDS_BOOTSTRAP=false
+if [ -z "${IS_SANDBOX:-}" ] && ! limactl list -q 2>/dev/null | grep -qx "$VM_NAME"; then
+  NEEDS_BOOTSTRAP=true
+elif ! kubectl --kubeconfig="$KUBECONFIG" get deployment platform-apiserver >/dev/null 2>&1; then
+  NEEDS_BOOTSTRAP=true
+fi
+if [ "$NEEDS_BOOTSTRAP" = true ]; then
+  echo "No warm e2e cluster found — bootstrapping once (slow, ~minutes)..."
+  mise run e2e:install
+fi
+
+# 2. Optional rebuild. Interactive prompt unless --rebuild was passed. Default
+# none: just reset data and rerun. The build tasks honor LIMA_INSTANCE so they
+# target the test VM rather than the dev cluster.
+if [ "$REBUILD_SET" = false ] && [ -t 0 ]; then
+  read -r -p "Rebuild which? [apiserver,ui,controller,keycloak,mock-agent] (default: none): " REBUILD || true
+fi
+if [ -n "$REBUILD" ]; then
+  export LIMA_INSTANCE="$VM_NAME"
+  IFS=',' read -ra COMPONENTS <<< "$REBUILD"
+  for c in "${COMPONENTS[@]}"; do
+    c="${c//[[:space:]]/}"
+    case "$c" in
+      "") ;;
+      apiserver)              mise run cluster:build-apiserver ;;
+      ui)                     mise run cluster:build-ui ;;
+      controller)             mise run cluster:build-controller ;;
+      keycloak)               mise run cluster:build-keycloak ;;
+      mock-agent|mock|agent)  mise run cluster:build-agent ;;
+      *) echo "WARN: unknown component '$c' — skipping" >&2 ;;
+    esac
+  done
+fi
+
+# 3. Wipe data to the specs' expected preconditions.
+mise run e2e:reset
+
+# 3b. Readiness gate. The warm cluster must actually serve on :5555 (Traefik /
+# ingress up) or the specs fail with an opaque ERR_CONNECTION_REFUSED. Poll
+# briefly — covers a just-bootstrapped Traefik still coming up or a UI rebuild
+# blip — then fail loud rather than auto-heal a wedged cluster.
+echo "Waiting for the cluster to serve on http://localhost:5555 ..."
+READY=false
+for _ in $(seq 1 30); do
+  if curl -fsS -o /dev/null --max-time 3 http://localhost:5555/ 2>/dev/null; then
+    READY=true; break
+  fi
+  sleep 3
+done
+if [ "$READY" != true ]; then
+  echo "ERROR: warm e2e cluster is up but not routing on http://localhost:5555." >&2
+  echo "Traefik/ingress likely failed to install. e2e:loop does not auto-heal —" >&2
+  echo "reprovision with 'mise run e2e', or check 'mise run cluster:fix-certs'." >&2
+  exit 1
+fi
+
+# 4. Run the specs against the warm cluster. No teardown — the cluster stays up
+# for the next loop.
 PLATFORM_BASE_URL="http://localhost:5555" \
 PLATFORM_KEYCLOAK_URL="http://keycloak.localhost:5555" \
   mise run "$PLAYWRIGHT_TASK"


### PR DESCRIPTION
## Why

Rerunning the e2e suite locally meant recreating the whole k3s cluster every time (VM + cert-manager + Istio + Keycloak boot + helm), which is slow. We want to keep the cluster warm, rebuild server/UI on demand, wipe all data, and rerun.

## What

New tasks:
- `e2e:loop` — fast rerun against a persistent `platform-k3s-test` VM (never deleted). Bootstraps once if missing, prompts for optional component rebuild (`--rebuild=apiserver,ui,controller,keycloak,mock-agent`, default none), wipes data, runs the specs. No teardown. Supports `--headed`.
- `e2e:reset` — data wipe only: scale apiserver to 0, `DROP DATABASE platform WITH (FORCE)` + recreate (apiserver remigrates from zero on the way back up), delete agents (ConfigMaps/StatefulSets/pods/PVCs in `platform-agents`), clear stored Playwright auth.
- `cluster:build-controller` — the missing rebuild task, mirrors `cluster:build-apiserver`.

Refactors:
- `cluster:build-*` (and `cluster:reclaim`) honor a `LIMA_INSTANCE` env var so the loop can retarget them at the test VM. `cluster:install`/`cluster:delete` keep their own `--vm-name` handling.
- Extracted `e2e:install` (hidden), shared by `e2e` and `e2e:loop`, so install args never drift. `e2e` (the full from-scratch CI path) is behaviorally unchanged.

Provisioning fix (surfaced while building the loop, affects `mise run e2e` too):
- k3s bundles Traefik v39, whose `traefik-crd` chart also ships the Gateway API CRDs. `cluster:install` installs those CRDs out-of-band for Istio via `kubectl apply`, so they carry no Helm ownership metadata. The `traefik-crd` Helm job then refuses to adopt them ("invalid ownership metadata"), Traefik never installs, and nothing serves the ingress port. Now `cluster:install` stamps the expected Helm ownership on the Gateway API CRDs so `traefik-crd` adopts them. Idempotent, covers either install order.
- `e2e:loop` has a readiness gate that polls the ingress and fails loud if the cluster is up but not routing, instead of an opaque Playwright `ERR_CONNECTION_REFUSED`. No auto-heal.

## Validation

- Recovered a live broken test cluster by stamping the ownership (the exact fix): `traefik-crd` + `traefik` installed, ingress returned HTTP 200.
- `mise run e2e:loop` passes end to end: reset overhead a few seconds, 3/3 specs green in ~35s. Confirmed it targets the test cluster, not the dev cluster.

## Not validated

The `cluster:install` ownership fix is proven by live recovery with identical commands, but not yet by a fully fresh from-scratch reprovision.