### PR TITLE
docs(architecture): fix channels/logging drift (dam-krz, dam-n3c)

### DIFF
--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-Last verified: 2026-06-12
+Last verified: 2026-06-15
 
 ## Overview
 
@@ -187,7 +187,7 @@ sequenceDiagram
 
 What the agent sees:
 
-- **Two tools** are registered on the per-Agent MCP server: `describe_channel` returns the authorized chats (DMs / threads / groups) for a given channel type, and `send_channel_message` posts text to a chat. The agent picks the channel by argument (`slack` or `telegram`); `chatId` addresses a specific chat, or omitting it uses the worker's last-active chat.
+- **Two tools** are registered on the per-Agent MCP server: `describe_channel` returns the authorized chats (DMs / threads / groups) for a given channel type, and `send_channel_message` posts text to a chat. The agent picks the channel by argument (`slack` or `telegram`); `chatId` addresses a specific chat. Omitting `chatId` resolves per channel type: Telegram posts to the worker's last-active thread (error if none); Slack posts to the single channel bound to the Agent, and rejects a `chatId` that isn't that bound channel.
 - **Tools are always registered.** Calls are rejected at invocation time when no channel is connected for the Agent — no dynamic tool list, no per-session toggle.
 - **Bidirectional channel.** If a channel is connected to an Agent, every session on that Agent can post — interactive sessions and scheduled sessions alike. There is no per-session outbound flag.
 

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Last verified: 2026-06-12
+Last verified: 2026-06-15
 
 ## Overview
 
@@ -39,7 +39,7 @@ Two disjoint mechanisms feed the one logger:
 | Approvals | `approval.verdict` (approve/deny once/permanent/host) |
 | Authorization lists | `agent.allowed_users_set` (with added/removed diff), `egress_rule.create|update|revoke|preset`, `secret.grants_set`, `connection.grants_set` |
 | Credentials | `secret.create|update|delete`, `oauth.token_mint`, `connection.create|delete`, `secret.orphan_cleanup_failed` |
-| Channels | `channel.authz` / `channel.authz_deny` (Slack unlinked + allowed-users gate; Telegram group-admin + unauthorized thread), `identity.link`, `channel.outbound` (agent post, incl. resolved attachment path), `channel.thread_revoked` |
+| Channels | `channel.authz` / `channel.authz_deny` (Slack unlinked + allowed-users gate; Telegram group-admin + unauthorized thread), `channel.turn` (inbound relay turn, prompt omitted), `channel.foreign_turn.begin` (non-owner driving another owner's agent under their own credentials, prompt omitted), `identity.link`, `channel.outbound` (agent post, incl. resolved attachment path), `channel.thread_revoked` |
 | Privileged | `skill.install` / `skill.uninstall` / `skill.publish`, `schedule.create|toggle|delete` (incl. agent-driven), `usage.inspect` / `usage.inspect.deny`, `agent.create|update|delete|restart|wake` |
 
 ## Invariants


### PR DESCRIPTION
Closes two doc-drift findings from the 2026-06-11 audit epic (dam-8oe).

## logging.md
Channels coverage row was missing two emitted bus events. Added:
- `channel.turn` (inbound relay turn, prompt omitted)
- `channel.foreign_turn.begin` (non-owner driving another owner's agent, prompt omitted)

Verified against `audit-log.ts:67` / `:112`.

## channels.md
The `chatId`-omitted fallback was described generically as "last-active chat" but the two channel types differ:
- Telegram posts to the worker's last-active thread (error if none)
- Slack posts to the single channel bound to the Agent, and rejects a non-matching `chatId`

Verified against `telegram.ts:495-514` / `slack.ts:797-808`.

Bumped `Last verified:` on both pages.