### PR TITLE
fix(connections): allowlist Google API discovery endpoint

### DIFF
--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -443,6 +443,14 @@ function googleService(
         headerName: "Authorization",
         valueFormat: "Bearer {value}",
       })),
+      // Google clients fetch the public discovery doc at startup (e.g.
+      // /discovery/v1/apis/gmail/v1/rest), outside each service's host scope.
+      // Public + read-only, so allow without credential injection.
+      {
+        kind: "egress-allow" as const,
+        host: "www.googleapis.com",
+        pathPattern: "/discovery/v1/apis/*",
+      },
     ],
   };
 }


### PR DESCRIPTION
Granting any Google connection (Gmail, Drive, …) held the agent at the HITL egress gate on its first call: Google client libraries fetch the discovery doc at startup (`GET www.googleapis.com/discovery/v1/apis/gmail/v1/rest`), which falls outside each service's allowlisted scope (`/gmail/*`, `/drive/*`).

Add one shared `egress-allow` in `googleService()` so every Google connection inherits it. It's `egress-allow` (not `egress-inject`) because discovery docs are public/read-only — no credential needed.