### PR TITLE
feat(helm): support external managed database connections

### DIFF
--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -174,21 +174,35 @@ API Server database host — uses external host if set, otherwise shared postgre
 {{- end }}
 
 {{/*
+API Server secrets name — chart-managed Secret holding the external DB password
+*/}}
+{{- define "platform.apiserver.secrets.fullname" -}}
+{{- printf "%s-apiserver-secrets" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 API Server database password secret name — uses shared postgres secret when db.password is empty
 */}}
 {{- define "platform.apiserver.db.password.secretName" -}}
 {{- if .Values.apiServer.db.password }}
-{{- printf "%s-apiserver-secrets" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- include "platform.apiserver.secrets.fullname" . }}
 {{- else }}
 {{- include "platform.postgres.secrets.fullname" . }}
 {{- end }}
 {{- end }}
 
 {{/*
-API Server PostgreSQL DSN
+API Server PostgreSQL DSN. When db.sslmode is set the connection is encrypted.
+A custom CA (db.caCert) reaches the api-server via DATABASE_CA_CERT_PATH (the DB
+client passes it as `ssl.ca`), not the DSN, because postgres-js does not read
+sslrootcert from the connection string.
 */}}
 {{- define "platform.apiserver.postgres.dsn" -}}
-{{- printf "postgresql://%s:$(POSTGRES_PASSWORD)@%s:%v/%s" .Values.apiServer.db.user (include "platform.apiserver.db.host" .) (int .Values.apiServer.db.port) .Values.apiServer.db.database }}
+{{- $dsn := printf "postgresql://%s:$(POSTGRES_PASSWORD)@%s:%v/%s" .Values.apiServer.db.user (include "platform.apiserver.db.host" .) (int .Values.apiServer.db.port) .Values.apiServer.db.database -}}
+{{- if .Values.apiServer.db.sslmode -}}
+{{- $dsn = printf "%s?sslmode=%s" $dsn .Values.apiServer.db.sslmode -}}
+{{- end -}}
+{{- $dsn -}}
 {{- end }}
 
 {{/*
@@ -237,10 +251,19 @@ Keycloak database password secret name — uses shared postgres secret when db.p
 {{- end }}
 
 {{/*
-Keycloak JDBC URL
+Keycloak JDBC URL. When db.sslmode is set the connection is encrypted; a custom
+CA (db.caCert) is trusted by pointing sslrootcert at the mounted CA file, which
+the PostgreSQL JDBC driver reads.
 */}}
 {{- define "platform.keycloak.db.url" -}}
-{{- printf "jdbc:postgresql://%s:%v/%s" (include "platform.keycloak.db.host" .) (int .Values.keycloak.db.port) .Values.keycloak.db.database }}
+{{- $url := printf "jdbc:postgresql://%s:%v/%s" (include "platform.keycloak.db.host" .) (int .Values.keycloak.db.port) .Values.keycloak.db.database -}}
+{{- if .Values.keycloak.db.sslmode -}}
+{{- $url = printf "%s?sslmode=%s" $url .Values.keycloak.db.sslmode -}}
+{{- if .Values.keycloak.db.caCert -}}
+{{- $url = printf "%s&sslrootcert=%s" $url "/etc/keycloak/pg-ca/ca.crt" -}}
+{{- end -}}
+{{- end -}}
+{{- $url -}}
 {{- end }}
 
 {{/* ---- Platform resources ---- */}}

--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -121,6 +121,13 @@ spec:
                   key: POSTGRES_PASSWORD
             - name: DATABASE_URL
               value: {{ include "platform.apiserver.postgres.dsn" . | quote }}
+            {{- if .Values.apiServer.db.caCert }}
+            # Verify the external DB's TLS cert against this CA (sslmode=verify-*).
+            # The api-server passes it as the DB client's `ssl.ca`, scoping trust
+            # to the database connection rather than the whole process.
+            - name: DATABASE_CA_CERT_PATH
+              value: /etc/platform/pg-ca/ca.crt
+            {{- end }}
             - name: NAMESPACE
               value: {{ .Values.agentNamespace | quote }}
             # ADR-041: api-server parses agent ID out of the per-agent
@@ -312,6 +319,11 @@ spec:
             - name: agent-templates
               mountPath: /etc/platform/agent-templates
               readOnly: true
+            {{- if .Values.apiServer.db.caCert }}
+            - name: pg-ca
+              mountPath: /etc/platform/pg-ca
+              readOnly: true
+            {{- end }}
           {{- if .Values.probes.enabled }}
           readinessProbe:
             httpGet:
@@ -341,3 +353,8 @@ spec:
         - name: git-repos
           configMap:
             name: {{ include "platform.fullname" . }}-git-repos
+        {{- if .Values.apiServer.db.caCert }}
+        - name: pg-ca
+          configMap:
+            name: {{ include "platform.fullname" . }}-apiserver-db-ca
+        {{- end }}

--- a/deploy/helm/platform/templates/apiserver/db-ca.yaml
+++ b/deploy/helm/platform/templates/apiserver/db-ca.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.apiServer.db.caCert }}
+{{- /* CA certificate for verifying an external DB's TLS cert. Mounted into the
+       api-server pod; DATABASE_CA_CERT_PATH points the DB client at it so the CA
+       is passed as the client's `ssl.ca` (trust scoped to the DB connection). */ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "platform.fullname" . }}-apiserver-db-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+data:
+  ca.crt: |
+    {{- .Values.apiServer.db.caCert | nindent 4 }}
+{{- end }}

--- a/deploy/helm/platform/templates/apiserver/db-secret.yaml
+++ b/deploy/helm/platform/templates/apiserver/db-secret.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.apiServer.db.password }}
+{{- /* External-DB password Secret. The in-cluster postgres password is
+       chart-generated (postgres-secrets.yaml, gated on postgres.enabled); for an
+       external DB the operator supplies apiServer.db.password and the chart
+       materialises it here so the api-server's POSTGRES_PASSWORD secretKeyRef
+       resolves. Operator-supplied, so no generate-and-persist lookup is needed. */ -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "platform.apiserver.secrets.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+type: Opaque
+data:
+  POSTGRES_PASSWORD: {{ .Values.apiServer.db.password | b64enc | quote }}
+{{- end }}

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -122,6 +122,11 @@ spec:
           volumeMounts:
             - name: gzip-cache
               mountPath: /opt/keycloak/data/tmp
+            {{- if .Values.keycloak.db.caCert }}
+            - name: pg-ca
+              mountPath: /etc/keycloak/pg-ca
+              readOnly: true
+            {{- end }}
       volumes:
         # Keycloak 26.6/26.6.1 ship /opt/keycloak/data/tmp root-owned and not
         # group-writable (0755), so under a non-root UID — i.e. OpenShift's
@@ -134,4 +139,9 @@ spec:
         # Keycloak >= 26.7.0, which fixes the perms upstream (keycloak#48608).
         - name: gzip-cache
           emptyDir: {}
+        {{- if .Values.keycloak.db.caCert }}
+        - name: pg-ca
+          configMap:
+            name: {{ include "platform.fullname" . }}-keycloak-db-ca
+        {{- end }}
 {{- end }}

--- a/deploy/helm/platform/templates/keycloak/db-ca.yaml
+++ b/deploy/helm/platform/templates/keycloak/db-ca.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.keycloak.enabled .Values.keycloak.db.caCert }}
+{{- /* CA certificate for verifying an external DB's TLS cert. Mounted into the
+       Keycloak pod; the JDBC URL's sslrootcert points at this file, which the
+       PostgreSQL JDBC driver reads for verify-ca/verify-full. */ -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "platform.fullname" . }}-keycloak-db-ca
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+data:
+  ca.crt: |
+    {{- .Values.keycloak.db.caCert | nindent 4 }}
+{{- end }}

--- a/deploy/helm/platform/templates/keycloak/secrets.yaml
+++ b/deploy/helm/platform/templates/keycloak/secrets.yaml
@@ -31,7 +31,14 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
 type: Opaque
+{{- /* When keycloak.db.password is set (external DB), the KC_DB_PASSWORD
+       secretKeyRef resolves to POSTGRES_PASSWORD here — see
+       platform.keycloak.db.password.secretName. The in-cluster postgres password
+       lives in postgres-secrets instead. */}}
 data:
   KEYCLOAK_ADMIN_PASSWORD: {{ $adminPassword | b64enc | quote }}
   PLATFORM_API_CLIENT_SECRET: {{ $apiClientSecret | b64enc | quote }}
+  {{- if .Values.keycloak.db.password }}
+  POSTGRES_PASSWORD: {{ .Values.keycloak.db.password | b64enc | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -268,6 +268,12 @@ keycloak:
     user: platform
     password: null
     database: keycloak
+    # Postgres TLS mode for an external DB: require | verify-ca | verify-full.
+    # null = no TLS (the in-cluster postgres). verify-ca/verify-full need caCert.
+    sslmode: null
+    # CA certificate (PEM) used to verify the external DB's TLS certificate.
+    # Required for sslmode verify-ca/verify-full when the DB presents a private CA.
+    caCert: ""
 
   resources:
     requests:
@@ -498,6 +504,12 @@ apiServer:
     user: platform
     password: null
     database: platform
+    # Postgres TLS mode for an external DB: require | verify-ca | verify-full.
+    # null = no TLS (the in-cluster postgres). verify-ca/verify-full need caCert.
+    sslmode: null
+    # CA certificate (PEM) used to verify the external DB's TLS certificate.
+    # Required for sslmode verify-ca/verify-full when the DB presents a private CA.
+    caCert: ""
   resources:
     requests:
       cpu: 100m

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -42,6 +42,11 @@ const configSchema = z.object({
    *  TLS-terminated chains) and network filter (L4, catch-all). */
   extAuthzPort: z.coerce.number().default(4002),
   databaseUrl: z.string(),
+  /** Filesystem path to a PEM CA cert for verifying the database's TLS
+   *  certificate (external managed DB with a private CA). Trust is scoped to
+   *  the DB connection — the client passes it as `ssl.ca`. The Helm chart
+   *  mounts the CA and sets this; unset means no custom CA. */
+  databaseCaCertPath: z.string().optional(),
   migrationsPath: z.string().default("./packages/db/drizzle"),
   slackBotToken: z.string().nullable().default(null),
   slackAppToken: z.string().nullable().default(null),
@@ -157,6 +162,7 @@ export function loadConfig(): Config {
     harnessServerUrl: process.env.PLATFORM_HARNESS_SERVER_URL,
     extAuthzPort: process.env.EXT_AUTHZ_PORT,
     databaseUrl: process.env.DATABASE_URL,
+    databaseCaCertPath: process.env.DATABASE_CA_CERT_PATH,
     migrationsPath: process.env.MIGRATIONS_PATH,
     slackBotToken: process.env.SLACK_BOT_TOKEN,
     slackAppToken: process.env.SLACK_APP_TOKEN,

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { createDb, runMigrations } from "db";
 import { createApi } from "./modules/agents/infrastructure/k8s.js";
 import {
@@ -95,8 +96,13 @@ const config = loadConfig();
 configureLogger({ level: config.logLevel });
 
 const { api, customObjects } = createApi(config.namespace);
-await runMigrations(config.databaseUrl, config.migrationsPath);
-const { db, sql } = createDb(config.databaseUrl);
+const dbTls = {
+  ca: config.databaseCaCertPath
+    ? readFileSync(config.databaseCaCertPath, "utf8")
+    : undefined,
+};
+await runMigrations(config.databaseUrl, config.migrationsPath, dbTls);
+const { db, sql } = createDb(config.databaseUrl, dbTls);
 
 if (!config.redisUrl)
   throw new Error(
@@ -223,8 +229,14 @@ const slackOauthCallbackUrl =
   `${config.uiBaseUrl}/api/slack/oauth/callback`;
 const telegramOauthCallbackUrl = `${config.uiBaseUrl}/api/telegram/oauth/callback`;
 
+// The chat-sdk state pool uses node-postgres (`pg`), which — unlike postgres-js
+// — reads a CA file from `sslrootcert` in the connection string. Append it so
+// the pool verifies against the same scoped CA; trust stays on this connection.
+const chatSdkDatabaseUrl = config.databaseCaCertPath
+  ? `${config.databaseUrl}${config.databaseUrl.includes("?") ? "&" : "?"}sslrootcert=${config.databaseCaCertPath}`
+  : config.databaseUrl;
 const chatSdkState = config.telegramEnabled
-  ? createPostgresState({ url: config.databaseUrl, keyPrefix: "chat-sdk" })
+  ? createPostgresState({ url: chatSdkDatabaseUrl, keyPrefix: "chat-sdk" })
   : undefined;
 
 const channelRegistry: ChannelRegistry = {

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -2,8 +2,25 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema.js";
 
-export function createDb(url: string) {
-  const sql = postgres(url);
+export interface DbTlsOptions {
+  /** PEM CA certificate used to verify the server's TLS certificate (an
+   *  external managed DB with a private CA). When set, it is passed as the
+   *  client's `ssl` option, scoping trust to this DB connection rather than the
+   *  process-global Node trust store. Unset means the connection string's
+   *  sslmode governs (system CAs / plaintext). */
+  ca?: string | undefined;
+}
+
+/** postgres-js `ssl` value for a custom CA, or undefined to let the connection
+ *  string's sslmode govern. postgres-js cannot read a CA from the DSN, so it
+ *  must come through here. */
+export function buildDbSsl(tls?: DbTlsOptions): { ca: string } | undefined {
+  return tls?.ca ? { ca: tls.ca } : undefined;
+}
+
+export function createDb(url: string, tls?: DbTlsOptions) {
+  const ssl = buildDbSsl(tls);
+  const sql = postgres(url, ssl ? { ssl } : {});
   return { db: drizzle(sql, { schema }), sql };
 }
 

--- a/packages/db/src/migrate.ts
+++ b/packages/db/src/migrate.ts
@@ -1,12 +1,15 @@
 import { drizzle } from "drizzle-orm/postgres-js";
 import { migrate } from "drizzle-orm/postgres-js/migrator";
 import postgres from "postgres";
+import { buildDbSsl, type DbTlsOptions } from "./client.js";
 
 export async function runMigrations(
   url: string,
   migrationsFolder: string,
+  tls?: DbTlsOptions,
 ): Promise<void> {
-  const sql = postgres(url, { max: 1 });
+  const ssl = buildDbSsl(tls);
+  const sql = postgres(url, ssl ? { max: 1, ssl } : { max: 1 });
   const db = drizzle(sql);
   await migrate(db, { migrationsFolder });
   await sql.end();


### PR DESCRIPTION
Closes #724.

The chart can be pointed at an external, managed PostgreSQL database (`postgres.enabled: false` + per-service `db.host`), but that path did not work end to end. This completes it for both the api-server and Keycloak.

## What was broken / missing

- **The DB password never reached the services.** When `apiServer.db.password` was set, the api-server's `POSTGRES_PASSWORD` `secretKeyRef` pointed at a `…-apiserver-secrets` Secret that **no template ever created** → references a non-existent Secret → pod can't start. Keycloak's `KC_DB_PASSWORD` pointed at `…-keycloak-secrets`, which exists but had **no `POSTGRES_PASSWORD` key** → missing key → pod can't start. The only working DB-password Secret was gated on the bundled in-cluster postgres — exactly what you disable for an external DB.
- **TLS couldn't be expressed.** No way to enable an encrypted connection or supply the DB's CA, which managed providers typically require.

## Changes

**Credentials**
- New `templates/apiserver/db-secret.yaml` renders `…-apiserver-secrets` (`POSTGRES_PASSWORD`) when `apiServer.db.password` is set.
- `templates/keycloak/secrets.yaml` adds a `POSTGRES_PASSWORD` key when `keycloak.db.password` is set.
- New `platform.apiserver.secrets.fullname` helper keeps the Secret name in one place.

**TLS**
- `apiServer.db.sslmode` / `keycloak.db.sslmode` append `?sslmode=…` to the connection strings.
- `apiServer.db.caCert` / `keycloak.db.caCert` hold the operator-supplied CA PEM, rendered into `db-ca.yaml` ConfigMaps and mounted into each pod.

**How the CA is trusted (scoped, not process-global)**
- **api-server (postgres-js):** postgres-js can't read a CA from the connection string, so the CA is passed as the client's `ssl: { ca }`. The chart mounts the CA and sets `DATABASE_CA_CERT_PATH`; the api-server reads it and hands the PEM to `createDb` / `runMigrations`. Trust is scoped to the DB connection rather than the whole process (no `NODE_EXTRA_CA_CERTS`).
- **chat-sdk pool (`pg`, only when Telegram is enabled):** `pg` reads `sslrootcert` from the connection string natively, so its URL gets the mounted CA path appended — same scoped result, no extra direct dependency.
- **Keycloak (PG JDBC):** the JDBC URL's `sslrootcert` points at the mounted CA, which the driver reads.

The `db` package takes the CA as PEM content (no filesystem I/O); the api-server does the file read.

## Compatibility

Every knob is opt-in and null/empty by default. The bundled in-cluster postgres path is unchanged. If the managed provider uses a publicly-trusted CA, `sslmode` alone validates against the system bundle and `caCert` stays empty.

## Verification

- `mise run helm:check:lint` ✅, `mise run helm:check:render` ✅; `db` + `api-server` `tsc` / `eslint` / `prettier` ✅.
- Rendered an external-DB + TLS values set: both password Secrets, `?sslmode=verify-full` on both connection strings, `sslrootcert` on the JDBC URL, `DATABASE_CA_CERT_PATH` (no `NODE_EXTRA_CA_CERTS`), the CA ConfigMaps, and the `pg-ca` mounts/volumes on both pods; `secretKeyRef`s resolve to the new secrets.
- Regression-checked the default render: zero occurrences of `sslmode`, `DATABASE_CA_CERT_PATH`, `NODE_EXTRA_CA_CERTS`, `pg-ca`, `apiserver-secrets`, or `db-ca`; connection strings and password sources unchanged.