### PR TITLE
fix(ui): make agent description editable and keep empty descriptions empty

### DIFF
--- a/packages/api-server/src/modules/agents/domain/spec-assembly.ts
+++ b/packages/api-server/src/modules/agents/domain/spec-assembly.ts
@@ -10,6 +10,8 @@ export function assembleSpecFromTemplate(
     name,
     version: SPEC_VERSION,
     image: tmplSpec.image,
+    // `??` not `||`: a cleared ("") description stays empty; only an omitted
+    // (undefined) one falls back to the template's default.
     description: opts.description ?? tmplSpec.description,
     mounts: tmplSpec.mounts,
     init: tmplSpec.init,

--- a/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
@@ -250,7 +250,11 @@ export function AddAgentDialog({
       name: values.name.trim(),
       templateId: selectedTemplate?.id,
       image: selectedTemplate ? undefined : customImage.trim(),
-      description: values.description.trim() || undefined,
+      // Send the trimmed value verbatim — including "" when the user clears
+      // it — so an explicitly-empty description stays empty. spec-assembly
+      // only falls back to the template's description when this is genuinely
+      // undefined (e.g. a non-UI API caller that omits the field entirely).
+      description: values.description.trim(),
       // Always send the picker's state — even when the user hasn't toggled,
       // the baselined default (single provider preset) is real intent and
       // `setAgentAccess` is what triggers the connection-rules sync

--- a/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
@@ -109,6 +109,7 @@ export function ConfigureAgentDialog({
     mode: "onChange",
     defaultValues: {
       name: agent.name,
+      description: agent.description ?? "",
       assigned: [],
       assignedAppIds: [],
       envVars: userInitialEnv,
@@ -126,6 +127,7 @@ export function ConfigureAgentDialog({
     baselinedRef.current = true;
     reset({
       name: agent.name,
+      description: agent.description ?? "",
       assigned: [...accessQuery.data.secretIds].sort(),
       assignedAppIds: connectionsQuery.data.connections
         .map((c) => c.connectionId)
@@ -137,6 +139,7 @@ export function ConfigureAgentDialog({
     connectionsQuery.data,
     userInitialEnv,
     agent.name,
+    agent.description,
     reset,
   ]);
   const ready = baselinedRef.current;
@@ -301,7 +304,9 @@ export function ConfigureAgentDialog({
         });
       }
       const wantsAgentUpdate =
-        Boolean(dirtyFields.envVars) || Boolean(dirtyFields.name);
+        Boolean(dirtyFields.envVars) ||
+        Boolean(dirtyFields.name) ||
+        Boolean(dirtyFields.description);
       if (wantsAgentUpdate) {
         await updateAgent.mutateAsync({
           id: agentId,
@@ -309,6 +314,9 @@ export function ConfigureAgentDialog({
             ? { env: sanitizeEnvVars(values.envVars) }
             : {}),
           ...(dirtyFields.name ? { name: values.name.trim() } : {}),
+          ...(dirtyFields.description
+            ? { description: values.description.trim() }
+            : {}),
         });
       }
       // Preset switch is its own mutation. The server sweeps preset:* rows
@@ -417,6 +425,14 @@ export function ConfigureAgentDialog({
               className="w-full h-10 rounded-lg border-2 border-border-light bg-bg px-4 text-[14px] text-text outline-none transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-glow)] placeholder:text-text-muted"
               disabled={saving}
               {...register("name")}
+            />
+          </FormField>
+          <FormField label="Description" error={errors.description?.message}>
+            <input
+              className="w-full h-10 rounded-lg border-2 border-border-light bg-bg px-4 text-[14px] text-text outline-none transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-glow)] placeholder:text-text-muted"
+              placeholder="Optional"
+              disabled={saving}
+              {...register("description")}
             />
           </FormField>
         </DialogHeader>

--- a/packages/ui/src/modules/agents/forms/configure-agent-schema.ts
+++ b/packages/ui/src/modules/agents/forms/configure-agent-schema.ts
@@ -14,6 +14,7 @@ const envVarSchema = z.object({
  */
 export const configureAgentSchema = z.object({
   name: z.string().trim().min(1, "Required"),
+  description: z.string().trim(),
   assigned: z.array(z.string()),
   assignedAppIds: z.array(z.string()),
   envVars: z


### PR DESCRIPTION
## Problem

Two related issues with agent descriptions reported by a user:

1. **Can't update the description in Configure Agent.** The Configure Agent dialog exposed no description field at all, so the description was locked to whatever was set at creation.
2. **Empty descriptions get auto-populated with the template default** (e.g. `"Default Claude Code agent"`). Leaving the field blank at creation re-applied the template's description, and there was no way to clear it afterward.

## Root cause

The backend already fully supported updating `description` — the `update` tRPC procedure accepts it (`agentUpdateInputSchema`) and `agents-service.update()` persists it. The gaps were entirely in the UI:

- `ConfigureAgentDialog` / `configureAgentSchema` had no `description` field.
- On creation, `add-agent-dialog` sent `values.description.trim() || undefined`, coercing a cleared field to `undefined`, and `spec-assembly` then fell back to the template default via `opts.description ?? tmplSpec.description`.

## Changes

- **Configure Agent dialog** (`configure-agent-dialog.tsx`, `configure-agent-schema.ts`): add a Description field — schema, form default + baseline `reset()`, the input, and the update mutation — so the description can be edited or cleared after creation.
- **Create flow** (`add-agent-dialog.tsx`): send the trimmed description verbatim (including `""`) instead of coercing empty to `undefined`, so an explicitly-cleared description stays empty.
- **`spec-assembly.ts`**: keep the `??` fallback (with a one-line note on why it's not `||`) — a genuinely-omitted (`undefined`) description still falls back to the template default for non-UI API callers; an explicit `""` stays empty.

The template description is still surfaced as a sensible default — the create dialog pre-fills it when a template is picked, so the default is conveyed up front and the user can keep, edit, or clear it.

## Resulting behavior

| Scenario | Result |
|---|---|
| Pick template, keep pre-filled description | Template description saved (unchanged) |
| Pick template, **clear** the description | Stays empty ✅ |
| Custom image, leave description blank | Stays empty (unchanged) |
| API create that omits `description` entirely | Falls back to template default (unchanged) |
| Edit description later in Configure dialog | Editable, including clearing to empty ✅ |

## Testing

- `mise run ui:check` — format, lint, tsc clean
- `mise run api-server:check` — format, lint, tsc clean
- UI-only behavior change; no existing tests encoded the old creation fallback.