### PR TITLE
fix(mise): generate CRD types to a temp file in the drift check (race) (ADR-058)

### DIFF
--- a/packages/api-server-api/scripts/gen-crd-types.sh
+++ b/packages/api-server-api/scripts/gen-crd-types.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Generate the Agent + Fork CR spec TypeScript types from the controller's CRDs
+# (ADR-058). Shared by api-server-api:gen:crd-types (writes the committed file)
+# and api-server-api:check:gen (writes a temp file, then diffs) so the drift
+# gate never rewrites the committed file that tsc consumers read.
+#
+# Usage: gen-crd-types.sh <repo-root> <output-file>
+set -eo pipefail
+root="$1"
+out="$2"
+crds="$root/deploy/helm/platform/files/crds"
+
+emit() { # <crd-file> <TypeName> — the CRD's .spec subschema as a TS interface
+  yq -o=json ".spec.versions[0].schema.openAPIV3Schema.properties.spec | .title = \"$2\"" "$crds/$1" \
+    | json2ts --no-additionalProperties --bannerComment ""
+}
+
+{
+  echo "/* Code generated from the agent-platform.ai CRDs by \`mise run api-server-api:gen:crd-types\`. DO NOT EDIT. */"
+  echo
+  emit agent-platform.ai_agents.yaml AgentSpecCR
+  echo
+  emit agent-platform.ai_forks.yaml ForkSpecCR
+} >"$out"
+
+pnpm exec prettier --write --config "$root/.prettierrc" "$out" >/dev/null

--- a/packages/api-server-api/tasks.toml
+++ b/packages/api-server-api/tasks.toml
@@ -36,33 +36,32 @@ run = "pnpm exec prettier --write 'src/**/*.ts'"
 description = "Regenerate the Agent + Fork CR spec TS types from the controller's CRDs (ADR-058). AgentSpec derives from AgentSpecCR and buildForkObject is typed against ForkSpecCR, so the Go-authored types are the single source."
 dir = "{{config_root}}/packages/api-server-api"
 # Chain: api/v1/*.go --(controller:generate)--> CRD yaml --(here)--> crd-types.gen.ts
-depends = ["controller:generate"]
+depends = ["controller:generate", "common:setup:pnpm"]
 sources = [
   "{{config_root}}/deploy/helm/platform/files/crds/agent-platform.ai_agents.yaml",
   "{{config_root}}/deploy/helm/platform/files/crds/agent-platform.ai_forks.yaml",
+  "scripts/gen-crd-types.sh",
 ]
 outputs = ["src/crd-types.gen.ts"]
+run = "bash scripts/gen-crd-types.sh {{config_root}} src/crd-types.gen.ts"
+
+["api-server-api:check:gen"]
+description = "Fail if the committed CRD types are stale vs the committed CRDs (ADR-058 drift gate). Generates to a temp file and diffs — it never rewrites the committed file, which the tsc consumers read concurrently during `mise run check`."
+dir = "{{config_root}}/packages/api-server-api"
+depends = ["common:setup:pnpm"]
+sources = [
+  "{{config_root}}/deploy/helm/platform/files/crds/agent-platform.ai_agents.yaml",
+  "{{config_root}}/deploy/helm/platform/files/crds/agent-platform.ai_forks.yaml",
+  "src/crd-types.gen.ts",
+  "scripts/gen-crd-types.sh",
+]
 run = '''
 #!/usr/bin/env bash
 set -eo pipefail
-crds="{{config_root}}/deploy/helm/platform/files/crds"
-out="src/crd-types.gen.ts"
-gen() { # <crd-file> <TypeName> — emit the .spec subschema as a TS interface
-  yq -o=json ".spec.versions[0].schema.openAPIV3Schema.properties.spec | .title = \"$2\"" "$crds/$1" \
-    | json2ts --no-additionalProperties --bannerComment ""
-}
-{
-  echo "/* Code generated from the agent-platform.ai CRDs by \`mise run api-server-api:gen:crd-types\`. DO NOT EDIT. */"
-  echo
-  gen agent-platform.ai_agents.yaml AgentSpecCR
-  echo
-  gen agent-platform.ai_forks.yaml ForkSpecCR
-} > "$out"
-pnpm exec prettier --write "$out" >/dev/null
+tmp="$(mktemp -d)/crd-types.gen.ts"
+bash scripts/gen-crd-types.sh "{{config_root}}" "$tmp"
+if ! diff -u src/crd-types.gen.ts "$tmp"; then
+  echo "crd-types.gen.ts is stale — run: mise run api-server-api:gen:crd-types" >&2
+  exit 1
+fi
 '''
-
-["api-server-api:check:gen"]
-description = "Fail if the generated CRD types are stale vs the committed CRDs (ADR-058 drift gate)."
-dir = "{{config_root}}/packages/api-server-api"
-depends = ["api-server-api:gen:crd-types"]
-run = "git diff --exit-code -- src/crd-types.gen.ts"


### PR DESCRIPTION
## Symptom (intermittent CI failure on main)

```
ui:check:tsc ../api-server-api/src/index.ts(53,28): error TS2305:
Module '"./crd-types.gen.js"' has no exported member 'ForkSpecCR'.
```

…even though the committed `crd-types.gen.ts` clearly exports `ForkSpecCR`.

## Root cause — a write/read race during `mise run check`

`api-server-api`'s `package.json` `main` is `./src/index.ts`, so consumers (the UI) resolve it **via source** — `tsc` reads `crd-types.gen.ts` directly.

`api-server-api:check:gen` depended on `api-server-api:gen:crd-types`, which **regenerates the committed `crd-types.gen.ts` in place** during the check (`> file`, write `AgentSpecCR`, then append `ForkSpecCR`). mise runs that concurrently with `ui:check:tsc` / `api-server-api:check:tsc`. A tsc task that reads the file mid-write sees `AgentSpecCR` but not yet `ForkSpecCR` → the error. The committed file is correct; the check transiently corrupts it.

## Fix

The drift check now **generates to a temp file and diffs** — it never rewrites the committed file the tsc consumers read. The generation is factored into `packages/api-server-api/scripts/gen-crd-types.sh`, shared by both tasks. `check:gen` no longer depends on `gen:crd-types`, so nothing regenerates committed files during `mise run check`.

## Verification

- Full `mise run check` green, and the committed `crd-types.gen.ts` is **untouched** afterward (`git status` clean) — proving no in-place regeneration during the check.
- `ui` + `api-server-api` tsc pass directly.
- `mise run api-server-api:check:gen` still gates drift (temp-vs-committed diff).