### PR TITLE
fix(tasks): avoid bash ${#arr[@]} tripping mise Tera parser

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -624,7 +624,7 @@ while IFS=$'\t' read -r name image; do
   fi
 done <<< "$DEPLOYED_AGENTS"
 
-if [ ${#AGENT_IMAGES[@]} -eq 0 ]; then
+if [ -z "${AGENT_IMAGES[*]:-}" ]; then
   echo "No agent templates deployed — nothing to build."
   exit 0
 fi
@@ -845,10 +845,10 @@ done < <(
   kubectl --kubeconfig="$KUBECONFIG" get pvc -A -l platform.ai/instance \
     -o jsonpath='{range .items[*]}{.metadata.namespace}|{.metadata.name}|{.metadata.labels.platform\.ai/instance}{"\n"}{end}'
 )
-if [ "${#ORPHANS[@]}" -eq 0 ]; then
+if [ -z "${ORPHANS[*]:-}" ]; then
   echo "  no orphan PVCs found"
 else
-  echo "  ${#ORPHANS[@]} orphan PVC(s):"
+  echo "  $(printf '%s\n' "${ORPHANS[@]}" | wc -l | tr -d ' ') orphan PVC(s):"
   printf '    %s\n' "${ORPHANS[@]}"
   echo "  controller will GC them automatically; or delete manually with: kubectl delete pvc -n <ns> <name>"
 fi


### PR DESCRIPTION
`${#...}` opens a Tera comment (`{#`) that mise never closes, so `mise run cluster:build-agent` fails with `Failed to parse '__tera_one_off'` (regressed in #596). The orphan-PVC task had the same latent bug.

Fix: use `${arr[*]:-}` emptiness checks (and `wc` for the count) — no `{#`.

Verified `cluster:build-agent` now builds + restarts agent pods cleanly.