### PR TITLE
fix(keycloak-theme): show IBM logo on the w3id login button

### DIFF
--- a/packages/keycloak-theme/package.json
+++ b/packages/keycloak-theme/package.json
@@ -3,6 +3,9 @@
   "version": "1.0.0",
   "type": "module",
   "private": true,
+  "scripts": {
+    "build-keycloak-theme": "vite build && keycloakify build"
+  },
   "dependencies": {
     "@ibm/plex": "^6.4.1",
     "class-variance-authority": "^0.7.1",

--- a/packages/keycloak-theme/src/login/components/social-provider-button.tsx
+++ b/packages/keycloak-theme/src/login/components/social-provider-button.tsx
@@ -1,8 +1,7 @@
 import { kcSanitize } from "keycloakify/lib/kcSanitize";
 
-// Realm alias of the IBM SSO IDP (w3id). The deployed instance configures
-// its OIDC provider under this exact alias; matching it lights up the
-// IBM-logo affordance on the button.
+import { BASE_URL } from "../../kc.gen";
+
 const IBM_SSO_ALIAS = "w3id";
 
 interface SocialProvider {
@@ -14,10 +13,9 @@ interface SocialProvider {
 
 interface Props {
   provider: SocialProvider;
-  resourcesPath: string;
 }
 
-export function SocialProviderButton({ provider, resourcesPath }: Props) {
+export function SocialProviderButton({ provider }: Props) {
   const isIbm =
     provider.alias === IBM_SSO_ALIAS ||
     provider.iconClasses?.includes(IBM_SSO_ALIAS);
@@ -30,7 +28,7 @@ export function SocialProviderButton({ provider, resourcesPath }: Props) {
     >
       {isIbm && (
         <img
-          src={`${resourcesPath}/ibm-logo.svg`}
+          src={`${BASE_URL}ibm-logo.svg`}
           alt=""
           className="h-2.5 w-auto shrink-0"
         />

--- a/packages/keycloak-theme/src/login/pages/Login.tsx
+++ b/packages/keycloak-theme/src/login/pages/Login.tsx
@@ -122,11 +122,7 @@ export default function Login(
 
             <div className="space-y-2">
               {social.providers.map((p) => (
-                <SocialProviderButton
-                  key={p.alias}
-                  provider={p}
-                  resourcesPath={url.resourcesPath}
-                />
+                <SocialProviderButton key={p.alias} provider={p} />
               ))}
             </div>
           </>

--- a/packages/keycloak-theme/tasks.toml
+++ b/packages/keycloak-theme/tasks.toml
@@ -10,12 +10,6 @@ run = "pnpm exec keycloakify update-kc-gen"
 sources = ["vite.config.ts", "package.json"]
 outputs = ["src/kc.gen.tsx"]
 
-["keycloak-theme:dev"]
-description = "Vite dev server with mocked kcContext (uncomment block in src/main.tsx to preview a page)"
-dir = "{{config_root}}/packages/keycloak-theme"
-depends = ["keycloak-theme:gen"]
-run = "pnpm exec vite"
-
 ["keycloak-theme:build"]
 description = "Build the theme JAR (update-kc-gen + tsc + vite build + keycloakify build)"
 dir = "{{config_root}}/packages/keycloak-theme"
@@ -37,6 +31,8 @@ pnpm exec keycloakify build
 description = "Boot Keycloak in Docker with the theme JAR loaded (full-fidelity preview)"
 dir = "{{config_root}}/packages/keycloak-theme"
 depends = ["keycloak-theme:gen"]
+# Relies on the `build-keycloak-theme` script in package.json: start-keycloak
+# discovers the app-build step from it and refuses to run if it's absent.
 run = "pnpm exec keycloakify start-keycloak -p ./"
 
 ["keycloak-theme:eject-page"]


### PR DESCRIPTION
## What

The IBM logo on the "Continue with w3id" SSO button now renders. It was requesting the image from a path that didn't exist (the theme's resources root rather than where bundled assets are actually published), so it 404'd and the button showed only text.

Also restores the one package.json script that `keycloakify start-keycloak` requires, so the local theme preview (`mise run keycloak-theme:run`) works again — that's what surfaced the logo bug.

Closes #945