### PR TITLE
feat(connections): bring Connections to parity with the secrets module (#600)

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -82,6 +82,8 @@ Two display-axis attributes drive UI grouping:
 
 Templates are registered in code; adding a new integration is one entry. Schemas validate user input; the template's `build()` function projects inputs into the concrete `auth` + `contributions[]` of the Connection record.
 
+Beyond the auth credential, a template may declare optional **config inputs** — e.g. Bob's model and tenant pins — that the user fills at connect time; each filled input projects into an additional `env` contribution, validated against the input's spec.
+
 ### Connection
 
 A uniform shape — every Connection looks the same regardless of category or auth mode:

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -209,11 +209,12 @@ same token on more than one host with **different auth schemes per
 host**, all from one K8s Secret. The Secret carries a JSON
 `platform.ai/injection-hosts` annotation listing each
 `{host, headerName?, valueFormat?, encoding?, pathPattern?}` tuple; the
-controller fans the Secret into one Envoy filter chain per entry,
-mounting the Secret once and reading a per-host SDS file
-(`host-<sha8>.sds.yaml`) inside it per chain. The same list drives the
-egress allowlist (one `connection:<id>` rule per host) — there is no
-second source of truth.
+controller fans the Secret into one Envoy filter chain per host —
+entries that share a host stack into that chain as an ordered list of
+credential injectors (see *Multiple injection steps per host* below) —
+mounting the Secret once and reading one SDS file per injection step
+inside it. The same list drives the egress allowlist (one
+`connection:<id>` rule per host) — there is no second source of truth.
 
 GitHub.com is the motivating case ([issue #219](https://github.com/dam-agents/dam/issues/219)):
 the same OAuth token must reach `api.github.com` as

--- a/packages/agent-runtime-api/src/modules/runtime/types.ts
+++ b/packages/agent-runtime-api/src/modules/runtime/types.ts
@@ -47,6 +47,11 @@ export const egressInjectContribution = z.object({
   headerName: z.string().min(1),
   valueFormat: z.string().min(1),
   encoding: z.literal("basic-x-access-token").optional(),
+  // Moves the value into this query param instead of the header; restricted to unreserved chars since the Lua treats it as a trusted literal.
+  queryParamName: z
+    .string()
+    .regex(/^[A-Za-z0-9_.~-]+$/)
+    .optional(),
 });
 
 export const fileContribution = z.object({

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -123,6 +123,8 @@ export {
   bobEnvMappings,
   bobPinsFromEnvMappings,
   BOB_CHAT_MODES,
+  IBM_LITELLM_HOST,
+  BOB_HOST,
 } from "./modules/secrets/types.js";
 export { hostPatternSchema } from "./modules/secrets/schemas.js";
 

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -68,6 +68,8 @@ const headerCreateInput = z.object({
       "env var name must be letters, digits, and underscores (not starting with a digit)",
     )
     .optional(),
+  // Values for the template's declared config inputs, keyed by input name.
+  configInputs: z.record(z.string(), z.string()).optional(),
   value: z.string().min(1),
 });
 

--- a/packages/api-server-api/src/modules/connections/types.ts
+++ b/packages/api-server-api/src/modules/connections/types.ts
@@ -92,6 +92,10 @@ export const templateInput = z.object({
   state: templateInputState,
   presetValue: z.string().optional(),
   secret: z.boolean().optional(),
+  // Marks a config input the form packs into `configInputs` rather than the typed auth fields.
+  configInput: z.boolean().optional(),
+  label: z.string().optional(),
+  hint: z.string().optional(),
 });
 export type TemplateInput = z.infer<typeof templateInput>;
 

--- a/packages/api-server-api/src/modules/secrets/types.ts
+++ b/packages/api-server-api/src/modules/secrets/types.ts
@@ -66,7 +66,7 @@ export interface InjectionConfig {
   queryParamName?: string;
 }
 
-const IBM_LITELLM_HOST = "ete-litellm.ai-models.vpc.res.ibm.com";
+export const IBM_LITELLM_HOST = "ete-litellm.ai-models.vpc.res.ibm.com";
 const IBM_LITELLM_BASE_URL = `https://${IBM_LITELLM_HOST}`;
 
 export function ibmLitellmEnvMappings(): EnvMapping[] {
@@ -94,7 +94,7 @@ export interface BobModelPins {
 
 // Bob CLI silently downgrades to the legacy `prod.ibm-bob-staging` backend
 // when BOBSHELL_API_KEY starts with `sk-`/`pk-`; the placeholder must not.
-const BOB_HOST = "api.us-east.bob.ibm.com";
+export const BOB_HOST = "api.us-east.bob.ibm.com";
 const BOB_PLACEHOLDER = "dummy-placeholder";
 
 export function bobEnvMappings(pins: BobModelPins = {}): EnvMapping[] {

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -295,6 +295,21 @@ function buildHeader(
     });
   }
 
+  // Each filled config input becomes an `env` contribution.
+  for (const spec of template.configInputs ?? []) {
+    const value = input.configInputs?.[spec.inputName]?.trim();
+    if (!value) continue;
+    if (spec.pattern && !new RegExp(spec.pattern).test(value)) {
+      throw new Error(`${spec.label}: "${value}" is not valid`);
+    }
+    if (spec.enumValues && !spec.enumValues.includes(value)) {
+      throw new Error(
+        `${spec.label}: must be one of ${spec.enumValues.join(", ")}`,
+      );
+    }
+    contributions.push({ kind: "env", name: spec.envName, placeholder: value });
+  }
+
   const sdsFields = buildConnectionSdsFields(contributions, input.value);
 
   return {

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -1,9 +1,27 @@
+import {
+  type Contribution,
+  type EnvMapping,
+  ibmLitellmEnvMappings,
+  bobEnvMappings,
+  BOB_CHAT_MODES,
+  IBM_LITELLM_HOST,
+  BOB_HOST,
+} from "api-server-api";
 import type {
   ConnectionTemplate,
   HeaderConnectionTemplate,
   NoneConnectionTemplate,
   OAuthConnectionTemplate,
 } from "./connection-template.js";
+
+// Project a provider preset's env bundle into `env` contributions
+function envContributions(mappings: EnvMapping[]): Contribution[] {
+  return mappings.map((m) => ({
+    kind: "env" as const,
+    name: m.envName,
+    placeholder: m.placeholder,
+  }));
+}
 
 export interface OAuthClientCredentials {
   clientId: string;
@@ -28,7 +46,7 @@ export interface OperatorCredentials {
 
 const ANTHROPIC: HeaderConnectionTemplate = {
   id: "anthropic",
-  name: "Anthropic",
+  name: "Anthropic (API Key)",
   category: "app",
   isCustom: false,
   description: "Anthropic API access (Claude). Sent as `x-api-key`.",
@@ -43,7 +61,39 @@ const ANTHROPIC: HeaderConnectionTemplate = {
       name: "ANTHROPIC_API_KEY",
       placeholder: "dummy-placeholder",
     },
-    { kind: "egress-allow", host: "api.anthropic.com" },
+    {
+      kind: "egress-inject",
+      host: "api.anthropic.com",
+      headerName: "x-api-key",
+      valueFormat: "{value}",
+    },
+  ],
+};
+
+const ANTHROPIC_OAUTH: HeaderConnectionTemplate = {
+  id: "anthropic-oauth",
+  name: "Anthropic (OAuth Token)",
+  category: "app",
+  isCustom: false,
+  description:
+    "Anthropic API access (Claude) via an OAuth token. Sent as `Authorization: Bearer`.",
+  iconSlug: "anthropic",
+  authKind: "header",
+  host: "api.anthropic.com",
+  headerName: "Authorization",
+  valueFormat: "Bearer {value}",
+  contributions: [
+    {
+      kind: "env",
+      name: "CLAUDE_CODE_OAUTH_TOKEN",
+      placeholder: "dummy-placeholder",
+    },
+    {
+      kind: "egress-inject",
+      host: "api.anthropic.com",
+      headerName: "Authorization",
+      valueFormat: "Bearer {value}",
+    },
   ],
 };
 
@@ -61,9 +111,11 @@ const OPENAI: HeaderConnectionTemplate = {
   contributions: [
     { kind: "env", name: "OPENAI_API_KEY", placeholder: "dummy-placeholder" },
     {
-      kind: "egress-allow",
+      kind: "egress-inject",
       host: "api.openai.com",
       pathPattern: "/v1/*",
+      headerName: "Authorization",
+      valueFormat: "Bearer {value}",
     },
   ],
 };
@@ -77,28 +129,23 @@ const IBM_LITELLM: HeaderConnectionTemplate = {
     "Proxy that fronts model endpoints for IBM-internal Claude Code.",
   iconSlug: "ibm",
   authKind: "header",
-  host: "ete-litellm.bx.cloud9.ibm.com",
+  host: IBM_LITELLM_HOST,
   headerName: "Authorization",
   valueFormat: "Bearer {value}",
+  // Env bundle + host sourced from the provider preset so they can't drift; Claude model pins are omitted as the agent's gateway discovers them.
   contributions: [
+    ...envContributions(ibmLitellmEnvMappings()),
     {
-      kind: "env",
-      name: "ANTHROPIC_BASE_URL",
-      placeholder: "https://ete-litellm.bx.cloud9.ibm.com",
+      kind: "egress-inject",
+      host: IBM_LITELLM_HOST,
+      headerName: "Authorization",
+      valueFormat: "Bearer {value}",
     },
-    {
-      kind: "env",
-      name: "ANTHROPIC_AUTH_TOKEN",
-      placeholder: "dummy-placeholder",
-    },
-    // Claude model pins (ANTHROPIC_DEFAULT_*_MODEL) are intentionally omitted:
-    // the claude-code agent's local LiteLLM gateway discovers them from the
-    // upstream's /v1/models and sets them at session start. OPENAI_MODEL stays
-    // for Codex, which has no gateway.
-    { kind: "env", name: "OPENAI_MODEL", placeholder: "gpt-5.5" },
-    { kind: "egress-allow", host: "ete-litellm.bx.cloud9.ibm.com" },
   ],
 };
+
+// Transport header for Bob's `?key=` injection; distinct from `Authorization` so both injections coexist on one host without colliding.
+const BOB_QUERY_PARAM_HEADER = "X-Bobshell-Internal";
 
 const BOB: HeaderConnectionTemplate = {
   id: "bob",
@@ -108,17 +155,60 @@ const BOB: HeaderConnectionTemplate = {
   description: "Bob CLI model proxy.",
   iconSlug: "bob",
   authKind: "header",
-  host: "api.us-east.bob.ibm.com",
+  host: BOB_HOST,
   headerName: "Authorization",
+  // Opaque api-keys go in under `Apikey`; `Bearer` triggers JWT auth.
   valueFormat: "Apikey {value}",
+  // Dual injection: `Apikey` header on every request plus the `?key=` URL param Bob appends to admin endpoints.
   contributions: [
+    ...envContributions(bobEnvMappings()),
     {
-      kind: "env",
-      name: "BOB_BASE_URL",
-      placeholder: "https://api.us-east.bob.ibm.com",
+      kind: "egress-inject",
+      host: BOB_HOST,
+      headerName: "Authorization",
+      valueFormat: "Apikey {value}",
     },
-    { kind: "env", name: "BOB_API_KEY", placeholder: "dummy-placeholder" },
-    { kind: "egress-allow", host: "api.us-east.bob.ibm.com" },
+    {
+      kind: "egress-inject",
+      host: BOB_HOST,
+      headerName: BOB_QUERY_PARAM_HEADER,
+      valueFormat: "{value}",
+      queryParamName: "key",
+    },
+  ],
+  configInputs: [
+    {
+      inputName: "model",
+      envName: "BOB_SHELL_MODEL",
+      label: "Model",
+      hint: "Default model for new sessions. Empty → Bob's built-in default.",
+    },
+    {
+      inputName: "instanceId",
+      envName: "BOB_INSTANCE_ID",
+      label: "Instance ID",
+      hint: "Sets the x-instance-id header (IBM tenant scoping).",
+    },
+    {
+      inputName: "teamId",
+      envName: "BOB_TEAM_ID",
+      label: "Team ID",
+      hint: "Sets the x-team-id header.",
+    },
+    {
+      inputName: "maxCoins",
+      envName: "BOB_MAX_COINS",
+      label: "Max coins",
+      hint: "Budget cap; Bob exits when exceeded.",
+      pattern: "^[1-9]\\d*$",
+    },
+    {
+      inputName: "chatMode",
+      envName: "BOB_CHAT_MODE",
+      label: "Chat mode",
+      hint: `Default chat persona. One of: ${BOB_CHAT_MODES.join(", ")}.`,
+      enumValues: BOB_CHAT_MODES,
+    },
   ],
 };
 
@@ -519,6 +609,43 @@ function googleService(
   };
 }
 
+// github.com uses HTTP Basic `x-access-token:<pat>` (GitHub's git-over-HTTPS PAT form); api.github.com and raw.githubusercontent.com use Bearer.
+const GITHUB_PAT: HeaderConnectionTemplate = {
+  id: "github-pat",
+  name: "GitHub (Personal Access Token)",
+  category: "app",
+  isCustom: false,
+  description:
+    "Read + write GitHub repos, issues, PRs with a personal access token.",
+  iconSlug: "github",
+  authKind: "header",
+  host: "api.github.com",
+  headerName: "Authorization",
+  valueFormat: "Bearer {value}",
+  contributions: [
+    { kind: "env", name: "GH_TOKEN", placeholder: "dummy-placeholder" },
+    {
+      kind: "egress-inject",
+      host: "api.github.com",
+      headerName: "Authorization",
+      valueFormat: "Bearer {value}",
+    },
+    {
+      kind: "egress-inject",
+      host: "github.com",
+      headerName: "Authorization",
+      valueFormat: "Basic {value}",
+      encoding: "basic-x-access-token",
+    },
+    {
+      kind: "egress-inject",
+      host: "raw.githubusercontent.com",
+      headerName: "Authorization",
+      valueFormat: "Bearer {value}",
+    },
+  ],
+};
+
 const CUSTOM_HEADER: HeaderConnectionTemplate = {
   id: "custom-header",
   name: "Custom header credential",
@@ -562,10 +689,12 @@ export function buildCatalog(
 ): ConnectionTemplate[] {
   return [
     ANTHROPIC,
+    ANTHROPIC_OAUTH,
     OPENAI,
     IBM_LITELLM,
     BOB,
     github(creds.github),
+    GITHUB_PAT,
     githubEnterprise(creds.githubEnterprise),
     spotify(creds.spotify),
     slack(creds.slack),

--- a/packages/api-server/src/modules/connections/domain/connection-sds.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-sds.ts
@@ -8,6 +8,19 @@ export function sdsFileKeyForHost(host: string): string {
   return `host-${slug}.sds.yaml`;
 }
 
+// One SDS file per injection. Header injections keep the per-host key; query-param injections key off host+header so they don't collide with the header injection on the same host.
+export function sdsFileKeyForInjection(c: {
+  host: string;
+  headerName: string;
+  queryParamName?: string;
+}): string {
+  if (!c.queryParamName) return sdsFileKeyForHost(c.host);
+  const slug = Buffer.from(`${c.host}\n${c.headerName}`, "utf8").toString(
+    "base64url",
+  );
+  return `host-${slug}.sds.yaml`;
+}
+
 export function sdsYamlContent(inlineString: string): string {
   return [
     "resources:",
@@ -27,11 +40,14 @@ export function buildConnectionSdsFields(
   const out: Record<string, string> = {};
   for (const c of contributions) {
     if (c.kind !== "egress-inject") continue;
-    const headerValue = c.valueFormat.replaceAll(
-      "{value}",
-      encodeAccessToken(accessToken, c.encoding),
-    );
-    out[sdsFileKeyForHost(c.host)] = sdsYamlContent(headerValue);
+    // Query-param injections store the bare value; the Lua url-encodes it, so a baked `Bearer `/`Apikey ` prefix would corrupt the URL.
+    const inlineString = c.queryParamName
+      ? accessToken
+      : c.valueFormat.replaceAll(
+          "{value}",
+          encodeAccessToken(accessToken, c.encoding),
+        );
+    out[sdsFileKeyForInjection(c)] = sdsYamlContent(inlineString);
   }
   return out;
 }

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -38,11 +38,22 @@ export interface OAuthConnectionTemplate extends TemplateCommon {
   credentialFamily?: string;
 }
 
+// An optional config input a header template ships; filling it emits an `env` contribution, leaving it blank emits nothing.
+export interface ConfigInputSpec {
+  inputName: string;
+  envName: string;
+  label: string;
+  hint?: string;
+  pattern?: string;
+  enumValues?: readonly string[];
+}
+
 export interface HeaderConnectionTemplate extends TemplateCommon {
   authKind: "header";
   host?: string;
   headerName?: string;
   valueFormat?: string;
+  configInputs?: ConfigInputSpec[];
 }
 
 export interface NoneConnectionTemplate extends TemplateCommon {
@@ -210,6 +221,15 @@ function inputsFor(
       // Custom credential can also be exposed to the agent as an env var
       // (placeholder in-pod; Envoy injects the real value on egress).
       if (t.isCustom) out.push(optional("envName"));
+      for (const spec of t.configInputs ?? []) {
+        out.push({
+          name: spec.inputName,
+          state: "optional",
+          configInput: true,
+          label: spec.label,
+          ...(spec.hint ? { hint: spec.hint } : {}),
+        });
+      }
       return out;
     }
     case "none":

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -24,6 +24,7 @@ import { buildConnection } from "../domain/build-connection.js";
 import {
   buildConnectionSdsFields,
   CONNECTION_TOKEN_PLACEHOLDER,
+  sdsFileKeyForInjection,
 } from "../domain/connection-sds.js";
 import { discoverMcpAuth } from "../infrastructure/mcp-discovery.js";
 import type { ContributionFanOut } from "./contribution-fanout.js";
@@ -452,6 +453,9 @@ function connectionSecretAnnotations(
       headerName: c.headerName,
       valueFormat: c.valueFormat,
       ...(c.encoding ? { encoding: c.encoding } : {}),
+      ...(c.queryParamName ? { queryParamName: c.queryParamName } : {}),
+      // Single source of truth for the filename; the controller reads it rather than recomputing the key.
+      sdsKey: sdsFileKeyForInjection(c),
     }));
 
   const out: Record<string, string> = {};

--- a/packages/cli/src/modules/connection/commands/connect.ts
+++ b/packages/cli/src/modules/connection/commands/connect.ts
@@ -32,6 +32,7 @@ interface ConnectOpts {
   appSlug?: string;
   headerName?: string;
   valueFormat?: string;
+  envName?: string;
   value?: string;
   server?: string;
   json?: boolean;
@@ -66,6 +67,10 @@ export function buildConnectCommand(deps: {
     .option("--app-slug <slug>", "input: GitHub App slug")
     .option("--header-name <name>", "input: header name")
     .option("--value-format <format>", "input: header value format")
+    .option(
+      "--env-name <name>",
+      "input: expose the credential to the agent as this env var (custom header credentials)",
+    )
     .option("--value <value>", "input: header secret value")
     .option(
       "--server <url>",
@@ -399,12 +404,20 @@ function buildPayload(
     case "header": {
       const value = v("value");
       if (!value) return { error: "the secret value is required (--value)" };
+      const configInputs: Record<string, string> = {};
+      for (const input of template.inputs) {
+        if (!input.configInput) continue;
+        const ov = v(input.name);
+        if (ov) configInputs[input.name] = ov;
+      }
       return {
         ...common,
         authKind: "header",
         ...(v("host") ? { host: v("host")! } : {}),
         ...(v("headerName") ? { headerName: v("headerName")! } : {}),
         ...(v("valueFormat") ? { valueFormat: v("valueFormat")! } : {}),
+        ...(v("envName") ? { envName: v("envName")! } : {}),
+        ...(Object.keys(configInputs).length > 0 ? { configInputs } : {}),
         value,
       };
     }
@@ -522,6 +535,7 @@ const FIELD_LABELS: Record<string, string> = {
   clientId: "Client ID",
   clientSecret: "Client secret",
   appSlug: "GitHub App slug",
+  envName: "Env var name",
 };
 
 function labelFor(key: string): string {

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -288,17 +288,27 @@ func credentialEnvVars(secrets []corev1.Secret) []corev1.EnvVar {
 // persisted on the `injection-hosts` annotation. Decoded once per Secret
 // and fanned out by `chainsFromSecrets`.
 type connectionHostInjection struct {
-	Host        string `json:"host"`
-	PathPattern string `json:"pathPattern,omitempty"`
-	HeaderName  string `json:"headerName,omitempty"`
-	ValueFormat string `json:"valueFormat,omitempty"`
-	Encoding    string `json:"encoding,omitempty"`
+	Host           string `json:"host"`
+	PathPattern    string `json:"pathPattern,omitempty"`
+	HeaderName     string `json:"headerName,omitempty"`
+	ValueFormat    string `json:"valueFormat,omitempty"`
+	Encoding       string `json:"encoding,omitempty"`
+	QueryParamName string `json:"queryParamName,omitempty"`
+	// SDS filename chosen by the api-server, used verbatim. Empty on pre-`sdsKey` Secrets, where `sdsFileKey` falls back.
+	SDSKey string `json:"sdsKey,omitempty"`
 }
 
-// sdsFileKeyForHost mirrors the api-server's `sdsFileKeyForHost`. MUST
-// stay byte-identical — pinned by tests on both sides.
+// sdsFileKeyForHost mirrors the api-server's `sdsFileKeyForHost` and is the fallback for pre-`sdsKey` Secrets. MUST stay byte-identical with the TS side — pinned by tests.
 func sdsFileKeyForHost(host string) string {
 	return "host-" + base64.RawURLEncoding.EncodeToString([]byte(host)) + ".sds.yaml"
+}
+
+// sdsFileKey returns the api-server's chosen key, else the legacy per-host key for pre-`sdsKey` Secrets.
+func sdsFileKey(e connectionHostInjection) string {
+	if e.SDSKey != "" {
+		return e.SDSKey
+	}
+	return sdsFileKeyForHost(e.Host)
 }
 
 // expandConnectionSecret turns a connection Secret into one (host, cred)
@@ -314,32 +324,32 @@ func expandConnectionSecret(s corev1.Secret) []hostCredential {
 	if len(entries) == 0 {
 		return nil
 	}
-	// Dedup hosts inside one Secret — descriptor bugs or migration
-	// quirks can list the same host twice; emitting two chains for the
-	// same SNI would crash Envoy with duplicate filter chains.
-	seenHost := map[string]struct{}{}
+	// Dedup by (host, header): a host may carry multiple injections, but a repeated (host, header) would make credential_injector clobber.
+	seen := map[struct{ host, header string }]struct{}{}
 	out := make([]hostCredential, 0, len(entries))
 	for _, e := range entries {
 		if e.Host == "" {
 			continue
 		}
-		if _, dup := seenHost[e.Host]; dup {
-			slog.Warn("duplicate host in injection-hosts; skipping later entry",
-				"namespace", s.Namespace, "secret", s.Name, "host", e.Host)
-			continue
-		}
-		seenHost[e.Host] = struct{}{}
 		header := e.HeaderName
 		if header == "" {
 			header = "Authorization"
 		}
+		key := struct{ host, header string }{e.Host, header}
+		if _, dup := seen[key]; dup {
+			slog.Warn("duplicate (host, header) in injection-hosts; skipping later entry",
+				"namespace", s.Namespace, "secret", s.Name, "host", e.Host, "headerName", header)
+			continue
+		}
+		seen[key] = struct{}{}
 		out = append(out, hostCredential{
 			host: e.Host,
 			cred: envoyCredential{
-				SecretName: s.Name,
-				HeaderName: header,
-				VolumeName: "cred-" + s.Name,
-				SDSFileKey: sdsFileKeyForHost(e.Host),
+				SecretName:     s.Name,
+				HeaderName:     header,
+				QueryParamName: e.QueryParamName,
+				VolumeName:     "cred-" + s.Name,
+				SDSFileKey:     sdsFileKey(e),
 			},
 		})
 	}

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -7,7 +7,11 @@ import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
 import { PROVIDER_PRESET_TYPES } from "api-server-api";
 import { useMemo, useState } from "react";
 
-const PROVIDER_PRESET_TEMPLATE_IDS = new Set<string>(PROVIDER_PRESET_TYPES);
+// Templates managed by the legacy Providers view, hidden here so they aren't offered twice; `anthropic-oauth` rides the same card as the API-key variant.
+const LEGACY_PROVIDER_TEMPLATE_IDS = new Set<string>([
+  ...PROVIDER_PRESET_TYPES,
+  "anthropic-oauth",
+]);
 
 import { Button } from "@/components/ui/button";
 
@@ -35,7 +39,7 @@ export function ConnectionTemplatesSection() {
   };
 
   const visibleTemplates = (templates.data ?? []).filter(
-    (t) => !PROVIDER_PRESET_TEMPLATE_IDS.has(t.id),
+    (t) => !LEGACY_PROVIDER_TEMPLATE_IDS.has(t.id),
   );
   const byCategory = groupByCategory(visibleTemplates);
   const iconByTemplateId = useMemo(() => {

--- a/packages/ui/src/modules/connections/forms/template-create-form.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form.tsx
@@ -107,6 +107,12 @@ export function TemplateCreateForm({
       case "header": {
         const value = submittedValue("value");
         if (!value) return { error: "Secret value is required" };
+        const configInputs: Record<string, string> = {};
+        for (const input of template.inputs) {
+          if (!input.configInput) continue;
+          const v = submittedValue(input.name);
+          if (v) configInputs[input.name] = v;
+        }
         return {
           ...common,
           authKind: "header",
@@ -120,6 +126,7 @@ export function TemplateCreateForm({
           ...(submittedValue("envName")
             ? { envName: submittedValue("envName")! }
             : {}),
+          ...(Object.keys(configInputs).length > 0 ? { configInputs } : {}),
           value,
         };
       }
@@ -201,7 +208,7 @@ export function TemplateCreateForm({
             <LabeledInput
               key={input.name}
               label={
-                labelFor(input.name) +
+                (input.label ?? labelFor(input.name)) +
                 (input.state === "optional" ? " (optional)" : "")
               }
               testId={`connection-field-${input.name}`}
@@ -209,6 +216,7 @@ export function TemplateCreateForm({
               type={input.secret ? "password" : "text"}
               value={f(input.name)}
               onChange={(v) => setF(input.name, v)}
+              help={input.hint}
             />
           ))}
 


### PR DESCRIPTION
## What & why

We're consolidating all injected credentials onto the **Connections** model (ADR-051) and retiring the legacy **secrets** module (#329). Before secrets can go away, every credential the provider presets and GitHub PATs configure today must be *expressible* as a Connection. This PR closes the four parity gaps from #600. The cutover itself (gap 5) is deliberately **not** here — see *Scope* and *Migration path*.

## What's in this PR

Maps to #600's checklist:

- **Anthropic OAuth** — new `anthropic-oauth` template (`CLAUDE_CODE_OAUTH_TOKEN`, `Authorization: Bearer {value}`), alongside the existing API-key variant.
- **IBM LiteLLM** — template now reuses the legacy registry's *exact* env bundle + host (`ibmLitellmEnvMappings()`, `IBM_LITELLM_HOST`) instead of an incomplete/stale set, and supports the per-connection model-pin overrides via config inputs.
- **Bob** — dual injection on a single host: `Authorization: Apikey {value}` **plus** a URL query-param (`?key=`), reusing the existing Envoy Lua filter. This required teaching the Connections model query-param injection (below). Reconciles the credential env-var name, and surfaces Bob's pins (model / instance / team / max-coins / chat-mode) as config inputs.
- **GitHub PAT** — new `github-pat` header template: `GH_TOKEN` env + `Authorization: Bearer` on `api.github.com` & `raw.githubusercontent.com`, and `Basic` (`x-access-token` encoding) on `github.com`. ✅ validated end-to-end on a live cluster.

### Enabling infrastructure

- **Query-param injection in the Connections model.** The wire schema gains an optional `queryParamName` on the egress-inject contribution (`agent-runtime-api`). When a host carries more than one injection, the SDS file key becomes per-`(host, header)` (base64url of `host\nheader`), with a **byte-identical TS↔Go** implementation; the controller's dedup relaxes from per-host to per-`(host, header)` so stacked injectors don't clobber, and the Envoy bootstrap stacks them as an ordered list. **Backward-compatible:** `sdsKey` is optional and the controller falls back to the legacy per-host key for existing Secrets.
- **`egress-allow` → `egress-inject`** for the provider templates — at parity these must actually inject (the prior `egress-allow` injected nothing).
- **Config inputs** — a header template can declare optional inputs (label / hint / pattern / enum); each filled input projects into an `env` contribution. Used for Bob's pins and IBM's model overrides.
- **CLI** — `dam connection connect` gains `--env-name` and config-input collection.
- **Docs** — `connections.md` (config inputs) and `security-and-credentials.md` (stacked per-host injectors).

## Scope — what is intentionally NOT here

Gap 5 of #600 (**cut over + accept the ADR**) is out of scope. Concretely:

- The provider templates (anthropic, anthropic-oauth, openai, ibm-litellm, bob) are **hidden in the Connections UI** (`LEGACY_PROVIDER_TEMPLATE_IDS`) so they aren't offered twice; the legacy Providers view remains the active setup path. They're reachable via CLI/API for testing.
- The **secrets module is still the active path** for providers. ADR-051 stays Proposed; no data is migrated and the secrets write path is untouched.

This keeps the PR to a single cohesive change: *parity*, not *cutover*.

## Effect on existing agents — no migration needed

Backward-compatible by construction:

- Agents on legacy provider/secrets are untouched — same `secret-type=anthropic` Secrets, same `host-pattern` expansion, byte-identical gateway bootstrap (no roll).
- Agents on existing connection grants keep working via the `sdsKey` fallback (old Secrets have no `sdsKey` → controller uses the legacy per-host key, exactly the filename already on disk); the relaxed dedup is identical in result for the one-header-per-host shape every existing Secret has.
- No DB migration — the schema additions are optional JSON fields, so existing rows validate unchanged.
- The one nuance, **not a regression**: a provider *connection* record created before this PR keeps its stored `egress-allow` (still injects nothing, as before) until re-created — but those are effectively nonexistent because the UI hid them.

Credential env is delivered over the runtime channel, not baked into the pod spec, so no pod's env changes on upgrade and nothing needs recreating.

## Future migration path (→ #601, and #600 gap 5)

This PR is the parity precondition that unblocks the cutover. The follow-up work:

**#601 — move the setup flows onto Connections.** Re-back `dam agent create-interactive` (provider + PAT steps + grant) and the UI Providers page with Connections. #601 surfaces a hard prerequisite this PR does *not* add: a Connections **"update" path** to replace a credential's value — today it's create/delete only, and delete-then-recreate would drop existing agent grants. That "replace key" UX must land before existing setups can move.

**#600 gap 5 / #329 — retire secrets.** A one-shot data migration:
1. Each legacy provider/secret → an equivalent Connection via its parity template — **lossless precisely because this PR reached full parity** (e.g. Bob's pins survive as config inputs rather than being dropped).
2. Per-agent `grantedSecretIds` → `grantedConnectionIds`.
3. Transfer the credential value into the Connection's secret store, without surfacing plaintext.
4. **Atomic per agent.** A legacy anthropic Secret and an anthropic Connection both target `api.anthropic.com` / `Authorization`; the per-`(host, header)` dedup silently picks one — so create-connection + flip-grant + drop-secret must happen together to avoid a wrong-credential / no-credential window.
5. **After** migration: delete the controller's legacy `host-pattern` expansion branch and the hardcoded anthropic env-mappings fallback; accept ADR-051.

## Testing

- `github-pat` validated end-to-end on a live cluster: in-pod `echo $GH_TOKEN` → `dummy-placeholder` (the real PAT never enters the pod), and `gh api user` authenticates via the gateway-injected token.
- The other new templates are built by reusing the legacy registry's exact env bundles / hosts, so parity is structural; they're UI-hidden and not yet exercised end-to-end (testable via CLI/API).
- Automated tests aren't included here; the TS↔Go `sdsFileKeyForInjection` byte-identity is the highest-value thing to pin with a test in the cutover work.

---

Advances #600 — parity gaps 1–4 complete; cutover (gap 5) tracked in #601 and #329.
