### PR TITLE
fix(cluster): force-conflicts on dev helm apply, pin helm to v4.2.0

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -427,7 +427,10 @@ echo "Installing/upgrading Platform chart..."
 # No --wait: the keycloak-provision post-install hook imports the platform realm
 # after deployments come up. With --wait, helm would block on readiness
 # before the hook runs.
-helm --kubeconfig="$KUBECONFIG" upgrade --install platform deploy/helm/platform -f deploy/helm/platform/values-local.yaml --timeout 15m ${HELM_VALUES:+-f "$HELM_VALUES"} "${HELM_EXTRA_ARGS[@]}"
+# --force-conflicts: Helm v4 applies server-side; field drift on a chart-managed
+# object (a stray kubectl patch/rollout, another controller) otherwise hard-fails
+# the upgrade with an ownership conflict. The chart is the source of truth here.
+helm --kubeconfig="$KUBECONFIG" upgrade --install platform deploy/helm/platform -f deploy/helm/platform/values-local.yaml --timeout 15m --force-conflicts ${HELM_VALUES:+-f "$HELM_VALUES"} "${HELM_EXTRA_ARGS[@]}"
 
 # 5. Restart pods to pick up new local images (dev only — :latest tags don't trigger rollout)
 if [ "$NO_RESTART" = true ]; then

--- a/mise.toml
+++ b/mise.toml
@@ -16,8 +16,6 @@ java = "21"
 maven = "latest"
 
 # Kubernetes
-# Pinned: Helm v4 applies server-side by default; floating "latest" silently
-# changes apply semantics. Bump deliberately.
 helm = "4.2.0"
 kubeconform = "latest"
 "lima" = "2"

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,9 @@ java = "21"
 maven = "latest"
 
 # Kubernetes
-helm = "latest"
+# Pinned: Helm v4 applies server-side by default; floating "latest" silently
+# changes apply semantics. Bump deliberately.
+helm = "4.2.0"
 kubeconform = "latest"
 "lima" = "2"
 


### PR DESCRIPTION
## Problem

`mise run cluster:install` fails with a server-side-apply conflict:

```
UPGRADE FAILED: conflict occurred while applying object default/platform-apiserver
... conflicts with "kubectl-patch" ... maxSurge / maxUnavailable
```

Helm pinned to `latest` floated up to **v4**, which applies **server-side** by default. Field drift on a chart-managed object (a stray `kubectl patch`/`rollout`, another controller) now becomes an ownership conflict that hard-fails the upgrade. Under v3's client-side merge this was silently reconciled.

## Change

- `deploy/tasks.toml`: add `--force-conflicts` to the dev `helm upgrade`. The chart is the source of truth in the install loop, so Helm reclaims drifted fields instead of wedging.
- `mise.toml`: pin `helm = "4.2.0"` (matches `mise.lock`) so floating `latest` can't silently change apply semantics again.

## Scope

Dev install loop only — not the prod upgrade path.