### PR TITLE
feat: /v2 sandbox UI

### DIFF
--- a/docs/plans/v2-sandbox-ui.md
+++ b/docs/plans/v2-sandbox-ui.md
@@ -1,0 +1,51 @@
+# /v2 Sandbox UI
+
+Shell-less, parallel entry point at `/v2`. v1 stays. Internal demo. Reuses v1 data models wholesale; "sandbox" is v2-only copy over the existing `agent` types and APIs. Terminal-only (no ACP/chat/approvals). LLM via provider-secrets, GitHub via connections.
+
+**Status: implemented and deployed to the local dev cluster.** Served over HTTP at `http://platform.localhost:4444/v2`. Verified via type-check, lint, and the OAuth unit test, plus an HTTP smoke check. Not yet committed.
+
+## Settled design
+
+- No sidebar. List shows status + name cards (click opens terminal), keeps trash with confirm, no refresh (keeps the 5s poll), no power button (terminal auto-wakes), plus a placeholder "create" card. A minimal degraded indicator stays; the verbose installs-failed badge was dropped.
+- Creation is in-place full-screen at `/v2/new`, two wizard steps (cancel/back) plus the terminal route.
+  - Step 1: name + LLM (Anthropic OAuth / Anthropic API / IBM LiteLLM, in that order). Inline-created via provider-secret create, verified (Anthropic only), reuse-if-exists. The credential UI renders inside the selected provider card.
+  - Step 2 (optional): GitHub and GitHub Enterprise as two independent connections — connect either, both, or neither. OAuth runs in a popup; every authorized connection is granted.
+  - Terminal: full-screen Claude Code terminal at `/v2/<id>`, breadcrumb back to the list, the terminal's own "Connecting…" overlay covers the auto-wake.
+- Agent CR is created at the step-2 to terminal transition (claude-code template, egress trusted, other fields defaulted) as a single create call that also grants the LLM secret and any GitHub connections. Cancelling before that leaves no pod.
+
+## Key findings that shaped the build
+
+- The connections / contributions subsystem is already fully implemented despite its architecture doc banner saying "Proposed". GitHub support is therefore UI-only on existing APIs.
+- The create-agent mutation already grants provider secrets and app connections in one call, so the step-2 to terminal transition is a single mutation, not three.
+- OAuth was reworked from full-page redirect to popups with postMessage (see step 2).
+
+## What was built
+
+1. Backend [x]
+- [x] Dynamic OAuth return: a `returnTo` is threaded through the OAuth pending-context keyed by state; the callback redirects there instead of the hardcoded connections view. Same-origin relative paths only (sanitized). The registered GitHub callback URL is untouched. v1's connections view still uses this redirect path.
+- [x] Popup OAuth mode: a `popup` flag on the pending-context makes the callback return a small page that postMessages the result to the opener and closes, instead of redirecting. Used by the v2 popup flow; v1 redirect behaviour is unchanged.
+
+2. Routing and layout [x]
+- [x] Custom router extended: `/v2` (list), `/v2/new` (wizard), `/v2/<id>` (terminal), with browser back/forward handled.
+- [x] Shell-less v2 layout (no sidebar or mobile nav), a thin breadcrumb header. Auth and terms gates are inherited at app entry, same as v1.
+
+3. List view [x]
+- [x] Reuses the existing agents query (5s poll retained). Cards restyled to status + name; click opens the terminal; trash kept with a confirm; refresh / power / configure dropped.
+- [x] A minimal "Some setup didn't apply" line shows when an agent has contribution failures; the verbose badge was dropped.
+- [x] Placeholder "create sandbox" card opens the wizard.
+
+4. Creation wizard [x]
+- [x] In-place full-screen wizard with breadcrumbs and cancel/back.
+- [x] Step 1: name + LLM picker; inline provider-secret create; verify-before-advance for Anthropic (the existing verify endpoint), create-and-trust for LiteLLM; reuse-if-exists matched on secret type plus identifying env var (so Anthropic API and Anthropic OAuth don't collide). The credential field, the reuse line, and the "credential ready" state all render inside the selected provider card.
+- [x] Step 2: GitHub and GitHub Enterprise as independent, parallel connections (host field for GHE; client ID/secret only when the template requires bring-your-own-app). Connection create + start OAuth in a popup; result via postMessage flips the right card to "Connected"; the other authorize button disables while one popup is in flight. Reuse by template id (and host for GHE). If the popup is blocked, it falls back to the full-page redirect flow.
+- [x] sessionStorage wizard snapshot (ids and pick-state, no secrets) persists across the redirect fallback and rehydrates on return; the popup path keeps the wizard mounted so no reload is needed.
+- [x] On the step-2 to terminal transition: a single agent create (claude-code template, egress trusted) granting the LLM secret and every authorized GitHub connection, then navigate to the terminal.
+
+5. Terminal step [x]
+- [x] Reuses the terminal component full-screen, keyed per agent for a fresh session. Its built-in "Connecting…" overlay covers the relay's auto-wake; breadcrumb returns to the list.
+
+## Resolved questions
+
+1. IBM LiteLLM verify — skipped. No verify path exists today and LiteLLM is create-and-trust; not worth building for an internal demo.
+2. GHE naming — support several. Connections are reused by template id plus host, and the connection name is host-keyed, so multiple GHE hosts don't collide. GitHub.com and GHE are connectable in parallel.
+3. v2 card — kept a minimal degraded indicator; dropped the verbose installs-failed badge.

--- a/packages/api-server-api/src/modules/connections/router.ts
+++ b/packages/api-server-api/src/modules/connections/router.ts
@@ -28,7 +28,10 @@ export const connectionsRouter = t.router({
   startOAuth: t.procedure
     .input(connectionStartOAuthInputSchema)
     .mutation(({ ctx, input }) =>
-      ctx.connections.startOAuth(input.connectionId),
+      ctx.connections.startOAuth(input.connectionId, {
+        returnTo: input.returnTo,
+        popup: input.popup,
+      }),
     ),
 
   discoverMcp: t.procedure

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -6,6 +6,16 @@ export const connectionIdInputSchema = z.object({
 
 export const connectionStartOAuthInputSchema = z.object({
   connectionId: z.string().min(1),
+  returnTo: z
+    .string()
+    .regex(
+      /^\/(?!\/)/,
+      "returnTo must be a relative path starting with a single /",
+    )
+    .optional(),
+  // When set, the callback returns a page that postMessages the result to the
+  // opener and closes, instead of redirecting. Used by the popup OAuth flow.
+  popup: z.boolean().optional(),
 });
 
 export const connectionDiscoverMcpInputSchema = z.object({

--- a/packages/api-server-api/src/modules/connections/types.ts
+++ b/packages/api-server-api/src/modules/connections/types.ts
@@ -132,7 +132,10 @@ export interface ConnectionsService {
     auth: "oauth" | "none";
   }>;
 
-  startOAuth(connectionId: string): Promise<{ authUrl: string }>;
+  startOAuth(
+    connectionId: string,
+    opts?: { returnTo?: string; popup?: boolean },
+  ): Promise<{ authUrl: string }>;
 
   deleteConnection(id: string): Promise<void>;
 

--- a/packages/api-server/src/apps/api-server/oauth.ts
+++ b/packages/api-server/src/apps/api-server/oauth.ts
@@ -50,7 +50,9 @@ export function createOAuthRoutes(deps: OAuthCallbackDeps) {
 
     const respondError = (message: string) => {
       if (popup)
-        return c.html(renderPopupResult(targetOrigin, { oauth: "error", message }));
+        return c.html(
+          renderPopupResult(targetOrigin, { oauth: "error", message }),
+        );
       const params = new URLSearchParams();
       params.set("oauth", "error");
       params.set("message", message);
@@ -94,10 +96,10 @@ interface PopupResult {
  * message can't break out of the <script> element.
  */
 function renderPopupResult(targetOrigin: string, result: PopupResult): string {
-  const payload = JSON.stringify({ source: "platform-oauth", ...result }).replace(
-    /</g,
-    "\\u003c",
-  );
+  const payload = JSON.stringify({
+    source: "platform-oauth",
+    ...result,
+  }).replace(/</g, "\\u003c");
   const origin = JSON.stringify(targetOrigin).replace(/</g, "\\u003c");
   return `<!doctype html>
 <html>

--- a/packages/api-server/src/apps/api-server/oauth.ts
+++ b/packages/api-server/src/apps/api-server/oauth.ts
@@ -8,6 +8,7 @@ import {
   type OAuthFlowPendingCtx,
 } from "../../modules/connections/services/oauth-flow.js";
 import { createConnectionsRepository } from "../../modules/connections/infrastructure/connections-repository.js";
+import { sanitizeReturnTo } from "../../modules/connections/domain/oauth-callback-url.js";
 
 export interface OAuthCallbackDeps {
   db: Db;
@@ -20,28 +21,45 @@ export interface OAuthCallbackDeps {
 export function createOAuthRoutes(deps: OAuthCallbackDeps) {
   const oauth = new Hono();
 
+  const targetOrigin = new URL(deps.uiBaseUrl).origin;
+
   oauth.get("/api/oauth/callback", async (c) => {
     const code = c.req.query("code");
     const state = c.req.query("state");
     const providerError = c.req.query("error");
 
-    if (providerError) {
-      return c.redirect(
-        `${deps.uiBaseUrl}/connections?oauth=error&message=${encodeURIComponent(providerError)}`,
-      );
-    }
-    if (!code || !state) {
-      return c.redirect(
-        `${deps.uiBaseUrl}/connections?oauth=error&message=missing+parameters`,
-      );
-    }
+    const peeked = state
+      ? deps.engine.peek<OAuthFlowPendingCtx>(state)
+      : undefined;
+    const returnTo = sanitizeReturnTo(peeked?.ctx.returnTo);
+    const popup = Boolean(peeked?.ctx.popup);
 
-    const peeked = deps.engine.peek<OAuthFlowPendingCtx>(state);
-    if (!peeked) {
-      return c.redirect(
-        `${deps.uiBaseUrl}/connections?oauth=error&message=invalid+state`,
-      );
-    }
+    const respondSuccess = (connectionId: string) => {
+      if (popup)
+        return c.html(
+          renderPopupResult(targetOrigin, {
+            oauth: "success",
+            connection: connectionId,
+          }),
+        );
+      const params = new URLSearchParams();
+      params.set("oauth", "success");
+      params.set("connection", connectionId);
+      return c.redirect(`${deps.uiBaseUrl}${returnTo}?${params.toString()}`);
+    };
+
+    const respondError = (message: string) => {
+      if (popup)
+        return c.html(renderPopupResult(targetOrigin, { oauth: "error", message }));
+      const params = new URLSearchParams();
+      params.set("oauth", "error");
+      params.set("message", message);
+      return c.redirect(`${deps.uiBaseUrl}${returnTo}?${params.toString()}`);
+    };
+
+    if (providerError) return respondError(providerError);
+    if (!code || !state) return respondError("missing parameters");
+    if (!peeked) return respondError("invalid state");
 
     const flow = createOAuthFlowService({
       engine: deps.engine,
@@ -54,17 +72,46 @@ export function createOAuthRoutes(deps: OAuthCallbackDeps) {
 
     try {
       const result = await flow.completeOAuth(state, code);
-      const params = new URLSearchParams();
-      params.set("oauth", "success");
-      params.set("connection", result.connectionId);
-      return c.redirect(`${deps.uiBaseUrl}/connections?${params.toString()}`);
+      return respondSuccess(result.connectionId);
     } catch (err) {
       const msg = err instanceof Error ? err.message : "Unknown error";
-      return c.redirect(
-        `${deps.uiBaseUrl}/connections?oauth=error&message=${encodeURIComponent(msg)}`,
-      );
+      return respondError(msg);
     }
   });
 
   return oauth;
+}
+
+interface PopupResult {
+  oauth: "success" | "error";
+  connection?: string;
+  message?: string;
+}
+
+/**
+ * Self-contained page for the popup OAuth flow: posts the result to the
+ * opener and closes. `<` is escaped in the embedded JSON so a provider error
+ * message can't break out of the <script> element.
+ */
+function renderPopupResult(targetOrigin: string, result: PopupResult): string {
+  const payload = JSON.stringify({ source: "platform-oauth", ...result }).replace(
+    /</g,
+    "\\u003c",
+  );
+  const origin = JSON.stringify(targetOrigin).replace(/</g, "\\u003c");
+  return `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>Authorizing…</title></head>
+  <body style="font-family: system-ui, sans-serif; padding: 2rem; color: #444;">
+    <p>You can close this window.</p>
+    <script>
+      (function () {
+        try {
+          if (window.opener) window.opener.postMessage(${payload}, ${origin});
+        } catch (e) {}
+        window.close();
+      })();
+    </script>
+  </body>
+</html>`;
 }

--- a/packages/api-server/src/modules/connections/domain/oauth-callback-url.ts
+++ b/packages/api-server/src/modules/connections/domain/oauth-callback-url.ts
@@ -8,3 +8,15 @@ export function applyCallbackAlias(
     `$1${localhostCallbackAlias}`,
   );
 }
+
+export const DEFAULT_OAUTH_RETURN_TO = "/connections";
+
+// The OAuth callback is public and unauthenticated; only same-origin relative
+// paths may be honored, so a stale or tampered state can never redirect off-site.
+export function sanitizeReturnTo(returnTo: string | undefined): string {
+  if (!returnTo) return DEFAULT_OAUTH_RETURN_TO;
+  if (!returnTo.startsWith("/") || returnTo.startsWith("//")) {
+    return DEFAULT_OAUTH_RETURN_TO;
+  }
+  return returnTo;
+}

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -157,8 +157,11 @@ export function createConnectionsService(deps: {
       return conn ? toView(conn) : null;
     },
 
-    startOAuth(connectionId: string): Promise<{ authUrl: string }> {
-      return deps.oauthFlow.startOAuth(connectionId);
+    startOAuth(
+      connectionId: string,
+      opts?: { returnTo?: string; popup?: boolean },
+    ): Promise<{ authUrl: string }> {
+      return deps.oauthFlow.startOAuth(connectionId, opts);
     },
 
     async deleteConnection(id: string): Promise<void> {

--- a/packages/api-server/src/modules/connections/services/oauth-flow.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-flow.ts
@@ -16,7 +16,10 @@ import { emit, EventType } from "../../../events.js";
 import { securityLog } from "../../../core/security-log.js";
 
 export interface OAuthFlowService {
-  startOAuth(connectionId: string): Promise<{ authUrl: string }>;
+  startOAuth(
+    connectionId: string,
+    opts?: { returnTo?: string; popup?: boolean },
+  ): Promise<{ authUrl: string }>;
   completeOAuth(
     state: string,
     code: string,
@@ -28,6 +31,8 @@ export interface OAuthFlowPendingCtx {
   ownerId: string;
   accessTokenRef: SecretRef;
   refreshTokenRef?: SecretRef;
+  returnTo?: string;
+  popup?: boolean;
 }
 
 export function createOAuthFlowService(deps: {
@@ -39,7 +44,7 @@ export function createOAuthFlowService(deps: {
   callbackUrl: string;
 }): OAuthFlowService {
   return {
-    async startOAuth(connectionId): Promise<{ authUrl: string }> {
+    async startOAuth(connectionId, opts): Promise<{ authUrl: string }> {
       const conn = await deps.repo.get(connectionId, deps.ownerId);
       if (!conn) throw new Error(`connection ${connectionId} not found`);
       if (conn.auth.kind !== "oauth") {
@@ -63,6 +68,8 @@ export function createOAuthFlowService(deps: {
           ...(conn.auth.refreshTokenRef
             ? { refreshTokenRef: conn.auth.refreshTokenRef }
             : {}),
+          ...(opts?.returnTo ? { returnTo: opts.returnTo } : {}),
+          ...(opts?.popup ? { popup: true } : {}),
         },
       });
       return { authUrl };

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -14,6 +14,7 @@ import { ChatView } from "./modules/sessions/views/chat-view.js";
 import { ProvidersView } from "./modules/settings/views/providers-view.js";
 import { SettingsView } from "./modules/settings/views/settings-view.js";
 import { TermsView } from "./modules/terms/views/terms-view.js";
+import { V2App } from "./modules/v2/views/v2-app.js";
 import { useStore } from "./store.js";
 
 export default function App() {
@@ -37,6 +38,9 @@ export default function App() {
   }, [theme]);
 
   useEffect(() => {
+    // The v2 wizard owns its own OAuth-return handling so it can rehydrate
+    // the in-progress sandbox before the params are stripped.
+    if (window.location.pathname.startsWith("/v2")) return;
     const params = new URLSearchParams(window.location.search);
     const oauthResult = params.get("oauth");
     if (!oauthResult) return;
@@ -68,6 +72,7 @@ export default function App() {
     };
     const onPopState = () => {
       const path = window.location.pathname;
+      const sandboxMatch = path.match(/^\/v2\/([^/]+)$/);
       if (path.startsWith("/chat/"))
         enterChat(decodeURIComponent(path.slice(6)));
       else if (path === "/providers") useStore.setState({ view: "providers" });
@@ -76,6 +81,15 @@ export default function App() {
       else if (path === "/settings") useStore.setState({ view: "settings" });
       else if (path === "/inbox") useStore.setState({ view: "inbox" });
       else if (path === "/terms") useStore.setState({ view: "terms" });
+      else if (path === "/v2")
+        useStore.setState({ view: "v2-list", agentId: null });
+      else if (path === "/v2/new")
+        useStore.setState({ view: "v2-new", agentId: null });
+      else if (sandboxMatch && path !== "/v2/new")
+        useStore.setState({
+          view: "v2-terminal",
+          agentId: decodeURIComponent(sandboxMatch[1]!),
+        });
       else if (path.startsWith("/agents/") && path.endsWith("/egress")) {
         const id = decodeURIComponent(
           path.slice("/agents/".length, -"/egress".length),
@@ -89,6 +103,15 @@ export default function App() {
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);
+
+  // v2 sandbox surface is shell-less (no sidebar / mobile nav)
+  if (view === "v2-list" || view === "v2-new" || view === "v2-terminal")
+    return (
+      <>
+        <V2App />
+        <DialogOverlay />
+      </>
+    );
 
   // Chat view is full-screen (has its own layout)
   if (view === "chat")

--- a/packages/ui/src/modules/platform/lib/routes.ts
+++ b/packages/ui/src/modules/platform/lib/routes.ts
@@ -9,6 +9,9 @@ export const viewSchema = z.enum([
   "inbox",
   "agent-egress",
   "terms",
+  "v2-list",
+  "v2-new",
+  "v2-terminal",
 ]);
 export type View = z.infer<typeof viewSchema>;
 
@@ -25,6 +28,10 @@ export function viewToPath(
   if (view === "agent-egress" && agentId)
     return `/agents/${encodeURIComponent(agentId)}/egress`;
   if (view === "terms") return "/terms";
+  if (view === "v2-list") return "/v2";
+  if (view === "v2-new") return "/v2/new";
+  if (view === "v2-terminal" && agentId)
+    return `/v2/${encodeURIComponent(agentId)}`;
   return "/";
 }
 
@@ -40,6 +47,14 @@ export function pathToState(path: string): {
   if (path === "/settings") return { view: "settings" };
   if (path === "/inbox") return { view: "inbox" };
   if (path === "/terms") return { view: "terms" };
+  if (path === "/v2") return { view: "v2-list" };
+  if (path === "/v2/new") return { view: "v2-new" };
+  const sandboxMatch = path.match(/^\/v2\/([^/]+)$/);
+  if (sandboxMatch)
+    return {
+      view: "v2-terminal",
+      agentId: decodeURIComponent(sandboxMatch[1]!),
+    };
   const egressMatch = path.match(/^\/agents\/([^/]+)\/egress$/);
   if (egressMatch)
     return {

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -14,6 +14,7 @@ export interface NavigationSlice {
   agentId: string | null;
   setView: (v: View) => void;
   navigateToAgentEgress: (agentId: string) => void;
+  openSandboxTerminal: (agentId: string) => void;
   mobileScreen: "sessions" | "chat";
   setMobileScreen: (screen: "sessions" | "chat") => void;
   showMobilePanel: boolean;
@@ -57,6 +58,10 @@ export const createNavigationSlice: StateCreator<
   navigateToAgentEgress: (agentId) => {
     history.pushState(null, "", viewToPath("agent-egress", null, agentId));
     set({ view: "agent-egress", agentId });
+  },
+  openSandboxTerminal: (agentId) => {
+    history.pushState(null, "", viewToPath("v2-terminal", null, agentId));
+    set({ view: "v2-terminal", agentId });
   },
   mobileScreen: "sessions",
   setMobileScreen: (screen) => set({ mobileScreen: screen }),

--- a/packages/ui/src/modules/sessions/components/terminal.tsx
+++ b/packages/ui/src/modules/sessions/components/terminal.tsx
@@ -22,12 +22,18 @@ export function Terminal({
   sessionId,
   fresh,
   onConnected,
+  onFirstOutput,
   autoConnect = true,
 }: {
   agentId: string;
   sessionId: string;
   fresh?: boolean;
   onConnected?: () => void;
+  /** Fires once when the first output frame arrives — i.e. the agent is awake
+   *  and the shell is producing output, which the relay only reaches after
+   *  `ensureReady`. Use this (not `onConnected`) to clear a "starting" overlay,
+   *  since `onConnected` fires on the immediate relay handshake. */
+  onFirstOutput?: () => void;
   autoConnect?: boolean;
 }) {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -66,6 +72,7 @@ export function Terminal({
     let ws: WebSocket | null = null;
     let term: XTerm | null = null;
     let ro: ResizeObserver | null = null;
+    let firstOutputSeen = false;
 
     (async () => {
       term = new XTerm({
@@ -116,9 +123,13 @@ export function Terminal({
         } catch {
           return;
         }
-        if (frame.op === OP_OUTPUT)
+        if (frame.op === OP_OUTPUT) {
+          if (!firstOutputSeen) {
+            firstOutputSeen = true;
+            onFirstOutput?.();
+          }
           term?.write(new TextDecoder().decode(frame.data));
-        else if (frame.op === OP_EXIT) {
+        } else if (frame.op === OP_EXIT) {
           setExitCode(frame.code);
           setState("exited");
         }
@@ -155,8 +166,8 @@ export function Terminal({
       termRef.current = null;
       container.innerHTML = "";
     };
-    // `fresh` and `onConnected` are intentionally captured once at mount.
-    // `reconnectKey` triggers a full teardown+reconnect cycle.
+    // `fresh`, `onConnected`, and `onFirstOutput` are intentionally captured
+    // once at mount. `reconnectKey` triggers a full teardown+reconnect cycle.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agentId, sessionId, reconnectKey]);
 

--- a/packages/ui/src/modules/v2/components/create-sandbox-card.tsx
+++ b/packages/ui/src/modules/v2/components/create-sandbox-card.tsx
@@ -1,14 +1,27 @@
 import { Plus } from "lucide-react";
 
-export function CreateSandboxCard({ onClick }: { onClick: () => void }) {
+export function CreateSandboxCard({
+  label,
+  description,
+  onClick,
+}: {
+  label: string;
+  description: string;
+  onClick: () => void;
+}) {
   return (
     <button
       type="button"
       onClick={onClick}
-      className="anim-in flex items-center justify-center gap-2 rounded-lg border border-dashed border-border px-5 py-4 text-[14px] font-semibold text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+      className="group anim-in flex flex-col items-start gap-1.5 rounded-xl border border-dashed border-border p-4 text-left transition-colors hover:border-primary hover:bg-primary/5"
     >
-      <Plus size={18} />
-      Create sandbox
+      <span className="flex items-center gap-1.5 text-[14px] font-semibold text-foreground transition-colors group-hover:text-primary">
+        <Plus size={15} />
+        {label}
+      </span>
+      <span className="text-[12px] leading-snug text-muted-foreground">
+        {description}
+      </span>
     </button>
   );
 }

--- a/packages/ui/src/modules/v2/components/create-sandbox-card.tsx
+++ b/packages/ui/src/modules/v2/components/create-sandbox-card.tsx
@@ -1,0 +1,14 @@
+import { Plus } from "lucide-react";
+
+export function CreateSandboxCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="anim-in flex items-center justify-center gap-2 rounded-lg border border-dashed border-border px-5 py-4 text-[14px] font-semibold text-muted-foreground hover:border-primary hover:text-primary transition-colors"
+    >
+      <Plus size={18} />
+      Create sandbox
+    </button>
+  );
+}

--- a/packages/ui/src/modules/v2/components/labeled-input.tsx
+++ b/packages/ui/src/modules/v2/components/labeled-input.tsx
@@ -1,0 +1,43 @@
+import { Input } from "@/components/ui/input";
+
+export function LabeledInput({
+  label,
+  hint,
+  type = "text",
+  value,
+  onChange,
+  placeholder,
+  autoFocus,
+}: {
+  label: string;
+  hint?: string;
+  type?: "text" | "password";
+  value: string;
+  onChange: (v: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+}) {
+  const secret = type === "password";
+  return (
+    <label className="block">
+      <span className="text-[13px] font-semibold text-foreground/80 block mb-1.5">
+        {label}
+      </span>
+      <Input
+        type={type}
+        value={value}
+        placeholder={placeholder}
+        autoFocus={autoFocus}
+        autoComplete={secret ? "off" : undefined}
+        data-1p-ignore={secret ? true : undefined}
+        data-lpignore={secret ? "true" : undefined}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      {hint && (
+        <span className="text-[11px] text-muted-foreground block mt-1">
+          {hint}
+        </span>
+      )}
+    </label>
+  );
+}

--- a/packages/ui/src/modules/v2/components/sandbox-card.tsx
+++ b/packages/ui/src/modules/v2/components/sandbox-card.tsx
@@ -1,0 +1,59 @@
+import { Trash2 } from "lucide-react";
+
+import { Card } from "@/components/ui/card";
+
+import { StatusBadge } from "../../../components/status-indicator.js";
+import type { AgentView } from "../../../types.js";
+import type { AgentDisplay } from "../../agents/utils/agent-resolver.js";
+
+export function SandboxCard({
+  agent,
+  display,
+  onOpen,
+  onDelete,
+  deleting,
+}: {
+  agent: AgentView;
+  display: AgentDisplay;
+  onOpen: () => void;
+  onDelete: () => void;
+  deleting: boolean;
+}) {
+  const degraded = agent.contributionFailures.length > 0;
+  return (
+    <Card
+      onClick={display.clickable ? onOpen : undefined}
+      className={`overflow-hidden anim-in transition-shadow ${
+        display.clickable
+          ? "group cursor-pointer hover:not-has-[button:hover]:shadow-md"
+          : "opacity-80"
+      }`}
+    >
+      <div className="flex items-center gap-3 px-5 py-4">
+        <StatusBadge state={display.state} />
+        <div className="flex-1 min-w-0">
+          <div className="text-[16px] font-bold text-foreground truncate transition-colors [.group:hover:not(:has(button:hover))_&]:text-primary">
+            {agent.name}
+          </div>
+          {degraded && (
+            <div className="text-[12px] text-warning">
+              Some setup didn't apply
+            </div>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete();
+          }}
+          disabled={deleting}
+          title="Delete sandbox"
+          className="shrink-0 rounded-md p-2 text-muted-foreground hover:text-destructive disabled:opacity-50 transition-colors"
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+    </Card>
+  );
+}

--- a/packages/ui/src/modules/v2/components/sandbox-card.tsx
+++ b/packages/ui/src/modules/v2/components/sandbox-card.tsx
@@ -5,6 +5,7 @@ import { Card } from "@/components/ui/card";
 import { StatusBadge } from "../../../components/status-indicator.js";
 import type { AgentView } from "../../../types.js";
 import type { AgentDisplay } from "../../agents/utils/agent-resolver.js";
+import { harnessLabel } from "../lib/harnesses.js";
 
 export function SandboxCard({
   agent,
@@ -20,6 +21,7 @@ export function SandboxCard({
   deleting: boolean;
 }) {
   const degraded = agent.contributionFailures.length > 0;
+  const typeLabel = harnessLabel(agent.templateId);
   return (
     <Card
       onClick={display.clickable ? onOpen : undefined}
@@ -32,8 +34,15 @@ export function SandboxCard({
       <div className="flex items-center gap-3 px-5 py-4">
         <StatusBadge state={display.state} />
         <div className="flex-1 min-w-0">
-          <div className="text-[16px] font-bold text-foreground truncate transition-colors [.group:hover:not(:has(button:hover))_&]:text-primary">
-            {agent.name}
+          <div className="flex items-center gap-2 min-w-0">
+            <span className="text-[16px] font-bold text-foreground truncate transition-colors [.group:hover:not(:has(button:hover))_&]:text-primary">
+              {agent.name}
+            </span>
+            {typeLabel && (
+              <span className="shrink-0 inline-flex items-center rounded-full bg-muted px-2 py-0.5 text-[11px] font-medium text-muted-foreground">
+                {typeLabel}
+              </span>
+            )}
           </div>
           {degraded && (
             <div className="text-[12px] text-warning">

--- a/packages/ui/src/modules/v2/components/sandbox-shell.tsx
+++ b/packages/ui/src/modules/v2/components/sandbox-shell.tsx
@@ -1,0 +1,61 @@
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { getBrand } from "../../../brand.js";
+
+export interface Breadcrumb {
+  label: string;
+  onClick?: () => void;
+}
+
+/**
+ * Shell-less full-screen frame for the v2 surface: a thin breadcrumb header
+ * over a flex content column. No sidebar or mobile nav — the v2 surface is
+ * deliberately chrome-free.
+ */
+export function SandboxShell({
+  breadcrumbs,
+  children,
+  contentClassName,
+}: {
+  breadcrumbs: Breadcrumb[];
+  children: ReactNode;
+  contentClassName?: string;
+}) {
+  return (
+    <div className="flex flex-col h-dvh bg-background">
+      <header className="flex items-center gap-1.5 border-b border-border px-4 md:px-6 h-14 shrink-0 text-[14px]">
+        <span className="font-bold text-foreground">{getBrand().name}</span>
+        {breadcrumbs.map((crumb, i) => (
+          <Crumb key={i} crumb={crumb} last={i === breadcrumbs.length - 1} />
+        ))}
+      </header>
+      <main className={cn("flex flex-1 flex-col min-h-0", contentClassName)}>
+        {children}
+      </main>
+    </div>
+  );
+}
+
+function Crumb({ crumb, last }: { crumb: Breadcrumb; last: boolean }) {
+  return (
+    <>
+      <ChevronRight size={14} className="text-muted-foreground shrink-0" />
+      {crumb.onClick && !last ? (
+        <button
+          type="button"
+          onClick={crumb.onClick}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {crumb.label}
+        </button>
+      ) : (
+        <span className={last ? "text-foreground" : "text-muted-foreground"}>
+          {crumb.label}
+        </span>
+      )}
+    </>
+  );
+}

--- a/packages/ui/src/modules/v2/components/wizard/github-step.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/github-step.tsx
@@ -1,0 +1,292 @@
+import { Check, Loader2 } from "lucide-react";
+import { type ReactNode, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { api } from "../../../../api.js";
+import { type GithubMode, useGithubConnect } from "../../hooks/use-github-connect.js";
+import { useOAuthPopup } from "../../hooks/use-oauth-popup.js";
+import { saveSnapshot, type WizardSnapshot } from "../../lib/wizard-snapshot.js";
+import { LabeledInput } from "../labeled-input.js";
+
+type Target = "github" | "ghe";
+
+const MODE: Record<Target, GithubMode> = {
+  github: "github",
+  ghe: "github-enterprise",
+};
+
+export function GithubStep({
+  snapshot,
+  update,
+  onBack,
+  onCreate,
+  creating,
+}: {
+  snapshot: WizardSnapshot;
+  update: (patch: Partial<WizardSnapshot>) => void;
+  onBack: () => void;
+  onCreate: () => void;
+  creating: boolean;
+}) {
+  const { isBringYourOwnApp, findExisting, ensureConnectionId } =
+    useGithubConnect();
+  const [gheHost, setGheHost] = useState(snapshot.gheHost);
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [authorizingTarget, setAuthorizingTarget] = useState<Target | null>(
+    null,
+  );
+  const pendingTargetRef = useRef<Target | null>(null);
+
+  const { open: openPopup, close: closePopup } = useOAuthPopup((result) => {
+    const target = pendingTargetRef.current;
+    pendingTargetRef.current = null;
+    setAuthorizingTarget(null);
+    if (result.ok && target) {
+      setError(null);
+      update(
+        target === "github"
+          ? { githubAuthorized: true }
+          : { gheAuthorized: true },
+      );
+    } else if (result.message) {
+      setError(result.message);
+    }
+  });
+
+  const markConnection = (target: Target, id: string, authorized: boolean) =>
+    update(
+      target === "github"
+        ? { githubConnectionId: id, githubAuthorized: authorized }
+        : {
+            gheConnectionId: id,
+            gheHost: gheHost.trim(),
+            gheAuthorized: authorized,
+          },
+    );
+
+  const connect = async (target: Target) => {
+    const mode = MODE[target];
+    const host = target === "ghe" ? gheHost.trim() : "";
+    if (target === "ghe" && !host)
+      return setError("Enter the GitHub Enterprise host.");
+    if (isBringYourOwnApp(mode) && (!clientId.trim() || !clientSecret.trim()))
+      return setError("Enter the OAuth app client ID and secret.");
+    setError(null);
+
+    const existing = findExisting(mode, host);
+    if (existing?.status === "active") {
+      markConnection(target, existing.id, true);
+      return;
+    }
+
+    const popup = openPopup();
+    setAuthorizingTarget(target);
+    pendingTargetRef.current = target;
+    try {
+      const { id } = await ensureConnectionId(mode, host, {
+        clientId: clientId.trim(),
+        clientSecret: clientSecret.trim(),
+      });
+      markConnection(target, id, false);
+      if (popup) {
+        const { authUrl } = await api.connections.startOAuth.mutate({
+          connectionId: id,
+          popup: true,
+        });
+        popup.location.href = authUrl;
+      } else {
+        // Popup blocked: persist synchronously, then full-page redirect.
+        saveSnapshot({
+          ...snapshot,
+          step: 2,
+          ...(target === "github"
+            ? { githubConnectionId: id, githubAuthorized: false }
+            : {
+                gheConnectionId: id,
+                gheHost: host,
+                gheAuthorized: false,
+              }),
+        });
+        const { authUrl } = await api.connections.startOAuth.mutate({
+          connectionId: id,
+          returnTo: "/v2/new",
+        });
+        window.location.href = authUrl;
+      }
+    } catch (err) {
+      closePopup();
+      pendingTargetRef.current = null;
+      setAuthorizingTarget(null);
+      setError(
+        err instanceof Error ? err.message : "Couldn't connect to GitHub.",
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div>
+        <h2 className="text-[17px] font-bold text-foreground">
+          Connect GitHub (optional)
+        </h2>
+        <p className="text-[13px] text-muted-foreground mt-1">
+          Authorize GitHub so the sandbox can use git and the gh CLI. Connect
+          either, both, or skip and add them later.
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <ConnectionCard
+          title="GitHub"
+          description="Read + write repos, issues, and PRs on github.com."
+          connected={snapshot.githubAuthorized && !!snapshot.githubConnectionId}
+          authorizing={authorizingTarget === "github"}
+          disabled={authorizingTarget !== null}
+          onAuthorize={() => connect("github")}
+          onChange={() =>
+            update({ githubConnectionId: null, githubAuthorized: false })
+          }
+        >
+          {isBringYourOwnApp("github") && (
+            <ByoFields
+              clientId={clientId}
+              clientSecret={clientSecret}
+              setClientId={setClientId}
+              setClientSecret={setClientSecret}
+            />
+          )}
+        </ConnectionCard>
+
+        <ConnectionCard
+          title="GitHub Enterprise"
+          description="Connect a self-hosted GitHub Enterprise host."
+          connected={snapshot.gheAuthorized && !!snapshot.gheConnectionId}
+          connectedLabel={`Connected to ${snapshot.gheHost}.`}
+          authorizing={authorizingTarget === "ghe"}
+          disabled={authorizingTarget !== null}
+          onAuthorize={() => connect("ghe")}
+          onChange={() =>
+            update({ gheConnectionId: null, gheAuthorized: false })
+          }
+        >
+          <LabeledInput
+            label="GitHub Enterprise host"
+            placeholder="ghe.example.com"
+            value={gheHost}
+            onChange={setGheHost}
+          />
+          {isBringYourOwnApp("github-enterprise") && (
+            <ByoFields
+              clientId={clientId}
+              clientSecret={clientSecret}
+              setClientId={setClientId}
+              setClientSecret={setClientSecret}
+            />
+          )}
+        </ConnectionCard>
+      </div>
+
+      {error && (
+        <p className="text-[12px] font-medium text-destructive">{error}</p>
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="outline" onClick={onBack} disabled={creating}>
+          Back
+        </Button>
+        <Button onClick={onCreate} disabled={creating}>
+          {creating && <Loader2 size={15} className="animate-spin" />}
+          Create sandbox
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function ConnectionCard({
+  title,
+  description,
+  connected,
+  connectedLabel = "Connected to GitHub.",
+  authorizing,
+  disabled,
+  onAuthorize,
+  onChange,
+  children,
+}: {
+  title: string;
+  description: string;
+  connected: boolean;
+  connectedLabel?: string;
+  authorizing: boolean;
+  disabled: boolean;
+  onAuthorize: () => void;
+  onChange: () => void;
+  children?: ReactNode;
+}) {
+  return (
+    <div className="rounded-lg border border-border px-4 py-3">
+      <div className="text-[14px] font-semibold text-foreground">{title}</div>
+      <div className="text-[12px] text-muted-foreground">{description}</div>
+      <div className="mt-3">
+        {connected ? (
+          <div className="flex items-center gap-2 text-[13px] text-success">
+            <Check size={15} /> {connectedLabel}
+            <button
+              type="button"
+              onClick={onChange}
+              className="text-muted-foreground hover:text-foreground underline ml-1"
+            >
+              change
+            </button>
+          </div>
+        ) : (
+          <div className="flex flex-col gap-3">
+            {children}
+            <Button
+              variant="outline"
+              onClick={onAuthorize}
+              disabled={disabled}
+              className="self-start"
+            >
+              {authorizing && <Loader2 size={15} className="animate-spin" />}
+              {authorizing ? "Authorizing…" : "Authorize with GitHub"}
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function ByoFields({
+  clientId,
+  clientSecret,
+  setClientId,
+  setClientSecret,
+}: {
+  clientId: string;
+  clientSecret: string;
+  setClientId: (v: string) => void;
+  setClientSecret: (v: string) => void;
+}) {
+  return (
+    <>
+      <LabeledInput
+        label="OAuth client ID"
+        placeholder="Iv1.…"
+        value={clientId}
+        onChange={setClientId}
+      />
+      <LabeledInput
+        label="OAuth client secret"
+        type="password"
+        value={clientSecret}
+        onChange={setClientSecret}
+      />
+    </>
+  );
+}

--- a/packages/ui/src/modules/v2/components/wizard/github-step.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/github-step.tsx
@@ -29,7 +29,7 @@ export function GithubStep({
   onCreate: () => void;
   creating: boolean;
 }) {
-  const { isBringYourOwnApp, findExisting, ensureConnectionId } =
+  const { isBringYourOwnApp, ghePresetHost, findExisting, ensureConnectionId } =
     useGithubConnect();
   const [gheHost, setGheHost] = useState(snapshot.gheHost);
   const [clientId, setClientId] = useState("");
@@ -56,20 +56,21 @@ export function GithubStep({
     }
   });
 
-  const markConnection = (target: Target, id: string, authorized: boolean) =>
+  const markConnection = (
+    target: Target,
+    id: string,
+    host: string,
+    authorized: boolean,
+  ) =>
     update(
       target === "github"
         ? { githubConnectionId: id, githubAuthorized: authorized }
-        : {
-            gheConnectionId: id,
-            gheHost: gheHost.trim(),
-            gheAuthorized: authorized,
-          },
+        : { gheConnectionId: id, gheHost: host, gheAuthorized: authorized },
     );
 
   const connect = async (target: Target) => {
     const mode = MODE[target];
-    const host = target === "ghe" ? gheHost.trim() : "";
+    const host = target === "ghe" ? (ghePresetHost ?? gheHost.trim()) : "";
     if (target === "ghe" && !host)
       return setError("Enter the GitHub Enterprise host.");
     if (isBringYourOwnApp(mode) && (!clientId.trim() || !clientSecret.trim()))
@@ -78,7 +79,7 @@ export function GithubStep({
 
     const existing = findExisting(mode, host);
     if (existing?.status === "active") {
-      markConnection(target, existing.id, true);
+      markConnection(target, existing.id, host, true);
       return;
     }
 
@@ -90,7 +91,7 @@ export function GithubStep({
         clientId: clientId.trim(),
         clientSecret: clientSecret.trim(),
       });
-      markConnection(target, id, false);
+      markConnection(target, id, host, false);
       if (popup) {
         const { authUrl } = await api.connections.startOAuth.mutate({
           connectionId: id,
@@ -172,12 +173,20 @@ export function GithubStep({
             update({ gheConnectionId: null, gheAuthorized: false })
           }
         >
-          <LabeledInput
-            label="GitHub Enterprise host"
-            placeholder="ghe.example.com"
-            value={gheHost}
-            onChange={setGheHost}
-          />
+          {ghePresetHost ? (
+            <p className="text-[12px] text-muted-foreground">
+              Host{" "}
+              <span className="font-mono text-foreground">{ghePresetHost}</span>{" "}
+              (configured by your operator).
+            </p>
+          ) : (
+            <LabeledInput
+              label="GitHub Enterprise host"
+              placeholder="ghe.example.com"
+              value={gheHost}
+              onChange={setGheHost}
+            />
+          )}
           {isBringYourOwnApp("github-enterprise") && (
             <ByoFields
               clientId={clientId}

--- a/packages/ui/src/modules/v2/components/wizard/github-step.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/github-step.tsx
@@ -4,9 +4,15 @@ import { type ReactNode, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { api } from "../../../../api.js";
-import { type GithubMode, useGithubConnect } from "../../hooks/use-github-connect.js";
+import {
+  type GithubMode,
+  useGithubConnect,
+} from "../../hooks/use-github-connect.js";
 import { useOAuthPopup } from "../../hooks/use-oauth-popup.js";
-import { saveSnapshot, type WizardSnapshot } from "../../lib/wizard-snapshot.js";
+import {
+  saveSnapshot,
+  type WizardSnapshot,
+} from "../../lib/wizard-snapshot.js";
 import { LabeledInput } from "../labeled-input.js";
 
 type Target = "github" | "ghe";

--- a/packages/ui/src/modules/v2/components/wizard/llm-step.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/llm-step.tsx
@@ -12,6 +12,7 @@ import {
   findReusableSecret,
   getLlmProvider,
   type LlmProvider,
+  providersForHarness,
 } from "../../lib/llm-providers.js";
 import type { WizardSnapshot } from "../../lib/wizard-snapshot.js";
 import { LabeledInput } from "../labeled-input.js";
@@ -31,6 +32,7 @@ export function LlmStep({
   const { data: secrets = [] } = useSecrets();
   const createSecret = useCreateSecret();
   const testAnthropic = useTestAnthropic();
+  const providers = providersForHarness(snapshot.harness);
 
   const [value, setValue] = useState("");
   const [manualOverride, setManualOverride] = useState(false);
@@ -108,9 +110,10 @@ export function LlmStep({
 
       <div>
         <span className="text-[13px] font-semibold text-foreground/80 block mb-1.5">
-          LLM provider
+          {snapshot.harness === "bob" ? "Credential" : "LLM provider"}
         </span>
         <ProviderPicker
+          providers={providers}
           selected={snapshot.llmProvider}
           onSelect={selectProvider}
           renderSelected={(selectedProvider) => (

--- a/packages/ui/src/modules/v2/components/wizard/llm-step.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/llm-step.tsx
@@ -1,0 +1,210 @@
+import { Check, Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import {
+  useCreateSecret,
+  useTestAnthropic,
+} from "../../../secrets/api/mutations.js";
+import { useSecrets } from "../../../secrets/api/queries.js";
+import {
+  findReusableSecret,
+  getLlmProvider,
+  type LlmProvider,
+} from "../../lib/llm-providers.js";
+import type { WizardSnapshot } from "../../lib/wizard-snapshot.js";
+import { LabeledInput } from "../labeled-input.js";
+import { ProviderPicker } from "./provider-picker.js";
+
+export function LlmStep({
+  snapshot,
+  update,
+  onCancel,
+  onNext,
+}: {
+  snapshot: WizardSnapshot;
+  update: (patch: Partial<WizardSnapshot>) => void;
+  onCancel: () => void;
+  onNext: () => void;
+}) {
+  const { data: secrets = [] } = useSecrets();
+  const createSecret = useCreateSecret();
+  const testAnthropic = useTestAnthropic();
+
+  const [value, setValue] = useState("");
+  const [manualOverride, setManualOverride] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const provider = snapshot.llmProvider
+    ? getLlmProvider(snapshot.llmProvider)
+    : null;
+  const reusable = provider ? findReusableSecret(provider, secrets) : undefined;
+  const useReuse =
+    Boolean(reusable) && !manualOverride && !snapshot.llmSecretId;
+
+  const selectProvider = (next: LlmProvider) => {
+    setValue("");
+    setError(null);
+    setManualOverride(false);
+    update({ llmProvider: next.id, llmSecretId: null });
+  };
+
+  const advance = async () => {
+    if (!provider || !snapshot.name.trim()) return;
+    setError(null);
+
+    if (snapshot.llmSecretId) return onNext();
+    if (useReuse && reusable) {
+      update({ llmSecretId: reusable.id });
+      return onNext();
+    }
+
+    const sanitized = value.trim();
+    if (!sanitized) return setError("Enter a credential.");
+
+    setBusy(true);
+    try {
+      if (provider.verifyEnvName) {
+        const result = await testAnthropic.mutateAsync({
+          value: sanitized,
+          envName: provider.verifyEnvName,
+        });
+        if (!result.ok) {
+          setError(result.message);
+          return;
+        }
+      }
+      const secret = await createSecret.mutateAsync({
+        type: provider.secretType,
+        name: provider.id,
+        value: sanitized,
+      });
+      update({ llmSecretId: secret.id });
+      onNext();
+    } catch {
+      setError("Could not save the credential.");
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const continueDisabled =
+    busy ||
+    !snapshot.name.trim() ||
+    !provider ||
+    (!snapshot.llmSecretId && !useReuse && value.trim().length === 0);
+
+  return (
+    <div className="flex flex-col gap-6">
+      <LabeledInput
+        label="Sandbox name"
+        placeholder="my-sandbox"
+        autoFocus
+        value={snapshot.name}
+        onChange={(name) => update({ name })}
+      />
+
+      <div>
+        <span className="text-[13px] font-semibold text-foreground/80 block mb-1.5">
+          LLM provider
+        </span>
+        <ProviderPicker
+          selected={snapshot.llmProvider}
+          onSelect={selectProvider}
+          renderSelected={(selectedProvider) => (
+            <CredentialField
+              provider={selectedProvider}
+              value={value}
+              onChange={setValue}
+              ready={Boolean(snapshot.llmSecretId)}
+              onChangeCredential={() => {
+                update({ llmSecretId: null });
+                setManualOverride(true);
+              }}
+              reuseName={useReuse ? reusable?.name : undefined}
+              onUseDifferent={() => setManualOverride(true)}
+            />
+          )}
+        />
+      </div>
+
+      {error && (
+        <p className="text-[12px] font-medium text-destructive">{error}</p>
+      )}
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="outline" onClick={onCancel} disabled={busy}>
+          Cancel
+        </Button>
+        <Button onClick={advance} disabled={continueDisabled}>
+          {busy && <Loader2 size={15} className="animate-spin" />}
+          Continue
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function CredentialField({
+  provider,
+  value,
+  onChange,
+  ready,
+  onChangeCredential,
+  reuseName,
+  onUseDifferent,
+}: {
+  provider: LlmProvider;
+  value: string;
+  onChange: (v: string) => void;
+  ready: boolean;
+  onChangeCredential: () => void;
+  reuseName?: string;
+  onUseDifferent: () => void;
+}) {
+  if (ready)
+    return (
+      <div className="flex items-center gap-2 text-[13px] text-success">
+        <Check size={15} /> Credential ready.
+        <button
+          type="button"
+          onClick={onChangeCredential}
+          className="text-muted-foreground hover:text-foreground underline ml-1"
+        >
+          change
+        </button>
+      </div>
+    );
+
+  if (reuseName)
+    return (
+      <div className="text-[13px] text-foreground/80">
+        Reusing existing credential{" "}
+        <strong className="text-foreground">{reuseName}</strong>.
+        <button
+          type="button"
+          onClick={onUseDifferent}
+          className="text-muted-foreground hover:text-foreground underline ml-1"
+        >
+          use a different credential
+        </button>
+      </div>
+    );
+
+  return (
+    <LabeledInput
+      label={`${provider.label} credential`}
+      type="password"
+      placeholder={provider.placeholder}
+      value={value}
+      onChange={onChange}
+      hint={
+        provider.verifyEnvName
+          ? "Verified with Anthropic before the sandbox is created."
+          : undefined
+      }
+    />
+  );
+}

--- a/packages/ui/src/modules/v2/components/wizard/provider-picker.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/provider-picker.tsx
@@ -1,24 +1,22 @@
 import { Check } from "lucide-react";
 import type { ReactNode } from "react";
 
-import {
-  LLM_PROVIDERS,
-  type LlmProvider,
-  type LlmProviderId,
-} from "../../lib/llm-providers.js";
+import type { LlmProvider, LlmProviderId } from "../../lib/llm-providers.js";
 
 export function ProviderPicker({
+  providers,
   selected,
   onSelect,
   renderSelected,
 }: {
+  providers: readonly LlmProvider[];
   selected: LlmProviderId | null;
   onSelect: (provider: LlmProvider) => void;
   renderSelected?: (provider: LlmProvider) => ReactNode;
 }) {
   return (
     <div className="flex flex-col gap-2">
-      {LLM_PROVIDERS.map((provider) => {
+      {providers.map((provider) => {
         const active = provider.id === selected;
         return (
           <div

--- a/packages/ui/src/modules/v2/components/wizard/provider-picker.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/provider-picker.tsx
@@ -1,0 +1,57 @@
+import { Check } from "lucide-react";
+import type { ReactNode } from "react";
+
+import {
+  LLM_PROVIDERS,
+  type LlmProvider,
+  type LlmProviderId,
+} from "../../lib/llm-providers.js";
+
+export function ProviderPicker({
+  selected,
+  onSelect,
+  renderSelected,
+}: {
+  selected: LlmProviderId | null;
+  onSelect: (provider: LlmProvider) => void;
+  renderSelected?: (provider: LlmProvider) => ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {LLM_PROVIDERS.map((provider) => {
+        const active = provider.id === selected;
+        return (
+          <div
+            key={provider.id}
+            className={`rounded-lg border transition-colors ${
+              active
+                ? "border-primary bg-primary/5"
+                : "border-border hover:border-primary/50"
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onSelect(provider)}
+              className="flex w-full items-center gap-3 px-4 py-3 text-left"
+            >
+              <div className="flex-1 min-w-0">
+                <div className="text-[14px] font-semibold text-foreground">
+                  {provider.label}
+                </div>
+                <div className="text-[12px] text-muted-foreground">
+                  {provider.description}
+                </div>
+              </div>
+              {active && <Check size={16} className="text-primary shrink-0" />}
+            </button>
+            {active && renderSelected && (
+              <div className="border-t border-primary/20 px-4 py-3">
+                {renderSelected(provider)}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/v2/hooks/use-github-connect.ts
+++ b/packages/ui/src/modules/v2/hooks/use-github-connect.ts
@@ -1,0 +1,71 @@
+import type { ConnectionCreateInput } from "api-server-api";
+
+import { useCreateConnection } from "../../connections/api/mutations.js";
+import {
+  useAppConnections,
+  useConnectionTemplates,
+} from "../../connections/api/queries.js";
+
+export type GithubMode = "github" | "github-enterprise";
+
+export interface EnsuredConnection {
+  id: string;
+  /** Already authorized (active) — no OAuth redirect needed. */
+  active: boolean;
+}
+
+export function useGithubConnect() {
+  const { data: templates = [] } = useConnectionTemplates();
+  const { data: connections = [] } = useAppConnections();
+  const createConnection = useCreateConnection();
+
+  const isBringYourOwnApp = (mode: GithubMode): boolean =>
+    templates
+      .find((t) => t.id === mode)
+      ?.inputs.find((i) => i.name === "clientId")?.state === "required";
+
+  // GitHub.com is one-per-user; GHE is keyed by host so distinct hosts get
+  // distinct connections rather than colliding on a single record.
+  const findExisting = (mode: GithubMode, host: string) =>
+    connections.find((c) =>
+      mode === "github"
+        ? c.templateId === "github"
+        : c.templateId === "github-enterprise" && c.host === host,
+    );
+
+  const ensureConnectionId = async (
+    mode: GithubMode,
+    host: string,
+    creds: { clientId: string; clientSecret: string },
+  ): Promise<EnsuredConnection> => {
+    const existing = findExisting(mode, host);
+    if (existing)
+      return { id: existing.id, active: existing.status === "active" };
+
+    const payload: ConnectionCreateInput = {
+      templateId: mode,
+      name: mode === "github" ? "github" : `ghe-${slugifyHost(host)}`,
+      authKind: "oauth",
+      ...(mode === "github-enterprise" ? { host } : {}),
+      ...(creds.clientId ? { clientId: creds.clientId } : {}),
+      ...(creds.clientSecret ? { clientSecret: creds.clientSecret } : {}),
+    };
+    const { id } = await createConnection.mutateAsync(payload);
+    return { id, active: false };
+  };
+
+  return {
+    isBringYourOwnApp,
+    findExisting,
+    ensureConnectionId,
+    creating: createConnection.isPending,
+  };
+}
+
+function slugifyHost(host: string): string {
+  return host
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 55);
+}

--- a/packages/ui/src/modules/v2/hooks/use-github-connect.ts
+++ b/packages/ui/src/modules/v2/hooks/use-github-connect.ts
@@ -24,6 +24,12 @@ export function useGithubConnect() {
       .find((t) => t.id === mode)
       ?.inputs.find((i) => i.name === "clientId")?.state === "required";
 
+  // Operator-configured GHE host (Helm `defaultGithubEnterpriseHost`) ships as
+  // the template's host preset; when present the user need not type it.
+  const ghePresetHost: string | undefined = templates
+    .find((t) => t.id === "github-enterprise")
+    ?.inputs.find((i) => i.name === "host")?.presetValue;
+
   // GitHub.com is one-per-user; GHE is keyed by host so distinct hosts get
   // distinct connections rather than colliding on a single record.
   const findExisting = (mode: GithubMode, host: string) =>
@@ -56,6 +62,7 @@ export function useGithubConnect() {
 
   return {
     isBringYourOwnApp,
+    ghePresetHost,
     findExisting,
     ensureConnectionId,
     creating: createConnection.isPending,

--- a/packages/ui/src/modules/v2/hooks/use-oauth-popup.ts
+++ b/packages/ui/src/modules/v2/hooks/use-oauth-popup.ts
@@ -59,7 +59,10 @@ export function useOAuthPopup(onResult: (result: OAuthPopupResult) => void) {
     pollRef.current = window.setInterval(() => {
       if (popupRef.current?.closed) {
         teardown();
-        onResultRef.current({ ok: false, message: "Authorization was cancelled." });
+        onResultRef.current({
+          ok: false,
+          message: "Authorization was cancelled.",
+        });
       }
     }, 600);
     return popup;

--- a/packages/ui/src/modules/v2/hooks/use-oauth-popup.ts
+++ b/packages/ui/src/modules/v2/hooks/use-oauth-popup.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useRef } from "react";
+
+export interface OAuthPopupResult {
+  ok: boolean;
+  /** Provider/flow message, or a cancellation note. Undefined on success. */
+  message?: string;
+}
+
+const POPUP_FEATURES = "popup,width=640,height=760";
+
+/**
+ * Drives a popup-based OAuth flow. `open()` synchronously opens a blank popup
+ * (so the browser doesn't block it), and the caller navigates it to the auth
+ * URL once available. The result arrives via a postMessage from the
+ * same-origin callback page; a dismissed popup is detected by polling `closed`.
+ * `open()` returns null when the popup is blocked, so the caller can fall back.
+ */
+export function useOAuthPopup(onResult: (result: OAuthPopupResult) => void) {
+  const popupRef = useRef<Window | null>(null);
+  const pollRef = useRef<number | null>(null);
+  const onResultRef = useRef(onResult);
+
+  useEffect(() => {
+    onResultRef.current = onResult;
+  }, [onResult]);
+
+  const teardown = useCallback(() => {
+    if (pollRef.current !== null) {
+      window.clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+    popupRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    const onMessage = (e: MessageEvent) => {
+      if (e.origin !== window.location.origin) return;
+      const data = e.data as
+        | { source?: string; oauth?: string; message?: string }
+        | null
+        | undefined;
+      if (!data || data.source !== "platform-oauth") return;
+      popupRef.current?.close();
+      teardown();
+      onResultRef.current({
+        ok: data.oauth === "success",
+        message: typeof data.message === "string" ? data.message : undefined,
+      });
+    };
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [teardown]);
+
+  const open = useCallback((): Window | null => {
+    const popup = window.open("about:blank", "platform-oauth", POPUP_FEATURES);
+    if (!popup) return null;
+    popupRef.current = popup;
+    if (pollRef.current !== null) window.clearInterval(pollRef.current);
+    pollRef.current = window.setInterval(() => {
+      if (popupRef.current?.closed) {
+        teardown();
+        onResultRef.current({ ok: false, message: "Authorization was cancelled." });
+      }
+    }, 600);
+    return popup;
+  }, [teardown]);
+
+  const close = useCallback(() => {
+    popupRef.current?.close();
+    teardown();
+  }, [teardown]);
+
+  return { open, close };
+}

--- a/packages/ui/src/modules/v2/hooks/use-sandbox-wizard.ts
+++ b/packages/ui/src/modules/v2/hooks/use-sandbox-wizard.ts
@@ -1,0 +1,39 @@
+import { useCallback, useState } from "react";
+
+import {
+  clearSnapshot,
+  EMPTY_SNAPSHOT,
+  loadSnapshot,
+  saveSnapshot,
+  type WizardSnapshot,
+} from "../lib/wizard-snapshot.js";
+
+export interface SandboxWizard {
+  snapshot: WizardSnapshot;
+  update: (patch: Partial<WizardSnapshot>) => void;
+  reset: () => void;
+}
+
+/**
+ * Snapshot-backed wizard state. Every mutation persists to sessionStorage so
+ * the in-progress sandbox survives the step-2 OAuth redirect; `reset` clears
+ * both the in-memory state and the snapshot once the agent is created.
+ */
+export function useSandboxWizard(): SandboxWizard {
+  const [snapshot, setSnapshot] = useState<WizardSnapshot>(loadSnapshot);
+
+  const update = useCallback((patch: Partial<WizardSnapshot>) => {
+    setSnapshot((prev) => {
+      const next = { ...prev, ...patch };
+      saveSnapshot(next);
+      return next;
+    });
+  }, []);
+
+  const reset = useCallback(() => {
+    clearSnapshot();
+    setSnapshot(EMPTY_SNAPSHOT);
+  }, []);
+
+  return { snapshot, update, reset };
+}

--- a/packages/ui/src/modules/v2/lib/harnesses.ts
+++ b/packages/ui/src/modules/v2/lib/harnesses.ts
@@ -1,0 +1,34 @@
+export type Harness = "claude-code" | "codex" | "bob";
+
+export interface HarnessMeta {
+  id: Harness;
+  label: string;
+  tagline: string;
+}
+
+export const HARNESSES: readonly HarnessMeta[] = [
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    tagline: "Anthropic's coding agent, ready in the terminal.",
+  },
+  {
+    id: "codex",
+    label: "Codex",
+    tagline: "OpenAI's Codex CLI, powered by your API key.",
+  },
+  {
+    id: "bob",
+    label: "Bob",
+    tagline: "IBM's Bob Shell, set up and waiting.",
+  },
+];
+
+/** Friendly name for an agent's template id; falls back to the raw id. */
+export function harnessLabel(
+  templateId: string | null | undefined,
+): string | null {
+  return (
+    HARNESSES.find((h) => h.id === templateId)?.label ?? templateId ?? null
+  );
+}

--- a/packages/ui/src/modules/v2/lib/llm-providers.ts
+++ b/packages/ui/src/modules/v2/lib/llm-providers.ts
@@ -1,6 +1,13 @@
 import type { SecretView } from "api-server-api";
 
-export type LlmProviderId = "anthropic-api" | "anthropic-oauth" | "ibm-litellm";
+import type { Harness } from "./harnesses.js";
+
+export type LlmProviderId =
+  | "anthropic-api"
+  | "anthropic-oauth"
+  | "ibm-litellm"
+  | "bob"
+  | "openai";
 
 type AnthropicVerifyEnv = "ANTHROPIC_API_KEY" | "CLAUDE_CODE_OAUTH_TOKEN";
 
@@ -8,10 +15,10 @@ export interface LlmProvider {
   id: LlmProviderId;
   label: string;
   description: string;
-  secretType: "anthropic" | "ibm-litellm";
+  secretType: "anthropic" | "ibm-litellm" | "bob" | "openai";
   placeholder: string;
   /** Env var that identifies an existing secret of this provider; also the
-   *  verify target for Anthropic. Absent verify ⇒ create-and-trust (LiteLLM). */
+   *  verify target for Anthropic. Absent verify ⇒ create-and-trust. */
   envName: string;
   verifyEnvName?: AnthropicVerifyEnv;
 }
@@ -43,7 +50,35 @@ export const LLM_PROVIDERS: readonly LlmProvider[] = [
     placeholder: "sk-…",
     envName: "ANTHROPIC_AUTH_TOKEN",
   },
+  {
+    id: "bob",
+    label: "Bob Shell",
+    description: "Bob Shell API key.",
+    secretType: "bob",
+    placeholder: "your Bob Shell API key",
+    envName: "BOBSHELL_API_KEY",
+  },
+  {
+    id: "openai",
+    label: "OpenAI",
+    description: "OpenAI API key (sk-…).",
+    secretType: "openai",
+    placeholder: "sk-…",
+    envName: "OPENAI_API_KEY",
+  },
 ];
+
+// Each harness uses its own credential: Claude Code on Anthropic/LiteLLM, Bob
+// on the Bob Shell key, Codex on the OpenAI key. The provider step only offers
+// the matching ones.
+export function providersForHarness(
+  harness: Harness,
+): readonly LlmProvider[] {
+  if (harness === "bob") return LLM_PROVIDERS.filter((p) => p.id === "bob");
+  if (harness === "codex")
+    return LLM_PROVIDERS.filter((p) => p.id === "openai");
+  return LLM_PROVIDERS.filter((p) => p.id !== "bob" && p.id !== "openai");
+}
 
 export function getLlmProvider(id: LlmProviderId): LlmProvider {
   const provider = LLM_PROVIDERS.find((p) => p.id === id);

--- a/packages/ui/src/modules/v2/lib/llm-providers.ts
+++ b/packages/ui/src/modules/v2/lib/llm-providers.ts
@@ -71,9 +71,7 @@ export const LLM_PROVIDERS: readonly LlmProvider[] = [
 // Each harness uses its own credential: Claude Code on Anthropic/LiteLLM, Bob
 // on the Bob Shell key, Codex on the OpenAI key. The provider step only offers
 // the matching ones.
-export function providersForHarness(
-  harness: Harness,
-): readonly LlmProvider[] {
+export function providersForHarness(harness: Harness): readonly LlmProvider[] {
   if (harness === "bob") return LLM_PROVIDERS.filter((p) => p.id === "bob");
   if (harness === "codex")
     return LLM_PROVIDERS.filter((p) => p.id === "openai");

--- a/packages/ui/src/modules/v2/lib/llm-providers.ts
+++ b/packages/ui/src/modules/v2/lib/llm-providers.ts
@@ -1,0 +1,68 @@
+import type { SecretView } from "api-server-api";
+
+export type LlmProviderId = "anthropic-api" | "anthropic-oauth" | "ibm-litellm";
+
+type AnthropicVerifyEnv = "ANTHROPIC_API_KEY" | "CLAUDE_CODE_OAUTH_TOKEN";
+
+export interface LlmProvider {
+  id: LlmProviderId;
+  label: string;
+  description: string;
+  secretType: "anthropic" | "ibm-litellm";
+  placeholder: string;
+  /** Env var that identifies an existing secret of this provider; also the
+   *  verify target for Anthropic. Absent verify ⇒ create-and-trust (LiteLLM). */
+  envName: string;
+  verifyEnvName?: AnthropicVerifyEnv;
+}
+
+export const LLM_PROVIDERS: readonly LlmProvider[] = [
+  {
+    id: "anthropic-oauth",
+    label: "Anthropic OAuth",
+    description: "Claude Code OAuth token from `claude setup-token`.",
+    secretType: "anthropic",
+    placeholder: "sk-ant-oat01-…",
+    envName: "CLAUDE_CODE_OAUTH_TOKEN",
+    verifyEnvName: "CLAUDE_CODE_OAUTH_TOKEN",
+  },
+  {
+    id: "anthropic-api",
+    label: "Anthropic API",
+    description: "Anthropic API key (sk-ant-api…).",
+    secretType: "anthropic",
+    placeholder: "sk-ant-api03-…",
+    envName: "ANTHROPIC_API_KEY",
+    verifyEnvName: "ANTHROPIC_API_KEY",
+  },
+  {
+    id: "ibm-litellm",
+    label: "IBM LiteLLM",
+    description: "IBM LiteLLM ETE proxy API token.",
+    secretType: "ibm-litellm",
+    placeholder: "sk-…",
+    envName: "ANTHROPIC_AUTH_TOKEN",
+  },
+];
+
+export function getLlmProvider(id: LlmProviderId): LlmProvider {
+  const provider = LLM_PROVIDERS.find((p) => p.id === id);
+  if (!provider) throw new Error(`unknown LLM provider: ${id}`);
+  return provider;
+}
+
+/**
+ * An existing secret the wizard can reuse instead of creating a duplicate.
+ * Matched on the provider's secret type plus its identifying env var, so an
+ * Anthropic API secret never collides with an Anthropic OAuth one.
+ */
+export function findReusableSecret(
+  provider: LlmProvider,
+  secrets: readonly SecretView[],
+): SecretView | undefined {
+  return secrets.find(
+    (s) =>
+      s.type === provider.secretType &&
+      (s.envMappings?.some((m) => m.envName === provider.envName) ?? false),
+  );
+}

--- a/packages/ui/src/modules/v2/lib/sandbox-name.ts
+++ b/packages/ui/src/modules/v2/lib/sandbox-name.ts
@@ -1,0 +1,62 @@
+const ADJECTIVES = [
+  "swift",
+  "calm",
+  "brave",
+  "clever",
+  "bright",
+  "gentle",
+  "bold",
+  "quiet",
+  "lucky",
+  "sunny",
+  "cosmic",
+  "amber",
+  "misty",
+  "nimble",
+  "mellow",
+  "stellar",
+  "crimson",
+  "golden",
+  "silent",
+  "breezy",
+  "frosty",
+  "jolly",
+  "rustic",
+  "velvet",
+];
+
+const NOUNS = [
+  "otter",
+  "falcon",
+  "river",
+  "panda",
+  "maple",
+  "comet",
+  "willow",
+  "sparrow",
+  "cedar",
+  "harbor",
+  "meadow",
+  "badger",
+  "lynx",
+  "heron",
+  "ember",
+  "pebble",
+  "glacier",
+  "fern",
+  "robin",
+  "canyon",
+  "lantern",
+  "beacon",
+  "grove",
+  "summit",
+];
+
+const pick = <T>(arr: readonly T[]): T =>
+  arr[Math.floor(Math.random() * arr.length)]!;
+
+/** A friendly default sandbox name, e.g. "swift-otter". Names are display
+ *  labels (not ids), so collisions are harmless. */
+export function generateSandboxName(): string {
+  return `${pick(ADJECTIVES)}-${pick(NOUNS)}`;
+}

--- a/packages/ui/src/modules/v2/lib/wizard-snapshot.ts
+++ b/packages/ui/src/modules/v2/lib/wizard-snapshot.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+
+const SNAPSHOT_KEY = "platform-v2-wizard";
+
+/**
+ * Persisted wizard state. Holds only ids and pick-state so the wizard can
+ * survive the full-page OAuth redirect in step 2 — never any secret value.
+ */
+export const wizardSnapshotSchema = z.object({
+  step: z.union([z.literal(1), z.literal(2)]),
+  name: z.string(),
+  llmProvider: z
+    .enum(["anthropic-api", "anthropic-oauth", "ibm-litellm"])
+    .nullable(),
+  llmSecretId: z.string().nullable(),
+  // GitHub.com and GitHub Enterprise are independent — a sandbox can have both.
+  githubConnectionId: z.string().nullable(),
+  githubAuthorized: z.boolean(),
+  gheHost: z.string(),
+  gheConnectionId: z.string().nullable(),
+  gheAuthorized: z.boolean(),
+});
+export type WizardSnapshot = z.infer<typeof wizardSnapshotSchema>;
+
+export const EMPTY_SNAPSHOT: WizardSnapshot = {
+  step: 1,
+  name: "",
+  llmProvider: null,
+  llmSecretId: null,
+  githubConnectionId: null,
+  githubAuthorized: false,
+  gheHost: "",
+  gheConnectionId: null,
+  gheAuthorized: false,
+};
+
+export function loadSnapshot(): WizardSnapshot {
+  const raw = sessionStorage.getItem(SNAPSHOT_KEY);
+  if (!raw) return EMPTY_SNAPSHOT;
+  try {
+    const parsed = wizardSnapshotSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : EMPTY_SNAPSHOT;
+  } catch {
+    return EMPTY_SNAPSHOT;
+  }
+}
+
+export function saveSnapshot(snapshot: WizardSnapshot): void {
+  sessionStorage.setItem(SNAPSHOT_KEY, JSON.stringify(snapshot));
+}
+
+export function clearSnapshot(): void {
+  sessionStorage.removeItem(SNAPSHOT_KEY);
+}

--- a/packages/ui/src/modules/v2/lib/wizard-snapshot.ts
+++ b/packages/ui/src/modules/v2/lib/wizard-snapshot.ts
@@ -9,8 +9,9 @@ const SNAPSHOT_KEY = "platform-v2-wizard";
 export const wizardSnapshotSchema = z.object({
   step: z.union([z.literal(1), z.literal(2)]),
   name: z.string(),
+  harness: z.enum(["claude-code", "bob", "codex"]),
   llmProvider: z
-    .enum(["anthropic-api", "anthropic-oauth", "ibm-litellm"])
+    .enum(["anthropic-api", "anthropic-oauth", "ibm-litellm", "bob", "openai"])
     .nullable(),
   llmSecretId: z.string().nullable(),
   // GitHub.com and GitHub Enterprise are independent — a sandbox can have both.
@@ -25,6 +26,7 @@ export type WizardSnapshot = z.infer<typeof wizardSnapshotSchema>;
 export const EMPTY_SNAPSHOT: WizardSnapshot = {
   step: 1,
   name: "",
+  harness: "claude-code",
   llmProvider: null,
   llmSecretId: null,
   githubConnectionId: null,

--- a/packages/ui/src/modules/v2/views/sandbox-list-view.tsx
+++ b/packages/ui/src/modules/v2/views/sandbox-list-view.tsx
@@ -1,0 +1,71 @@
+import { useMemo } from "react";
+
+import { Card } from "@/components/ui/card";
+
+import { useStore } from "../../../store.js";
+import { useDeleteAgent } from "../../agents/api/mutations.js";
+import { useAgents } from "../../agents/api/queries.js";
+import { useSyncRestartingAgents } from "../../agents/hooks/use-restart-agent.js";
+import { resolveAgentDisplay } from "../../agents/utils/agent-resolver.js";
+import { CreateSandboxCard } from "../components/create-sandbox-card.js";
+import { SandboxCard } from "../components/sandbox-card.js";
+import { SandboxShell } from "../components/sandbox-shell.js";
+
+export function SandboxListView() {
+  const { data, isSuccess: loaded } = useAgents();
+  const agents = data?.list ?? [];
+  const restartingAgents = useStore((s) => s.restartingAgents);
+  useSyncRestartingAgents();
+
+  const deleteAgent = useDeleteAgent();
+  const setView = useStore((s) => s.setView);
+  const openSandboxTerminal = useStore((s) => s.openSandboxTerminal);
+  const showConfirm = useStore((s) => s.showConfirm);
+
+  const restartingIds = useMemo(
+    () => new Set(restartingAgents.keys()),
+    [restartingAgents],
+  );
+
+  const confirmDelete = async (id: string, name: string) => {
+    const message = (
+      <>
+        Delete sandbox <strong className="text-foreground">"{name}"</strong>?
+        This also deletes <strong>all persistent data</strong> and cannot be
+        undone.
+      </>
+    );
+    if (await showConfirm(message, "Delete Sandbox", { kind: "destructive" }))
+      deleteAgent.mutate({ id });
+  };
+
+  return (
+    <SandboxShell breadcrumbs={[{ label: "Sandboxes" }]}>
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-[720px] px-4 py-8 md:py-12">
+          <h1 className="text-[22px] font-bold text-foreground mb-6">
+            Sandboxes
+          </h1>
+          <div className="flex flex-col gap-4">
+            {loaded &&
+              agents.map((agent) => (
+                <SandboxCard
+                  key={agent.id}
+                  agent={agent}
+                  display={resolveAgentDisplay(agent, restartingIds)}
+                  onOpen={() => openSandboxTerminal(agent.id)}
+                  onDelete={() => confirmDelete(agent.id, agent.name)}
+                  deleting={
+                    deleteAgent.isPending &&
+                    deleteAgent.variables?.id === agent.id
+                  }
+                />
+              ))}
+            {!loaded && <Card className="h-[68px] anim-pulse" />}
+            <CreateSandboxCard onClick={() => setView("v2-new")} />
+          </div>
+        </div>
+      </div>
+    </SandboxShell>
+  );
+}

--- a/packages/ui/src/modules/v2/views/sandbox-list-view.tsx
+++ b/packages/ui/src/modules/v2/views/sandbox-list-view.tsx
@@ -10,6 +10,9 @@ import { resolveAgentDisplay } from "../../agents/utils/agent-resolver.js";
 import { CreateSandboxCard } from "../components/create-sandbox-card.js";
 import { SandboxCard } from "../components/sandbox-card.js";
 import { SandboxShell } from "../components/sandbox-shell.js";
+import { type Harness, HARNESSES } from "../lib/harnesses.js";
+import { generateSandboxName } from "../lib/sandbox-name.js";
+import { EMPTY_SNAPSHOT, saveSnapshot } from "../lib/wizard-snapshot.js";
 
 export function SandboxListView() {
   const { data, isSuccess: loaded } = useAgents();
@@ -27,6 +30,11 @@ export function SandboxListView() {
     [restartingAgents],
   );
 
+  const startSandbox = (harness: Harness) => {
+    saveSnapshot({ ...EMPTY_SNAPSHOT, harness, name: generateSandboxName() });
+    setView("v2-new");
+  };
+
   const confirmDelete = async (id: string, name: string) => {
     const message = (
       <>
@@ -39,31 +47,67 @@ export function SandboxListView() {
       deleteAgent.mutate({ id });
   };
 
+  const isEmpty = loaded && agents.length === 0;
+
+  const createTiles = (
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+      {HARNESSES.map((harness) => (
+        <CreateSandboxCard
+          key={harness.id}
+          label={harness.label}
+          description={harness.tagline}
+          onClick={() => startSandbox(harness.id)}
+        />
+      ))}
+    </div>
+  );
+
   return (
     <SandboxShell breadcrumbs={[{ label: "Sandboxes" }]}>
       <div className="flex-1 overflow-y-auto">
         <div className="mx-auto w-full max-w-[720px] px-4 py-8 md:py-12">
-          <h1 className="text-[22px] font-bold text-foreground mb-6">
-            Sandboxes
-          </h1>
-          <div className="flex flex-col gap-4">
-            {loaded &&
-              agents.map((agent) => (
-                <SandboxCard
-                  key={agent.id}
-                  agent={agent}
-                  display={resolveAgentDisplay(agent, restartingIds)}
-                  onOpen={() => openSandboxTerminal(agent.id)}
-                  onDelete={() => confirmDelete(agent.id, agent.name)}
-                  deleting={
-                    deleteAgent.isPending &&
-                    deleteAgent.variables?.id === agent.id
-                  }
-                />
-              ))}
-            {!loaded && <Card className="h-[68px] anim-pulse" />}
-            <CreateSandboxCard onClick={() => setView("v2-new")} />
-          </div>
+          {!loaded ? (
+            <div className="flex flex-col gap-4">
+              <div className="mb-2 h-7 w-44 rounded bg-muted anim-pulse" />
+              <Card className="h-[68px] anim-pulse" />
+              <Card className="h-[68px] anim-pulse" />
+            </div>
+          ) : isEmpty ? (
+            <>
+              <h1 className="text-[22px] font-bold text-foreground mb-6">
+                Start a new sandbox
+              </h1>
+              {createTiles}
+            </>
+          ) : (
+            <>
+              <h1 className="text-[22px] font-bold text-foreground mb-6">
+                Sandboxes
+              </h1>
+              <div className="flex flex-col gap-4">
+                {agents.map((agent) => (
+                  <SandboxCard
+                    key={agent.id}
+                    agent={agent}
+                    display={resolveAgentDisplay(agent, restartingIds)}
+                    onOpen={() => openSandboxTerminal(agent.id)}
+                    onDelete={() => confirmDelete(agent.id, agent.name)}
+                    deleting={
+                      deleteAgent.isPending &&
+                      deleteAgent.variables?.id === agent.id
+                    }
+                  />
+                ))}
+              </div>
+
+              <div className="mt-8">
+                <span className="text-[12px] font-semibold uppercase tracking-wide text-muted-foreground">
+                  Start a new sandbox
+                </span>
+                <div className="mt-3">{createTiles}</div>
+              </div>
+            </>
+          )}
         </div>
       </div>
     </SandboxShell>

--- a/packages/ui/src/modules/v2/views/sandbox-terminal-view.tsx
+++ b/packages/ui/src/modules/v2/views/sandbox-terminal-view.tsx
@@ -1,3 +1,4 @@
+import { Loader2 } from "lucide-react";
 import { useState } from "react";
 
 import { useStore } from "../../../store.js";
@@ -32,5 +33,25 @@ export function SandboxTerminalView() {
 // Keyed by agentId so each sandbox gets its own fresh terminal session.
 function SandboxTerminal({ agentId }: { agentId: string }) {
   const [sessionId] = useState(() => crypto.randomUUID());
-  return <Terminal agentId={agentId} sessionId={sessionId} />;
+  // Cleared on the first output frame, not on socket open: the relay completes
+  // the client handshake immediately and only then wakes the agent, so the
+  // overlay must stay up through the wake until the shell actually responds.
+  const [ready, setReady] = useState(false);
+  return (
+    <div className="relative flex flex-1 min-h-0">
+      <Terminal
+        agentId={agentId}
+        sessionId={sessionId}
+        onFirstOutput={() => setReady(true)}
+      />
+      {!ready && (
+        <div className="absolute inset-0 z-20 flex items-center justify-center bg-stone-900/90 backdrop-blur-sm">
+          <div className="flex items-center gap-3 text-[14px] text-stone-300">
+            <Loader2 size={18} className="animate-spin" />
+            Starting sandbox…
+          </div>
+        </div>
+      )}
+    </div>
+  );
 }

--- a/packages/ui/src/modules/v2/views/sandbox-terminal-view.tsx
+++ b/packages/ui/src/modules/v2/views/sandbox-terminal-view.tsx
@@ -1,0 +1,36 @@
+import { useState } from "react";
+
+import { useStore } from "../../../store.js";
+import { useAgentsList } from "../../agents/api/queries.js";
+import { Terminal } from "../../sessions/components/terminal.js";
+import { SandboxShell } from "../components/sandbox-shell.js";
+
+export function SandboxTerminalView() {
+  const agentId = useStore((s) => s.agentId);
+  const setView = useStore((s) => s.setView);
+  const agents = useAgentsList();
+  const agent = agents.find((a) => a.id === agentId);
+
+  const breadcrumbs = [
+    { label: "Sandboxes", onClick: () => setView("v2-list") },
+    { label: agent?.name ?? "Sandbox" },
+  ];
+
+  return (
+    <SandboxShell breadcrumbs={breadcrumbs}>
+      {agentId ? (
+        <SandboxTerminal key={agentId} agentId={agentId} />
+      ) : (
+        <div className="flex flex-1 items-center justify-center text-[14px] text-muted-foreground">
+          No sandbox selected.
+        </div>
+      )}
+    </SandboxShell>
+  );
+}
+
+// Keyed by agentId so each sandbox gets its own fresh terminal session.
+function SandboxTerminal({ agentId }: { agentId: string }) {
+  const [sessionId] = useState(() => crypto.randomUUID());
+  return <Terminal agentId={agentId} sessionId={sessionId} />;
+}

--- a/packages/ui/src/modules/v2/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/v2/views/sandbox-wizard-view.tsx
@@ -1,0 +1,93 @@
+import { useEffect } from "react";
+
+import { emitToast } from "../../../lib/toast.js";
+import { useStore } from "../../../store.js";
+import { useCreateAgent } from "../../agents/api/mutations.js";
+import { SandboxShell } from "../components/sandbox-shell.js";
+import { GithubStep } from "../components/wizard/github-step.js";
+import { LlmStep } from "../components/wizard/llm-step.js";
+import { useSandboxWizard } from "../hooks/use-sandbox-wizard.js";
+import { loadSnapshot } from "../lib/wizard-snapshot.js";
+
+export function SandboxWizardView() {
+  const { snapshot, update, reset } = useSandboxWizard();
+  const setView = useStore((s) => s.setView);
+  const openSandboxTerminal = useStore((s) => s.openSandboxTerminal);
+  const createAgent = useCreateAgent();
+
+  // Resume after a popup-blocked, step-2 OAuth redirect lands back on /v2/new.
+  // Match the returned connection to GitHub or GHE so the right card flips.
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const result = params.get("oauth");
+    if (!result) return;
+    const connection = params.get("connection");
+    window.history.replaceState({}, "", "/v2/new");
+    if (result === "success") {
+      const saved = loadSnapshot();
+      update(
+        connection && connection === saved.gheConnectionId
+          ? { step: 2, gheAuthorized: true }
+          : { step: 2, githubAuthorized: true },
+      );
+    } else {
+      update({ step: 2 });
+      emitToast({
+        kind: "error",
+        message: `GitHub authorization failed: ${params.get("message") ?? "unknown error"}`,
+      });
+    }
+  }, [update]);
+
+  const cancel = () => {
+    reset();
+    setView("v2-list");
+  };
+
+  const createSandbox = async () => {
+    if (!snapshot.llmSecretId || !snapshot.name.trim()) return;
+    const appConnectionIds = [
+      snapshot.githubAuthorized ? snapshot.githubConnectionId : null,
+      snapshot.gheAuthorized ? snapshot.gheConnectionId : null,
+    ].filter((id): id is string => Boolean(id));
+    const agent = await createAgent.mutateAsync({
+      name: snapshot.name.trim(),
+      templateId: "claude-code",
+      egressPreset: "trusted",
+      secretIds: [snapshot.llmSecretId],
+      ...(appConnectionIds.length ? { appConnectionIds } : {}),
+    });
+    reset();
+    openSandboxTerminal(agent.id);
+  };
+
+  return (
+    <SandboxShell
+      breadcrumbs={[
+        { label: "Sandboxes", onClick: cancel },
+        { label: "New sandbox" },
+      ]}
+    >
+      <div className="flex-1 overflow-y-auto">
+        <div className="mx-auto w-full max-w-[520px] px-4 py-8 md:py-12">
+          {snapshot.step === 1 ? (
+            <LlmStep
+              snapshot={snapshot}
+              update={update}
+              onCancel={cancel}
+              onNext={() => update({ step: 2 })}
+            />
+          ) : (
+            <GithubStep
+              snapshot={snapshot}
+              update={update}
+              onBack={() => update({ step: 1 })}
+              onCreate={createSandbox}
+              creating={createAgent.isPending}
+            />
+          )}
+        </div>
+      </div>
+    </SandboxShell>
+  );
+}

--- a/packages/ui/src/modules/v2/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/v2/views/sandbox-wizard-view.tsx
@@ -52,7 +52,7 @@ export function SandboxWizardView() {
     ].filter((id): id is string => Boolean(id));
     const agent = await createAgent.mutateAsync({
       name: snapshot.name.trim(),
-      templateId: "claude-code",
+      templateId: snapshot.harness,
       egressPreset: "trusted",
       secretIds: [snapshot.llmSecretId],
       ...(appConnectionIds.length ? { appConnectionIds } : {}),

--- a/packages/ui/src/modules/v2/views/v2-app.tsx
+++ b/packages/ui/src/modules/v2/views/v2-app.tsx
@@ -1,0 +1,11 @@
+import { useStore } from "../../../store.js";
+import { SandboxListView } from "./sandbox-list-view.js";
+import { SandboxTerminalView } from "./sandbox-terminal-view.js";
+import { SandboxWizardView } from "./sandbox-wizard-view.js";
+
+export function V2App() {
+  const view = useStore((s) => s.view);
+  if (view === "v2-new") return <SandboxWizardView />;
+  if (view === "v2-terminal") return <SandboxTerminalView />;
+  return <SandboxListView />;
+}


### PR DESCRIPTION
Shell-less, parallel UI at `/v2` for terminal-only sandbox agents. v1 is untouched. Reuses the existing agent / provider-secret / connection APIs wholesale.

## What's in it
- **Routing + shell-less layout**: `/v2` (list), `/v2/new` (wizard), `/v2/<id>` (terminal). No sidebar/mobile nav; auth and terms gates inherited from v1.
- **List**: status + name cards, click opens the terminal, trash with confirm, 5s poll kept, placeholder create card. Minimal degraded indicator; no refresh/power/configure.
- **Wizard step 1**: name + LLM picker (Anthropic OAuth / Anthropic API / IBM LiteLLM). Inline provider-secret create, verify-before-advance for Anthropic, create-and-trust for LiteLLM, reuse-if-exists. Credential UI nested in the selected card.
- **Wizard step 2**: GitHub and GitHub Enterprise as independent connections (connect either, both, or skip). OAuth runs in a popup via `postMessage`, with a full-page redirect fallback if the popup is blocked.
- **Create**: on the step-2 to terminal transition, a single agent create grants the LLM secret and every authorized GitHub connection (claude-code template, egress trusted).
- **Terminal**: reuses the existing terminal full-screen; its connecting overlay covers the relay auto-wake.

## Backend
- OAuth callback now supports a per-flow `returnTo` and a `popup` mode (returns a `postMessage`+close page), both threaded through the OAuth pending-context. The registered GitHub callback URL and v1's redirect flow are unchanged.

## Notes
- IBM LiteLLM verify intentionally skipped (create-and-trust, matching v1).
- Verified by type-check, lint, and a manual run on the local dev cluster. No automated tests added.
- The connections subsystem this builds on is already implemented despite its architecture doc still saying "Proposed".
