### PR TITLE
chore: hide slack, yt, and google,  connections from the ui

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -77,7 +77,7 @@ Beyond the auth credential, a template may declare optional **config inputs** â€
 
 #### Internal-only templates
 
-Some templates (initially Spotify, Slack, YouTube, and all Google services) are hidden from regular users client-side, affecting only what's offered, not Connections already created. Testers reveal the full catalog by running `platformConnections.showInternal()` in the browser devtools console.
+Some templates (initially Spotify, Slack, YouTube, and all Google services) are hidden from regular users client-side, affecting only what's offered (on both the Connections settings page and the sandbox creation wizard), not Connections already created. Testers reveal the full catalog by running `platformConnections.showInternal()` in the browser devtools console, or by tapping the version string on the settings page five times.
 
 ### Connection
 

--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -73,7 +73,13 @@ Two display-axis attributes drive UI grouping:
 
 Templates are registered in code; adding a new integration is one entry. Schemas validate user input; the template's `build()` function projects inputs into the concrete `auth` + `contributions[]` of the Connection record.
 
+<<<<<<< HEAD
 Beyond the auth credential, a template may declare optional **config inputs** — e.g. Bob's model and tenant pins — that the user fills at connect time; each filled input projects into an additional `env` contribution, validated against the input's spec.
+=======
+#### Internal-only templates
+
+Some templates (initially Spotify, Slack, YouTube, and all Google services) are hidden from regular users client-side, affecting only what's offered, not Connections already created. Testers reveal the full catalog by running `platformConnections.showInternal()` in the browser devtools console.
+>>>>>>> 228366dd (hide connections)
 
 ### Connection
 

--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -73,13 +73,11 @@ Two display-axis attributes drive UI grouping:
 
 Templates are registered in code; adding a new integration is one entry. Schemas validate user input; the template's `build()` function projects inputs into the concrete `auth` + `contributions[]` of the Connection record.
 
-<<<<<<< HEAD
 Beyond the auth credential, a template may declare optional **config inputs** — e.g. Bob's model and tenant pins — that the user fills at connect time; each filled input projects into an additional `env` contribution, validated against the input's spec.
-=======
+
 #### Internal-only templates
 
 Some templates (initially Spotify, Slack, YouTube, and all Google services) are hidden from regular users client-side, affecting only what's offered, not Connections already created. Testers reveal the full catalog by running `platformConnections.showInternal()` in the browser devtools console.
->>>>>>> 228366dd (hide connections)
 
 ### Connection
 

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -1,4 +1,5 @@
 import "./App.css";
+import "./modules/connections/devtools.js";
 import "./modules/usage/devtools.js";
 
 import { QueryClientProvider } from "@tanstack/react-query";

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -13,6 +13,10 @@ import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useDeleteConnection, useStartOAuth } from "../api/mutations.js";
 import { useAppConnections, useConnectionTemplates } from "../api/queries.js";
 import { TemplateCreateForm } from "../forms/template-create-form.js";
+import {
+  filterOfferedTemplates,
+  isShowInternalConnectionsEnabled,
+} from "../internal-only.js";
 import { PROVIDER_TEMPLATE_IDS } from "../lib/provider-templates.js";
 import { ConnectionIcon } from "./connection-icon.js";
 
@@ -35,7 +39,11 @@ export function ConnectionTemplatesSection() {
   const visibleTemplates = (templates.data ?? []).filter(
     (t) => !PROVIDER_TEMPLATE_IDS.has(t.id),
   );
-  const byCategory = groupByCategory(visibleTemplates);
+  const offeredTemplates = filterOfferedTemplates(
+    visibleTemplates,
+    isShowInternalConnectionsEnabled(),
+  );
+  const byCategory = groupByCategory(offeredTemplates);
   const iconByTemplateId = useMemo(() => {
     const m = new Map<string, string | undefined>();
     for (const t of templates.data ?? []) m.set(t.id, t.iconSlug);

--- a/packages/ui/src/modules/connections/devtools.ts
+++ b/packages/ui/src/modules/connections/devtools.ts
@@ -1,0 +1,22 @@
+import {
+  isShowInternalConnectionsEnabled,
+  setShowInternalConnections,
+} from "./internal-only.js";
+
+// Run `platformConnections.showInternal()` in the browser console to reveal internal-only connections
+declare global {
+  interface Window {
+    platformConnections?: {
+      showInternal: (on?: boolean) => void;
+      status: () => boolean;
+    };
+  }
+}
+
+window.platformConnections = {
+  showInternal: (on = true) => {
+    setShowInternalConnections(on);
+    window.location.reload();
+  },
+  status: isShowInternalConnectionsEnabled,
+};

--- a/packages/ui/src/modules/connections/internal-only.ts
+++ b/packages/ui/src/modules/connections/internal-only.ts
@@ -8,7 +8,9 @@ export const INTERNAL_ONLY_TEMPLATE_IDS: ReadonlySet<string> = new Set([
 ]);
 
 // All Google services (catalog ids "google-*") are internal-only as a group.
-export const INTERNAL_ONLY_TEMPLATE_ID_PREFIXES: readonly string[] = ["google-"];
+export const INTERNAL_ONLY_TEMPLATE_ID_PREFIXES: readonly string[] = [
+  "google-",
+];
 
 export const SHOW_INTERNAL_CONNECTIONS_STORAGE_KEY =
   "platform-debug:show-internal-connections";

--- a/packages/ui/src/modules/connections/internal-only.ts
+++ b/packages/ui/src/modules/connections/internal-only.ts
@@ -1,0 +1,48 @@
+import type { ConnectionTemplateView } from "api-server-api";
+
+// Connections we support but don't want regular users setting up yet.
+export const INTERNAL_ONLY_TEMPLATE_IDS: ReadonlySet<string> = new Set([
+  "spotify",
+  "slack",
+  "youtube",
+]);
+
+// All Google services (catalog ids "google-*") are internal-only as a group.
+export const INTERNAL_ONLY_TEMPLATE_ID_PREFIXES: readonly string[] = ["google-"];
+
+export const SHOW_INTERNAL_CONNECTIONS_STORAGE_KEY =
+  "platform-debug:show-internal-connections";
+
+export function isInternalOnlyTemplate(id: string): boolean {
+  return (
+    INTERNAL_ONLY_TEMPLATE_IDS.has(id) ||
+    INTERNAL_ONLY_TEMPLATE_ID_PREFIXES.some((prefix) => id.startsWith(prefix))
+  );
+}
+
+export function isShowInternalConnectionsEnabled(): boolean {
+  try {
+    return (
+      localStorage.getItem(SHOW_INTERNAL_CONNECTIONS_STORAGE_KEY) === "true"
+    );
+  } catch {
+    // localStorage unavailable (private mode) — fail safe toward hidden.
+    return false;
+  }
+}
+
+export function setShowInternalConnections(enabled: boolean): void {
+  if (enabled) {
+    localStorage.setItem(SHOW_INTERNAL_CONNECTIONS_STORAGE_KEY, "true");
+  } else {
+    localStorage.removeItem(SHOW_INTERNAL_CONNECTIONS_STORAGE_KEY);
+  }
+}
+
+// Drops internal-only templates from the offered list unless revealed.
+export function filterOfferedTemplates<
+  T extends Pick<ConnectionTemplateView, "id">,
+>(templates: readonly T[], showInternal: boolean): T[] {
+  if (showInternal) return [...templates];
+  return templates.filter((t) => !isInternalOnlyTemplate(t.id));
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -10,6 +10,10 @@ import {
   useConnectionTemplates,
 } from "../../../connections/api/queries.js";
 import { TemplateCreateForm } from "../../../connections/forms/template-create-form.js";
+import {
+  filterOfferedTemplates,
+  isShowInternalConnectionsEnabled,
+} from "../../../connections/internal-only.js";
 import { PROVIDER_TEMPLATE_IDS } from "../../../connections/lib/provider-templates.js";
 import {
   saveSnapshot,
@@ -54,16 +58,19 @@ export function ConnectionsStep({
     [allTemplates],
   );
 
+  const showInternal = isShowInternalConnectionsEnabled();
+
   const byCategory = useMemo(() => {
+    const offered = filterOfferedTemplates(allTemplates, showInternal);
     const m = new Map<string, ConnectionTemplateView[]>();
-    for (const t of allTemplates) {
+    for (const t of offered) {
       if (PROVIDER_TEMPLATE_IDS.has(t.id)) continue;
       const list = m.get(t.category) ?? [];
       list.push(t);
       m.set(t.category, list);
     }
     return m;
-  }, [allTemplates]);
+  }, [allTemplates, showInternal]);
 
   const selected = new Set(snapshot.connectionIds);
 

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -4,6 +4,7 @@ import {
   Logout as LogOut,
   Screen as Monitor,
 } from "@carbon/icons-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -11,6 +12,10 @@ import { cn } from "@/lib/utils";
 
 import { getUser, logout } from "../../../auth.js";
 import { useStore } from "../../../store.js";
+import {
+  isShowInternalConnectionsEnabled,
+  setShowInternalConnections,
+} from "../../connections/internal-only.js";
 import { ConnectionsView } from "../../connections/views/connections-view.js";
 import type { SettingsTab } from "../../platform/lib/routes.js";
 import { useAppVersion } from "../api/queries.js";
@@ -52,6 +57,18 @@ export function SettingsView() {
   const setView = useStore((s) => s.setView);
   const user = getUser();
   const { data: appVersion } = useAppVersion();
+  const [versionTaps, setVersionTaps] = useState(0);
+
+  // Hidden: five taps on the version string flips the internal-only
+  // connections catalog (same toggle as the platformConnections devtools helper).
+  const onVersionTap = () => {
+    if (versionTaps + 1 < 5) {
+      setVersionTaps(versionTaps + 1);
+      return;
+    }
+    setShowInternalConnections(!isShowInternalConnectionsEnabled());
+    window.location.reload();
+  };
 
   return (
     <div className="flex gap-6 md:gap-10 flex-col md:flex-row">
@@ -164,7 +181,10 @@ export function SettingsView() {
             </div>
 
             {appVersion && (
-              <div className="mt-6 text-[12px] text-muted-foreground break-all">
+              <div
+                onClick={onVersionTap}
+                className="mt-6 text-[12px] text-muted-foreground break-all select-none"
+              >
                 Version {appVersion}
               </div>
             )}


### PR DESCRIPTION
Minimal UI-only design.

Persists only in the given browser where function was called

Not tied to the user identity in any way.

Closes #891 