### PR TITLE
feat(ui): gate agent detail when pod not running

### DIFF
--- a/packages/ui/src/__tests__/unit/agent-resolver.test.ts
+++ b/packages/ui/src/__tests__/unit/agent-resolver.test.ts
@@ -32,9 +32,9 @@ describe("resolveAgentDisplay", () => {
     },
   );
 
-  test("restart override: state flips to restarting and actions are suppressed", () => {
+  test("restart override: state shows starting and actions are suppressed", () => {
     const out = resolveAgentDisplay(agent("a", "running"), new Set(["a"]));
-    expect(out.state).toBe("restarting");
+    expect(out.state).toBe("starting");
     expect(out.clickable).toBe(false);
     expect(out.powerAction).toBe(null);
   });

--- a/packages/ui/src/components/status-indicator.tsx
+++ b/packages/ui/src/components/status-indicator.tsx
@@ -7,7 +7,6 @@ const stateLabel: Record<AgentDisplayState, string> = {
   hibernating: "Hibernating",
   hibernated: "Hibernated",
   error: "Error",
-  restarting: "Restarting",
 };
 
 const badgeColors: Record<AgentDisplayState, string> = {
@@ -17,7 +16,6 @@ const badgeColors: Record<AgentDisplayState, string> = {
   hibernating: "bg-warning-light text-warning border-warning",
   hibernated: "bg-info-light text-info/50 border-info/25",
   error: "bg-danger-light text-danger border-danger",
-  restarting: "bg-warning-light text-warning border-warning",
 };
 
 const dotColors: Record<AgentDisplayState, string> = {
@@ -27,7 +25,6 @@ const dotColors: Record<AgentDisplayState, string> = {
   hibernating: "bg-warning anim-pulse",
   hibernated: "bg-info/50",
   error: "bg-danger",
-  restarting: "bg-warning anim-pulse",
 };
 
 /** Shared state pill used in the agents list and the chat header. `sm` matches

--- a/packages/ui/src/modules/agents/agent-trpc.ts
+++ b/packages/ui/src/modules/agents/agent-trpc.ts
@@ -2,6 +2,7 @@ import { createTRPCClient, httpBatchLink } from "@trpc/client";
 import type { AppRouter } from "agent-runtime-api";
 
 import { getAccessToken } from "../../auth.js";
+import { useStore } from "../../store.js";
 
 export function createAgentTrpc(agentId: string) {
   return createTRPCClient<AppRouter>({
@@ -11,6 +12,18 @@ export function createAgentTrpc(agentId: string) {
         headers: async () => {
           const token = await getAccessToken();
           return { Authorization: `Bearer ${token}` };
+        },
+        // Reachability circuit breaker. The proxy returns 502 "agent
+        // unreachable" when the pod is down (distinct from a tRPC app error,
+        // which comes back with the pod's own status + error body). Trip on
+        // 502, clear once the pod answers, so every per-agent call feeds the
+        // gate without per-call-site handling.
+        fetch: async (url, options) => {
+          const res = await globalThis.fetch(url as RequestInfo, options);
+          const store = useStore.getState();
+          if (res.status === 502) store.markAgentUnreachable(agentId);
+          else if (res.ok) store.clearAgentUnreachable(agentId);
+          return res;
         },
       }),
     ],

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -131,7 +131,12 @@ export function useUpdateAgent() {
   });
 }
 
-export function useWakeAgent() {
+/**
+ * Raw wake mutation. The optimistic "Starting" lifecycle is managed by
+ * useWakeAgent in hooks/use-wake-agent.ts — consumers should call that so the
+ * overlay/pill flips the instant the user clicks Start, not on the next poll.
+ */
+export function useWakeAgentMutation() {
   return useMutation({
     ...trpc.agents.wake.mutationOptions(),
     meta: {

--- a/packages/ui/src/modules/agents/api/queries.ts
+++ b/packages/ui/src/modules/agents/api/queries.ts
@@ -1,8 +1,9 @@
 import { skipToken, useQuery } from "@tanstack/react-query";
 
 import { api } from "../../../api.js";
+import { useStore } from "../../../store.js";
 import { trpc } from "../../../trpc.js";
-import type { AgentView } from "../../../types.js";
+import type { AgentState, AgentView } from "../../../types.js";
 
 export const agentsKeys = {
   root: ["agents"] as const,
@@ -41,6 +42,39 @@ const EMPTY_AGENTS: readonly AgentView[] = Object.freeze([]);
 export function useAgentsList(): readonly AgentView[] {
   const { data } = useAgents();
   return data?.list ?? EMPTY_AGENTS;
+}
+
+/**
+ * Single source for an agent's lifecycle state. The gate for "can the UI talk
+ * to this pod?" is `=== "running"`; everything that reaches into the pod (ACP
+ * WS, file tree, terminal) keys off this so they all agree.
+ */
+export function useAgentRunState(
+  agentId: string | null,
+): AgentState | undefined {
+  const agents = useAgentsList();
+  return agentId ? agents.find((a) => a.id === agentId)?.state : undefined;
+}
+
+/**
+ * Whether the UI can actually talk to the pod right now. Three inputs, because
+ * each catches a gap the others miss:
+ *   - server reports `running` (the lifecycle truth, but it lags reality),
+ *   - no optimistic restart in flight (covers a self-initiated Restart before
+ *     the poll sees the dip),
+ *   - not circuit-broken (covers any pod-down the server hasn't caught up to
+ *     yet — env edits, controller restarts, schedules — via a real 502).
+ * This is the single gate for pod-touching calls and the overlay alike.
+ */
+export function useIsAgentOperable(agentId: string | null): boolean {
+  const runState = useAgentRunState(agentId);
+  const restarting = useStore((s) =>
+    agentId ? s.restartingAgents.has(agentId) : false,
+  );
+  const unreachable = useStore((s) =>
+    agentId ? s.unreachableAgents.has(agentId) : false,
+  );
+  return runState === "running" && !restarting && !unreachable;
 }
 
 /**

--- a/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
+++ b/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
@@ -1,0 +1,170 @@
+import {
+  AlertCircle,
+  ArrowLeft,
+  Loader2,
+  Moon,
+  Play,
+  RefreshCw,
+} from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { StatusBadge } from "../../../components/status-indicator.js";
+import type { AgentView } from "../../../types.js";
+import { useRestartAgent } from "../hooks/use-restart-agent.js";
+import { useWakeAgent } from "../hooks/use-wake-agent.js";
+import type {
+  AgentDisplay,
+  AgentDisplayState,
+} from "../utils/agent-resolver.js";
+
+interface OverlayCopy {
+  Icon: typeof Loader2;
+  description: string;
+  spinning: boolean;
+}
+
+/** Copy + iconography per non-running state. `running` is present only to
+ *  satisfy the exhaustive record; the overlay is never rendered for it. The
+ *  `error` description is replaced at render time with the agent's own message. */
+const OVERLAY_COPY: Record<AgentDisplayState, OverlayCopy> = {
+  running: { Icon: Loader2, description: "", spinning: false },
+  starting: {
+    Icon: Loader2,
+    description: "The agent pod is starting up.",
+    spinning: true,
+  },
+  preparing_workspace: {
+    Icon: Loader2,
+    description: "Cloning the workspace seed. This finishes shortly.",
+    spinning: true,
+  },
+  hibernating: {
+    Icon: Loader2,
+    description: "The agent is going to sleep.",
+    spinning: true,
+  },
+  hibernated: {
+    Icon: Moon,
+    description:
+      "The agent went to sleep after a period of inactivity. Start it to pick up where you left off.",
+    spinning: false,
+  },
+  error: {
+    Icon: AlertCircle,
+    description: "The agent hit an error and isn't running.",
+    spinning: false,
+  },
+};
+
+/** Shared chrome for every overlay variant: full-view takeover, back button,
+ *  centered content column. */
+function OverlayFrame({
+  onBack,
+  children,
+}: {
+  onBack: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="absolute inset-0 z-40 flex flex-col bg-bg/95 backdrop-blur-sm">
+      <button
+        onClick={onBack}
+        className="absolute left-4 top-3 flex items-center gap-1 text-[13px] font-medium text-text-secondary hover:text-accent transition-colors"
+      >
+        <ArrowLeft size={14} />
+        Agents
+      </button>
+      <div className="flex flex-1 flex-col items-center justify-center gap-5 px-6 text-center">
+        {children}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Full-view takeover shown whenever the open agent isn't confirmed `running`.
+ * Gates the chat/terminal beneath it and surfaces the lifecycle state, plus an
+ * explicit Start (hibernated) or Restart (error) — waking is never automatic.
+ * A null `display` means the agents list hasn't loaded yet (cold reload): show
+ * a neutral spinner so we never flash the chat before the state is known.
+ */
+export function AgentUnavailableOverlay({
+  agent,
+  display,
+  name,
+  onBack,
+}: {
+  agent: AgentView | null;
+  display: AgentDisplay | null;
+  name: string;
+  onBack: () => void;
+}) {
+  const { wake } = useWakeAgent();
+  const { restart, isPending: restarting } = useRestartAgent();
+
+  if (!agent || !display) {
+    return (
+      <OverlayFrame onBack={onBack}>
+        <Loader2 size={40} className="text-text-muted animate-spin" />
+        <h2 className="text-[18px] font-bold text-text">{name}</h2>
+        <p className="max-w-105 text-[14px] text-text-secondary">
+          Loading agent…
+        </p>
+      </OverlayFrame>
+    );
+  }
+
+  // Shown while displayState is `running` only because the breaker is open: the
+  // pod is unreachable but the lifecycle poll hasn't caught up to the dip yet.
+  if (display.state === "running") {
+    return (
+      <OverlayFrame onBack={onBack}>
+        <Loader2 size={40} className="text-text-muted animate-spin" />
+        <div className="flex flex-col items-center gap-2">
+          <h2 className="text-[18px] font-bold text-text">{agent.name}</h2>
+          <StatusBadge
+            label="Reconnecting"
+            colorClasses="bg-warning-light text-warning border-warning"
+            dotColorClasses="bg-warning anim-pulse"
+          />
+        </div>
+        <p className="max-w-105 text-[14px] text-text-secondary">
+          Lost contact with the agent. Reconnecting…
+        </p>
+      </OverlayFrame>
+    );
+  }
+
+  const { state, powerAction } = display;
+  const { Icon, spinning } = OVERLAY_COPY[state];
+  const description =
+    state === "error" && agent.error
+      ? agent.error
+      : OVERLAY_COPY[state].description;
+
+  return (
+    <OverlayFrame onBack={onBack}>
+      <Icon
+        size={40}
+        className={`text-text-muted ${spinning ? "animate-spin" : ""}`}
+      />
+      <div className="flex flex-col items-center gap-2">
+        <h2 className="text-[18px] font-bold text-text">{agent.name}</h2>
+        <StatusBadge state={state} />
+      </div>
+      <p className="max-w-105 text-[14px] text-text-secondary">{description}</p>
+      {powerAction === "start" && (
+        <Button onClick={() => wake(agent.id)}>
+          <Play size={14} /> Start agent
+        </Button>
+      )}
+      {powerAction === "restart" && (
+        <Button onClick={() => restart(agent.id)} disabled={restarting}>
+          <RefreshCw size={14} /> Restart agent
+        </Button>
+      )}
+    </OverlayFrame>
+  );
+}

--- a/packages/ui/src/modules/agents/hooks/use-agent-reachability-probe.ts
+++ b/packages/ui/src/modules/agents/hooks/use-agent-reachability-probe.ts
@@ -1,0 +1,51 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useMemo } from "react";
+
+import { useStore } from "../../../store.js";
+import { createAgentTrpc } from "../agent-trpc.js";
+import { useAgentRunState } from "../api/queries.js";
+
+const PROBE_INTERVAL_MS = 3000;
+
+/**
+ * Half-open probe for the reachability circuit breaker. While an agent is
+ * unreachable AND the server still reports it `running` (the window the
+ * lifecycle poll can't see yet), this retries one cheap pod call every few
+ * seconds. The createAgentTrpc fetch wrapper clears the breaker on the first
+ * 2xx, which disables this query — so the overlay dismisses only on a real
+ * success, never on a timer (no flicker). Real pod queries stay gated
+ * meanwhile, so the pod sees one probe per interval, not the full poll storm.
+ */
+export function useAgentReachabilityProbe(agentId: string | null) {
+  const runState = useAgentRunState(agentId);
+  const unreachable = useStore((s) =>
+    agentId ? s.unreachableAgents.has(agentId) : false,
+  );
+  const clearAgentUnreachable = useStore((s) => s.clearAgentUnreachable);
+
+  // Once the server catches up to the outage (state leaves `running`), the
+  // lifecycle gate owns the overlay; drop the breaker so the probe stops and
+  // we don't render "Reconnecting" over a pod that's openly "Starting".
+  useEffect(() => {
+    if (agentId && unreachable && runState !== "running") {
+      clearAgentUnreachable(agentId);
+    }
+  }, [agentId, unreachable, runState, clearAgentUnreachable]);
+
+  const client = useMemo(
+    () => (agentId ? createAgentTrpc(agentId) : null),
+    [agentId],
+  );
+
+  useQuery({
+    queryKey: ["agent-reachability-probe", agentId],
+    queryFn: async () => {
+      await client!.files.listDirs.query({ paths: [""] });
+      return null;
+    },
+    enabled: !!client && unreachable && runState === "running",
+    refetchInterval: PROBE_INTERVAL_MS,
+    retry: false,
+    gcTime: 0,
+  });
+}

--- a/packages/ui/src/modules/agents/hooks/use-wake-agent.ts
+++ b/packages/ui/src/modules/agents/hooks/use-wake-agent.ts
@@ -1,0 +1,22 @@
+import { useStore } from "../../../store.js";
+import { useWakeAgentMutation } from "../api/mutations.js";
+
+/**
+ * Wraps the raw wake mutation with the optimistic "coming up" lifecycle so the
+ * overlay/pill flips to "Starting" the instant the user clicks Start, instead
+ * of waiting for the next state poll. Reuses the same optimistic bridge as
+ * useRestartAgent — a wake is just another optimistic transition to running,
+ * and it ages out the same way (the hibernated state is the non-running dip).
+ */
+export function useWakeAgent() {
+  const setRestarting = useStore((s) => s.setRestartingAgent);
+  const clearRestarting = useStore((s) => s.clearRestartingAgent);
+  const wakeMutation = useWakeAgentMutation();
+
+  const wake = (id: string) => {
+    setRestarting(id, { seenNonRunning: false, clickedAt: Date.now() });
+    wakeMutation.mutate({ id }, { onError: () => clearRestarting(id) });
+  };
+
+  return { wake, isPending: wakeMutation.isPending };
+}

--- a/packages/ui/src/modules/agents/store.ts
+++ b/packages/ui/src/modules/agents/store.ts
@@ -30,6 +30,13 @@ export interface AgentsSlice {
   setRestartingAgents: (
     map: Map<string, { seenNonRunning: boolean; clickedAt: number }>,
   ) => void;
+  /** Reactive circuit breaker: agent IDs whose pod returned 502 ("agent
+   *  unreachable") on a per-agent tRPC call. Tripped by the createAgentTrpc
+   *  fetch wrapper, cleared once the reachability probe gets a 2xx. Gates pod
+   *  calls regardless of who restarted the pod (env edit, controller, schedule). */
+  unreachableAgents: ReadonlySet<string>;
+  markAgentUnreachable: (id: string) => void;
+  clearAgentUnreachable: (id: string) => void;
   selectAgent: (id: string) => void;
   goBack: () => void;
 }
@@ -56,6 +63,22 @@ export const createAgentsSlice: StateCreator<
       return { restartingAgents: next };
     }),
   setRestartingAgents: (map) => set({ restartingAgents: map }),
+
+  unreachableAgents: new Set(),
+  markAgentUnreachable: (id) =>
+    set((s) => {
+      if (s.unreachableAgents.has(id)) return {};
+      const next = new Set(s.unreachableAgents);
+      next.add(id);
+      return { unreachableAgents: next };
+    }),
+  clearAgentUnreachable: (id) =>
+    set((s) => {
+      if (!s.unreachableAgents.has(id)) return {};
+      const next = new Set(s.unreachableAgents);
+      next.delete(id);
+      return { unreachableAgents: next };
+    }),
 
   selectAgent: (id) => {
     history.pushState(null, "", viewToPath("chat", id));

--- a/packages/ui/src/modules/agents/utils/agent-resolver.ts
+++ b/packages/ui/src/modules/agents/utils/agent-resolver.ts
@@ -1,6 +1,6 @@
 import type { AgentState, AgentView } from "../../../types.js";
 
-export type AgentDisplayState = AgentState | "restarting";
+export type AgentDisplayState = AgentState;
 
 export interface AgentDisplay {
   /** Derived state that drives the status pill. */
@@ -14,14 +14,16 @@ export interface AgentDisplay {
 
 /**
  * Pure projection: derive the display-level state from an agent's runtime
- * status, layering the optimistic "Restarting" pill on top.
+ * status. An optimistic restart (Restart clicked before the poll sees the pod
+ * dip) presents as `starting` — a restart and a cold start are the same
+ * "coming up" state to the user, so they share one presentation.
  */
 export function resolveAgentDisplay(
   agent: AgentView,
   restartingAgentIds: ReadonlySet<string>,
 ): AgentDisplay {
   const restarting = restartingAgentIds.has(agent.id);
-  const state: AgentDisplayState = restarting ? "restarting" : agent.state;
+  const state: AgentDisplayState = restarting ? "starting" : agent.state;
   const clickable =
     !restarting && (agent.state === "running" || agent.state === "hibernated");
   const powerAction: AgentDisplay["powerAction"] = restarting

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -13,11 +13,7 @@ import { Card } from "@/components/ui/card";
 import { StatusBadge } from "../../../components/status-indicator.js";
 import { useStore } from "../../../store.js";
 import { useTemplates } from "../../templates/api/queries.js";
-import {
-  useCreateAgent,
-  useDeleteAgent,
-  useWakeAgent,
-} from "../api/mutations.js";
+import { useCreateAgent, useDeleteAgent } from "../api/mutations.js";
 import { useAgents } from "../api/queries.js";
 import { ContributionFailuresBadge } from "../components/contribution-failures-badge.js";
 import { AddAgentDialog } from "../dialogs/add-agent-dialog.js";
@@ -26,6 +22,7 @@ import {
   useRestartAgent,
   useSyncRestartingAgents,
 } from "../hooks/use-restart-agent.js";
+import { useWakeAgent } from "../hooks/use-wake-agent.js";
 import { resolveAgentDisplay } from "../utils/agent-resolver.js";
 
 export function ListView() {
@@ -109,14 +106,11 @@ export function ListView() {
           {initialLoaded &&
             agents.map((agent) => {
               const display = resolveAgentDisplay(agent, restartingIds);
-              const onOpen = () => {
-                if (display.clickable) selectAgent(agent.id);
-              };
               return (
                 <Card
                   key={agent.id}
-                  onClick={onOpen}
-                  className={`overflow-hidden anim-in transition-shadow ${display.clickable ? "group cursor-pointer hover:not-has-[button:hover]:shadow-md" : ""}`}
+                  onClick={() => selectAgent(agent.id)}
+                  className="overflow-hidden anim-in transition-shadow group cursor-pointer hover:not-has-[button:hover]:shadow-md"
                 >
                   <div className="px-4 md:px-6 py-4 md:py-5">
                     <div className="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
@@ -146,7 +140,7 @@ export function ListView() {
                           size="sm"
                           onClick={() => {
                             if (display.powerAction === "start")
-                              wakeAgent.mutate({ id: agent.id });
+                              wakeAgent.wake(agent.id);
                             else if (display.powerAction === "restart")
                               restartAgent(agent.id);
                           }}

--- a/packages/ui/src/modules/files/api/queries.ts
+++ b/packages/ui/src/modules/files/api/queries.ts
@@ -11,6 +11,7 @@ import { api } from "../../../api.js";
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
 import { createAgentTrpc } from "../../agents/agent-trpc.js";
+import { useIsAgentOperable } from "../../agents/api/queries.js";
 import { fileKeys } from "./keys.js";
 
 const EMPTY_EXPANDED: ReadonlySet<string> = new Set();
@@ -62,13 +63,14 @@ function paramsForExpanded(expanded: ReadonlySet<string>): string[] {
 export function useDirSnapshot(agentId: string | null, path: string) {
   const expanded = useExpandedDirs(agentId);
   const paths = paramsForExpanded(expanded);
+  const operable = useIsAgentOperable(agentId);
   return useQuery({
     queryKey: fileKeys.treeForPaths(agentId ?? "_none", paths),
     queryFn: async (): Promise<ListDirsResponse> => {
       const trpc = getAgentTrpc(agentId!);
       return trpc.files.listDirs.query({ paths });
     },
-    enabled: !!agentId,
+    enabled: !!agentId && operable,
     refetchInterval: 2000,
     staleTime: 2000,
     placeholderData: keepPreviousData,
@@ -81,10 +83,11 @@ export function useFileContentQuery(
   agentId: string | null,
   path: string | null,
 ) {
+  const operable = useIsAgentOperable(agentId);
   return useQuery({
     queryKey: fileKeys.content(agentId ?? "_none", path ?? "_none"),
     queryFn: async () => readFileContent(agentId!, path!),
-    enabled: !!agentId && !!path,
+    enabled: !!agentId && !!path && operable,
     refetchInterval: 2000,
     staleTime: 2000,
     // No retry — transient errors resolve on the next 2 s poll tick, and we

--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -3,7 +3,7 @@ import { ArrowLeft, Plus, RefreshCw } from "lucide-react";
 import { useCallback } from "react";
 
 import { useStore } from "../../../store.js";
-import { useAgentsList } from "../../agents/api/queries.js";
+import { useAgentRunState } from "../../agents/api/queries.js";
 import { AgentApprovalsTray } from "../../approvals/components/agent-approvals-tray.js";
 import { useAcpSessions } from "../api/queries.js";
 import { SessionRow } from "./session-row.js";
@@ -25,8 +25,7 @@ export function SessionsSidebar({
   const showConfirm = useStore((s) => s.showConfirm);
   const goBack = useStore((s) => s.goBack);
 
-  const agents = useAgentsList();
-  const agentRunState = agents.find((a) => a.id === selectedAgent)?.state;
+  const agentRunState = useAgentRunState(selectedAgent);
   const {
     data: sessions = [],
     isFetching,

--- a/packages/ui/src/modules/sessions/hooks/use-acp-config-cache.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-config-cache.ts
@@ -42,7 +42,7 @@ export interface AcpConfigCache {
 export function useAcpConfigCache(
   selectedAgent: string | null,
   sessionId: string | null,
-  agentRunState: string | undefined,
+  agentOperable: boolean,
 ): AcpConfigCache {
   const setSessionModes = useStore((s) => s.setSessionModes);
   const setSessionModels = useStore((s) => s.setSessionModels);
@@ -192,7 +192,7 @@ export function useAcpConfigCache(
       );
     }
 
-    if (agentRunState !== "running") return;
+    if (!agentOperable) return;
     let cancelled = false;
 
     (async () => {
@@ -245,7 +245,7 @@ export function useAcpConfigCache(
   }, [
     selectedAgent,
     sessionId,
-    agentRunState,
+    agentOperable,
     setSessionModes,
     setSessionModels,
     setSessionConfigOptions,

--- a/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
@@ -35,6 +35,11 @@ interface UseAcpConnectionOptions {
   /** Block live-WS opening (e.g. while resumeSession's throwaway is replaying
    *  history) — both channels would otherwise receive the replay stream. */
   liveBlocked: boolean;
+  /** Whether the pod is reachable now (running and not mid-restart). While
+   *  false the keep-alive and reconnect loop stay parked: the pod can't answer
+   *  ACP, and each connect attempt re-wakes a hibernated agent via the relay's
+   *  ensureReady. */
+  agentOperable: boolean;
   makeUpdateHandler: () => UpdateHandler;
   engage: (conn: ClientSideConnection) => Promise<void>;
   clearEngagement: () => void;
@@ -80,6 +85,7 @@ export function useAcpConnection(
     sessionId,
     sessionMode,
     liveBlocked,
+    agentOperable,
     makeUpdateHandler,
     engage,
     clearEngagement,
@@ -102,6 +108,13 @@ export function useAcpConnection(
   const pendingReloadRef = useRef(false);
 
   const [state, setState] = useState<ConnectionState>("idle");
+
+  // Mirror of agentOperable so the late-bound reconnect closure reads the
+  // latest value without re-subscribing.
+  const operableRef = useRef(agentOperable);
+  useEffect(() => {
+    operableRef.current = agentOperable;
+  }, [agentOperable]);
 
   // Cleanup on unmount: cancel any in-flight reconnect, close the live WS.
   useEffect(
@@ -213,6 +226,9 @@ export function useAcpConnection(
   useEffect(() => {
     reconnectFnRef.current = () => {
       if (!isMountedRef.current) return;
+      // Pod isn't reachable — don't reconnect (and don't re-wake it). The
+      // keep-alive effect re-engages once it flips back to operable.
+      if (!operableRef.current) return;
       const sid = useStore.getState().sessionId;
       const inst = useStore.getState().selectedAgent;
       if (!sid || inst !== selectedAgent) return;
@@ -226,7 +242,7 @@ export function useAcpConnection(
 
       reconnectTimerRef.current = setTimeout(async () => {
         reconnectTimerRef.current = null;
-        if (!isMountedRef.current) return;
+        if (!isMountedRef.current || !operableRef.current) return;
         const currentSid = useStore.getState().sessionId;
         const currentInst = useStore.getState().selectedAgent;
         if (!currentSid || currentInst !== selectedAgent) return;
@@ -255,10 +271,17 @@ export function useAcpConnection(
   // any pending tool-permission prompt replayed there has no live channel to
   // answer on.
   useEffect(() => {
-    if (!selectedAgent || !sessionId || liveBlocked) return;
+    if (!selectedAgent || !sessionId || liveBlocked || !agentOperable) return;
     if (sessionMode === SessionMode.Terminal) return;
     ensureLive().catch(() => {});
-  }, [selectedAgent, sessionId, sessionMode, liveBlocked, ensureLive]);
+  }, [
+    selectedAgent,
+    sessionId,
+    sessionMode,
+    liveBlocked,
+    agentOperable,
+    ensureLive,
+  ]);
 
   const reset = useCallback(() => {
     connectionRef.current?.ws.close();

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -1,11 +1,10 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { api } from "../../../api.js";
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
 import { hasStreamingAssistant } from "../../acp/session-projection.js";
 import { classifyResumeError, extractErrorMessage } from "../../acp/utils.js";
-import { useAgentsList } from "../../agents/api/queries.js";
+import { useIsAgentOperable } from "../../agents/api/queries.js";
 import {
   deleteAgentSession,
   listAgentSessions,
@@ -45,12 +44,10 @@ export function useAcpSession(
     setBusy(busy);
   }, [busy, setBusy]);
 
-  const agentRunState = useAgentsList().find(
-    (a) => a.id === selectedAgent,
-  )?.state;
+  const agentOperable = useIsAgentOperable(selectedAgent);
 
   const { captureSessionConfig, handleConfigUpdate, applySavedPreferences } =
-    useAcpConfigCache(selectedAgent, sessionId, agentRunState);
+    useAcpConfigCache(selectedAgent, sessionId, agentOperable);
 
   const { loadHistory } = useAcpHistory(
     selectedAgent,
@@ -73,6 +70,7 @@ export function useAcpSession(
   const {
     ensureLive,
     connectionRef,
+    state: connectionState,
     reset: resetConnection,
   } = useAcpConnection({
     selectedAgent,
@@ -82,19 +80,16 @@ export function useAcpSession(
     // replaying history — both channels would otherwise receive the replay
     // stream and the live projection would double-apply every update.
     liveBlocked: loadingSession,
+    // Only the pod can answer ACP. Gating here stops the keep-alive and
+    // reconnect loop from hammering (and re-waking, via the relay's
+    // ensureReady) an agent that's hibernated, starting, or mid-restart.
+    agentOperable,
     makeUpdateHandler,
     engage,
     clearEngagement,
     loadHistory,
     setMessages,
   });
-
-  // Wake hibernated agent on entry.
-  useEffect(() => {
-    if (selectedAgent && agentRunState === "hibernated") {
-      api.agents.wake.mutate({ id: selectedAgent }).catch(() => {});
-    }
-  }, [selectedAgent, agentRunState]);
 
   const resetSession = useCallback(() => {
     resetConnection();
@@ -177,5 +172,6 @@ export function useAcpSession(
     stopAgent,
     busy,
     loadingSession,
+    connectionState,
   };
 }

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -10,7 +10,7 @@ import {
   TerminalSquare,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
@@ -23,8 +23,12 @@ import { queryClient } from "../../../query-client.js";
 import type { SessionError } from "../../../store.js";
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
-import { useAgents } from "../../agents/api/queries.js";
+import { useAgents, useIsAgentOperable } from "../../agents/api/queries.js";
+import { AgentUnavailableOverlay } from "../../agents/components/agent-unavailable-overlay.js";
 import { ContributionFailuresBadge } from "../../agents/components/contribution-failures-badge.js";
+import { useAgentReachabilityProbe } from "../../agents/hooks/use-agent-reachability-probe.js";
+import { useSyncRestartingAgents } from "../../agents/hooks/use-restart-agent.js";
+import { resolveAgentDisplay } from "../../agents/utils/agent-resolver.js";
 import { FilesPanel } from "../../files/components/files-panel.js";
 import { ImportInProgressBadge } from "../../files/components/import-in-progress-badge.js";
 import { useFileTree } from "../../files/hooks/use-file-tree.js";
@@ -40,12 +44,26 @@ import { SessionsSidebar } from "../components/sessions-sidebar.js";
 import { Terminal } from "../components/terminal.js";
 import { ThoughtBlock } from "../components/thought-block.js";
 import { ToolChip } from "../components/tool-chip.js";
+import type { ConnectionState } from "../hooks/use-acp-connection.js";
 import { useAcpSession } from "../hooks/use-acp-session.js";
 
 export function ChatView() {
   const selectedAgent = useStore((s) => s.selectedAgent);
   const { data: agentsData } = useAgents();
   const agents = agentsData?.list ?? [];
+  const agentOperable = useIsAgentOperable(selectedAgent);
+
+  useSyncRestartingAgents();
+  useAgentReachabilityProbe(selectedAgent);
+  const restartingAgents = useStore((s) => s.restartingAgents);
+  const restartingIds = useMemo(
+    () => new Set(restartingAgents.keys()),
+    [restartingAgents],
+  );
+  const agentView = agents.find((a) => a.id === selectedAgent) ?? null;
+  const agentDisplay = agentView
+    ? resolveAgentDisplay(agentView, restartingIds)
+    : null;
   const selectedAgentName =
     agents.find((a) => a.id === selectedAgent)?.name ?? selectedAgent;
   const sessionId = useStore((s) => s.sessionId);
@@ -94,6 +112,7 @@ export function ChatView() {
     busy,
     engagedSessionIdRef,
     loadingSession,
+    connectionState,
   } = useAcpSession(selectedAgent, textareaRef);
 
   const { openFileHandler } = useFileTree(selectedAgent);
@@ -402,6 +421,7 @@ export function ChatView() {
               selectedAgent={selectedAgent}
               agents={agents}
               busy={busy}
+              connectionState={connectionState}
             />
           </div>
         </header>
@@ -413,7 +433,7 @@ export function ChatView() {
             agentId={selectedAgent}
             sessionId={sessionId}
             fresh={terminalFreshRef.current}
-            autoConnect={!terminalPaused}
+            autoConnect={!terminalPaused && agentOperable}
             onConnected={() => {
               terminalFreshRef.current = false;
               setTerminalPaused(false);
@@ -661,40 +681,59 @@ export function ChatView() {
           </div>
         </div>
       )}
+
+      {selectedAgent && !agentOperable && (
+        <AgentUnavailableOverlay
+          agent={agentView}
+          display={agentDisplay}
+          name={selectedAgentName ?? ""}
+          onBack={handleBack}
+        />
+      )}
     </div>
   );
 }
 
 /** Small pill in the chat header. Falls through to the shared `StatusBadge`,
- *  overriding to a "Busy" variant while the agent is mid-turn. */
+ *  overriding to a "Busy" variant while the agent is mid-turn. A transient WS
+ *  hiccup on a still-running agent adds a "Reconnecting" pill alongside —
+ *  full lifecycle outages are handled by the takeover overlay, not here. */
 function ChatHeaderStatus({
   selectedAgent,
   agents,
   busy,
+  connectionState,
 }: {
   selectedAgent: string | null;
   agents: AgentView[];
   busy: boolean;
+  connectionState: ConnectionState;
 }) {
-  if (busy) {
-    return (
-      <>
+  const agent = agents.find((a) => a.id === selectedAgent);
+  const reconnecting =
+    connectionState === "reconnecting" || connectionState === "reloading";
+  return (
+    <>
+      {busy ? (
         <StatusBadge
           size="sm"
           label="Busy"
           colorClasses="bg-accent-light text-accent border-accent"
           dotColorClasses="bg-accent anim-pulse"
         />
-        <ImportInProgressBadge size="sm" agentId={selectedAgent} />
-      </>
-    );
-  }
-  const agent = agents.find((a) => a.id === selectedAgent);
-  return (
-    <>
-      <StatusBadge size="sm" state={agent?.state ?? "starting"} />
+      ) : (
+        <StatusBadge size="sm" state={agent?.state ?? "starting"} />
+      )}
+      {reconnecting && (
+        <StatusBadge
+          size="sm"
+          label="Reconnecting"
+          colorClasses="bg-warning-light text-warning border-warning"
+          dotColorClasses="bg-warning anim-pulse"
+        />
+      )}
       <ImportInProgressBadge size="sm" agentId={selectedAgent} />
-      {agent && (
+      {!busy && agent && (
         <ContributionFailuresBadge
           size="sm"
           failures={agent.contributionFailures}


### PR DESCRIPTION
## Problem

When an agent isn't running (starting, preparing, hibernated, error, restarting) the detail view still looked operable and kept firing ACP / file-tree / terminal calls that 500. Worse, an idle tab on a hibernated agent re-woke it roughly every 30s: the reconnect loop hit `/acp`, which calls `ensureReady` server-side and scales the pod back up.

## What changed

- **Full-screen overlay** takes over the detail view whenever the pod isn't running, with explicit Start / Restart. Auto-wake on entry is removed, waking is only ever an explicit click.
- **One operability gate** (server running, not optimistically restarting, not circuit-broken) drives the overlay and every pod-touching call, so non-running agents go quiet and the wake-storm is gone. `!operable` and "overlay shows" are the same signal, so they can't disagree.
- **Reactive 502 circuit breaker** with a half-open probe catches server-initiated restarts (env edits, controller retries, schedules), not just self-initiated ones. Detection is a single fetch wrapper in `createAgentTrpc`; the probe retries without dismissing the overlay, so there's no flicker.
- **Inline "Reconnecting" pill** for transient WS drops while the agent is still running (lifecycle outages get the takeover, hiccups stay inline).
- Merged the optimistic `restarting` display state into `starting`, and made **wake optimistic** so Start flips the overlay instantly instead of waiting for the poll.

## Follow-up

- Promote the client-side 502 sniff to a typed `AGENT_UNREACHABLE` error from the proxy. Server change that needs a relay-consumer audit (channel workers key off the current 502).

## Testing

UI lint / type-check / format and 39 unit tests pass. Not yet verified against a live cluster (the behaviour is timing-sensitive: poll lag vs probe vs server transitions).
