### PR TITLE
fix(controller): answer np-gate probe via gateway health_check filter (#675)

### DIFF
--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -510,6 +510,10 @@ func hostShort(host string) string {
 //   - Admin interface intentionally omitted; the gateway pod's NetworkPolicy
 //      additionally admits ingress only from its paired agent pod.
 
+// Gateway liveness path the health_check filter answers locally before
+// ext_authz, so the np-gate probe doesn't trip the egress gate (#675).
+const platformGatewayHealthPath = "/__platform_healthz"
+
 const envoyBootstrapTmpl = `node:
   id: platform-credential-injector
   cluster: platform-credential-injector
@@ -531,6 +535,15 @@ static_resources:
                 upgrade_configs:
                   - upgrade_type: CONNECT
                 http_filters:
+                  # np-gate liveness probe (#675): answered locally before
+                  # ext_authz; pass_through_mode:false so it never forwards.
+                  - name: envoy.filters.http.health_check
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.health_check.v3.HealthCheck
+                      pass_through_mode: false
+                      headers:
+                        - name: ":path"
+                          string_match: { exact: "{{ $.HealthPath }}" }
                   # Gate plain-HTTP egress (ADR-035). The
                   # CONNECT route disables this via per-route config — TLS
                   # tunnels are gated downstream (per-host L7 chain or
@@ -1055,6 +1068,7 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		HarnessAuthority       string
 		HarnessHost            string
 		HarnessPort            int
+		HealthPath             string
 		ExtAuthzHost           string
 		ExtAuthzPort           int
 		ExtAuthzHoldSeconds    int
@@ -1067,6 +1081,7 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		CredentialSDSName:      envoyCredentialSDSName,
 		LeafTLSDir:             envoyLeafTLSMount,
 		HarnessAuthority:       harnessAuthority,
+		HealthPath:             platformGatewayHealthPath,
 		HarnessHost:            cfg.HarnessHost(),
 		HarnessPort:            cfg.HarnessServerPort,
 		ExtAuthzHost:           cfg.ExtAuthzHostFor(extAuthzInstanceID),
@@ -1157,7 +1172,7 @@ func ptrBool(b bool) *bool { return &b }
 // kubelet keeps the old bootstrap mounted.
 //
 // Bump on any template change that affects pod-visible behavior.
-const envoyBootstrapTemplateRev = "v10-url-encode-cred"
+const envoyBootstrapTemplateRev = "v11-gateway-health-probe"
 
 // envoySecretsRev digests the Secret set that drives Envoy's chain
 // rendering. Includes `injection-hosts` JSON so a descriptor change

--- a/packages/controller/pkg/reconciler/np_gate_init.go
+++ b/packages/controller/pkg/reconciler/np_gate_init.go
@@ -21,16 +21,9 @@ const npGateUser int64 = 65532
 // enforced — used on runtimes where the in-pod iptables init can't run
 // (Kata/CoCo guest kernels without netfilter).
 //
-// It runs a small shell+curl probe (from a hardened curl image) in a loop:
-// the kube-apiserver (kubelet-injected KUBERNETES_SERVICE_HOST/PORT) must be
-// UNREACHABLE — the agent egress NP DROPs it — while the paired gateway must
-// be REACHABLE. The apiserver is the chosen "denied" target because it's the
-// only one always actively listening AND always silently DROPped by the NP;
-// other targets admit TCP-RST false positives. Reachability is read from
-// curl's %{time_connect}: a completed TCP handshake records a non-zero time,
-// a silent DROP yields 0.000000. The http:// scheme only drives the connect —
-// the response is discarded — so it works against any TCP port regardless of
-// the protocol it actually speaks.
+// Probe: the kube-apiserver (kubelet-injected env) must stay DROPped, detected
+// by TCP handshake since it answers when reachable; the gateway must 200 on the
+// health path, which the health_check filter serves before ext_authz (#675).
 //
 // Fail-closed: timeout → exit 1 → pod stays in Init:CrashLoopBackOff.
 //
@@ -52,25 +45,29 @@ func buildNPGateInitContainer(cfg *config.Config, gatewayClusterIP string) *core
 	// kubelet into every pod — no plumbing needed here.
 	script := `set -u
 deadline=$(($(date +%s) + ${TIMEOUT_SECONDS}))
-echo "np-gate: probing denied=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}, deadline=${TIMEOUT_SECONDS}s"
-# connected HOST PORT -> 0 if the TCP handshake completes. curl's
-# %{time_connect} is 0.000000 only when no connection established (silent DROP
-# or refused); any completed handshake records a non-zero time, whatever the
-# port speaks afterwards. -o /dev/null discards the (irrelevant) response.
-connected() {
+echo "np-gate: probing denied=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}${HEALTH_PATH}, deadline=${TIMEOUT_SECONDS}s"
+# Denied-target probe: handshake completed iff %{time_connect} != 0 (the
+# apiserver answers TLS/non-200 when reachable, so status isn't the signal).
+reachable() {
     tc=$(curl -s -o /dev/null --connect-timeout 2 -m 3 -w '%{time_connect}' "http://$1:$2" 2>/dev/null)
     [ -n "$tc" ] && [ "$tc" != "0.000000" ]
 }
+# Gateway probe: 200 on the health path. The health_check filter answers it
+# before ext_authz, so this never trips the egress gate (#675).
+gateway_ready() {
+    code=$(curl -s -o /dev/null --connect-timeout 2 -m 3 -w '%{http_code}' "http://${GATEWAY_IP}:${ENVOY_PORT}${HEALTH_PATH}" 2>/dev/null)
+    [ "$code" = "200" ]
+}
 while [ "$(date +%s)" -lt "${deadline}" ]; do
-    if ! connected "${KUBERNETES_SERVICE_HOST}" "${KUBERNETES_SERVICE_PORT}"; then
-        if connected "${GATEWAY_IP}" "${ENVOY_PORT}"; then
-            echo "np-gate: NetworkPolicy enforced (denied ${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} blocked, gateway ${GATEWAY_IP}:${ENVOY_PORT} reachable)"
+    if ! reachable "${KUBERNETES_SERVICE_HOST}" "${KUBERNETES_SERVICE_PORT}"; then
+        if gateway_ready; then
+            echo "np-gate: NetworkPolicy enforced (denied ${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} blocked, gateway ${GATEWAY_IP}:${ENVOY_PORT} serving ${HEALTH_PATH})"
             exit 0
         fi
     fi
     sleep 0.3
 done
-echo "np-gate: FATAL — NetworkPolicy did not converge within ${TIMEOUT_SECONDS}s (denied=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT})" >&2
+echo "np-gate: FATAL — NetworkPolicy did not converge within ${TIMEOUT_SECONDS}s (denied=${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT} allowed=${GATEWAY_IP}:${ENVOY_PORT}${HEALTH_PATH})" >&2
 exit 1
 `
 
@@ -78,6 +75,8 @@ exit 1
 		{Name: "GATEWAY_IP", Value: gatewayClusterIP},
 		{Name: "ENVOY_PORT", Value: fmt.Sprintf("%d", cfg.EnvoyPort)},
 		{Name: "TIMEOUT_SECONDS", Value: fmt.Sprintf("%d", timeoutSeconds)},
+		// Matches the gateway health_check filter path (envoy.go).
+		{Name: "HEALTH_PATH", Value: platformGatewayHealthPath},
 	}
 
 	user := npGateUser

--- a/packages/controller/pkg/reconciler/np_gate_init_test.go
+++ b/packages/controller/pkg/reconciler/np_gate_init_test.go
@@ -69,14 +69,20 @@ func TestBuildNPGateInitContainer_ProbeShape(t *testing.T) {
 	assert.Equal(t, "/bin/sh", ic.Command[0])
 	script := ic.Command[2]
 
-	// Probe shape: curl connect-test against kube-apiserver (must be DROPped)
-	// and the gateway (must be reachable), read from %{time_connect}. Both
+	// Probe shape: the denied target (kube-apiserver) is a handshake test read
+	// from %{time_connect} — it must be DROPped. The allowed target (gateway)
+	// is an HTTP 200 from the platform health path read from %{http_code} —
+	// that route is answered by the health_check filter before ext_authz, so
+	// the probe never creates a HITL hold for the gateway IP (#675). Both
 	// conditions must hold before exit 0; fail-closed on the deadline.
 	assert.Contains(t, script, `--connect-timeout 2`)
-	assert.Contains(t, script, `%{time_connect}`)
-	assert.Contains(t, script, `connected "${KUBERNETES_SERVICE_HOST}" "${KUBERNETES_SERVICE_PORT}"`,
+	assert.Contains(t, script, `%{time_connect}`, "denied target uses TCP-handshake timing")
+	assert.Contains(t, script, `%{http_code}`, "allowed target asserts a 200 from the health endpoint")
+	assert.Contains(t, script, `reachable "${KUBERNETES_SERVICE_HOST}" "${KUBERNETES_SERVICE_PORT}"`,
 		"negative probe against kube-apiserver (kubelet-injected env)")
-	assert.Contains(t, script, `connected "${GATEWAY_IP}" "${ENVOY_PORT}"`, "positive probe against the paired gateway")
+	assert.Contains(t, script, `gateway_ready`, "positive probe is the gateway health check")
+	assert.Contains(t, script, `${HEALTH_PATH}`, "gateway probe targets the namespaced health path, not /")
+	assert.Contains(t, script, `[ "$code" = "200" ]`, "gateway probe requires a 200, not just a connect")
 	assert.Contains(t, script, "exit 1", "fail-closed on timeout — NP didn't converge")
 	assert.Contains(t, script, "exit 0", "release the workload when both probes match expectation")
 
@@ -87,6 +93,9 @@ func TestBuildNPGateInitContainer_ProbeShape(t *testing.T) {
 	assert.Equal(t, "10.96.42.42", envMap["GATEWAY_IP"])
 	assert.Equal(t, "30", envMap["TIMEOUT_SECONDS"])
 	assert.NotEmpty(t, envMap["ENVOY_PORT"])
+	// The probe path is plumbed from the controller and must match the path
+	// the gateway's health_check filter answers (envoy.go).
+	assert.Equal(t, platformGatewayHealthPath, envMap["HEALTH_PATH"])
 	// kube-apiserver isn't plumbed via our env block — kubelet does it.
 	_, kubeHostSet := envMap["KUBERNETES_SERVICE_HOST"]
 	_, kubePortSet := envMap["KUBERNETES_SERVICE_PORT"]


### PR DESCRIPTION
## Problem

New agents don't respond out of the box on deployments using `npGateInit` egress lockdown (OpenShift Sandboxed Containers): the first traffic surfaces a HITL network-approval prompt for an opaque internal address (e.g. `172.30.x.x`), which is the **paired gateway Service's own ClusterIP**. Fixes #675.

## Root cause — a regression from #434

The `npGateInit` egress-lockdown init container probes the paired gateway to confirm the agent egress NetworkPolicy has converged. #434 (hardened-image migration) switched that probe from `nc -z` to `curl http://$GATEWAY_IP:$ENVOY_PORT`.

- `nc -z` only completes the TCP handshake and sends **no application bytes**, so the gateway's Envoy HCM never decodes a request and ext_authz never runs.
- `curl http://…` sends a real `GET /`. With no proxy env, it lands directly on the gateway Envoy's outer HCM and matches the **plain-HTTP fallthrough route** — the one route where the `ext_authz` filter is *not* disabled (the CONNECT and harness routes all opt out). So the gate fires with `host = <gatewayIP>`, finds no egress rule, and opens a HITL hold → the spurious internal-IP prompt.

Invisible on k3s dev/e2e because those run `iptablesInit` (no HTTP probe); only `npGateInit` deployments hit it.

## Fix

Add an `envoy.filters.http.health_check` filter on the gateway's outer HCM, **ordered before `ext_authz`**, `pass_through_mode: false`, matched on an exact, deliberately-namespaced path `/__platform_healthz`:

- It answers the path locally with `200` and short-circuits the filter chain before the gate — so the probe never creates a hold.
- `pass_through_mode: false` means it **never forwards upstream**, so it cannot become an egress bypass.
- The path is `__`-namespaced so it can't collide with real plain-HTTP egress (HTTPS egress arrives as CONNECT, whose `:path` is the authority, so it never matches).

The np-gate probe now asserts a `200` from that path for the *allowed* (gateway) target; the kube-apiserver *denied* target stays a TCP-handshake (`%{time_connect}`) check. The egress gate is unchanged for every other path. The bootstrap template rev is bumped so existing gateway pods roll.

## Verification (live, against a rolled gateway)

| request | result | ext_authz hold? |
|---|---|---|
| `GET /__platform_healthz` | `200`, ~5ms | none (no log line) |
| `GET /` (control) | held 4s, `000` | `egress.hold` for gateway IP |
| spoofed `Host:` / proxied to real host on the path | local `200`, `size_download=0` | none — never forwarded |
| `/__platform_healthz/`, `/__platform_healthzX`, `/healthz` | held, `000` | gated — carve-out is exact-match only |

So the probe works, the gate stays fully active for everything except the one local-reply path, and the path never forwards (no exfil channel).

## Follow-up (not in this PR)

The gateway pod has no readiness/liveness probe today. A dedicated gateway health listener for real kubelet probes is worth doing as a separate change (it carries the Istio-ambient + NetworkPolicy probe-wiring question), tracked separately.