### PR TITLE
fix(security): suppress Trivy false positive for CVE-2025-59250

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,3 @@
+# False positive: Trivy miscompares 13.2.1 with fix version 13.2.1.jre11 (same artifact, JRE classifier stripped)
+# https://github.com/aquasecurity/trivy/discussions/9990
+CVE-2025-59250


### PR DESCRIPTION
## Summary

- Add `.trivyignore` to suppress CVE-2025-59250 (mssql-jdbc) — a Trivy false positive where the installed version 13.2.1 is the same artifact as the fix version 13.2.1.jre11 (JRE classifier stripped during detection). See [aquasecurity/trivy#9990](https://github.com/aquasecurity/trivy/discussions/9990).
- Once merged, the next daily CI scan will auto-close #690 (no longer in findings → reconciler closes it).

Closes #690

## Test plan

- [ ] CI `container-scan` for keycloak no longer reports CVE-2025-59250
- [ ] `manage-security-issues` reconciler auto-closes #690 on the next `main` push or scheduled run