### PR TITLE
fix(cluster): unbreak cluster:build-agent Tera parse error

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -624,7 +624,7 @@ while IFS=$'\t' read -r name image; do
   fi
 done <<< "$DEPLOYED_AGENTS"
 
-if [ ${#AGENT_IMAGES[@]} -eq 0 ]; then
+if [ -z "${AGENT_IMAGES[*]}" ]; then
   echo "No agent templates deployed — nothing to build."
   exit 0
 fi


### PR DESCRIPTION
## Problem

`mise run cluster:build-agent` fails immediately with a Tera template parse error and never runs:

```
[cluster:build-agent] ERROR Failed to parse '__tera_one_off'
  = expected a comment end (`#}`)
```

`mise` renders task `run` scripts through the Tera template engine before executing them (that's how `{{ mise_bin }}` expands). Tera treats `{#` … `#}` as a comment. Bash's array-length syntax `${#AGENT_IMAGES[@]}` contains the substring `{#`, so Tera opens a comment that never closes, swallows the rest of the script, and the task dies at parse time before a single line runs.

Introduced in #596, which replaced the safe `[ -z "${AGENT_TASKS[*]}" ]` check with an array-length test.

## Fix

Use the same emptiness-check idiom already used for `AGENT_TASKS` in the task, which avoids the `{#` token:

```diff
-if [ ${#AGENT_IMAGES[@]} -eq 0 ]; then
+if [ -z "${AGENT_IMAGES[*]}" ]; then
```

## Verification

`mise run cluster:build-agent` now parses and proceeds into the actual image build.

## Follow-up

The same `${#...}` / `{#` collision still exists in the orphan-PVC task (`deploy/tasks.toml` ~lines 848/851). Left out to keep this PR scoped; worth a separate fix.