### PR TITLE
feat: env injection without pod rolls

### DIFF
--- a/docs/adrs/DRAFT-runtime-env-injection.md
+++ b/docs/adrs/DRAFT-runtime-env-injection.md
@@ -1,0 +1,49 @@
+# ADR-DRAFT: Credential env via the runtime channel — injected at harness spawn, not baked into the pod
+
+**Date:** 2026-06-04
+**Status:** Proposed
+**Owner:** @janjeliga
+
+## Context
+
+Credential env reaches an agent only by being baked into its pod spec. A running pod's environment is immutable, so every change to the granted set rolls the pod — ADR-040 codified this as unavoidable ("there is no hot path"). The costs: a freshly created agent restarts itself the moment its initial grants land, and any mid-life grant change drops the running agent's in-flight sessions.
+
+The env the agent holds is only *placeholders* — the real credential is injected at the gateway on the wire (ADR-005/033/038). The pod is already untrusted and holds no secret bytes, so moving where placeholders are delivered does not touch the credential boundary. That is what makes a non-pod delivery path viable.
+
+## Decision
+
+**Credential-placeholder env is delivered as a contribution on the runtime channel (ADR-052) and merged into the harness process environment at spawn, not baked into the pod spec. The agent pod template becomes independent of the granted set — no grant or credential-env change rolls it.**
+
+- **Env is a contribution kind.** It rides the same channel, snapshot reconciliation, and acknowledgement model as the other contributions (ADR-051), persisted on the agent's volume — no separate transport.
+- **Injection is at spawn.** Reconciled env is composed into the harness process environment and inherited by its tool subprocesses; a running process's environment is never mutated. User-supplied env still wins on collision (ADR-040).
+- **Mid-life changes respawn the harness, not roll the pod.** The harness is long-lived and reused across turns, so it needs a respawn to pick up new env — taken at an idle turn boundary, forced after a bound if the agent never idles. Agent-owned resumable sessions (ADR-055) absorb it, and even a forced respawn restarts only the harness — strictly less disruptive than the whole-pod roll it replaces.
+- **First spawn waits for the first delivery, then falls back to best-effort.** On a cold start the spawn is held until the channel delivers env once, so the first turn has credentials; the hold is bounded and in-pod, not a readiness gate. If delivery never lands within the bound the harness spawns anyway and the respawn-on-change path heals it.
+- **An open interactive terminal is not disturbed** by a mid-life change — it picks up new env only on its next spawn. Refreshing it would destroy the live session; a recorded limitation.
+- **The agent pod template is decoupled from the granted set.** With env gone, its only remaining grant-derived input was the `ca.crt` mount (the cluster MITM CA). The controller now always issues the per-agent leaf cert and the agent mounts `ca.crt` unconditionally, so the mounted bytes never change with the grant set and granting the first credential no longer rolls the pod. Only the *gateway* pod still re-renders its filter chains (out of scope, ADR-038).
+- **Forks keep env baked into their pod spec.** A fork is an ephemeral one-task pod that never rolls mid-life and draws placeholders from the foreign replier's secrets, not a grant set; the channel's async first-spawn window buys it nothing and is riskier for a one-shot pod. The in-pod mechanism is shared — only the placeholder origin differs.
+
+## Alternatives Considered
+
+- **Single-shot create** — *adopted as a create-time optimisation, not the roll fix.* Settling the initial secret/connection selection into the Agent spec before the first reconcile lets the gateway render its chains once (no readiness flap) and the credentials ride the agent's first snapshot. The pod is grant-independent regardless; this only helps create-time credentials.
+- **Hot-reload env on the running pod** — impossible; pod env is immutable (the ADR-040 premise).
+- **Mutate the runtime process's own env and rely on inheritance** — not durable across a pod restart, risks clobbering platform env; rejected.
+- **Deliver env as a file the harness reads** — the harness consumes a real process environment, forcing a per-harness-image change; rejected.
+
+## Consequences
+
+- **Easier:** Grant and secret-env changes no longer roll the agent pod, so a running agent's sessions survive a credential edit that today drops them, and a new agent no longer self-restarts when its initial grants land. The change also stops flipping the agent to not-ready under ADR-059's revision-gated readiness.
+- **Easier:** Env joins the one reconciliation-and-settlement path the other contributions use — adding or removing a credential is a data change, not a pod lifecycle event.
+- **Harder:** Delivery is asynchronous, so "pod ready" no longer implies "credentials present" — and any signal that infers credential-presence from startup env inherits a first-spawn window where it reads "not yet known," not "absent." The cold-start spawn-hold covers the common case; ADR-059 readiness is gated on the rolled-out revision and channel env participates in no revision, so making readiness wait for env would need a delivered-signal no path tracks today. (Forks, which keep baked env, are unaffected.)
+- **Harder:** The env-change lifecycle moves from Kubernetes (change spec → roll) into platform runtime code (detect change → respawn at an idle boundary, force after a bound). It reuses existing spawn and session-idle tracking, so the addition is small, but it is now platform code rather than a K8s guarantee.
+- **Harder:** Keeping the template grant-independent means always issuing the leaf cert, so every agent — even a credential-less one — depends on cert-manager minting it before the pod starts and carries a leaf Secret it may never use. A one-time start dependency, not a recurring cost.
+- **Harder:** Env now reaches only a harness that advertises the capability to consume it; one that predates this starts credential-less rather than failing loud. Delivery rests on harness capability where the pod spec was unconditional — tolerable because harness and delivery path ship together.
+- **Committed-to:** The runtime channel is the sole delivery path for credential env; the pod spec is no longer a source of grant-derived env. Reverting means re-coupling the two. Credential env now follows the channel's projected-state model and inherits its repair/staleness behaviour rather than being recomputed by the controller at every render.
+
+## Related ADRs
+
+- [ADR-040](040-unified-secret-contributions.md) — amends its premise that credential env must live in the pod spec and roll on change; its unified fanout and user-wins precedence are retained.
+- [ADR-052](052-runtime-channel.md) / [ADR-051](051-connections-and-contributions.md) — env becomes one more contribution kind on the channel and model they define.
+- [ADR-058](058-crds-over-configmaps.md) — grant intent (`grantedSecretIds`/`grantedConnectionIds`) lives in the typed Agent spec it introduced; this decision moves env delivery off the rendered pod spec onto the channel.
+- [ADR-059](059-agent-readiness-status.md) — revision-gated readiness does not wait for channel-delivered env (see Consequences).
+- [ADR-005](005-credential-gateway.md) / [ADR-033](033-envoy-credential-gateway.md) / [ADR-038](038-paired-gateway-pod.md) — the credential boundary and on-the-wire injection are unchanged.
+- [ADR-055](055-agent-owned-session-metadata.md) — resumable, agent-owned sessions are what make harness respawn tolerable.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -71,3 +71,4 @@ This directory contains ADRs for the Platform project.
 | Draft | Title | Owner |
 |-------|-------|-------|
 | [DRAFT](DRAFT-multi-agent.md) | Multi-agent collaboration — isolated instances with shared artifacts | @tomkis |
+| [DRAFT](DRAFT-runtime-env-injection.md) | Credential env via the runtime channel — injected at harness spawn, not baked into the pod | @janjeliga |

--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-05-22
+Last verified: 2026-06-05
 
 > **Status: Proposed — not yet implemented.** This page describes the target shape of the subsystem per [ADR-051](../adrs/051-connections-and-contributions.md), [ADR-052](../adrs/052-runtime-channel.md), and [ADR-053](../adrs/053-runtime-outbox-worker.md). The current system still uses the parallel OAuth-app / provider-preset registries, pod-files SSE (ADR-034), and exec-based trigger delivery (ADR-008). Other architecture pages that describe those retiring mechanisms are not updated yet — they will be revised in the implementation PR(s).
 
@@ -11,7 +11,8 @@ Last verified: 2026-05-22
 - [ADR-053 — Transactional outbox + worker](../adrs/053-runtime-outbox-worker.md) — how mutations decouple from agent reachability
 - [ADR-036 — Redis as a platform primitive](../adrs/036-redis-platform-primitive.md) — the signal-path substrate the worker wakes on
 - [ADR-022 — Harness API server](../adrs/022-harness-api-server.md) — the restricted port the agent reaches; per-kind event handlers live here
-- [ADR-040 — Unified secret contributions](../adrs/040-unified-secret-contributions.md) — the `env` Contribution's render-time merge survives unchanged
+- [ADR-040 — Unified secret contributions](../adrs/040-unified-secret-contributions.md) — established the `env` Contribution and user-wins precedence; its render-into-pod delivery is superseded below
+- [ADR-DRAFT — Credential env via the runtime channel](../adrs/DRAFT-runtime-env-injection.md) — moves `env` delivery off the pod spec onto the runtime channel, injected at harness spawn; a grant change no longer rolls the agent pod
 
 ## Overview
 
@@ -28,22 +29,18 @@ A grant of one Connection produces Contributions of several kinds. They don't al
 ```mermaid
 flowchart LR
   grant[Connection grant on Agent A]
-  envRail[env Contributions]
   hostRail[egress-host Contributions]
-  rtRail[file / mcp-entry / skill-ref Contributions]
-  controller[controller render then pod roll]
+  rtRail[env / file / mcp-entry / skill-ref Contributions]
   envoy[egress_rules then Envoy ext_authz]
   channel[runtime channel]
 
-  grant --> envRail
   grant --> hostRail
   grant --> rtRail
-  envRail -->|bump annotation| controller
   hostRail -->|sync rows| envoy
   rtRail -->|outbox row| channel
 ```
 
-Two of the three rails were already in place before this subsystem and stay unchanged ([ADR-040](../adrs/040-unified-secret-contributions.md) for envs; [ADR-035](../adrs/035-unified-hitl-ux.md) for egress_rules). The third rail — the runtime channel — is new and is what the rest of this page is about.
+After [ADR-DRAFT](../adrs/DRAFT-runtime-env-injection.md) there are two rails. `egress-host` Contributions sync into Postgres `egress_rules` and are read live by Envoy ([ADR-035](../adrs/035-unified-hitl-ux.md)) — unchanged. Everything else — `env` (formerly a controller-render/pod-roll rail, [ADR-040](../adrs/040-unified-secret-contributions.md)), `file`, `mcp-entry`, `skill-ref` — now travels the runtime channel and is what the rest of this page is about.
 
 The runtime channel is two routes between api-server and agent-runtime, plus per-kind event handlers on the harness API:
 
@@ -214,13 +211,13 @@ The api-server's contribution-fanout layer routes each Contribution kind to the 
 
 | Kind | Rail | Delivery semantics | Note |
 |---|---|---|---|
-| `env` | Controller render at next pod start | Requires pod roll; immutable on a running pod | Implemented by bumping the `secrets-rev` annotation on the agent's ConfigMap; controller's existing reconciler re-renders. ADR-040 mechanism preserved. |
+| `env` | Runtime channel `applyState` (state slice) | Sub-second push; applied at next harness spawn | Written to a JSON file on the PV; the harness spawn path merges it into the process env (user env wins). A change recycles the harness at an idle turn boundary — no pod roll. |
 | `egress-host` | Postgres `egress_rules` → Envoy `ext_authz` | Live read; no pod involvement | Joined per-grant; revoke sweeps rows. Agent never sees these. |
 | `file` | Runtime channel `applyState` (state slice) | Sub-second push; idempotent reconciliation | Per-format + per-mergeMode driver materializes. |
 | `mcp-entry` | Runtime channel `applyState` (state slice) | Sub-second push; idempotent reconciliation | Driver dispatches to harness-specific path. |
 | `skill-ref` | Runtime channel `applyState` (state slice) | Sub-second push; per-version installer | Driver wraps existing skill-fetch helpers. |
 
-The rail choice is a property of the kind, not of the Connection. A single grant of GitHub Enterprise produces Contributions on three rails: `env` (controller render → pod roll), `egress-host` (egress_rules → Envoy live), and `file` (runtime channel push). They flow independently.
+The rail choice is a property of the kind, not of the Connection. A single grant of GitHub Enterprise produces Contributions on both rails: `egress-host` (egress_rules → Envoy live), and `env` + `file` (runtime channel push). They flow independently.
 
 ## The runtime channel
 
@@ -417,6 +414,7 @@ flowchart TD
   noop[exit clean, return]
   check{agent running?}
   defer[exit clean, sweep re-enqueues later]
+  retry[throw, fast-retry on backoff]
   compute[compute state slice + non-dispatched events]
   dispatch[POST runtime.v1.applyState]
   stamp["UPDATE outbox last_applied and stamp events dispatched_at up to acked"]
@@ -426,13 +424,14 @@ flowchart TD
   handlerStart --> load --> exists
   exists -->|no| noop
   exists -->|yes| check
-  check -->|no| defer
+  check -->|"no (plain)"| defer
+  check -->|"no (hello-triggered)"| retry
   check -->|yes| compute --> dispatch
   dispatch -->|appliedVersion, appliedHash| stamp --> ok
   dispatch -->|error| fail
 ```
 
-BullMQ retries are reserved for transport failures (network blip, agent crash mid-call). "Agent not running" exits clean — the cron sweep re-enqueues the row on its next tick, and `hello` picks up the payload when the agent eventually wakes.
+BullMQ retries cover transport failures (network blip, agent crash mid-call) and the boot window: a `hello`-triggered dispatch whose agent is a heartbeat short of Ready throws to fast-retry on the backoff, so fresh config lands in ~a second instead of waiting a full sweep tick. A plain dispatch to an agent that isn't running exits clean — the cron sweep re-enqueues on its next tick, and `hello` picks up the payload when the agent eventually wakes.
 
 ### Cron sweep
 
@@ -443,7 +442,7 @@ A scheduled job runs every minute and does two things:
 
 ### Agent-state cache
 
-The worker handler reads agent running-state from an in-memory cache fed by the existing ConfigMap watch in the agents service — never from a direct K8s API call. When the agent is not running the handler exits clean; the outbox row remains for the cron sweep to re-enqueue when the agent transitions back to running, and `hello` clears it on wake.
+The worker handler reads agent running-state from an in-memory cache fed by the existing ConfigMap watch in the agents service — never from a direct K8s API call. When the agent is not running a plain dispatch exits clean and the outbox row waits for the cron sweep to re-enqueue once it transitions back to running. A `hello`-triggered dispatch instead fast-retries on the queue backoff: `hello` means the agent is up and Ready is imminent, so the brief miss resolves in ~a second rather than at the next sweep tick.
 
 ### Redis-down behavior
 
@@ -563,7 +562,7 @@ The UI surfaces the gap at grant time: connecting GitHub to a Claude-Code agent 
 | Redis (BullMQ queues) | Pending BullMQ jobs referencing outbox row ids | Relaxed durability per ADR-036; Postgres outbox + cron sweep is the recovery path. |
 | Postgres `egress_rules` | `egress-host` Contributions joined per grant | Existing table; same as today (ADR-035). |
 | K8s Secret per Connection | Auth credentials (refresh tokens, api-keys) | Owner-label-scoped; mounted into the paired gateway pod, never into the agent pod. |
-| Agent ConfigMap `secrets-rev` annotation | Bump triggers env re-render | Existing ADR-040 mechanism unchanged. |
+| Per-agent PVC `$HOME/.platform/runtime-env.json` | Reconciled credential-placeholder env | Written by the `env` driver from the channel snapshot; read by the harness/terminal spawn paths. |
 | `agents` table — new columns | `runtime_protocol_version`, `runtime_capabilities`, `runtime_last_hello_at`, `runtime_agent_version` | Populated on every `hello`. |
 | Per-Agent PVC | Materialized files, MCP config, installed skills | Driver-written via runtime channel. No event-dedupe log — events dedupe server-side. |
 | Per-agent state file under `$HOME/.platform/<kind>.json` | Driver's tracking of what it has previously written | Per-contribution-driver, opt-in. Section-marker file driver doesn't need it; key-targeted does. |

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -1,6 +1,6 @@
 # Persistence
 
-Last verified: 2026-06-01
+Last verified: 2026-06-05
 
 ## Motivated by
 
@@ -88,7 +88,7 @@ Each reconciled ConfigMap carries two `data` keys with strict single-writer owne
 - **`spec.yaml`** — user intent. Written exclusively by the api-server.
 - **`status.yaml`** — observed state and scheduler bookkeeping (next fire, last fire, error). Written exclusively by the controller.
 
-High-frequency, lightweight metadata (heartbeats, activity timestamps, `granted-secret-ids`, `granted-connection-ids`, `secrets-rev`, `last-activity`) lives on **annotations** rather than `status.yaml` to avoid rewriting the spec/status payload on every update.
+High-frequency, lightweight metadata (heartbeats, activity timestamps, `granted-secret-ids`, `granted-connection-ids`, `last-activity`) lives on **annotations** rather than `status.yaml` to avoid rewriting the spec/status payload on every update. (Credential `env` no longer has a `secrets-rev` annotation — it rides the runtime channel; see [connections.md](connections.md) and ADR-DRAFT.)
 
 ConfigMaps were chosen over CRDs so that Platform installs without cluster-admin — the schema maps directly onto a CRD spec if the constraint ever lifts. There is no schema validation at the K8s API layer; both the api-server (on write) and the controller (on read) validate in application code.
 

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -145,6 +145,8 @@ Agent-runtime never holds a real GitHub token. The paired gateway pod performs t
 
 If the user has not connected GitHub, no Secret exists and the request leaves authenticated only when the agent has supplied its own token. The agent runtime exposes `PLATFORM_GH_TOKEN_AVAILABLE=true|false` so wrapper scripts can short-circuit instead of making a 401-eliciting request first.
 
+Since credential env moved to the runtime channel (ADR-DRAFT), the flag is derived in-pod from the reconciled env rather than stamped on the pod by the controller. It therefore inherits the channel's best-effort first-spawn semantics: on a cold pod it reads `false` until the first env snapshot arrives, then flips to `true` on the harness respawn that follows. A wrapper that short-circuits on `false` may do so during that boot window — treat it as "not yet known," not "permanently absent."
+
 The same path lets `git clone` of a private repo work without any credential being mounted into the agent pod.
 
 ## Flows

--- a/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
@@ -32,6 +32,7 @@ function fakeRuntime(): { runtime: AcpRuntime; sent: any[] } {
       agentAlive: true,
     }),
     resetSession: () => {},
+    refreshEnv: () => {},
     shutdown: () => {},
   };
   return { runtime, sent };

--- a/packages/agent-runtime/src/core/runtime-env.ts
+++ b/packages/agent-runtime/src/core/runtime-env.ts
@@ -1,0 +1,39 @@
+import { mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+// Placeholder env on the PV: written by the env driver, read by spawn paths.
+const RUNTIME_ENV_NOTE =
+  "Managed by the platform runtime. Do not edit — overwritten on the next sync.";
+
+export function runtimeEnvPath(agentHome: string): string {
+  return join(agentHome, ".platform", "runtime-env.json");
+}
+
+// Atomic overwrite (temp + rename) so a concurrent spawn never reads a torn file.
+export function writeRuntimeEnv(
+  agentHome: string,
+  env: Record<string, string>,
+): void {
+  const path = runtimeEnvPath(agentHome);
+  mkdirSync(dirname(path), { recursive: true });
+  const body = JSON.stringify({ _note: RUNTIME_ENV_NOTE, env }, null, 2);
+  const tmp = `${path}.tmp`;
+  writeFileSync(tmp, body, "utf8");
+  renameSync(tmp, path);
+}
+
+// A missing or unparseable file yields {} (the next snapshot heals it).
+export function readRuntimeEnv(agentHome: string): Record<string, string> {
+  let raw: string;
+  try {
+    raw = readFileSync(runtimeEnvPath(agentHome), "utf8");
+  } catch {
+    return {};
+  }
+  try {
+    const parsed = JSON.parse(raw) as { env?: Record<string, string> };
+    return parsed.env ?? {};
+  } catch {
+    return {};
+  }
+}

--- a/packages/agent-runtime/src/modules/acp/compose.ts
+++ b/packages/agent-runtime/src/modules/acp/compose.ts
@@ -1,4 +1,6 @@
+import { existsSync } from "node:fs";
 import type { DocumentStoreBackend } from "../../core/document-store.js";
+import { readRuntimeEnv, runtimeEnvPath } from "../../core/runtime-env.js";
 import { createChildAgentProcess } from "./infrastructure/create-child-agent-process.js";
 import { createSessionMetadataStore } from "./infrastructure/session-metadata-store.js";
 import { createAcpRuntime, type AcpRuntime } from "./services/acp-runtime.js";
@@ -10,8 +12,8 @@ import {
 export interface ComposeAcpOptions {
   command: string[];
   workingDir: string;
+  agentHome: string;
   stateBackend: DocumentStoreBackend;
-  env?: Record<string, string | undefined>;
   log?: (msg: string) => void;
 }
 
@@ -21,15 +23,18 @@ export function composeAcp(opts: ComposeAcpOptions): {
 } {
   const sessionMetadata = createSessionMetadataStore(opts.stateBackend);
   const runtime = createAcpRuntime({
+    // Channel env read fresh per spawn; process.env wins (user env > placeholders).
     spawnAgent: () =>
       createChildAgentProcess({
         command: opts.command,
         workingDir: opts.workingDir,
-        env: opts.env,
+        env: { ...readRuntimeEnv(opts.agentHome), ...process.env },
       }),
     workingDir: opts.workingDir,
     sessionMetadata,
     log: opts.log,
+    // Warm restart (env on the PV) spawns now; cold boot gates until env arrives.
+    envReadyAtBoot: existsSync(runtimeEnvPath(opts.agentHome)),
   });
   const triggerDriver = createTriggerSessionDriver({ acpRuntime: runtime });
   return { runtime, triggerDriver };

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -28,6 +28,12 @@ const PROMPT_QUEUE_CAP = 32;
  */
 const DEFAULT_ORPHAN_TTL_MS = 10 * 60 * 1000;
 
+// Wait this long for an idle turn boundary before forcing a harness recycle to apply changed env.
+const DEFAULT_ENV_FORCE_RECYCLE_MS = 60 * 1000;
+
+// Cold boot: hold the first spawn this long for env to arrive, then spawn anyway.
+const DEFAULT_WARM_START_TIMEOUT_MS = 15 * 1000;
+
 /**
  * Soft cap on per-session log size. Once an append would push the log past
  * this, we drop the oldest entry and mark the log as `truncated` — future
@@ -63,6 +69,8 @@ export interface AcpRuntime {
   attach(channel: ClientChannel): void;
   status(): AcpRuntimeStatus;
   resetSession(sessionId: string): void;
+  /** Env on disk changed: recycle a running harness so it respawns with the new env. */
+  refreshEnv(): void;
   shutdown(): void;
 }
 
@@ -72,6 +80,12 @@ export interface AcpRuntimeDeps {
   log?: (msg: string) => void;
   /** Override the orphan TTL — exposed for tests; production defaults to 10 min. */
   orphanTtlMs?: number;
+  /** Override the env force-recycle bound — exposed for tests; default 60s. */
+  envForceRecycleMs?: number;
+  /** Env already on disk at boot → spawn now; false gates the first spawn until env arrives. Defaults true. */
+  envReadyAtBoot?: boolean;
+  /** Override the cold-boot warm-start bound — exposed for tests; default 15s. */
+  warmStartTimeoutMs?: number;
   /** Override the log size cap — exposed for tests. */
   logBytesCap?: number;
   /** Owns the `_meta.platform.*` round-trip (ADR-055); skipped when omitted. */
@@ -194,8 +208,19 @@ interface BootstrapState {
 export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   const orphanTtlMs = deps.orphanTtlMs ?? DEFAULT_ORPHAN_TTL_MS;
   const logBytesCap = deps.logBytesCap ?? DEFAULT_LOG_BYTES_CAP;
+  const envForceRecycleMs =
+    deps.envForceRecycleMs ?? DEFAULT_ENV_FORCE_RECYCLE_MS;
+  const warmStartTimeoutMs =
+    deps.warmStartTimeoutMs ?? DEFAULT_WARM_START_TIMEOUT_MS;
+  // Cold-boot spawn gate: channels attaching before env lands buffer until it does.
+  let envReady = deps.envReadyAtBoot ?? true;
+  const warmWaiters = new Set<() => void>();
+  let warmTimer: ReturnType<typeof setTimeout> | null = null;
   let agent: AgentProcess | null = null;
   let agentExited = false;
+  /** Env on disk changed; a running harness must be recycled to pick it up. */
+  let envRefreshPending = false;
+  let envForceTimer: ReturnType<typeof setTimeout> | null = null;
   /**
    * Whether the agent advertised `agentCapabilities.sessionCapabilities.close`
    * in its `initialize` response. Some harnesses (notably pi-acp) don't
@@ -506,6 +531,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
     agent = a;
     a.onLine(handleAgentLine);
     a.exited.then(() => {
+      // A detached (recycled) process exiting must not clobber the current one.
+      if (agent !== a) return;
       agentExited = true;
       for (const channel of engagedSessions.keys()) {
         channel.close(1011, "agent exited");
@@ -519,6 +546,61 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       pendingFromAgent.clear();
     });
     return a;
+  }
+
+  // ── Cold-boot warm-start gate ──
+  // Release the gate: spawn the harness for every channel parked while waiting.
+  function markEnvReady(): void {
+    if (envReady) return;
+    envReady = true;
+    if (warmTimer) {
+      clearTimeout(warmTimer);
+      warmTimer = null;
+    }
+    for (const release of [...warmWaiters]) release();
+    warmWaiters.clear();
+  }
+
+  // Safety valve: never hold the gate forever if env never arrives.
+  if (!envReady) warmTimer = setTimeout(markEnvReady, warmStartTimeoutMs);
+
+  // ── Env-change recycle ──
+  // Kills the harness but leaves agentExited false, so the next attach respawns.
+
+  function clearEnvForceTimer(): void {
+    if (envForceTimer) {
+      clearTimeout(envForceTimer);
+      envForceTimer = null;
+    }
+  }
+
+  function recycleAgentForEnv(): void {
+    clearEnvForceTimer();
+    envRefreshPending = false;
+    const old = agent;
+    if (!old || agentExited) return;
+    deps.log?.("recycling harness to apply env change");
+    // Close code 1011 matches a real agent exit; clients reconnect and resume (ADR-055).
+    for (const channel of engagedSessions.keys())
+      channel.close(1011, "agent recycled for env change");
+    engagedSessions.clear();
+    channelCursors.clear();
+    sessionLogs.clear();
+    bootstrapBySession.clear();
+    for (const t of orphanTimers.values()) clearTimeout(t);
+    orphanTimers.clear();
+    pendingFromAgent.clear();
+    activePromptBySession.clear();
+    promptQueueBySession.clear();
+    // Detach before kill so the old process's exit handler no-ops.
+    agent = null;
+    old.kill();
+  }
+
+  /** Recycle now if an env refresh is pending and no turn is in flight. */
+  function maybeRecycleForEnv(): void {
+    if (envRefreshPending && activePromptBySession.size === 0)
+      recycleAgentForEnv();
   }
 
   // ── Channel lifecycle ──
@@ -872,6 +954,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
           if (active && active.outboundId === outboundId) {
             activePromptBySession.delete(sid);
             if (agent && !agentExited) advanceQueue(agent, sid);
+            // Turn boundary — apply a deferred env change if nothing's in flight.
+            maybeRecycleForEnv();
           }
           appendAndFanOut(
             sid,
@@ -1137,16 +1221,34 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
 
   return {
     attach(channel) {
-      const a = ensureAgent();
-      if (!a) {
-        channel.close(1011, "agent process is not running");
-        return;
-      }
-
+      // One path for both: buffer frames until the agent is bound, then replay.
+      // Warm (env present) releases synchronously below — buffered stays empty.
+      // Cold-boot parks the release until env lands (or the safety timer fires).
       engagedSessions.set(channel, new Set());
+      const buffered: string[] = [];
+      let live: AgentProcess | null = null;
+      const release = (): void => {
+        if (live) return;
+        const a = ensureAgent();
+        if (!a) {
+          channel.close(1011, "agent process is not running");
+          return;
+        }
+        live = a;
+        for (const data of buffered) handleClientMessage(a, channel, data);
+        buffered.length = 0;
+      };
+      channel.onMessage((data) => {
+        if (live) handleClientMessage(live, channel, data);
+        else buffered.push(data);
+      });
+      channel.onClose(() => {
+        warmWaiters.delete(release);
+        detach(channel);
+      });
 
-      channel.onMessage((data) => handleClientMessage(a, channel, data));
-      channel.onClose(() => detach(channel));
+      if (envReady) release();
+      else warmWaiters.add(release);
     },
 
     status() {
@@ -1165,6 +1267,24 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       deps.log?.(`reset session ${sessionId}`);
     },
 
+    refreshEnv() {
+      // First delivery after a cold boot just releases the gate — no recycle.
+      if (!envReady) {
+        markEnvReady();
+        return;
+      }
+      // Nothing running → the next spawn reads the new env for free.
+      if (!agent || agentExited) return;
+      envRefreshPending = true;
+      if (activePromptBySession.size === 0) {
+        recycleAgentForEnv();
+        return;
+      }
+      // A turn is in flight: recycle at the next turn boundary, or force after a bound.
+      if (!envForceTimer)
+        envForceTimer = setTimeout(recycleAgentForEnv, envForceRecycleMs);
+    },
+
     shutdown() {
       for (const channel of engagedSessions.keys())
         channel.close(1000, "shutdown");
@@ -1174,6 +1294,9 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       bootstrapBySession.clear();
       for (const t of orphanTimers.values()) clearTimeout(t);
       orphanTimers.clear();
+      clearEnvForceTimer();
+      if (warmTimer) clearTimeout(warmTimer);
+      warmWaiters.clear();
       if (agent && !agentExited) agent.kill();
     },
   };

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/env-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/env-plugin.ts
@@ -1,0 +1,55 @@
+import type { DriverBinding, KindHandler, Plugin } from "agent-runtime-api";
+import { readRuntimeEnv, writeRuntimeEnv } from "../../../core/runtime-env.js";
+
+const IMPL_NAME = "env";
+const GH_TOKEN_ENV = "GH_TOKEN";
+const GH_AVAILABLE_ENV = "PLATFORM_GH_TOKEN_AVAILABLE";
+
+export interface EnvPluginDeps {
+  /** Fired only when the written env changed, so a running harness can recycle. */
+  onChange?: () => void;
+}
+
+export function createEnvPlugin(deps: EnvPluginDeps = {}): Plugin {
+  return {
+    name: IMPL_NAME,
+
+    bind(kind: string, _binding: DriverBinding): KindHandler {
+      if (kind !== "env") {
+        throw new Error(
+          `plugin "${IMPL_NAME}" does not handle kind "${kind}" — bind it to "env" only`,
+        );
+      }
+      return async (contributions, ctx) => {
+        const env: Record<string, string> = {};
+        // First occurrence wins on collision (connection env precedes secret env).
+        for (const c of contributions) {
+          if (c.kind !== "env") continue;
+          if (!(c.name in env)) env[c.name] = c.placeholder;
+        }
+        // Flag the harness wrapper scripts read for GitHub auth availability.
+        env[GH_AVAILABLE_ENV] = GH_TOKEN_ENV in env ? "true" : "false";
+
+        // Only rewrite + recycle when env actually changed (dispatcher fires on any snapshot change).
+        if (envEquals(readRuntimeEnv(ctx.agentHome), env)) {
+          ctx.log("env unchanged");
+          return;
+        }
+        writeRuntimeEnv(ctx.agentHome, env);
+        ctx.log(`wrote ${Object.keys(env).length} env var(s)`);
+        deps.onChange?.();
+      };
+    },
+  };
+}
+
+function envEquals(
+  a: Record<string, string>,
+  b: Record<string, string>,
+): boolean {
+  const ak = Object.keys(a);
+  if (ak.length !== Object.keys(b).length) return false;
+  return ak.every((k) => a[k] === b[k]);
+}
+
+export const ENV_PLUGIN_NAME = IMPL_NAME;

--- a/packages/agent-runtime/src/modules/runtime-channel/index.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/index.ts
@@ -2,6 +2,7 @@ export { composeRuntimeChannel } from "./compose.js";
 export type { RuntimeChannelComposition } from "./compose.js";
 export type { RuntimeManifest } from "./manifest.js";
 
+export { createEnvPlugin } from "./drivers/env-plugin.js";
 export { createFilePlugin } from "./drivers/file-plugin.js";
 export { createMcpEntryPlugin } from "./drivers/mcp-entry-plugin.js";
 export {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -21,6 +21,7 @@ import {
 } from "api-server-api";
 import { createFileDocumentStoreBackend } from "./core/document-store.js";
 import { expandHome } from "./core/expand-home.js";
+import { readRuntimeEnv } from "./core/runtime-env.js";
 import { createFilesService } from "./modules/files.js";
 import { createImportHandlers, sweepStaging } from "./modules/import/index.js";
 import { composeSkills } from "./modules/skills/index.js";
@@ -29,6 +30,7 @@ import { composeAcp } from "./modules/acp/compose.js";
 import { createWebSocketChannel } from "./modules/acp/infrastructure/create-websocket-channel.js";
 import {
   composeRuntimeChannel,
+  createEnvPlugin,
   createFilePlugin,
   createMcpEntryPlugin,
   createSkillInstallPlugin,
@@ -80,6 +82,7 @@ const { runtime: acpRuntime, triggerDriver } = composeAcp({
     ? ["npx", "tsx", join(__dir, "agent.ts")]
     : ["/usr/local/bin/harness-chat"],
   workingDir: workDir,
+  agentHome: homeDir,
   stateBackend,
   log: (msg) => process.stderr.write(`[acp] ${msg}\n`),
 });
@@ -93,6 +96,7 @@ const runtimeChannel = await composeRuntimeChannel({
   agentId: process.env.PLATFORM_AGENT_ID ?? process.env.HOSTNAME ?? "unknown",
   triggerDriver,
   plugins: [
+    createEnvPlugin({ onChange: () => acpRuntime.refreshEnv() }),
     createFilePlugin(),
     createMcpEntryPlugin(),
     createSkillInstallPlugin({ install: skillsService.install }),
@@ -219,6 +223,8 @@ function attachPty(
         rows,
         cwd: workDir,
         env: {
+          // Runtime-channel env first; process.env wins on collision.
+          ...readRuntimeEnv(homeDir),
           ...(Object.fromEntries(
             Object.entries(process.env).filter(
               ([k, v]) =>

--- a/packages/api-server-api/src/modules/agents/schemas.ts
+++ b/packages/api-server-api/src/modules/agents/schemas.ts
@@ -34,6 +34,10 @@ export const agentCreateInputSchema = z
     gitRepo: z
       .object({ url: z.url(), ref: z.string().min(1).optional() })
       .optional(),
+    // Initial grants, settled into the spec at create so credentials ride the
+    // first snapshot and the gateway renders its chains once (no readiness flap).
+    secretIds: z.array(z.string()).optional(),
+    connectionIds: z.array(z.string()).optional(),
   })
   .refine((d) => d.templateId !== undefined || d.image !== undefined, {
     message: "Either templateId or image is required",

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -405,4 +405,8 @@ export interface SecretsService {
   delete(id: string): Promise<void>;
   getAgentAccess(agentId: string): Promise<AgentAccess>;
   setAgentAccess(agentId: string, access: AgentAccess): Promise<void>;
+  /** Expand a selection of primary secret ids to the full granted set
+   *  (adds GitHub-PAT twins). Used to settle grants into an Agent spec at
+   *  create time without re-implementing twin expansion. */
+  expandSecretGrants(secretIds: string[]): Promise<string[]>;
 }

--- a/packages/api-server/src/__tests__/unit/agent-grants-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/agent-grants-port.test.ts
@@ -4,10 +4,7 @@ import type {
   K8sClient,
   KubeObject,
 } from "../../modules/agents/infrastructure/k8s.js";
-import {
-  ANN_ROLL_REV,
-  LABEL_OWNER,
-} from "../../modules/agents/infrastructure/labels.js";
+import { LABEL_OWNER } from "../../modules/agents/infrastructure/labels.js";
 
 /** ADR-058: an agent is a single custom resource; grants live in its spec
  *  (`grantedSecretIds` / `grantedConnectionIds`). */
@@ -202,17 +199,5 @@ describe("createAgentGrantsPort.listAgentsGrantedSecret", () => {
     ]);
     const port = createAgentGrantsPort(client, "owner-1");
     expect(await port.listAgentsGrantedSecret("secret-x")).toEqual([]);
-  });
-});
-
-describe("createAgentGrantsPort.bumpSecretsRev", () => {
-  it("patches the roll-rev annotation on the named agent", async () => {
-    const { client, patches } = fakeClient([agentObj("agent-1")]);
-    const port = createAgentGrantsPort(client, "owner-1");
-    await port.bumpSecretsRev("agent-1", "abc123def456");
-    expect(patches.at(-1)).toEqual({
-      name: "agent-1",
-      body: { metadata: { annotations: { [ANN_ROLL_REV]: "abc123def456" } } },
-    });
   });
 });

--- a/packages/api-server/src/__tests__/unit/secrets-service-create-github-pat.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-create-github-pat.test.ts
@@ -60,7 +60,6 @@ function makeGrants() {
     async listAgentsGrantedSecret() {
       return [];
     },
-    async bumpSecretsRev() {},
   };
   return { port };
 }

--- a/packages/api-server/src/__tests__/unit/secrets-service-fanout.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-fanout.test.ts
@@ -24,6 +24,19 @@ import type {
   AgentGrantsPort,
   GrantedAgentSummary,
 } from "../../modules/agents/infrastructure/agent-grants-port.js";
+import type { RuntimeMutator } from "../../modules/runtime-delivery/index.js";
+
+function makeMutator() {
+  const delivered: string[] = [];
+  const mutator: RuntimeMutator = {
+    async bump(agentId) {
+      delivered.push(agentId);
+      return 1;
+    },
+    async enqueueAfterCommit() {},
+  };
+  return { mutator, delivered };
+}
 
 function makePort(initial: K8sStoredSecret[]) {
   const store = new Map(initial.map((s) => [s.id, s]));
@@ -99,7 +112,6 @@ function makePort(initial: K8sStoredSecret[]) {
 }
 
 function makeGrants(initial: GrantedAgentSummary[] = []) {
-  const bumps: { cmName: string; hash: string }[] = [];
   const secretGrantCalls: { agentId: string; secretIds: readonly string[] }[] =
     [];
   const port: AgentGrantsPort = {
@@ -113,11 +125,8 @@ function makeGrants(initial: GrantedAgentSummary[] = []) {
     async listAgentsGrantedSecret() {
       return initial;
     },
-    async bumpSecretsRev(cmName, hash) {
-      bumps.push({ cmName, hash });
-    },
   };
-  return { port, bumps, secretGrantCalls };
+  return { port, secretGrantCalls };
 }
 
 describe("PROVIDERS registry shape", () => {
@@ -282,13 +291,15 @@ describe("secrets-service.update — fanout (ADR-040)", () => {
     granted?: GrantedAgentSummary[];
   }) {
     const { port, updated } = makePort([opts.secret]);
-    const { port: grants, bumps } = makeGrants(opts.granted ?? []);
+    const { port: grants } = makeGrants(opts.granted ?? []);
+    const { mutator, delivered } = makeMutator();
     const svc = createSecretsService({
       k8sPort: port,
       grants,
       ownerSub: "owner-1",
+      runtimeMutator: mutator,
     });
-    return { svc, updated, bumps };
+    return { svc, updated, delivered };
   }
 
   const baseSecret: K8sStoredSecret = {
@@ -300,8 +311,8 @@ describe("secrets-service.update — fanout (ADR-040)", () => {
     createdAt: "2026-01-01T00:00:00Z",
   };
 
-  it("envMappings change → bumps secrets-rev", async () => {
-    const { svc, bumps } = setup({
+  it("envMappings change → delivers to granted agent over the runtime channel", async () => {
+    const { svc, delivered } = setup({
       secret: baseSecret,
       granted: [
         {
@@ -314,12 +325,11 @@ describe("secrets-service.update — fanout (ADR-040)", () => {
       id: "secret-x",
       envMappings: [{ envName: "BAR", placeholder: "ph2" }],
     });
-    expect(bumps).toHaveLength(1);
-    expect(bumps[0]!.cmName).toBe("agent-a");
+    expect(delivered).toEqual(["agent-a"]);
   });
 
   it("name-only edit → no fanout", async () => {
-    const { svc, bumps } = setup({
+    const { svc, delivered } = setup({
       secret: baseSecret,
       granted: [
         {
@@ -329,11 +339,11 @@ describe("secrets-service.update — fanout (ADR-040)", () => {
       ],
     });
     await svc.update({ id: "secret-x", name: "Renamed" });
-    expect(bumps).toHaveLength(0);
+    expect(delivered).toHaveLength(0);
   });
 
   it("no granted agents → no fanout even on render-affecting edit", async () => {
-    const { svc, bumps } = setup({
+    const { svc, delivered } = setup({
       secret: baseSecret,
       granted: [],
     });
@@ -341,7 +351,7 @@ describe("secrets-service.update — fanout (ADR-040)", () => {
       id: "secret-x",
       envMappings: [{ envName: "BAR", placeholder: "ph2" }],
     });
-    expect(bumps).toHaveLength(0);
+    expect(delivered).toHaveLength(0);
   });
 });
 
@@ -469,7 +479,6 @@ describe("secrets-service — extraInjections (twin secrets, e.g. Bob)", () => {
         async listAgentsGrantedSecret() {
           return [];
         },
-        async bumpSecretsRev() {},
       },
       ownerSub: "owner-1",
     });
@@ -495,7 +504,6 @@ describe("secrets-service — extraInjections (twin secrets, e.g. Bob)", () => {
         async listAgentsGrantedSecret() {
           return [];
         },
-        async bumpSecretsRev() {},
       },
       ownerSub: "owner-1",
     });
@@ -558,5 +566,55 @@ describe("secrets-service — extraInjections (twin secrets, e.g. Bob)", () => {
       svc.create({ type: "bob", name: "Bob Shell", value: "sk-bob-foo" }),
     ).rejects.toThrow("twin write boom");
     expect(store.size).toBe(0);
+  });
+});
+
+describe("secrets-service.expandSecretGrants — GitHub PAT twins (single-shot create)", () => {
+  const ghApi: K8sStoredSecret = {
+    id: "gh-api",
+    name: "My PAT",
+    type: "generic",
+    hostPattern: "api.github.com",
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+  const ghGit: K8sStoredSecret = {
+    id: "gh-git",
+    name: "My PAT",
+    type: "generic",
+    hostPattern: "github.com",
+    primarySecretId: "gh-api",
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+  const anthropic: K8sStoredSecret = {
+    id: "anthropic",
+    name: "Key",
+    type: "anthropic",
+    hostPattern: "api.anthropic.com",
+    createdAt: "2026-01-01T00:00:00Z",
+  };
+
+  function setup() {
+    const { port } = makePort([ghApi, ghGit, anthropic]);
+    const { port: grants } = makeGrants();
+    return createSecretsService({ k8sPort: port, grants, ownerSub: "owner-1" });
+  }
+
+  it("expands a selected primary to include its twin", async () => {
+    expect(await setup().expandSecretGrants(["gh-api"])).toEqual([
+      "gh-api",
+      "gh-git",
+    ]);
+  });
+
+  it("leaves a non-twinned secret untouched", async () => {
+    expect(await setup().expandSecretGrants(["anthropic"])).toEqual([
+      "anthropic",
+    ]);
+  });
+
+  it("expands across a mixed selection", async () => {
+    expect(
+      [...(await setup().expandSecretGrants(["gh-api", "anthropic"]))].sort(),
+    ).toEqual(["anthropic", "gh-api", "gh-git"]);
   });
 });

--- a/packages/api-server/src/__tests__/unit/secrets-service-update-anthropic-mode.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-update-anthropic-mode.test.ts
@@ -65,7 +65,6 @@ function makeGrants() {
     async listAgentsGrantedSecret() {
       return [];
     },
-    async bumpSecretsRev() {},
   };
   return { port };
 }

--- a/packages/api-server/src/__tests__/unit/secrets-service-update-github-pat.test.ts
+++ b/packages/api-server/src/__tests__/unit/secrets-service-update-github-pat.test.ts
@@ -63,7 +63,6 @@ function makeGrants() {
     async listAgentsGrantedSecret() {
       return [];
     },
-    async bumpSecretsRev() {},
   };
   return { port };
 }

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -605,6 +605,27 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
 
     const { templates, readSpec: readTemplateSpec } =
       composeTemplatesModule(templatesRepo);
+    // Before the agents module so grantProvisioner (single-shot create) can use them.
+    const grants = createAgentGrantsPort(k8sClient, user.sub);
+    const secrets = createSecretsService({
+      k8sPort: createK8sSecretsPort(k8sClient, user.sub),
+      grants,
+      connectionRules: createConnectionRulesSyncAdapter(db),
+      ownerSub: user.sub,
+      runtimeMutator,
+    });
+    const connections = composeConnectionsForOwner({
+      ownerId: user.sub,
+      db,
+      templates: connectionsBoot.templates,
+      oauthEngine: connectionsBoot.oauthEngine,
+      secretStore: secretStores.default(),
+      runtimeMutator,
+      agentsRepo,
+      connectionRulesSync: createConnectionRulesSyncAdapter(db),
+      oauthCallbackUrl: `${config.uiBaseUrl}/api/oauth/callback`,
+      brandName: config.brand.name,
+    });
     const { agents, isOwnedAgent } = composeAgentsModule({
       api,
       namespace: config.namespace,
@@ -617,6 +638,22 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       cleanupHooks: agentCleanupHooks,
       runtimeMutator,
       contributionsSettled,
+      grantProvisioner: {
+        async resolveSpecGrants(sel) {
+          return {
+            grantedSecretIds: sel.secretIds.length
+              ? await secrets.expandSecretGrants(sel.secretIds)
+              : [],
+            grantedConnectionIds: Array.from(new Set(sel.connectionIds)),
+          };
+        },
+        async applyAfterCreate(agentId, sel) {
+          if (sel.secretIds.length)
+            await secrets.setAgentAccess(agentId, { secretIds: sel.secretIds });
+          if (sel.connectionIds.length)
+            await connections.setAgentConnections(agentId, sel.connectionIds);
+        },
+      },
     });
     const { schedules } = composeSchedulesForOwner({
       boot: schedulesBoot,
@@ -633,25 +670,6 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       runtimeMutator,
       templatesRepo,
     );
-    const grants = createAgentGrantsPort(k8sClient, user.sub);
-    const secrets = createSecretsService({
-      k8sPort: createK8sSecretsPort(k8sClient, user.sub),
-      grants,
-      connectionRules: createConnectionRulesSyncAdapter(db),
-      ownerSub: user.sub,
-    });
-    const connections = composeConnectionsForOwner({
-      ownerId: user.sub,
-      db,
-      templates: connectionsBoot.templates,
-      oauthEngine: connectionsBoot.oauthEngine,
-      secretStore: secretStores.default(),
-      runtimeMutator,
-      agentsRepo,
-      connectionRulesSync: createConnectionRulesSyncAdapter(db),
-      oauthCallbackUrl: `${config.uiBaseUrl}/api/oauth/callback`,
-      brandName: config.brand.name,
-    });
     const isAgentOwnedBy = async (agentId: string, ownerSub: string) =>
       (await agents.get(agentId)) !== null && ownerSub === user.sub;
     const { service: egressRules } = composeEgressRulesModule({

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -52,6 +52,7 @@ import {
   createBullConnection,
 } from "./modules/runtime-delivery/index.js";
 import { composeSchedulesAtBoot } from "./modules/schedules/index.js";
+import { createSecretEnvSource } from "./modules/secrets/services/secret-env-source.js";
 import {
   createKubernetesSecretStore,
   createSecretStoreRegistry,
@@ -122,6 +123,7 @@ const runtimeDelivery = composeRuntimeDelivery({
     isRunning: (agentId) => agentsRepo.isReady(agentId),
   },
   harnessServerUrl: config.harnessServerUrl,
+  secretEnv: createSecretEnvSource({ k8sClient }),
 });
 runtimeDelivery.sweep.start();
 const contributionsSettledPort = {

--- a/packages/api-server/src/modules/agents/compose.ts
+++ b/packages/api-server/src/modules/agents/compose.ts
@@ -52,6 +52,17 @@ export function composeAgentsModule(deps: {
   cleanupHooks?: readonly AgentCleanupHook[];
   runtimeMutator: RuntimeMutator;
   contributionsSettled: ContributionsSettledPort;
+  /** Single-shot create; wired from secrets + connections. Omitted system-side. */
+  grantProvisioner?: {
+    resolveSpecGrants(sel: {
+      secretIds: string[];
+      connectionIds: string[];
+    }): Promise<{ grantedSecretIds: string[]; grantedConnectionIds: string[] }>;
+    applyAfterCreate(
+      agentId: string,
+      sel: { secretIds: string[]; connectionIds: string[] },
+    ): Promise<void>;
+  };
 }): {
   agents: AgentsService;
   repo: AgentsRepository;
@@ -72,6 +83,7 @@ export function composeAgentsModule(deps: {
       cleanupHooks: deps.cleanupHooks,
       runtimeMutator: deps.runtimeMutator,
       contributionsSettled: deps.contributionsSettled,
+      grantProvisioner: deps.grantProvisioner,
       listChannelsByOwner: listChannelsByOwner(deps.db, owner),
       listChannelsByAgent: listChannelsByAgent(deps.db, owner),
       upsertChannel: upsertChannel(deps.db, owner),

--- a/packages/api-server/src/modules/agents/infrastructure/agent-grants-port.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-grants-port.ts
@@ -9,7 +9,7 @@
  * grant set, never "all granted."
  */
 import { type K8sClient, type KubeObject } from "./k8s.js";
-import { AGENTS_PLURAL, ANN_ROLL_REV, LABEL_OWNER } from "./labels.js";
+import { AGENTS_PLURAL, LABEL_OWNER } from "./labels.js";
 
 export interface AgentGrants {
   grantedSecretIds: string[];
@@ -40,11 +40,6 @@ export interface AgentGrantsPort {
    * (ADR-040).
    */
   listAgentsGrantedSecret(secretId: string): Promise<GrantedAgentSummary[]>;
-  /**
-   * Bump the render-affecting roll-rev annotation on the Agent so the
-   * controller rolls the pod to re-render merged env (ADR-040 / ADR-058 A3).
-   */
-  bumpSecretsRev(agentId: string, hash: string): Promise<void>;
 }
 
 function toStringArray(v: unknown): string[] {
@@ -116,12 +111,6 @@ export function createAgentGrantsPort(
         out.push({ agentId, grantedSecretIds });
       }
       return out;
-    },
-
-    async bumpSecretsRev(agentId, hash) {
-      await client.patchCustomObject(AGENTS_PLURAL, agentId, {
-        metadata: { annotations: { [ANN_ROLL_REV]: hash } },
-      });
     },
   };
 }

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -88,6 +88,18 @@ export function createAgentsService(deps: {
   cleanupHooks?: readonly AgentCleanupHook[];
   runtimeMutator: RuntimeMutator;
   contributionsSettled: ContributionsSettledPort;
+  /** Single-shot create: seeds spec grant fields before first render, then
+   *  applies egress/DB/delivery side-effects. Omitted by system compositions. */
+  grantProvisioner?: {
+    resolveSpecGrants(sel: {
+      secretIds: string[];
+      connectionIds: string[];
+    }): Promise<{ grantedSecretIds: string[]; grantedConnectionIds: string[] }>;
+    applyAfterCreate(
+      agentId: string,
+      sel: { secretIds: string[]; connectionIds: string[] },
+    ): Promise<void>;
+  };
   // --- Runtime / channels / allowed-users dependencies (formerly Instance) ---
   listChannelsByOwner: () => Promise<Map<string, ChannelConfig[]>>;
   listChannelsByAgent: (agentId: string) => Promise<ChannelConfig[]>;
@@ -240,6 +252,24 @@ export function createAgentsService(deps: {
         spec.env = preserveProtectedEnvs(base, [...base, ...input.env]);
       }
       if (input.secretRef !== undefined) spec.secretRef = input.secretRef;
+
+      // Single-shot create: seed grants into the spec before first render so
+      // credentials ride the first snapshot and the gateway renders its chains
+      // once. (Not the roll fix — the agent template is grant-independent.)
+      const grantSel = {
+        secretIds: input.secretIds ?? [],
+        connectionIds: input.connectionIds ?? [],
+      };
+      const hasInitialGrants =
+        grantSel.secretIds.length > 0 || grantSel.connectionIds.length > 0;
+      if (deps.grantProvisioner && hasInitialGrants) {
+        const g = await deps.grantProvisioner.resolveSpecGrants(grantSel);
+        if (g.grantedSecretIds.length)
+          spec.grantedSecretIds = g.grantedSecretIds;
+        if (g.grantedConnectionIds.length)
+          spec.grantedConnectionIds = g.grantedConnectionIds;
+      }
+
       // ADR-058: no desiredState — a freshly-created agent runs (recent
       // activity), and the idle checker hibernates it once it goes quiet.
       const owner = deps.owner ?? "";
@@ -286,6 +316,12 @@ export function createAgentsService(deps: {
             ]
           : [],
       );
+
+      // Side-effects now the CR exists: egress sync, connection-grant rows,
+      // channel delivery. Re-states the seeded grants (idempotent, no roll).
+      if (deps.grantProvisioner && hasInitialGrants) {
+        await deps.grantProvisioner.applyAfterCreate(infra.id, grantSel);
+      }
 
       const agent = assembleAgent(infra, [], emails, []);
       // Records the agent's initial security posture (preset, secret ref,

--- a/packages/api-server/src/modules/connections/compose.ts
+++ b/packages/api-server/src/modules/connections/compose.ts
@@ -73,14 +73,6 @@ export function composeConnectionsForOwner(opts: {
         grantedConnectionIds: connectionIds,
       });
     },
-    async bumpSecretsRev(agentId): Promise<void> {
-      // ADR-058 A3: roll-rev is the api-server-driven roll trigger.
-      await opts.agentsRepo.patchAnnotation(
-        agentId,
-        "agent-platform.ai/roll-rev",
-        String(Date.now()),
-      );
-    },
     async syncEgressHosts(input): Promise<void> {
       await opts.connectionRulesSync.syncForAgent(input);
     },

--- a/packages/api-server/src/modules/connections/services/contribution-fanout.ts
+++ b/packages/api-server/src/modules/connections/services/contribution-fanout.ts
@@ -3,7 +3,6 @@ import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 
 export interface FanOutPort {
   setConnectionGrants(agentId: string, connectionIds: string[]): Promise<void>;
-  bumpSecretsRev(agentId: string): Promise<void>;
   syncEgressHosts(input: {
     agentId: string;
     decidedBy: string;
@@ -32,10 +31,6 @@ export function createContributionFanOut(deps: {
       grantedConnections,
       allOwnerConnectionIds,
     }) {
-      const allContribs: Contribution[] = grantedConnections.flatMap(
-        (c) => c.contributions,
-      );
-
       await deps.port.setConnectionGrants(
         agentId,
         grantedConnections.map((c) => c.id),
@@ -69,11 +64,6 @@ export function createContributionFanOut(deps: {
         grants: egressGrants,
         ownedSourceIds: allOwnerConnectionIds,
       });
-
-      const hasEnvContribs = allContribs.some((c) => c.kind === "env");
-      if (hasEnvContribs) {
-        await deps.port.bumpSecretsRev(agentId);
-      }
 
       await deps.runtimeMutator.bump(agentId, []);
 

--- a/packages/api-server/src/modules/runtime-delivery/compose.ts
+++ b/packages/api-server/src/modules/runtime-delivery/compose.ts
@@ -16,6 +16,7 @@ import {
 } from "./infrastructure/state-queue.js";
 import {
   createStateBuilder,
+  type SecretEnvSource,
   type StateBuilder,
 } from "./services/state-builder.js";
 import {
@@ -62,6 +63,7 @@ export interface ComposeRuntimeDeliveryOpts {
   bullConnection: ConnectionOptions;
   agentRunningPort: IsAgentRunning;
   harnessServerUrl: string;
+  secretEnv: SecretEnvSource;
   log?: (msg: string) => void;
 }
 
@@ -75,7 +77,12 @@ export function composeRuntimeDelivery(
   const builtin = createBuiltinContributions({
     harnessServerUrl: opts.harnessServerUrl,
   });
-  const stateBuilder = createStateBuilder({ db: opts.db, outboxRepo, builtin });
+  const stateBuilder = createStateBuilder({
+    db: opts.db,
+    outboxRepo,
+    builtin,
+    secretEnv: opts.secretEnv,
+  });
   const queue = createStateQueue(opts.bullConnection);
 
   const handler = createWorkerHandler({

--- a/packages/api-server/src/modules/runtime-delivery/index.ts
+++ b/packages/api-server/src/modules/runtime-delivery/index.ts
@@ -6,3 +6,4 @@ export type {
 export { createBullConnection } from "./infrastructure/state-queue.js";
 export type { IsAgentRunning } from "./services/worker-handler.js";
 export type { RuntimeMutator } from "./services/runtime-mutator.js";
+export type { SecretEnvSource } from "./services/state-builder.js";

--- a/packages/api-server/src/modules/runtime-delivery/infrastructure/state-queue.ts
+++ b/packages/api-server/src/modules/runtime-delivery/infrastructure/state-queue.ts
@@ -5,21 +5,23 @@ export const RUNTIME_STATE_QUEUE = "runtime-state";
 
 export interface StateJob {
   agentId: string;
+  /** Set by `hello`: fast-retry on the queue backoff if not yet Ready, instead of deferring to the sweep. */
+  retryUntilReady?: boolean;
 }
 
 export interface StateQueue {
-  enqueue(agentId: string): Promise<void>;
+  enqueue(agentId: string, opts?: { retryUntilReady?: boolean }): Promise<void>;
   close(): Promise<void>;
 }
 
 export function createStateQueue(connection: ConnectionOptions): StateQueue {
   const queue = new Queue<StateJob>(RUNTIME_STATE_QUEUE, { connection });
   return {
-    async enqueue(agentId): Promise<void> {
+    async enqueue(agentId, opts): Promise<void> {
       // No jobId dedup on purpose: applyState is idempotent, so a prompt redundant apply beats stalling fresh config behind an in-flight job.
       await queue.add(
         "state",
-        { agentId },
+        { agentId, retryUntilReady: opts?.retryUntilReady },
         {
           attempts: 8,
           backoff: { type: "exponential", delay: 1_000 },
@@ -36,7 +38,10 @@ export function createStateQueue(connection: ConnectionOptions): StateQueue {
 
 export interface StartWorkerOpts {
   connection: ConnectionOptions;
-  handler: (agentId: string) => Promise<void>;
+  handler: (
+    agentId: string,
+    opts?: { retryUntilReady?: boolean },
+  ) => Promise<void>;
   log: (msg: string) => void;
 }
 
@@ -47,7 +52,10 @@ export interface RunningWorker {
 export function startStateWorker(opts: StartWorkerOpts): RunningWorker {
   const worker = new Worker<StateJob>(
     RUNTIME_STATE_QUEUE,
-    async (job) => opts.handler(job.data.agentId),
+    async (job) =>
+      opts.handler(job.data.agentId, {
+        retryUntilReady: job.data.retryUntilReady,
+      }),
     {
       connection: opts.connection,
       concurrency: 16,

--- a/packages/api-server/src/modules/runtime-delivery/services/hello-handler.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/hello-handler.ts
@@ -26,7 +26,8 @@ export function createHelloHandler(deps: {
 
       const row = await deps.outboxRepo.getRow(agentId);
       if (row && row.version > (input.lastAppliedVersion ?? 0)) {
-        await deps.queue.enqueue(agentId);
+        // Ready is about to flip true; retryUntilReady so a sub-second miss fast-retries, not waits for the sweep.
+        await deps.queue.enqueue(agentId, { retryUntilReady: true });
       }
       return { events: [] };
     },

--- a/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
@@ -40,19 +40,26 @@ export interface StateBuilder {
   ): Promise<StatePayload>;
 }
 
+/** `env` contributions for an agent's granted standalone secrets (secrets module, ADR-040). */
+export interface SecretEnvSource {
+  forAgent(agentId: string): Promise<Contribution[]>;
+}
+
 export function createStateBuilder(deps: {
   db: Db;
   outboxRepo: OutboxRepo;
   builtin: BuiltinContributions;
+  secretEnv: SecretEnvSource;
 }): StateBuilder {
   return {
     async build(agentId, capabilities): Promise<StatePayload> {
-      const [granted, skills] = await Promise.all([
+      const [granted, skills, secretEnv] = await Promise.all([
         readGrantedContributions(deps.db, agentId),
         readSkillRefContributions(deps.db, agentId),
+        deps.secretEnv.forAgent(agentId),
       ]);
       const builtin = deps.builtin.for(agentId);
-      const rawContribs = [...builtin, ...granted, ...skills];
+      const rawContribs = [...builtin, ...granted, ...skills, ...secretEnv];
       const pending = await deps.outboxRepo.pendingEvents(agentId);
       const events = pending.map(toEvent).filter((e): e is Event => e !== null);
       const filtered = filterByCapabilities(capabilities, rawContribs, events);

--- a/packages/api-server/src/modules/runtime-delivery/services/worker-handler.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/worker-handler.ts
@@ -21,16 +21,22 @@ export interface WorkerHandlerDeps {
   log: (msg: string) => void;
 }
 
-export type WorkerHandler = (agentId: string) => Promise<void>;
+export type WorkerHandler = (
+  agentId: string,
+  opts?: { retryUntilReady?: boolean },
+) => Promise<void>;
 
 export function createWorkerHandler(deps: WorkerHandlerDeps): WorkerHandler {
-  return async (agentId: string) => {
+  return async (agentId: string, opts?: { retryUntilReady?: boolean }) => {
     const row = await deps.outboxRepo.getRow(agentId);
     if (!row) return;
 
-    // Don't dispatch to an agent that isn't Ready (ADR-059): the row stays
-    // unsettled, so the sweep re-dispatches once it becomes Ready.
+    // Not Ready (ADR-059): hello-triggered jobs fast-retry on the queue backoff
+    // (Ready is ~1s away); others defer to the sweep. Gate holds either way.
     if (!(await deps.agentRunningPort.isRunning(agentId))) {
+      if (opts?.retryUntilReady) {
+        throw new Error(`${agentId}: not Ready yet — retrying until Ready`);
+      }
       deps.log(
         `[runtime-worker] ${agentId}: agent not Ready; deferring to sweep`,
       );

--- a/packages/api-server/src/modules/secrets/services/secret-env-source.ts
+++ b/packages/api-server/src/modules/secrets/services/secret-env-source.ts
@@ -1,0 +1,57 @@
+import type { Contribution } from "api-server-api";
+import type { K8sClient } from "../../agents/infrastructure/k8s.js";
+import {
+  AGENTS_PLURAL,
+  LABEL_OWNER,
+} from "../../agents/infrastructure/labels.js";
+import { createK8sSecretsPort } from "../infrastructure/k8s-secrets-port.js";
+
+/** `env` contributions for an agent's granted standalone secrets (ADR-040). */
+export function createSecretEnvSource(deps: { k8sClient: K8sClient }): {
+  forAgent(agentId: string): Promise<Contribution[]>;
+} {
+  return {
+    async forAgent(agentId): Promise<Contribution[]> {
+      const agent = await deps.k8sClient.getCustomObject(
+        AGENTS_PLURAL,
+        agentId,
+      );
+      const owner = agent?.metadata?.labels?.[LABEL_OWNER];
+      if (!owner) return [];
+      const grantedSecretIds = toStringArray(
+        (agent?.spec as { grantedSecretIds?: unknown } | undefined)
+          ?.grantedSecretIds,
+      );
+      if (grantedSecretIds.length === 0) return [];
+
+      const granted = new Set(grantedSecretIds);
+      const secrets = await createK8sSecretsPort(
+        deps.k8sClient,
+        owner,
+      ).listSecrets();
+
+      const out: Contribution[] = [];
+      const seen = new Set<string>();
+      for (const s of secrets) {
+        if (!granted.has(s.id)) continue;
+        for (const m of s.envMappings ?? []) {
+          // First occurrence in secret-list order wins on name collision.
+          if (seen.has(m.envName)) continue;
+          seen.add(m.envName);
+          out.push({
+            kind: "env",
+            name: m.envName,
+            placeholder: m.placeholder,
+          });
+        }
+      }
+      return out;
+    },
+  };
+}
+
+function toStringArray(v: unknown): string[] {
+  return Array.isArray(v)
+    ? v.filter((x): x is string => typeof x === "string")
+    : [];
+}

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -495,6 +495,8 @@ export function createSecretsService(deps: {
     },
 
     async delete(id) {
+      // Capture grant holders before deletion so we can re-deliver after.
+      const granted = await deps.grants.listAgentsGrantedSecret(id);
       // Twins first; primary last on success so retry-after-failure is clean.
       const allSecrets = await deps.k8sPort.listSecrets();
       const twinIds = allSecrets
@@ -513,6 +515,9 @@ export function createSecretsService(deps: {
         result: "success",
         detail: { twins: twinIds.length },
       });
+      // Re-deliver so the deleted secret's placeholder drops from each granted
+      // agent's env on the next snapshot (the env-source omits missing secrets).
+      await Promise.all(granted.map((g) => deliverToAgent(g.agentId)));
     },
 
     async getAgentAccess(agentId: string) {

--- a/packages/api-server/src/modules/secrets/services/secrets-service.ts
+++ b/packages/api-server/src/modules/secrets/services/secrets-service.ts
@@ -1,5 +1,6 @@
-import { createHash, randomUUID } from "node:crypto";
+import { randomUUID } from "node:crypto";
 import { TRPCError } from "@trpc/server";
+import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 import {
   DEFAULT_ENV_PLACEHOLDER,
   isProviderPresetType,
@@ -106,23 +107,6 @@ async function anthropicModeRotationFor(
   return { authMode: newAuthMode, envMappings: [...mode.defaultEnvMappings] };
 }
 
-// `secrets-rev` hashes only what affects the agent pod's env. hostPattern,
-// pathPattern, and injectionConfig are gateway-side and have their own roll
-// trigger (envoy-secrets-rev on the gateway StatefulSet); rolling the agent
-// pod for them would be gratuitous. ADR-040 §Fanout: host edits hot, env
-// edits roll.
-function combinedSecretsRev(
-  grantedSecrets: readonly K8sStoredSecret[],
-): string {
-  const data = [...grantedSecrets]
-    .sort((a, b) => a.id.localeCompare(b.id))
-    .map((s) => ({ id: s.id, envMappings: s.envMappings ?? [] }));
-  return createHash("sha256")
-    .update(JSON.stringify(data))
-    .digest("hex")
-    .slice(0, 16);
-}
-
 function envMappingsChanged(
   before: K8sStoredSecret,
   after: K8sStoredSecret,
@@ -206,7 +190,37 @@ export function createSecretsService(deps: {
   /** Owner sub for the calling user, stamped onto auto-inserted rules
    *  (`decided_by`). Required when `connectionRules` is set. */
   ownerSub?: string;
+  /** Delivers env changes to granted agents over the runtime channel. */
+  runtimeMutator?: RuntimeMutator;
 }): SecretsService {
+  async function deliverToAgent(agentId: string): Promise<void> {
+    if (!deps.runtimeMutator) return;
+    await deps.runtimeMutator.bump(agentId, []);
+    await deps.runtimeMutator.enqueueAfterCommit(agentId);
+  }
+
+  // Pull in twins so a GitHub PAT's two halves are always granted together.
+  function expandWith(
+    secretIds: string[],
+    allSecrets: readonly K8sStoredSecret[],
+  ): string[] {
+    const twinIds = new Set(
+      allSecrets.filter((s) => s.primarySecretId).map((s) => s.id),
+    );
+    const twinsByPrimary = new Map<string, string[]>();
+    for (const s of allSecrets) {
+      if (!s.primarySecretId) continue;
+      const list = twinsByPrimary.get(s.primarySecretId) ?? [];
+      list.push(s.id);
+      twinsByPrimary.set(s.primarySecretId, list);
+    }
+    const primaries = secretIds.filter((id) => !twinIds.has(id));
+    return [
+      ...primaries,
+      ...primaries.flatMap((id) => twinsByPrimary.get(id) ?? []),
+    ];
+  }
+
   async function createOne(input: InternalSecretCreate): Promise<SecretView> {
     const hostPattern = hostPatternFor(input.type, input.hostPattern);
     const id = randomUUID();
@@ -476,17 +490,8 @@ export function createSecretsService(deps: {
       const granted = await deps.grants.listAgentsGrantedSecret(id);
       if (granted.length === 0) return;
 
-      const allSecrets = await deps.k8sPort.listSecrets();
-
-      await Promise.all(
-        granted.map(async (g) => {
-          const grantedForAgent = allSecrets.filter((s) =>
-            g.grantedSecretIds.includes(s.id),
-          );
-          const hash = combinedSecretsRev(grantedForAgent);
-          await deps.grants.bumpSecretsRev(g.agentId, hash);
-        }),
-      );
+      // Re-deliver to each granted agent; the state-builder reads the new env-mappings live.
+      await Promise.all(granted.map((g) => deliverToAgent(g.agentId)));
     },
 
     async delete(id) {
@@ -521,23 +526,16 @@ export function createSecretsService(deps: {
       };
     },
 
+    async expandSecretGrants(secretIds: string[]) {
+      return expandWith(secretIds, await deps.k8sPort.listSecrets());
+    },
+
     async setAgentAccess(agentId: string, access: AgentAccess) {
       const allSecrets = await deps.k8sPort.listSecrets();
-      const twinIds = new Set(
-        allSecrets.filter((s) => s.primarySecretId).map((s) => s.id),
+      const expanded = expandWith(access.secretIds, allSecrets);
+      const primaries = access.secretIds.filter(
+        (id) => !allSecrets.find((s) => s.id === id)?.primarySecretId,
       );
-      const twinsByPrimary = new Map<string, string[]>();
-      for (const s of allSecrets) {
-        if (!s.primarySecretId) continue;
-        const list = twinsByPrimary.get(s.primarySecretId) ?? [];
-        list.push(s.id);
-        twinsByPrimary.set(s.primarySecretId, list);
-      }
-      const primaries = access.secretIds.filter((id) => !twinIds.has(id));
-      const expanded = [
-        ...primaries,
-        ...primaries.flatMap((id) => twinsByPrimary.get(id) ?? []),
-      ];
       await deps.grants.setSecretGrants(agentId, expanded);
       // Central to "which agent could use credential X at time T".
       securityLog("info", "secret.grants_set", {
@@ -558,6 +556,9 @@ export function createSecretsService(deps: {
           ownedSourceIds,
         });
       }
+
+      // Deliver the new grant set over the runtime channel.
+      await deliverToAgent(agentId);
     },
   };
 }

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -42,10 +42,9 @@ func (d Duration) MarshalJSON() ([]byte, error) {
 // scheduling and security are controller-internal.
 //
 // On metadata collision: controller-managed labels on agent pods (selector
-// labels `agent-platform.ai/agent|pair|role`) and annotations the
-// controller sets itself (e.g. `agent-platform.ai/gh-token-available`)
-// always win. ExtraLabels/ExtraAnnotations entries with the same key
-// drop silently — see applyAgentBaseMeta.
+// labels `agent-platform.ai/agent|pair|role`) and annotations the controller
+// sets itself always win. ExtraLabels/ExtraAnnotations entries with the same
+// key drop silently — see applyAgentBaseMeta.
 type AgentBase struct {
 	// Cluster details
 	ImagePullSecrets []string `json:"imagePullSecrets,omitempty"`

--- a/packages/controller/pkg/reconciler/agent_reconciler.go
+++ b/packages/controller/pkg/reconciler/agent_reconciler.go
@@ -71,7 +71,8 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, agent *apiv1.Agent) err
 	if err := r.applyConfigMap(ctx, bootstrapCM); err != nil {
 		return r.setError(ctx, name, fmt.Sprintf("applying envoy bootstrap: %v", err))
 	}
-	if cert := BuildEnvoyLeafCertificate(name, r.config, ownerRef, credentialSecrets); cert != nil {
+	// alwaysIssue: agent mounts ca.crt unconditionally, so the leaf must exist.
+	if cert := BuildEnvoyLeafCertificate(name, r.config, ownerRef, credentialSecrets, true); cert != nil {
 		if err := r.applyCertificate(ctx, cert); err != nil {
 			return r.setError(ctx, name, fmt.Sprintf("applying envoy leaf certificate: %v", err))
 		}
@@ -169,7 +170,7 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, agent *apiv1.Agent) err
 		return fmt.Errorf("agent %s: gateway Service ClusterIP not yet assigned, requeuing", name)
 	}
 
-	agentSS := BuildAgentStatefulSet(name, agentSpec, r.config, ownerRef, credentialSecrets, gatewayIP)
+	agentSS := BuildAgentStatefulSet(name, agentSpec, r.config, ownerRef, gatewayIP)
 	stampRollRev(agentSS, rollRev)
 	agentSvc := BuildAgentService(name, r.config, ownerRef)
 	if err := r.applyStatefulSet(ctx, agentSS, running); err != nil {

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -86,7 +86,8 @@ func (r *ForkReconciler) Reconcile(ctx context.Context, fork *apiv1.Fork) error 
 	if err := r.applyConfigMap(ctx, bootstrapCM); err != nil {
 		return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying envoy bootstrap: %v", err))
 	}
-	if cert := BuildEnvoyLeafCertificate(forkName, r.config, ownerRef, credentialSecrets); cert != nil {
+	// Forks keep the credential-gated leaf (ephemeral; out of no-roll scope).
+	if cert := BuildEnvoyLeafCertificate(forkName, r.config, ownerRef, credentialSecrets, false); cert != nil {
 		if err := r.applyCertificate(ctx, cert); err != nil {
 			return r.setForkFailed(ctx, forkName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying envoy leaf certificate: %v", err))
 		}

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -110,7 +110,7 @@ func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
-	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), nil, "10.96.42.42")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "10.96.42.42")
 
 	ics := ss.Spec.Template.Spec.InitContainers
 	require.Len(t, ics, 2, "egress-lockdown + user init")
@@ -133,7 +133,7 @@ func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 func TestBuildAgentStatefulSet_IptablesInitSkippedWithoutGatewayIP(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
-	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "")
 
 	for _, ic := range ss.Spec.Template.Spec.InitContainers {
 		assert.NotEqual(t, "egress-lockdown", ic.Name, "lockdown must skip until gateway IP is known")
@@ -145,6 +145,6 @@ func TestBuildAgentStatefulSet_IptablesInitSkippedWithoutGatewayIP(t *testing.T)
 // any code path.
 func TestBuildAgentStatefulSet_NoHostAliases(t *testing.T) {
 	cfg := *testConfig
-	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), nil, "10.96.42.42")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "10.96.42.42")
 	assert.Empty(t, ss.Spec.Template.Spec.HostAliases, "no hostAliases — proxy URL is IP-direct")
 }

--- a/packages/controller/pkg/reconciler/leaf.go
+++ b/packages/controller/pkg/reconciler/leaf.go
@@ -41,14 +41,22 @@ func dnsNamesFromChains(chains []envoyHostChain) []string {
 	return out
 }
 
-// BuildEnvoyLeafCertificate is the desired cert-manager Certificate that
-// produces the per-instance Envoy TLS Secret. Returns nil if there are no
-// hosts to MITM (no credential Secrets) — the caller should treat that as
-// "do not apply".
-func BuildEnvoyLeafCertificate(instanceName string, cfg *config.Config, ownerRef metav1.OwnerReference, secrets []corev1.Secret) *cmv1.Certificate {
+// Placeholder SAN for a leaf issued with no credential hosts; never presented.
+func leafPlaceholderDNS(instanceName string) string {
+	return instanceName + ".mitm-placeholder.invalid"
+}
+
+// BuildEnvoyLeafCertificate renders the per-instance Envoy leaf Certificate.
+// alwaysIssue=true (long-lived agent) issues even with no hosts (placeholder
+// SAN) so the leaf Secret — and the agent's mounted ca.crt — always exists;
+// false (forks) returns nil when there's nothing to MITM.
+func BuildEnvoyLeafCertificate(instanceName string, cfg *config.Config, ownerRef metav1.OwnerReference, secrets []corev1.Secret, alwaysIssue bool) *cmv1.Certificate {
 	hosts := dnsNamesFromChains(chainsFromSecrets(secrets))
 	if len(hosts) == 0 {
-		return nil
+		if !alwaysIssue {
+			return nil
+		}
+		hosts = []string{leafPlaceholderDNS(instanceName)}
 	}
 	cert := &cmv1.Certificate{
 		ObjectMeta: metav1.ObjectMeta{

--- a/packages/controller/pkg/reconciler/leaf_test.go
+++ b/packages/controller/pkg/reconciler/leaf_test.go
@@ -8,9 +8,17 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
-func TestBuildEnvoyLeafCertificate_NoSecretsReturnsNil(t *testing.T) {
-	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), nil)
-	assert.Nil(t, cert, "no credential Secrets means nothing to MITM, so no leaf needed")
+func TestBuildEnvoyLeafCertificate_NoSecrets_NotAlwaysIssue_ReturnsNil(t *testing.T) {
+	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), nil, false)
+	assert.Nil(t, cert, "no credential Secrets and not alwaysIssue (fork): nothing to MITM, no leaf")
+}
+
+func TestBuildEnvoyLeafCertificate_NoSecrets_AlwaysIssue_PlaceholderSAN(t *testing.T) {
+	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), nil, true)
+	require.NotNil(t, cert, "alwaysIssue (long-lived agent): leaf exists so the ca-cert mount is stable")
+	assert.Equal(t, "my-instance-envoy-tls", cert.Spec.SecretName)
+	// Placeholder SAN so cert-manager mints the leaf; never presented.
+	assert.Equal(t, []string{"my-instance.mitm-placeholder.invalid"}, cert.Spec.DNSNames)
 }
 
 func TestBuildEnvoyLeafCertificate_DedupesAndSortsHosts(t *testing.T) {
@@ -19,7 +27,7 @@ func TestBuildEnvoyLeafCertificate_DedupesAndSortsHosts(t *testing.T) {
 		credSecret("platform-cred-aaa", "a.example.com"),
 		credSecret("platform-cred-dup", "a.example.com"), // same host as -aaa
 	}
-	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), secrets)
+	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), secrets, false)
 	require.NotNil(t, cert)
 
 	assert.Equal(t, "my-instance-envoy-tls", cert.Name)
@@ -36,7 +44,7 @@ func TestBuildEnvoyLeafCertificate_IssuerRef(t *testing.T) {
 	cfg.EnvoyMitmCAIssuer = "platform-mitm-ca-issuer"
 	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
 
-	cert := BuildEnvoyLeafCertificate("my-instance", &cfg, configMapOwnerRef(testOwnerCM), secrets)
+	cert := BuildEnvoyLeafCertificate("my-instance", &cfg, configMapOwnerRef(testOwnerCM), secrets, false)
 	require.NotNil(t, cert)
 
 	assert.Equal(t, "platform-mitm-ca-issuer", cert.Spec.IssuerRef.Name)
@@ -46,7 +54,7 @@ func TestBuildEnvoyLeafCertificate_IssuerRef(t *testing.T) {
 
 func TestBuildEnvoyLeafCertificate_OwnerReferences(t *testing.T) {
 	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
-	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), secrets)
+	cert := BuildEnvoyLeafCertificate("my-instance", testConfig, configMapOwnerRef(testOwnerCM), secrets, false)
 	require.NotNil(t, cert)
 
 	require.Len(t, cert.OwnerReferences, 1)

--- a/packages/controller/pkg/reconciler/pod_overrides_test.go
+++ b/packages/controller/pkg/reconciler/pod_overrides_test.go
@@ -101,7 +101,7 @@ func TestApplyAgentBaseScheduling_StampsAllFields(t *testing.T) {
 
 func TestBuildAgentStatefulSet_AgentBase_FullSurface(t *testing.T) {
 	cfg := configWith(fullAgentBase())
-	ss := BuildAgentStatefulSet("my-instance", testAgent, cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, cfg, configMapOwnerRef(testOwnerCM), "")
 	require.NotNil(t, ss)
 	spec := ss.Spec.Template.Spec
 	meta := ss.Spec.Template.ObjectMeta
@@ -142,7 +142,7 @@ func TestBuildAgentStatefulSet_TemplateOverridesPullPolicyAndResources(t *testin
 	tmpl.Resources = types.ResourceSpec{
 		Requests: map[string]string{"cpu": "2", "memory": "4Gi"},
 	}
-	ss := BuildAgentStatefulSet("my-instance", &tmpl, &cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", &tmpl, &cfg, configMapOwnerRef(testOwnerCM), "")
 	c := ss.Spec.Template.Spec.Containers[0]
 	assert.Equal(t, corev1.PullAlways, c.ImagePullPolicy, "template pullPolicy wins")
 	assert.Equal(t, resource.MustParse("2"), c.Resources.Requests[corev1.ResourceCPU], "template resources win")
@@ -162,7 +162,7 @@ func TestBuildAgentStatefulSet_FallsBackToTemplateDefaultsMountsAndEnv(t *testin
 	cfg.AgentTemplateDefaults.Env = []config.EnvVar{{Name: "PORT", Value: "8080"}}
 
 	bare := &types.AgentSpec{Image: "ghcr.io/myorg/agent:latest"}
-	ss := BuildAgentStatefulSet("my-instance", bare, &cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", bare, &cfg, configMapOwnerRef(testOwnerCM), "")
 
 	var sawHome bool
 	for _, vm := range ss.Spec.Template.Spec.Containers[0].VolumeMounts {

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -67,9 +67,9 @@ func agentProxyAddr(cfg *config.Config, gatewayClusterIP string) string {
 // (ADR-038). The agent container holds zero credentials; egress credential
 // injection happens in the paired gateway pod, reached via HTTPS_PROXY.
 //
-// `credentialSecrets` is consulted only for the GH_TOKEN-availability signal
-// surfaced as an env var and pod annotation; no Secret material is mounted
-// into the agent pod.
+// The template is independent of the granted set: it always mounts the leaf
+// Secret's `ca.crt` (the cluster MITM CA), and that leaf is always issued, so
+// a grant change never alters the agent pod and never rolls it.
 //
 // `gatewayClusterIP` is the paired gateway Service's assigned ClusterIP,
 // used directly as the HTTPS_PROXY target. The caller requeues when
@@ -82,7 +82,7 @@ func agentProxyAddr(cfg *config.Config, gatewayClusterIP string) string {
 // reconciler's applyStatefulSet, which scales up on activity and defers
 // scale-down to the idle checker (ADR-058: run state is activity-driven, not a
 // stored desiredState).
-func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.Config, ownerRef metav1.OwnerReference, credentialSecrets []corev1.Secret, gatewayClusterIP string) *appsv1.StatefulSet {
+func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.Config, ownerRef metav1.OwnerReference, gatewayClusterIP string) *appsv1.StatefulSet {
 	base := cfg.AgentBase
 	defaults := cfg.AgentTemplateDefaults
 
@@ -168,13 +168,7 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		{Name: "PLATFORM_POD_FILES_EVENTS_URL", Value: fmt.Sprintf("%s/api/agents/%s/pod-files/events", cfg.HarnessServerURL, name)},
 	}
 
-	// Order matters: K8s resolves duplicate env names by keeping the last
-	// occurrence, so credential placeholders < agent env — user overrides
-	// win. The placeholders only need to satisfy the harness's "is this env
-	// set?" check; Envoy in the paired gateway overwrites the header on the
-	// wire. ADR-046 collapsed the former template + instance env layers
-	// into the single Agent env list.
-	env = append(env, credentialEnvVars(credentialSecrets)...)
+	// User-supplied agent env; credential placeholders arrive via the runtime channel.
 	for _, e := range specEnv {
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
 	}
@@ -235,29 +229,21 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		}
 	}
 
-	// CA cert volume — projected from the cert-manager-issued Envoy leaf
-	// Secret. We expose only the `ca.crt` key; the `tls.key` stays inside
-	// the gateway pod's mount, never the agent's. This is the only
-	// platform-issued data the agent pod mounts (ADR-038).
-	if len(credentialSecrets) > 0 {
-		volumes = append(volumes, corev1.Volume{
-			Name: "ca-cert",
-			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{
-					SecretName: EnvoyLeafSecretName(name),
-					Items: []corev1.KeyToPath{{
-						Key:  "ca.crt",
-						Path: "ca.crt",
-					}},
-				},
+	// ca.crt only (the tls.key stays on the gateway) — the only platform data
+	// the agent mounts (ADR-038). The leaf is always issued, so this Secret
+	// always exists and the volume never flips with the granted set.
+	volumes = append(volumes, corev1.Volume{
+		Name: "ca-cert",
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: EnvoyLeafSecretName(name),
+				Items: []corev1.KeyToPath{{
+					Key:  "ca.crt",
+					Path: "ca.crt",
+				}},
 			},
-		})
-	} else {
-		volumes = append(volumes, corev1.Volume{
-			Name:         "ca-cert",
-			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
-		})
-	}
+		},
+	})
 	volumeMounts = append(volumeMounts, corev1.VolumeMount{
 		Name: "ca-cert", MountPath: "/etc/platform/ca", ReadOnly: true,
 	})
@@ -309,15 +295,6 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 	for _, n := range base.ImagePullSecrets {
 		pullSecrets = append(pullSecrets, corev1.LocalObjectReference{Name: n})
 	}
-
-	// GH_TOKEN signal. Surface whether a GitHub credential is wired up so
-	// wrapper scripts and operators can detect missing auth without making
-	// a 401-eliciting request first.
-	ghAvail := "false"
-	if hasGHTokenEnv(credentialSecrets) {
-		ghAvail = "true"
-	}
-	env = append(env, corev1.EnvVar{Name: "PLATFORM_GH_TOKEN_AVAILABLE", Value: ghAvail})
 
 	// Fast (1s) during startup so wake-up is detected quickly, slow
 	// (10s) afterwards so we're not probing every agent pod every
@@ -371,10 +348,6 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		VolumeMounts:    volumeMounts,
 	}}
 
-	podAnnotations := map[string]string{
-		"agent-platform.ai/gh-token-available": ghAvail,
-	}
-
 	// ADR-033 Threat Model: agent must have no SA token (Secret-read RBAC
 	// would otherwise bypass the per-pod credential boundary). With the
 	// paired-pod split (ADR-038) the agent and gateway are different pods
@@ -385,8 +358,7 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 	shareProcessNS := &falseVal
 
 	podMeta := metav1.ObjectMeta{
-		Labels:      podLabels,
-		Annotations: podAnnotations,
+		Labels: podLabels,
 	}
 	applyAgentBaseMeta(&podMeta, base)
 

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -99,7 +99,7 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	agent.Env = append([]types.EnvVar{}, testAgent.Env...)
 	agent.Env = append(agent.Env, types.EnvVar{Name: "GITHUB_ORG", Value: "alpha"})
 	agent.SecretRef = "my-secrets"
-	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), nil, "10.96.42.42")
+	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), "10.96.42.42")
 
 	require.NotNil(t, ss)
 	assert.Equal(t, "my-instance", ss.Name)
@@ -170,7 +170,7 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 func TestBuildAgentStatefulSet_ProbesDisabled(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentProbesEnabled = false
-	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "")
 
 	c := ss.Spec.Template.Spec.Containers[0]
 	assert.Nil(t, c.StartupProbe)
@@ -182,12 +182,12 @@ func TestBuildAgentStatefulSet_DefaultsToRunningReplicas(t *testing.T) {
 	// Replicas are owned by the reconciler's applyStatefulSet (ADR-058): the
 	// builder always renders the running default of 1. Hibernation scales the
 	// live StatefulSet to zero — it is not a property of the rendered spec.
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	assert.Equal(t, int32(1), *ss.Spec.Replicas)
 }
 
 func TestBuildAgentStatefulSet_InitContainer(t *testing.T) {
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	require.Len(t, ss.Spec.Template.Spec.InitContainers, 1, "only the user-defined init runs")
 	ic := ss.Spec.Template.Spec.InitContainers[0]
 	assert.Equal(t, "init", ic.Name)
@@ -198,12 +198,12 @@ func TestBuildAgentStatefulSet_InitContainer(t *testing.T) {
 func TestBuildAgentStatefulSet_NoUserInitWhenEmpty(t *testing.T) {
 	agent := *testAgent
 	agent.Init = ""
-	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	assert.Empty(t, ss.Spec.Template.Spec.InitContainers)
 }
 
 func TestBuildAgentStatefulSet_Volumes(t *testing.T) {
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 1)
 	pvc := ss.Spec.VolumeClaimTemplates[0]
@@ -216,8 +216,11 @@ func TestBuildAgentStatefulSet_Volumes(t *testing.T) {
 		volMap[v.Name] = v
 	}
 	assert.NotNil(t, volMap["tmp"].EmptyDir)
-	// Without credential secrets, the ca-cert volume is an emptyDir fallback.
-	assert.NotNil(t, volMap["ca-cert"].EmptyDir)
+	// Always the leaf Secret (always-issued), even with no credentials — never an emptyDir.
+	require.NotNil(t, volMap["ca-cert"].Secret)
+	assert.Equal(t, "my-instance-envoy-tls", volMap["ca-cert"].Secret.SecretName)
+	require.Len(t, volMap["ca-cert"].Secret.Items, 1)
+	assert.Equal(t, "ca.crt", volMap["ca-cert"].Secret.Items[0].Key)
 
 	c := ss.Spec.Template.Spec.Containers[0]
 	mountPaths := make(map[string]string)
@@ -237,7 +240,7 @@ func TestBuildAgentStatefulSet_PVCSize(t *testing.T) {
 			{Path: "/cache", Persist: true},
 		},
 	}
-	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), "")
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 2)
 	byName := map[string]corev1.PersistentVolumeClaim{}
@@ -253,7 +256,7 @@ func TestBuildAgentStatefulSet_PVCSize(t *testing.T) {
 func TestBuildAgentStatefulSet_AgentStorageClass(t *testing.T) {
 	cfg := *testConfig
 	cfg.AgentBase.StorageClass = "platform-rwx"
-	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "")
 
 	require.Len(t, ss.Spec.VolumeClaimTemplates, 1)
 	pvc := ss.Spec.VolumeClaimTemplates[0]
@@ -264,7 +267,7 @@ func TestBuildAgentStatefulSet_AgentStorageClass(t *testing.T) {
 func TestBuildAgentStatefulSet_PodFilesEventsURL(t *testing.T) {
 	cfg := *testConfig
 	cfg.HarnessServerURL = "http://platform-apiserver.default.svc:4001"
-	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "")
 
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t,
@@ -273,16 +276,14 @@ func TestBuildAgentStatefulSet_PodFilesEventsURL(t *testing.T) {
 }
 
 func TestBuildAgentStatefulSet_NoSecretRef(t *testing.T) {
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	assert.Empty(t, ss.Spec.Template.Spec.Containers[0].EnvFrom)
 }
 
 func TestBuildAgentStatefulSet_NoCredentialMountsOnAgent(t *testing.T) {
-	// ADR-038: the agent pod's only platform-issued data is the CA cert
-	// (single-key projection of the leaf Secret). No credential Secrets,
-	// no Envoy bootstrap CM, no leaf private key.
-	secrets := []corev1.Secret{credSecret("platform-cred-aaa", "api.example.com")}
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), secrets, "")
+	// ADR-038: the agent's only platform-issued data is the CA cert (ca.crt
+	// projection of the leaf). No credential Secrets, no bootstrap CM, no tls.key.
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 
 	require.Len(t, ss.Spec.Template.Spec.Containers, 1, "no sidecar — gateway is its own pod")
 
@@ -336,31 +337,8 @@ func envToMap(envs []corev1.EnvVar) map[string]string {
 	return m
 }
 
-// --- GH_TOKEN signal ---
-
-func TestBuildAgentStatefulSet_GHTokenSignal_NoCredential(t *testing.T) {
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
-
-	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
-	assert.Equal(t, "false", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
-	assert.Equal(t, "false", ss.Spec.Template.Annotations["agent-platform.ai/gh-token-available"])
-}
-
-func TestBuildAgentStatefulSet_GHTokenSignal_WithCredential(t *testing.T) {
-	secrets := []corev1.Secret{credSecret("platform-cred-gh", "api.github.com")}
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), secrets, "")
-
-	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
-	assert.Equal(t, "true", envMap["PLATFORM_GH_TOKEN_AVAILABLE"])
-	assert.Equal(t, "true", ss.Spec.Template.Annotations["agent-platform.ai/gh-token-available"])
-	// Declarative env-mappings on the Secret land as actual container env
-	// — the agent SDK reads GH_TOKEN, sends Bearer, Envoy overwrites on
-	// the wire. Without this on the StatefulSet, the SDK never dispatches.
-	assert.Equal(t, "dummy-placeholder", envMap["GH_TOKEN"])
-}
-
 func TestBuildAgentStatefulSet_PodHardening(t *testing.T) {
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	require.NotNil(t, ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	assert.False(t, *ss.Spec.Template.Spec.AutomountServiceAccountToken)
 	require.NotNil(t, ss.Spec.Template.Spec.ShareProcessNamespace)
@@ -372,7 +350,7 @@ func TestBuildAgentStatefulSet_PodHardening(t *testing.T) {
 // deny port 53 entirely. Falls back to the Service DNS name only when
 // the IP isn't known yet (first reconcile race).
 func TestBuildAgentStatefulSet_ProxyURLUsesIPDirectly(t *testing.T) {
-	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), nil, "10.96.42.42")
+	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "10.96.42.42")
 	envMap := envToMap(ss.Spec.Template.Spec.Containers[0].Env)
 	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTPS_PROXY"], "must be IP-direct when gateway IP is known")
 	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTP_PROXY"])

--- a/packages/platform-base/runtime-manifest.yaml
+++ b/packages/platform-base/runtime-manifest.yaml
@@ -7,6 +7,10 @@
 manifestVersion: 1
 
 drivers:
+  # `env` kind — credential-placeholder env vars written to a JSON file the spawn paths read.
+  env:
+    impl: env
+
   # `file` kind — params per contribution; impl needs no extra config.
   file:
     impl: file

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -23,8 +23,8 @@ export interface CreateAgentInput {
   image?: string;
   description?: string;
   env?: EnvVar[];
-  /** undefined ⇒ accept controller's default (auto-assign Anthropic selective).
-   *  explicit array (incl. []) ⇒ override. */
+  /** Initial secret grants, settled into the Agent spec at create. Omitted or
+   *  empty ⇒ no secrets granted (grants are selective; there is no default). */
   secretIds?: string[];
   appConnectionIds?: string[];
   egressPreset?: EgressPreset;
@@ -58,17 +58,14 @@ export function useCreateAgent() {
       importRawBundle: rawBundle,
       ...input
     }: CreateAgentInput) => {
-      // Step order is tuned for fastest user-visible feedback:
-      //   1. agents.create + invalidate → tile appears with runtime state
-      //   2. buildBundle (lazy Blob, microseconds) + upload
-      //   3. setAgentAccess / setAgentConnections
-      // Import goes BEFORE access/connection mutations: those rewrite the
-      // agent ConfigMap's grant annotations, which the controller applies
-      // by deleting and recreating the pod — running the import after them
-      // races with the pod swap and surfaces as "agent unreachable". The
-      // PVC outlives the pod so files land regardless of when the pod
-      // comes back. Raw bundle wins when both are provided.
-      const agent = await api.agents.create.mutate({ ...input, egressPreset });
+      // Single-shot create: grants ride the create call (no post-create swap).
+      // Import follows; raw bundle wins over entries when both are present.
+      const agent = await api.agents.create.mutate({
+        ...input,
+        egressPreset,
+        secretIds,
+        connectionIds: appConnectionIds,
+      });
       void queryClient.invalidateQueries({
         queryKey: trpc.agents.list.queryKey(),
       });
@@ -105,22 +102,6 @@ export function useCreateAgent() {
         }
       }
 
-      if (secretIds !== undefined) {
-        await withRetry(() =>
-          api.secrets.setAgentAccess.mutate({
-            agentId: agent.id,
-            secretIds,
-          }),
-        );
-      }
-      if (appConnectionIds?.length) {
-        await withRetry(() =>
-          api.connections.setAgentConnections.mutate({
-            agentId: agent.id,
-            connectionIds: appConnectionIds,
-          }),
-        );
-      }
       return agent;
     },
     meta: {
@@ -256,20 +237,4 @@ export async function fetchAgentAccess(agentId: string) {
   return queryClient.fetchQuery({
     ...trpc.secrets.getAgentAccess.queryOptions({ agentId: agentId }),
   });
-}
-
-async function withRetry(
-  fn: () => Promise<void>,
-  maxAttempts = 5,
-  delayMs = 2000,
-) {
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    try {
-      await fn();
-      return;
-    } catch (err) {
-      if (attempt === maxAttempts - 1) throw err;
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
-    }
-  }
 }


### PR DESCRIPTION
Summary:

Moves credential-placeholder env off the agent pod spec onto the runtime channel, so grant/credential changes no longer roll the pod (ADR: DRAFT-runtime-env-injection).

- Env is a channel contribution, merged into the harness process at spawn instead of baked into the pod. Mid-life changes respawn the harness (resumable per ADR-055), not the pod.
- Agent pod template is grant-independent — leaf cert always issued, ca.crt mounted unconditionally — so the first/last credential no longer rolls the agent. Forks keep baked env.
- Single-shot create settles initial grants into the spec before first render (gateway chains rendered once, creds on the first snapshot).
- Cold-boot startup fixes: harness spawn is gated until env is delivered (buffering client frames) so the first turn isn't credential-less; and a hello-triggered delivery fast-retries on the queue backoff instead of waiting for the ~60s sweep.
- Docs: new draft ADR; updated connections.md / persistence.md / skills.md.
 
Refs: #168  