### PR TITLE
fix(e2e): raise expect timeout to deflake post-login assertion

### DIFF
--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
   workers: 1,
   retries: 0,
   reporter: [["list"], ["html", { open: "never" }]],
+  // First paint after the Keycloak redirect can exceed the 5s default on a
+  // cold CI cluster (bundle load + auth round-trips), which made 01-auth flaky.
+  expect: { timeout: 15_000 },
   use: {
     baseURL,
     trace: "on",


### PR DESCRIPTION
The `01-auth` spec asserts the terms button or sidebar is visible immediately after the Keycloak redirect. On a cold CI cluster, first paint (bundle load + auth round-trips) can exceed Playwright's default 5s expect timeout, causing the flaky failure seen on main.

Fix: set a 15s `expect.timeout` in the shared Playwright config, covering this and any other slow first-load assertions. Navigation waits were already on the 30s default and unaffected.