### PR TITLE
fix(keycloak): mount writable emptyDir for gzip cache

### DIFF
--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -83,16 +83,6 @@ spec:
                   key: KEYCLOAK_ADMIN_PASSWORD
             - name: KC_HEALTH_ENABLED
               value: "true"
-            # Keycloak 26.6/26.6.1 ship /opt/keycloak/data/tmp root-owned and
-            # not group-writable, so under a non-root UID (OpenShift's
-            # arbitrary SCC UID) the gzip resource cache fails to initialise and
-            # every static /resources/* asset 404s under `Accept-Encoding: gzip`
-            # — i.e. in every browser (keycloak/keycloak#48566). Point the io
-            # tmpdir at world-writable /tmp so the cache initialises under any
-            # UID. The cache holds only public theme assets. Remove once on
-            # Keycloak >= 26.7.0 (fix: keycloak/keycloak#48608).
-            - name: JAVA_OPTS_APPEND
-              value: "-Dkc.io.tmpdir=/tmp"
             - name: KC_LOG_CONSOLE_OUTPUT
               value: {{ .Values.keycloak.log.consoleOutput | quote }}
             - name: KC_SPI_EVENTS_LISTENER_JBOSS_LOGGING_SUCCESS_LEVEL
@@ -129,4 +119,19 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.keycloak.resources | nindent 12 }}
+          volumeMounts:
+            - name: gzip-cache
+              mountPath: /opt/keycloak/data/tmp
+      volumes:
+        # Keycloak 26.6/26.6.1 ship /opt/keycloak/data/tmp root-owned and not
+        # group-writable (0755), so under a non-root UID — i.e. OpenShift's
+        # arbitrary SCC UID — GzipResourceEncodingProviderFactory can't create
+        # its cache dir, and from then on every static /resources/* theme asset
+        # 404s under `Accept-Encoding: gzip`, which every browser sends
+        # (keycloak/keycloak#48566). A writable emptyDir at that path lets the
+        # gzip cache initialise under any UID. It holds only the gzip cache of
+        # public theme assets — regenerable, non-sensitive. Drop once on
+        # Keycloak >= 26.7.0, which fixes the perms upstream (keycloak#48608).
+        - name: gzip-cache
+          emptyDir: {}
 {{- end }}


### PR DESCRIPTION
## Problem

The previous fix (#587, `JAVA_OPTS_APPEND=-Dkc.io.tmpdir=/tmp`) **did not work on dev** — the login still 404s its theme bundle under `Accept-Encoding: gzip`.

## Why #587 was a no-op

`kc.io.tmpdir` does **not** relocate Keycloak's gzip resource cache. That cache is created at `/opt/keycloak/data/tmp/kc-gzip-cache` by `GzipResourceEncodingProviderFactory`. In the 26.6/26.6.1 images that dir is **root-owned, mode 0755 (not group-writable)** while its parent `data/` is `0775`. Under a **non-root UID — OpenShift's arbitrary SCC UID** — the provider can't create the cache dir, logs only a WARN, and then returns a bare **404 for every `/resources/*` asset under gzip** ([keycloak#48566](https://github.com/keycloak/keycloak/issues/48566)). It surfaced only now because the keycloakify login is a React SPA that hard-requires its JS bundle (the stock login degraded gracefully without CSS).

## Fix

Mount a writable **`emptyDir` at `/opt/keycloak/data/tmp`** so the gzip cache initialises under any UID — independent of file ownership, the runtime UID, and read-only root filesystems. Removes the no-op env from #587. The volume holds only the regenerable gzip cache of **public theme assets** (non-sensitive).

Drop once on **Keycloak ≥ 26.7.0**, which fixes the perms upstream ([keycloak#48608](https://github.com/keycloak/keycloak/pull/48608)).

## Verification — reproduced and fixed locally (not inferred)

Reproduced the exact dev condition on local k3s: Keycloak in production `start`, forced to an OpenShift-faithful security context (arbitrary non-root **UID 12345 + `fsGroup`**), probed via the Service / a port-forward straight to the pod (Traefik masks gzip, so it's bypassed).

| Config | `gzip` asset | `GzipResourceEncodingProviderFactory` WARN |
|---|---|---|
| no fix | **404** | "Failed to create gzip cache directory" |
| `kc.io.tmpdir=/tmp` (#587) | **404** (still) | still firing |
| **emptyDir at data/tmp** | **200** (js + css) | gone; dir is writable |

- Reproduced symptom matches dev exactly (gzip 404 / identity 200) **and** the upstream issue's WARN.
- Under the fix, with `fsGroup` set, the emptyDir mounts writable and the gzip cache initialises.
- **Browser render** against the fixed pod (port-forward, real `Accept-Encoding: gzip`): the keycloakify login renders fully styled; assets `200`, only `/favicon.ico` 404s.
- `helm lint` + `kubeconform` pass; rendered keycloak Deployment carries the volume/mount and **no** `JAVA_OPTS_APPEND`.

Refs: keycloak/keycloak#48566. Supersedes the workaround from #587.
