### PR TITLE
fix: better import ux

### DIFF
--- a/packages/agent-runtime/src/core/import-staging.ts
+++ b/packages/agent-runtime/src/core/import-staging.ts
@@ -1,0 +1,3 @@
+/** Prefix for the import module's per-request staging dirs under the agent home;
+ *  `import` creates them, `files` hides them, the sweeper reclaims stale ones. */
+export const IMPORT_STAGING_PREFIX = ".import-staging-";

--- a/packages/agent-runtime/src/modules/files.ts
+++ b/packages/agent-runtime/src/modules/files.ts
@@ -20,6 +20,8 @@ import type {
 } from "agent-runtime-api";
 import { err, ok } from "agent-runtime-api";
 
+import { IMPORT_STAGING_PREFIX } from "../core/import-staging.js";
+
 // Wire-level per-file cap for tRPC-shaped reads and uploads. The transport
 // is JSON-base64 — ~10 MB fits well below the 32 MB tRPC body ceiling.
 // Larger transfers want a streaming endpoint, not this surface.
@@ -85,7 +87,11 @@ async function listDir(
   try {
     const ents = await readdir(abs, { withFileTypes: true });
     const entries: DirEntry[] = ents
-      .filter((ent) => !RESERVED.has(ent.name))
+      .filter(
+        (ent) =>
+          !RESERVED.has(ent.name) &&
+          !ent.name.startsWith(IMPORT_STAGING_PREFIX),
+      )
       .map(
         (ent): DirEntry => ({
           name: ent.name,

--- a/packages/agent-runtime/src/modules/import/constants.ts
+++ b/packages/agent-runtime/src/modules/import/constants.ts
@@ -1,7 +1,0 @@
-/**
- * Prefix for per-import staging directories created under the agent's home
- * dir. The HTTP handler (`http.ts`) creates `mkdtemp(homeDir, STAGING_PREFIX)`
- * per request; the boot sweeper (`sweeper.ts`) reclaims stale ones from
- * earlier crashes by matching this prefix — keep the two in sync.
- */
-export const STAGING_PREFIX = ".import-staging-";

--- a/packages/agent-runtime/src/modules/import/http.ts
+++ b/packages/agent-runtime/src/modules/import/http.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import type { ImportBundleResult } from "agent-runtime-api";
 import busboy from "busboy";
 
-import { STAGING_PREFIX } from "./constants.js";
+import { IMPORT_STAGING_PREFIX } from "../../core/import-staging.js";
 import type { ImportDomainError } from "./errors.js";
 import { extractBundle } from "./extract.js";
 import { finalize } from "./finalize.js";
@@ -106,6 +106,9 @@ export function createImportHandlers(
       if (finished) return;
       finished = true;
       log(`fail ${status}: ${message}`);
+      // Let extraction settle before rm — abort paths destroy the socket, so
+      // awaiting here means the tar writer stopped and can't race the cleanup.
+      if (extractPromise) await extractPromise.catch(() => {});
       if (staging)
         await rm(staging, { recursive: true, force: true }).catch(() => {});
       try {
@@ -157,7 +160,7 @@ export function createImportHandlers(
       sawFile = true;
       log(`file part received — extracting`);
       extractPromise = (async () => {
-        staging = await mkdtemp(join(homeDir, STAGING_PREFIX));
+        staging = await mkdtemp(join(homeDir, IMPORT_STAGING_PREFIX));
         log(`staging dir created: ${staging}`);
         const result = await extractBundle(fileStream as never, staging);
         log(`extract complete (ok=${result.ok})`);

--- a/packages/agent-runtime/src/modules/import/sweeper.ts
+++ b/packages/agent-runtime/src/modules/import/sweeper.ts
@@ -1,7 +1,7 @@
 import { readdir, rm, stat } from "node:fs/promises";
 import { join } from "node:path";
 
-import { STAGING_PREFIX } from "./constants.js";
+import { IMPORT_STAGING_PREFIX } from "../../core/import-staging.js";
 
 const MAX_AGE_MS = 60 * 60 * 1000;
 
@@ -25,7 +25,7 @@ export async function sweepStaging(
   }
   const now = Date.now();
   for (const name of entries) {
-    if (!name.startsWith(STAGING_PREFIX)) continue;
+    if (!name.startsWith(IMPORT_STAGING_PREFIX)) continue;
     const abs = join(homeDir, name);
     try {
       const s = await stat(abs);

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -3,7 +3,6 @@ import { useMutation } from "@tanstack/react-query";
 import { api } from "../../../api.js";
 import { emitToast } from "../../../lib/toast.js";
 import { queryClient } from "../../../query-client.js";
-import { useStore } from "../../../store.js";
 import { trpc } from "../../../trpc.js";
 import type { EgressPreset, EnvVar } from "../../../types.js";
 import { egressRulesKeys } from "../../egress-rules/api/queries.js";
@@ -12,6 +11,7 @@ import {
   type BundleEntry,
   importRawBundle,
 } from "../../files/api/import-bundle.js";
+import { trackImport } from "../../files/track-import.js";
 import { agentsKeys } from "./queries.js";
 
 const invalidatesAgentsList = {
@@ -86,16 +86,12 @@ export function useCreateAgent() {
       }
 
       if (preparedBundle) {
-        // The create dialog has already closed, so the in-flight signal must
-        // ride the store keyed on the new agent — that's where its status pill
-        // (list + chat header) reads `useIsImporting`.
-        const { beginImport, endImport } = useStore.getState();
-        beginImport(agent.id);
+        // Dialog has closed; the signal rides the store keyed on the new agent,
+        // where the chat-header pill reads `useIsImporting`.
         try {
-          await importRawBundle({
-            agentId: agent.id,
-            bundle: preparedBundle.blob,
-          });
+          await trackImport(agent.id, () =>
+            importRawBundle({ agentId: agent.id, bundle: preparedBundle.blob }),
+          );
           emitToast({
             kind: "success",
             message: `Imported ${preparedBundle.label} into ${input.name}`,
@@ -105,8 +101,6 @@ export function useCreateAgent() {
             kind: "error",
             message: `Agent created, but import failed: ${err instanceof Error ? err.message : String(err)}`,
           });
-        } finally {
-          endImport(agent.id);
         }
       }
 

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -86,8 +86,6 @@ export function useCreateAgent() {
       }
 
       if (preparedBundle) {
-        // Dialog has closed; the signal rides the store keyed on the new agent,
-        // where the chat-header pill reads `useIsImporting`.
         try {
           await trackImport(agent.id, () =>
             importRawBundle({ agentId: agent.id, bundle: preparedBundle.blob }),

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -3,6 +3,7 @@ import { useMutation } from "@tanstack/react-query";
 import { api } from "../../../api.js";
 import { emitToast } from "../../../lib/toast.js";
 import { queryClient } from "../../../query-client.js";
+import { useStore } from "../../../store.js";
 import { trpc } from "../../../trpc.js";
 import type { EgressPreset, EnvVar } from "../../../types.js";
 import { egressRulesKeys } from "../../egress-rules/api/queries.js";
@@ -85,6 +86,11 @@ export function useCreateAgent() {
       }
 
       if (preparedBundle) {
+        // The create dialog has already closed, so the in-flight signal must
+        // ride the store keyed on the new agent — that's where its status pill
+        // (list + chat header) reads `useIsImporting`.
+        const { beginImport, endImport } = useStore.getState();
+        beginImport(agent.id);
         try {
           await importRawBundle({
             agentId: agent.id,
@@ -99,6 +105,8 @@ export function useCreateAgent() {
             kind: "error",
             message: `Agent created, but import failed: ${err instanceof Error ? err.message : String(err)}`,
           });
+        } finally {
+          endImport(agent.id);
         }
       }
 

--- a/packages/ui/src/modules/files/components/files-panel-controller.ts
+++ b/packages/ui/src/modules/files/components/files-panel-controller.ts
@@ -94,8 +94,14 @@ export function useFilesPanelController({
 
   const rootSnapshot = useDirSnapshot(selectedAgent, "");
 
-  const { createEntry, renameEntry, deleteEntry, uploadFiles, uploadBundle } =
-    useFileMutations(selectedAgent);
+  const {
+    createEntry,
+    renameEntry,
+    deleteEntry,
+    uploadFiles,
+    uploadBundle,
+    isUploading,
+  } = useFileMutations(selectedAgent);
   const { data: openFile, error: openFileError } = useFileContentQuery(
     selectedAgent,
     openFilePath,
@@ -357,6 +363,7 @@ export function useFilesPanelController({
     menu,
     rootIsLoadedEmpty,
     showPanelOverlay,
+    isUploading,
     fileInputRef,
     folderInputRef,
     closeFile,

--- a/packages/ui/src/modules/files/components/files-panel-toolbar.tsx
+++ b/packages/ui/src/modules/files/components/files-panel-toolbar.tsx
@@ -3,12 +3,17 @@ import { FilePlus, FolderPlus, FolderUp, Upload } from "lucide-react";
 import type { FileEntryKind } from "../hooks/use-file-mutations.js";
 
 interface Props {
+  isUploading: boolean;
   onUploadFiles: () => void;
   onUploadFolder: () => void;
   onNew: (kind: FileEntryKind) => void;
 }
 
+const uploadButtonClass =
+  "text-text-muted hover:text-accent p-0.5 rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-muted";
+
 export function FilesPanelToolbar({
+  isUploading,
   onUploadFiles,
   onUploadFolder,
   onNew,
@@ -19,15 +24,17 @@ export function FilesPanelToolbar({
         /home/agent
       </span>
       <button
-        className="text-text-muted hover:text-accent p-0.5 rounded transition-colors"
-        title="Upload files"
+        className={uploadButtonClass}
+        title={isUploading ? "Upload in progress…" : "Upload files"}
+        disabled={isUploading}
         onClick={onUploadFiles}
       >
         <Upload size={13} />
       </button>
       <button
-        className="text-text-muted hover:text-accent p-0.5 rounded transition-colors"
-        title="Upload folder"
+        className={uploadButtonClass}
+        title={isUploading ? "Upload in progress…" : "Upload folder"}
+        disabled={isUploading}
         onClick={onUploadFolder}
       >
         <FolderUp size={13} />

--- a/packages/ui/src/modules/files/components/files-panel.tsx
+++ b/packages/ui/src/modules/files/components/files-panel.tsx
@@ -51,6 +51,7 @@ export function FilesPanel({
         onChange={controller.handleFolderInputChange}
       />
       <FilesPanelToolbar
+        isUploading={controller.isUploading}
         onUploadFiles={() => controller.openFilePickerFor("")}
         onUploadFolder={controller.openFolderPicker}
         onNew={(kind) => controller.startNewIn(kind, "")}

--- a/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
+++ b/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
@@ -1,14 +1,13 @@
 import { StatusBadge } from "../../../components/status-indicator.js";
 import { useIsImporting } from "../hooks/use-is-importing.js";
 
-/** Active indicator: a file upload/import is in flight for this agent. */
-export function ImportInProgressBadge({
-  agentId,
-  size = "md",
-}: {
+interface Props {
   agentId: string | null;
   size?: "sm" | "md";
-}) {
+}
+
+/** Active indicator: a file upload/import is in flight for this agent. */
+export function ImportInProgressBadge({ agentId, size = "md" }: Props) {
   const importing = useIsImporting(agentId);
   if (!importing) return null;
   return (

--- a/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
+++ b/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
@@ -1,0 +1,24 @@
+import { StatusBadge } from "../../../components/status-indicator.js";
+import { useIsImporting } from "../hooks/use-is-importing.js";
+
+/** Active indicator: a file upload/import is in flight for this agent. */
+export function ImportInProgressBadge({
+  agentId,
+  size = "md",
+}: {
+  agentId: string | null;
+  size?: "sm" | "md";
+}) {
+  const importing = useIsImporting(agentId);
+  if (!importing) return null;
+  return (
+    <span title="Importing files into the agent">
+      <StatusBadge
+        size={size}
+        label="Importing…"
+        colorClasses="bg-accent-light text-accent border-accent"
+        dotColorClasses="bg-accent anim-pulse"
+      />
+    </span>
+  );
+}

--- a/packages/ui/src/modules/files/hooks/use-file-mutations.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-mutations.ts
@@ -11,6 +11,7 @@ import {
   useFileUploadMutation,
   useFolderCreateMutation,
 } from "../api/queries.js";
+import { trackImport } from "../track-import.js";
 import { useIsImporting } from "./use-is-importing.js";
 
 export type FileEntryKind = "file" | "dir";
@@ -70,8 +71,6 @@ export function useFileMutations(agentId: string | null) {
   const deleteMutation = useFileDeleteMutation(agentId);
   const uploadMutation = useFileUploadMutation(agentId);
 
-  const beginImport = useStore((s) => s.beginImport);
-  const endImport = useStore((s) => s.endImport);
   const isUploading = useIsImporting(agentId);
 
   const createEntry = useCallback(
@@ -182,7 +181,6 @@ export function useFileMutations(agentId: string | null) {
     async (files: FileList | File[], targetDir?: string) => {
       const list = Array.from(files);
       if (list.length === 0) return;
-      if (agentId) beginImport(agentId);
       const dir = (targetDir ?? "").replace(/^\/+|\/+$/g, "");
       const prefix = dir ? `${dir}/` : "";
 
@@ -215,7 +213,7 @@ export function useFileMutations(agentId: string | null) {
         }
       };
 
-      try {
+      await trackImport(agentId, async () => {
         for (const file of list) {
           if (file.size > MAX_UPLOAD_BYTES) {
             emitToast({
@@ -240,19 +238,16 @@ export function useFileMutations(agentId: string | null) {
             });
           }
         }
-      } finally {
-        if (agentId) endImport(agentId);
-      }
+      });
     },
-    [uploadMutation, showConfirm, agentId, beginImport, endImport],
+    [uploadMutation, showConfirm, agentId],
   );
 
   const uploadBundle = useCallback(
     async (entries: BundleEntry[]) => {
       if (!agentId || entries.length === 0) return;
-      beginImport(agentId);
       try {
-        await importBundle({ agentId, entries });
+        await trackImport(agentId, () => importBundle({ agentId, entries }));
         emitToast({
           kind: "success",
           message: `Imported ${entries.length} file${entries.length === 1 ? "" : "s"}`,
@@ -262,11 +257,9 @@ export function useFileMutations(agentId: string | null) {
           kind: "error",
           message: errorMessage(err, "Import failed"),
         });
-      } finally {
-        endImport(agentId);
       }
     },
-    [agentId, beginImport, endImport],
+    [agentId],
   );
 
   return {

--- a/packages/ui/src/modules/files/hooks/use-file-mutations.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-mutations.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
@@ -11,6 +11,7 @@ import {
   useFileUploadMutation,
   useFolderCreateMutation,
 } from "../api/queries.js";
+import { useIsImporting } from "./use-is-importing.js";
 
 export type FileEntryKind = "file" | "dir";
 
@@ -69,9 +70,9 @@ export function useFileMutations(agentId: string | null) {
   const deleteMutation = useFileDeleteMutation(agentId);
   const uploadMutation = useFileUploadMutation(agentId);
 
-  // Counter, not a boolean: a folder pick and a drag-drop can overlap, and we
-  // must stay "uploading" until the last one settles.
-  const [pendingUploads, setPendingUploads] = useState(0);
+  const beginImport = useStore((s) => s.beginImport);
+  const endImport = useStore((s) => s.endImport);
+  const isUploading = useIsImporting(agentId);
 
   const createEntry = useCallback(
     async ({ kind, dir, name }: CreateEntryInput) => {
@@ -181,7 +182,7 @@ export function useFileMutations(agentId: string | null) {
     async (files: FileList | File[], targetDir?: string) => {
       const list = Array.from(files);
       if (list.length === 0) return;
-      setPendingUploads((n) => n + 1);
+      if (agentId) beginImport(agentId);
       const dir = (targetDir ?? "").replace(/^\/+|\/+$/g, "");
       const prefix = dir ? `${dir}/` : "";
 
@@ -240,16 +241,16 @@ export function useFileMutations(agentId: string | null) {
           }
         }
       } finally {
-        setPendingUploads((n) => n - 1);
+        if (agentId) endImport(agentId);
       }
     },
-    [uploadMutation, showConfirm],
+    [uploadMutation, showConfirm, agentId, beginImport, endImport],
   );
 
   const uploadBundle = useCallback(
     async (entries: BundleEntry[]) => {
       if (!agentId || entries.length === 0) return;
-      setPendingUploads((n) => n + 1);
+      beginImport(agentId);
       try {
         await importBundle({ agentId, entries });
         emitToast({
@@ -262,10 +263,10 @@ export function useFileMutations(agentId: string | null) {
           message: errorMessage(err, "Import failed"),
         });
       } finally {
-        setPendingUploads((n) => n - 1);
+        endImport(agentId);
       }
     },
-    [agentId],
+    [agentId, beginImport, endImport],
   );
 
   return {
@@ -274,6 +275,6 @@ export function useFileMutations(agentId: string | null) {
     deleteEntry,
     uploadFiles,
     uploadBundle,
-    isUploading: pendingUploads > 0,
+    isUploading,
   };
 }

--- a/packages/ui/src/modules/files/hooks/use-file-mutations.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-mutations.ts
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
@@ -68,6 +68,10 @@ export function useFileMutations(agentId: string | null) {
   const renameMutation = useFileRenameMutation(agentId);
   const deleteMutation = useFileDeleteMutation(agentId);
   const uploadMutation = useFileUploadMutation(agentId);
+
+  // Counter, not a boolean: a folder pick and a drag-drop can overlap, and we
+  // must stay "uploading" until the last one settles.
+  const [pendingUploads, setPendingUploads] = useState(0);
 
   const createEntry = useCallback(
     async ({ kind, dir, name }: CreateEntryInput) => {
@@ -177,6 +181,7 @@ export function useFileMutations(agentId: string | null) {
     async (files: FileList | File[], targetDir?: string) => {
       const list = Array.from(files);
       if (list.length === 0) return;
+      setPendingUploads((n) => n + 1);
       const dir = (targetDir ?? "").replace(/^\/+|\/+$/g, "");
       const prefix = dir ? `${dir}/` : "";
 
@@ -209,29 +214,33 @@ export function useFileMutations(agentId: string | null) {
         }
       };
 
-      for (const file of list) {
-        if (file.size > MAX_UPLOAD_BYTES) {
-          emitToast({
-            kind: "error",
-            message: `${file.name} exceeds 10 MB — skipped`,
-          });
-          continue;
+      try {
+        for (const file of list) {
+          if (file.size > MAX_UPLOAD_BYTES) {
+            emitToast({
+              kind: "error",
+              message: `${file.name} exceeds 10 MB — skipped`,
+            });
+            continue;
+          }
+          const safe = sanitizeUploadName(file.name);
+          if (!safe) continue;
+          const path = `${prefix}${safe}`;
+          try {
+            const contentBase64 = await fileToBase64(file);
+            const contentType = file.type || undefined;
+            const written = await uploadOne(path, contentBase64, contentType);
+            if (written)
+              emitToast({ kind: "success", message: `Uploaded ${path}` });
+          } catch (err) {
+            emitToast({
+              kind: "error",
+              message: errorMessage(err, `Upload failed: ${path}`),
+            });
+          }
         }
-        const safe = sanitizeUploadName(file.name);
-        if (!safe) continue;
-        const path = `${prefix}${safe}`;
-        try {
-          const contentBase64 = await fileToBase64(file);
-          const contentType = file.type || undefined;
-          const written = await uploadOne(path, contentBase64, contentType);
-          if (written)
-            emitToast({ kind: "success", message: `Uploaded ${path}` });
-        } catch (err) {
-          emitToast({
-            kind: "error",
-            message: errorMessage(err, `Upload failed: ${path}`),
-          });
-        }
+      } finally {
+        setPendingUploads((n) => n - 1);
       }
     },
     [uploadMutation, showConfirm],
@@ -240,6 +249,7 @@ export function useFileMutations(agentId: string | null) {
   const uploadBundle = useCallback(
     async (entries: BundleEntry[]) => {
       if (!agentId || entries.length === 0) return;
+      setPendingUploads((n) => n + 1);
       try {
         await importBundle({ agentId, entries });
         emitToast({
@@ -251,6 +261,8 @@ export function useFileMutations(agentId: string | null) {
           kind: "error",
           message: errorMessage(err, "Import failed"),
         });
+      } finally {
+        setPendingUploads((n) => n - 1);
       }
     },
     [agentId],
@@ -262,5 +274,6 @@ export function useFileMutations(agentId: string | null) {
     deleteEntry,
     uploadFiles,
     uploadBundle,
+    isUploading: pendingUploads > 0,
   };
 }

--- a/packages/ui/src/modules/files/hooks/use-is-importing.ts
+++ b/packages/ui/src/modules/files/hooks/use-is-importing.ts
@@ -1,0 +1,8 @@
+import { useStore } from "../../../store.js";
+
+/** True while one or more uploads/imports are in flight for this agent. */
+export function useIsImporting(agentId: string | null): boolean {
+  return useStore((s) =>
+    agentId ? (s.importingAgents[agentId] ?? 0) > 0 : false,
+  );
+}

--- a/packages/ui/src/modules/files/store.ts
+++ b/packages/ui/src/modules/files/store.ts
@@ -14,10 +14,7 @@ export interface FilesSlice {
    *  the tree-click handler can prompt before discarding. */
   openFileDirty: boolean;
   expandedDirs: Record<string, Set<string>>;
-  /** In-flight upload/import count per agent id. A count, not a boolean: a
-   *  folder pick and a drag-drop can overlap, and the agent stays "importing"
-   *  until the last one settles. Shared so the status pill — in a different
-   *  subtree from the files panel — can badge it. */
+  /** In-flight import count per agent; count not bool so overlapping uploads compose. */
   importingAgents: Record<string, number>;
   setOpenFilePath: (path: string | null) => void;
   setRightTab: (tab: RightTab) => void;

--- a/packages/ui/src/modules/files/store.ts
+++ b/packages/ui/src/modules/files/store.ts
@@ -14,12 +14,19 @@ export interface FilesSlice {
    *  the tree-click handler can prompt before discarding. */
   openFileDirty: boolean;
   expandedDirs: Record<string, Set<string>>;
+  /** In-flight upload/import count per agent id. A count, not a boolean: a
+   *  folder pick and a drag-drop can overlap, and the agent stays "importing"
+   *  until the last one settles. Shared so the status pill — in a different
+   *  subtree from the files panel — can badge it. */
+  importingAgents: Record<string, number>;
   setOpenFilePath: (path: string | null) => void;
   setRightTab: (tab: RightTab) => void;
   setOpenFileDirty: (dirty: boolean) => void;
   toggleExpandedDir: (agentId: string, path: string) => void;
   pruneExpandedDir: (agentId: string, path: string) => void;
   renameExpandedDir: (agentId: string, from: string, to: string) => void;
+  beginImport: (agentId: string) => void;
+  endImport: (agentId: string) => void;
 }
 
 /** Drop `prefix` and every path nested under it. Collapsing a parent must
@@ -60,6 +67,7 @@ export const createFilesSlice: StateCreator<
   rightTab: "files",
   openFileDirty: false,
   expandedDirs: {},
+  importingAgents: {},
   setOpenFilePath: (path) => set({ openFilePath: path, openFileDirty: false }),
   setRightTab: (tab) => set({ rightTab: tab }),
   setOpenFileDirty: (dirty) => set({ openFileDirty: dirty }),
@@ -94,6 +102,23 @@ export const createFilesSlice: StateCreator<
           [agentId]: rewritePrefix(current, from, to),
         },
       };
+    });
+  },
+  beginImport: (agentId) => {
+    set((state) => ({
+      importingAgents: {
+        ...state.importingAgents,
+        [agentId]: (state.importingAgents[agentId] ?? 0) + 1,
+      },
+    }));
+  },
+  endImport: (agentId) => {
+    set((state) => {
+      const next = (state.importingAgents[agentId] ?? 0) - 1;
+      const importingAgents = { ...state.importingAgents };
+      if (next > 0) importingAgents[agentId] = next;
+      else delete importingAgents[agentId];
+      return { importingAgents };
     });
   },
 });

--- a/packages/ui/src/modules/files/track-import.ts
+++ b/packages/ui/src/modules/files/track-import.ts
@@ -1,0 +1,16 @@
+import { useStore } from "../../store.js";
+
+/** Run `fn` while the agent reads as importing; balances begin/end on throw, no-ops when agentId is null. */
+export async function trackImport<T>(
+  agentId: string | null,
+  fn: () => Promise<T>,
+): Promise<T> {
+  if (!agentId) return fn();
+  const { beginImport, endImport } = useStore.getState();
+  beginImport(agentId);
+  try {
+    return await fn();
+  } finally {
+    endImport(agentId);
+  }
+}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -26,6 +26,7 @@ import type { AgentView } from "../../../types.js";
 import { useAgents } from "../../agents/api/queries.js";
 import { ContributionFailuresBadge } from "../../agents/components/contribution-failures-badge.js";
 import { FilesPanel } from "../../files/components/files-panel.js";
+import { ImportInProgressBadge } from "../../files/components/import-in-progress-badge.js";
 import { useFileTree } from "../../files/hooks/use-file-tree.js";
 import { prefetchSchedules } from "../../schedules/api/queries.js";
 import { setSessionMode as applySessionMode } from "../api/acp-session-ops.js";
@@ -640,6 +641,7 @@ function ChatHeaderStatus({
   return (
     <>
       <StatusBadge size="sm" state={agent?.state ?? "starting"} />
+      <ImportInProgressBadge size="sm" agentId={selectedAgent} />
       {agent && (
         <ContributionFailuresBadge
           size="sm"

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -629,12 +629,15 @@ function ChatHeaderStatus({
 }) {
   if (busy) {
     return (
-      <StatusBadge
-        size="sm"
-        label="Busy"
-        colorClasses="bg-accent-light text-accent border-accent"
-        dotColorClasses="bg-accent anim-pulse"
-      />
+      <>
+        <StatusBadge
+          size="sm"
+          label="Busy"
+          colorClasses="bg-accent-light text-accent border-accent"
+          dotColorClasses="bg-accent anim-pulse"
+        />
+        <ImportInProgressBadge size="sm" agentId={selectedAgent} />
+      </>
     );
   }
   const agent = agents.find((a) => a.id === selectedAgent);


### PR DESCRIPTION
- **Disabled the Files-panel upload buttons while an upload is in-flight** — the toolbar's *Upload files* / *Upload folder* buttons go disabled (with a "Upload in progress…" title) so you can't fire overlapping imports.

- **Fixed a staging-dir leak race + hid the staging dirs** — in agent-runtime, the abort path (`fail()`) now awaits the in-flight extraction before `rm`-ing the staging dir, so the tar writer can't recreate it mid-cleanup; the `.import-staging-*` dirs are also filtered out of the file listing. The shared prefix constant was relocated to `core/import-staging.ts` (shared kernel) so `import`, `files`, and the sweeper reference one source without crossing module boundaries.

- **Added an "Importing…" status pill** — a per-agent in-flight counter in the Zustand files store (`importingAgents`, via `beginImport`/`endImport`), surfaced as a badge next to the status pill in the **agent-detail chat header only** (not the agent list), with a hover tooltip "Importing files into the agent". Wired for both the toolbar/drag upload path and the import-at-create path.

Closes #701