### PR TITLE
fix(agents): trust platform CA via OS store, not SSL_CERT_FILE override

### DIFF
--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -99,9 +99,8 @@ func BuildForkAgentJob(
 		{Name: "HTTP_PROXY", Value: proxyAddr},
 		{Name: "https_proxy", Value: proxyAddr},
 		{Name: "http_proxy", Value: proxyAddr},
-		{Name: "SSL_CERT_FILE", Value: caCertPath},
+		// SSL_CERT_FILE / GIT_SSL_CAINFO left unset — see resources.go.
 		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
-		{Name: "GIT_SSL_CAINFO", Value: caCertPath},
 		{Name: "NODE_USE_ENV_PROXY", Value: "1"},
 		{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
 		{Name: "PLATFORM_AGENT_ID", Value: forkSpec.AgentName},

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -150,9 +150,12 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		{Name: "HTTP_PROXY", Value: proxyAddr},
 		{Name: "https_proxy", Value: proxyAddr},
 		{Name: "http_proxy", Value: proxyAddr},
-		{Name: "SSL_CERT_FILE", Value: caCertPath},
+		// Node doesn't read the system trust store, so it gets the cluster CA
+		// through NODE_EXTRA_CA_CERTS (which adds to its built-in CAs). Other
+		// tools (git, curl, Go, Python) read the system store, where the agent
+		// entrypoint installs the CA — so we don't set SSL_CERT_FILE /
+		// GIT_SSL_CAINFO, which would replace and drop the public CAs.
 		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
-		{Name: "GIT_SSL_CAINFO", Value: caCertPath},
 		{Name: "NODE_USE_ENV_PROXY", Value: "1"},
 		{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
 		{Name: "PLATFORM_AGENT_ID", Value: name},

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -143,8 +143,14 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	for _, e := range c.Env {
 		assert.NotEqual(t, "AGENT_RUNTIME_TOKEN", e.Name)
 	}
-	assert.Equal(t, "/etc/platform/ca/ca.crt", envMap["SSL_CERT_FILE"])
+	// Node gets the CA via NODE_EXTRA_CA_CERTS; SSL_CERT_FILE / GIT_SSL_CAINFO
+	// stay unset because the entrypoint installs the CA into the system trust
+	// store for the other tools. See resources.go.
 	assert.Equal(t, "/etc/platform/ca/ca.crt", envMap["NODE_EXTRA_CA_CERTS"])
+	_, hasSSLCertFile := envMap["SSL_CERT_FILE"]
+	assert.False(t, hasSSLCertFile, "SSL_CERT_FILE must be left to the entrypoint")
+	_, hasGitCAInfo := envMap["GIT_SSL_CAINFO"]
+	assert.False(t, hasGitCAInfo, "GIT_SSL_CAINFO must be left to the entrypoint")
 	assert.Equal(t, "my-instance", envMap["PLATFORM_AGENT_ID"])
 	assert.Equal(t, "8080", envMap["ACP_PORT"])
 	assert.Equal(t, "alpha", envMap["GITHUB_ORG"])

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -89,6 +89,16 @@ COPY packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
 RUN chmod +x /usr/local/bin/harness-chat /usr/local/bin/harness-terminal
 
+# CA-trust shim (entrypoint.sh): at startup it adds the cluster's CA to the
+# system trust store. It runs as the non-root agent user, so give that user
+# write access to the dirs update-ca-trust touches — the CA input dir, the
+# generated-bundle dir, and the legacy cert dir (/etc/pki/tls/certs, where only
+# the dir itself needs to be writable; its symlinks stay root-owned).
+COPY packages/platform-base/entrypoint.sh /usr/local/bin/agent-entrypoint
+RUN chmod +x /usr/local/bin/agent-entrypoint \
+    && chown -R 65532 /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted \
+    && chown 65532 /etc/pki/tls/certs
+
 COPY packages/platform-base/skills/ /app/working-dir/.agents/skills/
 COPY packages/platform-base/working-dir/.claude.json /app/working-dir/.claude.json
 COPY packages/platform-base/working-dir/.claude/settings.json /app/working-dir/.claude/settings.json
@@ -122,4 +132,5 @@ USER 65532
 ENV PORT=8080
 EXPOSE 8080
 
+ENTRYPOINT ["/usr/local/bin/agent-entrypoint"]
 CMD ["node", "dist/server.js"]

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# The agent reaches the internet only through its Envoy gateway. For some hosts
+# the gateway intercepts the TLS connection and returns a certificate signed by
+# the cluster's own CA (the "platform MITM CA"), so the agent must trust that CA
+# on top of the normal public ones. We add it to the system trust store here
+# (update-ca-trust) instead of via SSL_CERT_FILE / GIT_SSL_CAINFO, because those
+# env vars replace the public CAs rather than add to them. Node is the exception:
+# it doesn't read the system store, so the controller hands it the CA through
+# NODE_EXTRA_CA_CERTS. Runs as the non-root agent user; the trust dirs are made
+# writable at build time (see Dockerfile).
+set -eu
+
+mitm_ca=/etc/platform/ca/ca.crt
+anchor=/etc/pki/ca-trust/source/anchors/platform-mitm-ca.crt
+
+# No CA file mounted means the gateway never intercepts this agent's traffic, so
+# every host returns its real public certificate, which the public CAs cover.
+if [ -s "$mitm_ca" ]; then
+	cp "$mitm_ca" "$anchor" && /usr/sbin/update-ca-trust extract \
+		|| echo "agent-entrypoint: WARNING: could not trust the platform CA; intercepted hosts may fail TLS" >&2
+fi
+
+exec "$@"


### PR DESCRIPTION
## Problem

Agent `git clone`/curl to **tunnelled (pass-through) hosts** failed with `SSL certificate ... unable to get local issuer certificate (20)`.

The controller set `SSL_CERT_FILE`/`GIT_SSL_CAINFO` to the bare 1-cert platform MITM CA. Those vars **replace** the CA bundle, so they dropped the ~146 public roots. That was fine in the original "gateway MITMs the host" model — the gateway's leaf is signed by the platform CA, which is exactly what that file contains. It breaks once a host is **allowed but not MITM'd**:

- **Credentialed hosts** (a granted connection, in the Envoy leaf SAN) → gateway MITMs, presents a platform-CA-signed cert → verifies against the bare CA. **Always worked** (e.g. `api.anthropic.com`).
- **Host-level allow-listed hosts** (e.g. `github.com` via the `trusted` preset, `method=* path=*`) → gateway L4-tunnels to the real upstream, which presents its **genuine public cert** → the platform-CA-only bundle can't verify it. **Failed.**

Reproduced on `claude-code-test` (only `api.anthropic.com` in its leaf SAN; `github.com` on `preset:trusted`): with `--cacert /etc/platform/ca/ca.crt`, `api.anthropic.com` → HTTP 400 (TLS OK), `github.com` → error 60.

## Fix

Install the per-cluster MITM CA into the **OS trust store** at pod start (`update-ca-trust`), so OS TLS clients (git, curl, Go, Python) trust both the public roots **and** the MITM CA — both the MITM'd and tunnelled cases verify. Drop `SSL_CERT_FILE`/`GIT_SSL_CAINFO`; keep the **additive** `NODE_EXTRA_CA_CERTS` for Node (which ignores the OS store). No regression to the previously-working MITM'd path.

- `platform-base`: new non-root entrypoint runs `update-ca-trust`; trust dirs chowned to UID 65532 so it works without root.
- `controller`: remove the two replace-semantics env vars from agent + fork pods.

Verified: CA mounted → bundle 146→147, anchor trusted, `update-ca-trust` exits 0; no CA mounted → clean no-op. Controller tests pass.

## Security

`/etc/pki/ca-trust/*` (+ the `/etc/pki/tls/certs` dir) are now writable by the agent UID. This is **not** a privilege escalation:

- A process already controls its own TLS trust (`curl -k`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, its own `SSL_CERT_FILE`). Writing the OS store adds nothing it couldn't already do to its own connections.
- TLS trust is not the egress boundary — that's enforced **outside** the pod by NetworkPolicy + Envoy `ext_authz` (ADR-035). Trusting an extra CA can't reach a host the gateway/NP blocks, nor mint credentials (those live only in the gateway pod, ADR-038; agent has no SA token, ADR-033).
- Blast radius is one ephemeral pod: `/etc/pki` is on the container rootfs (not persisted), with `runAsNonRoot`, `allowPrivilegeEscalation: false`, `drop ALL` caps.
- Chosen over a root init container with a read-only-mounted store: marginally stricter but adds a privileged container for a boundary that isn't the real control; keeping the whole pod non-root is more valuable.
- chown scope is tight: recursive on the CA-input + generated-bundle dirs; `/etc/pki/tls/certs` is dir-only (its root-owned symlinks untouched).

## Out of scope

User-init scripts (`agentSpec.Init`) bypass the entrypoint and lack proxy+CA env — tracked in #626.