### PR TITLE
fix(skills): correct architecture overview path in grill-with-adr

### DIFF
--- a/.agents/skills/grill-with-adr/SKILL.md
+++ b/.agents/skills/grill-with-adr/SKILL.md
@@ -21,7 +21,7 @@ During codebase exploration, also look for related ADRs and existing documentati
 
 ### File
 
-- `docs/architecture/index.md` — the main system architecture overview
+- `docs/architecture.md` — the main system architecture overview
 - `docs/ubiquitous-language.md` — the glossary of domain terms and their definitions.
 - `docs/adrs/` — the directory of ADRs
 


### PR DESCRIPTION
## Problem

The `grill-with-adr` skill lists `docs/architecture/index.md` as "the main system architecture overview", but that file does not exist.

## Fix

Point the reference at `docs/architecture.md` — the actual canonical overview, which `CLAUDE.md` mandates as the starting point for understanding the system.

## Scope note

The `typescript-engineering/modes/*.md` files also reference `../architecture/index.md`, but those resolve correctly to the **skill-local** `.agents/skills/typescript-engineering/architecture/index.md` (which exists) — so they are intentionally left untouched.