### PR TITLE
fix(api-server): evaluate schedule fires and quiet hours in the schedule's timezone

### DIFF
--- a/packages/api-server/src/__tests__/unit/schedules-recurrences.test.ts
+++ b/packages/api-server/src/__tests__/unit/schedules-recurrences.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import type { ScheduleSpec } from "api-server-api";
+import { nextFireAt } from "../../modules/schedules/domain/recurrences.js";
+
+function rruleSpec(
+  rrule: string,
+  timezone: string,
+  quietHours?: { startTime: string; endTime: string; enabled: boolean }[],
+): ScheduleSpec {
+  return {
+    version: "platform.ai/v1",
+    type: "rrule",
+    rrule,
+    timezone,
+    quietHours,
+    enabled: true,
+    createdBy: "user",
+  };
+}
+
+describe("nextFireAt (rrule)", () => {
+  it("fires at the wall-clock time in the schedule's timezone, not UTC", () => {
+    // 09:00 Europe/Prague in June is 07:00Z (CEST, UTC+2).
+    const spec = rruleSpec(
+      "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0",
+      "Europe/Prague",
+    );
+    const next = nextFireAt(spec, new Date("2026-06-11T00:00:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-11T07:00:00.000Z");
+  });
+
+  it("tracks the timezone's winter offset", () => {
+    // 09:00 Europe/Prague in January is 08:00Z (CET, UTC+1).
+    const spec = rruleSpec(
+      "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0",
+      "Europe/Prague",
+    );
+    const next = nextFireAt(spec, new Date("2026-01-15T00:00:00Z"));
+    expect(next?.toISOString()).toBe("2026-01-15T08:00:00.000Z");
+  });
+
+  it("does not skip a same-day occurrence in zones behind UTC", () => {
+    // 07:00 in New York (11:00Z); today's 09:00 fire is still ahead.
+    const spec = rruleSpec(
+      "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0",
+      "America/New_York",
+    );
+    const next = nextFireAt(spec, new Date("2026-06-11T11:00:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-11T13:00:00.000Z");
+  });
+
+  it("rolls to the next day once today's occurrence has passed locally", () => {
+    // 09:30 Prague (07:30Z) — today's 09:00 already fired.
+    const spec = rruleSpec(
+      "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0",
+      "Europe/Prague",
+    );
+    const next = nextFireAt(spec, new Date("2026-06-11T07:30:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-12T07:00:00.000Z");
+  });
+
+  it("evaluates quiet hours against the schedule's local clock", () => {
+    // Hourly from 21:30 Prague (19:30Z). Occurrences 22:30, 23:30, ... local
+    // are suppressed by the cross-midnight window; 06:30 local (04:30Z) is
+    // the first survivor.
+    const spec = rruleSpec("FREQ=HOURLY", "Europe/Prague", [
+      { startTime: "22:00", endTime: "06:00", enabled: true },
+    ]);
+    const next = nextFireAt(spec, new Date("2026-06-11T19:30:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-12T04:30:00.000Z");
+  });
+
+  it("ignores disabled quiet windows", () => {
+    const spec = rruleSpec("FREQ=HOURLY", "Europe/Prague", [
+      { startTime: "22:00", endTime: "06:00", enabled: false },
+    ]);
+    const next = nextFireAt(spec, new Date("2026-06-11T19:30:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-11T20:30:00.000Z");
+  });
+
+  it("returns null when quiet hours suppress every occurrence", () => {
+    const spec = rruleSpec(
+      "FREQ=DAILY;BYHOUR=23;BYMINUTE=0;BYSECOND=0;COUNT=3",
+      "Europe/Prague",
+      [{ startTime: "22:00", endTime: "06:00", enabled: true }],
+    );
+    expect(nextFireAt(spec, new Date("2026-06-11T00:00:00Z"))).toBeNull();
+  });
+
+  it("keeps UTC schedules unchanged", () => {
+    const spec = rruleSpec("FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0", "UTC");
+    const next = nextFireAt(spec, new Date("2026-06-11T08:00:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-11T09:00:00.000Z");
+  });
+
+  it("resolves wall times erased by spring-forward to just past the jump", () => {
+    // Prague skips 02:00→03:00 on 2026-03-29; the nonexistent 02:30 local
+    // resolves to 03:30 local (01:30Z), past the gap.
+    const spec = rruleSpec(
+      "FREQ=DAILY;BYHOUR=2;BYMINUTE=30;BYSECOND=0",
+      "Europe/Prague",
+    );
+    const next = nextFireAt(spec, new Date("2026-03-29T00:00:00Z"));
+    expect(next?.toISOString()).toBe("2026-03-29T01:30:00.000Z");
+  });
+});
+
+describe("nextFireAt (cron)", () => {
+  it("stays UTC for legacy cron schedules", () => {
+    const spec: ScheduleSpec = {
+      version: "platform.ai/v1",
+      type: "cron",
+      cron: "0 9 * * *",
+      enabled: true,
+      createdBy: "user",
+    };
+    const next = nextFireAt(spec, new Date("2026-06-11T08:00:00Z"));
+    expect(next?.toISOString()).toBe("2026-06-11T09:00:00.000Z");
+  });
+});

--- a/packages/api-server/src/__tests__/unit/schedules-recurrences.test.ts
+++ b/packages/api-server/src/__tests__/unit/schedules-recurrences.test.ts
@@ -49,6 +49,14 @@ describe("nextFireAt (rrule)", () => {
     expect(next?.toISOString()).toBe("2026-06-11T13:00:00.000Z");
   });
 
+  it("does not inherit seconds from the evaluation instant", () => {
+    // Real schedules carry no BYSECOND; a from-instant with stray seconds
+    // must not shift the fire time off the whole minute.
+    const spec = rruleSpec("FREQ=DAILY;BYHOUR=9;BYMINUTE=0", "Europe/Prague");
+    const next = nextFireAt(spec, new Date("2026-06-11T00:00:59Z"));
+    expect(next?.toISOString()).toBe("2026-06-11T07:00:00.000Z");
+  });
+
   it("rolls to the next day once today's occurrence has passed locally", () => {
     // 09:30 Prague (07:30Z) — today's 09:00 already fired.
     const spec = rruleSpec(

--- a/packages/api-server/src/modules/schedules/domain/recurrences.ts
+++ b/packages/api-server/src/modules/schedules/domain/recurrences.ts
@@ -99,8 +99,7 @@ function parseHHMM(s: string): number | null {
 export function nextFireAt(spec: ScheduleSpec, from: Date): Date | null {
   if (spec.type === "cron") {
     try {
-      // Legacy cron schedules are UTC by contract (ADR-031); cron-parser
-      // otherwise defaults to the server's local timezone.
+      // Legacy cron schedules are UTC by contract (ADR-031).
       const cron = CronExpressionParser.parse(spec.cron, {
         currentDate: from,
         tz: "UTC",
@@ -110,12 +109,6 @@ export function nextFireAt(spec: ScheduleSpec, from: Date): Date | null {
       return null;
     }
   }
-  // rrule.js occurrences live in the wall-clock frame (see isInQuietHours),
-  // not real time. Iterate there — quiet-hours HH:MM are wall-clock too —
-  // and convert only the surviving occurrence back to a real instant.
-  // dtstart is anchored explicitly: rrule.js's default (real "now" at parse
-  // time) sits in the wrong frame and skips same-day occurrences in zones
-  // behind UTC.
   const wallFrom = toWallClock(from, spec.timezone);
   const rule = new RRule({
     dtstart: wallFrom,
@@ -134,8 +127,7 @@ export function nextFireAt(spec: ScheduleSpec, from: Date): Date | null {
   return null;
 }
 
-// Wall-clock fields of `instant` in `tz`, re-encoded as a Date whose UTC
-// fields carry those values — the frame rrule.js occurrences live in.
+// Wall-clock fields of `instant` in `tz`, carried in the Date's UTC fields.
 function toWallClock(instant: Date, tz: string): Date {
   const parts = new Intl.DateTimeFormat("en-US", {
     timeZone: tz,
@@ -156,9 +148,7 @@ function toWallClock(instant: Date, tz: string): Date {
   );
 }
 
-// Inverse of toWallClock. Second pass re-reads the offset at the guessed
-// instant so DST boundaries resolve; wall times skipped by spring-forward
-// land just past the transition.
+// Inverse of toWallClock; the second offset read resolves DST boundaries.
 function toInstant(wall: Date, tz: string): Date {
   const guess = wall.getTime() - tzOffsetMs(wall, tz);
   return new Date(wall.getTime() - tzOffsetMs(new Date(guess), tz));

--- a/packages/api-server/src/modules/schedules/domain/recurrences.ts
+++ b/packages/api-server/src/modules/schedules/domain/recurrences.ts
@@ -110,6 +110,8 @@ export function nextFireAt(spec: ScheduleSpec, from: Date): Date | null {
     }
   }
   const wallFrom = toWallClock(from, spec.timezone);
+  // Without BYSECOND, occurrences inherit dtstart's seconds — zero them.
+  wallFrom.setUTCSeconds(0, 0);
   const rule = new RRule({
     dtstart: wallFrom,
     ...RRule.parseString(spec.rrule),

--- a/packages/api-server/src/modules/schedules/domain/recurrences.ts
+++ b/packages/api-server/src/modules/schedules/domain/recurrences.ts
@@ -71,9 +71,10 @@ export function validateHasVisibleOccurrence(
 }
 
 // Compare against UTC components rather than local: rrule.js produces
-// Dates whose UTC h:m echoes the RRULE's BYHOUR/BYMINUTE verbatim, which
-// is what the Go controller treats as wall-clock-in-schedule-tz. Reading
-// local components would apply the server's own tz offset incorrectly.
+// Dates whose UTC h:m echoes the RRULE's BYHOUR/BYMINUTE verbatim, i.e.
+// wall clock in the schedule's timezone — the same frame quiet-hours
+// HH:MM strings are in. Reading local components would apply the
+// server's own tz offset incorrectly.
 function isInQuietHours(date: Date, windows: QuietWindow[]): boolean {
   const m = date.getUTCHours() * 60 + date.getUTCMinutes();
   for (const w of windows) {
@@ -98,20 +99,71 @@ function parseHHMM(s: string): number | null {
 export function nextFireAt(spec: ScheduleSpec, from: Date): Date | null {
   if (spec.type === "cron") {
     try {
-      const cron = CronExpressionParser.parse(spec.cron, { currentDate: from });
+      // Legacy cron schedules are UTC by contract (ADR-031); cron-parser
+      // otherwise defaults to the server's local timezone.
+      const cron = CronExpressionParser.parse(spec.cron, {
+        currentDate: from,
+        tz: "UTC",
+      });
       return cron.next().toDate();
     } catch {
       return null;
     }
   }
-  const rule = RRule.fromString(spec.rrule);
+  // rrule.js occurrences live in the wall-clock frame (see isInQuietHours),
+  // not real time. Iterate there — quiet-hours HH:MM are wall-clock too —
+  // and convert only the surviving occurrence back to a real instant.
+  // dtstart is anchored explicitly: rrule.js's default (real "now" at parse
+  // time) sits in the wrong frame and skips same-day occurrences in zones
+  // behind UTC.
+  const wallFrom = toWallClock(from, spec.timezone);
+  const rule = new RRule({
+    dtstart: wallFrom,
+    ...RRule.parseString(spec.rrule),
+  });
   const enabled = (spec.quietHours ?? []).filter((w) => w.enabled);
-  let cursor = from;
+  let cursor = wallFrom;
   for (let i = 0; i < 1440; i++) {
     const next = rule.after(cursor, false);
     if (!next) return null;
-    if (enabled.length === 0 || !isInQuietHours(next, enabled)) return next;
+    if (enabled.length === 0 || !isInQuietHours(next, enabled)) {
+      return toInstant(next, spec.timezone);
+    }
     cursor = next;
   }
   return null;
+}
+
+// Wall-clock fields of `instant` in `tz`, re-encoded as a Date whose UTC
+// fields carry those values — the frame rrule.js occurrences live in.
+function toWallClock(instant: Date, tz: string): Date {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hour12: false,
+  }).formatToParts(instant);
+  const f: Record<string, number> = {};
+  for (const p of parts) {
+    if (p.type !== "literal") f[p.type] = Number(p.value);
+  }
+  return new Date(
+    Date.UTC(f.year, f.month - 1, f.day, f.hour % 24, f.minute, f.second),
+  );
+}
+
+// Inverse of toWallClock. Second pass re-reads the offset at the guessed
+// instant so DST boundaries resolve; wall times skipped by spring-forward
+// land just past the transition.
+function toInstant(wall: Date, tz: string): Date {
+  const guess = wall.getTime() - tzOffsetMs(wall, tz);
+  return new Date(wall.getTime() - tzOffsetMs(new Date(guess), tz));
+}
+
+function tzOffsetMs(instant: Date, tz: string): number {
+  return toWallClock(instant, tz).getTime() - instant.getTime();
 }

--- a/packages/api-server/src/modules/schedules/domain/recurrences.ts
+++ b/packages/api-server/src/modules/schedules/domain/recurrences.ts
@@ -42,10 +42,10 @@ interface QuietWindow {
 
 /**
  * Refuse to save a schedule whose every RRULE occurrence falls inside a
- * quiet-hours window — the controller's goroutine would spin its iteration
- * cap once and then never fire. Iteration cap matches the Go side (1440,
- * i.e. one day of minute-granularity occurrences). Uses rule.all with
- * early-exit instead of a rule.after loop, which is O(N²) in rrule.js.
+ * quiet-hours window — nextFireAt would exhaust its iteration cap and the
+ * schedule would never fire. Cap matches nextFireAt's (1440, i.e. one day
+ * of minute-granularity occurrences). Uses rule.all with early-exit
+ * instead of a rule.after loop, which is O(N²) in rrule.js.
  */
 export function validateHasVisibleOccurrence(
   rruleExpr: string,

--- a/packages/ui/src/modules/schedules/domain/rrule-builder.ts
+++ b/packages/ui/src/modules/schedules/domain/rrule-builder.ts
@@ -174,15 +174,14 @@ interface QuietWindow {
 }
 
 /**
- * Client-side mirror of the controller's isInQuietHours.
+ * Client-side mirror of the api-server's isInQuietHours (recurrences.ts).
  *
  * rrule.js returns occurrences as UTC Date objects whose UTC components
- * reflect the RRULE's BY* fields verbatim (BYHOUR=9 → 09:00Z). The Go
- * controller interprets the rule in the schedule's timezone, so that UTC
- * 09:00 really means "09:00 wall clock" in the user's frame — exactly
- * what their quiet-hours HH:MM is in. Hence: compare UTC components,
- * NOT local — otherwise the browser's offset (e.g. Europe/Prague +2h)
- * silently shifts fire times into or out of quiet windows.
+ * reflect the RRULE's BY* fields verbatim (BYHOUR=9 → 09:00Z) — wall
+ * clock in the schedule's timezone, exactly the frame quiet-hours HH:MM
+ * strings are in. Hence: compare UTC components, NOT local — otherwise
+ * the browser's offset (e.g. Europe/Prague +2h) silently shifts fire
+ * times into or out of quiet windows.
  */
 export function isInQuietHours(date: Date, windows: QuietWindow[]): boolean {
   if (windows.length === 0) return false;


### PR DESCRIPTION
Fixes #827

## Root cause

`nextFireAt` (`packages/api-server/src/modules/schedules/domain/recurrences.ts`) returned rrule.js occurrences verbatim. rrule.js emits Dates whose **UTC fields echo the RRULE's `BYHOUR`/`BYMINUTE`** — i.e. wall clock in the schedule's timezone, not a real instant. That convention dates from when the Go controller owned firing and applied `TZID` itself; when scheduling moved into the api-server's BullMQ queue, `spec.timezone` stopped being applied anywhere, so:

- a 9:00 Europe/Prague schedule fired at 9:00 **UTC** (11:00 local), and
- quiet hours were suppressed against occurrence wall-times while actual runs executed offset-shifted, landing inside windows the user marked quiet (e.g. a 21:30-local occurrence survives suppression but executes at 23:30 local).

## Fix

- Convert `from` into the schedule-timezone wall-clock frame, iterate occurrences + quiet-hours there (the frame quiet-hour `HH:MM` strings are defined in), and convert only the surviving occurrence back to a real instant. The inverse conversion uses a two-pass offset lookup so DST boundaries resolve; spring-forward-erased wall times land just past the jump.
- Anchor `dtstart` explicitly in the wall-clock frame — rrule.js defaults it to real parse-time "now", which silently skips same-day occurrences in zones behind UTC.
- Pin legacy `type: cron` schedules to UTC per the ADR-031 contract — cron-parser 5.x otherwise evaluates in the *server's* local timezone (correct-by-accident in UTC pods, wrong everywhere else, including this laptop, which is how the test caught it).

Existing schedules keep the wall-clock times their owners entered — only the instant they map to changes (to the correct one). No schema or stored-spec changes.

## Tests

`schedules-recurrences.test.ts`: summer/winter offsets, zone-behind-UTC same-day fire, local-clock quiet-hour suppression across midnight, disabled windows, all-suppressed → null, UTC passthrough, spring-forward gap, legacy cron UTC pin. `mise run check` and `mise run api-server:test` (203/203) pass.

## Noted drift (not addressed here)

`docs/architecture/agent-lifecycle.md` ("Trigger fire") and `persistence.md` still describe the per-schedule **controller goroutine** computing occurrences in `TZID` and delivering trigger files via `kubectl exec` — scheduling actually lives in the api-server (BullMQ + runtime outbox). This page predates the move; worth a follow-up doc pass.