### PR TITLE
fix(connections): restore dropped Spotify OAuth scopes

### DIFF
--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -216,11 +216,19 @@ function spotify(creds?: OAuthClientCredentials): OAuthConnectionTemplate {
     authorizationUrl: "https://accounts.spotify.com/authorize",
     tokenUrl: "https://accounts.spotify.com/api/token",
     scopes: [
-      "user-read-email",
       "user-read-private",
+      "user-read-email",
+      "playlist-read-private",
+      "playlist-read-collaborative",
+      "playlist-modify-private",
+      "playlist-modify-public",
       "user-library-read",
-      "user-modify-playback-state",
+      "user-library-modify",
+      "user-top-read",
+      "user-read-recently-played",
       "user-read-playback-state",
+      "user-modify-playback-state",
+      "user-read-currently-playing",
     ],
     contributions: [
       {


### PR DESCRIPTION
## Problem

The Spotify connector template was missing scopes — a regression. The unified Connections refactor (#381, commit `02c274fe`) moved the Spotify connector from `oauth-apps.ts` (`DEFAULT_SPOTIFY_SCOPES`) into `catalog.ts`, but trimmed the requested scope set from **13 down to 5** in the process. The dropped scopes cover all playlist access (read + write), library writes, top items, listening history, and the currently-playing track — so agents could no longer triage playlists, save tracks, or read recently-played items.

## Fix

Restore the 8 missing scopes to match the original `DEFAULT_SPOTIFY_SCOPES`:

| Scope | Capability |
|---|---|
| `playlist-read-private` | Read private playlists |
| `playlist-read-collaborative` | Read collaborative playlists |
| `playlist-modify-private` | Edit private playlists |
| `playlist-modify-public` | Edit public playlists |
| `user-library-modify` | Save/remove tracks & albums |
| `user-top-read` | Read top artists/tracks |
| `user-read-recently-played` | Read listening history |
| `user-read-currently-playing` | Read currently-playing track |

The deliberately-excluded scopes from the original (`streaming`, `ugc-image-upload`) remain excluded.

## Verification

`mise run check` passes (ran automatically via pre-commit hook).