### PR TITLE
fix: improve removal of stale orphaned connections from agents

### DIFF
--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -89,6 +89,10 @@ import {
   createPresetSeederAdapter,
   listEgressRuleAgentIds,
 } from "./modules/egress-rules/compose.js";
+import {
+  createConnectionGrantsCleanupHook,
+  listConnectionGrantAgentIds,
+} from "./modules/connections/compose.js";
 import { createAgentArtifactsSweeper } from "./sagas/agent-artifacts-sweeper.js";
 import { createK8sClient as createAgentsK8sClient } from "./modules/agents/infrastructure/k8s.js";
 import { loadTrustedHosts } from "./bootstrap/trusted-hosts.js";
@@ -378,11 +382,13 @@ deliverySweeper.start();
 // hook threw, etc.).
 const agentsCleanupK8s = createAgentsK8sClient(api, config.namespace);
 const registrySecretPort = createAgentRegistrySecretPort(agentsCleanupK8s);
+const connectionGrantsCleanupHook = createConnectionGrantsCleanupHook(db);
 
 const agentCleanupHooks = [
   createEgressRulesCleanupHook(db),
   createApprovalsCleanupHook(db),
   (agentId: string) => registrySecretPort.delete(agentId),
+  connectionGrantsCleanupHook,
 ];
 
 // Cross-store orphan reaper. Lists live agent ConfigMaps, finds DB rows
@@ -406,6 +412,11 @@ const agentArtifactsSweeper = createAgentArtifactsSweeper({
       name: "registry-pull-secrets",
       listAgentIds: () => registrySecretPort.listAgentIds(),
       cleanup: agentCleanupHooks[2]!,
+    },
+    {
+      name: "connection-grants",
+      listAgentIds: () => listConnectionGrantAgentIds(db),
+      cleanup: connectionGrantsCleanupHook,
     },
   ],
   intervalMs: 30 * 60_000,

--- a/packages/api-server/src/modules/connections/compose.ts
+++ b/packages/api-server/src/modules/connections/compose.ts
@@ -52,6 +52,17 @@ export function composeConnectionsAtBoot(
   return { templates, oauthEngine, refreshLoop };
 }
 
+export function createConnectionGrantsCleanupHook(
+  db: Db,
+): (agentId: string) => Promise<void> {
+  const repo = createConnectionsRepository(db);
+  return (agentId) => repo.revokeAllForAgent(agentId);
+}
+
+export function listConnectionGrantAgentIds(db: Db): Promise<string[]> {
+  return createConnectionsRepository(db).listDistinctGrantAgentIds();
+}
+
 export function composeConnectionsForOwner(opts: {
   ownerId: string;
   db: Db;

--- a/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
@@ -197,9 +197,9 @@ export function createConnectionsRepository(db: Db): ConnectionsRepository {
     },
 
     async listDistinctGrantAgentIds(): Promise<string[]> {
-      const rows = (await db
+      const rows = await db
         .selectDistinct({ agentId: connectionGrantsTable.agentId })
-        .from(connectionGrantsTable)) as { agentId: string }[];
+        .from(connectionGrantsTable);
       return rows.map((r) => r.agentId);
     },
   };

--- a/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
@@ -42,6 +42,8 @@ export interface ConnectionsRepository {
   ): Promise<{ connectionId: string; grantedAt: Date }[]>;
   listConnectionsForAgent(agentId: string): Promise<Connection[]>;
   listAgentsForConnection(connectionId: string): Promise<string[]>;
+  revokeAllForAgent(agentId: string): Promise<void>;
+  listDistinctGrantAgentIds(): Promise<string[]>;
 }
 
 interface InternalConnectionRow {
@@ -185,6 +187,19 @@ export function createConnectionsRepository(db: Db): ConnectionsRepository {
         .where(eq(connectionGrantsTable.connectionId, connectionId))) as {
         agentId: string;
       }[];
+      return rows.map((r) => r.agentId);
+    },
+
+    async revokeAllForAgent(agentId): Promise<void> {
+      await db
+        .delete(connectionGrantsTable)
+        .where(eq(connectionGrantsTable.agentId, agentId));
+    },
+
+    async listDistinctGrantAgentIds(): Promise<string[]> {
+      const rows = (await db
+        .selectDistinct({ agentId: connectionGrantsTable.agentId })
+        .from(connectionGrantsTable)) as { agentId: string }[];
       return rows.map((r) => r.agentId);
     },
   };

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -194,7 +194,14 @@ export function createConnectionsService(deps: {
 
       if (affectedAgents.length > 0) {
         const ownerConnsAfter = await deps.repo.listByOwner(deps.ownerId);
-        const allOwnerConnectionIds = new Set(ownerConnsAfter.map((c) => c.id));
+        // The fan-out's egress sweep only revokes rules whose source id is in
+        // this owned set; `id` is already gone from `ownerConnsAfter`, so keep
+        // it here or the deleted connection's egress-allow rows would leak onto
+        // every affected agent.
+        const allOwnerConnectionIds = new Set([
+          ...ownerConnsAfter.map((c) => c.id),
+          id,
+        ]);
         for (const agentId of affectedAgents) {
           try {
             const grantedConnections =

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -196,14 +196,26 @@ export function createConnectionsService(deps: {
         const ownerConnsAfter = await deps.repo.listByOwner(deps.ownerId);
         const allOwnerConnectionIds = new Set(ownerConnsAfter.map((c) => c.id));
         for (const agentId of affectedAgents) {
-          const grantedConnections =
-            await deps.repo.listConnectionsForAgent(agentId);
-          await deps.fanOut.apply({
-            agentId,
-            ownerId: deps.ownerId,
-            grantedConnections,
-            allOwnerConnectionIds,
-          });
+          try {
+            const grantedConnections =
+              await deps.repo.listConnectionsForAgent(agentId);
+            await deps.fanOut.apply({
+              agentId,
+              ownerId: deps.ownerId,
+              grantedConnections,
+              allOwnerConnectionIds,
+            });
+          } catch (err) {
+            securityLog("warn", "connection.delete.fanout_failed", {
+              category: "credential",
+              actor: deps.ownerId,
+              actorKind: "user",
+              agentId,
+              target: conn.id,
+              result: "failure",
+              reason: err instanceof Error ? err.message : "unknown",
+            });
+          }
         }
       }
 

--- a/packages/ui/src/modules/agents/api/queries.ts
+++ b/packages/ui/src/modules/agents/api/queries.ts
@@ -88,6 +88,7 @@ export function useAgentAccess(agentId: string | null) {
       agentId ? { agentId: agentId } : skipToken,
     ),
     retry: false,
+    refetchOnMount: "always",
   });
 }
 
@@ -102,5 +103,6 @@ export function useAgentConnections(agentId: string | null) {
       agentId ? { agentId: agentId } : skipToken,
     ),
     retry: false,
+    refetchOnMount: "always",
   });
 }

--- a/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
@@ -131,6 +131,9 @@ export function useSandboxSettingsForm() {
   // agent + its grants resolve. `reset` makes subsequent toggles read as dirty.
   useEffect(() => {
     if (baselinedRef.current) return;
+    // Grants/access refetch on mount; baselining off a stale cache would adopt
+    // a since-deleted connection and render it as an unavailable grant.
+    if (accessQuery.isFetching || connectionsQuery.isFetching) return;
     if (!agent || !accessQuery.data || !connectionsQuery.data) return;
     baselinedRef.current = true;
     reset({
@@ -142,7 +145,15 @@ export function useSandboxSettingsForm() {
       envVars: userInitialEnv,
     });
     setFormReady(true);
-  }, [agent, accessQuery.data, connectionsQuery.data, userInitialEnv, reset]);
+  }, [
+    agent,
+    accessQuery.data,
+    accessQuery.isFetching,
+    connectionsQuery.data,
+    connectionsQuery.isFetching,
+    userInitialEnv,
+    reset,
+  ]);
 
   const assigned = watch("assigned");
   const assignedAppIds = watch("assignedAppIds");


### PR DESCRIPTION
Some of the behavior described in the original ticket was already fixed, this change tightens the connection removal from agents upon it's deletion.

- Not exiting the cleanup process with error toast in UI after encountering deleted agent during connection removal
- Not showing stale "unresolved" connections in the agent settings (refetch, no cache)

Closes #828 