### PR TITLE
fix(helm): gate agent pod ingress to api-server and controller

### DIFF
--- a/deploy/helm/platform/templates/agent-ingress-np.yaml
+++ b/deploy/helm/platform/templates/agent-ingress-np.yaml
@@ -1,0 +1,42 @@
+{{- /*
+Ingress gate for agent pods: only the api-server (ACP/tRPC relay) and the
+controller (idle-checker busy-probe) may dial the agent port. agent-runtime
+serves unauthenticated on the assumption that this policy is the auth
+boundary (packages/agent-runtime/src/server.ts). Kubelet probes are
+node-originated and unaffected. Role-scoped to `agent`, so fork pods are
+covered and gateway pods are untouched.
+*/}}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: agent-ingress-platform-only
+  namespace: {{ .Values.agentNamespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    agent-platform.ai/managed-by: platform-helm
+    agent-platform.ai/role: agent
+spec:
+  podSelector:
+    matchLabels:
+      agent-platform.ai/role: agent
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: apiserver
+              app.kubernetes.io/instance: {{ .Release.Name }}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ .Release.Namespace | quote }}
+          podSelector:
+            matchLabels:
+              app.kubernetes.io/component: controller
+              app.kubernetes.io/instance: {{ .Release.Name }}
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -84,6 +84,12 @@ other than its paired gateway. Enforcement is layered:
   destination IPs rather than HBONE tunnelled to ztunnel; the policy
   admits exactly DNS and the paired gateway pod's Envoy port. HBONE
   15008 is not admitted — the agent never speaks it.
+- **Agent ingress NetworkPolicy** (chart-rendered,
+  `agent-ingress-platform-only`) admits ingress to the agent port only
+  from the api-server (ACP/tRPC relay) and the controller (idle-checker
+  busy-probe). agent-runtime serves unauthenticated on the assumption
+  that this kernel gate is the auth boundary; kubelet probes are
+  node-originated and unaffected.
 - **Gateway Envoy ext_authz** gates everything the gateway
   forwards on behalf of the agent — external upstreams via the HITL
   rule model, and the harness path is special-cased to pass through.
@@ -323,6 +329,13 @@ differ:
   HBONE. Pair pinning is structural — the policy's pod-selector is
   the gateway pod itself, so a compromised agent has no admitted
   IP-and-port combination to reach anything else in the cluster.
+- **api-server / controller → agent** is gated at the kernel by the
+  chart-rendered `agent-ingress-platform-only` NetworkPolicy. The agent
+  port admits ingress only from api-server pods (ACP/tRPC relay — the
+  api-server has verified the user JWT and agent ownership before
+  forwarding) and controller pods (idle-checker busy-probe). Everything
+  else, gateway pods included, is dropped; the policy selects
+  `role=agent`, so fork pods are covered too.
 - **Gateway → api-server harness.** All agent egress (including the
   harness call) flows through the paired gateway pod's Envoy, so what
   reaches the mesh is gateway → harness. The harness Service is

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -150,9 +150,10 @@ const CORS = {
 const TRPC_MAX_BODY_SIZE = 32 * 1024 * 1024;
 
 // The agent's NetworkPolicy admits ingress on this port only from the
-// api-server pod; the api-server has already verified the user JWT and
-// agent ownership before forwarding. So tRPC routes need no in-process
-// auth check — the kernel-level gate is the auth boundary.
+// api-server and controller pods; the api-server has already verified
+// the user JWT and agent ownership before forwarding. So tRPC routes
+// need no in-process auth check — the kernel-level gate is the auth
+// boundary.
 const trpcHandler = createHTTPHandler({
   router: appRouter,
   createContext: (): AgentRuntimeContext => ({


### PR DESCRIPTION
## Problem

`agent-runtime` serves unauthenticated ACP, tRPC, terminal, and SSH endpoints on `:8080`, with an explicit comment stating that a kernel-level ingress NetworkPolicy is the auth boundary (`packages/agent-runtime/src/server.ts`). **That policy was never rendered** — any pod in the cluster that can route to the agent namespace (gateway pods included, which have unrestricted egress) could dial an agent's `:8080` directly.

## Change

Adds a chart-rendered `agent-ingress-platform-only` NetworkPolicy in the agent namespace. It selects `role=agent` pods (long-lived agents and forks; gateway pods untouched) and admits TCP 8080 only from:

- **api-server** pods in the release namespace — the ACP/tRPC/terminal/SSH relay; it verifies user JWT and agent ownership before forwarding
- **controller** pods in the release namespace — the idle-checker busy-probe (`GET /api/status`, `idlechecker.go`). Note: blocking this probe would not fail loudly — a dropped probe parses as *busy*, silently disabling hibernation, which is why the controller must be admitted

Kubelet `/healthz` probes are node-originated and unaffected by ingress policy.

Mesh interplay: agents are out of the ambient mesh, so in-mesh sources (api-server, controller) reach them as plaintext passthrough with pod source IPs preserved — no HBONE/15008 rule needed, and the egress credential boundary is untouched.

Also updates the `server.ts` comment (api-server → api-server *and controller*) and the security-and-credentials architecture page.

## Testing

- `mise run helm:check:lint` and `helm:check:render` (kubeconform) pass; `mise run check` passes.
- No new e2e spec: the allow paths are exercised by the entire existing suite (every test relays through the api-server, and agents only go Ready if kubelet probes pass). A deny-path test needs an in-cluster client pod the Playwright suite can drive, which doesn't exist today — `e2e.performFetch` goes through the gateway's egress gate, so it would test the wrong layer.