### PR TITLE
docs(adr): add ADR-058 superseding ADR-006 (CRDs over ConfigMaps)

### DIFF
--- a/docs/adrs/058-crds-over-configmaps.md
+++ b/docs/adrs/058-crds-over-configmaps.md
@@ -1,7 +1,7 @@
 # ADR-058: CRDs over ConfigMaps — reconciled resources become custom resources
 
 **Date:** 2026-06-03
-**Status:** Proposed
+**Status:** Accepted
 **Owner:** @jezekra1
 
 ## Context
@@ -14,7 +14,7 @@
 
 - **Scope.** Agent and Fork become CRDs with a status subresource (both are reconciled). Template stays a ConfigMap — it is chart-rendered, read-only at runtime, and never reconciled, so it earns neither a status subresource nor migration cost. Schedules remain in Postgres, unchanged.
 - **Eliminate the desired-state latch.** "Running" is no longer stored intent. Wake is a one-off activity poke; the controller hibernates on idleness and records running-vs-hibernated as observed status. This removes the only field both parties wrote and restores single-writer ownership by elimination, not negotiation.
-- **Field placement.** Connection and secret grants are intent and move into `spec` (they were annotations only to avoid rewriting the opaque ConfigMap spec blob; a structured CRD spec removes that reason). High-frequency signals — activity timestamp, active-session, secrets-revision — stay annotations: independently patchable, not part of the agent definition, and not subject to the spec/status writer split.
+- **Field placement.** Connection and secret grants are intent and move into `spec` (they were annotations only to avoid rewriting the opaque ConfigMap spec blob; a structured CRD spec removes that reason). High-frequency, out-of-band signals — activity timestamp, active-session, secrets-revision, and the api-server-set roll trigger that forces a rolling restart/re-render — stay annotations: independently patchable, not part of the agent definition, and not subject to the spec/status writer split.
 - **One validation point.** The CRD schema is authored Go-first; the K8s API server validates at admission. The controller and api-server consume generated types for typing only and do not re-validate the resource shape. Cross-field and referential rules stay application logic.
 - **Bundling.** The CRD ships as a values-gated templated chart manifest so `helm upgrade` propagates schema changes — not the non-upgradable `crds/` directory, and not a controller self-install. Templates-as-ConfigMaps keeps the chart free of custom-resource instances, so no CRD-before-CR install ordering hazard exists.
 - **Schema evolution without conversion webhooks.** Agent/Fork CRs are single-writer (api-server) and co-released with the controller, so there is no version skew to bridge. Evolve additively under one served and stored version; for a breaking change, use expand/contract with a Helm post-upgrade backfill (spec backfill runs from the api-server, status backfill from the controller). A conversion webhook plus storage-version migration is the documented escalation, valid only if Agent/Fork CRs ever become externally authored.

--- a/docs/adrs/058-crds-over-configmaps.md
+++ b/docs/adrs/058-crds-over-configmaps.md
@@ -1,0 +1,41 @@
+# ADR-058: CRDs over ConfigMaps — reconciled resources become custom resources
+
+**Date:** 2026-06-03
+**Status:** Proposed
+**Owner:** @jezekra1
+
+## Context
+
+[ADR-006](006-configmaps-over-crds.md) chose labeled ConfigMaps over CRDs for one reason: CRDs require cluster-admin to install, which blocked namespace-scoped (OpenShift) deployments. That constraint no longer holds — every current deployment target realistically grants cluster-admin or CRD-install permission, and ADR-006 explicitly anticipated being revisited if it lifted. With the blocker gone, the ConfigMap model's costs are unmitigated: no schema validation at the K8s layer (the spec shape is validated twice in app code — Zod on write, Go parse on read), weak `kubectl` UX, and write contention avoided only by convention. The spec/status split is already leaky — the controller rewrites `spec.yaml` in the idle-hibernation path, contradicting the documented "controller never writes spec" invariant.
+
+## Decision
+
+**Migrate the controller-reconciled domain resources — Agent and Fork — from labeled ConfigMaps to Kubernetes CRDs with a status subresource. Templates stay ConfigMaps.** The rules and boundaries:
+
+- **Scope.** Agent and Fork become CRDs with a status subresource (both are reconciled). Template stays a ConfigMap — it is chart-rendered, read-only at runtime, and never reconciled, so it earns neither a status subresource nor migration cost. Schedules remain in Postgres, unchanged.
+- **Eliminate the desired-state latch.** "Running" is no longer stored intent. Wake is a one-off activity poke; the controller hibernates on idleness and records running-vs-hibernated as observed status. This removes the only field both parties wrote and restores single-writer ownership by elimination, not negotiation.
+- **Field placement.** Connection and secret grants are intent and move into `spec` (they were annotations only to avoid rewriting the opaque ConfigMap spec blob; a structured CRD spec removes that reason). High-frequency signals — activity timestamp, active-session, secrets-revision — stay annotations: independently patchable, not part of the agent definition, and not subject to the spec/status writer split.
+- **One validation point.** The CRD schema is authored Go-first; the K8s API server validates at admission. The controller and api-server consume generated types for typing only and do not re-validate the resource shape. Cross-field and referential rules stay application logic.
+- **Bundling.** The CRD ships as a values-gated templated chart manifest so `helm upgrade` propagates schema changes — not the non-upgradable `crds/` directory, and not a controller self-install. Templates-as-ConfigMaps keeps the chart free of custom-resource instances, so no CRD-before-CR install ordering hazard exists.
+- **Schema evolution without conversion webhooks.** Agent/Fork CRs are single-writer (api-server) and co-released with the controller, so there is no version skew to bridge. Evolve additively under one served and stored version; for a breaking change, use expand/contract with a Helm post-upgrade backfill (spec backfill runs from the api-server, status backfill from the controller). A conversion webhook plus storage-version migration is the documented escalation, valid only if Agent/Fork CRs ever become externally authored.
+- **Cutover is big-bang.** No data migration from existing ConfigMaps — a CRD is a different Kind, which CRD versioning cannot bridge regardless.
+
+## Alternatives Considered
+
+- **Keep ConfigMaps (ADR-006)** — its sole rationale (no cluster-admin) no longer applies, while its costs (no API-layer validation, leaky spec/status) persist.
+- **Template as a CRD** — not reconciled and chart-shipped; a CRD without a controller is a typed envelope earning only validation, which the create-time copy into a (validated) Agent already provides.
+- **Template to Postgres** — needs an imperative seed/upgrade job and loses the declarative Helm lifecycle for what is operator-authored install config.
+- **Conversion webhook for schema evolution** — solves external-client version skew the platform does not have; adds a TLS webhook service for no benefit.
+- **Controller self-installs the CRD on boot** — couples schema lifecycle to a cluster-scoped RBAC grant and is GitOps-unfriendly; a Helm-owned CRD keeps the lifecycle declarative.
+
+## Consequences
+
+- **Easier:** malformed specs are rejected by the K8s API at write time, closing the validation gap ADR-006 named; the controller drops its parse-and-validate step (the typed client deserializes); `kubectl get`/`describe` gain real status columns; the single-writer invariant becomes true once no shared desired-state field exists, removing the idle-hibernation spec-write the docs already contradict.
+- **Harder:** a build step must generate the CRD schema and consumer types, and CI must fail on drift across Go and TS; CRD installation requires cluster-admin at install time, dropping namespace-scoped install as a supported target — the capability ADR-006 protected is deliberately given up; a breaking schema change now costs a two-release expand/contract with a backfill Job rather than a free in-place edit.
+- **Committed-to:** cluster-admin (or CRD-install permission) is required in every deployment target; the api-server remains the sole writer of Agent/Fork CRs — the moment they become externally authored, the no-webhook migration policy is invalid and the conversion-webhook escalation becomes mandatory; running-vs-hibernated is derived status and never stored intent, so any future "pin always-on" or "suspend" capability must add an explicit spec field.
+
+## Supersedes
+
+- **ADR-006** (ConfigMaps over CRDs) — its rationale is preserved for historical reading; the canonical position is this ADR.
+
+This ADR also revises the field-placement specifics of [ADR-046](046-eliminate-instance.md) — grants move from annotations into `spec`, and the `desiredState` field it carried over is eliminated — without disturbing ADR-046's core decision (Instance collapsed into Agent). The persistence-doc refinement rule ("belongs on a ConfigMap iff the controller reconciles it") and the "controller never writes spec" invariant need correcting in the architecture docs; those are doc edits handled outside this ADR.

--- a/docs/adrs/059-agent-readiness-status.md
+++ b/docs/adrs/059-agent-readiness-status.md
@@ -1,0 +1,35 @@
+# ADR-059: Agent readiness is controller-computed status — agent ∧ gateway
+
+**Date:** 2026-06-03
+**Status:** Proposed
+**Owner:** @jezekra1
+
+## Context
+
+[ADR-032](032-pod-reachability-primitive.md) made the *live, observed agent-pod `Ready` condition* the source of truth for "can I call this pod?" via a hot-path `ensureReady` probe, and explicitly **deferred** a reconciler-maintained lifecycle state as "valuable later … can be layered on top." Two things now force that "later": [ADR-058](058-crds-over-configmaps.md) gives the Agent a real status subresource and eliminates `desiredState`, and ADR-032's probe observes **only the agent pod** — an agent whose paired gateway pod ([ADR-038](038-paired-gateway-pod.md)) is NotReady has no credentialed egress yet still reads as `Ready`. (ADR-032 is itself still Proposed and owned by @janjeliga — coordinate.)
+
+## Decision
+
+**The controller computes Agent readiness as the intersection of the agent and gateway pod `Ready` conditions and publishes it on the Agent status subresource; the api-server reads that condition as the authoritative routing signal instead of probing pods itself.**
+
+- `Ready` is the agent-and-gateway intersection: both pods of the pair must be Ready. The controller is the sole computor — it is the only component that already observes both pods of the pair.
+- Conditions are the source of truth (`Ready`, `AgentPodReady`, `GatewayPodReady`, `Reconciled`). The status phase is a derived, non-authoritative human summary; no machine consumer branches on it.
+- The api-server's readiness/wake path becomes "poke (bump activity) → wait for `Ready`", with **no pod probing in the api-server**. This composes with the activity-driven wake from ADR-058.
+- Because the published condition is eventually consistent, the api-server keeps a **live-probe fallback** when the condition is stale relative to the controller's observed generation, preserving ADR-032's freshness guarantee against a lagging controller.
+
+## Alternatives Considered
+
+- **Keep ADR-032's live agent-pod check** — misses the gateway dimension; the api-server cannot cheaply observe the paired gateway, so a "Ready" agent can still fail credentialed egress.
+- **api-server probes both pods itself** — duplicates pod-pairing logic in the api-server and adds a second hot-path probe; the controller already watches both pods.
+- **A single `phase` enum as the source of truth** — discouraged by K8s API conventions, not extensible, and conflates run intent (Running/Hibernated) with operational readiness, which are orthogonal axes.
+- **No freshness fallback — trust status unconditionally** — a stalled controller would strand every caller on stale readiness; ADR-032 chose live observation precisely to avoid that failure mode.
+
+## Consequences
+
+- **Easier:** the api-server reads one field and deletes its pod-probe primitive; readiness finally accounts for the gateway, so credentialed egress can no longer fail against an agent the platform reported Ready; `kubectl get agents` and the UI gain a real readiness column sourced from one place.
+- **Harder:** the controller must watch both pods' `Ready` transitions and write status promptly — a new pod-informer path and more frequent status writes than spec-driven reconciliation alone; readiness becomes eventually consistent, so the api-server must carry the staleness fallback to match the freshness ADR-032 had for free.
+- **Committed-to:** the controller is the single computor of agent readiness; if any caller ever needs sub-controller-latency readiness it must use the live fallback rather than reintroducing its own probe; "observed agent-pod Ready is the truth" (ADR-032) is replaced by "controller-computed agent ∧ gateway readiness is the truth."
+
+## Supersedes
+
+- **ADR-032** (pod-reachability primitive) — the `ensureReady` contract is preserved as the api-server's *fallback*, but the authoritative readiness signal moves to controller-computed status and now includes the gateway. ADR-032's rationale is retained for historical reading.

--- a/docs/adrs/059-agent-readiness-status.md
+++ b/docs/adrs/059-agent-readiness-status.md
@@ -1,7 +1,7 @@
 # ADR-059: Agent readiness is controller-computed status — agent ∧ gateway
 
 **Date:** 2026-06-03
-**Status:** Proposed
+**Status:** Accepted
 **Owner:** @jezekra1
 
 ## Context
@@ -10,26 +10,26 @@
 
 ## Decision
 
-**The controller computes Agent readiness as the intersection of the agent and gateway pod `Ready` conditions and publishes it on the Agent status subresource; the api-server reads that condition as the authoritative routing signal instead of probing pods itself.**
+**The controller computes Agent readiness as the intersection of the agent and gateway pod `Ready` conditions — each gated on the pod being current to its StatefulSet's latest rolled-out revision — and publishes it on the Agent status subresource; the api-server reads that condition as the *sole* routing signal and never touches pods.**
 
 - `Ready` is the agent-and-gateway intersection: both pods of the pair must be Ready. The controller is the sole computor — it is the only component that already observes both pods of the pair.
+- Readiness reflects the *observed rollout*, not an instantaneous pod check: a pod counts only when it is Ready **and** on the latest revision its StatefulSet has rolled out. A still-Ready pod that a pending change — restart, spec edit, credential set — is about to replace reads as not-ready, so readiness never flashes to Ready on a soon-to-be-replaced pod. The controller keeps no rollout state of its own; it compares live-read, Kubernetes-maintained revision fields.
 - Conditions are the source of truth (`Ready`, `AgentPodReady`, `GatewayPodReady`, `Reconciled`). The status phase is a derived, non-authoritative human summary; no machine consumer branches on it.
-- The api-server's readiness/wake path becomes "poke (bump activity) → wait for `Ready`", with **no pod probing in the api-server**. This composes with the activity-driven wake from ADR-058.
-- Because the published condition is eventually consistent, the api-server keeps a **live-probe fallback** when the condition is stale relative to the controller's observed generation, preserving ADR-032's freshness guarantee against a lagging controller.
+- The api-server's readiness/wake path becomes "poke (bump activity) → wait for `Ready`", with **no pod access in the api-server at all**: an absent or False `Ready` condition means not-ready, full stop. There is no live-probe fallback — the controller is the single source of readiness, so the api-server's pod-read primitive and its pod RBAC are removed entirely. This composes with the activity-driven wake from ADR-058.
 
 ## Alternatives Considered
 
 - **Keep ADR-032's live agent-pod check** — misses the gateway dimension; the api-server cannot cheaply observe the paired gateway, so a "Ready" agent can still fail credentialed egress.
 - **api-server probes both pods itself** — duplicates pod-pairing logic in the api-server and adds a second hot-path probe; the controller already watches both pods.
 - **A single `phase` enum as the source of truth** — discouraged by K8s API conventions, not extensible, and conflates run intent (Running/Hibernated) with operational readiness, which are orthogonal axes.
-- **No freshness fallback — trust status unconditionally** — a stalled controller would strand every caller on stale readiness; ADR-032 chose live observation precisely to avoid that failure mode.
+- **Keep ADR-032's live-probe as an api-server staleness fallback** — retains pod-pairing logic and pod RBAC in the api-server to cover controller lag; rejected because the pod-informer-driven status makes that lag window vanishingly small, and the least-privilege win of zero api-server pod access outweighs guarding an edge the platform has not observed. The fallback was specified in the original draft and removed during implementation.
 
 ## Consequences
 
-- **Easier:** the api-server reads one field and deletes its pod-probe primitive; readiness finally accounts for the gateway, so credentialed egress can no longer fail against an agent the platform reported Ready; `kubectl get agents` and the UI gain a real readiness column sourced from one place.
-- **Harder:** the controller must watch both pods' `Ready` transitions and write status promptly — a new pod-informer path and more frequent status writes than spec-driven reconciliation alone; readiness becomes eventually consistent, so the api-server must carry the staleness fallback to match the freshness ADR-032 had for free.
-- **Committed-to:** the controller is the single computor of agent readiness; if any caller ever needs sub-controller-latency readiness it must use the live fallback rather than reintroducing its own probe; "observed agent-pod Ready is the truth" (ADR-032) is replaced by "controller-computed agent ∧ gateway readiness is the truth."
+- **Easier:** the api-server reads one field and drops **all** pod access — its pod-probe primitive and pod RBAC are gone, shrinking its footprint to Secrets + the Agent/Fork CRs + PVC cleanup (least privilege); readiness accounts for the gateway *and* rollout state, so it never reports Ready against a pod with no credentialed egress or one mid-replacement; `kubectl get agents` and the UI gain a real readiness column sourced from one place.
+- **Harder:** the controller must watch both pods' `Ready` transitions and write status promptly — a pod-informer path and more frequent status writes than spec-driven reconciliation alone; readiness is eventually consistent with **no** api-server fallback, so a stalled controller strands callers on stale readiness — accepted because the pod-informer path is prompt and the api-server has no cheap way to observe the paired gateway anyway.
+- **Committed-to:** the controller is the *sole* source of agent readiness — there is no fallback; any future need for sub-controller-latency readiness must make the controller prompter, never reintroduce an api-server pod probe; "observed agent-pod Ready is the truth" (ADR-032) is replaced by "controller-computed agent ∧ gateway readiness, gated on the rolled-out revision, is the truth."
 
 ## Supersedes
 
-- **ADR-032** (pod-reachability primitive) — the `ensureReady` contract is preserved as the api-server's *fallback*, but the authoritative readiness signal moves to controller-computed status and now includes the gateway. ADR-032's rationale is retained for historical reading.
+- **ADR-032** (pod-reachability primitive) — fully superseded: the `ensureReady` pod-probe is removed from the api-server, not retained as a fallback. The authoritative — and only — readiness signal is controller-computed status, which now includes the gateway and the rolled-out revision. ADR-032's rationale is retained for historical reading.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -11,7 +11,7 @@ This directory contains ADRs for the Platform project.
 | [003](003-k8s-from-the-start.md)              | Kubernetes from the start — k3s for local dev, K8s for production | @jezekra1 |
 | [004](004-acp-over-a2a.md)                    | ACP over A2A for the experiment | @tomkis |
 | [005](005-credential-gateway.md)              | Gateway pattern for credentials — agent never sees tokens | @pilartomas |
-| [006](006-configmaps-over-crds.md)            | ConfigMaps over CRDs — namespace-scoped resource model | @jezekra1 |
+| [006](006-configmaps-over-crds.md)            | ConfigMaps over CRDs — namespace-scoped resource model — superseded by ADR-058 | @jezekra1 |
 | [007](007-acp-relay.md)                       | ACP traffic always proxied through the API Server | @tomkis |
 | [008](008-trigger-files.md)                   | Controller-owned cron with exec-based trigger delivery | @jezekra1 |
 | [009](009-go-and-typescript.md)               | Go for Controller, TypeScript for API Server | @jezekra1 |
@@ -37,7 +37,7 @@ This directory contains ADRs for the Platform project.
 | [029](029-per-instance-channels.md)           | Per-instance messenger channels — secrets in k8s Secrets, per-thread authorization | @pilartomas |
 | [030](030-skills-marketplace.md)              | Skills — connectable sources and install | @PetrBulanek |
 | [031](031-schedule-rrule-quiet-hours.md)      | Schedules use RRULE for includes and structured quiet hours for exclusions | @jezekra1 |
-| [032](032-pod-reachability-primitive.md)      | Centralized pod-reachability primitive; observed pod Ready is the truth | @janjeliga |
+| [032](032-pod-reachability-primitive.md)      | Centralized pod-reachability primitive; observed pod Ready is the truth — superseded by ADR-059 | @janjeliga |
 | [033](033-envoy-credential-gateway.md)        | Envoy-based credential gateway with ext_authz HITL — drop OneCLI | @pilartomas |
 | [035](035-unified-hitl-ux.md)                 | Unified HITL UX — verdict authority outside the agent pod | @jezekra1 |
 | [036](036-redis-platform-primitive.md)        | Redis as a platform primitive — pub/sub, queues, cache | @jezekra1 |
@@ -62,6 +62,8 @@ This directory contains ADRs for the Platform project.
 | [055](055-agent-owned-session-metadata.md)    | Agent-owned session metadata via ACP `_meta`; no server-side session store | @jezekra1 |
 | [056](056-browser-driven-e2e.md)              | Browser-driven E2E tracer with values-gated test affordances | @tomkis |
 | [057](057-structured-logging.md)              | Structured logging for the api-server — Pino, JSON to stdout, security audit trail as first consumer | @pilartomas |
+| [058](058-crds-over-configmaps.md)            | CRDs over ConfigMaps — reconciled resources become custom resources | @jezekra1 |
+| [059](059-agent-readiness-status.md)          | Agent readiness is controller-computed status — agent ∧ gateway | @jezekra1 |
 
 ## Drafts
 


### PR DESCRIPTION
## What

Adds **ADR-058 — CRDs over ConfigMaps** (status: **Proposed**), superseding [ADR-006](../blob/main/docs/adrs/006-configmaps-over-crds.md). Docs-only; no code or architecture-doc migration in this PR.

## Why

ADR-006 chose labeled ConfigMaps because CRDs needed cluster-admin to install, blocking namespace-scoped (OpenShift) deployments. That constraint no longer holds — every current deployment target grants cluster-admin or CRD-install permission. ADR-006 anticipated being revisited if it lifted.

## The decision (for review)

- **Agent + Fork → CRDs** with a status subresource (both are reconciled). **Template stays a ConfigMap** — chart-rendered, read-only, never reconciled. Schedules stay in Postgres.
- **Eliminate the `desiredState` latch** → activity-driven hibernation. Wake is a one-off poke; running-vs-hibernated becomes derived `status`. This restores the "controller never writes spec" invariant by elimination (today `idlechecker` violates it).
- **Grants move into `spec`** (intent); activity/active-session/secrets-rev signals stay annotations.
- **One validation point** — Go-first schema, K8s validates at admission; controller + api-server consume generated types, no app-layer re-validation.
- **Bundling** — values-gated templated CRD manifest (cert-manager style), upgradable via `helm upgrade`.
- **Schema evolution** — additive-only + expand/contract with a Helm post-upgrade backfill. **No conversion webhook** (CRs are single-writer/co-released — no version skew). Webhook + storage-version migration documented as the escalation *if* CRs ever become externally authored.
- **Cutover is big-bang** — no data migration from existing ConfigMaps.

## Not in this PR

- Architecture-doc + glossary corrections (`persistence.md`, `platform-topology.md`, `ubiquitous-language.md`) and two known drifts (label is `agent-platform.ai/type`; schedules are Postgres) — to follow.
- `006`'s status line left untouched pending the immutability call.
- Implementation (controller/api-server/Helm) — see the effort breakdown in the ADR thread.