### PR TITLE
feat(helm): add link-guardian to seedable gitRepos

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -799,6 +799,11 @@ gitRepos:
     url: https://github.com/dam-agents/spotify-dj.git
     description: "Build sets, run playback, curate playlists, and discover music on Spotify"
     compatibleTemplates: [claude-code]
+  - id: link-guardian
+    name: Link Guardian
+    url: https://github.com/dam-agents/link-guardian.git
+    description: "Monitor and validate links to guard against broken or malicious URLs"
+    compatibleTemplates: [claude-code, bob]
 
 # -- Opt-in in-cluster NFS server + external provisioner. Provides an RWX
 # StorageClass for dev clusters whose default provisioner is RWO-only.


### PR DESCRIPTION
## What

Adds the [`dam-agents/link-guardian`](https://github.com/dam-agents/link-guardian) repo to the `gitRepos` seed list in the Helm chart, so it can be selected as a workspace seed when creating an agent.

Enabled for both the **claude-code** and **bob** harnesses (`compatibleTemplates: [claude-code, bob]`).

## Notes

- The `url` uses the `.git` clone form to match the existing entries and the repo schema.
- `description` is a placeholder summary — adjust if the repo's purpose differs.
- `mise run helm:check:render` passes.