### PR TITLE
fix(schedules): wake hibernated agents on schedule fire

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -76,10 +76,10 @@ Contributions are applied out-of-band by a single background worker (a pod's `he
 Three paths trigger a wake:
 
 - **Connect-driven** — the api-server is about to forward an ACP frame to a hibernated Agent and ensures readiness before the relay completes. The frame can originate from a UI tab attaching to a session or from a channel worker (Slack / Telegram) routing an inbound message to its bound session.
-- **Schedule-driven** — the controller's schedule loop is about to deliver a trigger and `kubectl exec` requires the pod to be running.
+- **Schedule-driven** — a schedule fire commits a `trigger` event to the runtime outbox, then pokes the Agent awake without waiting for readiness; the boot-time `hello` catch-up delivers the event once the pod is `Ready`, and the event's TTL bounds how stale a fire can land.
 - **Skills-management-driven** — install / uninstall / private-source scan / publish all route through the same primitive before reaching the agent (scan and publish reach agent-runtime directly over the harness port; install/uninstall keep the pod warm so the apply worker dispatches the bumped outbox). See [skills](skills.md).
 
-Wake is bounded — the primitive polls pod readiness with backoff and gives up after two minutes, surfacing a loud error to its caller (schedule status, WS close code, or channel log).
+Wake is bounded — the primitive polls pod readiness with backoff and gives up after two minutes, surfacing a loud error to its caller (WS close code, channel log, or skills call error). The schedule-driven poke is the exception: it doesn't wait, so there is no bounded wait to fail.
 
 ### Trigger fire
 

--- a/packages/api-server/src/__tests__/unit/scheduler-runner.test.ts
+++ b/packages/api-server/src/__tests__/unit/scheduler-runner.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from "vitest";
+import type { Schedule } from "api-server-api";
+import { createSchedulerRunner } from "../../modules/schedules/services/scheduler-runner.js";
+import type { SchedulesRepository } from "../../modules/schedules/infrastructure/schedules-repository.js";
+import type { ScheduleQueue } from "../../modules/schedules/infrastructure/schedule-queue.js";
+import type { RuntimeMutator } from "../../modules/runtime-delivery/index.js";
+
+const AGENT_ID = "agent-1";
+const SCHEDULE_ID = "sched-1";
+
+function makeSchedule(): Schedule {
+  return {
+    id: SCHEDULE_ID,
+    agentId: AGENT_ID,
+    name: "hourly",
+    spec: {
+      version: "1",
+      type: "cron",
+      cron: "0 * * * *",
+      task: "do the thing",
+      enabled: true,
+      createdBy: "user",
+    },
+  };
+}
+
+function makeDeps(opts?: { wakeError?: Error }) {
+  const calls: string[] = [];
+  const fires: { result: string; nextRun: Date | null }[] = [];
+  const enqueued: Date[] = [];
+
+  const repo = {
+    async getById(id: string) {
+      return id === SCHEDULE_ID ? makeSchedule() : null;
+    },
+    async getOwnerById() {
+      return "owner-sub";
+    },
+    async recordFire(_id: string, result: string, nextRun: Date | null) {
+      fires.push({ result, nextRun });
+    },
+    async setNextRun() {},
+    async listAllEnabled() {
+      return [makeSchedule()];
+    },
+  } as unknown as SchedulesRepository;
+
+  const queue = {
+    async enqueue(_id: string, fireAt: Date) {
+      enqueued.push(fireAt);
+    },
+    async cancel() {},
+    async close() {},
+  } as unknown as ScheduleQueue;
+
+  const runtimeMutator: RuntimeMutator = {
+    async bump(agentId) {
+      calls.push(`bump:${agentId}`);
+      return 1;
+    },
+    async enqueueAfterCommit(agentId) {
+      calls.push(`enqueue:${agentId}`);
+    },
+  };
+
+  const runner = createSchedulerRunner({
+    repo,
+    queue,
+    runtimeMutator,
+    wakeAgent: async (agentId) => {
+      calls.push(`wake:${agentId}`);
+      if (opts?.wakeError) throw opts.wakeError;
+    },
+    log: () => {},
+    now: () => new Date("2026-06-12T10:30:00Z"),
+  });
+
+  return { runner, calls, fires, enqueued };
+}
+
+describe("scheduler-runner fire", () => {
+  it("commits the trigger event, then pokes the agent awake", async () => {
+    const { runner, calls, fires } = makeDeps();
+
+    await runner.buildFireHandler()(SCHEDULE_ID);
+
+    expect(calls).toEqual([
+      `bump:${AGENT_ID}`,
+      `enqueue:${AGENT_ID}`,
+      `wake:${AGENT_ID}`,
+    ]);
+    expect(fires).toHaveLength(1);
+    expect(fires[0]!.result).toBe("success");
+  });
+
+  it("records a failed fire and still re-arms when the wake poke fails", async () => {
+    const { runner, calls, fires, enqueued } = makeDeps({
+      wakeError: new Error("k8s api unreachable"),
+    });
+
+    await runner.buildFireHandler()(SCHEDULE_ID);
+
+    // The event was committed before the poke — it survives in the outbox.
+    expect(calls).toContain(`bump:${AGENT_ID}`);
+    expect(fires).toHaveLength(1);
+    expect(fires[0]!.result).toContain("k8s api unreachable");
+    expect(enqueued).toHaveLength(1);
+    expect(enqueued[0]!.toISOString()).toBe("2026-06-12T11:00:00.000Z");
+  });
+});

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -394,6 +394,9 @@ const schedulesBoot = composeSchedulesAtBoot({
   db,
   bullConnection,
   runtimeMutator: runtimeDelivery.runtimeMutator,
+  wakeAgent: async (agentId) => {
+    await agentsRepo.wakeIfHibernated(agentId);
+  },
 });
 schedulesBoot.runner.restoreAll().catch((err) => {
   process.stderr.write(

--- a/packages/api-server/src/modules/schedules/compose.ts
+++ b/packages/api-server/src/modules/schedules/compose.ts
@@ -30,6 +30,7 @@ export interface ComposeSchedulesAtBootOpts {
   db: Db;
   bullConnection: ConnectionOptions;
   runtimeMutator: RuntimeMutator;
+  wakeAgent: (agentId: string) => Promise<void>;
   log?: (msg: string) => void;
 }
 
@@ -43,6 +44,7 @@ export function composeSchedulesAtBoot(
     repo,
     queue,
     runtimeMutator: opts.runtimeMutator,
+    wakeAgent: opts.wakeAgent,
     log,
   });
   const worker = startScheduleWorker({

--- a/packages/api-server/src/modules/schedules/services/scheduler-runner.ts
+++ b/packages/api-server/src/modules/schedules/services/scheduler-runner.ts
@@ -16,6 +16,8 @@ export interface SchedulerRunnerDeps {
   repo: SchedulesRepository;
   queue: ScheduleQueue;
   runtimeMutator: RuntimeMutator;
+  /** Activity poke — starts a hibernated agent's wake without waiting for Ready. */
+  wakeAgent: (agentId: string) => Promise<void>;
   log?: (msg: string) => void;
   now?: () => Date;
   triggerTtlSeconds?: number;
@@ -54,12 +56,17 @@ export function createSchedulerRunner(
         { id: eventId, kind: "trigger", payload, expiresAt },
       ]);
       await deps.runtimeMutator.enqueueAfterCommit(sched.agentId);
+      // Poke after the commit: a hibernated agent would otherwise let the
+      // trigger sit in the outbox until its TTL expires. The poke doesn't
+      // wait for Ready — the boot-time hello catch-up delivers the event
+      // once the pod is up.
+      await deps.wakeAgent(sched.agentId);
       result = "success";
       outcome = "success";
     } catch (err) {
       result = (err as Error).message ?? String(err);
       outcome = "failure";
-      log(`fire: schedule ${scheduleId} commit failed: ${result}`);
+      log(`fire: schedule ${scheduleId} failed: ${result}`);
     }
 
     const ownerSub = await deps.repo.getOwnerById(scheduleId);


### PR DESCRIPTION
## Problem

A schedule fire against a hibernated agent never runs. The fire path commits a `trigger` event to the runtime outbox and enqueues delivery, but the delivery worker dispatches only to a `Ready` agent and nothing wakes the pod:

- the worker defers to the sweep when the agent isn't Ready (`worker-handler.ts`), and the sweep just re-enqueues — neither ever wakes
- the trigger event expires after its TTL (default 1 h) and is silently dropped by the sweep
- meanwhile `recordFire` stores `success` and a `ScheduleFired` event with `outcome: "success"` is emitted, because the commit succeeded — so the UI shows a successful fire that never executed

Every other caller that sends *work* to a pod (ACP relay, channels, skills management) wakes it first; schedules lost that step when trigger delivery moved from the controller's `kubectl exec` loop to the runtime outbox. Config contributions can wait for the next wake — TTL'd trigger events can't.

## Fix

`fire()` now pokes the agent awake **after** committing the trigger event, via `wakeIfHibernated` — the fire-and-forget activity bump, not the blocking `ensureReady` wait:

- commit first, poke second — a crash or failed poke never loses the event; it stays in the outbox and still delivers if the agent comes up within the TTL
- the poke doesn't wait for `Ready`, so the schedule worker never blocks on a cold pod; the boot-time `hello` catch-up (`retryUntilReady`) delivers the event seconds after the pod is up, with the sweep as backstop
- a failed poke (e.g. K8s API error) is recorded as a failed fire in the schedule status; the schedule re-arms for its next occurrence regardless of outcome, as before

Wired through `composeSchedulesAtBoot` as an injected `wakeAgent` port; no change to the delivery worker — it stays wake-free by design.

## Note for reviewers — overlap with #900

#900 (docs) describes the current no-wake behavior as-is, including "Schedule fires do not wake … or expires". This PR changes that behavior, so whichever lands second needs a one-paragraph reconciliation in `agent-lifecycle.md`: schedule fires poke the agent awake again (as the pre-#900 page claimed), but via outbox-commit-then-poke rather than the retired controller exec path. The doc lines updated here are written to read correctly against either base.

## Testing

- new unit tests for the fire path: commit-before-poke ordering, and poke-failure → failed fire recorded + schedule still re-armed
- `mise run api-server:check` and `mise run api-server:test` (195 tests) pass