### PR TITLE
fix(helm): grant controller agents/forks finalizers for owner-ref GC (ADR-058)

### DIFF
--- a/deploy/helm/platform/templates/controller/rbac.yaml
+++ b/deploy/helm/platform/templates/controller/rbac.yaml
@@ -36,14 +36,20 @@ rules:
   - apiGroups: ["agent-platform.ai"]
     resources: ["agents/status", "forks/status"]
     verbs: ["get", "update", "patch"]
-  # ConfigMaps remain for the chart-shipped templates and the controller-
-  # rendered Envoy bootstrap CM (owner-refed to the Agent/Fork).
+  # The children the controller renders (Envoy bootstrap CM, StatefulSets,
+  # Services, …) are owner-refed to the Agent/Fork CR with blockOwnerDeletion.
+  # K8s admission only permits that if the creator can update the owner's
+  # finalizers, so the controller needs the agents/forks finalizers subresource.
+  # (Pre-ADR-058 the children were owned by the agent ConfigMap, hence the old
+  # configmaps/finalizers grant — now dead.)
+  - apiGroups: ["agent-platform.ai"]
+    resources: ["agents/finalizers", "forks/finalizers"]
+    verbs: ["update"]
+  # ConfigMaps for the chart-shipped templates and the controller-rendered Envoy
+  # bootstrap CM (owner-refed to the Agent/Fork).
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  - apiGroups: [""]
-    resources: ["configmaps/finalizers"]
-    verbs: ["update"]
   - apiGroups: [""]
     resources: ["secrets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]


### PR DESCRIPTION
## Prod incident

The controller fails to reconcile agents:

```
applying envoy bootstrap: configmaps "agent-…-envoy-bootstrap" is forbidden:
cannot set blockOwnerDeletion if an ownerReference refers to a resource you
can't set finalizers on
```

## Root cause

Every child the controller renders (Envoy bootstrap ConfigMap, StatefulSets, Services, SA, NetworkPolicy, AuthorizationPolicies, leaf Certificate) is owner-refed to the **Agent/Fork custom resource** via `metav1.NewControllerRef`, which sets `blockOwnerDeletion: true`. K8s admission (`OwnerReferencesPermissionEnforcement`) only permits that if the creator can `update` the **owner's `/finalizers` subresource**.

The ADR-058 CRD migration changed the owner of these children from the agent **ConfigMap** to the Agent/Fork **CR**, but the controller RBAC kept the old `configmaps/finalizers` grant and never added the CR equivalent. The bootstrap ConfigMap is just the first child created in `Reconcile`, so that's where it dies.

## Fix

Grant the controller `agents/finalizers` + `forks/finalizers` (`update`); drop the now-dead `configmaps/finalizers`. RBAC-only — no controller image change.

## Deploy

Requires a `helm upgrade` to apply the updated controller Role. Once applied, reconciliation proceeds.

## Test

`mise run helm:check` (lint + kubeconform) clean; rendered `platform-controller` Role carries `agents/finalizers, forks/finalizers`.