### PR TITLE
ci(e2e): skip cluster teardown in CI

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -74,9 +74,11 @@ cleanup() {
     echo "=== End diagnostics ==="
   fi
 
-  echo ""
-  echo "=== Tearing down test cluster ==="
-  mise run cluster:delete -- --vm-name="$VM_NAME" --force || true
+  if [ -z "${IS_SANDBOX:-}" ]; then
+    echo ""
+    echo "=== Tearing down test cluster ==="
+    mise run cluster:delete -- --vm-name="$VM_NAME" --force || true
+  fi
 
   exit $exit_code
 }


### PR DESCRIPTION
## What

Skip the `=== Tearing down test cluster ===` step (`cluster:delete`) when running under CI/sandbox.

## Why

CI runners are ephemeral and discarded after the job, so deleting the lima/k3s VM at the end is wasted time. The teardown is gated on `IS_SANDBOX`, mirroring the existing pre-nuke skip already in the same task.

Failure diagnostics dump still runs in CI, so we keep logs/events on failures. Local runs (no `IS_SANDBOX`) tear down as before, so the warm-VM contract for `e2e:loop` is unaffected.