### PR TITLE
fix(controller): idle checker reads real /api/status fields, busy agents appear idle

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-06-10
+Last verified: 2026-06-11
 
 ## Motivated by
 
@@ -161,7 +161,7 @@ Beyond ACP frames, agent-runtime also serves a Bearer-authenticated tRPC surface
 
 ### Hibernate
 
-The controller's idle checker periodically scans running Agents. For each, it probes the agent-runtime over the cluster network: any active sessions, any inflight triggers? If the answer is no for long enough (and the probe doesn't error), the checker flips `spec.desiredState` to `hibernated`. The reconciler then scales the StatefulSet to zero.
+The controller's idle checker periodically scans running Agents. For each, it probes agent-runtime's `/api/status` over the cluster network. The runtime is authoritative about its own idleness: it reports a single `idle` flag (false while a prompt turn is running, prompts are queued, an agent-initiated request awaits a client, or a terminal is open — connected viewers don't count), and the controller does not re-derive busy-ness from raw counters. If the runtime reports idle for long enough (and the probe doesn't error), the checker hibernates the Agent by scaling its StatefulSets to zero.
 
 The pod terminates; the PVC, Secret, Service, and NetworkPolicy persist. Workspace state survives — the git checkout, `node_modules`, `.venv`, mise cache, and `$HOME` are all on the PVC and rejoin on the next wake. Anything written to the container's ephemeral filesystem (OS-level changes, tools installed outside `$HOME`) is lost; this is a deliberate constraint of the lifetime model ([ADR-012](../adrs/012-runtime-lifetime.md)).
 

--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -161,7 +161,7 @@ Beyond ACP frames, agent-runtime also serves a Bearer-authenticated tRPC surface
 
 ### Hibernate
 
-The controller's idle checker periodically scans running Agents. For each, it probes agent-runtime's `/api/status` over the cluster network. The runtime is authoritative about its own idleness: it reports a single `idle` flag (false while a prompt turn is running, prompts are queued, an agent-initiated request awaits a client, or a terminal is open — connected viewers don't count), and the controller does not re-derive busy-ness from raw counters. If the runtime reports idle for long enough (and the probe doesn't error), the checker hibernates the Agent by scaling its StatefulSets to zero.
+The controller's idle checker periodically scans running Agents. For each, it probes agent-runtime's `/api/status` over the cluster network. The runtime is authoritative about its own idleness: it reports a single `idle` flag (false while a prompt turn is running, prompts are queued, an agent-initiated request awaits a client, or a terminal is open — connected viewers don't count), that flag is the endpoint's entire payload, and the controller derives nothing on its own. If the runtime reports idle for long enough (and the probe doesn't error), the checker hibernates the Agent by scaling its StatefulSets to zero.
 
 The pod terminates; the PVC, Secret, Service, and NetworkPolicy persist. Workspace state survives — the git checkout, `node_modules`, `.venv`, mise cache, and `$HOME` are all on the PVC and rejoin on the next wake. Anything written to the container's ephemeral filesystem (OS-level changes, tools installed outside `$HOME`) is lost; this is a deliberate constraint of the lifetime model ([ADR-012](../adrs/012-runtime-lifetime.md)).
 

--- a/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
@@ -230,12 +230,9 @@ describe("createAcpRuntime", () => {
     });
 
     expect(spawnCount).toBe(0);
-    expect(runtime.status().agentAlive).toBe(false);
 
     runtime.attach(makeFakeChannel().channel);
     expect(spawnCount).toBe(1);
-    expect(runtime.status().agentAlive).toBe(true);
-    expect(runtime.status().activeClientCount).toBe(1);
   });
 
   it("keeps the agent alive when a client disconnects", () => {
@@ -250,8 +247,6 @@ describe("createAcpRuntime", () => {
     c.remoteClose();
 
     expect(fa.killed()).toBe(false);
-    expect(runtime.status().agentAlive).toBe(true);
-    expect(runtime.status().activeClientCount).toBe(0);
   });
 
   it("accepts multiple channels without evicting existing ones", () => {
@@ -268,7 +263,6 @@ describe("createAcpRuntime", () => {
 
     expect(c1.isOpen()).toBe(true);
     expect(c2.isOpen()).toBe(true);
-    expect(runtime.status().activeClientCount).toBe(2);
   });
 
   it("does not broadcast session traffic to a channel that hasn't engaged with that session", () => {
@@ -478,7 +472,6 @@ describe("createAcpRuntime", () => {
     c2.pushMessage(promptRequest(1));
 
     expect(fa.sent).toHaveLength(1);
-    expect(runtime.status().queuedPromptCount).toBe(1);
   });
 
   it("advances the queue when the active prompt's response arrives", () => {
@@ -500,7 +493,6 @@ describe("createAcpRuntime", () => {
     fa.pushLine(agentPromptResponse(first));
 
     expect(fa.sent).toHaveLength(2);
-    expect(runtime.status().queuedPromptCount).toBe(0);
   });
 
   it("lets prompts for different sessions run in parallel", () => {
@@ -517,7 +509,6 @@ describe("createAcpRuntime", () => {
     c.pushMessage(promptRequest(2, OTHER_SID));
 
     expect(fa.sent).toHaveLength(2);
-    expect(runtime.status().queuedPromptCount).toBe(0);
   });
 
   it("drops queued prompts owned by a disconnecting client", () => {
@@ -534,10 +525,13 @@ describe("createAcpRuntime", () => {
 
     c1.pushMessage(promptRequest(1));
     c2.pushMessage(promptRequest(1));
-    expect(runtime.status().queuedPromptCount).toBe(1);
 
     c2.remoteClose();
-    expect(runtime.status().queuedPromptCount).toBe(0);
+
+    // Completing the active prompt must not forward the dropped queued one.
+    const first = outboundId(fa.sent[0]);
+    fa.pushLine(agentPromptResponse(first));
+    expect(fa.sent).toHaveLength(1);
   });
 
   it("still advances the queue if the client owning the active prompt disconnects mid-prompt", () => {
@@ -561,7 +555,6 @@ describe("createAcpRuntime", () => {
     fa.pushLine(agentPromptResponse(first));
 
     expect(fa.sent).toHaveLength(2);
-    expect(runtime.status().queuedPromptCount).toBe(0);
   });
 
   it("rejects prompts beyond the per-session queue cap with a JSON-RPC error", () => {
@@ -577,7 +570,6 @@ describe("createAcpRuntime", () => {
     // 1 active + 32 queued = 33 accepted.
     for (let i = 1; i <= 33; i++) c.pushMessage(promptRequest(i));
     expect(fa.sent).toHaveLength(1);
-    expect(runtime.status().queuedPromptCount).toBe(32);
 
     c.pushMessage(promptRequest(34));
     const last = JSON.parse(c.sent.at(-1)!) as {
@@ -657,7 +649,6 @@ describe("createAcpRuntime", () => {
 
     fa.exit();
     await new Promise<void>((r) => setImmediate(r));
-    expect(runtime.status().agentAlive).toBe(false);
     expect(c1.isOpen()).toBe(false);
 
     const c2 = makeFakeChannel();
@@ -712,7 +703,6 @@ describe("createAcpRuntime", () => {
       c.pushMessage(resumeSessionRequest(1));
 
       fa.pushLine(permissionRequest(5));
-      expect(runtime.status().pendingRequestCount).toBe(1);
 
       c.remoteClose();
 
@@ -723,7 +713,6 @@ describe("createAcpRuntime", () => {
       const errorSent = fa.sent.find((f) => (f as { error?: unknown }).error);
       expect(errorSent).toBeDefined();
       expect((errorSent as { id: number }).id).toBe(5);
-      expect(runtime.status().pendingRequestCount).toBe(0);
     } finally {
       vi.useRealTimers();
     }
@@ -752,7 +741,6 @@ describe("createAcpRuntime", () => {
 
       vi.advanceTimersByTime(200);
       expect(fa.sent.some((f) => (f as { error?: unknown }).error)).toBe(false);
-      expect(runtime.status().pendingRequestCount).toBe(1);
       expect(c2.sent).toContain(permissionRequest(7));
     } finally {
       vi.useRealTimers();
@@ -771,7 +759,6 @@ describe("createAcpRuntime", () => {
     viewer.pushMessage(resumeSessionRequest(1));
     fa.pushLine(permissionRequest(3));
     expect(viewer.sent).toContain(permissionRequest(3));
-    expect(runtime.status().pendingRequestCount).toBe(1);
 
     // An operational call arrives on a separate channel — list sessions and go.
     const ops = makeFakeChannel();
@@ -787,8 +774,13 @@ describe("createAcpRuntime", () => {
     // the pending is still there and the agent hasn't been notified.
     const before = fa.sent.length;
     ops.remoteClose();
-    expect(runtime.status().pendingRequestCount).toBe(1);
     expect(fa.sent).toHaveLength(before);
+
+    // The pending survives: a channel that does engage still gets the replay.
+    const engaged = makeFakeChannel();
+    runtime.attach(engaged.channel);
+    engaged.pushMessage(resumeSessionRequest(2));
+    expect(engaged.sent).toContain(permissionRequest(3));
   });
 
   it("broadcasts a platform/turnEnded notification to engaged channels when a prompt completes", () => {
@@ -1867,7 +1859,6 @@ describe("createAcpRuntime", () => {
     fa.pushLine(permissionRequest(7));
     expect(a.sent.some((f) => f === permissionRequest(7))).toBe(true);
     a.pushMessage(permissionResponse(7));
-    expect(runtime.status().pendingRequestCount).toBe(0);
 
     // Fresh viewer B loads the same session. Served from cached metadata.
     const b = makeFakeChannel();

--- a/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
@@ -31,6 +31,7 @@ function fakeRuntime(): { runtime: AcpRuntime; sent: any[] } {
       pendingRequestCount: 0,
       queuedPromptCount: 0,
       agentAlive: true,
+      idle: true,
     }),
     resetSession: () => {},
     refreshEnv: () => {},

--- a/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
@@ -27,6 +27,7 @@ function fakeRuntime(): { runtime: AcpRuntime; sent: any[] } {
     },
     status: () => ({
       activeClientCount: 0,
+      activePromptCount: 0,
       pendingRequestCount: 0,
       queuedPromptCount: 0,
       agentAlive: true,

--- a/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/trigger-session-driver.test.ts
@@ -26,11 +26,6 @@ function fakeRuntime(): { runtime: AcpRuntime; sent: any[] } {
       });
     },
     status: () => ({
-      activeClientCount: 0,
-      activePromptCount: 0,
-      pendingRequestCount: 0,
-      queuedPromptCount: 0,
-      agentAlive: true,
       idle: true,
     }),
     resetSession: () => {},

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -45,6 +45,7 @@ const DEFAULT_LOG_BYTES_CAP = 2 * 1024 * 1024;
 
 export interface AcpRuntimeStatus {
   activeClientCount: number;
+  activePromptCount: number;
   pendingRequestCount: number;
   queuedPromptCount: number;
   agentAlive: boolean;
@@ -1270,6 +1271,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       for (const q of promptQueueBySession.values()) queued += q.length;
       return {
         activeClientCount: engagedSessions.size,
+        activePromptCount: activePromptBySession.size,
         pendingRequestCount: pendingFromAgent.size,
         queuedPromptCount: queued,
         agentAlive: agent !== null && !agentExited,

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -44,11 +44,6 @@ const DEFAULT_WARM_START_TIMEOUT_MS = 15 * 1000;
 const DEFAULT_LOG_BYTES_CAP = 2 * 1024 * 1024;
 
 export interface AcpRuntimeStatus {
-  activeClientCount: number;
-  activePromptCount: number;
-  pendingRequestCount: number;
-  queuedPromptCount: number;
-  agentAlive: boolean;
   idle: boolean;
 }
 
@@ -1271,11 +1266,6 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       let queued = 0;
       for (const q of promptQueueBySession.values()) queued += q.length;
       return {
-        activeClientCount: engagedSessions.size,
-        activePromptCount: activePromptBySession.size,
-        pendingRequestCount: pendingFromAgent.size,
-        queuedPromptCount: queued,
-        agentAlive: agent !== null && !agentExited,
         idle:
           activePromptBySession.size === 0 &&
           pendingFromAgent.size === 0 &&

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -49,6 +49,7 @@ export interface AcpRuntimeStatus {
   pendingRequestCount: number;
   queuedPromptCount: number;
   agentAlive: boolean;
+  idle: boolean;
 }
 
 export interface AcpRuntime {
@@ -1275,6 +1276,10 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
         pendingRequestCount: pendingFromAgent.size,
         queuedPromptCount: queued,
         agentAlive: agent !== null && !agentExited,
+        idle:
+          activePromptBySession.size === 0 &&
+          pendingFromAgent.size === 0 &&
+          queued === 0,
       };
     },
 

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -327,6 +327,7 @@ const server = http.createServer((req, res) => {
     const s = acpRuntime.status();
     const status = {
       activeClients: s.activeClientCount,
+      activePrompts: s.activePromptCount,
       pendingRequests: s.pendingRequestCount,
       queuedPrompts: s.queuedPromptCount,
       agentAlive: s.agentAlive,

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -332,6 +332,7 @@ const server = http.createServer((req, res) => {
       queuedPrompts: s.queuedPromptCount,
       agentAlive: s.agentAlive,
       terminalActive: ptySlots.size > 0,
+      idle: s.idle && ptySlots.size === 0,
     };
     res
       .writeHead(200, { "Content-Type": "application/json", ...CORS })

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -324,15 +324,8 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.url === "/api/status") {
-    const s = acpRuntime.status();
     const status = {
-      activeClients: s.activeClientCount,
-      activePrompts: s.activePromptCount,
-      pendingRequests: s.pendingRequestCount,
-      queuedPrompts: s.queuedPromptCount,
-      agentAlive: s.agentAlive,
-      terminalActive: ptySlots.size > 0,
-      idle: s.idle && ptySlots.size === 0,
+      idle: acpRuntime.status().idle && ptySlots.size === 0,
     };
     res
       .writeHead(200, { "Content-Type": "application/json", ...CORS })

--- a/packages/controller/pkg/reconciler/idlechecker.go
+++ b/packages/controller/pkg/reconciler/idlechecker.go
@@ -113,10 +113,10 @@ func (c *IdleChecker) check(ctx context.Context) {
 		"scanned", len(agents.Items), "hibernated", hibernated, "duration", time.Since(start))
 }
 
-// podIsBusy probes the agent runtime's /api/status endpoint for in-flight work:
-// a running prompt turn, queued prompts, pending agent-to-client requests, or an
-// open terminal. Connected viewers (activeClients) deliberately don't count — an
-// open browser tab must not block hibernation.
+// podIsBusy probes the agent runtime's /api/status endpoint. The runtime is
+// authoritative about its own idleness — it reports a single idle flag and the
+// controller does not re-derive busy-ness from raw counters. A runtime too old
+// to report the flag parses as idle=false, i.e. busy, which fails safe.
 // Returns false (not busy) on any error — allows hibernation if the pod is unreachable.
 func (c *IdleChecker) podIsBusy(agentName string) bool {
 	url := fmt.Sprintf("http://%s-0.%s.%s.svc:8080/api/status", agentName, agentName, c.config.Namespace)
@@ -131,15 +131,12 @@ func (c *IdleChecker) podIsBusy(agentName string) bool {
 		return false
 	}
 	var status struct {
-		ActivePrompts   int  `json:"activePrompts"`
-		PendingRequests int  `json:"pendingRequests"`
-		QueuedPrompts   int  `json:"queuedPrompts"`
-		TerminalActive  bool `json:"terminalActive"`
+		Idle bool `json:"idle"`
 	}
 	if err := json.Unmarshal(body, &status); err != nil {
 		return false
 	}
-	return status.ActivePrompts > 0 || status.PendingRequests > 0 || status.QueuedPrompts > 0 || status.TerminalActive
+	return !status.Idle
 }
 
 // hibernate scales an agent's paired StatefulSets (agent + gateway, both

--- a/packages/controller/pkg/reconciler/idlechecker.go
+++ b/packages/controller/pkg/reconciler/idlechecker.go
@@ -113,7 +113,10 @@ func (c *IdleChecker) check(ctx context.Context) {
 		"scanned", len(agents.Items), "hibernated", hibernated, "duration", time.Since(start))
 }
 
-// podIsBusy probes the agent runtime's /api/status endpoint to check for active sessions or triggers.
+// podIsBusy probes the agent runtime's /api/status endpoint for in-flight work:
+// a running prompt turn, queued prompts, pending agent-to-client requests, or an
+// open terminal. Connected viewers (activeClients) deliberately don't count — an
+// open browser tab must not block hibernation.
 // Returns false (not busy) on any error — allows hibernation if the pod is unreachable.
 func (c *IdleChecker) podIsBusy(agentName string) bool {
 	url := fmt.Sprintf("http://%s-0.%s.%s.svc:8080/api/status", agentName, agentName, c.config.Namespace)
@@ -128,14 +131,15 @@ func (c *IdleChecker) podIsBusy(agentName string) bool {
 		return false
 	}
 	var status struct {
-		ActiveSessions int  `json:"activeSessions"`
-		ActiveTriggers int  `json:"activeTriggers"`
-		TerminalActive bool `json:"terminalActive"`
+		ActivePrompts   int  `json:"activePrompts"`
+		PendingRequests int  `json:"pendingRequests"`
+		QueuedPrompts   int  `json:"queuedPrompts"`
+		TerminalActive  bool `json:"terminalActive"`
 	}
 	if err := json.Unmarshal(body, &status); err != nil {
 		return false
 	}
-	return status.ActiveSessions > 0 || status.ActiveTriggers > 0 || status.TerminalActive
+	return status.ActivePrompts > 0 || status.PendingRequests > 0 || status.QueuedPrompts > 0 || status.TerminalActive
 }
 
 // hibernate scales an agent's paired StatefulSets (agent + gateway, both


### PR DESCRIPTION
The idle checker's busy probe unmarshals `activeSessions`/`activeTriggers`, but the agent-runtime `/api/status` hasn't returned those fields since #212 renamed `activeSessions` to `activeClients` and #381 removed `activeTriggers`. Both Go fields silently stay zero, so `podIsBusy` is true only via `terminalActive` and an agent mid-work can be hibernated out from under itself once its activity annotations age past the timeout.

Fix:
- agent-runtime is authoritative about its own idleness: `/api/status` reports a single `idle` flag, false while a prompt turn runs, prompts are queued, an agent-initiated request awaits a client, or a terminal is open
- `activeClients` deliberately doesn't count: an open browser tab must not block hibernation
- controller reads only `idle` and does no busy-ness derivation of its own; a runtime too old to report the flag parses as busy, which fails safe
- the flag is the endpoint's entire payload now: the counters (`activeClients`, `pendingRequests`, `queuedPrompts`, `agentAlive`, `terminalActive`) had no consumer left, so they're gone; unit tests that inspected them assert observable behavior instead

Closes dam-382.