### PR TITLE
feat: surface platform app version

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -140,6 +140,8 @@ spec:
               value: {{ .Values.apiServer.extAuthzPort | quote }}
             - name: UI_BASE_URL
               value: {{ include "platform.url.ui" . | quote }}
+            - name: PLATFORM_APP_VERSION
+              value: {{ .Chart.AppVersion | quote }}
             {{- if .Values.apiServer.minClientCliVersion }}
             - name: MIN_CLIENT_CLI_VERSION
               value: {{ .Values.apiServer.minClientCliVersion | quote }}

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -226,6 +226,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       ...(config.minClientCliVersion !== undefined && {
         minClientVersion: config.minClientCliVersion,
       }),
+      appVersion: config.appVersion,
     }),
   );
   app.get("/api/auth/config", (c) =>

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -20,6 +20,7 @@ const configSchema = z.object({
    *  Bundled into `dist/index.js` by tsup at build time; in dev (tsx) it
    *  resolves at module import. Surfaced on `GET /api/version`. */
   serverVersion: z.string().min(1),
+  appVersion: z.string().min(1),
   namespace: z.string().default("platform-agents"),
   /** Helm release name. ADR-041: required at startup — used to parse
    *  instance ID out of the per-instance ext-authz Service hostname
@@ -149,6 +150,7 @@ export type Config = z.infer<typeof configSchema>;
 export function loadConfig(): Config {
   return configSchema.parse({
     serverVersion: pkg.version,
+    appVersion: process.env.PLATFORM_APP_VERSION ?? "0.0.0",
     namespace: process.env.NAMESPACE,
     releaseName: process.env.PLATFORM_RELEASE_NAME,
     logLevel: process.env.LOG_LEVEL,

--- a/packages/api-server/src/core/logger.ts
+++ b/packages/api-server/src/core/logger.ts
@@ -17,7 +17,10 @@ import pino, { type Logger, type LoggerOptions } from "pino";
 export type { Logger };
 export type LogLevel = "error" | "warn" | "info" | "debug";
 
-function options(level: LogLevel): LoggerOptions {
+function options(
+  level: LogLevel,
+  base?: Record<string, unknown>,
+): LoggerOptions {
   return {
     level,
     // String level labels and an ISO `time` — readable, parseable, and
@@ -25,7 +28,8 @@ function options(level: LogLevel): LoggerOptions {
     formatters: { level: (label: string) => ({ level: label }) },
     timestamp: pino.stdTimeFunctions.isoTime,
     // Drop pid/hostname noise — the log pipeline annotates pod identity.
-    base: undefined,
+    // A provided base (e.g. build identity) stamps every line instead.
+    base,
     // Defense-in-depth: even though call sites must never pass secret values,
     // censor a few well-known credential keys (top-level and one nesting deep)
     // so a careless field can't leak a token onto the forensic stream.
@@ -54,11 +58,12 @@ let instance: Logger = pino(options("info"));
 export function configureLogger(opts: {
   level?: LogLevel;
   write?: (line: string) => void;
+  base?: Record<string, unknown>;
 }): void {
   const level = opts.level ?? (instance.level as LogLevel);
   instance = opts.write
-    ? pino(options(level), { write: opts.write })
-    : pino(options(level));
+    ? pino(options(level, opts.base), { write: opts.write })
+    : pino(options(level, opts.base));
 }
 
 /** The current Pino instance. Read at call time so reconfiguration applies. */

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -68,7 +68,7 @@ import { createK8sForkOrchestrator } from "./modules/forks/infrastructure/k8s-fo
 import { composeE2eModule } from "./modules/e2e/compose.js";
 import { composeTermsModule } from "./modules/terms/index.js";
 import { loadConfig } from "./config.js";
-import { configureLogger } from "./core/logger.js";
+import { configureLogger, getLogger } from "./core/logger.js";
 import { startApiServerApp } from "./apps/api-server/app.js";
 import { startHarnessApiServerApp } from "./apps/harness-api-server/app.js";
 import { startExtAuthzGrpcApp } from "./apps/ext-authz/grpc.js";
@@ -92,7 +92,11 @@ import { createSubPseudonymizer } from "./core/sub-pseudonymizer.js";
 import { podBaseUrl } from "./modules/agents/infrastructure/k8s.js";
 
 const config = loadConfig();
-configureLogger({ level: config.logLevel });
+configureLogger({
+  level: config.logLevel,
+  base: { appVersion: config.appVersion },
+});
+getLogger().info("api-server starting");
 
 const { api, customObjects } = createApi(config.namespace);
 await runMigrations(config.databaseUrl, config.migrationsPath);

--- a/packages/ui/src/modules/settings/api/queries.ts
+++ b/packages/ui/src/modules/settings/api/queries.ts
@@ -1,0 +1,21 @@
+import { useQuery } from "@tanstack/react-query";
+import { z } from "zod";
+
+const versionResponseSchema = z.object({ appVersion: z.string() });
+
+export const versionKeys = {
+  all: () => ["version"] as const,
+};
+
+export function useAppVersion() {
+  return useQuery({
+    queryKey: versionKeys.all(),
+    queryFn: async () => {
+      const res = await fetch("/api/version", { credentials: "omit" });
+      if (!res.ok) throw new Error(`Failed to fetch version (${res.status})`);
+      return versionResponseSchema.parse(await res.json()).appVersion;
+    },
+    staleTime: Infinity,
+    meta: { errorToast: "Couldn't load version" },
+  });
+}

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
 
 import { getUser, logout } from "../../../auth.js";
 import { useStore } from "../../../store.js";
+import { useAppVersion } from "../api/queries.js";
 
 type Tab = "appearance" | "account";
 
@@ -47,6 +48,7 @@ export function SettingsView() {
   const setTheme = useStore((s) => s.setTheme);
   const setView = useStore((s) => s.setView);
   const user = getUser();
+  const { data: appVersion } = useAppVersion();
 
   return (
     <div className="flex gap-6 md:gap-10 flex-col md:flex-row">
@@ -160,6 +162,12 @@ export function SettingsView() {
                 View Terms of Use
               </button>
             </div>
+
+            {appVersion && (
+              <div className="mt-6 text-[12px] text-muted-foreground break-all">
+                Version {appVersion}
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## What

Surface the deployed platform version, sourced from the Helm chart's `appVersion`.

The chart injects `PLATFORM_APP_VERSION: {{ .Chart.AppVersion }}` as env on the api-server. Because the publish step already sets `appVersion` to the commit SHA on main charts and to the semver on release charts, one value answers both:
- on a dev deploy it's the **commit SHA** -> "is the commit I pushed live yet"
- on staging/prod it's the **semver** (`0.2.0-rc2`, `0.2.0`) -> "what's the latest RC / current prod version"

No build-time machinery, no separate channel/commit fields.

## Where it shows
- `GET /api/version`: additive `appVersion` field
- api-server logs carry `appVersion`
- UI settings shows it

## Notes
- `serverVersion` (API/compat version, drives the CLI handshake) is untouched; the new field is additive
- Local `cluster:install` shows the literal Chart.yaml `appVersion` (`0.2.1`), since there's no CI-set SHA/semver