### PR TITLE
fix: faster hello apply + guard not ready seeding agents 

### DIFF
--- a/packages/agent-runtime/src/modules/runtime-channel/compose.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/compose.ts
@@ -40,7 +40,11 @@ export interface ComposeRuntimeChannelOpts {
 export async function composeRuntimeChannel(
   opts: ComposeRuntimeChannelOpts,
 ): Promise<RuntimeChannelComposition> {
-  const log = opts.log ?? ((m) => process.stderr.write(`[runtime] ${m}\n`));
+  // Timestamp the in-pod seed/apply lines so the boot timeline is diagnosable (#695).
+  const log =
+    opts.log ??
+    ((m) =>
+      process.stderr.write(`${new Date().toISOString()} [runtime] ${m}\n`));
 
   const manifest = loadManifest(opts.manifestPath);
 

--- a/packages/api-server-api/src/modules/agents/types.ts
+++ b/packages/api-server-api/src/modules/agents/types.ts
@@ -36,6 +36,7 @@ export type ChannelConfig = SlackChannel | TelegramChannel;
 
 export type AgentState =
   | "starting"
+  | "preparing_workspace"
   | "running"
   | "hibernating"
   | "hibernated"

--- a/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
@@ -53,11 +53,15 @@ export interface InfraAgent {
   error?: string;
 }
 
-/** Map the controller's conditions to the public-facing AgentState. Purely
- *  condition-driven (ADR-059) — the non-authoritative phase is not read. */
-export function computeAgentState(infra: InfraAgent): AgentState {
+/** Map the controller's conditions to the public-facing AgentState. Mostly
+ *  condition-driven (ADR-059); `preparingWorkspace` (a pending workspace-seed
+ *  clone) refines a Ready agent into the not-yet-usable phase. */
+export function computeAgentState(
+  infra: InfraAgent,
+  preparingWorkspace = false,
+): AgentState {
   if (infra.error) return "error";
-  if (infra.ready) return "running";
+  if (infra.ready) return preparingWorkspace ? "preparing_workspace" : "running";
   if (infra.hibernated) return "hibernated";
   return "starting";
 }
@@ -121,13 +125,14 @@ export function assembleAgent(
   channels: ChannelConfig[],
   allowedUserEmails: string[],
   contributionFailures: DriverFailure[],
+  preparingWorkspace = false,
 ): Agent {
   return {
     id: infra.id,
     name: infra.name,
     templateId: infra.templateId,
     spec: infra.spec,
-    state: computeAgentState(infra),
+    state: computeAgentState(infra, preparingWorkspace),
     error: infra.error,
     contributionFailures,
     channels,

--- a/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
@@ -61,7 +61,8 @@ export function computeAgentState(
   preparingWorkspace = false,
 ): AgentState {
   if (infra.error) return "error";
-  if (infra.ready) return preparingWorkspace ? "preparing_workspace" : "running";
+  if (infra.ready)
+    return preparingWorkspace ? "preparing_workspace" : "running";
   if (infra.hibernated) return "hibernated";
   return "starting";
 }

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -17,6 +17,7 @@ import type { AgentsRepository } from "../infrastructure/agents-repository.js";
 export interface ContributionsStatus {
   settled: boolean;
   failures: DriverFailure[];
+  preparingWorkspace: boolean;
 }
 
 /** Port: the failed contributions surfaced on an agent (the degraded badge). */
@@ -143,24 +144,30 @@ export function createAgentsService(deps: {
   }
 
   // Fail-soft: a transient outbox-DB error must never 500 an agent read.
-  async function safeFailures(id: string): Promise<DriverFailure[]> {
+  async function safeStatus(id: string): Promise<ContributionsStatus> {
     try {
-      return (await deps.contributionsSettled.status(id)).failures;
+      return await deps.contributionsSettled.status(id);
     } catch {
-      return [];
+      return { settled: true, failures: [], preparingWorkspace: false };
     }
   }
 
   async function project(
     infra: InfraAgent,
   ): Promise<ReturnType<typeof assembleAgent>> {
-    const [channels, allowedSubs, failures] = await Promise.all([
+    const [channels, allowedSubs, status] = await Promise.all([
       deps.listChannelsByAgent(infra.id),
       deps.listAllowedUsersByAgent(infra.id),
-      safeFailures(infra.id),
+      safeStatus(infra.id),
     ]);
     const emails = await subsToEmails(allowedSubs);
-    return assembleAgent(infra, channels, emails, failures);
+    return assembleAgent(
+      infra,
+      channels,
+      emails,
+      status.failures,
+      status.preparingWorkspace,
+    );
   }
 
   return {
@@ -208,11 +215,13 @@ export function createAgentsService(deps: {
       return infraAgents.map((infra) => {
         const subs = allowedUsersMap.get(infra.id) ?? [];
         const emails = subs.map((s) => subEmailMap.get(s) ?? s);
+        const status = failuresMap.get(infra.id);
         return assembleAgent(
           infra,
           channelMap.get(infra.id) ?? [],
           emails,
-          failuresMap.get(infra.id)?.failures ?? [],
+          status?.failures ?? [],
+          status?.preparingWorkspace ?? false,
         );
       });
     },
@@ -514,9 +523,15 @@ export function createAgentsService(deps: {
 
       const allowedSubs = await deps.listAllowedUsersByAgent(id);
       const emails = await subsToEmails(allowedSubs);
-      const failures = await safeFailures(id);
+      const status = await safeStatus(id);
       return ok(
-        assembleAgent(infra, txResult.value.channels, emails, failures),
+        assembleAgent(
+          infra,
+          txResult.value.channels,
+          emails,
+          status.failures,
+          status.preparingWorkspace,
+        ),
       );
     },
 

--- a/packages/api-server/src/modules/runtime-delivery/compose.ts
+++ b/packages/api-server/src/modules/runtime-delivery/compose.ts
@@ -56,6 +56,7 @@ export interface RuntimeDeliveryComposition {
 export interface ContributionsStatus {
   settled: boolean;
   failures: DriverFailure[];
+  preparingWorkspace: boolean;
 }
 
 export interface ComposeRuntimeDeliveryOpts {
@@ -126,11 +127,16 @@ export function composeRuntimeDelivery(
     stateBuilder,
     builtin,
     async contributionsStatus(agentId): Promise<ContributionsStatus> {
-      const row = await outboxRepo.getRow(agentId);
-      if (!row) return { settled: true, failures: [] };
+      const [row, seeding] = await Promise.all([
+        outboxRepo.getRow(agentId),
+        outboxRepo.seedingAgentIds([agentId]),
+      ]);
+      const preparingWorkspace = seeding.has(agentId);
+      if (!row) return { settled: true, failures: [], preparingWorkspace };
       return {
         settled: row.lastSettledVersion >= row.version,
         failures: row.applyFailures,
+        preparingWorkspace,
       };
     },
 
@@ -139,18 +145,23 @@ export function composeRuntimeDelivery(
     ): Promise<Map<string, ContributionsStatus>> {
       const result = new Map<string, ContributionsStatus>();
       if (agentIds.length === 0) return result;
-      const rows = await outboxRepo.getRows(agentIds);
+      const [rows, seeding] = await Promise.all([
+        outboxRepo.getRows(agentIds),
+        outboxRepo.seedingAgentIds(agentIds),
+      ]);
       const byId = new Map(rows.map((r) => [r.agentId, r]));
       for (const id of agentIds) {
         const row = byId.get(id);
+        const preparingWorkspace = seeding.has(id);
         result.set(
           id,
           row
             ? {
                 settled: row.lastSettledVersion >= row.version,
                 failures: row.applyFailures,
+                preparingWorkspace,
               }
-            : { settled: true, failures: [] },
+            : { settled: true, failures: [], preparingWorkspace },
         );
       }
       return result;

--- a/packages/api-server/src/modules/runtime-delivery/compose.ts
+++ b/packages/api-server/src/modules/runtime-delivery/compose.ts
@@ -1,6 +1,7 @@
 import type { ConnectionOptions } from "bullmq";
 import type { Db } from "db";
 import type { DriverFailure, RuntimeDeliveryService } from "api-server-api";
+import { getLogger } from "../../core/logger.js";
 import {
   createOutboxRepo,
   createAgentsRuntimeRepo,
@@ -70,7 +71,8 @@ export interface ComposeRuntimeDeliveryOpts {
 export function composeRuntimeDelivery(
   opts: ComposeRuntimeDeliveryOpts,
 ): RuntimeDeliveryComposition {
-  const log = opts.log ?? ((m) => process.stderr.write(`[runtime] ${m}\n`));
+  // Via Pino so apply/sweep lines carry an ISO timestamp (#695).
+  const log = opts.log ?? ((m) => getLogger().info(`[runtime] ${m}`));
 
   const outboxRepo = createOutboxRepo(opts.db);
   const agentsRuntimeRepo = createAgentsRuntimeRepo(opts.db);

--- a/packages/api-server/src/modules/runtime-delivery/infrastructure/outbox-repo.ts
+++ b/packages/api-server/src/modules/runtime-delivery/infrastructure/outbox-repo.ts
@@ -73,6 +73,8 @@ export interface OutboxRepo {
   ): Promise<ApplyTransitions>;
   /** Rows the sweep should re-dispatch: unsettled, or settled-with-failures under the attempt cap. */
   listRetryable(maxAttempts: number, limit: number): Promise<OutboxRow[]>;
+  /** Of `agentIds`, those with an undispatched, unexpired `workspace-seed` event — drives the "preparing workspace" state (#695). */
+  seedingAgentIds(agentIds: string[]): Promise<Set<string>>;
   deleteExpiredEvents(): Promise<number>;
   insertEvent(
     input: PendingEventRow & { createdAt?: Date },
@@ -250,6 +252,22 @@ export function createOutboxRepo(db: Db): OutboxRepo {
         .orderBy(asc(runtimeStateOutbox.applyAttempts))
         .limit(limit)) as InternalRow[];
       return rows;
+    },
+
+    async seedingAgentIds(agentIds): Promise<Set<string>> {
+      if (agentIds.length === 0) return new Set();
+      const rows = (await db
+        .select({ agentId: runtimeEvents.agentId })
+        .from(runtimeEvents)
+        .where(
+          and(
+            inArray(runtimeEvents.agentId, agentIds),
+            eq(runtimeEvents.kind, "workspace-seed"),
+            isNull(runtimeEvents.dispatchedAt),
+            sql`${runtimeEvents.expiresAt} > now()`,
+          ),
+        )) as { agentId: string }[];
+      return new Set(rows.map((r) => r.agentId));
     },
 
     async deleteExpiredEvents(): Promise<number> {

--- a/packages/api-server/src/modules/runtime-delivery/infrastructure/state-queue.ts
+++ b/packages/api-server/src/modules/runtime-delivery/infrastructure/state-queue.ts
@@ -14,17 +14,29 @@ export interface StateQueue {
   close(): Promise<void>;
 }
 
+// `retryUntilReady` jobs wait on the Ready condition (ADR-059/060): re-check on a tight fixed cadence (~wake budget) so the apply lands seconds after Ready, not at the next sparse exponential retry.
+const READY_RECHECK_MS = 1_000;
+const READY_RECHECK_ATTEMPTS = 120;
+
 export function createStateQueue(connection: ConnectionOptions): StateQueue {
   const queue = new Queue<StateJob>(RUNTIME_STATE_QUEUE, { connection });
   return {
     async enqueue(agentId, opts): Promise<void> {
       // No jobId dedup on purpose: applyState is idempotent, so a prompt redundant apply beats stalling fresh config behind an in-flight job.
+      const retry = opts?.retryUntilReady
+        ? {
+            attempts: READY_RECHECK_ATTEMPTS,
+            backoff: { type: "fixed" as const, delay: READY_RECHECK_MS },
+          }
+        : {
+            attempts: 8,
+            backoff: { type: "exponential" as const, delay: 1_000 },
+          };
       await queue.add(
         "state",
         { agentId, retryUntilReady: opts?.retryUntilReady },
         {
-          attempts: 8,
-          backoff: { type: "exponential", delay: 1_000 },
+          ...retry,
           removeOnComplete: { age: 3600, count: 1000 },
           removeOnFail: { age: 86_400, count: 1000 },
         },

--- a/packages/api-server/src/modules/runtime-delivery/services/worker-handler.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/worker-handler.ts
@@ -31,8 +31,7 @@ export function createWorkerHandler(deps: WorkerHandlerDeps): WorkerHandler {
     const row = await deps.outboxRepo.getRow(agentId);
     if (!row) return;
 
-    // Not Ready (ADR-059): hello-triggered jobs fast-retry on the queue backoff
-    // (Ready is ~1s away); others defer to the sweep. Gate holds either way.
+    // Not Ready (ADR-059): hello-triggered jobs re-check on a tight cadence until Ready; others defer to the sweep.
     if (!(await deps.agentRunningPort.isRunning(agentId))) {
       if (opts?.retryUntilReady) {
         throw new Error(`${agentId}: not Ready yet — retrying until Ready`);

--- a/packages/ui/src/components/status-indicator.tsx
+++ b/packages/ui/src/components/status-indicator.tsx
@@ -3,6 +3,7 @@ import type { AgentDisplayState } from "../modules/agents/utils/agent-resolver.j
 const stateLabel: Record<AgentDisplayState, string> = {
   running: "Running",
   starting: "Starting",
+  preparing_workspace: "Preparing workspace",
   hibernating: "Hibernating",
   hibernated: "Hibernated",
   error: "Error",
@@ -12,6 +13,7 @@ const stateLabel: Record<AgentDisplayState, string> = {
 const badgeColors: Record<AgentDisplayState, string> = {
   running: "bg-success-light text-success border-success",
   starting: "bg-warning-light text-warning border-warning",
+  preparing_workspace: "bg-warning-light text-warning border-warning",
   hibernating: "bg-warning-light text-warning border-warning",
   hibernated: "bg-info-light text-info/50 border-info/25",
   error: "bg-danger-light text-danger border-danger",
@@ -21,6 +23,7 @@ const badgeColors: Record<AgentDisplayState, string> = {
 const dotColors: Record<AgentDisplayState, string> = {
   running: "bg-success",
   starting: "bg-warning anim-pulse",
+  preparing_workspace: "bg-warning anim-pulse",
   hibernating: "bg-warning anim-pulse",
   hibernated: "bg-info/50",
   error: "bg-danger",

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -102,6 +102,7 @@ export interface TemplateView {
 
 export type AgentState =
   | "starting"
+  | "preparing_workspace"
   | "running"
   | "hibernating"
   | "hibernated"


### PR DESCRIPTION
Fix slow first-apply after agent boot: a freshly-started agent's initial configuration/working-directory seed could take up to ~1 minute to land because the apply retried on an exponential backoff that grew sparse right as the agent became ready. Hello-triggered apply jobs now re-check readiness on a tight fixed cadence, so config/seed lands within ~1s of the agent going Ready. Also added timestamps to the api-server and in-pod setup/apply logs so the boot timeline is diagnosable.

Add a "preparing workspace" agent state: an agent seeded from a git repo no longer shows as "Running" before its clone has finished. While the agent is ready but its workspace-seed is still pending, it now surfaces a preparing_workspace state — an amber pill in the UI that keeps the agent non-clickable — flipping to "Running" once the seed settles, so sessions can't be opened against a half-seeded working directory.

Touches only the git-seeded agents, not local file imports

Closes #695 