### PR TITLE
build(cd): version main chart builds as <version>-main.<run>

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -307,8 +307,12 @@ jobs:
           RUN_NUMBER: ${{ github.run_number }}
           COMPOSITE: ${{ needs.appversion.outputs.composite }}
         run: |
-          helm package deploy/helm/platform --version "0.0.0-main.${RUN_NUMBER}" --app-version "$COMPOSITE"
-          helm push "platform-0.0.0-main.${RUN_NUMBER}.tgz" oci://quay.io/dam-agents/charts
+          # <in-development version>-main.<run> sorts between the previous and
+          # next release, so semver "latest" resolution ranks main builds
+          # correctly; 0.0.0-main stays as the floating alias dev Flux tracks.
+          VERSION="$(yq -r .version deploy/helm/platform/Chart.yaml)-main.${RUN_NUMBER}"
+          helm package deploy/helm/platform --version "$VERSION" --app-version "$COMPOSITE"
+          helm push "platform-${VERSION}.tgz" oci://quay.io/dam-agents/charts
           helm package deploy/helm/platform --version 0.0.0-main --app-version "$COMPOSITE"
           helm push platform-0.0.0-main.tgz oci://quay.io/dam-agents/charts
 

--- a/docs/guidelines/release-process.md
+++ b/docs/guidelines/release-process.md
@@ -67,4 +67,4 @@ On every `v*` tag push, the release jobs in [`cd.yml`](../../.github/workflows/c
 - Packages and pushes the Helm chart to `oci://quay.io/dam-agents/charts`
 - Publishes `@dam-agents/cli` to npm (stable tags get `latest`, RC tags get `rc`)
 
-On every push to `main` (no tag), CD builds images and pushes a dev Helm chart (`0.0.0-main.*`).
+On every push to `main` (no tag), CD builds images and pushes a dev Helm chart versioned `<in-development version>-main.<run number>` (e.g. `0.2.2-main.359`), plus the floating `0.0.0-main` alias that the dev environment tracks. The semver prerelease suffix makes main builds sort above the last release, so registry version resolution treats them as the newest published chart.


### PR DESCRIPTION
Main-branch chart builds are currently versioned `0.0.0-main.<run>`, which sorts below every release in semver — so any registry version resolution (e.g. the dam-ops `upgrade-crds.sh` default, dam-agents/dam-ops#36) can never consider them, even though they are valid published versions and usually the newest content.

This versions them as `<in-development version>-main.<run>` (e.g. `0.2.2-main.359`, read from Chart.yaml, which `common:check:version` keeps as the single source). Main builds then sort above the last release and below the next one — semver "latest" resolution ranks them correctly with no registry-API tricks.

Unchanged: the floating `0.0.0-main` alias (dev's Flux `OCIRepository` tracks it) is still pushed; release tag publishing is untouched.

Known caveat: between cutting an rc and merging the `release:new` main version bump, rc tags of the same base version still outrank main builds (`main` < `rc` alphabetically in prerelease ordering). The window is short and the dam-ops downgrade guard makes misordering harmless.