### PR TITLE
feat(ui): unified Sandboxes home

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -23,6 +23,7 @@ Persistence vocabulary shared by every bounded context. See [`docs/architecture/
 |------|-----------|
 | Template | A read-only catalog blueprint that defines the base image, mounts, env, and resources for creating an agent |
 | Agent | The durable, owned, runnable resource — definition, runtime state, and lifecycle. A single ConfigMap whose `spec.yaml` (api-server writer) carries env, secret refs, allowed users, and `desiredState`, and whose `status.yaml` (controller writer) carries observed state. Optionally derived from a Template at create-time |
+| Sandbox | The user-facing name for an Agent across the redesigned UI (#892); "Agent" remains the domain/code term |
 | Session | One conversation with the agent harness, with its own lifecycle and metadata |
 | Schedule | A time-triggered task attached to an Agent — either cron-based or heartbeat |
 | Desired State | The target lifecycle state of an Agent: running or hibernated |

--- a/packages/api-server-api/src/modules/agents/router.ts
+++ b/packages/api-server-api/src/modules/agents/router.ts
@@ -22,6 +22,8 @@ function toView(agent: Agent) {
     image: agent.spec.image,
     description: agent.spec.description,
     env: agent.spec.env,
+    grantedSecretIds: agent.spec.grantedSecretIds ?? [],
+    grantedConnectionIds: agent.spec.grantedConnectionIds ?? [],
     state: agent.state,
     error: agent.error,
     podTerminationReason: agent.podTerminationReason,

--- a/packages/e2e/playwright/src/lib/agents.ts
+++ b/packages/e2e/playwright/src/lib/agents.ts
@@ -167,7 +167,8 @@ export function agentCardStatus(
   agentName: string,
   label: string,
 ): Locator {
-  return agentNameHeading(page, agentName)
-    .locator("..")
+  return page
+    .getByTestId("agent-row")
+    .filter({ has: agentNameHeading(page, agentName) })
     .getByText(label, { exact: true });
 }

--- a/packages/e2e/playwright/src/tests/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-agent.spec.ts
@@ -28,7 +28,7 @@ test("create a mock agent with the connection attached", async ({ page }) => {
   await test.step("create the agent with the connection selected", async () => {
     const connectionId = await getConnectionId(api, connectionName);
 
-    await page.getByRole("button", { name: /add agent/i }).click();
+    await page.getByRole("button", { name: /create sandbox/i }).click();
     await page.getByText(harnessName, { exact: true }).click();
     await page.getByPlaceholder("my-agent").fill(agentName);
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,6 +16,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/packages/ui/src/__tests__/unit/agent-resolver.test.ts
+++ b/packages/ui/src/__tests__/unit/agent-resolver.test.ts
@@ -9,6 +9,8 @@ const agent = (id: string, state: AgentView["state"]): AgentView => ({
   name: id,
   templateId: null,
   image: "x:latest",
+  grantedSecretIds: [],
+  grantedConnectionIds: [],
   state,
   contributionFailures: [],
   channels: [],

--- a/packages/ui/src/components/status-indicator.tsx
+++ b/packages/ui/src/components/status-indicator.tsx
@@ -5,7 +5,7 @@ const stateLabel: Record<AgentDisplayState, string> = {
   starting: "Starting",
   preparing_workspace: "Preparing workspace",
   hibernating: "Hibernating",
-  hibernated: "Hibernated",
+  hibernated: "Hibernating",
   error: "Error",
 };
 
@@ -13,7 +13,7 @@ const badgeColors: Record<AgentDisplayState, string> = {
   running: "bg-success-light text-success border-success",
   starting: "bg-warning-light text-warning border-warning",
   preparing_workspace: "bg-warning-light text-warning border-warning",
-  hibernating: "bg-warning-light text-warning border-warning",
+  hibernating: "bg-info-light text-info/50 border-info/25",
   hibernated: "bg-info-light text-info/50 border-info/25",
   error: "bg-danger-light text-danger border-danger",
 };
@@ -22,7 +22,7 @@ const dotColors: Record<AgentDisplayState, string> = {
   running: "bg-success",
   starting: "bg-warning anim-pulse",
   preparing_workspace: "bg-warning anim-pulse",
-  hibernating: "bg-warning anim-pulse",
+  hibernating: "bg-info/50 anim-pulse",
   hibernated: "bg-info/50",
   error: "bg-danger",
 };

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,77 @@
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
+>(({ className, align = "end", sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      collisionPadding={8}
+      className={cn(
+        "z-50 min-w-[160px] rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=top]:slide-in-from-bottom-2",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const dropdownMenuItemVariants = cva(
+  "flex h-9 w-full cursor-pointer select-none items-center gap-2 rounded-md px-3 text-sm font-medium outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+  {
+    variants: {
+      tone: {
+        default:
+          "data-[highlighted]:bg-muted data-[highlighted]:text-foreground",
+        danger:
+          "data-[highlighted]:bg-danger-light data-[highlighted]:text-danger",
+      },
+    },
+    defaultVariants: { tone: "default" },
+  },
+);
+
+const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> &
+    VariantProps<typeof dropdownMenuItemVariants>
+>(({ className, tone, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(dropdownMenuItemVariants({ tone }), className)}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("my-1 h-px bg-border", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -1,0 +1,93 @@
+import { OverflowMenuVertical } from "@carbon/icons-react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+
+import { StatusBadge } from "../../../components/status-indicator.js";
+import type { AgentView } from "../../../types.js";
+import type { AgentDisplay } from "../utils/agent-resolver.js";
+import { ContributionFailuresBadge } from "./contribution-failures-badge.js";
+
+interface Props {
+  agent: AgentView;
+  display: AgentDisplay;
+  subtitle: string;
+  deletePending: boolean;
+  onSelect: () => void;
+  onWake: () => void;
+  onRestart: () => void;
+  onConfigure: () => void;
+  onDelete: () => void;
+}
+
+export function AgentRow({
+  agent,
+  display,
+  subtitle,
+  deletePending,
+  onSelect,
+  onWake,
+  onRestart,
+  onConfigure,
+  onDelete,
+}: Props) {
+  return (
+    <Card
+      data-testid="agent-row"
+      onClick={onSelect}
+      className="group flex cursor-pointer items-center justify-between gap-3 border border-border p-4 anim-in transition-shadow hover:not-has-[button:hover]:shadow-md"
+    >
+      <div className="min-w-0 flex-1">
+        <h2 className="truncate text-[16px] font-medium text-foreground transition-colors [.group:hover:not(:has(button:hover))_&]:text-primary">
+          {agent.name}
+        </h2>
+        <p className="mt-1 truncate text-[14px] text-muted-foreground">
+          {subtitle}
+        </p>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <ContributionFailuresBadge failures={agent.contributionFailures} />
+        <StatusBadge state={display.state} />
+        {/* Menu clicks (incl. portaled items, which bubble through the React
+            tree) must not trigger the row's onSelect. */}
+        <span onClick={(e) => e.stopPropagation()}>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="ghost" size="icon" title="Sandbox actions">
+                <OverflowMenuVertical />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {display.powerAction === "start" ? (
+                <DropdownMenuItem onSelect={onWake}>Wake</DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  disabled={display.powerAction === null}
+                  onSelect={onRestart}
+                >
+                  Restart
+                </DropdownMenuItem>
+              )}
+              <DropdownMenuItem onSelect={onConfigure}>
+                Configure
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                tone="danger"
+                disabled={deletePending}
+                onSelect={onDelete}
+              >
+                Delete sandbox
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </span>
+      </div>
+    </Card>
+  );
+}

--- a/packages/ui/src/modules/agents/utils/sandbox-subtitle.ts
+++ b/packages/ui/src/modules/agents/utils/sandbox-subtitle.ts
@@ -1,0 +1,44 @@
+import type { SecretType } from "api-server-api";
+import { isProviderPresetType, PROVIDERS } from "api-server-api";
+
+import type { AgentView } from "../../../types.js";
+import { providerTemplateDisplayName } from "../../connections/lib/provider-templates.js";
+
+export interface SandboxSubtitleLookup {
+  templateNameById: ReadonlyMap<string, string>;
+  connectionTemplateIdById: ReadonlyMap<string, string>;
+  secretTypeById: ReadonlyMap<string, SecretType>;
+}
+
+/** "harness · provider" row subtitle. The harness segment degrades to the raw
+ *  image ref when the template is unknown; the provider segment is omitted
+ *  when no granted connection/secret resolves to a provider. */
+export function sandboxSubtitle(
+  agent: AgentView,
+  lookup: SandboxSubtitleLookup,
+): string {
+  const harness =
+    (agent.templateId
+      ? lookup.templateNameById.get(agent.templateId)
+      : undefined) ?? agent.image;
+  const provider = providerLabel(agent, lookup);
+  return provider ? `${harness} · ${provider}` : harness;
+}
+
+function providerLabel(
+  agent: AgentView,
+  lookup: SandboxSubtitleLookup,
+): string | null {
+  for (const connectionId of agent.grantedConnectionIds) {
+    const templateId = lookup.connectionTemplateIdById.get(connectionId);
+    const name = templateId ? providerTemplateDisplayName(templateId) : null;
+    if (name) return name;
+  }
+  // Secrets fallback for pre-Connections provider grants — delete after the
+  // #601 cutover.
+  for (const secretId of agent.grantedSecretIds) {
+    const type = lookup.secretTypeById.get(secretId);
+    if (type && isProviderPresetType(type)) return PROVIDERS[type].displayName;
+  }
+  return null;
+}

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -102,10 +102,8 @@ export function ListView() {
           </Button>
         </div>
 
-        {/* Skeleton during initial load — only when we expect agents */}
-        {!initialLoaded && agents.length > 0 && (
-          <ListSkeleton rows={2} rowHeight={70} />
-        )}
+        {/* Skeleton during the initial load, before the first fetch resolves. */}
+        {!initialLoaded && <ListSkeleton rows={2} rowHeight={70} />}
 
         {/* Empty state — the header's Create sandbox button is the only CTA. */}
         {initialLoaded && agents.length === 0 && !busyAgent && (

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -1,21 +1,17 @@
-import {
-  Add as Plus,
-  Password as KeyRound,
-  Play,
-  Renew,
-  TrashCan as Trash2,
-} from "@carbon/icons-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
-import { StatusBadge } from "../../../components/status-indicator.js";
+import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useStore } from "../../../store.js";
+import type { AgentView, TemplateView } from "../../../types.js";
+import { useAppConnections } from "../../connections/api/queries.js";
+import { useSecrets } from "../../secrets/api/queries.js";
 import { useTemplates } from "../../templates/api/queries.js";
 import { useCreateAgent, useDeleteAgent } from "../api/mutations.js";
 import { useAgents } from "../api/queries.js";
-import { ContributionFailuresBadge } from "../components/contribution-failures-badge.js";
+import { AgentRow } from "../components/agent-row.js";
 import { AddAgentDialog } from "../dialogs/add-agent-dialog.js";
 import { ConfigureAgentDialog } from "../dialogs/configure-agent-dialog.js";
 import {
@@ -24,14 +20,21 @@ import {
 } from "../hooks/use-restart-agent.js";
 import { useWakeAgent } from "../hooks/use-wake-agent.js";
 import { resolveAgentDisplay } from "../utils/agent-resolver.js";
+import {
+  sandboxSubtitle,
+  type SandboxSubtitleLookup,
+} from "../utils/sandbox-subtitle.js";
+
+// Stable fallback so `subtitleLookup`'s memo isn't defeated while the
+// templates query has no data yet.
+const NO_TEMPLATES: TemplateView[] = [];
 
 export function ListView() {
-  const { data: templates = [], refetch: refetchTemplates } = useTemplates();
-  const {
-    data: agentsData,
-    refetch: refetchAgents,
-    isSuccess: agentsLoaded,
-  } = useAgents();
+  const { data: templatesData } = useTemplates();
+  const templates = templatesData ?? NO_TEMPLATES;
+  const { data: agentsData } = useAgents();
+  const connections = useAppConnections();
+  const secrets = useSecrets();
   const agents = agentsData?.list ?? [];
   const restartingAgents = useStore((s) => s.restartingAgents);
   useSyncRestartingAgents();
@@ -48,7 +51,9 @@ export function ListView() {
   const [showAddAgent, setShowAddAgent] = useState(false);
   const [configAgentId, setConfigAgentId] = useState<string | null>(null);
 
-  const initialLoaded = agentsLoaded;
+  // Gate on data presence, not query success: a transient poll failure keeps
+  // the cached list rendered instead of flashing skeletons over it.
+  const initialLoaded = agentsData !== undefined;
   const busyAgent = createAgent.isPending;
 
   const restartingIds = useMemo(
@@ -56,157 +61,79 @@ export function ListView() {
     [restartingAgents],
   );
 
+  const subtitleLookup = useMemo<SandboxSubtitleLookup>(
+    () => ({
+      templateNameById: new Map(templates.map((t) => [t.id, t.name])),
+      connectionTemplateIdById: new Map(
+        (connections.data ?? []).map((c) => [c.id, c.templateId]),
+      ),
+      secretTypeById: new Map((secrets.data ?? []).map((s) => [s.id, s.type])),
+    }),
+    [templates, connections.data, secrets.data],
+  );
+
   const configAgent = configAgentId
     ? (agents.find((a) => a.id === configAgentId) ?? null)
     : null;
 
+  const deleteSandbox = async (agent: AgentView) => {
+    const msg = (
+      <>
+        Delete sandbox{" "}
+        <strong className="text-foreground">"{agent.name}"</strong>? This will
+        also delete <strong>all persistent data</strong> and cannot be undone.
+      </>
+    );
+    if (!(await showConfirm(msg, "Delete Sandbox", { kind: "destructive" })))
+      return;
+    deleteAgent.mutate({ id: agent.id });
+  };
+
   return (
     <>
-      <div>
+      <div className="mx-auto w-full max-w-[666px]">
         {/* Page header */}
-        <div className="flex items-center gap-3 mb-8">
-          <h1 className="text-[20px] md:text-[24px] font-bold text-foreground">
-            Agents
+        <div className="mb-8 flex items-center justify-between gap-3">
+          <h1 className="text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
+            Sandboxes
           </h1>
-          <div className="ml-auto flex items-center gap-2 md:gap-3">
-            <Button
-              variant="outline"
-              size="icon"
-              onClick={() => {
-                refetchTemplates();
-                refetchAgents();
-              }}
-              title="Refresh"
-            >
-              <Renew />
-            </Button>
-            <Button onClick={() => setShowAddAgent(true)} disabled={busyAgent}>
-              <Plus /> <span className="hidden sm:inline">Add</span> Agent
-            </Button>
-          </div>
+          <Button onClick={() => setShowAddAgent(true)} disabled={busyAgent}>
+            Create sandbox
+          </Button>
         </div>
 
         {/* Skeleton during initial load — only when we expect agents */}
         {!initialLoaded && agents.length > 0 && (
-          <div className="flex flex-col gap-6">
-            <Card className="h-[88px] anim-pulse" />
-            <Card className="h-[88px] anim-pulse" />
-          </div>
+          <ListSkeleton rows={2} rowHeight={70} />
         )}
 
-        {/* Empty state — consistent placeholder when no agents exist */}
+        {/* Empty state — the header's Create sandbox button is the only CTA. */}
         {initialLoaded && agents.length === 0 && !busyAgent && (
-          <Card className="px-6 py-8 text-center text-[14px] text-muted-foreground anim-in">
-            No agents yet
+          <Card className="border border-border px-6 py-10 text-center text-[14px] text-muted-foreground anim-in">
+            No sandboxes yet
           </Card>
         )}
 
-        {/* One row per agent. */}
-        <div className="flex flex-col gap-6">
+        {/* One row per sandbox. */}
+        <div className="flex flex-col gap-3">
           {initialLoaded &&
-            agents.map((agent) => {
-              const display = resolveAgentDisplay(agent, restartingIds);
-              return (
-                <Card
-                  key={agent.id}
-                  onClick={() => selectAgent(agent.id)}
-                  className="overflow-hidden anim-in transition-shadow group cursor-pointer hover:not-has-[button:hover]:shadow-md"
-                >
-                  <div className="px-4 md:px-6 py-4 md:py-5">
-                    <div className="flex flex-col md:flex-row md:items-center gap-3 md:gap-4">
-                      <div className="flex-1 min-w-0">
-                        <div className="flex items-center gap-3 mb-2 flex-wrap">
-                          <h2 className="text-[16px] md:text-[17px] font-bold text-foreground transition-colors [.group:hover:not(:has(button:hover))_&]:text-primary">
-                            {agent.name}
-                          </h2>
-                          <StatusBadge state={display.state} />
-                          <ContributionFailuresBadge
-                            failures={agent.contributionFailures}
-                          />
-                        </div>
-                        {agent.description && (
-                          <p className="text-[13px] text-foreground/80">
-                            {agent.description}
-                          </p>
-                        )}
-                      </div>
-
-                      <div
-                        className="flex items-center gap-2 shrink-0 flex-wrap"
-                        onClick={(e) => e.stopPropagation()}
-                      >
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => {
-                            if (display.powerAction === "start")
-                              wakeAgent.wake(agent.id);
-                            else if (display.powerAction === "restart")
-                              restartAgent(agent.id);
-                          }}
-                          disabled={display.powerAction === null}
-                          title={
-                            display.powerAction === "start"
-                              ? "Wake the hibernated agent"
-                              : "Restart the agent pod"
-                          }
-                        >
-                          {display.powerAction === "start" ? (
-                            <>
-                              <Play /> Start
-                            </>
-                          ) : (
-                            <>
-                              <Renew /> Restart
-                            </>
-                          )}
-                        </Button>
-                        <Button
-                          variant="outline"
-                          size="sm"
-                          onClick={() => setConfigAgentId(agent.id)}
-                          title="Configure agent credentials and env vars"
-                        >
-                          <KeyRound /> Configure
-                        </Button>
-                        <Button
-                          variant="ghost"
-                          size="icon"
-                          className="text-muted-foreground hover:text-destructive"
-                          onClick={async () => {
-                            const msg = (
-                              <>
-                                Delete agent{" "}
-                                <strong className="text-foreground">
-                                  "{agent.name}"
-                                </strong>
-                                ? This will also delete{" "}
-                                <strong>all persistent data</strong> and cannot
-                                be undone.
-                              </>
-                            );
-                            if (
-                              !(await showConfirm(msg, "Delete Agent", {
-                                kind: "destructive",
-                              }))
-                            )
-                              return;
-                            deleteAgent.mutate({ id: agent.id });
-                          }}
-                          disabled={
-                            deleteAgent.isPending &&
-                            deleteAgent.variables?.id === agent.id
-                          }
-                          title="Delete agent"
-                        >
-                          <Trash2 />
-                        </Button>
-                      </div>
-                    </div>
-                  </div>
-                </Card>
-              );
-            })}
+            agents.map((agent) => (
+              <AgentRow
+                key={agent.id}
+                agent={agent}
+                display={resolveAgentDisplay(agent, restartingIds)}
+                subtitle={sandboxSubtitle(agent, subtitleLookup)}
+                deletePending={
+                  deleteAgent.isPending &&
+                  deleteAgent.variables?.id === agent.id
+                }
+                onSelect={() => selectAgent(agent.id)}
+                onWake={() => wakeAgent.wake(agent.id)}
+                onRestart={() => restartAgent(agent.id)}
+                onConfigure={() => setConfigAgentId(agent.id)}
+                onDelete={() => void deleteSandbox(agent)}
+              />
+            ))}
         </div>
       </div>
 

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -4,14 +4,7 @@ import {
   TrashCan as Trash2,
 } from "@carbon/icons-react";
 import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
-import { PROVIDER_PRESET_TYPES } from "api-server-api";
 import { useMemo, useState } from "react";
-
-// Templates managed by the legacy Providers view, hidden here so they aren't offered twice; `anthropic-oauth` rides the same card as the API-key variant.
-const LEGACY_PROVIDER_TEMPLATE_IDS = new Set<string>([
-  ...PROVIDER_PRESET_TYPES,
-  "anthropic-oauth",
-]);
 
 import { Button } from "@/components/ui/button";
 
@@ -20,6 +13,7 @@ import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useDeleteConnection, useStartOAuth } from "../api/mutations.js";
 import { useAppConnections, useConnectionTemplates } from "../api/queries.js";
 import { TemplateCreateForm } from "../forms/template-create-form.js";
+import { PROVIDER_TEMPLATE_IDS } from "../lib/provider-templates.js";
 import { ConnectionIcon } from "./connection-icon.js";
 
 export function ConnectionTemplatesSection() {
@@ -39,7 +33,7 @@ export function ConnectionTemplatesSection() {
   };
 
   const visibleTemplates = (templates.data ?? []).filter(
-    (t) => !LEGACY_PROVIDER_TEMPLATE_IDS.has(t.id),
+    (t) => !PROVIDER_TEMPLATE_IDS.has(t.id),
   );
   const byCategory = groupByCategory(visibleTemplates);
   const iconByTemplateId = useMemo(() => {

--- a/packages/ui/src/modules/connections/lib/provider-templates.ts
+++ b/packages/ui/src/modules/connections/lib/provider-templates.ts
@@ -1,0 +1,18 @@
+import type { ProviderPresetType } from "api-server-api";
+import { PROVIDER_PRESET_TYPES, PROVIDERS } from "api-server-api";
+
+const PRESET_BY_TEMPLATE_ID: ReadonlyMap<string, ProviderPresetType> = new Map([
+  ...PROVIDER_PRESET_TYPES.map((id): [string, ProviderPresetType] => [id, id]),
+  ["anthropic-oauth", "anthropic"],
+]);
+
+// Provider templates managed by the legacy Providers view; `anthropic-oauth`
+// rides the same card as the API-key variant.
+export const PROVIDER_TEMPLATE_IDS: ReadonlySet<string> = new Set(
+  PRESET_BY_TEMPLATE_ID.keys(),
+);
+
+export function providerTemplateDisplayName(templateId: string): string | null {
+  const presetId = PRESET_BY_TEMPLATE_ID.get(templateId);
+  return presetId ? PROVIDERS[presetId].displayName : null;
+}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -115,6 +115,8 @@ export interface AgentView {
   image: string;
   description?: string;
   env?: EnvVar[];
+  grantedSecretIds: string[];
+  grantedConnectionIds: string[];
   state: AgentState;
   error?: string;
   /** Abnormal pod-termination cause (OOM / crash) while the pod is down; absent on normal lifecycle. */

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       '@radix-ui/react-checkbox':
         specifier: ^1.3.3
         version: 1.3.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.16
+        version: 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-label':
         specifier: ^2.1.8
         version: 2.1.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2316,6 +2319,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.7':
+    resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
@@ -2347,8 +2363,30 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-direction@1.1.1':
+    resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.16':
+    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2393,6 +2431,19 @@ packages:
 
   '@radix-ui/react-label@2.1.8':
     resolution: {integrity: sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.16':
+    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2458,6 +2509,19 @@ packages:
 
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.11':
+    resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8314,6 +8378,18 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-collection@1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
   '@radix-ui/react-compose-refs@1.1.2(@types/react@18.3.28)(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -8348,6 +8424,12 @@ snapshots:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
 
+  '@radix-ui/react-direction@1.1.1(@types/react@18.3.28)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.28
+
   '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.3
@@ -8355,6 +8437,21 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
       '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:
@@ -8390,6 +8487,32 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-menu@2.1.16(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.2.3(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      aria-hidden: 1.2.6
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.7.2(@types/react@18.3.28)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.28
       '@types/react-dom': 18.3.7(@types/react@18.3.28)
@@ -8444,6 +8567,23 @@ snapshots:
   '@radix-ui/react-primitive@2.1.4(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-slot': 1.2.4(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.28
+      '@types/react-dom': 18.3.7(@types/react@18.3.28)
+
+  '@radix-ui/react-roving-focus@1.1.11(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-collection': 1.1.7(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.28))(@types/react@18.3.28)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@18.3.28)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:


### PR DESCRIPTION
The home page is now a single **Sandboxes** list for everything you have running. Each sandbox shows its name, a short subtitle describing what it is (e.g. "Claude Code · IBM LiteLLM"), and a status pill that clearly distinguishes **Running** from **Hibernating**. A per-row menu offers the common actions — **Wake**/**Restart**, **Configure**, and **Delete sandbox** — and clicking a row opens the chat. A primary **Create sandbox** action replaces the old Add Agent button, and an empty state points first-time users at it.

Everything the previous list could do carries over: wake and restart, configure, delete with confirmation, the setup-failure warning badge, and click-through to a hibernated sandbox's wake prompt.

Creating a sandbox (#894) and configuring one (#895) keep their existing dialogs for now — this page only opens those flows.

Closes #893