### PR TITLE
refactor(ui): unify buttons and inputs via variant-based components

### DIFF
--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -22,13 +22,39 @@ const buttonVariants = cva(
       size: {
         default: "h-10 px-4 py-2",
         sm: "h-9 rounded-md px-3",
+        xs: "h-7 rounded-md px-2.5 text-xs",
         lg: "h-11 rounded-md px-8",
         icon: "h-10 w-10",
+        "icon-sm": "h-7 w-7",
+        "icon-xs": "h-6 w-6",
+      },
+      tone: {
+        default: "",
+        danger: "",
       },
     },
+    compoundVariants: [
+      {
+        variant: "ghost",
+        tone: "danger",
+        className: "hover:bg-danger-light hover:text-danger",
+      },
+      {
+        variant: "outline",
+        tone: "danger",
+        className:
+          "hover:bg-danger-light hover:text-danger hover:border-danger",
+      },
+      {
+        variant: "link",
+        tone: "danger",
+        className: "text-danger",
+      },
+    ],
     defaultVariants: {
       variant: "default",
       size: "default",
+      tone: "default",
     },
   },
 );
@@ -41,11 +67,11 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  ({ className, variant, size, tone, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button";
     return (
       <Comp
-        className={cn(buttonVariants({ variant, size, className }))}
+        className={cn(buttonVariants({ variant, size, tone, className }))}
         ref={ref}
         {...props}
       />

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -1,23 +1,46 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Input = React.forwardRef<
-  HTMLInputElement,
-  React.InputHTMLAttributes<HTMLInputElement>
->(({ className, type, ...props }, ref) => {
-  return (
-    <input
-      type={type}
-      className={cn(
-        "flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className,
-      )}
-      ref={ref}
-      {...props}
-    />
-  );
-});
+const inputVariants = cva(
+  "flex w-full rounded-md border bg-background ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        standard: "border-input",
+        monospace: "border-input font-mono",
+        invalid: "border-destructive focus-visible:ring-destructive",
+      },
+      size: {
+        default: "h-10 px-3 py-2 text-sm",
+        sm: "h-8 px-3 text-xs",
+      },
+    },
+    defaultVariants: {
+      variant: "standard",
+      size: "default",
+    },
+  },
+);
+
+export interface InputProps
+  extends
+    Omit<React.InputHTMLAttributes<HTMLInputElement>, "size">,
+    VariantProps<typeof inputVariants> {}
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, variant, size, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(inputVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
 Input.displayName = "Input";
 
-export { Input };
+export { Input, inputVariants };

--- a/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/add-agent-dialog.tsx
@@ -532,13 +532,14 @@ export function AddAgentDialog({
                         <FileIcon /> Choose files
                       </Button>
                       {importPicker.hasContent && (
-                        <button
+                        <Button
                           type="button"
+                          variant="link"
+                          size="sm"
                           onClick={importPicker.clear}
-                          className="text-[12px] text-muted-foreground hover:text-foreground underline"
                         >
                           Clear
-                        </button>
+                        </Button>
                       )}
                     </div>
                     <div className="text-[11px] text-muted-foreground italic">
@@ -570,14 +571,16 @@ export function AddAgentDialog({
                           >
                             {pick.name}
                           </span>
-                          <button
+                          <Button
                             type="button"
+                            variant="ghost"
+                            size="icon-xs"
                             onClick={() => importPicker.removePick(pick.key)}
-                            className="text-muted-foreground hover:text-foreground shrink-0"
+                            className="shrink-0"
                             aria-label={`Remove ${pick.name}`}
                           >
                             <X size={12} />
-                          </button>
+                          </Button>
                         </span>
                       ))}
                     </div>

--- a/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
+++ b/packages/ui/src/modules/agents/dialogs/configure-agent-dialog.tsx
@@ -8,6 +8,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { Tooltip } from "@/components/ui/tooltip";
 
 import {
@@ -419,15 +420,10 @@ export function ConfigureAgentDialog({
             </p>
           </div>
           <FormField label="Name" error={errors.name?.message}>
-            <input
-              className="w-full h-10 rounded-lg border-2 border-border-light bg-bg px-4 text-[14px] text-text outline-none transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-glow)] placeholder:text-text-muted"
-              disabled={saving}
-              {...register("name")}
-            />
+            <Input disabled={saving} {...register("name")} />
           </FormField>
           <FormField label="Description" error={errors.description?.message}>
-            <input
-              className="w-full h-10 rounded-lg border-2 border-border-light bg-bg px-4 text-[14px] text-text outline-none transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-glow)] placeholder:text-text-muted"
+            <Input
               placeholder="Optional"
               disabled={saving}
               {...register("description")}

--- a/packages/ui/src/modules/approvals/components/approvals-list.tsx
+++ b/packages/ui/src/modules/approvals/components/approvals-list.tsx
@@ -9,6 +9,8 @@ import {
 } from "lucide-react";
 import { useMemo } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { useStore } from "../../../store.js";
 import {
   useApproveHost,
@@ -134,8 +136,10 @@ function ApprovalRow({
       </div>
       {row.status !== "resolved" && (
         <div className="flex flex-wrap gap-1.5">
-          <button
+          <Button
             type="button"
+            variant="outline"
+            size="xs"
             disabled={inflight || allowOnceDisabled}
             onClick={() => approveOnce.mutate({ id: row.id })}
             title={
@@ -143,32 +147,36 @@ function ApprovalRow({
                 ? "Original request already failed; pick Allow permanently to allow future retries"
                 : "Allow this single request"
             }
-            className="h-7 inline-flex items-center gap-1 rounded-md border border-border-light px-2 text-[11px] text-text-secondary hover:text-accent hover:border-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             <Check size={11} /> Allow once
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="outline"
+            size="xs"
             disabled={inflight}
             onClick={() => approvePermanent.mutate({ id: row.id })}
             title="Allow this exact path on this host (writes a rule)"
-            className="h-7 inline-flex items-center gap-1 rounded-md border border-border-light px-2 text-[11px] text-text-secondary hover:text-accent hover:border-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             <CheckCheck size={11} /> Allow permanently
-          </button>
+          </Button>
           {showHostActions && (
-            <button
+            <Button
               type="button"
+              variant="outline"
+              size="xs"
               disabled={inflight}
               onClick={() => approveHost.mutate({ id: row.id })}
               title={`Allow all requests to ${hostLabel} (writes a wildcard rule)`}
-              className="h-7 inline-flex items-center gap-1 rounded-md border border-border-light px-2 text-[11px] text-text-secondary hover:text-accent hover:border-accent disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
             >
               <Globe size={11} /> Allow {hostLabel}
-            </button>
+            </Button>
           )}
-          <button
+          <Button
             type="button"
+            variant="outline"
+            tone="danger"
+            size="xs"
             disabled={inflight || !live}
             onClick={() => dismiss.mutate({ id: row.id })}
             title={
@@ -176,29 +184,31 @@ function ApprovalRow({
                 ? "Original request already failed; nothing to dismiss"
                 : "Deny this single request — re-prompts on the next attempt"
             }
-            className="h-7 inline-flex items-center gap-1 rounded-md border border-border-light px-2 text-[11px] text-text-secondary hover:text-danger hover:border-danger disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             <X size={11} /> Dismiss
-          </button>
-          <button
+          </Button>
+          <Button
             type="button"
+            variant="outline"
+            tone="danger"
+            size="xs"
             disabled={inflight}
             onClick={() => denyForever.mutate({ id: row.id })}
             title="Deny this exact path on this host (writes a deny rule)"
-            className="h-7 inline-flex items-center gap-1 rounded-md border border-border-light px-2 text-[11px] text-text-secondary hover:text-danger hover:border-danger disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
           >
             <ShieldOff size={11} /> Deny forever
-          </button>
+          </Button>
           {showHostActions && (
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="xs"
               disabled={inflight}
               onClick={() => navigateToAgentEgress(row.agentId)}
               title="Manage all network access rules for this agent"
-              className="h-7 inline-flex items-center gap-1 rounded-md px-2 text-[11px] text-text-muted hover:text-text transition-colors"
             >
               <Settings2 size={11} /> Customize…
-            </button>
+            </Button>
           )}
         </div>
       )}

--- a/packages/ui/src/modules/connections/forms/template-create-form.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form.tsx
@@ -305,10 +305,12 @@ function OAuthAppHint({
             <code className="text-[11px] font-mono text-foreground/90 break-all">
               {callbackUrl}
             </code>
-            <button
+            <Button
               type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="shrink-0"
               onClick={copy}
-              className="h-5 w-5 shrink-0 rounded inline-flex items-center justify-center text-muted-foreground hover:text-primary"
               title="Copy redirect URI"
             >
               {copied ? (
@@ -316,7 +318,7 @@ function OAuthAppHint({
               ) : (
                 <Copy size={12} />
               )}
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/packages/ui/src/modules/files/components/file-row-menu.tsx
+++ b/packages/ui/src/modules/files/components/file-row-menu.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 
+import { Button } from "@/components/ui/button";
+
 export type FileRowMenuAction =
   | "new-file"
   | "new-folder"
@@ -110,12 +112,15 @@ function MenuItem({
   onSelect: () => void;
 }) {
   return (
-    <button
+    <Button
       role="menuitem"
-      className={`block w-full text-left px-3 py-1.5 hover:bg-muted ${danger ? "text-destructive" : ""}`}
+      variant="ghost"
+      tone={danger ? "danger" : undefined}
+      size="sm"
+      className="w-full justify-start"
       onClick={onSelect}
     >
       {children}
-    </button>
+    </Button>
   );
 }

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -7,6 +7,8 @@ import {
   MoreHorizontal,
 } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
+
 import { useFileRowDrag } from "../hooks/use-file-row-drag.js";
 import { useFilesPanel } from "./files-panel-controller.js";
 
@@ -71,8 +73,10 @@ export function FileRow({
       >
         <RowIcons isDir={isDir} isCollapsed={isCollapsed} name={name} />
         <span className="truncate flex-1">{name}</span>
-        <button
-          className="opacity-0 group-hover:opacity-100 focus:opacity-100 text-text-muted hover:text-text-secondary p-0.5 rounded transition-opacity"
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          className="opacity-0 group-hover:opacity-100 focus:opacity-100"
           onMouseDown={(e) => e.stopPropagation()}
           onClick={(e) => {
             e.stopPropagation();
@@ -81,7 +85,7 @@ export function FileRow({
           title="More actions"
         >
           <MoreHorizontal size={13} />
-        </button>
+        </Button>
       </div>
     </div>
   );

--- a/packages/ui/src/modules/files/components/files-panel-toolbar.tsx
+++ b/packages/ui/src/modules/files/components/files-panel-toolbar.tsx
@@ -1,5 +1,7 @@
 import { FilePlus, FolderPlus, FolderUp, Upload } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
+
 import type { FileEntryKind } from "../hooks/use-file-mutations.js";
 
 interface Props {
@@ -8,9 +10,6 @@ interface Props {
   onUploadFolder: () => void;
   onNew: (kind: FileEntryKind) => void;
 }
-
-const uploadButtonClass =
-  "text-text-muted hover:text-accent p-0.5 rounded transition-colors disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:text-text-muted";
 
 export function FilesPanelToolbar({
   isUploading,
@@ -23,36 +22,40 @@ export function FilesPanelToolbar({
       <span className="text-[11px] font-mono text-text-muted flex-1 truncate">
         /home/agent
       </span>
-      <button
-        className={uploadButtonClass}
+      <Button
+        variant="ghost"
+        size="icon-xs"
         title={isUploading ? "Upload in progress…" : "Upload files"}
         disabled={isUploading}
         onClick={onUploadFiles}
       >
         <Upload size={13} />
-      </button>
-      <button
-        className={uploadButtonClass}
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-xs"
         title={isUploading ? "Upload in progress…" : "Upload folder"}
         disabled={isUploading}
         onClick={onUploadFolder}
       >
         <FolderUp size={13} />
-      </button>
-      <button
-        className="text-text-muted hover:text-accent p-0.5 rounded transition-colors"
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-xs"
         title="New file"
         onClick={() => onNew("file")}
       >
         <FilePlus size={13} />
-      </button>
-      <button
-        className="text-text-muted hover:text-accent p-0.5 rounded transition-colors"
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon-xs"
         title="New folder"
         onClick={() => onNew("dir")}
       >
         <FolderPlus size={13} />
-      </button>
+      </Button>
     </div>
   );
 }

--- a/packages/ui/src/modules/schedules/components/schedules-panel.tsx
+++ b/packages/ui/src/modules/schedules/components/schedules-panel.tsx
@@ -1,6 +1,8 @@
 import { Plus } from "lucide-react";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { useStore } from "../../../store.js";
 import { useSchedules, useScheduleSessions } from "../api/queries.js";
 import { CreateScheduleForm } from "../forms/create-schedule-form.js";
@@ -26,15 +28,17 @@ export function SchedulesPanel({
   return (
     <div className="flex flex-col">
       <div className="px-3 py-2.5 shrink-0">
-        <button
-          className="w-full h-7 rounded-md border border-border-light text-[11px] font-semibold text-text-secondary hover:text-accent hover:border-accent flex items-center justify-center gap-1 transition-colors"
+        <Button
+          variant="outline"
+          size="xs"
+          className="w-full"
           onClick={() => {
             setIsCreating(true);
             setEditingId(null);
           }}
         >
           <Plus size={12} /> Add Schedule
-        </button>
+        </Button>
       </div>
 
       {isCreating && selectedAgent && (

--- a/packages/ui/src/modules/sessions/components/channels-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/channels-panel.tsx
@@ -191,12 +191,15 @@ function ChannelsForm({
                       <span className="flex-1 text-[12px] font-mono text-foreground truncate">
                         {u}
                       </span>
-                      <button
+                      <Button
+                        variant="ghost"
+                        tone="danger"
+                        size="icon-xs"
                         onClick={() => removeUser(u)}
-                        className="text-muted-foreground hover:text-destructive shrink-0"
+                        className="shrink-0"
                       >
                         <X size={12} />
-                      </button>
+                      </Button>
                     </div>
                   ))}
                 </div>

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -2,6 +2,8 @@ import { SessionMode, SessionType, type SessionView } from "api-server-api";
 import { Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 const LONG_PRESS_MS = 400;
 
 interface Props {
@@ -111,8 +113,11 @@ export function SessionRow({
         </span>
       </div>
       {/* Desktop: hover-visible delete button */}
-      <button
-        className="shrink-0 h-6 w-6 rounded-md flex items-center justify-center text-text-muted opacity-0 group-hover:opacity-100 hover:text-danger transition-all"
+      <Button
+        variant="ghost"
+        tone="danger"
+        size="icon-xs"
+        className="shrink-0 opacity-0 group-hover:opacity-100"
         onClick={(e) => {
           e.stopPropagation();
           onDelete();
@@ -120,15 +125,18 @@ export function SessionRow({
         title="Delete session"
       >
         <Trash2 size={12} />
-      </button>
+      </Button>
       {/* Context menu — long press (mobile) or right-click */}
       {menuOpen && (
         <div
           ref={menuRef}
           className="absolute right-3 top-2 z-30 rounded-lg border border-border bg-surface py-1 anim-scale-in shadow-md"
         >
-          <button
-            className="flex items-center gap-2 w-full px-4 py-2 text-[13px] text-danger hover:bg-danger-light transition-colors"
+          <Button
+            variant="ghost"
+            tone="danger"
+            size="sm"
+            className="w-full justify-start"
             onClick={(e) => {
               e.stopPropagation();
               setMenuOpen(false);
@@ -136,7 +144,7 @@ export function SessionRow({
             }}
           >
             <Trash2 size={13} /> Delete session
-          </button>
+          </Button>
         </div>
       )}
     </div>

--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -2,6 +2,8 @@ import { SessionMode } from "api-server-api";
 import { ArrowLeft, Plus, RefreshCw } from "lucide-react";
 import { useCallback } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { useStore } from "../../../store.js";
 import { useAgentRunState } from "../../agents/api/queries.js";
 import { AgentApprovalsTray } from "../../approvals/components/agent-approvals-tray.js";
@@ -51,23 +53,27 @@ export function SessionsSidebar({
     <>
       <div className="flex items-center justify-between px-4 h-11 border-b border-border-light shrink-0 relative">
         {/* Mobile: back to agents */}
-        <button
-          className="md:hidden h-6 w-6 rounded-md flex items-center justify-center text-text-muted hover:text-accent transition-colors mr-2"
+        <Button
+          variant="ghost"
+          size="icon-xs"
+          className="md:hidden mr-2"
           onClick={goBack}
         >
           <ArrowLeft size={14} />
-        </button>
+        </Button>
         <span className="text-[11px] font-bold text-text-muted uppercase tracking-[0.05em]">
           Sessions
         </span>
-        <button
-          className={`ml-auto h-6 w-6 rounded-md border border-border-light flex items-center justify-center text-text-muted hover:text-accent hover:border-accent transition-colors`}
+        <Button
+          variant="outline"
+          size="icon-xs"
+          className="ml-auto"
           onClick={() => refetch()}
         >
           <span className={loading ? "anim-spin" : ""}>
             <RefreshCw size={11} />
           </span>
-        </button>
+        </Button>
         {loading && (
           <div className="absolute bottom-0 left-0 right-0 h-[2px] bg-accent/20 overflow-hidden">
             <div className="h-full w-1/3 bg-accent rounded-full anim-slide" />
@@ -106,12 +112,14 @@ export function SessionsSidebar({
       </div>
       <AgentApprovalsTray agentId={selectedAgent} />
       <div className="px-3 py-3 border-t border-border-light shrink-0">
-        <button
-          className="w-full h-9 rounded-md border border-border-light text-[12px] font-semibold text-text-secondary hover:text-accent hover:border-accent flex items-center justify-center gap-1.5 transition-colors"
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full"
           onClick={onNewSession}
         >
           <Plus size={13} /> New Session
-        </button>
+        </Button>
       </div>
     </>
   );

--- a/packages/ui/src/modules/sessions/components/skills-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/skills-panel.tsx
@@ -19,6 +19,7 @@ import { useCallback, useEffect, useState } from "react";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 
 import { api } from "../../../api.js";
 import { ACTION_FAILED, runAction } from "../../../lib/query-helpers.js";
@@ -490,8 +491,8 @@ export function SkillsPanel({
                   </option>
                 ))}
               </select>
-              <input
-                className={inp}
+              <Input
+                size="sm"
                 placeholder="Pull request title"
                 value={publishForm.title}
                 onChange={(e) =>
@@ -510,15 +511,13 @@ export function SkillsPanel({
               <div className="flex justify-end gap-2">
                 <Button
                   variant="outline"
-                  size="sm"
-                  className="h-7 text-[11px]"
+                  size="xs"
                   onClick={() => setPublishFor(null)}
                 >
                   Cancel
                 </Button>
                 <Button
-                  size="sm"
-                  className="h-7 text-[11px]"
+                  size="xs"
                   disabled={publishBusy || !publishForm.sourceId}
                   onClick={publish}
                 >
@@ -554,18 +553,22 @@ export function SkillsPanel({
                     );
                   })()}
                   {onOpenFile && (
-                    <button
+                    <Button
                       type="button"
-                      className="text-text-muted hover:text-accent transition-colors shrink-0"
+                      variant="ghost"
+                      size="icon-xs"
+                      className="shrink-0"
                       title="View SKILL.md in Files"
                       onClick={() => onOpenFile(localSkillMdPath(skill))}
                     >
                       <Eye size={11} />
-                    </button>
+                    </Button>
                   )}
-                  <button
+                  <Button
                     type="button"
-                    className="text-text-muted hover:text-accent transition-colors shrink-0 disabled:opacity-40 disabled:hover:text-text-muted"
+                    variant="ghost"
+                    size="icon-xs"
+                    className="shrink-0"
                     title={
                       publishableSources.length === 0
                         ? "Add a GitHub source first to publish there"
@@ -575,7 +578,7 @@ export function SkillsPanel({
                     onClick={() => openPublish(skill)}
                   >
                     <Share2 size={11} />
-                  </button>
+                  </Button>
                 </div>
                 {skill.description && (
                   <div
@@ -592,29 +595,32 @@ export function SkillsPanel({
       )}
 
       <div className="px-3 py-2.5 shrink-0">
-        <button
-          className="w-full h-7 rounded-md border border-border-light text-[11px] font-semibold text-text-secondary hover:text-accent hover:border-accent flex items-center justify-center gap-1 transition-colors"
+        <Button
+          variant="outline"
+          size="xs"
+          className="w-full"
           onClick={() => {
             setAddForm({ name: "", gitUrl: "" });
             setShowAdd(true);
           }}
         >
           <Plus size={12} /> Add Source
-        </button>
+        </Button>
       </div>
 
       {showAdd && (
         <div className="flex flex-col gap-3 border-b border-border-light p-4 anim-in">
-          <input
-            className={inp}
+          <Input
+            size="sm"
             placeholder='Name (e.g. "My Skills")'
             value={addForm.name}
             onChange={(e) =>
               setAddForm((f) => ({ ...f, name: e.target.value }))
             }
           />
-          <input
-            className={`${inp} font-mono`}
+          <Input
+            size="sm"
+            variant="monospace"
             placeholder="https://github.com/your-org/skills"
             value={addForm.gitUrl}
             onChange={(e) =>

--- a/packages/ui/src/modules/sessions/components/terminal.tsx
+++ b/packages/ui/src/modules/sessions/components/terminal.tsx
@@ -13,6 +13,8 @@ import {
 import { Loader2, TerminalIcon, XCircle } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { getAccessToken } from "../../../auth.js";
 
 type ConnectionState = "connecting" | "live" | "disconnected" | "exited";
@@ -195,12 +197,9 @@ export function Terminal({
             <p className="text-[14px] text-text-secondary">
               Session disconnected
             </p>
-            <button
-              className="rounded-md border border-border-light bg-surface-raised px-4 py-2 text-[13px] text-text-primary hover:bg-surface-hover transition-colors"
-              onClick={handleReconnect}
-            >
+            <Button variant="outline" onClick={handleReconnect}>
               Reconnect
-            </button>
+            </Button>
           </div>
         </div>
       )}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -411,12 +411,14 @@ export function ChatView() {
             </button>
           </div>
           <div className="ml-auto flex items-center gap-2">
-            <button
-              className="md:hidden h-7 w-7 rounded-md border border-border-light flex items-center justify-center text-text-muted hover:text-accent hover:border-accent transition-colors"
+            <Button
+              variant="outline"
+              size="icon-sm"
+              className="md:hidden"
               onClick={() => setShowMobilePanel(true)}
             >
               <Settings2 size={14} />
-            </button>
+            </Button>
             <ChatHeaderStatus
               selectedAgent={selectedAgent}
               agents={agents}
@@ -670,12 +672,13 @@ export function ChatView() {
           <div className="absolute right-0 top-0 bottom-0 w-full max-w-[400px] bg-surface flex flex-col anim-slide-in-right">
             <div className="flex items-center justify-between px-4 h-11 border-b border-border-light shrink-0">
               <span className="text-[13px] font-bold text-text">Panel</span>
-              <button
-                className="h-7 w-7 rounded-md border border-border-light flex items-center justify-center text-text-muted hover:text-accent hover:border-accent transition-colors"
+              <Button
+                variant="outline"
+                size="icon-sm"
                 onClick={() => setShowMobilePanel(false)}
               >
                 <ArrowLeft size={14} />
-              </button>
+              </Button>
             </div>
             {rightPanelContent}
           </div>

--- a/packages/ui/src/modules/settings/components/anthropic/form.tsx
+++ b/packages/ui/src/modules/settings/components/anthropic/form.tsx
@@ -186,10 +186,11 @@ function QuickSetupHint() {
         <code className="font-mono font-semibold text-primary">
           claude setup-token
         </code>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          size="icon-xs"
           onClick={copy}
-          className="h-5 w-5 rounded inline-flex items-center justify-center text-muted-foreground hover:text-primary"
           title="Copy command"
         >
           {copied ? (
@@ -197,7 +198,7 @@ function QuickSetupHint() {
           ) : (
             <Copy size={12} />
           )}
-        </button>
+        </Button>
       </span>{" "}
       on your own machine (with Claude Code installed) to generate a token.
     </div>

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -155,12 +155,9 @@ export function SettingsView() {
             </Card>
 
             <div className="mt-6">
-              <button
-                onClick={() => setView("terms")}
-                className="text-[13px] font-medium text-foreground/80 hover:text-foreground underline underline-offset-2"
-              >
+              <Button variant="link" onClick={() => setView("terms")}>
                 View Terms of Use
-              </button>
+              </Button>
             </div>
 
             {appVersion && (

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -1,3 +1,5 @@
+import { Button } from "@/components/ui/button";
+
 import { Markdown } from "../../../components/markdown.js";
 import { useAcceptTerms } from "../api/mutations.js";
 import { useLatestAcceptance, useTermsDocument } from "../api/queries.js";
@@ -76,26 +78,17 @@ function AcceptButton({
   onClick: () => void;
 }) {
   return (
-    <button
-      type="button"
-      disabled={pending}
-      onClick={onClick}
-      className="bg-accent text-white px-4 py-2 rounded disabled:opacity-50"
-    >
+    <Button type="button" disabled={pending} onClick={onClick}>
       {pending ? "Accepting…" : "I accept the Terms of Use"}
-    </button>
+    </Button>
   );
 }
 
 function BackButton() {
   return (
-    <button
-      type="button"
-      onClick={() => window.location.assign("/")}
-      className="bg-accent text-white px-4 py-2 rounded"
-    >
+    <Button type="button" onClick={() => window.location.assign("/")}>
       Back
-    </button>
+    </Button>
   );
 }
 

--- a/packages/ui/src/modules/v2/components/sandbox-card.tsx
+++ b/packages/ui/src/modules/v2/components/sandbox-card.tsx
@@ -1,5 +1,6 @@
 import { Trash2 } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
 import { StatusBadge } from "../../../components/status-indicator.js";
@@ -50,18 +51,21 @@ export function SandboxCard({
             </div>
           )}
         </div>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          tone="danger"
+          size="icon-sm"
+          className="shrink-0"
           onClick={(e) => {
             e.stopPropagation();
             onDelete();
           }}
           disabled={deleting}
           title="Delete sandbox"
-          className="shrink-0 rounded-md p-2 text-muted-foreground hover:text-destructive disabled:opacity-50 transition-colors"
         >
           <Trash2 size={16} />
-        </button>
+        </Button>
       </div>
     </Card>
   );


### PR DESCRIPTION
## Summary

Buttons and inputs across the app were styled by hand at every call site, with the same long className strings copy-pasted and small inconsistencies creeping in. This migrates the app's action buttons and text inputs onto a single shared `Button` and `Input`, so every button at a given role looks identical app-wide and cross-cutting style changes land in one place. No functional change.

- **Button** gains an `xs` size and a `tone="danger"` axis (neutral at rest, danger on hover), so call sites express small and danger buttons by name rather than with ad-hoc padding/color classes. The primary button stays black/white.
- **Input** gains `standard` / `monospace` / `invalid` variants and a `sm` size.
- Call sites keep only layout classes (`w-full`, `justify-*`, `shrink-0`, …) — no padding, color, or danger classes.

Surfaces migrated: sessions, agents dialogs, approvals, files, settings, connections, schedules, terms, and the sandbox card.

Closes #223