### PR TITLE
feat(skills): wake a hibernated agent for skills management

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-06-03
+Last verified: 2026-06-05
 
 ## Motivated by
 
@@ -88,10 +88,11 @@ Connector state that doesn't fit the env model (per-host CLI configs, allowlists
 Every caller that sends work to a pod — the controller's schedule loop, the api-server's ACP relay, channel adapters — routes through a single reachability primitive ([ADR-032](../adrs/032-pod-reachability-primitive.md)). The primitive's contract: **observed pod `Ready` is the authoritative answer to "can I call this pod?"** `spec.desiredState` is user intent (running vs. hibernated) and continues to drive the reconciler, but it is no longer read as a reachability signal by callers. The primitive flips `desiredState` to `running` if needed, single-flights concurrent waits per Agent, bumps the `platform.ai/last-activity` annotation on every successful call (so any caller implicitly keeps the pod warm), and is implemented in parallel in Go (controller) and TypeScript (api-server).
 Per [ADR-060](../adrs/060-unified-apply-path-and-contributions-settled-gate.md), Contributions are applied out-of-band by a single background worker (a pod's `hello` is presence-only — it just signals the worker to dispatch). The worker dispatches **only to a Ready agent** — the same readiness gate the relay's `ensureReady` uses (the controller's `Ready` condition, [ADR-059](../adrs/059-agent-readiness-status.md)) — so an apply never targets a pod that is down or rolling; when the agent isn't Ready the outbox row stays unsettled and the periodic sweep re-dispatches once it is. Each apply runs every contribution to termination and records which drivers failed; a degraded agent (failed installs retrying in the background, capped) surfaces via its `contributionFailures` badge and never wedges. Readiness itself does **not** wait on contributions — configuration applies in the background.
 
-Two paths trigger a wake:
+Three paths trigger a wake:
 
 - **Connect-driven** — the api-server is about to forward an ACP frame to a hibernated Agent and ensures readiness before the relay completes. The frame can originate from a UI tab attaching to a session or from a channel worker (Slack / Telegram) routing an inbound message to its bound session.
 - **Schedule-driven** — the controller's schedule loop is about to deliver a trigger and `kubectl exec` requires the pod to be running ([ADR-008](../adrs/008-trigger-files.md)).
+- **Skills-management-driven** — install / uninstall / private-source scan / publish all route through the same primitive before reaching the agent (scan and publish reach agent-runtime directly over the harness port; install/uninstall keep the pod warm so the [ADR-060](../adrs/060-unified-apply-path-and-contributions-settled-gate.md) apply worker dispatches the bumped outbox). See [skills](skills.md).
 
 Wake is bounded — the primitive polls pod readiness with backoff and gives up after two minutes, surfacing a loud error to its caller (schedule status, WS close code, or channel log).
 
@@ -131,7 +132,7 @@ Terminal-mode sessions ([ADR-037](../adrs/037-remote-terminal.md)) follow a diff
 
 Switching a session's mode (e.g. chat → terminal) is metadata-only ([ADR-055](../adrs/055-agent-owned-session-metadata.md)): the switching client persists the new mode over ACP (`session/resume` carrying `_meta.platform.mode`), which the runtime merges into its session-metadata store. The running harness is unaffected — mode is a UI hint about which surface (chat vs. terminal PTY) to render. There is no cross-client notification; other clients reflect the change on their next `session/list`. The `--reset` / terminal-reset path is independent: it closes the terminal WebSocket and calls agent-runtime's `resetSession`, which sends `session/close` to the harness and clears the in-memory log and cursors.
 
-Beyond ACP frames, agent-runtime also serves a Bearer-authenticated tRPC surface on the harness port for skill install / uninstall / scan / publish / listLocal. The api-server is the sole caller; skill files land on the PVC under the configured Skill Paths and are picked up by the harness on the next session start (no hot-reload). See [skills](skills.md).
+Beyond ACP frames, agent-runtime also serves a Bearer-authenticated tRPC surface on the harness port for skill install / uninstall / scan / publish / listLocal. The api-server is the sole caller; the skills-*management* calls wake a hibernated pod through the reachability primitive (above) before reaching it, while the read paths (`state` / `listLocal`) degrade gracefully and never wake. Skill files land on the PVC under the configured Skill Paths and are picked up by the harness on the next session start (no hot-reload). See [skills](skills.md).
 
 [ADR-012](../adrs/012-runtime-lifetime.md) is the **target** lifetime model — single-use Kubernetes Jobs per turn, with a Redis-backed read cache for lightweight queries and a two-tier PVC layout (per-session + shared). Migration is on a parallel track and not blocking. The current prototype uses the persistent runtime described above.
 

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Last verified: 2026-05-22
+Last verified: 2026-06-05
 
 ## Motivated by
 
@@ -10,6 +10,7 @@ Last verified: 2026-05-22
 - [ADR-024 — Connector-declared envs and per-agent overrides](../adrs/024-connector-declared-envs.md) — env composition rules for agent pods
 - [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy performs the credential swap
 - [ADR-038 — Paired agent and gateway pods](../adrs/038-paired-gateway-pod.md) — Envoy lives in a paired gateway pod, not a sidecar
+- [ADR-032 — Centralized pod-reachability primitive](../adrs/032-pod-reachability-primitive.md) — skill *management* (install / uninstall / private scan / publish) wakes a hibernated agent through the shared `ensureReady` primitive rather than refusing
 
 ## Overview
 
@@ -111,9 +112,9 @@ Lives in [`packages/api-server/src/modules/skills/`](../../packages/api-server/s
 - The **Skill Source catalogue** — CRUD on user sources, merging in system seeds and template sources, dedupe and badge resolution.
 - The **scan cache** — per-`gitUrl`, 5-minute TTL, invalidated on `sources.refresh` or after a successful publish to that source.
 - **Public-archive scanning** — for `github.com` URLs, downloads `archive/HEAD.tar.gz` directly from GitHub, walks for `SKILL.md`, parses frontmatter, computes `contentHash`. No credentials required. This is the path that lets the catalog UI render even when no agent is running.
-- **Private / non-GitHub fallback** — falls through to the agent-runtime `skills.scan` over the harness port. Requires a running agent because the credential path needs the paired gateway pod; the api-server has none.
-- **Install / uninstall orchestration** — calls agent-runtime over its harness-port tRPC and on success upserts the `agent_skills` row with the returned `contentHash`. The api-server is the only pod whose NetworkPolicy can reach the agent's tRPC listener; no Bearer token is sent.
-- **Publish orchestration** ([`publish-service`](../../packages/api-server/src/modules/skills/services/publish-service.ts)) — validates that the source is a GitHub URL (only host that supports publish), calls agent-runtime, and on success writes the `agent_skill_publishes` row and invalidates the scan cache for that source.
+- **Private / non-GitHub fallback** — falls through to the agent-runtime `skills.scan` over the harness port. Needs the credential path's paired gateway pod, so it **wakes a hibernated agent** via the [ADR-032](../adrs/032-pod-reachability-primitive.md) `ensureReady` primitive (still requires an `agentId` to target).
+- **Install / uninstall orchestration** — wakes a hibernated agent ([ADR-032](../adrs/032-pod-reachability-primitive.md)) before recording the change, then upserts the `agent_skills` row and bumps the outbox; the [ADR-060](../adrs/060-unified-apply-path-and-contributions-settled-gate.md) apply worker applies it onto the (now-warm) pod. The api-server is the only pod whose NetworkPolicy can reach the agent's tRPC listener; no Bearer token is sent.
+- **Publish orchestration** ([`publish-service`](../../packages/api-server/src/modules/skills/services/publish-service.ts)) — validates that the source is a GitHub URL (only host that supports publish), wakes a hibernated agent ([ADR-032](../adrs/032-pod-reachability-primitive.md)), calls agent-runtime, and on success writes the `agent_skill_publishes` row and invalidates the scan cache for that source.
 - **Reconciled `state` view** — joins live `listLocal` from agent-runtime with the `agent_skills` rows, drops ghost rows whose directories were deleted out-of-band (and persists the cleanup), and folds in the `agent_skill_publishes` rows.
 - **MCP tools** — five tools registered on the per-agent MCP endpoint ([`mcp-endpoint.ts`](../../packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts)): `list_skill_sources`, `list_skills_in_source`, `install_skill`, `uninstall_skill`, `publish_skill`. `agentId` is bound by the verified MCP session token, not user input — agents cannot spoof which agent they're acting on.
 - **Cleanup saga** — subscribes to `AgentDeleted` and deletes both `agent_skills` and `agent_skill_publishes` rows for the deleted agent. User-owned `skill_sources` are unaffected; they outlive any single agent.
@@ -210,7 +211,7 @@ GitHub errors (missing scope, repo not found) surface to agent-runtime as the up
 `skills.list(sourceId, agentId?)` resolves the source and dispatches:
 
 - **Public GitHub** → `public-archive-scanner` from the api-server, served from the per-`gitUrl` cache when fresh. No agent required.
-- **Anything else** → agent-runtime `skills.scan`. Requires a running agent and surfaces a clear error if `agentId` is missing.
+- **Anything else** → agent-runtime `skills.scan`. Requires an `agentId` (surfaces a clear error if missing) and **wakes a hibernated agent** via the [ADR-032](../adrs/032-pod-reachability-primitive.md) primitive before scanning.
 
 The cache is invalidated on `sources.refresh` and after every successful publish to that source — the latter so a freshly-merged PR shows up on the next list.
 

--- a/packages/api-server/src/modules/skills/services/ensure-agent-reachable.ts
+++ b/packages/api-server/src/modules/skills/services/ensure-agent-reachable.ts
@@ -1,0 +1,41 @@
+import { TRPCError } from "@trpc/server";
+import type { AgentsRepository } from "../../agents/infrastructure/agents-repository.js";
+import {
+  computeAgentState,
+  type InfraAgent,
+} from "../../agents/infrastructure/agent-mappers.js";
+
+/**
+ * Make an agent's pod reachable for a skills-management call, or fail clearly.
+ * Fast-fails on a known error state (waking is hopeless); otherwise wakes via
+ * the ADR-032 reachability primitive and maps its timeout/error into a clean
+ * TRPCError so the caller never sees a raw Error and never hangs. Returns the
+ * fetched agent so callers that need the spec (e.g. publish → skillPaths) skip
+ * a second get.
+ */
+export async function ensureAgentReachable(
+  repo: AgentsRepository,
+  agentId: string,
+  owner: string,
+): Promise<InfraAgent> {
+  const infra = await repo.get(agentId, owner);
+  if (!infra) {
+    throw new TRPCError({ code: "NOT_FOUND", message: "agent not found" });
+  }
+  if (computeAgentState(infra) === "error") {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message:
+        "agent is in an error state and can't be reached; resolve the error before managing skills",
+    });
+  }
+  try {
+    await repo.ensureReady(agentId);
+  } catch (err) {
+    throw new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `agent could not be made ready: ${(err as Error).message}`,
+    });
+  }
+  return infra;
+}

--- a/packages/api-server/src/modules/skills/services/publish-service.ts
+++ b/packages/api-server/src/modules/skills/services/publish-service.ts
@@ -6,8 +6,8 @@ import type {
   SkillSource,
 } from "api-server-api";
 import type { AgentsRepository } from "../../agents/infrastructure/agents-repository.js";
-import { computeAgentState } from "../../agents/infrastructure/agent-mappers.js";
 import type { AgentSkillsRepository } from "../infrastructure/agent-skills-repository.js";
+import { ensureAgentReachable } from "./ensure-agent-reachable.js";
 import {
   AgentRuntimeUpstreamError,
   type AgentRuntimeSkillsClient,
@@ -34,9 +34,9 @@ export interface PublishServiceDeps {
 
 /**
  * Publish orchestrator — thin proxy. Validates that the user owns the
- * instance + source and the instance is running, then delegates everything
- * else to agent-runtime (which goes through the in-pod Envoy sidecar's
- * credential injector for the GitHub token swap, ADR-033).
+ * instance + source and wakes a hibernated agent (ADR-032), then delegates
+ * everything else to agent-runtime (which goes through the in-pod Envoy
+ * sidecar's credential injector for the GitHub token swap, ADR-033).
  *
  * Upstream gateway errors (app_not_connected / access_restricted) get
  * re-thrown as tRPC errors with the `connect_url` / `manage_url` carried
@@ -46,15 +46,11 @@ export async function publishSkill(
   deps: PublishServiceDeps,
   input: SkillPublishInput,
 ): Promise<SkillPublishResult> {
-  const agent = await deps.agents.get(input.agentId, deps.owner);
-  if (!agent)
-    throw new TRPCError({ code: "NOT_FOUND", message: "agent not found" });
-  if (computeAgentState(agent) !== "running") {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: `agent is ${computeAgentState(agent)}; start it before publishing`,
-    });
-  }
+  const agent = await ensureAgentReachable(
+    deps.agents,
+    input.agentId,
+    deps.owner,
+  );
 
   const source = await deps.resolveSource(input.sourceId);
   if (!source)

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -32,6 +32,7 @@ import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 import { detectHost } from "../infrastructure/git-host.js";
 import { PublicArchiveNotFoundError } from "../infrastructure/public-archive-scanner.js";
 import { publishSkill as runPublishSkill } from "./publish-service.js";
+import { ensureAgentReachable } from "./ensure-agent-reachable.js";
 import { upstreamToTrpc } from "../infrastructure/upstream-to-trpc.js";
 
 /** Stable, deterministic id for a template-derived source row. The hash
@@ -104,19 +105,6 @@ async function resolveSkillPaths(
   }
 
   return DEFAULT_SKILL_PATHS;
-}
-
-async function loadRunningInstance(deps: SkillsServiceDeps, agentId: string) {
-  const infra = await deps.agentsRepo.get(agentId, deps.owner);
-  if (!infra)
-    throw new TRPCError({ code: "NOT_FOUND", message: "instance not found" });
-  if (computeAgentState(infra) !== "running") {
-    throw new TRPCError({
-      code: "PRECONDITION_FAILED",
-      message: `instance is ${computeAgentState(infra)}; wake it before installing skills`,
-    });
-  }
-  return infra;
 }
 
 /**
@@ -343,18 +331,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
           message: "source is private; select an instance to scan it",
         });
       }
-      const infra = await deps.agentsRepo.get(agentId, deps.owner);
-      if (!infra)
-        throw new TRPCError({
-          code: "NOT_FOUND",
-          message: "instance not found",
-        });
-      if (computeAgentState(infra) !== "running") {
-        throw new TRPCError({
-          code: "PRECONDITION_FAILED",
-          message: `instance is ${computeAgentState(infra)}; start it before browsing private sources`,
-        });
-      }
+      await ensureAgentReachable(deps.agentsRepo, agentId, deps.owner);
       try {
         return await deps.scanSource(src.gitUrl, (gitUrl) =>
           deps.runtimeClient.scan(agentId, gitUrl),
@@ -366,7 +343,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
     },
 
     async install(input: SkillInstallInput) {
-      await loadRunningInstance(deps, input.agentId);
+      await ensureAgentReachable(deps.agentsRepo, input.agentId, deps.owner);
 
       const ref: SkillRef = {
         source: input.source,
@@ -401,7 +378,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
     },
 
     async uninstall(input: SkillUninstallInput) {
-      await loadRunningInstance(deps, input.agentId);
+      await ensureAgentReachable(deps.agentsRepo, input.agentId, deps.owner);
 
       await deps.agentSkillsRepo.removeSkill(input.agentId, {
         source: input.source,

--- a/packages/ui/src/modules/sessions/components/configuration-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/configuration-panel.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronRight } from "lucide-react";
 import { useState } from "react";
 
+import type { AgentState } from "../../../types.js";
 import { SchedulesPanel } from "../../schedules/components/schedules-panel.js";
 import { ChannelsPanel } from "./channels-panel.js";
 import { SkillsPanel } from "./skills-panel.js";
@@ -32,13 +33,13 @@ function Section({
 export function ConfigurationPanel({
   onResumeSession,
   agentId,
-  agentRunning,
+  agentState,
   onOpenFile,
 }: {
   /** Called when the user clicks a past run under a schedule card. */
   onResumeSession?: (sessionId: string) => void;
   agentId: string | null;
-  agentRunning: boolean;
+  agentState: AgentState | undefined;
   onOpenFile?: (path: string) => void;
 }) {
   return (
@@ -54,7 +55,7 @@ export function ConfigurationPanel({
       <Section title="Skills">
         <SkillsPanel
           agentId={agentId}
-          isRunning={agentRunning}
+          agentState={agentState}
           onOpenFile={onOpenFile}
         />
       </Section>

--- a/packages/ui/src/modules/sessions/components/skills-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/skills-panel.tsx
@@ -24,6 +24,7 @@ import { api } from "../../../api.js";
 import { ACTION_FAILED, runAction } from "../../../lib/query-helpers.js";
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
+import type { AgentState } from "../../../types.js";
 
 /** localStorage key for per-user persistence of collapsed source ids. Per
  *  browser, not per instance — catalog preferences apply everywhere. */
@@ -68,7 +69,7 @@ function isCuratedSource(src: SkillSource): boolean {
 
 interface SkillsPanelProps {
   agentId: string | null;
-  isRunning: boolean;
+  agentState: AgentState | undefined;
   /** Opens a file in the Files tab. Threaded from useFileTree via ChatView. */
   onOpenFile?: (path: string) => void;
 }
@@ -114,10 +115,13 @@ function skillSourceUrl(
 
 export function SkillsPanel({
   agentId,
-  isRunning,
+  agentState,
   onOpenFile,
 }: SkillsPanelProps) {
   const showConfirm = useStore((s) => s.showConfirm);
+
+  const isError = agentState === "error";
+  const isAsleep = !!agentId && agentState !== "running" && !isError;
 
   const [sources, setSources] = useState<SkillSource[]>([]);
   const [skillsBySource, setSkillsBySource] = useState<Record<string, Skill[]>>(
@@ -284,7 +288,7 @@ export function SkillsPanel({
     installed.find((s) => s.source === source && s.name === name);
 
   const toggle = async (skill: Skill) => {
-    if (!agentId || !isRunning) return;
+    if (!agentId || isError) return;
     const key = skillKey(skill.source, skill.name);
     setBusyRow(key);
     const currentlyInstalled = isInstalled(skill.source, skill.name);
@@ -310,7 +314,7 @@ export function SkillsPanel({
   };
 
   const updateDrift = async (skill: Skill) => {
-    if (!agentId || !isRunning) return;
+    if (!agentId || isError) return;
     const key = skillKey(skill.source, skill.name);
     setBusyRow(key);
     const result = await runAction(
@@ -446,9 +450,15 @@ export function SkillsPanel({
 
   return (
     <div className="flex flex-col">
-      {!isRunning && agentId && (
+      {isError && (
         <div className="px-4 py-2 border-b border-border-light text-[11px] text-text-muted bg-warning-light">
-          Start the agent to manage skills.
+          Agent is in an error state — resolve it before managing skills.
+        </div>
+      )}
+      {isAsleep && (
+        <div className="px-4 py-2 border-b border-border-light text-[11px] text-text-muted">
+          Asleep — installing or removing a skill will wake the agent; this can
+          take a moment.
         </div>
       )}
 
@@ -782,7 +792,7 @@ export function SkillsPanel({
                   installed.contentHash !== skill.contentHash;
                 const key = skillKey(skill.source, skill.name);
                 const rowBusy = busyRow === key;
-                const disabled = !agentId || !isRunning || rowBusy;
+                const disabled = !agentId || isError || rowBusy;
 
                 return (
                   <label

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -281,9 +281,7 @@ export function ChatView() {
           <ConfigurationPanel
             onResumeSession={mobileResumeSession}
             agentId={selectedAgent}
-            agentRunning={
-              agents.find((a) => a.id === selectedAgent)?.state === "running"
-            }
+            agentState={agents.find((a) => a.id === selectedAgent)?.state}
             onOpenFile={openFileHandler}
           />
         </div>


### PR DESCRIPTION
Managing skills on an idle agent now "just works." Previously, installing or removing a skill, browsing a private skill source, or publishing a skill would fail with a "wake the agent first" error whenever the agent had hibernated — which happens automatically after a period of inactivity. There was no way to manage skills on a quiet agent without manually starting it first.

Now these actions wake the agent on demand: the call transparently starts the hibernated agent, waits for it to be ready (bounded to ~2 minutes), and then proceeds. An agent that genuinely can't be reached (an error state, or a wake that times out) still surfaces a clear error instead of hanging.

The Skills panel in the UI reflects this: the install/remove controls are no longer disabled for a sleeping agent, and the old "start the agent to manage skills" banner is replaced by a soft hint that the action will wake it. Only an agent in an error state keeps a blocking message and disabled controls.

Reading what's installed is unchanged — it still works against a sleeping agent without waking it.

Closes #670