### PR TITLE
fix(e2e): drive sandbox wizard flow after UI rework

### DIFF
--- a/packages/e2e/playwright/src/tests/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-agent.spec.ts
@@ -18,6 +18,18 @@ test("create a mock agent with the connection attached", async ({ page }) => {
       (a) => a.name === agentName,
     );
     expect(agent, `agent ${agentName} already exists`).toBeUndefined();
+
+    const providerTypes = new Set([
+      "anthropic",
+      "ibm-litellm",
+      "openai",
+      "bob",
+    ]);
+    const secrets = await api.secrets.list.query();
+    for (const secret of secrets) {
+      if (providerTypes.has(secret.type))
+        await api.secrets.delete.mutate({ id: secret.id });
+    }
   });
 
   await test.step("open app", async () => {
@@ -25,12 +37,25 @@ test("create a mock agent with the connection attached", async ({ page }) => {
     await expect(page.getByTestId("app-sidebar")).toBeVisible();
   });
 
-  await test.step("create the agent with the connection selected", async () => {
-    const connectionId = await getConnectionId(api, connectionName);
-
+  await test.step("pick the mock image", async () => {
     await page.getByRole("button", { name: /create sandbox/i }).click();
     await page.getByText(harnessName, { exact: true }).click();
-    await page.getByPlaceholder("my-agent").fill(agentName);
+  });
+
+  await test.step("name the sandbox and connect a provider", async () => {
+    await page.getByPlaceholder("my-sandbox").fill(agentName);
+
+    const dialog = page.getByRole("dialog");
+    await page.getByRole("button", { name: /openai/i }).click();
+    await dialog.locator('input[type="password"]').fill("sk-e2e-dummy-key");
+    await dialog.getByRole("button", { name: "Save" }).click();
+    await expect(dialog).toBeHidden();
+
+    await page.getByRole("button", { name: /continue/i }).click();
+  });
+
+  await test.step("grant the connection and create", async () => {
+    const connectionId = await getConnectionId(api, connectionName);
 
     const checkbox = page
       .getByTestId(`connection-grant-${connectionId}`)
@@ -38,7 +63,7 @@ test("create a mock agent with the connection attached", async ({ page }) => {
     await checkbox.click();
     await expect(checkbox).toBeChecked();
 
-    await page.getByRole("button", { name: /create agent/i }).click();
+    await page.getByRole("button", { name: /create sandbox/i }).click();
   });
 
   await test.step("agent reaches running", async () => {

--- a/packages/ui/src/modules/sandboxes/components/connection-row.tsx
+++ b/packages/ui/src/modules/sandboxes/components/connection-row.tsx
@@ -49,6 +49,7 @@ export function MyConnectionRow({
   selected,
   onToggle,
   onDisconnect,
+  testId,
 }: {
   title: string;
   subtitle: string;
@@ -57,9 +58,11 @@ export function MyConnectionRow({
   selected: boolean;
   onToggle: (on: boolean) => void;
   onDisconnect: () => void;
+  testId?: string;
 }) {
   return (
     <div
+      data-testid={testId}
       className={cn(
         "flex items-center gap-3 rounded-lg border bg-card px-4 py-3",
         selected ? "border-foreground" : "border-border",

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -122,6 +122,7 @@ export function ConnectionsStep({
                 selected={selected.has(c.id)}
                 onToggle={(on) => toggle(c.id, on)}
                 onDisconnect={() => disconnect(c.id)}
+                testId={`connection-grant-${c.id}`}
               />
             ))}
           </div>


### PR DESCRIPTION
## Why

The full-page sandbox creation wizard (#926) replaced the old add-agent dialog but the e2e specs were never updated. `03-agent` drove the removed flow (placeholder `my-agent`, "Create agent" button, old `connection-grant` testid) and timed out, blocking `04`/`05` behind it.

## What

- **03-agent**: rewritten for the 3-step wizard — pick image, name + connect a provider through the real provider dialog, grant the connection, Create sandbox. Drives the actual UI, no API shortcut for the flow under test.
- Clear leftover provider secrets at clean-slate so warm reruns always hit the connect dialog (mirrors the existing agent clean-slate check).
- Restore the `connection-grant-${id}` testid on `MyConnectionRow` so the connection checkbox is selectable.

Coverage: create agent + connection (03) and egress/injection (05) both green.

## Verification

Full suite green against the warm e2e cluster:

```
✓ 1 [auth]       login via Keycloak and accept terms
✓ 2 [connection] create a custom-header connection
✓ 3 [agent]      create a mock agent with the connection attached
✓ 4 [messages]   exchange messages with the agent
✓ 5 [messages]   background prompt mid-turn (#703)
✓ 6 [injection]  connection injects the credential (env + egress)
6 passed
```

## Note

`e2e:reset` wipes the DB and agents but not provider secrets (K8s Secrets), so a stale provider survives warm reruns. Handled in-test for now; worth fixing at the task level separately.