### PR TITLE
feat(skills): add plan-feature and implement-feature

### DIFF
--- a/.agents/skills/implement-feature/SKILL.md
+++ b/.agents/skills/implement-feature/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: implement-feature
+description: >
+  Implement a feature from the plan that plan-feature produced under docs/plan/<feature>/, one
+  reviewed sub-issue at a time. Use when the user wants to implement or build a feature from a
+  docs/plan/<feature>/ plan or a planned GitHub issue.
+---
+
+This skill implements a feature that `plan-feature` has already planned. It consumes the
+ephemeral plan under `docs/plan/<NNN-slug>/` (README + one file per sub-issue) and turns it into
+code: a feature branch, one atomic commit per sub-issue, and a single PR for the whole feature.
+
+**Core rhythm:** read everything first and clear up confusion *before* writing code; implement
+one sub-issue at a time; after each, **pause for the user to smoke-test and review** before
+committing and moving on. The whole feature lands as one PR.
+
+## Input
+
+Accept either a GitHub issue number/URL or a `docs/plan/<NNN-slug>/` path. Given an issue,
+locate the plan folder by its issue-number prefix.
+
+## Steps
+
+### 1. Read everything
+
+Before touching code, read the full context:
+
+- The issue, via `gh`.
+- The plan: `README.md` **and every** sub-issue file in the folder.
+- The linked ADR, if the README/issue references one.
+- The architecture page(s) the README points at (the docs are the source of truth for *why*).
+
+### 2. Resume check
+
+Derive the feature branch name deterministically (see step 4) and check whether it already
+exists:
+
+- **Branch exists** — this is a resumed run. Read the README's sub-issue checkmarks and verify
+  them against the branch's `git log` to find which sub-issues are already done. If the working
+  tree has **uncommitted changes** from a sub-issue that was implemented but not yet
+  approved/committed, offer to continue *that* sub-issue rather than restart it.
+- **No branch** — fresh start.
+
+### 3. Upfront blocking-questions pass
+
+In one consolidated pass, surface every contradiction, ambiguity, or gap you found across the
+issue, plan, ADR, and architecture. **Write no code until the user clears the blockers** — or
+state explicitly that there are none and proceed.
+
+### 4. Create the feature branch
+
+If fresh, branch from `main`. Name it `<type>/<NNN-slug>`, where the slug matches the plan
+folder name (e.g. plan `docs/plan/344-egress-cli/` → branch `feat/344-egress-cli`) and `<type>`
+follows the issue's nature (`feat`, `fix`, …) per the branch convention. Work in the **main
+working tree** — not a git worktree — so manual smoke-testing happens in the normal checkout.
+
+### 5. Per sub-issue, in dependency order
+
+Process sub-issues in a topological order consistent with the README's dependency graph. For
+each one:
+
+1. **Read** the sub-issue (context, implementation plan, acceptance criteria, smoke test)
+   against the shared README context.
+2. **Implement** the slice. Apply the `/typescript-engineering` skill for server-side TS and the
+   `/react-ui-engineering` skill for UI (`packages/ui`) work — the sub-issue names which.
+   **Don't author new tests**, even when the sub-issue's plan lists them — verification leans on
+   the manual smoke test plus the existing suite. Write one only when the user asks or the
+   behavior is otherwise unverifiable (no manual smoke path, e.g. a pure algorithm with tricky
+   edges); if the plan calls for tests, treat it as a divergence (see below) and get the user's
+   go-ahead first.
+   **Comment sparingly.** Comment only the non-obvious *why* — a constraint, an edge case, a
+   deliberate departure; never narrate *what* a line does. Match the file's existing comment density.
+3. **Self-validate:** confirm each acceptance criterion is met; run the **scoped tests** for the
+   touched package(s) (`mise run <pkg>:test`) to confirm you haven't regressed the **existing**
+   suite; run the sub-issue's **smoke test yourself**.
+4. **Hand off to the user:** present a brief summary of what changed and the manual smoke-test
+   guide from the sub-issue. **Wait** for the user to smoke-test and give review feedback.
+5. **Incorporate** the user's feedback, then make **one clean atomic commit** — conventional
+   `type(scope): summary`, `git commit -s`, body line `Refs #NNN`. The pre-commit hook runs the
+   full `mise run check`; **never** bypass it with `--no-verify`, and never add the attribution
+   trailer by hand (the hook does it).
+6. **Mark progress:** check the sub-issue off in the README's sub-issue table (the plan folder
+   is the resume state).
+
+> **If the plan turns out wrong while coding** (can fire any time during 1–5): *stop and ask*
+> when the deviation is structural — it changes scope, breaks a stated acceptance criterion,
+> contradicts the README/ADR, or invalidates an assumption a *later* sub-issue depends on; once
+> agreed, update the affected README/sub-issue so not-yet-done slices stay consistent. *Adapt and
+> note* for purely local, in-intent details.
+>
+> The commit lands **after** the user's sign-off, never before — so history stays one clean
+> commit per reviewed slice, with no amend churn.
+
+### 6. Whole-feature gate
+
+Once every sub-issue is approved and committed:
+
+- Run the **full** `mise run test` to catch cross-slice regressions.
+- Run a final review pass on the whole branch diff with **both** `/review-work` (requirements)
+  and `/code-review` (correctness). Fix blocking findings by **amending the relevant sub-issue's
+  commit** — safe because nothing is pushed yet, so the one-commit-per-sub-issue history stays
+  intact.
+
+### 7. Open the PR
+
+Only after the user confirms the final sub-issue is done: push the branch and open the PR via
+`gh`. The PR description is **brief and product-level** — what the feature does for the user, no
+implementation details, no file paths; it reads like the issue, not the plan. Include `Closes
+#NNN` so the issue closes on merge.
+
+### 8. Clean up
+
+Ask the user whether to delete the `docs/plan/<NNN-slug>/` folder now or keep it until the PR
+merges. This is the **last** action — so an interrupted run always leaves the plan in place.

--- a/.agents/skills/plan-feature/SKILL.md
+++ b/.agents/skills/plan-feature/SKILL.md
@@ -33,13 +33,27 @@ context lives once in the README; each sub-issue carries only what is specific t
 - Explore the codebase to ground the plan in real files, modules, and seams. Use the `Explore`
   agent for breadth.
 
-### 2. Grill
+### 2. Grill — mandatory gate
 
-Invoke `/grill-with-adr` with the user to resolve every unknown that affects the plan — scope,
-boundaries, edge cases, where things live, naming. It pressure-tests vocabulary and architecture
-against the domain model and files or amends an ADR when a decision warrants it. Walk down each
-branch of the decision tree until you reach a solid, shared understanding. Do not skip this; the
-quality of the plan depends on it.
+**This is a hard gate. You MUST run a grilling session and get the user's explicit sign-off
+before step 3. Create nothing under `docs/plan/` until then — no decomposition outline, no
+files.** This holds even when the plan feels obvious: a short session confirming shared
+understanding is the floor, never a step to skip.
+
+Invoke `/grill-with-adr` to run it — that skill is the canonical procedure. But the gate does
+**not** depend on the nested call landing: if it doesn't fire, run the session yourself, one
+question at a time, recommending an answer to each. Either way the session must:
+
+- Resolve scope, boundaries, edge cases, where things live, and naming — walking each branch of
+  the decision tree. Prefer exploring the codebase over asking whenever a question is answerable
+  there.
+- Challenge the plan's vocabulary against [`docs/ubiquitous-language.md`](../../../docs/ubiquitous-language.md),
+  sharpen fuzzy terms to canonical ones, and cross-reference claims against the code.
+- File or amend an ADR (via `/adr`) — sparingly, only when a decision is hard to reverse,
+  surprising without context, and the result of a real trade-off.
+
+**Exit condition:** every branch of the decision tree is resolved and the user confirms they're
+satisfied. Only then proceed to step 3.
 
 ### 3. Decompose and get sign-off
 

--- a/.agents/skills/plan-feature/SKILL.md
+++ b/.agents/skills/plan-feature/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: plan-feature
+description: >
+  Turn a GitHub issue into an implementation plan under docs/plan/<feature>/: a feature spec
+  decomposed into self-contained, independently-shippable sub-issues. Use when the user wants to
+  plan a feature, decompose a GitHub issue into sub-issues, or produce an implementation plan from
+  an issue.
+---
+
+This skill turns a GitHub issue into a feature spec and implementation plan: a `README.md`
+plus one Markdown file per sub-issue, written under `docs/plan/<feature-slug>/`.
+
+**The plan files are temporary.** They are working artifacts for the implementation phase, not
+permanent docs. Write them to disk, but **never `git add` or commit them, and never add them to
+`.gitignore`.** They will show as untracked — that is intended. A separate skill,
+`implement-feature`, consumes them and cleans them up at the end.
+
+A sub-issue is "self-contained" in the sense that **README + that sub-issue together** give a
+fresh agent (plus the linked issue/ADR) everything needed to implement the slice cold. Shared
+context lives once in the README; each sub-issue carries only what is specific to it.
+
+## Steps
+
+### 1. Gather context
+
+- Fetch the issue with `gh` (accept a URL or a number). Read the title, body, and discussion.
+- If the issue links an ADR, read it. Don't write ADRs here — if the work hinges on an
+  undocumented, hard-to-reverse decision, the grill step (below) is where it surfaces and an ADR
+  gets filed.
+- Read the relevant architecture page(s) under [`docs/architecture/`](../../../docs/architecture/),
+  starting from [`docs/architecture.md`](../../../docs/architecture.md). The docs are the source
+  of truth for *why* the system is shaped the way it is.
+- Explore the codebase to ground the plan in real files, modules, and seams. Use the `Explore`
+  agent for breadth.
+
+### 2. Grill
+
+Invoke `/grill-with-adr` with the user to resolve every unknown that affects the plan — scope,
+boundaries, edge cases, where things live, naming. It pressure-tests vocabulary and architecture
+against the domain model and files or amends an ADR when a decision warrants it. Walk down each
+branch of the decision tree until you reach a solid, shared understanding. Do not skip this; the
+quality of the plan depends on it.
+
+### 3. Decompose and get sign-off
+
+Decide how the feature splits into sub-issues:
+
+- **Split only along independently-shippable seams** — e.g. one slice for tRPC methods, one for
+  API endpoints, one for UI. (Illustrative, not a fixed taxonomy.)
+- **Do not split artificially.** If the feature is small, a single sub-issue is correct. Each
+  sub-issue should be sized to roughly one atomic commit's worth of work — big enough to be
+  meaningful, small enough for an agent to implement comfortably.
+
+Present the **decomposition outline** to the user and wait for explicit approval before writing
+the detailed files:
+
+- Feature summary (1–2 sentences).
+- The sub-issue list: number, title, one-line scope, and dependency order.
+
+### 4. Write the files
+
+Create `docs/plan/<feature-slug>/`. Derive the slug from the issue title, prefixed with the
+issue number for traceability (e.g. `docs/plan/344-egress-cli/`). Write `README.md` and one
+`NN-slug.md` per sub-issue (`01-`, `02-`, … to encode order), using the templates below.
+
+While drafting, keep the plan architecturally sound and consistent with existing code:
+
+- Apply `/typescript-engineering` (server-side TS) and `/react-ui-engineering` (UI,
+  `packages/ui`), and name the relevant skill inside each sub-issue so the implementing agent
+  applies it too.
+- **Don't prescribe new tests.** The implementing agent doesn't author tests by default;
+  verification leans on the **existing** suite (`mise run test` / `mise run check`) plus a
+  **manual** smoke test. Call for a new test only when behavior is otherwise unverifiable (e.g. a
+  pure algorithm with tricky edges and no manual smoke path) — and flag it as the exception.
+
+### 5. Report
+
+Print where the plan lives and a one-paragraph summary of the sub-issues and their order. Remind
+the user the files are uncommitted working artifacts, and that `/implement-feature` is the next
+step.
+
+## README.md template
+
+```markdown
+# <Feature title>
+
+> Working plan — uncommitted, temporary. Delete once the feature ships.
+
+**Issue:** <link>
+**ADR:** <link, or "none">
+
+## Goal
+
+<What we're building and why, from the issue + grill. User-visible outcome.>
+
+## Approach
+
+<Overall architecture and how the feature fits the system. Reference the architecture
+page(s) it touches. The shared context every sub-issue assumes.>
+
+## Sub-issues
+
+| #  | Title | Scope | Depends on |
+|----|-------|-------|------------|
+| 01 | …     | …     | —          |
+| 02 | …     | …     | 01         |
+
+<If the order isn't linear, add a Mermaid dependency graph. Omit this whole section if the
+feature is a single sub-issue.>
+
+## Conventions & glossary
+
+<Shared terms and definitions, conventions, and the engineering skills the implementing agent
+must apply: /typescript-engineering, /react-ui-engineering.>
+
+## Whole-feature smoke test
+
+<End-to-end check that the assembled feature works, once all sub-issues are done.>
+
+## Delivery
+
+Each sub-issue is one atomic commit. The whole feature lands as a single PR for <issue link>.
+```
+
+## Sub-issue template (`NN-slug.md`)
+
+```markdown
+# NN — <title>
+
+**Depends on:** <NN-slug, or omit this line if standalone>
+**Part of:** <feature> — see [README](./README.md)
+
+## Context
+
+<One paragraph: what this slice is and why. Everything beyond this lives in the README.>
+
+## Implementation plan
+
+<Detailed, ordered steps with real file paths. Concrete enough that a fresh agent can follow
+them without rediscovering the design. Apply the /typescript-engineering skill (server-side TS)
+and/or /react-ui-engineering skill (UI) while implementing.>
+
+## Acceptance criteria
+
+<Checks the implementing agent validates before declaring the slice done. Phrase each as
+something verifiable, not aspirational.>
+
+- [ ] …
+- [ ] …
+
+## Smoke test
+
+<A concrete, runnable check that proves *this slice* works using what already exists — a
+`mise run test`/`check` invocation against the **current** suite, a CLI/tRPC call with expected
+output, or a manual `mise run cluster:*` step. Never "verify it works," and never "add a test
+that …" — the smoke test exercises existing checks and manual steps, it does not author new
+tests.>
+
+The implementing agent runs this itself, then prints a short manual smoke-test guide so the
+user can confirm it by hand.
+```

--- a/.claude/skills/implement-feature
+++ b/.claude/skills/implement-feature
@@ -1,0 +1,1 @@
+../../.agents/skills/implement-feature

--- a/.claude/skills/plan-feature
+++ b/.claude/skills/plan-feature
@@ -1,0 +1,1 @@
+../../.agents/skills/plan-feature


### PR DESCRIPTION
Two paired skills for the feature workflow:

- **plan-feature** — turns a GitHub issue into an ephemeral plan (spec + self-contained sub-issues) under `docs/plan/<feature>/`.
- **implement-feature** — consumes that plan one reviewed sub-issue at a time, landing the feature as a single PR.