### PR TITLE
test(e2e): stabilize agent and messages specs

### DIFF
--- a/packages/e2e/playwright/src/tests/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-agent.spec.ts
@@ -8,6 +8,8 @@ import { getConnectionId } from "../lib/connections.js";
 import { agentName, connectionName, harnessName } from "../lib/fixtures.js";
 
 test("create a mock agent with the connection attached", async ({ page }) => {
+  test.setTimeout(60_000);
+
   const token = await getAccessToken();
   const api = createApiClient(token);
 

--- a/packages/e2e/playwright/src/tests/04-messages.spec.ts
+++ b/packages/e2e/playwright/src/tests/04-messages.spec.ts
@@ -2,6 +2,8 @@ import { expect, test } from "@playwright/test";
 
 import { baseUrl } from "../config.js";
 import {
+  agentCardStatus,
+  gotoAgentDetail,
   sendMessageToAgent,
   setMockAgentReply,
   waitForAgentRunning,
@@ -20,8 +22,14 @@ test("exchange messages with the agent", async ({ page }) => {
   const agentId = await waitForAgentRunning(api, agentName);
   await setMockAgentReply(api, agentId, scriptedReply);
 
-  await test.step("open the agent chat", async () => {
-    await page.goto(`${baseUrl}/chat/${agentId}`);
+  await test.step("open the agent chat from the agent list", async () => {
+    await page.goto(baseUrl);
+    await expect(page.getByTestId("app-sidebar")).toBeVisible();
+
+    await expect(agentCardStatus(page, agentName, "Running")).toBeVisible();
+
+    await gotoAgentDetail(page, agentName, agentId);
+
     await expect(page.getByPlaceholder(/message agent/i)).toBeVisible();
   });
 


### PR DESCRIPTION
## What

- Bump the `03-agent` create-agent test timeout to 60s. It was occasionally blowing past the 30s default while waiting for the mock agent to reach running.
- `04-messages` now opens the chat from the agent list (via `gotoAgentDetail`) instead of navigating straight to the `/chat/:id` URL, matching how a user actually gets there.

## Notes

No production code touched, e2e specs only.