### PR TITLE
docs(architecture): rewrite resource model for CRD migration (ADR-058/059)

### DIFF
--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -1,13 +1,13 @@
 # Persistence
 
-Last verified: 2026-06-09
+Last verified: 2026-06-12
 
 ## Motivated by
 
 - [ADR-001 — Ephemeral containers + persistent workspace volumes](../adrs/001-ephemeral-containers.md) — agents are stateless processes; their state lives on PVCs that outlive the pod
-- [ADR-006 — ConfigMaps over CRDs](../adrs/006-configmaps-over-crds.md) — domain resources are namespace-scoped ConfigMaps with a single-writer-per-key split
+- [ADR-058 — CRDs over ConfigMaps](../adrs/058-crds-over-configmaps.md) — reconciled domain resources (Agent, Fork) are CRDs with a status subresource; the `desiredState` latch is eliminated (supersedes [ADR-006](../adrs/006-configmaps-over-crds.md))
 - [ADR-055 — Agent-owned session metadata](../adrs/055-agent-owned-session-metadata.md) — sessions are owned by the agent and carried over ACP `_meta.platform`; Postgres holds no session state (supersedes [ADR-017](../adrs/017-db-backed-sessions.md))
-- [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — the merged `agent` ConfigMap is the sole resource per Agent and carries both `spec.yaml` and `status.yaml`
+- [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — the merged Agent is the sole resource per Agent and carries both definition and runtime state
 - [ADR-8 — Usage tracking with pseudonymized identifiers](../adrs/048-usage-tracking.md) — append-only activity log + agent mirror table, with HMAC-pseudonymized `sub` values at the write boundary
 - [ADR-061 — Warm PVC pool](../adrs/061-warm-pvc-pool.md) — pre-provisioned, size-keyed spare workspace volumes claimed at create time to skip first-start provisioning latency
 - [ADR-063 — Generated table migrations, hand-written views, squashed baseline](../adrs/063-hand-written-migrations.md) — table changes are generated from the schema, the reporting views are hand-written; the history is squashed to a baseline that existing deployments skip, with a no-database guard asserting every schema change was generated
@@ -18,16 +18,16 @@ Platform persists state on three durable substrates, split cleanly between the p
 
 **Platform-owned** (the agent never touches these):
 
-- **Postgres** — application state the api-server owns end-to-end. Sole writer: api-server; the controller never reads from or writes to Postgres. Holds anything that has to be queryable when no agent pod is running (channel bindings, identity links, allow-listed users) plus any other api-server-only domain resource. Session metadata is *not* here — it is agent-owned ([ADR-055](../adrs/055-agent-owned-session-metadata.md)).
-- **ConfigMaps** — resource state the controller reconciles into running infrastructure (templates, agents, schedules, forks), with a `spec.yaml` / `status.yaml` ownership split. Sole writer of `spec.yaml`: api-server. Sole writer of `status.yaml`: controller.
+- **Postgres** — application state the api-server owns end-to-end. Sole writer: api-server; the controller never reads from or writes to Postgres. Holds anything that has to be queryable when no agent pod is running (channel bindings, identity links, allow-listed users, schedules) plus any other api-server-only domain resource. Session metadata is *not* here — it is agent-owned ([ADR-055](../adrs/055-agent-owned-session-metadata.md)).
+- **Custom resources** — resource state the controller reconciles into running infrastructure (Agents, Forks), as CRDs with a `spec` / `status` ownership split enforced by the status subresource ([ADR-058](../adrs/058-crds-over-configmaps.md)). Sole writer of `spec`: api-server. Sole writer of `status`: controller.
 
 **Agent-owned**:
 
-- **Per-Agent PVCs** — the workspace and `$HOME` mounted into the agent pod. The agent process reads and writes here freely; it has no direct access to Postgres or to the ConfigMaps that describe it. Persists across hibernation; reclaimed when the Agent is deleted.
+- **Per-Agent PVCs** — the workspace and `$HOME` mounted into the agent pod. The agent process reads and writes here freely; it has no direct access to Postgres or to the custom resources that describe it. Persists across hibernation; reclaimed when the Agent is deleted.
 
-**Choosing between Postgres and ConfigMaps.** A new resource belongs on a ConfigMap iff the controller reconciles it. If only the api-server reads and writes it, it belongs in Postgres. The spec/status single-writer split exists to coordinate api-server and controller; without a controller reader, it has no purpose, and putting api-server-only state on a ConfigMap is using the K8s API as a generic key-value store. ADR-006's "K8s is the database" framing predates Postgres landing in the platform — the rule above is the post-[ADR-017](../adrs/017-db-backed-sessions.md) refinement.
+**Choosing between Postgres and the K8s API.** A new resource belongs on a CRD iff the controller reconciles it. If only the api-server reads and writes it, it belongs in Postgres. The spec/status single-writer split exists to coordinate api-server and controller; without a controller reader, it has no purpose, and putting api-server-only state on the K8s API is using it as a generic key-value store. ADR-006's "K8s is the database" framing predates Postgres landing in the platform — the rule above is the post-[ADR-017](../adrs/017-db-backed-sessions.md) refinement, carried forward unchanged by [ADR-058](../adrs/058-crds-over-configmaps.md). This is why schedules live in Postgres and templates never became a CRD.
 
-The controller and api-server never share writes on the same key — write contention is impossible by convention rather than by lock. The agent's only durable surface is the PVC; everything the platform knows *about* the agent is mirrored onto Postgres or a ConfigMap by the api-server or controller, not by the agent itself.
+The controller and api-server never write the same surface — the status subresource makes the split structural, not conventional. The agent's only durable surface is the PVC; everything the platform knows *about* the agent is mirrored onto Postgres or the Agent CR by the api-server or controller, not by the agent itself.
 
 ## Diagram
 
@@ -40,20 +40,20 @@ flowchart LR
   postgres[(Postgres)]
 
   subgraph k8s[K8s API]
-    cm-spec[ConfigMap<br/>spec.yaml]
-    cm-status[ConfigMap<br/>status.yaml]
-    cm-anno[ConfigMap<br/>annotations]
+    cr-spec[Agent / Fork CR<br/>spec]
+    cr-status[Agent / Fork CR<br/>status subresource]
+    cr-anno[Agent / Fork CR<br/>annotations]
   end
 
   pvc[(Per-Agent PVC)]
 
   api-server -->|write| postgres
-  api-server -->|write| cm-spec
-  api-server -->|read| cm-status
-  api-server -->|annotate| cm-anno
+  api-server -->|write| cr-spec
+  api-server -->|read| cr-status
+  api-server -->|annotate| cr-anno
 
-  controller -->|write| cm-status
-  controller -->|read| cm-spec
+  controller -->|write| cr-status
+  controller -->|read| cr-spec
   controller -.kubectl exec into running pod.-> agent-runtime
 
   agent-runtime -->|read/write| pvc
@@ -69,30 +69,32 @@ Postgres carries application state the api-server owns end-to-end — anything t
 - **identity and auth** — links between channel-side identities and platform users, plus the auth allow-list. Owned by [security-and-credentials](security-and-credentials.md).
 - **skills catalog** — connected sources, per-Agent install records, and publish history. Owned by [skills](skills.md).
 - **activity log + agent mirror** — append-only event log (`activity_events`), per-sub role flags (`actor_roles`), and the K8s↔Postgres agent ownership mirror (`agents`). Pseudonymized `actor_sub` and `owner_sub` columns at the write boundary. Owned by [usage-tracking](usage-tracking.md).
+- **schedules** — RRULE, quiet hours, task payload, session mode, and firing bookkeeping (`schedules`). The api-server's schedule loop fires them; the controller plays no part. Owned by [agent-lifecycle](agent-lifecycle.md).
 
-The api-server is the sole writer for all of it. The controller does not touch Postgres — its bookkeeping lives on `status.yaml` of the ConfigMap it owns. The authoritative schema and migrations live in [`packages/db/`](../../packages/db/): migrations run automatically on api-server startup — table/index/enum changes generated from the schema, the reporting views hand-written — with the original history squashed to a baseline that fresh installs run and existing deployments skip, and a no-database guard asserting every schema change was generated ([ADR-063](../adrs/063-hand-written-migrations.md); workflow in [`packages/db/README.md`](../../packages/db/README.md)).
+The api-server is the sole writer for all of it. The controller does not touch Postgres — its bookkeeping lives on the `status` subresource of the custom resources it owns. The authoritative schema and migrations live in [`packages/db/`](../../packages/db/): migrations run automatically on api-server startup — table/index/enum changes generated from the schema, the reporting views hand-written — with the original history squashed to a baseline that fresh installs run and existing deployments skip, and a no-database guard asserting every schema change was generated ([ADR-063](../adrs/063-hand-written-migrations.md); workflow in [`packages/db/README.md`](../../packages/db/README.md)).
 
-### ConfigMaps
+### Custom resources
 
-Resources the controller reconciles are labeled ConfigMaps ([ADR-006](../adrs/006-configmaps-over-crds.md)). Four types after [ADR-046](../adrs/046-eliminate-instance.md) collapsed the former `agent` (template) + `agent-instance` (instance) pair into a single `agent` CM that owns both definition and runtime state, distinguished by `platform.ai/type`:
+Resources the controller reconciles are Kubernetes CRDs under the `agent-platform.ai/v1` API group, each with a status subresource ([ADR-058](../adrs/058-crds-over-configmaps.md)):
 
-| Type | What it declares | `spec.yaml` writer | `status.yaml` writer |
+| Kind | What it declares | `spec` writer | `status` writer |
 |---|---|---|---|
-| `template` | Template: image, command, default env, mount declarations, injection rules (read-only blueprint copied into an Agent at create time) | api-server | (no status — templates are not reconciled) |
-| `agent` | Agent: image / mount declarations, env, secret refs, allowed users, `desiredState`. **Both** `spec.yaml` (api-server) **and** `status.yaml` (controller) live on this single CM — there is no longer a separate "instance" CM where status lives | api-server | controller |
-| `agent-schedule` | Schedule: RRULE, quiet hours, task payload, session mode | api-server | controller |
-| `agent-fork` | Forked run: parent Agent ref + overrides | api-server | controller |
+| `Agent` | Agent definition and runtime state: image, mount declarations, env, secret refs, granted secret and connection IDs. The sole resource per Agent after [ADR-046](../adrs/046-eliminate-instance.md) collapsed the former template/instance pair | api-server | controller |
+| `Fork` | Forked run: parent Agent ref + overrides | api-server | controller |
 
-The single-writer split for the merged `agent` CM is the same `spec.yaml` / `status.yaml` pattern used elsewhere — what changed in ADR-046 is that the runtime state (`status.yaml`, plus the high-frequency annotations) now lives on the **same** ConfigMap as the definition, rather than on a paired `agent-instance` CM. The `inst-` ID prefix retires; the merged Agent uses `agent-` as the sole ID prefix.
+Each CR carries strict single-writer ownership, made structural by the status subresource rather than held by convention:
 
-Each reconciled ConfigMap carries two `data` keys with strict single-writer ownership:
+- **`spec`** — user intent. Written exclusively by the api-server and validated by the K8s API server at admission against the CRD schema; the controller consumes typed objects without re-validating shape. Cross-field and referential rules stay application logic.
+- **`status`** — observed state, written exclusively by the controller through the status subresource. Conditions are the source of truth (`Ready`, `AgentPodReady`, `GatewayPodReady`, `Reconciled`); `Ready` is the agent-and-gateway pod intersection and the api-server's sole routing signal ([ADR-059](../adrs/059-agent-readiness-status.md)).
 
-- **`spec.yaml`** — user intent. Written exclusively by the api-server.
-- **`status.yaml`** — observed state and scheduler bookkeeping (next fire, last fire, error). Written exclusively by the controller.
+There is no stored desired state — ADR-058 eliminated the `desiredState` field. Wake is a one-off activity poke, the controller hibernates on idleness, and running-vs-hibernated is recorded as observed status; see [agent-lifecycle](agent-lifecycle.md).
 
-High-frequency, lightweight metadata (heartbeats, activity timestamps, `granted-secret-ids`, `granted-connection-ids`, `last-activity`) lives on **annotations** rather than `status.yaml` to avoid rewriting the spec/status payload on every update. (Credential `env` no longer has a `secrets-rev` annotation — it rides the runtime channel; see [connections.md](connections.md) and ADR-DRAFT.)
+High-frequency, out-of-band signals live on **annotations** rather than `status`, so they are independently patchable without a spec or status write: the last-activity timestamp and active-session marker that drive hibernation, and the roll trigger the api-server bumps to force a rolling restart of the pair. Connection and secret grants are intent and moved from annotations into `spec`. (Credential `env` rides the runtime channel; see [connections.md](connections.md).)
 
-ConfigMaps were chosen over CRDs so that Platform installs without cluster-admin — the schema maps directly onto a CRD spec if the constraint ever lifts. There is no schema validation at the K8s API layer; both the api-server (on write) and the controller (on read) validate in application code.
+Two domain resources are deliberately not CRDs:
+
+- **Templates** stay ConfigMaps — chart-rendered, read-only blueprints copied into an Agent at create time, never reconciled, loaded by the api-server at boot.
+- **Schedules** live in Postgres — only the api-server reads and writes them (see the Postgres/K8s rule above).
 
 ### Per-Agent PVCs
 
@@ -119,17 +121,17 @@ Claimed-versus-spare is tracked entirely by labels: an unclaimed spare carries a
 
 ## Lifetime
 
-| Event | Postgres | ConfigMap (spec/status) | PVC |
+| Event | Postgres | Agent CR (spec/status) | PVC |
 |---|---|---|---|
 | Pod restart | survives | survives | survives |
 | Hibernate (replicas → 0) | survives | survives | survives |
 | Wake (replicas → 1) | survives | survives | survives |
 | api-server restart | survives | survives | survives |
 | Controller restart | survives | survives | survives |
-| Agent delete | session rows removed by api-server | ConfigMap removed | PVCs removed by controller |
-| Schedule delete | session rows optionally removed (UI checkbox) | ConfigMap removed | n/a |
+| Agent delete | session rows removed by api-server | CR removed | PVCs removed by controller |
+| Schedule delete | schedule row removed; linked sessions optionally removed (UI checkbox) | n/a | n/a |
 
-Schedules are independent ConfigMaps and survive Agent deletion as orphans unless the deletion path explicitly cascades. Sessions linked to a deleted schedule are kept by default; the UI offers a checkbox to remove them with the schedule.
+Schedules are independent Postgres rows and survive Agent deletion as orphans unless the deletion path explicitly cascades. Sessions linked to a deleted schedule are kept by default; the UI offers a checkbox to remove them with the schedule.
 
 Unclaimed warm-pool spares are not tied to any Agent and so are absent from this table — the pool manager reclaims them when it trims a pool below its inventory or when their size pool is removed, never via Agent deletion. Once claimed, a spare follows the PVC column above.
 

--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -1,6 +1,6 @@
 # Platform topology
 
-Last verified: 2026-06-02
+Last verified: 2026-06-12
 
 ## Motivated by
 
@@ -16,11 +16,13 @@ Last verified: 2026-06-02
 - [ADR-033 — Envoy-based credential gateway](../adrs/033-envoy-credential-gateway.md) — Envoy is the credential gateway; mounts owner-labelled K8s Secrets and injects credentials on the wire
 - [ADR-038 — Paired agent and gateway pods](../adrs/038-paired-gateway-pod.md) — agent and gateway run in two paired pods per agent
 - [ADR-041 — Istio ambient mesh](../adrs/041-istio-ambient-mesh.md) — SPIFFE identity for every internal hop; replaces the pair-key NetworkPolicy and the trusted `x-platform-instance` header
-- [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — a single Agent ConfigMap carries both definition and runtime state; the `agent-instance` type is gone
+- [ADR-046 — Eliminate Instance, collapse into Agent](../adrs/046-eliminate-instance.md) — a single Agent resource carries both definition and runtime state; the separate instance type is gone
+- [ADR-058 — CRDs over ConfigMaps](../adrs/058-crds-over-configmaps.md) — Agent and Fork are CRDs with a status subresource, validated at admission; the `desiredState` latch is eliminated
+- [ADR-059 — Agent readiness is controller-computed status](../adrs/059-agent-readiness-status.md) — the controller publishes agent ∧ gateway readiness on the Agent status; the api-server routes on it and never touches pods
 
 ## Overview
 
-Platform runs as four long-lived subsystems on Kubernetes: a Go **controller** that reconciles ConfigMap-declared resources, a TypeScript **api-server** that brokers user requests and relays agent traffic, per-agent paired **agent-runtime** + **gateway** pods that host the agent process and its egress proxy, and a React **ui** served by the api-server. The controller and api-server never talk to each other directly — they coordinate through the K8s API, using a `spec.yaml` / `status.yaml` split on each ConfigMap so that writes never contend.
+Platform runs as four long-lived subsystems on Kubernetes: a Go **controller** that reconciles the Agent and Fork custom resources, a TypeScript **api-server** that brokers user requests and relays agent traffic, per-agent paired **agent-runtime** + **gateway** pods that host the agent process and its egress proxy, and a React **ui** served by the api-server. The controller and api-server never talk to each other directly — they coordinate through the K8s API, using the `spec` / `status` subresource split on each custom resource so that writes never contend.
 
 ## Diagram
 
@@ -51,7 +53,7 @@ flowchart LR
 
 ### controller
 
-A stateless Go reconciler built on client-go. It watches ConfigMaps labelled `platform.ai/type` (template, agent, schedule, fork), reconciles the StatefulSet, Service, NetworkPolicy, and per-agent Secret for each agent, runs the schedule loop, and delivers trigger files to agent pods via `exec` (see [ADR-008](../adrs/008-trigger-files.md)). The controller writes only `status.yaml` on owned ConfigMaps; it never writes `spec.yaml`. See [`packages/controller/`](../../packages/controller/).
+A stateless Go reconciler built on client-go. It watches the `Agent` and `Fork` custom resources (`agent-platform.ai/v1`) plus agent-labelled pods, reconciles the StatefulSet, Service, NetworkPolicy, and per-agent Secret for each agent, computes agent readiness from the pod pair onto the Agent status ([ADR-059](../adrs/059-agent-readiness-status.md)), and hibernates idle agents by scaling the pair to zero. The schedule loop lives in the api-server, not here (see [agent-lifecycle](agent-lifecycle.md)). The controller writes only the `status` subresource on the resources it owns; it never writes `spec`. See [`packages/controller/`](../../packages/controller/).
 
 ### api-server
 
@@ -111,23 +113,23 @@ ACP frames are JSON-RPC 2.0, one logical message per WebSocket frame.
 
 ## K8s resource model
 
-Platform models all of its domain state as ConfigMaps labelled `platform.ai/type` ([ADR-006](../adrs/006-configmaps-over-crds.md)). Each ConfigMap carries two keys:
+The controller-reconciled domain resources are CRDs under the `agent-platform.ai/v1` API group, each with a status subresource ([ADR-058](../adrs/058-crds-over-configmaps.md)):
 
-- `spec.yaml` — user intent. Owned exclusively by the api-server.
-- `status.yaml` — observed state and scheduler bookkeeping. Owned exclusively by the controller.
+- `spec` — user intent. Owned exclusively by the api-server; validated by the K8s API server at admission.
+- `status` — observed state. Owned exclusively by the controller, written through the status subresource. Conditions (`Ready`, `AgentPodReady`, `GatewayPodReady`, `Reconciled`) are the source of truth; the api-server routes on `Ready` alone ([ADR-059](../adrs/059-agent-readiness-status.md)).
 
-| `platform.ai/type` | Purpose |
+| Kind | Purpose |
 |---|---|
-| `agent-template` | Template: image, command, default env, injection rules |
-| `agent` | Agent: image, command, env, skills, secret refs, allowed users, `desiredState`. Carries **both** `spec.yaml` (api-server) and `status.yaml` (controller) per [ADR-046](../adrs/046-eliminate-instance.md) |
-| `agent-schedule` | Schedule: cron or RRULE, quiet hours, task payload, session mode |
-| `agent-fork` | Forked run: parent agent ref + overrides |
+| `Agent` | Agent definition and runtime state: image, mounts, env, secret refs, granted secret and connection IDs. The sole resource per Agent per [ADR-046](../adrs/046-eliminate-instance.md); there is no `desiredState` — running-vs-hibernated is derived from activity annotations |
+| `Fork` | Forked run: parent agent ref + overrides |
 
-For each `agent`, the controller reconciles **two paired StatefulSets** (agent + gateway, both at replicas 0 when hibernated and 1 when running), **two pair-scoped Services** (agent's ACP and the gateway's `<agent>-gateway` proxy DNS), a **per-agent ServiceAccount** (in the agent ns), a **per-agent ext-authz Service** (`<release>-extauthz-<id>`, in the release ns), **three per-agent Istio AuthorizationPolicies** (gateway admission, harness path-prefix at the waypoint, ext-authz Service principal), and a per-agent Envoy bootstrap ConfigMap + leaf-TLS Certificate ([ADR-033](../adrs/033-envoy-credential-gateway.md), [ADR-038](../adrs/038-paired-gateway-pod.md), [ADR-041](../adrs/041-istio-ambient-mesh.md)). ConfigMaps are chosen over CRDs for the domain types so Platform installs without cluster-admin; the controller does need write access to ServiceAccounts and Istio AuthorizationPolicies. See [`deploy/helm/platform/templates/`](../../deploy/helm/platform/templates/) for the install layout.
+Two domain resources are deliberately not CRDs: **Templates** are chart-rendered ConfigMaps loaded by the api-server at boot (read-only, never reconciled), and **Schedules** are Postgres rows owned by the api-server — see [persistence](persistence.md).
+
+For each `Agent`, the controller reconciles **two paired StatefulSets** (agent + gateway, both at replicas 0 when hibernated and 1 when running), **two pair-scoped Services** (agent's ACP and the gateway's `<agent>-gateway` proxy DNS), a **per-agent ServiceAccount** (in the agent ns), a **per-agent ext-authz Service** (`<release>-extauthz-<id>`, in the release ns), **three per-agent Istio AuthorizationPolicies** (gateway admission, harness path-prefix at the waypoint, ext-authz Service principal), and a per-agent Envoy bootstrap ConfigMap + leaf-TLS Certificate ([ADR-033](../adrs/033-envoy-credential-gateway.md), [ADR-038](../adrs/038-paired-gateway-pod.md), [ADR-041](../adrs/041-istio-ambient-mesh.md)). Installing the CRDs requires cluster-admin at install time — [ADR-058](../adrs/058-crds-over-configmaps.md) deliberately gave up the namespace-scoped install that ADR-006's ConfigMap model protected; the controller also needs write access to ServiceAccounts and Istio AuthorizationPolicies. See [`deploy/helm/platform/`](../../deploy/helm/platform/) for the install layout.
 
 ## Invariants
 
-- **Spec/status ownership.** Controller never writes `spec.yaml`; api-server never writes `status.yaml`. Write contention between the two is impossible by convention.
+- **Spec/status ownership.** Controller never writes `spec`; api-server never writes `status`. The status subresource makes the split structural — write contention between the two is impossible.
 - **Relay-only ACP.** All ACP traffic is proxied through the api-server. Agent pods do not accept ACP connections from outside the cluster and the UI never dials pods directly.
 - **Two-port api-server.** The public port is user-authenticated; the harness port is cluster-internal and has no user authentication. They do not share routes.
 - **Credential isolation.** Agent pods never hold real upstream credentials. The paired gateway pod intercepts agent TLS using a per-agent leaf cert and injects the credential header from a K8s Secret mounted only on the gateway — the agent pod has no path to TCP 80/443 except through the paired gateway ([ADR-033](../adrs/033-envoy-credential-gateway.md), [ADR-038](../adrs/038-paired-gateway-pod.md)). See [security-and-credentials](security-and-credentials.md).

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-05-29
+Last verified: 2026-06-12
 
 ## Motivated by
 
@@ -126,7 +126,7 @@ user agent flow:
 2. UI sends the JWT to the api-server on every tRPC and ACP call. The
    api-server validates it against Keycloak's JWKS.
 3. The api-server's `sub` claim becomes `platform.ai/owner=<sub>` on every
-   resource the user creates (Agent ConfigMap, K8s credential Secret,
+   resource the user creates (Agent CR, K8s credential Secret,
    etc.).
 
 There is no token exchange — credential storage is K8s-native and label-
@@ -171,7 +171,7 @@ values under [`deploy/helm/platform/`](../../deploy/helm/platform/).
 
 Multi-tenancy is **soft** — a single Kubernetes namespace, with a
 `platform.ai/owner` label on every owned resource carrying the authenticated
-user's `sub`. The api-server is the sole writer of `spec.yaml` and stamps
+user's `sub`. The api-server is the sole writer of resource spec and stamps
 the label on create; every list and get filters by it. There is no
 namespace-per-user.
 
@@ -296,7 +296,7 @@ filter on the catch-all chain sees SNI only.
 ## Per-turn fork pods (Slack foreign replier)
 
 When a user other than the Agent owner replies in a Slack thread,
-the api-server emits a fork ConfigMap that the controller materialises
+the api-server creates a Fork CR that the controller materialises
 into a per-turn paired pod set: a fork agent Job and a fork gateway Pod
 (ADR-038). The fork's gateway pod mounts the **replier's** K8s credential
 Secrets — selected by `platform.ai/owner=<replier-sub>`, not the Agent


### PR DESCRIPTION
Fixes doc drift tracked in beads dam-86o. The persistence, platform-topology, and security pages still described the pre-ADR-058 ConfigMap model.

What changed:

- Agent and Fork are now documented as CRDs (agent-platform.ai/v1) with a status subresource. Spec is api-server owned and validated at admission, status is controller owned with conditions per ADR-059.
- desiredState is gone everywhere. Hibernation is described as activity derived (annotations), wake as an activity poke.
- Grants (secret and connection IDs) documented in spec instead of annotations.
- Schedules documented as Postgres rows fired by the api-server schedule loop, not agent-schedule ConfigMaps reconciled by the controller.
- Templates documented as chart-rendered ConfigMaps loaded at api-server boot.
- Lifetime table, diagrams, and invariants updated to match.

Not touched here: trigger delivery drift (controller exec vs runtime outbox) in agent-lifecycle.md and the remaining exec references on these pages. That is tracked separately as dam-dbl.

🤖 Generated with [Claude Code](https://claude.com/claude-code)