### PR TITLE
feat(e2e): foreign fork tracer via fake Slack gateway

### DIFF
--- a/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
+++ b/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
@@ -157,6 +157,26 @@ data:
           {{- end }}
         },
         {{- end }}
+        {{- if .Values.keycloak.testUser2.enabled }}
+        {
+          "username": {{ .Values.keycloak.testUser2.username | quote }},
+          "enabled": true,
+          "emailVerified": true,
+          "firstName": "Dev",
+          "lastName": "UserTwo",
+          "email": "dev2@platform.local",
+          "credentials": [
+            {
+              "type": "password",
+              "value": {{ .Values.keycloak.testUser2.password | quote }},
+              "temporary": false
+            }
+          ]
+          {{- if .Values.keycloak.requiredRole }}
+          ,"realmRoles": [{{ .Values.keycloak.requiredRole | quote }}]
+          {{- end }}
+        },
+        {{- end }}
         {
           "username": {{ printf "service-account-%s" (lower .Values.keycloak.apiClientId) | quote }},
           "enabled": true,

--- a/deploy/helm/platform/values-e2e.yaml
+++ b/deploy/helm/platform/values-e2e.yaml
@@ -6,6 +6,14 @@
 e2e:
   enabled: true
 
+# Second user for the foreign-fork Slack spec (07-slack). The primary
+# dev/dev user comes from values-local.yaml's keycloak.testUser.
+keycloak:
+  testUser2:
+    enabled: true
+    username: dev2
+    password: dev2
+
 # Helm replaces lists wholesale — narrow values-local.yaml's agentTemplates
 # down to just `mock`. The e2e task builds only platform-base + mock images,
 # so registering claude-code / codex / pi-agent / bob would

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -254,6 +254,13 @@ keycloak:
     username: null
     password: null
 
+  # -- Second test user for e2e foreign-user (fork) scenarios.
+  # DISABLED by default — only the e2e overlay (values-e2e.yaml) enables it.
+  testUser2:
+    enabled: false
+    username: null
+    password: null
+
   # -- Database connection (empty host = use shared local postgres)
   db:
     host: ""

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -327,7 +327,14 @@ export { authConfigSchema } from "./modules/auth/types.js";
 export type { AuthConfig } from "./modules/auth/types.js";
 
 // E2E
-export type { E2eService } from "./modules/e2e/types.js";
+export type {
+  E2eService,
+  SlackFireCommandInput,
+  SlackFireCommandResult,
+  SlackFireMentionInput,
+  SlackOutboundRecord,
+  SlackReadOutboundResult,
+} from "./modules/e2e/types.js";
 export {
   e2eAgentIdInputSchema,
   e2eSetScriptInputSchema,

--- a/packages/api-server-api/src/modules/e2e/router.ts
+++ b/packages/api-server-api/src/modules/e2e/router.ts
@@ -9,6 +9,10 @@ import {
   getReceivedPromptsResultSchema,
   performFetchResultSchema,
   resetResultSchema,
+  slackFireCommandInputSchema,
+  slackFireCommandResultSchema,
+  slackFireMentionInputSchema,
+  slackReadOutboundResultSchema,
 } from "./schemas.js";
 
 function gate(ctx: { e2eEnabled: boolean }): void {
@@ -57,5 +61,35 @@ export const e2eRouter = t.router({
         url: input.url,
         headers: input.headers,
       });
+    }),
+
+  slackFireMention: t.procedure
+    .input(slackFireMentionInputSchema)
+    .output(resetResultSchema)
+    .mutation(({ ctx, input }) => {
+      gate(ctx);
+      return ctx.e2e.slackFireMention(input);
+    }),
+
+  slackFireCommand: t.procedure
+    .input(slackFireCommandInputSchema)
+    .output(slackFireCommandResultSchema)
+    .mutation(({ ctx, input }) => {
+      gate(ctx);
+      return ctx.e2e.slackFireCommand(input);
+    }),
+
+  slackReadOutbound: t.procedure
+    .output(slackReadOutboundResultSchema)
+    .query(({ ctx }) => {
+      gate(ctx);
+      return ctx.e2e.slackReadOutbound();
+    }),
+
+  slackResetOutbound: t.procedure
+    .output(resetResultSchema)
+    .mutation(({ ctx }) => {
+      gate(ctx);
+      return ctx.e2e.slackResetOutbound();
     }),
 });

--- a/packages/api-server-api/src/modules/e2e/schemas.ts
+++ b/packages/api-server-api/src/modules/e2e/schemas.ts
@@ -74,3 +74,64 @@ export const e2ePerformFetchInputSchema = z
     headers: z.record(z.string(), z.string()).optional(),
   })
   .strict();
+
+export const slackFireMentionInputSchema = z
+  .object({
+    user: z.string().min(1),
+    channel: z.string().min(1),
+    ts: z.string().min(1),
+    threadTs: z.string().optional(),
+    text: z.string(),
+  })
+  .strict();
+
+export const slackFireCommandInputSchema = z
+  .object({
+    text: z.string(),
+    userId: z.string().min(1),
+    channelId: z.string().min(1),
+  })
+  .strict();
+
+export const slackFireCommandResultSchema = z
+  .object({ ack: z.string() })
+  .strict();
+
+export const slackOutboundRecordSchema = z.discriminatedUnion("kind", [
+  z
+    .object({
+      kind: z.literal("message"),
+      channel: z.string(),
+      text: z.string(),
+      threadTs: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("ephemeral"),
+      channel: z.string(),
+      user: z.string(),
+      text: z.string(),
+      threadTs: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("reaction"),
+      channel: z.string(),
+      ts: z.string(),
+      name: z.string(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("upload"),
+      channelId: z.string(),
+      filename: z.string(),
+    })
+    .strict(),
+]);
+
+export const slackReadOutboundResultSchema = z
+  .object({ records: z.array(slackOutboundRecordSchema) })
+  .strict();

--- a/packages/api-server-api/src/modules/e2e/types.ts
+++ b/packages/api-server-api/src/modules/e2e/types.ts
@@ -6,6 +6,11 @@ import type {
   performFetchResultSchema,
   resetResultSchema,
   setScriptInputSchema,
+  slackFireCommandInputSchema,
+  slackFireCommandResultSchema,
+  slackFireMentionInputSchema,
+  slackOutboundRecordSchema,
+  slackReadOutboundResultSchema,
 } from "./schemas.js";
 
 export type SetScriptInput = z.infer<typeof setScriptInputSchema>;
@@ -20,6 +25,16 @@ export type PerformFetchInput = Omit<
   "agentId"
 >;
 
+export type SlackFireMentionInput = z.infer<typeof slackFireMentionInputSchema>;
+export type SlackFireCommandInput = z.infer<typeof slackFireCommandInputSchema>;
+export type SlackFireCommandResult = z.infer<
+  typeof slackFireCommandResultSchema
+>;
+export type SlackOutboundRecord = z.infer<typeof slackOutboundRecordSchema>;
+export type SlackReadOutboundResult = z.infer<
+  typeof slackReadOutboundResultSchema
+>;
+
 export interface E2eService {
   setScript(agentId: string, input: SetScriptInput): Promise<ResetResult>;
   getReceivedPrompts(agentId: string): Promise<GetReceivedPromptsResult>;
@@ -29,4 +44,10 @@ export interface E2eService {
     agentId: string,
     input: PerformFetchInput,
   ): Promise<PerformFetchResult>;
+  slackFireMention(input: SlackFireMentionInput): Promise<ResetResult>;
+  slackFireCommand(
+    input: SlackFireCommandInput,
+  ): Promise<SlackFireCommandResult>;
+  slackReadOutbound(): Promise<SlackReadOutboundResult>;
+  slackResetOutbound(): Promise<ResetResult>;
 }

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -315,7 +315,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
 
   deps.mountUsageRoutes(app);
 
-  if (config.slackBotToken && config.slackAppToken) {
+  if ((config.slackBotToken && config.slackAppToken) || config.e2eEnabled) {
     app.route(
       "/",
       createSlackOAuthRoutes({

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -31,6 +31,7 @@ import {
   type ChannelRegistry,
 } from "./modules/channels/infrastructure/slack.js";
 import { createBoltSlackGateway } from "./modules/channels/infrastructure/bolt-slack-gateway.js";
+import { createFakeSlackGateway } from "./modules/channels/infrastructure/fake-slack-gateway.js";
 import {
   createTelegramWorker,
   type TelegramOAuthPending,
@@ -156,8 +157,14 @@ const { service: termsService, isAcceptedPort: isTermsAccepted } =
     text: config.terms.text,
   });
 
+const fakeSlackGateway =
+  config.e2eEnabled && !(config.slackBotToken && config.slackAppToken)
+    ? createFakeSlackGateway()
+    : undefined;
+
 const { service: e2eService } = composeE2eModule({
   namespace: config.namespace,
+  slack: fakeSlackGateway,
 });
 
 const channelSecretCleanupSub =
@@ -257,15 +264,21 @@ const slackTokens =
     ? { botToken: config.slackBotToken, appToken: config.slackAppToken }
     : null;
 
-const slackWorker = slackTokens
+const slackGatewayFactory = slackTokens
+  ? () =>
+      createBoltSlackGateway({
+        botToken: slackTokens.botToken,
+        appToken: slackTokens.appToken,
+        commandName: `/${config.brand.short}`,
+      })
+  : fakeSlackGateway
+    ? () => fakeSlackGateway
+    : undefined;
+
+const slackWorker = slackGatewayFactory
   ? createSlackWorker(
       config.namespace,
-      () =>
-        createBoltSlackGateway({
-          botToken: slackTokens.botToken,
-          appToken: slackTokens.appToken,
-          commandName: `/${config.brand.short}`,
-        }),
+      slackGatewayFactory,
       () => systemAgents,
       identityLinkService,
       {

--- a/packages/api-server/src/modules/channels/infrastructure/fake-slack-gateway.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/fake-slack-gateway.ts
@@ -1,0 +1,107 @@
+import type { SlackOutboundRecord } from "api-server-api";
+import type {
+  SlackGateway,
+  SlackGatewayHandlers,
+  SlackMentionEvent,
+  SlackSlashCommand,
+} from "./slack-gateway.js";
+
+export interface FakeSlackGateway extends SlackGateway {
+  fireMention(event: SlackMentionEvent): Promise<void>;
+  fireCommand(command: SlackSlashCommand): Promise<string>;
+  readOutbound(): SlackOutboundRecord[];
+  resetOutbound(): void;
+}
+
+export function createFakeSlackGateway(): FakeSlackGateway {
+  let handlers: SlackGatewayHandlers | null = null;
+  const outbound: SlackOutboundRecord[] = [];
+
+  function requireHandlers(): SlackGatewayHandlers {
+    if (!handlers) {
+      throw new Error(
+        "fake slack gateway not started — connect a Slack channel first",
+      );
+    }
+    return handlers;
+  }
+
+  return {
+    async start(h) {
+      handlers = h;
+      return true;
+    },
+
+    async stop() {
+      handlers = null;
+    },
+
+    async postMessage(args) {
+      outbound.push({
+        kind: "message",
+        channel: args.channel,
+        text: args.text,
+        ...(args.threadTs !== undefined ? { threadTs: args.threadTs } : {}),
+      });
+    },
+
+    async postEphemeral(args) {
+      outbound.push({
+        kind: "ephemeral",
+        channel: args.channel,
+        user: args.user,
+        text: args.text,
+        ...(args.threadTs !== undefined ? { threadTs: args.threadTs } : {}),
+      });
+    },
+
+    async addReaction(args) {
+      outbound.push({
+        kind: "reaction",
+        channel: args.channel,
+        ts: args.ts,
+        name: args.name,
+      });
+    },
+
+    async getThreadReplies() {
+      return [];
+    },
+
+    async getChannelHistory() {
+      return [];
+    },
+
+    async uploadFile(args) {
+      outbound.push({
+        kind: "upload",
+        channelId: args.channelId,
+        filename: args.filename,
+      });
+    },
+
+    async downloadFile() {
+      throw new Error("downloadFile is not supported by the fake gateway");
+    },
+
+    async fireMention(event) {
+      await requireHandlers().onMention(event);
+    },
+
+    async fireCommand(command) {
+      let ackText = "";
+      await requireHandlers().onCommand(command, async ({ text }) => {
+        ackText = text;
+      });
+      return ackText;
+    },
+
+    readOutbound() {
+      return [...outbound];
+    },
+
+    resetOutbound() {
+      outbound.length = 0;
+    },
+  };
+}

--- a/packages/api-server/src/modules/e2e/compose.ts
+++ b/packages/api-server/src/modules/e2e/compose.ts
@@ -1,7 +1,13 @@
 import type { E2eService } from "api-server-api";
-import { createE2eService } from "./services/e2e-service.js";
+import {
+  createE2eService,
+  type SlackE2eControl,
+} from "./services/e2e-service.js";
 
-export function composeE2eModule(deps: { namespace: string }): {
+export function composeE2eModule(deps: {
+  namespace: string;
+  slack?: SlackE2eControl;
+}): {
   service: E2eService;
 } {
   return { service: createE2eService(deps) };

--- a/packages/api-server/src/modules/e2e/services/e2e-service.ts
+++ b/packages/api-server/src/modules/e2e/services/e2e-service.ts
@@ -1,10 +1,32 @@
 import { createTRPCClient, createWSClient, wsLink } from "@trpc/client";
-import type { E2eService } from "api-server-api";
+import type {
+  E2eService,
+  SlackFireCommandInput,
+  SlackFireMentionInput,
+  SlackOutboundRecord,
+} from "api-server-api";
 import type { AppRouter as MockAppRouter } from "mock-agent-api";
 import WS from "ws";
 import { podBaseUrl } from "../../agents/infrastructure/k8s.js";
 
-export function createE2eService(deps: { namespace: string }): E2eService {
+export interface SlackE2eControl {
+  fireMention(event: SlackFireMentionInput): Promise<void>;
+  fireCommand(command: SlackFireCommandInput): Promise<string>;
+  readOutbound(): SlackOutboundRecord[];
+  resetOutbound(): void;
+}
+
+export function createE2eService(deps: {
+  namespace: string;
+  slack?: SlackE2eControl;
+}): E2eService {
+  function requireSlack(): SlackE2eControl {
+    if (!deps.slack) {
+      throw new Error("slack e2e control is not available on this deployment");
+    }
+    return deps.slack;
+  }
+
   async function withClient<T>(
     agentId: string,
     fn: (
@@ -38,5 +60,20 @@ export function createE2eService(deps: { namespace: string }): E2eService {
       withClient(agentId, (c) => c.scriptedMock.getEnv.query({ name })),
     performFetch: (agentId, input) =>
       withClient(agentId, (c) => c.scriptedMock.performFetch.mutate(input)),
+    slackFireMention: async (input) => {
+      await requireSlack().fireMention(input);
+      return { ok: true };
+    },
+    slackFireCommand: async (input) => {
+      const ack = await requireSlack().fireCommand(input);
+      return { ack };
+    },
+    slackReadOutbound: async () => ({
+      records: requireSlack().readOutbound(),
+    }),
+    slackResetOutbound: async () => {
+      requireSlack().resetOutbound();
+      return { ok: true };
+    },
   };
 }

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -58,5 +58,11 @@ export default defineConfig({
       dependencies: ["auth"],
       use: { ...devices["Desktop Chrome"] },
     },
+    {
+      name: "slack",
+      testMatch: /07-.*\.spec\.ts$/,
+      dependencies: ["injection"],
+      use: { ...devices["Desktop Chrome"], storageState },
+    },
   ],
 });

--- a/packages/e2e/playwright/src/config.ts
+++ b/packages/e2e/playwright/src/config.ts
@@ -12,3 +12,8 @@ export const testUser = {
   username: process.env.PLATFORM_E2E_USERNAME ?? "dev",
   password: process.env.PLATFORM_E2E_PASSWORD ?? "dev",
 };
+
+export const testUser2 = {
+  username: process.env.PLATFORM_E2E_USERNAME2 ?? "dev2",
+  password: process.env.PLATFORM_E2E_PASSWORD2 ?? "dev2",
+};

--- a/packages/e2e/playwright/src/tests/07-slack.spec.ts
+++ b/packages/e2e/playwright/src/tests/07-slack.spec.ts
@@ -1,0 +1,133 @@
+import { expect, test } from "@playwright/test";
+
+import { baseUrl, testUser2 } from "../config.js";
+import { waitForAgentRunning } from "../lib/agents.js";
+import { createApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+import { agentName } from "../lib/fixtures.js";
+
+const slackChannelId = "C-E2E-TRACER";
+const foreignSlackUserId = "U-E2E-FOREIGN";
+const mockDefaultReply = "Hello from the mock agent.";
+
+test("foreign user mention forks the agent and the reply lands back in the thread", async ({
+  browser,
+}) => {
+  test.setTimeout(420_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+
+  const agentId = await waitForAgentRunning(api, agentName);
+
+  await test.step("bind the agent to a slack channel", async () => {
+    await api.agents.connectSlack.mutate({ id: agentId, slackChannelId });
+  });
+
+  let loginUrl = "";
+  await test.step("request a login link as the foreign slack user", async () => {
+    await expect
+      .poll(
+        async () => {
+          try {
+            const { ack } = await api.e2e.slackFireCommand.mutate({
+              text: "login",
+              userId: foreignSlackUserId,
+              channelId: slackChannelId,
+            });
+            loginUrl = ack.match(/<([^|>]+)\|/)?.[1] ?? "";
+            return loginUrl !== "";
+          } catch {
+            return false;
+          }
+        },
+        {
+          timeout: 30_000,
+          message: "slack gateway did not produce a login link",
+        },
+      )
+      .toBe(true);
+  });
+
+  await test.step("link the foreign user via Keycloak OAuth and accept terms", async () => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await page.goto(baseUrl);
+    await page.waitForURL(/\/realms\/platform\/protocol\/openid-connect\/auth/);
+    await page.locator("#username").fill(testUser2.username);
+    await page.locator("#password").fill(testUser2.password);
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    await page.waitForURL(
+      (url) =>
+        url.origin === baseUrl && !url.pathname.startsWith("/auth/callback"),
+    );
+
+    const termsButton = page.getByRole("button", {
+      name: /I accept the Terms of Use/,
+    });
+    const appSidebar = page.getByTestId("app-sidebar");
+    await expect(termsButton.or(appSidebar)).toBeVisible();
+    if (await termsButton.isVisible()) {
+      await termsButton.click();
+      await page.waitForURL(`${baseUrl}/`);
+    }
+    await expect(appSidebar).toBeVisible();
+
+    await page.goto(loginUrl);
+    await expect(page.getByText(/account linked/i)).toBeVisible();
+
+    await context.close();
+  });
+
+  await test.step("fire a foreign mention and watch the fork run", async () => {
+    await api.e2e.slackResetOutbound.mutate();
+    await api.e2e.slackFireMention.mutate({
+      user: foreignSlackUserId,
+      channel: slackChannelId,
+      ts: "1700000001.000100",
+      text: "hello from the foreign user",
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const { records } = await api.e2e.slackReadOutbound.query();
+          return records.some(
+            (r) => r.kind === "reaction" && r.name === "eyes",
+          );
+        },
+        {
+          timeout: 30_000,
+          message:
+            "foreign mention was not acknowledged with the eyes reaction",
+        },
+      )
+      .toBe(true);
+
+    await expect
+      .poll(
+        async () => {
+          const { records } = await api.e2e.slackReadOutbound.query();
+          return records.some(
+            (r) => r.kind === "message" && r.text.includes(mockDefaultReply),
+          );
+        },
+        {
+          timeout: 300_000,
+          intervals: [5_000],
+          message: "fork reply did not land back in the slack thread",
+        },
+      )
+      .toBe(true);
+
+    const { records } = await api.e2e.slackReadOutbound.query();
+    const failures = records.filter(
+      (r) =>
+        (r.kind === "ephemeral" && /could not run turn/i.test(r.text)) ||
+        (r.kind === "message" && r.text.startsWith("Error:")),
+    );
+    expect(failures).toEqual([]);
+  });
+});

--- a/packages/e2e/playwright/src/tests/07-slack.spec.ts
+++ b/packages/e2e/playwright/src/tests/07-slack.spec.ts
@@ -50,7 +50,9 @@ test("foreign user mention forks the agent and the reply lands back in the threa
   });
 
   await test.step("link the foreign user via Keycloak OAuth and accept terms", async () => {
-    const context = await browser.newContext();
+    const context = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+    });
     const page = await context.newPage();
 
     await page.goto(baseUrl);


### PR DESCRIPTION
Tracer bullet for the Slack e2e strategy (ADR-064): proves foreign forks can be driven and observed in e2e. A foreign Slack user links via the real OAuth flow, mentions the agent, and the real fork Job posts the mock reply back into the thread. No #444 repro yet, that stays in the follow-up.

- Fake SlackGateway behind the existing port: outbound buffer, fireMention/fireCommand injection, history reads return empty
- Slack worker is built with the fake when e2e is enabled and no real tokens are set, prod path untouched
- New e2e control endpoints: slackFireMention, slackFireCommand (returns ack text), slackReadOutbound, slackResetOutbound
- Second Keycloak test user (dev2) seeded only in the e2e overlay
- 06-slack.spec.ts: connectSlack binding, /login ack to Keycloak OAuth in a fresh browser context including terms, foreign mention, asserts eyes reaction plus the fork reply landing in the buffer and no failure ephemeral

The fork path is fully real: K8s Job, paired gateway pod, pod IP ACP. Only the Slack edge is faked.

Tracked as dam-4uk, blocks dam-rf1 (full slice: owner roundtrip, #444 repro spec).