### PR TITLE
feat: attribute agent commits to the connected GitHub user

### DIFF
--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -293,6 +293,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       secretStore: secretStores.default(),
       engine: connectionsBoot.oauthEngine,
       templates: connectionsBoot.templates,
+      runtimeMutator,
       uiBaseUrl: config.uiBaseUrl,
     }),
   );

--- a/packages/api-server/src/apps/api-server/oauth.ts
+++ b/packages/api-server/src/apps/api-server/oauth.ts
@@ -9,12 +9,14 @@ import {
 } from "../../modules/connections/services/oauth-flow.js";
 import { createConnectionsRepository } from "../../modules/connections/infrastructure/connections-repository.js";
 import { sanitizeReturnTo } from "../../modules/connections/domain/oauth-callback-url.js";
+import type { RuntimeMutator } from "../../modules/runtime-delivery/index.js";
 
 export interface OAuthCallbackDeps {
   db: Db;
   secretStore: SecretStore;
   engine: OAuthEngine;
   templates: ConnectionTemplateRegistry;
+  runtimeMutator: RuntimeMutator;
   uiBaseUrl: string;
 }
 
@@ -68,6 +70,7 @@ export function createOAuthRoutes(deps: OAuthCallbackDeps) {
       repo: createConnectionsRepository(deps.db),
       templates: deps.templates,
       secretStore: deps.secretStore,
+      runtimeMutator: deps.runtimeMutator,
       ownerId: peeked.ctx.ownerId,
       callbackUrl: "",
     });

--- a/packages/api-server/src/modules/connections/compose.ts
+++ b/packages/api-server/src/modules/connections/compose.ts
@@ -88,6 +88,7 @@ export function composeConnectionsForOwner(opts: {
     repo,
     templates: opts.templates,
     secretStore: opts.secretStore,
+    runtimeMutator: opts.runtimeMutator,
     ownerId: opts.ownerId,
     callbackUrl: opts.oauthCallbackUrl,
   });

--- a/packages/api-server/src/modules/connections/domain/gitconfig-contribution.ts
+++ b/packages/api-server/src/modules/connections/domain/gitconfig-contribution.ts
@@ -3,12 +3,6 @@ import type { GitHubIdentity } from "../infrastructure/github-identity.js";
 
 export const GITCONFIG_PATH = "$HOME/.gitconfig";
 
-/**
- * A `~/.gitconfig` `[user]` section authoring the agent's commits as the
- * connected account. `section-marker` is the only remove-safe mode that works
- * for `ini` — the file driver's `ini` parser returns a raw string, so a
- * `key-targeted` merge would corrupt the file.
- */
 export function buildGitconfigContribution(
   identity: GitHubIdentity,
 ): Contribution {
@@ -16,15 +10,13 @@ export function buildGitconfigContribution(
     kind: "file",
     path: GITCONFIG_PATH,
     format: "ini",
+    // section-marker is the only remove-safe mode for ini: the file driver's
+    // ini parser returns a raw string, so key-targeted would corrupt the file.
     mergeMode: "section-marker",
     content: { user: { name: identity.name, email: identity.email } },
   };
 }
 
-/**
- * Replaces any prior platform gitconfig contribution with a fresh one so
- * re-auth doesn't accumulate duplicates in the stored array.
- */
 export function upsertGitconfigContribution(
   existing: Contribution[],
   identity: GitHubIdentity,

--- a/packages/api-server/src/modules/connections/domain/gitconfig-contribution.ts
+++ b/packages/api-server/src/modules/connections/domain/gitconfig-contribution.ts
@@ -1,0 +1,36 @@
+import type { Contribution } from "api-server-api";
+import type { GitHubIdentity } from "../infrastructure/github-identity.js";
+
+export const GITCONFIG_PATH = "$HOME/.gitconfig";
+
+/**
+ * A `~/.gitconfig` `[user]` section authoring the agent's commits as the
+ * connected account. `section-marker` is the only remove-safe mode that works
+ * for `ini` — the file driver's `ini` parser returns a raw string, so a
+ * `key-targeted` merge would corrupt the file.
+ */
+export function buildGitconfigContribution(
+  identity: GitHubIdentity,
+): Contribution {
+  return {
+    kind: "file",
+    path: GITCONFIG_PATH,
+    format: "ini",
+    mergeMode: "section-marker",
+    content: { user: { name: identity.name, email: identity.email } },
+  };
+}
+
+/**
+ * Replaces any prior platform gitconfig contribution with a fresh one so
+ * re-auth doesn't accumulate duplicates in the stored array.
+ */
+export function upsertGitconfigContribution(
+  existing: Contribution[],
+  identity: GitHubIdentity,
+): Contribution[] {
+  const withoutPrior = existing.filter(
+    (c) => !(c.kind === "file" && c.path === GITCONFIG_PATH),
+  );
+  return [...withoutPrior, buildGitconfigContribution(identity)];
+}

--- a/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/connections-repository.ts
@@ -33,6 +33,8 @@ export interface ConnectionsRepository {
 
   updateAuth(id: string, auth: ConnectionAuthConfig): Promise<void>;
 
+  updateContributions(id: string, contributions: Contribution[]): Promise<void>;
+
   delete(id: string, ownerId: string): Promise<void>;
 
   grant(connectionId: string, agentId: string): Promise<void>;
@@ -112,6 +114,13 @@ export function createConnectionsRepository(db: Db): ConnectionsRepository {
       await db
         .update(connectionsTable)
         .set({ auth, updatedAt: new Date() })
+        .where(eq(connectionsTable.id, id));
+    },
+
+    async updateContributions(id, contributions): Promise<void> {
+      await db
+        .update(connectionsTable)
+        .set({ contributions, updatedAt: new Date() })
         .where(eq(connectionsTable.id, id));
     },
 

--- a/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+export interface GitHubIdentity {
+  name: string;
+  email: string;
+}
+
+const userSchema = z.object({
+  login: z.string(),
+  id: z.number(),
+  name: z.string().nullable(),
+  email: z.string().nullable(),
+});
+
+/**
+ * Resolves the identity of the account a GitHub access token belongs to, for
+ * authoring the agent's git commits. `email` is the account's *public profile*
+ * email when the user has published one (`GET /user` only ever exposes that),
+ * otherwise the `{id}+{login}` no-reply — so a private primary address is never
+ * pulled into commit history.
+ */
+export async function resolveGitHubIdentity(
+  accessToken: string,
+  opts: { fetchImpl?: typeof fetch } = {},
+): Promise<GitHubIdentity> {
+  const fetchImpl = opts.fetchImpl ?? fetch;
+  const res = await fetchImpl("https://api.github.com/user", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+      "User-Agent": "platform",
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`GitHub GET /user failed: ${res.status} ${res.statusText}`);
+  }
+  const user = userSchema.parse(await res.json());
+  return {
+    name: user.name ?? user.login,
+    email: user.email ?? `${user.id}+${user.login}@users.noreply.github.com`,
+  };
+}

--- a/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
@@ -1,5 +1,7 @@
 import { z } from "zod";
 
+const USER_LOOKUP_TIMEOUT_MS = 10_000;
+
 export interface GitHubIdentity {
   name: string;
   email: string;
@@ -18,6 +20,7 @@ export async function resolveGitHubIdentity(
 ): Promise<GitHubIdentity> {
   const fetchImpl = opts.fetchImpl ?? fetch;
   const res = await fetchImpl("https://api.github.com/user", {
+    signal: AbortSignal.timeout(USER_LOOKUP_TIMEOUT_MS),
     headers: {
       Authorization: `Bearer ${accessToken}`,
       Accept: "application/vnd.github+json",

--- a/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
@@ -14,6 +14,17 @@ const userSchema = z.object({
   email: z.string().nullable(),
 });
 
+// Drop control chars (incl. CR/LF) so a display name can't inject extra
+// ~/.gitconfig sections when serialized into the [user] block.
+function sanitizeName(name: string): string {
+  return [...name]
+    .filter((c) => {
+      const code = c.codePointAt(0) ?? 0;
+      return code >= 0x20 && code !== 0x7f;
+    })
+    .join("");
+}
+
 export async function resolveGitHubIdentity(
   accessToken: string,
   opts: { fetchImpl?: typeof fetch } = {},
@@ -34,7 +45,7 @@ export async function resolveGitHubIdentity(
   const user = userSchema.parse(await res.json());
   // No-reply fallback keeps a private primary email out of commit history.
   return {
-    name: user.name ?? user.login,
+    name: sanitizeName(user.name ?? user.login),
     email: user.email ?? `${user.id}+${user.login}@users.noreply.github.com`,
   };
 }

--- a/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/github-identity.ts
@@ -12,13 +12,6 @@ const userSchema = z.object({
   email: z.string().nullable(),
 });
 
-/**
- * Resolves the identity of the account a GitHub access token belongs to, for
- * authoring the agent's git commits. `email` is the account's *public profile*
- * email when the user has published one (`GET /user` only ever exposes that),
- * otherwise the `{id}+{login}` no-reply — so a private primary address is never
- * pulled into commit history.
- */
 export async function resolveGitHubIdentity(
   accessToken: string,
   opts: { fetchImpl?: typeof fetch } = {},
@@ -36,6 +29,7 @@ export async function resolveGitHubIdentity(
     throw new Error(`GitHub GET /user failed: ${res.status} ${res.statusText}`);
   }
   const user = userSchema.parse(await res.json());
+  // No-reply fallback keeps a private primary email out of commit history.
   return {
     name: user.name ?? user.login,
     email: user.email ?? `${user.id}+${user.login}@users.noreply.github.com`,

--- a/packages/api-server/src/modules/connections/services/oauth-flow.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-flow.ts
@@ -11,7 +11,10 @@ import type { ConnectionsRepository } from "../infrastructure/connections-reposi
 import type { ConnectionTemplateRegistry } from "../domain/connection-template.js";
 import { buildConnectionSdsFields } from "../domain/connection-sds.js";
 import { applyCallbackAlias } from "../domain/oauth-callback-url.js";
+import { upsertGitconfigContribution } from "../domain/gitconfig-contribution.js";
+import { resolveGitHubIdentity } from "../infrastructure/github-identity.js";
 import type { SecretStore } from "../../secret-store/index.js";
+import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 import { emit, EventType } from "../../../events.js";
 import { securityLog } from "../../../core/security-log.js";
 
@@ -40,6 +43,7 @@ export function createOAuthFlowService(deps: {
   repo: ConnectionsRepository;
   templates: ConnectionTemplateRegistry;
   secretStore: SecretStore;
+  runtimeMutator: RuntimeMutator;
   ownerId: string;
   callbackUrl: string;
 }): OAuthFlowService {
@@ -138,12 +142,49 @@ export function createOAuthFlowService(deps: {
         kind: template?.category === "mcp" ? "mcp" : "oauth_app",
       });
 
+      if (template?.id === "github") {
+        await applyGitHubIdentity(conn, tokens.accessToken, deps);
+      }
+
       return {
         connectionId: pending.ctx.connectionId,
         ownerId: pending.ctx.ownerId,
       };
     },
   };
+}
+
+// Best-effort: the token is already minted, so a failed identity lookup must
+// never fail the connection — identity lands on the next successful re-auth.
+async function applyGitHubIdentity(
+  conn: Connection,
+  accessToken: string,
+  deps: {
+    repo: ConnectionsRepository;
+    runtimeMutator: RuntimeMutator;
+  },
+): Promise<void> {
+  try {
+    const identity = await resolveGitHubIdentity(accessToken);
+    const next = upsertGitconfigContribution(conn.contributions, identity);
+    await deps.repo.updateContributions(conn.id, next);
+
+    // State-builder reads contributions live, so a version bump re-pushes them.
+    const agentIds = await deps.repo.listAgentsForConnection(conn.id);
+    for (const agentId of agentIds) {
+      await deps.runtimeMutator.bump(agentId, []);
+      await deps.runtimeMutator.enqueueAfterCommit(agentId);
+    }
+  } catch (err) {
+    securityLog("warn", "oauth.github_identity", {
+      category: "credential",
+      actor: conn.ownerId,
+      actorKind: "user",
+      target: conn.id,
+      result: "failure",
+      detail: { error: err instanceof Error ? err.message : String(err) },
+    });
+  }
 }
 
 async function buildProvider(

--- a/packages/api-server/src/modules/connections/services/oauth-flow.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-flow.ts
@@ -1,3 +1,4 @@
+import { ZodError } from "zod";
 import type {
   Connection,
   ConnectionAuthConfig,
@@ -182,9 +183,20 @@ async function applyGitHubIdentity(
       actorKind: "user",
       target: conn.id,
       result: "failure",
-      detail: { error: err instanceof Error ? err.message : String(err) },
+      detail: githubIdentityErrorDetail(err),
     });
   }
+}
+
+function githubIdentityErrorDetail(err: unknown): Record<string, unknown> {
+  if (err instanceof ZodError) {
+    return {
+      error: "ZodError",
+      fields: err.issues.map((i) => i.path.join(".")),
+    };
+  }
+  if (err instanceof Error) return { error: err.name, message: err.message };
+  return { error: String(err) };
 }
 
 async function buildProvider(


### PR DESCRIPTION
## What

When a GitHub connection is connected, the agent's git commits are now authored as that connected GitHub account — the user's name plus a GitHub-recognized email. Commits show up attributed to the user (avatar, profile link, contribution graph), exactly as if they'd committed themselves, instead of the anonymous machine identity (`UID@hostname`) git falls back to today.

Identity is resolved when the GitHub connection is connected and delivered to every agent that has the connection granted; it refreshes on re-auth.

## Notes

- Scope is github.com connections. The email is the account's public profile email when the user has published one, otherwise the GitHub no-reply address — so a private primary email is never written into commit history. Both attribute correctly on GitHub.
- Best-effort: if the identity lookup fails, the connection still completes normally and identity lands on the next successful re-auth.
- The agent owns the `[user]` section it writes; manual edits to it in the pod are re-applied on the next sync.

Closes #639