### PR TITLE
docs: v0.2 deliverable scope + acceptance criteria

### DIFF
--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -7,7 +7,6 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 - [ ] 1.1 A new user is blocked from all authenticated actions until acceptance (API returns 412, UI redirects to the terms page).
 - [ ] 1.2 Accepting records the user, the terms version, and a hash of the accepted text in Postgres.
 - [ ] 1.3 Bumping the configured terms version re-prompts every user on their next request.
-- [ ] 1.4 Bootstrap routes (health, brand, auth config, the terms endpoints themselves) are reachable before acceptance; everything else is gated.
 
 ## 2. Agent template: Claude Code
 
@@ -82,3 +81,11 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 - [ ] 11.1 Agent and user activity is recorded to the append-only log.
 - [ ] 11.2 Usage insights are readable only by a user holding the inspector role.
 - [ ] 11.3 Identifiers in the insights surface are pseudonymized.
+
+## 12. Agent status handling
+
+- [ ] 12.1 A running agent can be opened from the agent list (card is clickable and navigates to the chat).
+- [ ] 12.2 A hibernated agent cannot be opened from the agent list; it must be woken first (card is not clickable, only the wake action is offered).
+- [ ] 12.3 Transient and error states (starting, hibernating, restarting, error) are not openable; only the appropriate power action is offered, and it is disabled while a state is transient.
+- [ ] 12.4 When the open agent goes offline (loses readiness or the live connection drops without recovery), the chat input and all interactive controls on the page are disabled until it recovers.
+- [ ] 12.5 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -13,10 +13,9 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 - [ ] 2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
 - [ ] 2.2 The template supplies image, workspace mounts, and default env without manual configuration.
 - [ ] 2.3 A running agent opens from the agent list to a fully interactive chat.
-- [ ] 2.4 A hibernated agent can be opened from the agent list; opening it triggers a wake, and the chat stays disabled (per 2.6) until the agent is ready.
-- [ ] 2.5 The agent list offers the appropriate power action per state (wake when hibernated, restart when running or error), disabled during transient states (starting, hibernating, restarting).
-- [ ] 2.6 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled until it becomes ready.
-- [ ] 2.7 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
+- [ ] 2.4 A hibernated agent can be opened from the agent list; opening it triggers a wake, and the chat stays disabled (per 2.5) until the agent is ready.
+- [ ] 2.5 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled until it becomes ready.
+- [ ] 2.6 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
 
 ## 3. LLM providers
 

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -12,6 +12,11 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 
 - [ ] 2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
 - [ ] 2.2 The template supplies image, workspace mounts, and default env without manual configuration.
+- [ ] 2.3 A running agent can be opened from the agent list (card is clickable and navigates to the chat).
+- [ ] 2.4 A hibernated agent cannot be opened from the agent list; it must be woken first (card is not clickable, only the wake action is offered).
+- [ ] 2.5 Transient and error states (starting, hibernating, restarting, error) are not openable; only the appropriate power action is offered, and it is disabled while a state is transient.
+- [ ] 2.6 When the open agent goes offline (loses readiness or the live connection drops without recovery), the chat input and all interactive controls on the page are disabled until it recovers.
+- [ ] 2.7 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
 
 ## 3. LLM providers
 
@@ -81,11 +86,3 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 - [ ] 11.1 Agent and user activity is recorded to the append-only log.
 - [ ] 11.2 Usage insights are readable only by a user holding the inspector role.
 - [ ] 11.3 Identifiers in the insights surface are pseudonymized.
-
-## 12. Agent status handling
-
-- [ ] 12.1 A running agent can be opened from the agent list (card is clickable and navigates to the chat).
-- [ ] 12.2 A hibernated agent cannot be opened from the agent list; it must be woken first (card is not clickable, only the wake action is offered).
-- [ ] 12.3 Transient and error states (starting, hibernating, restarting, error) are not openable; only the appropriate power action is offered, and it is disabled while a state is transient.
-- [ ] 12.4 When the open agent goes offline (loses readiness or the live connection drops without recovery), the chat input and all interactive controls on the page are disabled until it recovers.
-- [ ] 12.5 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -1,0 +1,84 @@
+# DAM v0.2 Acceptance Criteria
+
+Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a test-case seed.
+
+## 1. Onboarding: Terms of Use
+
+1.1 A new user is blocked from all authenticated actions until acceptance (API returns 412, UI redirects to the terms page).
+1.2 Accepting records the user, the terms version, and a hash of the accepted text in Postgres.
+1.3 Bumping the configured terms version re-prompts every user on their next request.
+1.4 Bootstrap routes (health, brand, auth config, the terms endpoints themselves) are reachable before acceptance; everything else is gated.
+
+## 2. Agent template: Claude Code
+
+2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
+2.2 The template supplies image, workspace mounts, and default env without manual configuration.
+
+## 3. LLM providers
+
+3.1 With an Anthropic subscription token configured, the agent completes a chat turn against `api.anthropic.com`.
+3.2 With IBM LiteLLM configured, the agent completes a chat turn routed through the LiteLLM host using the configured model pins.
+3.3 The real provider credential is never present in the agent pod (placeholder env only; real value injected at the gateway).
+
+## 4. GitHub connectivity
+
+4.1 PAT, github.com: after connecting, `gh api` succeeds and `git clone`/`push` of a private repo succeeds inside the agent.
+4.2 PAT, GitHub Enterprise: after connecting with a custom host, `GH_HOST` is set, and both `gh` and `git` work against the enterprise host.
+4.3 GitHub App, github.com: after OAuth authorize + install, both `gh` and `git` work; the token auto-refreshes and access survives past the initial token expiry window.
+4.4 GitHub App, GitHub Enterprise: same as 4.3 against the enterprise host.
+4.5 Token isolation: the agent pod has no mounted credential secret and no service-account token; the token exists only on the paired gateway. An attempt to read the token from inside the agent fails.
+
+## 5. Egress filtering and approvals
+
+5.1 A fresh agent reaches trusted-default hosts (Anthropic, GitHub, common package registries) without prompting.
+5.2 A request to a non-allowlisted host is blocked and a pending approval appears in the UI inbox.
+5.3 "Approve once" lets the single held request through; the next identical request re-prompts.
+5.4 "Approve permanently" / "Allow host" writes a rule; future requests pass and the rule survives a pod restart.
+5.5 "Deny" blocks the request.
+5.6 Editing the allowlist on an existing agent: adding a host-wide allow takes effect live (no restart); adding a path/method-specific rule applies after an automatic pod restart.
+5.7 A scheduled or hibernated agent's approval is visible in the inbox and resolvable even when no chat session is open.
+
+## 6. Workspace import and custom env
+
+6.1 Importing a local folder lands its contents under the agent's `~/work/` directory.
+6.2 Import is atomic per top-level entry and excludes heavy/irrelevant dirs (`node_modules`, `.venv`, `__pycache__`, `.DS_Store`).
+6.3 Custom env vars set at creation are present in the agent.
+6.4 Custom env vars edited after creation take effect after the automatic pod roll and survive restarts. `PORT` is protected and cannot be set.
+
+## 7. Skills
+
+7.1 A user can add a git skill source.
+7.2 Installing a skill from a source places it on the agent; it is available in the next session.
+7.3 An installed skill is usable by the agent in a session.
+7.4 Publishing a local skill opens a pull request on the source GitHub repo (requires the agent running and GitHub connected).
+
+## 8. Scheduling
+
+8.1 Creating a schedule (RRULE + timezone, optional quiet hours) fires the agent at the computed times.
+8.2 Fresh mode: every fire starts a new session.
+8.3 Continuous mode: the first fire starts a session; subsequent fires resume the same session.
+8.4 Scheduled sessions are listed under the schedule in the UI and open in the chat pane when clicked.
+8.5 Toggling a schedule off cancels its queued run without deleting it; toggling on re-queues it.
+8.6 Quiet-hours windows that would mask all occurrences are rejected at save time.
+
+## 9. Chat interface and session history
+
+9.1 Agent responses stream live; tool calls render with status and expandable output.
+9.2 An inline permission prompt can be approved or denied and unblocks the agent.
+9.3 A user can attach a file (up to the configured cap) and interrupt a running turn.
+9.4 Past sessions are listed; opening one replays the full transcript.
+9.5 Two viewers on the same session stay consistent (live fan-out + catch-up replay).
+
+## 10. Slack integration
+
+10.1 An operator/owner can connect Slack and bind a channel to an agent.
+10.2 A Slack user links their identity to a platform user via the login flow.
+10.3 Mentioning the agent in the bound channel relays the message and posts the agent's reply back to the thread.
+10.4 A non-owner (foreign) user's turn runs in an isolated fork using that user's own credentials.
+10.5 Only allowed users can drive the agent from Slack.
+
+## 11. Usage insights
+
+11.1 Agent and user activity is recorded to the append-only log.
+11.2 Usage insights are readable only by a user holding the inspector role.
+11.3 Identifiers in the insights surface are pseudonymized.

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -12,10 +12,10 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 
 - [ ] 2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
 - [ ] 2.2 The template supplies image, workspace mounts, and default env without manual configuration.
-- [ ] 2.3 A running agent can be opened from the agent list (card is clickable and navigates to the chat).
-- [ ] 2.4 A hibernated agent cannot be opened from the agent list; it must be woken first (card is not clickable, only the wake action is offered).
-- [ ] 2.5 Transient and error states (starting, hibernating, restarting, error) are not openable; only the appropriate power action is offered, and it is disabled while a state is transient.
-- [ ] 2.6 When the open agent goes offline (loses readiness or the live connection drops without recovery), the chat input and all interactive controls on the page are disabled until it recovers.
+- [ ] 2.3 A running agent opens from the agent list to a fully interactive chat.
+- [ ] 2.4 A hibernated agent can be opened from the agent list; opening it triggers a wake, and the chat stays disabled (per 2.6) until the agent is ready.
+- [ ] 2.5 The agent list offers the appropriate power action per state (wake when hibernated, restart when running or error), disabled during transient states (starting, hibernating, restarting).
+- [ ] 2.6 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled until it becomes ready.
 - [ ] 2.7 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
 
 ## 3. LLM providers

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -14,7 +14,7 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 - [ ] 2.2 The template supplies image, workspace mounts, and default env without manual configuration.
 - [ ] 2.3 A running agent opens from the agent list to a fully interactive chat.
 - [ ] 2.4 A hibernated agent can be opened from the agent list; opening it triggers a wake, and the chat stays disabled (per 2.5) until the agent is ready.
-- [ ] 2.5 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled until it becomes ready.
+- [ ] 2.5 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled, and the not-running state is clearly visualised to the user, until it becomes ready.
 - [ ] 2.6 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
 
 ## 3. LLM providers

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -4,81 +4,81 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 
 ## 1. Onboarding: Terms of Use
 
-1.1 A new user is blocked from all authenticated actions until acceptance (API returns 412, UI redirects to the terms page).
-1.2 Accepting records the user, the terms version, and a hash of the accepted text in Postgres.
-1.3 Bumping the configured terms version re-prompts every user on their next request.
-1.4 Bootstrap routes (health, brand, auth config, the terms endpoints themselves) are reachable before acceptance; everything else is gated.
+- [ ] 1.1 A new user is blocked from all authenticated actions until acceptance (API returns 412, UI redirects to the terms page).
+- [ ] 1.2 Accepting records the user, the terms version, and a hash of the accepted text in Postgres.
+- [ ] 1.3 Bumping the configured terms version re-prompts every user on their next request.
+- [ ] 1.4 Bootstrap routes (health, brand, auth config, the terms endpoints themselves) are reachable before acceptance; everything else is gated.
 
 ## 2. Agent template: Claude Code
 
-2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
-2.2 The template supplies image, workspace mounts, and default env without manual configuration.
+- [ ] 2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
+- [ ] 2.2 The template supplies image, workspace mounts, and default env without manual configuration.
 
 ## 3. LLM providers
 
-3.1 With an Anthropic subscription token configured, the agent completes a chat turn against `api.anthropic.com`.
-3.2 With IBM LiteLLM configured, the agent completes a chat turn routed through the LiteLLM host using the configured model pins.
-3.3 The real provider credential is never present in the agent pod (placeholder env only; real value injected at the gateway).
+- [ ] 3.1 With an Anthropic subscription token configured, the agent completes a chat turn against `api.anthropic.com`.
+- [ ] 3.2 With IBM LiteLLM configured, the agent completes a chat turn routed through the LiteLLM host using the configured model pins.
+- [ ] 3.3 The real provider credential is never present in the agent pod (placeholder env only; real value injected at the gateway).
 
 ## 4. GitHub connectivity
 
-4.1 PAT, github.com: after connecting, `gh api` succeeds and `git clone`/`push` of a private repo succeeds inside the agent.
-4.2 PAT, GitHub Enterprise: after connecting with a custom host, `GH_HOST` is set, and both `gh` and `git` work against the enterprise host.
-4.3 GitHub App, github.com: after OAuth authorize + install, both `gh` and `git` work; the token auto-refreshes and access survives past the initial token expiry window.
-4.4 GitHub App, GitHub Enterprise: same as 4.3 against the enterprise host.
-4.5 Token isolation: the agent pod has no mounted credential secret and no service-account token; the token exists only on the paired gateway. An attempt to read the token from inside the agent fails.
+- [ ] 4.1 PAT, github.com: after connecting, `gh api` succeeds and `git clone`/`push` of a private repo succeeds inside the agent.
+- [ ] 4.2 PAT, GitHub Enterprise: after connecting with a custom host, `GH_HOST` is set, and both `gh` and `git` work against the enterprise host.
+- [ ] 4.3 GitHub App, github.com: after OAuth authorize + install, both `gh` and `git` work; the token auto-refreshes and access survives past the initial token expiry window.
+- [ ] 4.4 GitHub App, GitHub Enterprise: same as 4.3 against the enterprise host.
+- [ ] 4.5 Token isolation: the agent pod has no mounted credential secret and no service-account token; the token exists only on the paired gateway. An attempt to read the token from inside the agent fails.
 
 ## 5. Egress filtering and approvals
 
-5.1 A fresh agent reaches trusted-default hosts (Anthropic, GitHub, common package registries) without prompting.
-5.2 A request to a non-allowlisted host is blocked and a pending approval appears in the UI inbox.
-5.3 "Approve once" lets the single held request through; the next identical request re-prompts.
-5.4 "Approve permanently" / "Allow host" writes a rule; future requests pass and the rule survives a pod restart.
-5.5 "Deny" blocks the request.
-5.6 Editing the allowlist on an existing agent: adding a host-wide allow takes effect live (no restart); adding a path/method-specific rule applies after an automatic pod restart.
-5.7 A scheduled or hibernated agent's approval is visible in the inbox and resolvable even when no chat session is open.
+- [ ] 5.1 A fresh agent reaches trusted-default hosts (Anthropic, GitHub, common package registries) without prompting.
+- [ ] 5.2 A request to a non-allowlisted host is blocked and a pending approval appears in the UI inbox.
+- [ ] 5.3 "Approve once" lets the single held request through; the next identical request re-prompts.
+- [ ] 5.4 "Approve permanently" / "Allow host" writes a rule; future requests pass and the rule survives a pod restart.
+- [ ] 5.5 "Deny" blocks the request.
+- [ ] 5.6 Editing the allowlist on an existing agent: adding a host-wide allow takes effect live (no restart); adding a path/method-specific rule applies after an automatic pod restart.
+- [ ] 5.7 A scheduled or hibernated agent's approval is visible in the inbox and resolvable even when no chat session is open.
 
 ## 6. Workspace import and custom env
 
-6.1 Importing a local folder lands its contents under the agent's `~/work/` directory.
-6.2 Import is atomic per top-level entry and excludes heavy/irrelevant dirs (`node_modules`, `.venv`, `__pycache__`, `.DS_Store`).
-6.3 Custom env vars set at creation are present in the agent.
-6.4 Custom env vars edited after creation take effect after the automatic pod roll and survive restarts. `PORT` is protected and cannot be set.
+- [ ] 6.1 Importing a local folder lands its contents under the agent's `~/work/` directory.
+- [ ] 6.2 Import is atomic per top-level entry and excludes heavy/irrelevant dirs (`node_modules`, `.venv`, `__pycache__`, `.DS_Store`).
+- [ ] 6.3 Custom env vars set at creation are present in the agent.
+- [ ] 6.4 Custom env vars edited after creation take effect after the automatic pod roll and survive restarts. `PORT` is protected and cannot be set.
 
 ## 7. Skills
 
-7.1 A user can add a git skill source.
-7.2 Installing a skill from a source places it on the agent; it is available in the next session.
-7.3 An installed skill is usable by the agent in a session.
-7.4 Publishing a local skill opens a pull request on the source GitHub repo (requires the agent running and GitHub connected).
+- [ ] 7.1 A user can add a git skill source.
+- [ ] 7.2 Installing a skill from a source places it on the agent; it is available in the next session.
+- [ ] 7.3 An installed skill is usable by the agent in a session.
+- [ ] 7.4 Publishing a local skill opens a pull request on the source GitHub repo (requires the agent running and GitHub connected).
 
 ## 8. Scheduling
 
-8.1 Creating a schedule (RRULE + timezone, optional quiet hours) fires the agent at the computed times.
-8.2 Fresh mode: every fire starts a new session.
-8.3 Continuous mode: the first fire starts a session; subsequent fires resume the same session.
-8.4 Scheduled sessions are listed under the schedule in the UI and open in the chat pane when clicked.
-8.5 Toggling a schedule off cancels its queued run without deleting it; toggling on re-queues it.
-8.6 Quiet-hours windows that would mask all occurrences are rejected at save time.
+- [ ] 8.1 Creating a schedule (RRULE + timezone, optional quiet hours) fires the agent at the computed times.
+- [ ] 8.2 Fresh mode: every fire starts a new session.
+- [ ] 8.3 Continuous mode: the first fire starts a session; subsequent fires resume the same session.
+- [ ] 8.4 Scheduled sessions are listed under the schedule in the UI and open in the chat pane when clicked.
+- [ ] 8.5 Toggling a schedule off cancels its queued run without deleting it; toggling on re-queues it.
+- [ ] 8.6 Quiet-hours windows that would mask all occurrences are rejected at save time.
 
 ## 9. Chat interface and session history
 
-9.1 Agent responses stream live; tool calls render with status and expandable output.
-9.2 An inline permission prompt can be approved or denied and unblocks the agent.
-9.3 A user can attach a file (up to the configured cap) and interrupt a running turn.
-9.4 Past sessions are listed; opening one replays the full transcript.
-9.5 Two viewers on the same session stay consistent (live fan-out + catch-up replay).
+- [ ] 9.1 Agent responses stream live; tool calls render with status and expandable output.
+- [ ] 9.2 An inline permission prompt can be approved or denied and unblocks the agent.
+- [ ] 9.3 A user can attach a file (up to the configured cap) and interrupt a running turn.
+- [ ] 9.4 Past sessions are listed; opening one replays the full transcript.
+- [ ] 9.5 Two viewers on the same session stay consistent (live fan-out + catch-up replay).
 
 ## 10. Slack integration
 
-10.1 An operator/owner can connect Slack and bind a channel to an agent.
-10.2 A Slack user links their identity to a platform user via the login flow.
-10.3 Mentioning the agent in the bound channel relays the message and posts the agent's reply back to the thread.
-10.4 A non-owner (foreign) user's turn runs in an isolated fork using that user's own credentials.
-10.5 Only allowed users can drive the agent from Slack.
+- [ ] 10.1 An operator/owner can connect Slack and bind a channel to an agent.
+- [ ] 10.2 A Slack user links their identity to a platform user via the login flow.
+- [ ] 10.3 Mentioning the agent in the bound channel relays the message and posts the agent's reply back to the thread.
+- [ ] 10.4 A non-owner (foreign) user's turn runs in an isolated fork using that user's own credentials.
+- [ ] 10.5 Only allowed users can drive the agent from Slack.
 
 ## 11. Usage insights
 
-11.1 Agent and user activity is recorded to the append-only log.
-11.2 Usage insights are readable only by a user holding the inspector role.
-11.3 Identifiers in the insights surface are pseudonymized.
+- [ ] 11.1 Agent and user activity is recorded to the append-only log.
+- [ ] 11.2 Usage insights are readable only by a user holding the inspector role.
+- [ ] 11.3 Identifiers in the insights surface are pseudonymized.

--- a/docs/notes/v0.2-acceptance-criteria.md
+++ b/docs/notes/v0.2-acceptance-criteria.md
@@ -4,18 +4,16 @@ Companion to [v0.2-deliverable.md](v0.2-deliverable.md). Each criterion is a tes
 
 ## 1. Onboarding: Terms of Use
 
-- [ ] 1.1 A new user is blocked from all authenticated actions until acceptance (API returns 412, UI redirects to the terms page).
-- [ ] 1.2 Accepting records the user, the terms version, and a hash of the accepted text in Postgres.
-- [ ] 1.3 Bumping the configured terms version re-prompts every user on their next request.
+- [ ] 1.1 A user who has not accepted the current terms of use cannot reach the app; accepting unblocks access and an accepted user is not prompted again.
 
 ## 2. Agent template: Claude Code
 
-- [ ] 2.1 Creating an agent from the Claude Code template starts a running agent reachable from the chat UI.
-- [ ] 2.2 The template supplies image, workspace mounts, and default env without manual configuration.
-- [ ] 2.3 A running agent opens from the agent list to a fully interactive chat.
-- [ ] 2.4 A hibernated agent can be opened from the agent list; opening it triggers a wake, and the chat stays disabled (per 2.5) until the agent is ready.
-- [ ] 2.5 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled, and the not-running state is clearly visualised to the user, until it becomes ready.
-- [ ] 2.6 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
+- [ ] 2.1 A user can create an agent from the Claude Code template (image, workspace mounts, and default env supplied automatically) and, once it reaches the running state, open it from the agent list to a fully interactive chat.
+- [ ] 2.2 While the open agent is not ready (waking, hibernating, restarting, error, or the live connection has dropped without recovery), the chat input and all interactive controls on the page are disabled, and the not-running state is clearly visualised to the user, until it becomes ready.
+- [ ] 2.3 Agent state is shown as a live status pill in both the agent list and the chat header, updating as the state changes.
+- [ ] 2.4 A user can delete an agent; it disappears from the agent list and its underlying resources are torn down.
+- [ ] 2.5 At creation a user can attach connections — a provider (e.g. Anthropic) and/or an app (e.g. GitHub) — and each attached connection is usable inside the running agent: the provider serves chat turns, and an app's credentials/env are present and functional.
+- [ ] 2.6 At creation a user can import local context — drag-and-drop or pick a mix of folders and files (`.tar.gz` bundles pass through verbatim) — and the imported content is present in the running agent's workspace.
 
 ## 3. LLM providers
 

--- a/docs/notes/v0.2-deliverable.md
+++ b/docs/notes/v0.2-deliverable.md
@@ -1,0 +1,87 @@
+# DAM v0.2 Deliverable
+
+## Scope statement
+
+v0.2 delivers a single supported path: run a **Claude Code** agent in an isolated pod, backed by **Anthropic** (Claude Code subscription token) or **Anthropic via the IBM LiteLLM ETE proxy**, connected to **GitHub** (PAT or GitHub App, public or Enterprise), with **egress filtering**, **human approvals** for anything off the allowlist, **schedules**, **Slack**, **skills**, a **chat UI**, **session history**, and **usage insights**.
+
+Everything else present in the codebase (other agent templates, other providers, CLI, Telegram, terminal mode, multi-agent, forensic audit log) is either explicitly out of scope or present-but-not-guaranteed. See the last two sections.
+
+---
+
+## 1. Onboarding: Terms of Use
+
+**Delivered.** A user cannot use the platform until they accept the current Terms of Use. Terms text and version are operator-configured via Helm.
+
+---
+
+## 2. Agent template: Claude Code
+
+**Delivered.** Creating an agent from the Claude Code template provisions a Claude Code pod with the correct image, mounts, env, and resources.
+
+---
+
+## 3. LLM providers
+
+**Delivered.** Two provider configurations are supported:
+
+- **Anthropic (Claude Code subscription token):** the user supplies their Claude Code OAuth token. Traffic egresses to `api.anthropic.com` with the token injected at the gateway.
+- **Anthropic via IBM LiteLLM ETE proxy:** the user supplies a LiteLLM key. `ANTHROPIC_BASE_URL` points at the fixed LiteLLM host, model pins (Opus/Sonnet/Haiku) are set, and traffic egresses to the LiteLLM host with the key injected at the gateway.
+
+---
+
+## 4. GitHub connectivity
+
+**Delivered.** GitHub connection by **PAT** and by **GitHub App** (operator-registered, client ID configured via Helm), for both **github.com** and **GitHub Enterprise**. Both `gh` CLI and `git` work inside the agent. The agent never holds the token.
+
+How GitHub App works: the operator registers a GitHub App and sets its client ID, secret, and app slug in Helm. The user authorizes via OAuth, then clicks an install link to install the App on their org/repos. The minted user-to-server token is injected at the gateway and auto-refreshed before expiry.
+
+---
+
+## 5. Egress filtering and approvals
+
+**Delivered.** Each agent egresses only to an allowlist. A trusted-defaults set (including GitHub and the configured LLM provider) is seeded out of the box. The allowlist is editable on existing agents. Any request to a host off the allowlist is blocked and surfaced as an approval in the UI inbox.
+
+---
+
+## 6. Workspace import and custom env
+
+**Delivered.** A user can import a local folder into the agent workspace and set custom environment variables at creation and later.
+
+---
+
+## 7. Skills
+
+**Delivered.** Connect a git-based skill source, install a skill onto the agent, use it, and publish a local skill back to GitHub as a pull request.
+
+---
+
+## 8. Scheduling
+
+**Delivered.** RRULE-based schedules with timezone and optional quiet hours. Each schedule runs in either fresh-session or continuous-session mode. Scheduled sessions are visible in the UI, and schedules can be toggled on/off on demand.
+
+---
+
+## 9. Chat interface and session history
+
+**Delivered.** A live streaming chat UI with tool-call rendering, markdown, thinking blocks, inline permission prompts, file attachment, interrupt, and queued prompts. Past sessions are listed and resumable with full transcript replay.
+
+---
+
+## 10. Slack integration
+
+**Delivered.** Connect Slack to an agent, link Slack users to platform identities, relay channel mentions to the agent, and post responses back. Non-owner users run in an isolated fork with their own credentials.
+
+---
+
+## 11. Usage insights
+
+**Delivered.** An append-only activity log in Postgres feeds usage insights, read through SQL views, gated to an inspector role, with pseudonymized identifiers.
+
+---
+
+## Present but not guaranteed (in the build, not part of the v0.2 guarantee)
+
+These ship in the image but are not tested or supported for v0.2. They should not appear in v0.2 test cases.
+
+- Agent templates other than Claude Code: codex, pi-agent, bob, google-workspace, and bare-image agents.
+- Providers other than the two named: OpenAI, Bob, Google Workspace services, Spotify, custom MCP servers.

--- a/docs/notes/v0.2-deliverable.md
+++ b/docs/notes/v0.2-deliverable.md
@@ -79,6 +79,12 @@ How GitHub App works: the operator registers a GitHub App and sets its client ID
 
 ---
 
+## 12. Agent status handling
+
+**Delivered.** The agent list and chat page track agent lifecycle state. Running agents open directly; hibernated agents must be woken before they can be opened; transient and error states are not openable; and an agent that goes offline disables the chat interface until it recovers. State is shown as a live status pill in the list and the chat header.
+
+---
+
 ## Present but not guaranteed (in the build, not part of the v0.2 guarantee)
 
 These ship in the image but are not tested or supported for v0.2. They should not appear in v0.2 test cases.

--- a/docs/notes/v0.2-deliverable.md
+++ b/docs/notes/v0.2-deliverable.md
@@ -79,12 +79,6 @@ How GitHub App works: the operator registers a GitHub App and sets its client ID
 
 ---
 
-## 12. Agent status handling
-
-**Delivered.** The agent list and chat page track agent lifecycle state. Running agents open directly; hibernated agents must be woken before they can be opened; transient and error states are not openable; and an agent that goes offline disables the chat interface until it recovers. State is shown as a live status pill in the list and the chat header.
-
----
-
 ## Present but not guaranteed (in the build, not part of the v0.2 guarantee)
 
 These ship in the image but are not tested or supported for v0.2. They should not appear in v0.2 test cases.


### PR DESCRIPTION
Defines the v0.2 deliverable scope and the acceptance criteria that test cases will derive from.

- `docs/notes/v0.2-deliverable.md` — scope statement, 11 delivered capabilities, present-but-not-guaranteed list.
- `docs/notes/v0.2-acceptance-criteria.md` — title + numbered ACs per capability (44 criteria), companion to the deliverable.