### PR TITLE
fix(ui): keep long approval option text readable

### DIFF
--- a/packages/ui/src/modules/approvals/components/approvals-list.tsx
+++ b/packages/ui/src/modules/approvals/components/approvals-list.tsx
@@ -165,11 +165,13 @@ function ApprovalRow({
               type="button"
               variant="outline"
               size="xs"
+              className="min-w-0 max-w-full"
               disabled={inflight}
               onClick={() => approveHost.mutate({ id: row.id })}
               title={`Allow all requests to ${hostLabel} (writes a wildcard rule)`}
             >
-              <Globe size={11} /> Allow {hostLabel}
+              <Globe size={11} />
+              <span className="truncate">Allow {hostLabel}</span>
             </Button>
           )}
           <Button

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -96,12 +96,12 @@ export function PermissionPrompt() {
               key={opt.optionId}
               variant="outline"
               onClick={() => pick(opt)}
-              className={`h-auto justify-start gap-3 rounded-md border-2 border-border bg-card px-3 py-2 text-left text-[13px] text-foreground ${optionAccent(opt.kind)}`}
+              className={`h-auto items-start justify-start gap-3 whitespace-normal rounded-md border-2 border-border bg-card px-3 py-2 text-left text-[13px] text-foreground ${optionAccent(opt.kind)}`}
             >
               <span className="text-muted-foreground font-mono text-[11px] w-4 shrink-0">
                 {i + 1}
               </span>
-              <span className="flex-1">{opt.name}</span>
+              <span className="min-w-0 flex-1 break-words">{opt.name}</span>
             </Button>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Approval options that embed a long value — a shell command, a suggested rule, or a hostname — overflowed their box and got clipped, so the user couldn't read what they were approving. Short options ("Allow", "Reject", "Dismiss") were unaffected.

- **Inline tool-approval prompt** (#823): long option text now wraps instead of running off the edge; the prompt grows taller as needed.
- **Sidebar Approvals "Allow &lt;host&gt;"** (#824): the label truncates with the full value on hover, and the button caps its width so the icon stays aligned on one tidy line.

Both stem from the shared `Button`'s `whitespace-nowrap`; each option type gets the treatment that fits — wrap for the multi-line prompt, truncate for the compact sidebar row.

## Test plan

- [x] `mise run ui:check` (lint + tsc + prettier)
- [ ] Manual: trigger a tool-approval with a long command → option wraps, fully readable
- [ ] Manual: an egress prompt for a long hostname → sidebar "Allow &lt;host&gt;" truncates with hover tooltip, icon aligned

Closes #823
Closes #824