### PR TITLE
chore: clean up example placeholders and comment wording

### DIFF
--- a/packages/agent-runtime/src/modules/skills/domain/frontmatter.ts
+++ b/packages/agent-runtime/src/modules/skills/domain/frontmatter.ts
@@ -2,7 +2,7 @@
  * Extract `name` and `description` from a SKILL.md's YAML frontmatter.
  * Handles plain scalars (`description: foo`), folded block scalars
  * (`description: >`), and literal block scalars (`description: |`) —
- * apocohq's catalog uses `>` with line continuations, which a naive parser
+ * some catalogs use `>` with line continuations, which a naive parser
  * surfaces as the literal character `>`.
  */
 export function parseFrontmatter(content: string): {

--- a/packages/ui/src/modules/sessions/components/skills-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/skills-panel.tsx
@@ -597,7 +597,7 @@ export function SkillsPanel({
         <div className="flex flex-col gap-3 border-b border-border-light p-4 anim-in">
           <input
             className={inp}
-            placeholder='Name (e.g. "Apocohq Skills")'
+            placeholder='Name (e.g. "My Skills")'
             value={addForm.name}
             onChange={(e) =>
               setAddForm((f) => ({ ...f, name: e.target.value }))
@@ -605,7 +605,7 @@ export function SkillsPanel({
           />
           <input
             className={`${inp} font-mono`}
-            placeholder="https://github.com/apocohq/skills"
+            placeholder="https://github.com/your-org/skills"
             value={addForm.gitUrl}
             onChange={(e) =>
               setAddForm((f) => ({ ...f, gitUrl: e.target.value }))


### PR DESCRIPTION
## Summary

Minor cleanup of example/placeholder text in the application code.

- Generalize the skill-source name and URL placeholders in the skills panel to neutral examples.
- Reword a comment in the frontmatter parser to use a generic example instead of a vendor-specific one.

## Notes

No behavioral change — comments and input placeholder text only.