### PR TITLE
fix(ui): don't reload the session you're already viewing

### DIFF
--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -149,10 +149,24 @@ export function ChatView() {
       setMobileScreen("chat");
       setSessionMode(mode ?? SessionMode.Chat);
       // Terminal sessions don't use ACP.
-      if (mode === SessionMode.Terminal) setSessionId(sid);
-      else resumeSession(sid);
+      if (mode === SessionMode.Terminal) {
+        setSessionId(sid);
+        return;
+      }
+      if (sid === sessionId) {
+        scrollToBottom();
+        return;
+      }
+      resumeSession(sid);
     },
-    [setMobileScreen, setSessionMode, setSessionId, resumeSession],
+    [
+      sessionId,
+      setMobileScreen,
+      setSessionMode,
+      setSessionId,
+      resumeSession,
+      scrollToBottom,
+    ],
   );
 
   const handleNewSession = useCallback(() => {


### PR DESCRIPTION
## Summary

Re-selecting the session you're already viewing — clicking it in the sidebar or opening it from the Configuration panel — ran `resumeSession`, which tore down the live connection and replayed history from scratch. Any in-flight stream was dropped, leaving a hole in the conversation. (Reloading the page and then clicking the session worked, confirming the resume machinery itself is fine.)

This guards the re-select: when the clicked session is already the open chat session, just scroll to the latest instead of reloading. Switching to a *different* session still reloads as before; terminal sessions are unaffected. The guard lives at the single shared entry point, so it covers both desktop and mobile.

## Test plan

- [x] `mise run ui:check` (lint + tsc + prettier)
- [ ] Manual: while a session is streaming, click that same session in the sidebar → stream continues, view scrolls to latest, no reload
- [ ] Manual: click a *different* session → reloads as before

Closes #747