### PR TITLE
docs(architecture): drop stale Proposed banner from connections.md

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,8 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-06-05
-
-> **Status: Proposed — not yet implemented.** This page describes the target shape of the subsystem per [ADR-051](../adrs/051-connections-and-contributions.md), [ADR-052](../adrs/052-runtime-channel.md), and [ADR-053](../adrs/053-runtime-outbox-worker.md). The current system still uses the parallel OAuth-app / provider-preset registries, pod-files SSE (ADR-034), and exec-based trigger delivery (ADR-008). Other architecture pages that describe those retiring mechanisms are not updated yet — they will be revised in the implementation PR(s).
+Last verified: 2026-06-11
 
 ## Motivated by
 


### PR DESCRIPTION
connections.md claimed the subsystem was not implemented. It is built end to end: template catalog incl GitHub Enterprise, contribution fan-out, runtime-delivery module (outbox, hello handler, state builder, worker handler).

Per documentation guidelines, phase markers are volatile content, so I removed the banner instead of flipping it to Implemented. Also bumped Last verified.

Closes dam-108 (part of doc drift epic dam-8oe).