### PR TITLE
fix(ui): unstick restart pill on error

### DIFF
--- a/packages/ui/src/modules/agents/hooks/use-restart-agent.ts
+++ b/packages/ui/src/modules/agents/hooks/use-restart-agent.ts
@@ -35,7 +35,7 @@ export function useRestartAgent() {
  * "Restarting" pill so stuck/resolved entries age out correctly.
  */
 export function useSyncRestartingAgents() {
-  const { data } = useAgents();
+  const { data, dataUpdatedAt } = useAgents();
   const setRestartingAgents = useStore((s) => s.setRestartingAgents);
 
   useEffect(() => {
@@ -43,5 +43,5 @@ export function useSyncRestartingAgents() {
     const current = useStore.getState().restartingAgents;
     const next = transitionRestartingAgents(current, data.list);
     if (next !== current) setRestartingAgents(next);
-  }, [data, setRestartingAgents]);
+  }, [data, dataUpdatedAt, setRestartingAgents]);
 }


### PR DESCRIPTION
## Problem

Clicking Restart shows a RESTARTING pill that never clears when the agent ends in error. Only a full page reload (F5) fixes it.

## Cause

`useSyncRestartingAgents` re-runs its cleanup (`transitionRestartingAgents`) only when the agents query `data` *reference* changes. TanStack Query structural sharing keeps that reference stable when a poll returns a deep-equal payload. Restarting an agent that is already in `error` and fails the restart identically produces byte-identical poll payloads, so the cleanup never runs and the optimistic pill sticks. Reload "fixes" it only because it wipes the client store.

## Fix

Depend on `dataUpdatedAt`, which advances on every successful fetch regardless of structural sharing. The transition now runs each poll and drops the pill within one cycle.

## Notes

- `transitionRestartingAgents` was already correct (it drops on `error`); only the effect trigger was wrong.
- The restart failure in the repro was the istiod validating-webhook outage (#283), a separate infra issue, not part of this fix.

## Test

`ui:check:tsc`, `ui:check:lint`, `ui:test` (39) all pass.