### PR TITLE
fix(api-server): surface "Slack channel already bound" instead of raw SQL

### DIFF
--- a/packages/api-server/src/__tests__/unit/slack-channel-unique-violation.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-channel-unique-violation.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import { isSlackChannelUniqueViolation } from "../../modules/agents/infrastructure/channel-bindings-repository.js";
+
+// Shape of the postgres.js error raised when the partial unique index
+// `channels_slack_channel_unique_idx` is violated (one Slack channel per agent).
+const driverError = {
+  code: "23505",
+  constraint_name: "channels_slack_channel_unique_idx",
+};
+
+// Drizzle (>=0.44) re-throws driver failures wrapped in a DrizzleQueryError
+// whose message is `Failed query: ...` and which carries the original error on
+// `.cause`. This is what `connectSlack`'s catch block actually receives.
+class DrizzleQueryErrorLike extends Error {
+  cause: unknown;
+  constructor(cause: unknown) {
+    super('Failed query: insert into "channels" ...\nparams: ...');
+    this.cause = cause;
+  }
+}
+
+describe("isSlackChannelUniqueViolation", () => {
+  it("matches the raw postgres.js unique violation", () => {
+    expect(isSlackChannelUniqueViolation(driverError)).toBe(true);
+  });
+
+  it("matches when the violation is wrapped in a DrizzleQueryError (.cause)", () => {
+    expect(
+      isSlackChannelUniqueViolation(new DrizzleQueryErrorLike(driverError)),
+    ).toBe(true);
+  });
+
+  it("matches when nested deeper in the cause chain", () => {
+    const nested = new DrizzleQueryErrorLike(
+      new DrizzleQueryErrorLike(driverError),
+    );
+    expect(isSlackChannelUniqueViolation(nested)).toBe(true);
+  });
+
+  it("ignores a unique violation on a different constraint", () => {
+    expect(
+      isSlackChannelUniqueViolation({
+        code: "23505",
+        constraint_name: "channels_agent_type_idx",
+      }),
+    ).toBe(false);
+  });
+
+  it("ignores a different postgres error code", () => {
+    expect(
+      isSlackChannelUniqueViolation({
+        code: "23503",
+        constraint_name: "channels_slack_channel_unique_idx",
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false for non-error values", () => {
+    expect(isSlackChannelUniqueViolation(null)).toBe(false);
+    expect(isSlackChannelUniqueViolation(undefined)).toBe(false);
+    expect(isSlackChannelUniqueViolation("boom")).toBe(false);
+  });
+
+  it("does not loop forever on a self-referential cause chain", () => {
+    const cyclic: { cause?: unknown } = {};
+    cyclic.cause = cyclic;
+    expect(isSlackChannelUniqueViolation(cyclic)).toBe(false);
+  });
+});

--- a/packages/api-server/src/modules/agents/infrastructure/channel-bindings-repository.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/channel-bindings-repository.ts
@@ -134,12 +134,24 @@ export function findBySlackChannelId(db: Db) {
 }
 
 export function isSlackChannelUniqueViolation(e: unknown): boolean {
-  if (e === null || typeof e !== "object") return false;
-  const obj = e as { code?: unknown; constraint_name?: unknown };
-  return (
-    obj.code === "23505" &&
-    obj.constraint_name === "channels_slack_channel_unique_idx"
-  );
+  // Drizzle (>=0.44) wraps every driver failure in a DrizzleQueryError and
+  // stashes the original postgres.js error — the one carrying `code` and
+  // `constraint_name` — on `.cause`. Walk the cause chain so the guard matches
+  // whether it is handed the raw driver error or the Drizzle wrapper.
+  for (
+    let cur: unknown = e, depth = 0;
+    cur !== null && typeof cur === "object" && depth < 10;
+    cur = (cur as { cause?: unknown }).cause, depth++
+  ) {
+    const obj = cur as { code?: unknown; constraint_name?: unknown };
+    if (
+      obj.code === "23505" &&
+      obj.constraint_name === "channels_slack_channel_unique_idx"
+    ) {
+      return true;
+    }
+  }
+  return false;
 }
 
 export function findSlackChannelByAgent(db: Db) {


### PR DESCRIPTION
## Problem

Connecting a Slack channel that is already bound to another agent surfaces a raw query dump in the UI:

> Failed to connect Slack: Failed query: insert into "channels" (...) on conflict ("agent_id","type") do update ... params: ...

The DB schema and migrations are correct — `channels_agent_type_idx` (the `ON CONFLICT` target) exists. The insert legitimately violates the *other* unique index, `channels_slack_channel_unique_idx` (partial unique on `config->>'slackChannelId'` where `type='slack'`), which enforces one Slack channel ↔ one agent. Reproduced against the dev DB:

```
23505: duplicate key value violates unique constraint "channels_slack_channel_unique_idx"
```

`connectSlack` already intends to translate this into a friendly `ChannelAlreadyBound` → tRPC `CONFLICT` ("Slack channel already bound"). The bug is that `isSlackChannelUniqueViolation` only inspected the **top-level** error object.

## Root cause

`drizzle-orm` (>=0.44) wraps every driver failure in a `DrizzleQueryError` (message `Failed query: …\nparams: …` — exactly the leaked string) and moves the original `postgres.js` error — the one carrying `code` / `constraint_name` — onto `.cause`. The guard checked `e.code` / `e.constraint_name`, which are `undefined` on the wrapper, so it returned `false`, the wrapper was re-thrown, and the raw SQL reached the UI.

## Fix

Walk the `.cause` chain (with a depth guard against cyclic causes) so the guard matches whether it receives the raw driver error or the Drizzle wrapper. This mirrors the existing handling in `connections-service` (`e.code === "23505" || e.cause?.code === "23505"`).

After the fix, the attempt surfaces **"Slack channel already bound"** (409) instead of the SQL dump. Note: this only corrects the *message* — the bind is still correctly refused, since the channel is genuinely in use.

## Tests

Added `slack-channel-unique-violation.test.ts` covering the raw driver error, the `DrizzleQueryError`-wrapped error, deeper nesting, non-matching constraint/code, non-error values, and a cyclic cause chain.

- `mise run check` ✅
- `mise run api-server:test` ✅ (188 passed)