### PR TITLE
Update LiteLLM ETE default models configuration

### DIFF
--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -84,11 +84,11 @@ export interface IbmLitellmModelPins {
 }
 
 export const IBM_LITELLM_DEFAULT_MODEL_PINS: IbmLitellmModelPins = {
-  opus: "aws/claude-opus-4-6",
+  opus: "aws/claude-opus-4-8",
   sonnet: "aws/claude-sonnet-4-6",
-  haiku: "aws/claude-haiku-4-5",
-  subagent: "aws/claude-opus-4-6",
-  default: "aws/claude-opus-4-6",
+  haiku: "aws/claude-sonnet-4-6",
+  subagent: "aws/claude-opus-4-8",
+  default: "aws/claude-opus-4-8",
   openaiModel: "gpt-5.5",
 };
 


### PR DESCRIPTION
## Summary

Updates the LiteLLM ETE default model pins in `IBM_LITELLM_DEFAULT_MODEL_PINS`.

| Pin | Before | After |
| --- | --- | --- |
| `opus` | `aws/claude-opus-4-6` | `aws/claude-opus-4-8` |
| `haiku` | `aws/claude-haiku-4-5` | `aws/claude-sonnet-4-6` |
| `subagent` | `aws/claude-opus-4-6` | `aws/claude-opus-4-8` |
| `default` | `aws/claude-opus-4-6` | `aws/claude-opus-4-8` |

`sonnet` (`aws/claude-sonnet-4-6`) and `openaiModel` (`gpt-5.5`) are unchanged.

## Test plan

- [ ] CI lint + type-check