### PR TITLE
fix(keycloak): work around 26.6 gzip-cache 404 on non-root UID

### DIFF
--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -83,6 +83,16 @@ spec:
                   key: KEYCLOAK_ADMIN_PASSWORD
             - name: KC_HEALTH_ENABLED
               value: "true"
+            # Keycloak 26.6/26.6.1 ship /opt/keycloak/data/tmp root-owned and
+            # not group-writable, so under a non-root UID (OpenShift's
+            # arbitrary SCC UID) the gzip resource cache fails to initialise and
+            # every static /resources/* asset 404s under `Accept-Encoding: gzip`
+            # — i.e. in every browser (keycloak/keycloak#48566). Point the io
+            # tmpdir at world-writable /tmp so the cache initialises under any
+            # UID. The cache holds only public theme assets. Remove once on
+            # Keycloak >= 26.7.0 (fix: keycloak/keycloak#48608).
+            - name: JAVA_OPTS_APPEND
+              value: "-Dkc.io.tmpdir=/tmp"
             - name: KC_LOG_CONSOLE_OUTPUT
               value: {{ .Values.keycloak.log.consoleOutput | quote }}
             - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL


### PR DESCRIPTION
## Problem

On the first remote (OpenShift) deploy, the Keycloak login page renders blank/unstyled. The theme's JS/CSS bundle 404s **only when the request carries `Accept-Encoding: gzip`** (which every browser sends); `identity`/`br`/`zstd` and `curl`/HEAD all return 200, which is why it looked fine via `curl` and port-forward but broke in browsers.

## Root cause

Upstream regression **[keycloak/keycloak#48566](https://github.com/keycloak/keycloak/issues/48566)**: the `quay.io/keycloak/keycloak:26.6 / 26.6.1` images ship `/opt/keycloak/data/tmp` root-owned and not group-writable. Under a **non-root UID** — i.e. OpenShift's arbitrary restricted-SCC UID — `GzipResourceEncodingProviderFactory` can't create its cache dir, logs only a WARN, and then returns a bare **404 for every static `/resources/*` asset under `Accept-Encoding: gzip`**.

Why it only bit us now:
- **`/realms/*` (dynamic) is unaffected** → page HTML loads, only the static bundle 404s (this is the "why only `/resources`?" tell — it uses the gzip cache, dynamic endpoints don't).
- **Local works**: k3s runs the pod as a UID that can write the dir, and `start-dev` doesn't use the gzip cache; **OpenShift's non-root UID** can't write it.
- **Surfaced now** because we switched to our own keycloakify image: the login became a React SPA that hard-depends on its JS bundle, so the latent gzip-cache failure went from invisible (stock HTML degrades without CSS) to fatal. Also rides on the `26.6.2-2` base bumped in #553.

## Fix

Set `JAVA_OPTS_APPEND=-Dkc.io.tmpdir=/tmp` on the Keycloak deployment so the gzip cache initialises under any UID (the maintainer-documented workaround #1). The cache holds only **public theme assets**; `/tmp` is sticky (`1777`) and per-pod ephemeral, so this is non-sensitive and adds no new exposure (a world-writable-`/tmp` attack needs a second hostile process *inside* the pod = already a full compromise).

Drop this once we move to **Keycloak >= 26.7.0** ([fix PR keycloak#48608](https://github.com/keycloak/keycloak/pull/48608)).

## Verification

- `helm lint` + `kubeconform` render clean; rendered Keycloak env carries `JAVA_OPTS_APPEND=-Dkc.io.tmpdir=/tmp`.
- Diagnosis confirmed against dev: `/resources/.../dist/assets/*.js` → 404 with `Accept-Encoding: gzip`, 200 without; `/realms/*` HTML → 200 with gzip; pod serves the asset 200 directly. Matches #48566 exactly.
- **Final confirmation is the dev redeploy** — after this lands and dev picks up the env, the login page should load styled.

## Alternative considered

Dockerfile `chown -R 1000:0 /opt/keycloak/data && chmod -R g+rwX` (more OpenShift-idiomatic, fixes image perms directly). Chose the env var as the smaller, reversible change; easy to swap if preferred.
