### PR TITLE
fix(crds): enforce per-PR schema-generation bump; bump Agent to gen 2

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,8 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-          # controller:check:crd-backwards-compatibility diffs CRDs against the latest v* tag
+          # CRD checks diff against history: crd-backwards-compatibility vs the
+          # latest v* tag, crd-schema-generation vs the origin/main merge-base.
           fetch-depth: 0
       - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
       - run: mise run setup

--- a/deploy/helm/platform/crds/agent-platform.ai_agents.yaml
+++ b/deploy/helm/platform/crds/agent-platform.ai_agents.yaml
@@ -4,7 +4,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    agent-platform.ai/crd-schema-generation: "1"
+    agent-platform.ai/crd-schema-generation: "2"
     controller-gen.kubebuilder.io/version: v0.21.0
     helm.sh/resource-policy: keep
   name: agents.agent-platform.ai

--- a/packages/controller/api/v1/agent_types.go
+++ b/packages/controller/api/v1/agent_types.go
@@ -144,7 +144,7 @@ type ResourceSpec struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Namespaced,shortName=agt
 // +kubebuilder:metadata:annotations=helm.sh/resource-policy=keep
-// +kubebuilder:metadata:annotations=agent-platform.ai/crd-schema-generation=1
+// +kubebuilder:metadata:annotations=agent-platform.ai/crd-schema-generation=2
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Reason",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].reason`
 // +kubebuilder:printcolumn:name="Image",type=string,JSONPath=`.spec.image`,priority=1

--- a/packages/controller/api/v1/schema_generation.go
+++ b/packages/controller/api/v1/schema_generation.go
@@ -9,6 +9,7 @@ package v1
 const (
 	SchemaGenerationAnnotation = "agent-platform.ai/crd-schema-generation"
 
-	AgentSchemaGeneration = 1
+	// Agent gen 2: imagePullSecretRef added to AgentSpec (#930/#932).
+	AgentSchemaGeneration = 2
 	ForkSchemaGeneration  = 1
 )

--- a/packages/controller/tasks.toml
+++ b/packages/controller/tasks.toml
@@ -61,7 +61,9 @@ for f in $(git ls-tree -r --name-only "$baseline" -- "$crds" "$legacy"); do
     status=1
   fi
 done
-gen_annotation='.metadata.annotations["agent-platform.ai/crd-schema-generation"] // "0"'
+# Schema-generation bumps are enforced per-PR by controller:check:crd-schema-generation
+# (baseline = origin/main, not a release tag) so a schema change can't slip
+# through against a v* tag that predates the CRDs.
 for f in "$crds"/*.yaml; do
   base="$baseline:$crds/$(basename "$f")"
   if ! git cat-file -e "$base" 2>/dev/null; then
@@ -75,9 +77,51 @@ for f in "$crds"/*.yaml; do
     echo "crd-compat: $f is incompatible with $baseline (see findings above)" >&2
     status=1
   fi
-  if [ "$(git show "$base" | yq '.spec')" != "$(yq '.spec' "$f")" ] \
-    && [ "$(yq "$gen_annotation" "$f")" -le "$(git show "$base" | yq "$gen_annotation")" ]; then
-    echo "crd-compat: $f schema changed since $baseline without a crd-schema-generation bump (ADR-068)" >&2
+done
+exit $status
+'''
+
+# ADR-068: any CRD .spec change must bump agent-platform.ai/crd-schema-generation.
+# Baseline is the origin/main merge-base, so every PR that touches a schema must
+# bump (not just the first since a release); an unresolvable baseline is a hard
+# error, never a silent skip (a v* tag predating the CRDs is how #932 slipped through).
+["controller:check:crd-schema-generation"]
+dir = "{{config_root}}"
+sources = ["deploy/helm/platform/crds/*.yaml"]
+usage = 'flag "--baseline <ref>" help="Git ref to compare against (default: origin/main merge-base)"'
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${usage_baseline:-}" ]; then
+  base_ref="$usage_baseline"
+elif base_ref=$(git merge-base HEAD origin/main 2>/dev/null); then
+  :
+elif base_ref=$(git merge-base HEAD main 2>/dev/null); then
+  :
+else
+  echo "crd-generation: cannot resolve a baseline (no origin/main or main reachable); pass --baseline <ref>" >&2
+  exit 1
+fi
+if ! git rev-parse -q --verify "$base_ref^{commit}" >/dev/null; then
+  echo "crd-generation: baseline ref '$base_ref' does not resolve to a commit" >&2
+  exit 1
+fi
+crds=deploy/helm/platform/crds
+gen='.metadata.annotations["agent-platform.ai/crd-schema-generation"] // "0"'
+status=0
+for f in "$crds"/*.yaml; do
+  base="$base_ref:$crds/$(basename "$f")"
+  if ! git cat-file -e "$base" 2>/dev/null; then
+    echo "crd-generation: $(basename "$f") is new since $base_ref — no prior schema to compare"
+    continue
+  fi
+  if [ "$(git show "$base" | yq '.spec')" = "$(yq '.spec' "$f")" ]; then
+    continue
+  fi
+  new_gen=$(yq "$gen" "$f")
+  old_gen=$(git show "$base" | yq "$gen")
+  if [ "$new_gen" -le "$old_gen" ]; then
+    echo "crd-generation: $(basename "$f") .spec changed vs $base_ref but agent-platform.ai/crd-schema-generation is still $new_gen (was $old_gen) — bump the constant in api/v1/schema_generation.go and its +kubebuilder:metadata:annotations marker, then run mise run controller:generate (ADR-068)" >&2
     status=1
   fi
 done


### PR DESCRIPTION
## Why

PR #932 added `AgentSpec.imagePullSecretRef` — a real change to the Agent CRD `.spec` — **without bumping `agent-platform.ai/crd-schema-generation`**, and CI passed. ADR-068 requires that any CRD schema change bump the generation, so the controller's startup assertion (`crdcheck.Assert`) can refuse a cluster whose CRDs predate the build.

### Root cause

The generation guard lived inside `controller:check:crd-backwards-compatibility` and used **the latest `v*` tag** as its baseline. At `v0.2.1-rc4`:

- the CRD existed only at the legacy path (`files/crds/`) with **no** generation annotation → `yq` defaults it to `0`;
- #932's manifest carried generation `1`, inherited from #864 (the ADR-068 introduction, `0→1`).

So the check evaluated `spec-changed AND new_gen(1) ≤ baseline_gen(0)` → `TRUE AND FALSE` → it never fired. **#864's one-time `0→1` bump "covered" every later PR in the release cycle**, #932 included. A release-tag baseline only ever demands *one* bump per release, not one per change.

## What changed

- **New `controller:check:crd-schema-generation` task** — baseline is the **`origin/main` merge-base**, so *every PR* that changes a CRD `.spec` must bump. An unresolvable baseline is a **hard error, never a silent skip** (the exact failure mode that let #932 through).
- **Moved** generation enforcement out of `crd-backwards-compatibility` (now purely `crdify` vs the release tag) — separation of concerns.
- **Bumped** `AgentSchemaGeneration 1 → 2` + its `+kubebuilder` marker + regenerated `agent-platform.ai_agents.yaml`. `forks` is untouched (its `.spec` never drifted) and stays at `1`.
- Updated the `fetch-depth: 0` comment in `cd.yml` to cover both baselines.

## Verification

- New check **passes** on this branch; proven it **catches** the #932 state — comparing #932 (gen 1 + field) against its parent flags "spec changed, gen not bumped" → fails.
- `go test` (constant/marker/manifest consistency), `fmt`/`vet`/`staticcheck`/`build`, and the ADR-058 TS-types drift gate all green.

## Note

`controller:check:crd-backwards-compatibility` fails **only inside a git worktree** — `crdify`/go-git can't resolve the `v*` tag there (`reference not found`). It's pre-existing (the `crdify` line is unchanged here) and passes in CI's full clone. Worth a separate issue if local `mise run check` in worktrees matters.