### PR TITLE
fix(runtime-channel): preserve seeded/user-added skills and MCP servers

### DIFF
--- a/packages/agent-runtime/src/core/document-store.ts
+++ b/packages/agent-runtime/src/core/document-store.ts
@@ -35,7 +35,7 @@ export function createFileDocumentStoreBackend(
 /** A missing, unreadable, or schema-rejected file yields `initial`, never throws. */
 export function openJsonFile<T>(
   path: string,
-  { schema, initial }: { schema: ZodType<T>; initial: () => T },
+  { schema, initial }: { schema: ZodType<T>; initial: () => NoInfer<T> },
 ): DocumentStore<T> {
   let cache: T;
   let loaded = false;

--- a/packages/agent-runtime/src/core/document-store.ts
+++ b/packages/agent-runtime/src/core/document-store.ts
@@ -33,7 +33,7 @@ export function createFileDocumentStoreBackend(
 }
 
 /** A missing, unreadable, or schema-rejected file yields `initial`, never throws. */
-function openJsonFile<T>(
+export function openJsonFile<T>(
   path: string,
   { schema, initial }: { schema: ZodType<T>; initial: () => T },
 ): DocumentStore<T> {

--- a/packages/agent-runtime/src/modules/runtime-channel/compose.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/compose.ts
@@ -43,7 +43,9 @@ export async function composeRuntimeChannel(
   const manifest = loadManifest(opts.manifestPath);
 
   const stateStore = createStateStore(opts.stateBackend);
-  const triggerStateStore = createTriggerStateStore(opts.stateBackend);
+  const triggerStateStore = createTriggerStateStore(
+    join(opts.agentHome, ".platform", "trigger"),
+  );
 
   const registry = createPluginRegistry();
   for (const plugin of opts.plugins) registry.register(plugin);

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
@@ -1,12 +1,6 @@
 import { existsSync, readFileSync } from "node:fs";
 import { z } from "zod";
-import type {
-  DriverBinding,
-  FileFormat,
-  KindHandler,
-  MergeMode,
-  Plugin,
-} from "agent-runtime-api";
+import type { DriverBinding, KindHandler, Plugin } from "agent-runtime-api";
 import { createFileOps, type FileDesired } from "../infrastructure/file-ops.js";
 import {
   createMcpEntryStateStore,
@@ -16,16 +10,11 @@ import {
 const IMPL_NAME = "mcp-entry";
 const DEFAULT_KEY_PATH = "mcpServers";
 
+// MCP config is always a JSON object merged under `keyPath` — format and merge
+// strategy are intrinsic to the kind, not per-binding knobs.
 const bindingSchema = z.object({
   impl: z.literal(IMPL_NAME),
   path: z.string().min(1),
-  format: z.enum(["yaml", "json", "text", "ini"]),
-  mergeMode: z.enum([
-    "overwrite",
-    "section-marker",
-    "key-targeted",
-    "yaml-fill-if-missing",
-  ]),
   keyPath: z.string().optional(),
 });
 
@@ -47,7 +36,7 @@ export function createMcpEntryPlugin(): Plugin {
           `plugin "${IMPL_NAME}" invalid binding: ${parsed.error.message}`,
         );
       }
-      const { path, format, mergeMode, keyPath } = parsed.data;
+      const { path, keyPath } = parsed.data;
       const effectiveKey = keyPath ?? DEFAULT_KEY_PATH;
       let stateStore: McpEntryStateStore | undefined;
 
@@ -83,16 +72,14 @@ export function createMcpEntryPlugin(): Plugin {
         const content: Record<string, unknown> = keyPath
           ? next
           : { [effectiveKey]: next };
-        ctx.log(
-          `writing → ${targetPath} (format=${format}, mergeMode=${mergeMode}, keyPath=${keyPath ?? "<root>"})`,
-        );
+        ctx.log(`writing → ${targetPath} (keyPath=${effectiveKey})`);
         const desired = new Map<string, FileDesired[]>([
           [
             targetPath,
             [
               {
-                format: format as FileFormat,
-                mergeMode: mergeMode as MergeMode,
+                format: "json",
+                mergeMode: "key-targeted",
                 content,
                 ...(keyPath ? { keyPath } : {}),
               },

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
@@ -1,3 +1,4 @@
+import { existsSync, readFileSync } from "node:fs";
 import { z } from "zod";
 import type {
   DriverBinding,
@@ -7,6 +8,10 @@ import type {
   Plugin,
 } from "agent-runtime-api";
 import { createFileOps, type FileDesired } from "../infrastructure/file-ops.js";
+import {
+  createMcpEntryStateStore,
+  type McpEntryStateStore,
+} from "../infrastructure/mcp-entry-state-store.js";
 
 const IMPL_NAME = "mcp-entry";
 const DEFAULT_KEY_PATH = "mcpServers";
@@ -44,8 +49,12 @@ export function createMcpEntryPlugin(): Plugin {
       }
       const { path, format, mergeMode, keyPath } = parsed.data;
       const effectiveKey = keyPath ?? DEFAULT_KEY_PATH;
+      let stateStore: McpEntryStateStore | undefined;
 
       return async (contributions, ctx) => {
+        stateStore ??= createMcpEntryStateStore(ctx.pluginStateDir);
+        const installed = new Set(stateStore.getInstalled());
+
         const entries: Record<string, unknown> = {};
         for (const c of contributions) {
           if (c.kind !== "mcp-entry") continue;
@@ -56,13 +65,24 @@ export function createMcpEntryPlugin(): Plugin {
           };
         }
         const names = Object.keys(entries);
+        const targetPath = expandHome(path, ctx.agentHome);
+
+        // Preserve user-added servers: start from what's on disk, drop only the
+        // servers this driver installed before that are no longer desired, then
+        // set the desired ones. Anything the user added stays untouched.
+        const segs = effectiveKey.split(".");
+        const next = { ...readKeyedObject(targetPath, segs) };
+        for (const name of installed) {
+          if (!(name in entries)) delete next[name];
+        }
+        Object.assign(next, entries);
+
         ctx.log(
-          `desired entries (${names.length}): ${names.length === 0 ? "<none>" : names.join(", ")}`,
+          `desired entries (${names.length}): ${names.length === 0 ? "<none>" : names.join(", ")}; preserved ${Object.keys(next).length - names.length} other server(s)`,
         );
         const content: Record<string, unknown> = keyPath
-          ? entries
-          : { [effectiveKey]: entries };
-        const targetPath = expandHome(path, ctx.agentHome);
+          ? next
+          : { [effectiveKey]: next };
         ctx.log(
           `writing → ${targetPath} (format=${format}, mergeMode=${mergeMode}, keyPath=${keyPath ?? "<root>"})`,
         );
@@ -83,6 +103,7 @@ export function createMcpEntryPlugin(): Plugin {
           agentHome: ctx.agentHome,
           log: ctx.log,
         });
+        stateStore.setInstalled(names);
       };
     },
   };
@@ -90,6 +111,26 @@ export function createMcpEntryPlugin(): Plugin {
 
 function expandHome(path: string, agentHome: string): string {
   return path.replace(/\$HOME\b/g, agentHome).replace(/\$\{HOME\}/g, agentHome);
+}
+
+// Reads the object at `segs` from a JSON file, or {} if missing/unreadable.
+function readKeyedObject(
+  targetPath: string,
+  segs: string[],
+): Record<string, unknown> {
+  try {
+    if (!existsSync(targetPath)) return {};
+    let cur: unknown = JSON.parse(readFileSync(targetPath, "utf8"));
+    for (const s of segs) {
+      if (!cur || typeof cur !== "object") return {};
+      cur = (cur as Record<string, unknown>)[s];
+    }
+    return cur && typeof cur === "object"
+      ? (cur as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
 }
 
 export const MCP_ENTRY_PLUGIN_NAME = IMPL_NAME;

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/skill-install-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/skill-install-plugin.ts
@@ -1,4 +1,4 @@
-import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { z } from "zod";
 import type {
@@ -10,6 +10,10 @@ import type {
   Result,
   SkillsDomainError,
 } from "agent-runtime-api";
+import {
+  createSkillInstallStateStore,
+  type SkillInstallStateStore,
+} from "../infrastructure/skill-install-state-store.js";
 
 const IMPL_NAME = "skill-install";
 
@@ -41,13 +45,18 @@ export function createSkillInstallPlugin(deps: {
         );
       }
       const configuredPaths = parsed.data.paths;
+      // State lives in this plugin's own dir (ctx.pluginStateDir), known only
+      // at dispatch; created once and reused across dispatches.
+      let stateStore: SkillInstallStateStore | undefined;
 
       return async (contributions, ctx) => {
+        stateStore ??= createSkillInstallStateStore(ctx.pluginStateDir);
         const skillPaths = configuredPaths.map((p) =>
           expandHome(p, ctx.agentHome),
         );
         const resolvedPaths = skillPaths.map((p) => resolve(p));
         const skillRefs = contributions.filter((c) => c.kind === "skill-ref");
+        const managed = new Set(stateStore.getInstalled());
         ctx.log(
           `wanted (${skillRefs.length}): ${
             skillRefs.length === 0
@@ -57,12 +66,16 @@ export function createSkillInstallPlugin(deps: {
                     c.kind === "skill-ref" ? `${c.name}@${c.version}` : "",
                   )
                   .join(", ")
-          }; targets: ${resolvedPaths.join(", ") || "<none>"}`,
+          }; targets: ${resolvedPaths.join(", ") || "<none>"}; managed: ${
+            [...managed].join(", ") || "<none>"
+          }`,
         );
-        const wantedDirs = new Set<string>();
 
+        const desired = new Set<string>();
+        const installed = new Set<string>();
         for (const c of contributions) {
           if (c.kind !== "skill-ref") continue;
+          desired.add(c.name);
           const installInput: SkillInstallInput = {
             sourceUrl: c.sourceUrl,
             name: c.name,
@@ -80,39 +93,35 @@ export function createSkillInstallPlugin(deps: {
             continue;
           }
           ctx.log(`${c.name}@${c.version}: install ok`);
-          for (const root of resolvedPaths) {
-            wantedDirs.add(join(root, c.name));
-          }
+          installed.add(c.name);
         }
 
+        // Only remove skills this driver installed before that are no longer
+        // desired. Seeded skills (platform-base) and standalone skills authored
+        // on disk are never in `managed`, so the sweep leaves them untouched.
+        const toRemove = [...managed].filter((name) => !desired.has(name));
         for (const root of resolvedPaths) {
-          if (!existsSync(root)) {
-            ctx.log(`root missing, nothing to sweep: ${root}`);
-            continue;
-          }
-          let kept = 0;
-          let removed = 0;
-          for (const entry of readdirSync(root)) {
-            const p = join(root, entry);
-            try {
-              if (!statSync(p).isDirectory()) continue;
-            } catch {
-              continue;
-            }
-            if (wantedDirs.has(p)) {
-              kept++;
-              continue;
-            }
+          for (const name of toRemove) {
+            const p = join(root, name);
+            if (!existsSync(p)) continue;
             try {
               rmSync(p, { recursive: true, force: true });
               ctx.log(`removed ${p}`);
-              removed++;
             } catch (err) {
               ctx.log(`failed to remove ${p}: ${(err as Error).message}`);
             }
           }
-          ctx.log(`sweep ${root}: kept=${kept} removed=${removed}`);
         }
+
+        const nextManaged = [...desired].filter(
+          (name) => managed.has(name) || installed.has(name),
+        );
+        stateStore.setInstalled(nextManaged);
+        ctx.log(
+          `managed now (${nextManaged.length}): ${
+            nextManaged.join(", ") || "<none>"
+          }; removed ${toRemove.length}`,
+        );
       };
     },
   };

--- a/packages/agent-runtime/src/modules/runtime-channel/infrastructure/mcp-entry-state-store.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/infrastructure/mcp-entry-state-store.ts
@@ -1,0 +1,30 @@
+import { join } from "node:path";
+import { z } from "zod";
+import { openJsonFile } from "../../../core/document-store.js";
+
+const mcpEntryStateSchema = z.object({
+  installed: z.array(z.string()).catch([]).default([]),
+});
+
+export type McpEntryState = z.infer<typeof mcpEntryStateSchema>;
+
+export interface McpEntryStateStore {
+  getInstalled(): string[];
+  setInstalled(names: string[]): void;
+}
+
+export function createMcpEntryStateStore(stateDir: string): McpEntryStateStore {
+  const store = openJsonFile(join(stateDir, "mcp-entry-state.json"), {
+    schema: mcpEntryStateSchema,
+    initial: () => ({ installed: [] }),
+  });
+
+  return {
+    getInstalled() {
+      return store.read().installed;
+    },
+    setInstalled(names) {
+      store.write({ installed: [...names].sort() });
+    },
+  };
+}

--- a/packages/agent-runtime/src/modules/runtime-channel/infrastructure/skill-install-state-store.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/infrastructure/skill-install-state-store.ts
@@ -1,0 +1,32 @@
+import { join } from "node:path";
+import { z } from "zod";
+import { openJsonFile } from "../../../core/document-store.js";
+
+const skillInstallStateSchema = z.object({
+  installed: z.array(z.string()).catch([]).default([]),
+});
+
+export type SkillInstallState = z.infer<typeof skillInstallStateSchema>;
+
+export interface SkillInstallStateStore {
+  getInstalled(): string[];
+  setInstalled(names: string[]): void;
+}
+
+export function createSkillInstallStateStore(
+  stateDir: string,
+): SkillInstallStateStore {
+  const store = openJsonFile(join(stateDir, "skill-install-state.json"), {
+    schema: skillInstallStateSchema,
+    initial: () => ({ installed: [] }),
+  });
+
+  return {
+    getInstalled() {
+      return store.read().installed;
+    },
+    setInstalled(names) {
+      store.write({ installed: [...names].sort() });
+    },
+  };
+}

--- a/packages/agent-runtime/src/modules/runtime-channel/infrastructure/trigger-state-store.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/infrastructure/trigger-state-store.ts
@@ -1,5 +1,6 @@
+import { join } from "node:path";
 import { z } from "zod";
-import type { DocumentStoreBackend } from "../../../core/document-store.js";
+import { openJsonFile } from "../../../core/document-store.js";
 
 const triggerStateSchema = z.object({
   scheduleSessions: z.record(z.string(), z.string()).catch({}).default({}),
@@ -13,10 +14,8 @@ export interface TriggerStateStore {
   clearSessionForSchedule(scheduleId: string): void;
 }
 
-export function createTriggerStateStore(
-  backend: DocumentStoreBackend,
-): TriggerStateStore {
-  const store = backend.open("trigger-state", {
+export function createTriggerStateStore(stateDir: string): TriggerStateStore {
+  const store = openJsonFile(join(stateDir, "trigger-state.json"), {
     schema: triggerStateSchema,
     initial: () => ({ scheduleSessions: {} }),
   });

--- a/packages/agents/bob/Dockerfile
+++ b/packages/agents/bob/Dockerfile
@@ -25,6 +25,9 @@ RUN chmod +x /usr/local/bin/harness-chat /usr/local/bin/harness-terminal
 RUN mkdir -p /app/working-dir/.bob \
     && ln -s ../.agents/skills /app/working-dir/.bob/skills
 
+# Bob reads MCP servers from $HOME/.bob/settings.json (ADR-052).
+COPY --chown=65532:0 runtime-manifest.yaml /app/runtime-manifest.yaml
+
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
 # Bob's default auth is W3ID SSO — opens a browser that never arrives

--- a/packages/agents/bob/runtime-manifest.yaml
+++ b/packages/agents/bob/runtime-manifest.yaml
@@ -1,0 +1,17 @@
+# Bob runtime manifest. Bob reads MCP servers from $HOME/.bob/settings.json,
+# so the mcp-entry path is overridden here; other drivers match platform-base.
+manifestVersion: 1
+
+drivers:
+  file:
+    impl: file
+
+  mcp-entry:
+    impl: mcp-entry
+    path: "$HOME/.bob/settings.json"
+    keyPath: mcpServers
+
+  skill-ref:
+    impl: skill-install
+    paths:
+      - "$HOME/.agents/skills"

--- a/packages/agents/bob/runtime-manifest.yaml
+++ b/packages/agents/bob/runtime-manifest.yaml
@@ -8,7 +8,7 @@ drivers:
 
   mcp-entry:
     impl: mcp-entry
-    path: "$HOME/.bob/settings.json"
+    path: "$HOME/.bob/mcp_settings.json"
     keyPath: mcpServers
 
   skill-ref:

--- a/packages/platform-base/runtime-manifest.yaml
+++ b/packages/platform-base/runtime-manifest.yaml
@@ -18,8 +18,6 @@ drivers:
   mcp-entry:
     impl: mcp-entry
     path: "$HOME/.mcp.json"
-    format: json
-    mergeMode: key-targeted
     keyPath: mcpServers
 
   # `skill-ref` kind — installs into the shared .agents/skills tree;


### PR DESCRIPTION
Closes #684.

Runtime-channel drivers reconciled by treating their whole target as platform-owned and deleting anything not in the current desired set — wiping data the platform didn't put there. This fixes that across the stateful drivers, tidies where per-driver state lives, and removes dead configuration on the mcp-entry binding.

## 1. Skills — don't sweep what we didn't install

`skill-install` deleted every directory in the skill path that wasn't a currently-desired `skill-ref`, so the first `applyState` after boot wiped the platform-base seeded skill (`platform-schedules`) and any standalone skill authored on disk. Now it tracks the skills it installed and removes only those no longer desired; seeded/standalone skills survive. A transient reinstall failure of a still-desired skill no longer deletes it.

## 2. MCP servers — preserve user-added entries

`mcp-entry` replaced the whole `mcpServers` object on every snapshot, wiping any server a user added by hand. Now it tracks the servers it installed and merges: drop only previously-installed servers no longer desired, set the desired ones, leave user-added servers untouched.

## 3. mcp-entry binding is JSON-only

MCP config is always a JSON object merged under `mcpServers` (the read path is JSON-only, the write is key-targeted). The `format`/`mergeMode` enums on the binding could never be anything else and were misleading — removed; the binding now takes just `path` and an optional `keyPath`, with json + key-targeted hardcoded.

## 4. Per-driver state placement

State lives in each driver's own directory via the shared `DocumentStore` primitive (atomic write-then-rename, schema-validated):

- `skill-install` → `.platform/plugins/skill-install/skill-install-state.json`
- `mcp-entry` → `.platform/plugins/mcp-entry/mcp-entry-state.json`
- `trigger` → `.platform/trigger/trigger-state.json` (moved out of flat `.platform/`)

Channel cursor stays global at `.platform/runtime-state.json`. Each store mirrors `trigger-state-store`'s shape (domain interface over `openJsonFile`).

## 5. Bob reads MCP from its settings file

Bob ships a runtime-manifest overriding the mcp-entry path to `$HOME/.bob/settings.json`. Combined with (2)+(3), only the `mcpServers` key is touched and only platform-managed entries within it — bob's other settings and user-added servers are preserved.

## Notes

- No data migration: on upgrade each driver starts with an empty install-history (nothing wrongly removed on first apply); a continuous trigger schedule begins one fresh session.
- Existing agents that already lost `platform-schedules` won't get it back automatically (seeded only on first boot) — separate concern, flagged in #684.