### PR TITLE
fix(ui): hide "Jump to latest" when the conversation is empty

### DIFF
--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -144,6 +144,13 @@ export function ChatView() {
     };
   }, []);
 
+  useEffect(() => {
+    if (messages.length === 0) {
+      stickRef.current = true;
+      setShowJump(false);
+    }
+  }, [messages.length]);
+
   const mobileResumeSession = useCallback(
     (sid: string, mode?: SessionMode) => {
       setMobileScreen("chat");


### PR DESCRIPTION
## Summary

When the **"Jump to latest"** button was visible (you'd scrolled up) and you clicked **New Session**, the button stayed stuck on screen over the empty chat — it only cleared once you scrolled the new conversation. Its visibility was driven solely by scroll events, which don't fire when the conversation is reset.

This resets the scroll state (re-pin to bottom, hide the button) whenever the message list becomes empty, so the fresh-session state is clean. Covers New Session and every other path that clears the conversation.

## Test plan

- [x] `mise run ui:check` (lint + tsc + prettier)
- [ ] Manual: scroll up in a conversation so "Jump to latest" shows → click New Session → button is gone over the blank chat

Closes #748