### PR TITLE
feat(brand): tagline tab title + consistent DAM casing

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -241,6 +241,8 @@ spec:
               value: {{ .Values.brand.name | quote }}
             - name: BRAND_SHORT
               value: {{ .Values.brand.short | quote }}
+            - name: BRAND_TAGLINE
+              value: {{ .Values.brand.tagline | quote }}
             - name: BRAND_THEME_LIGHT_ACCENT
               value: {{ .Values.brand.theme.light.accent | quote }}
             - name: BRAND_THEME_LIGHT_ACCENT_HOVER

--- a/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
+++ b/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
@@ -13,6 +13,7 @@ data:
   platform-realm.json: |-
     {
       "realm": {{ .Values.keycloak.realm | quote }},
+      "displayName": {{ .Values.brand.name | quote }},
       "enabled": true,
       "loginTheme": "platform",
       "sslRequired": {{ if eq .Values.scheme "https" }}"external"{{ else }}"none"{{ end }},

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -5,13 +5,17 @@
 # ("agent-platform.ai/...") are permanent and unrelated to brand; this
 # section is the only knob users see.
 brand:
-  # Display name shown in the UI title bar, PWA manifest, OAuth dynamic
-  # client_name, and skill-publish git author.
-  name: Dam
+  # Display name shown in the PWA manifest, OAuth dynamic client_name,
+  # skill-publish git author, and the Keycloak realm display name (sign-in
+  # heading + tab title).
+  name: DAM
   # Lowercase identifier (DNS/URL-safe). Used for the Slack slash command
   # (`/<short> login`), GitHub publish branch prefix, and git-author email
   # local-part.
   short: dam
+  # Marketing tagline shown as the browser tab title in the web app (the
+  # `name` expansion). Empty string falls back to `name`.
+  tagline: "Deploy Agents Massively"
   # UI theme — applied at runtime as CSS custom properties so a brand
   # change requires no UI rebuild.
   theme:

--- a/packages/api-server-api/src/modules/brand/types.ts
+++ b/packages/api-server-api/src/modules/brand/types.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 export const brandSchema = z.object({
   name: z.string(),
   short: z.string(),
+  tagline: z.string(),
   theme: z.object({
     light: z.object({
       accent: z.string(),

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -185,6 +185,7 @@ export function loadConfig(): Config {
     brand: {
       name: process.env.BRAND_NAME ?? "Platform",
       short: process.env.BRAND_SHORT ?? "platform",
+      tagline: process.env.BRAND_TAGLINE ?? "",
       theme: {
         light: {
           accent: process.env.BRAND_THEME_LIGHT_ACCENT ?? "#1D6BE1",

--- a/packages/keycloak-theme/src/login/Template.tsx
+++ b/packages/keycloak-theme/src/login/Template.tsx
@@ -9,7 +9,7 @@ import { useApplyThemeScript } from "./hooks/use-apply-theme-script.js";
 import type { I18n } from "./i18n.js";
 import type { KcContext } from "./KcContext.js";
 
-const APP_NAME = import.meta.env.VITE_APP_NAME ?? "Dam";
+const APP_NAME = import.meta.env.VITE_APP_NAME ?? "DAM";
 
 export default function Template(props: TemplateProps<KcContext, I18n>) {
   const {
@@ -29,8 +29,8 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
 
   useEffect(() => {
     document.title =
-      documentTitle ?? msgStr("loginTitle", realm.displayName || realm.name);
-  }, [documentTitle, msgStr, realm.displayName, realm.name]);
+      documentTitle ?? msgStr("loginTitle", realm.displayName || APP_NAME);
+  }, [documentTitle, msgStr, realm.displayName]);
 
   useSetClassName({ qualifiedName: "html", className: "" });
   useSetClassName({ qualifiedName: "body", className: "" });

--- a/packages/keycloak-theme/src/login/Template.tsx
+++ b/packages/keycloak-theme/src/login/Template.tsx
@@ -9,7 +9,10 @@ import { useApplyThemeScript } from "./hooks/use-apply-theme-script.js";
 import type { I18n } from "./i18n.js";
 import type { KcContext } from "./KcContext.js";
 
-const APP_NAME = import.meta.env.VITE_APP_NAME ?? "DAM";
+// Brand shown on the auth screens comes from the realm `displayName` at
+// runtime (Helm `brand.name`). This is only the fallback for when it's
+// absent — e.g. the local mocked-kcContext dev preview.
+const BRAND_FALLBACK = "Platform";
 
 export default function Template(props: TemplateProps<KcContext, I18n>) {
   const {
@@ -29,7 +32,8 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
 
   useEffect(() => {
     document.title =
-      documentTitle ?? msgStr("loginTitle", realm.displayName || APP_NAME);
+      documentTitle ??
+      msgStr("loginTitle", realm.displayName || BRAND_FALLBACK);
   }, [documentTitle, msgStr, realm.displayName]);
 
   useSetClassName({ qualifiedName: "html", className: "" });
@@ -96,4 +100,4 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
   );
 }
 
-export { APP_NAME };
+export { BRAND_FALLBACK };

--- a/packages/keycloak-theme/src/login/pages/Login.tsx
+++ b/packages/keycloak-theme/src/login/pages/Login.tsx
@@ -34,7 +34,7 @@ export default function Login(
       doUseDefaultCss={doUseDefaultCss}
       classes={classes}
       displayMessage={!usernameError}
-      headerNode={`Sign in to ${APP_NAME}`}
+      headerNode={`Sign in to ${realm.displayName || APP_NAME}`}
     >
       {realm.password && (
         <form

--- a/packages/keycloak-theme/src/login/pages/Login.tsx
+++ b/packages/keycloak-theme/src/login/pages/Login.tsx
@@ -8,7 +8,7 @@ import { Label } from "../../components/label.js";
 import { SocialProviderButton } from "../components/social-provider-button.js";
 import type { I18n } from "../i18n.js";
 import type { KcContext } from "../KcContext.js";
-import { APP_NAME } from "../Template.js";
+import { BRAND_FALLBACK } from "../Template.js";
 
 export default function Login(
   props: PageProps<Extract<KcContext, { pageId: "login.ftl" }>, I18n>,
@@ -34,7 +34,7 @@ export default function Login(
       doUseDefaultCss={doUseDefaultCss}
       classes={classes}
       displayMessage={!usernameError}
-      headerNode={`Sign in to ${realm.displayName || APP_NAME}`}
+      headerNode={`Sign in to ${realm.displayName || BRAND_FALLBACK}`}
     >
       {realm.password && (
         <form

--- a/packages/keycloak-theme/vite.config.ts
+++ b/packages/keycloak-theme/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from "vite";
 export default defineConfig({
   define: {
     "import.meta.env.VITE_APP_NAME": JSON.stringify(
-      process.env.APP_NAME ?? "Dam",
+      process.env.APP_NAME ?? "DAM",
     ),
   },
   plugins: [

--- a/packages/keycloak-theme/vite.config.ts
+++ b/packages/keycloak-theme/vite.config.ts
@@ -4,11 +4,6 @@ import { keycloakify } from "keycloakify/vite-plugin";
 import { defineConfig } from "vite";
 
 export default defineConfig({
-  define: {
-    "import.meta.env.VITE_APP_NAME": JSON.stringify(
-      process.env.APP_NAME ?? "DAM",
-    ),
-  },
   plugins: [
     react(),
     tailwindcss(),

--- a/packages/ui/src/brand.ts
+++ b/packages/ui/src/brand.ts
@@ -16,6 +16,7 @@ import { type Brand, brandSchema } from "api-server-api";
 const FALLBACK: Brand = {
   name: "Platform",
   short: "platform",
+  tagline: "",
   theme: {
     light: {
       accent: "#1D6BE1",
@@ -72,7 +73,7 @@ function setSafe(el: HTMLElement, prop: string, value: string): void {
 }
 
 export function applyBrand(brand: Brand): void {
-  document.title = brand.name;
+  document.title = brand.tagline || brand.name;
 
   const themeMeta = document.querySelector<HTMLMetaElement>(
     'meta[name="theme-color"]',


### PR DESCRIPTION
## What

Closes #443 — fixes the browser tab text on both surfaces, and makes the brand casing consistent ("DAM") with a single runtime source.

### Tab titles (#443)
- **Web app** tab now shows the brand **tagline** ("Deploy Agents Massively") instead of the bare name.
- **Keycloak sign-in** heading and tab title now read **"Sign in to DAM"** (both were inconsistent before — heading said "Dam", tab said "platform").

### Brand consistency
- Helm `brand.name`: `Dam → DAM`. Propagates to the PWA manifest, OAuth dynamic `client_name`, skill-publish git author, and realm role descriptions.
- No hard-coded `Dam` literal remains anywhere in code/config.

## How it's wired

- **Tagline** is a new configurable field on the brand contract: `brandSchema.tagline` → `BRAND_TAGLINE` env → `/api/brand` → `getBrand()`. Helm sets it; the code default is `""` and the UI falls back to `brand.name` when empty (so no regression without Helm). Same flow as `name`/`short`/`theme`.
- **Keycloak** can't read `/api/brand` (its theme is a build-time artifact), so the brand reaches it through the **realm `displayName`**, set from `brand.name` in the realm ConfigMap. The theme reads `kcContext.realm.displayName` at runtime for both the heading and the tab title. The `post-upgrade` provision job applies the realm state idempotently, so `helm upgrade` pushes the new `displayName`.
- Removed the theme's dead build-time `VITE_APP_NAME`/`process.env.APP_NAME` indirection (nothing ever set `APP_NAME` at build); the only fallback now is a neutral `"Platform"` for local mocked-context preview.

## Heads-up

External-facing surfaces now read "DAM" (greenlit as "brand consistent everywhere"): OAuth consent screens show `DAM Agent Platform`, and generated skill-publish PR bodies say `Published from DAM.`

## Commits
1. `feat(brand): tagline tab title + consistent DAM casing`
2. `refactor(keycloak-theme): drop dead build-time APP_NAME indirection`

## Verification
- tsc + lint + format pass on api-server-api, api-server, ui, keycloak-theme.
- `helm lint` + `kubeconform` render clean; rendered output confirms `displayName: "DAM"`, `BRAND_NAME: "DAM"`, `BRAND_TAGLINE: "Deploy Agents Massively"`.
- Verified in the running cluster.
