### PR TITLE
feat(ui): direct users to the LiteLLM key guide from the provider step

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/provider-connect-dialog.tsx
+++ b/packages/ui/src/modules/sandboxes/components/provider-connect-dialog.tsx
@@ -55,7 +55,7 @@ export function ProviderConnectDialog({
   };
 
   return (
-    <Modal widthClass="w-[480px]">
+    <Modal widthClass="w-[505px]">
       <div className="min-h-0 flex-1 overflow-y-auto">
         {provider === "anthropic" && (
           <AnthropicForm

--- a/packages/ui/src/modules/settings/components/anthropic/form.tsx
+++ b/packages/ui/src/modules/settings/components/anthropic/form.tsx
@@ -1,15 +1,13 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Check, Copy, X } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 import { useTestAnthropic } from "../../../secrets/api/mutations.js";
-import { CardIcon } from "../shared/card-icon.js";
-import { IconButton } from "../shared/icon-button.js";
+import { ProviderFormShell } from "../shared/provider-form-shell.js";
 import {
   anthropicCredentialSchema,
   type AnthropicCredentialValues,
@@ -92,83 +90,72 @@ export function AnthropicForm({
   };
 
   return (
-    <Card className="anim-in">
-      <form onSubmit={onSubmit} className="flex flex-col gap-4 p-5">
-        <div className="flex items-center gap-3">
-          <CardIcon provider="anthropic" />
-          <div className="flex-1 min-w-0">
-            <div className="text-[15px] font-bold text-foreground">
-              Anthropic
-            </div>
-            <div className="text-[12px] text-muted-foreground">
-              {isEdit
-                ? "Pick mode and paste a new credential to replace the existing one."
-                : "Required for Claude Code agents. Pick the mode that matches your credential."}
-            </div>
-          </div>
-          {onCancel && (
-            <IconButton onClick={onCancel} title="Cancel" hoverTone="neutral">
-              <X size={13} />
-            </IconButton>
-          )}
-        </div>
+    <ProviderFormShell
+      provider="anthropic"
+      title="Anthropic"
+      description={
+        isEdit
+          ? "Pick mode and paste a new credential to replace the existing one."
+          : "Required for Claude Code agents. Pick the mode that matches your credential."
+      }
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    >
+      <Controller
+        control={control}
+        name="mode"
+        render={({ field }) => (
+          <ModeToggle mode={field.value} onChange={field.onChange} />
+        )}
+      />
 
-        <Controller
-          control={control}
-          name="mode"
-          render={({ field }) => (
-            <ModeToggle mode={field.value} onChange={field.onChange} />
-          )}
+      {mode === "oauth" && <QuickSetupHint />}
+
+      <div className="flex gap-3">
+        <Input
+          type="password"
+          autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
+          data-form-type="other"
+          placeholder={MODES[mode].placeholder}
+          {...register("value")}
         />
+        <Button
+          type="button"
+          variant="outline"
+          onClick={test}
+          disabled={submitDisabled}
+          title="Verify the credential with Anthropic"
+          className="shrink-0"
+        >
+          {testing ? "..." : "Test"}
+        </Button>
+        <Button type="submit" disabled={submitDisabled} className="shrink-0">
+          {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
+        </Button>
+      </div>
 
-        {mode === "oauth" && <QuickSetupHint />}
-
-        <div className="flex gap-3">
-          <Input
-            type="password"
-            autoComplete="off"
-            data-1p-ignore
-            data-lpignore="true"
-            data-form-type="other"
-            placeholder={MODES[mode].placeholder}
-            {...register("value")}
-          />
-          <Button
-            type="button"
-            variant="outline"
-            onClick={test}
-            disabled={submitDisabled}
-            title="Verify the credential with Anthropic"
-            className="shrink-0"
-          >
-            {testing ? "..." : "Test"}
-          </Button>
-          <Button type="submit" disabled={submitDisabled} className="shrink-0">
-            {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
-          </Button>
-        </div>
-
-        {/* Mismatch errors live on the value field; "Required" is suppressed
-            until the user actually types so the form doesn't yell on first paint. */}
-        {errors.value &&
-          value.length > 0 &&
-          errors.value.message !== "Required" && (
-            <div className="text-[12px] font-medium text-destructive">
-              {errors.value.message}
-            </div>
-          )}
-        {!errors.value && testResult?.ok && (
-          <div className="text-[12px] font-medium text-success flex items-center gap-1.5">
-            <Check size={13} /> Credential is valid.
-          </div>
-        )}
-        {!errors.value && testResult && !testResult.ok && (
+      {/* Mismatch errors live on the value field; "Required" is suppressed
+          until the user actually types so the form doesn't yell on first paint. */}
+      {errors.value &&
+        value.length > 0 &&
+        errors.value.message !== "Required" && (
           <div className="text-[12px] font-medium text-destructive">
-            {testResult.message}
+            {errors.value.message}
           </div>
         )}
-      </form>
-    </Card>
+      {!errors.value && testResult?.ok && (
+        <div className="text-[12px] font-medium text-success flex items-center gap-1.5">
+          <Check size={13} /> Credential is valid.
+        </div>
+      )}
+      {!errors.value && testResult && !testResult.ok && (
+        <div className="text-[12px] font-medium text-destructive">
+          {testResult.message}
+        </div>
+      )}
+    </ProviderFormShell>
   );
 }
 

--- a/packages/ui/src/modules/settings/components/bob/form.tsx
+++ b/packages/ui/src/modules/settings/components/bob/form.tsx
@@ -1,16 +1,14 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ChevronDown, ChevronRight, ExternalLink, X } from "lucide-react";
+import { ChevronDown, ChevronRight, ExternalLink } from "lucide-react";
 import { useState } from "react";
 import { useForm, type UseFormRegisterReturn } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 import { BOB_CHAT_MODES, type BobModelPins } from "../../../../types.js";
-import { CardIcon } from "../shared/card-icon.js";
-import { IconButton } from "../shared/icon-button.js";
+import { ProviderFormShell } from "../shared/provider-form-shell.js";
 import { MODES, stripWhitespace } from "./modes.js";
 
 const bobCredentialSchema = z
@@ -103,116 +101,103 @@ export function BobForm({
   });
 
   return (
-    <Card className="anim-in">
-      <form onSubmit={onSubmit} className="flex flex-col gap-4 p-5">
-        <div className="flex items-center gap-3">
-          <CardIcon provider="bob" />
-          <div className="flex-1 min-w-0">
-            <div className="text-[15px] font-bold text-foreground">
-              Bob Shell
-            </div>
-            <div className="text-[12px] text-muted-foreground">
-              {isEdit
-                ? "Paste a new token to replace the existing one. Advanced settings are passed to Bob as CLI flags / env."
-                : "IBM's AI shell assistant. Paste a Bob API key of type Inference to get started."}{" "}
-              <a
-                href="https://bob.ibm.com/admin/apikeys"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary hover:underline inline-flex items-center gap-1"
-              >
-                Manage keys <ExternalLink size={11} />
-              </a>
-            </div>
-          </div>
-          {onCancel && (
-            <IconButton onClick={onCancel} title="Cancel" hoverTone="neutral">
-              <X size={13} />
-            </IconButton>
-          )}
-        </div>
+    <ProviderFormShell
+      provider="bob"
+      title="Bob Shell"
+      description={
+        <>
+          {isEdit
+            ? "Paste a new token to replace the existing one. Advanced settings are passed to Bob as CLI flags / env."
+            : "IBM's AI shell assistant. Paste a Bob API key of type Inference to get started."}{" "}
+          <a
+            href="https://bob.ibm.com/admin/apikeys"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline inline-flex items-center gap-1"
+          >
+            Manage keys <ExternalLink size={11} />
+          </a>
+        </>
+      }
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    >
+      <div className="flex gap-3">
+        <Input
+          type="password"
+          autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
+          data-form-type="other"
+          placeholder={MODES["api-key"].placeholder}
+          {...register("value")}
+        />
+        <Button type="submit" disabled={submitDisabled} className="shrink-0">
+          {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
+        </Button>
+      </div>
 
-        <div className="flex gap-3">
-          <Input
-            type="password"
-            autoComplete="off"
-            data-1p-ignore
-            data-lpignore="true"
-            data-form-type="other"
-            placeholder={MODES["api-key"].placeholder}
-            {...register("value")}
-          />
-          <Button type="submit" disabled={submitDisabled} className="shrink-0">
-            {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
-          </Button>
-        </div>
-
-        {errors.value &&
-          value.length > 0 &&
-          errors.value.message !== "Required" && (
-            <div className="text-[12px] font-medium text-destructive">
-              {errors.value.message}
-            </div>
-          )}
-
-        <button
-          type="button"
-          onClick={() => setAdvancedOpen((o) => !o)}
-          className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground hover:text-foreground -mt-1 self-start"
-        >
-          {advancedOpen ? (
-            <ChevronDown size={13} />
-          ) : (
-            <ChevronRight size={13} />
-          )}
-          Advanced — model & tenant scoping
-        </button>
-
-        {advancedOpen && (
-          <div className="grid grid-cols-1 gap-3">
-            <PinField
-              label="Model"
-              hint="BOB_SHELL_MODEL — empty → Bob's built-in default."
-              placeholder="premium-shell"
-              error={errors.model?.message}
-              register={register("model")}
-            />
-            <PinField
-              label="Instance ID"
-              hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping for outbound API calls."
-              error={errors.agentId?.message}
-              register={register("agentId")}
-            />
-            <PinField
-              label="Team ID"
-              hint="BOB_TEAM_ID → --team-id."
-              error={errors.teamId?.message}
-              register={register("teamId")}
-            />
-            <PinField
-              label="Max coins"
-              hint="BOB_MAX_COINS → --max-coins. Budget cap; Bob exits when exceeded."
-              placeholder="(no cap)"
-              error={errors.maxCoins?.message}
-              register={register("maxCoins")}
-            />
-            <PinField
-              label="Chat mode"
-              hint={`BOB_CHAT_MODE → --chat-mode. One of: ${BOB_CHAT_MODES.join(", ")}.`}
-              placeholder="(Bob default)"
-              list="bob-chat-modes"
-              error={errors.chatMode?.message}
-              register={register("chatMode")}
-            />
-            <datalist id="bob-chat-modes">
-              {BOB_CHAT_MODES.map((m) => (
-                <option key={m} value={m} />
-              ))}
-            </datalist>
+      {errors.value &&
+        value.length > 0 &&
+        errors.value.message !== "Required" && (
+          <div className="text-[12px] font-medium text-destructive">
+            {errors.value.message}
           </div>
         )}
-      </form>
-    </Card>
+
+      <button
+        type="button"
+        onClick={() => setAdvancedOpen((o) => !o)}
+        className="flex items-center gap-1.5 text-[12px] font-semibold text-muted-foreground hover:text-foreground -mt-1 self-start"
+      >
+        {advancedOpen ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        Advanced — model & tenant scoping
+      </button>
+
+      {advancedOpen && (
+        <div className="grid grid-cols-1 gap-3">
+          <PinField
+            label="Model"
+            hint="BOB_SHELL_MODEL — empty → Bob's built-in default."
+            placeholder="premium-shell"
+            error={errors.model?.message}
+            register={register("model")}
+          />
+          <PinField
+            label="Instance ID"
+            hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping for outbound API calls."
+            error={errors.agentId?.message}
+            register={register("agentId")}
+          />
+          <PinField
+            label="Team ID"
+            hint="BOB_TEAM_ID → --team-id."
+            error={errors.teamId?.message}
+            register={register("teamId")}
+          />
+          <PinField
+            label="Max coins"
+            hint="BOB_MAX_COINS → --max-coins. Budget cap; Bob exits when exceeded."
+            placeholder="(no cap)"
+            error={errors.maxCoins?.message}
+            register={register("maxCoins")}
+          />
+          <PinField
+            label="Chat mode"
+            hint={`BOB_CHAT_MODE → --chat-mode. One of: ${BOB_CHAT_MODES.join(", ")}.`}
+            placeholder="(Bob default)"
+            list="bob-chat-modes"
+            error={errors.chatMode?.message}
+            register={register("chatMode")}
+          />
+          <datalist id="bob-chat-modes">
+            {BOB_CHAT_MODES.map((m) => (
+              <option key={m} value={m} />
+            ))}
+          </datalist>
+        </div>
+      )}
+    </ProviderFormShell>
   );
 }
 

--- a/packages/ui/src/modules/settings/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/settings/components/ibm-litellm/form.tsx
@@ -1,3 +1,4 @@
+import { Launch } from "@carbon/icons-react";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { X } from "lucide-react";
 import { useForm } from "react-hook-form";
@@ -10,6 +11,9 @@ import { Input } from "@/components/ui/input";
 import { CardIcon } from "../shared/card-icon.js";
 import { IconButton } from "../shared/icon-button.js";
 import { MODES, stripWhitespace } from "./modes.js";
+
+const KEY_GUIDE_URL =
+  "https://pages.github.ibm.com/dam-agents/docs/guides/litellm-key/";
 
 const ibmLitellmCredentialSchema = z
   .object({ value: z.string() })
@@ -52,25 +56,50 @@ export function IbmLitellmForm({
 
   return (
     <Card className="anim-in">
-      <form onSubmit={onSubmit} className="flex flex-col gap-4 p-5">
+      <form onSubmit={onSubmit} className="flex flex-col gap-6 p-6">
         <div className="flex items-center gap-3">
-          <CardIcon provider="ibm-litellm" />
+          <CardIcon provider="ibm-litellm" size="lg" />
           <div className="flex-1 min-w-0">
-            <div className="text-[15px] font-bold text-foreground">
+            <div className="text-[18px] font-bold text-foreground">
               IBM LiteLLM ETE Proxy
             </div>
-            <div className="text-[12px] text-muted-foreground">
+            <div className="text-[14px] text-muted-foreground">
               {isEdit
                 ? "Paste a new token to replace the existing one."
-                : "Routes Claude Code and pi-agent through IBM's internal LiteLLM proxy. Paste your LiteLLM API token."}
+                : "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS."}
             </div>
           </div>
           {onCancel && (
-            <IconButton onClick={onCancel} title="Cancel" hoverTone="neutral">
+            <IconButton
+              onClick={onCancel}
+              title="Cancel"
+              hoverTone="neutral"
+              className="self-start"
+            >
               <X size={13} />
             </IconButton>
           )}
         </div>
+
+        <a
+          href={KEY_GUIDE_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary hover:bg-muted"
+        >
+          <div className="flex flex-col gap-0.5">
+            <span className="text-[14px] font-bold text-foreground">
+              Need an API key?
+            </span>
+            <span className="text-[14px] text-muted-foreground">
+              Follow the guide and generate your LiteLLM token
+            </span>
+          </div>
+          <Launch
+            size={16}
+            className="mt-0.5 shrink-0 text-muted-foreground group-hover:text-primary"
+          />
+        </a>
 
         <div className="flex gap-3">
           <Input

--- a/packages/ui/src/modules/settings/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/settings/components/ibm-litellm/form.tsx
@@ -1,15 +1,12 @@
 import { Launch } from "@carbon/icons-react";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { X } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
-import { CardIcon } from "../shared/card-icon.js";
-import { IconButton } from "../shared/icon-button.js";
+import { ProviderFormShell } from "../shared/provider-form-shell.js";
 import { MODES, stripWhitespace } from "./modes.js";
 
 const KEY_GUIDE_URL =
@@ -55,67 +52,51 @@ export function IbmLitellmForm({
   });
 
   return (
-    <Card className="anim-in">
-      <form onSubmit={onSubmit} className="flex flex-col gap-6 p-6">
-        <div className="flex items-center gap-3">
-          <CardIcon provider="ibm-litellm" size="lg" />
-          <div className="flex-1 min-w-0">
-            <div className="text-[18px] font-bold text-foreground">
-              IBM LiteLLM ETE Proxy
-            </div>
-            <div className="text-[14px] text-muted-foreground">
-              {isEdit
-                ? "Paste a new token to replace the existing one."
-                : "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS."}
-            </div>
-          </div>
-          {onCancel && (
-            <IconButton
-              onClick={onCancel}
-              title="Cancel"
-              hoverTone="neutral"
-              className="self-start"
-            >
-              <X size={13} />
-            </IconButton>
-          )}
+    <ProviderFormShell
+      provider="ibm-litellm"
+      title="IBM LiteLLM ETE Proxy"
+      description={
+        isEdit
+          ? "Paste a new token to replace the existing one."
+          : "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS."
+      }
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    >
+      <a
+        href={KEY_GUIDE_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary hover:bg-muted"
+      >
+        <div className="flex flex-col gap-0.5">
+          <span className="text-[14px] font-bold text-foreground">
+            Need an API key?
+          </span>
+          <span className="text-[14px] text-muted-foreground">
+            Follow the guide and generate your LiteLLM token
+          </span>
         </div>
+        <Launch
+          size={16}
+          className="mt-0.5 shrink-0 text-muted-foreground group-hover:text-primary"
+        />
+      </a>
 
-        <a
-          href={KEY_GUIDE_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary hover:bg-muted"
-        >
-          <div className="flex flex-col gap-0.5">
-            <span className="text-[14px] font-bold text-foreground">
-              Need an API key?
-            </span>
-            <span className="text-[14px] text-muted-foreground">
-              Follow the guide and generate your LiteLLM token
-            </span>
-          </div>
-          <Launch
-            size={16}
-            className="mt-0.5 shrink-0 text-muted-foreground group-hover:text-primary"
-          />
-        </a>
-
-        <div className="flex gap-3">
-          <Input
-            type="password"
-            autoComplete="off"
-            data-1p-ignore
-            data-lpignore="true"
-            data-form-type="other"
-            placeholder={MODES["api-key"].placeholder}
-            {...register("value")}
-          />
-          <Button type="submit" disabled={submitDisabled} className="shrink-0">
-            {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
-          </Button>
-        </div>
-      </form>
-    </Card>
+      <div className="flex gap-3">
+        <Input
+          type="password"
+          autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
+          data-form-type="other"
+          placeholder={MODES["api-key"].placeholder}
+          {...register("value")}
+        />
+        <Button type="submit" disabled={submitDisabled} className="shrink-0">
+          {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
+        </Button>
+      </div>
+    </ProviderFormShell>
   );
 }

--- a/packages/ui/src/modules/settings/components/openai/form.tsx
+++ b/packages/ui/src/modules/settings/components/openai/form.tsx
@@ -1,15 +1,12 @@
 import { zodResolver } from "@hookform/resolvers/zod";
-import { X } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 
 import { PROVIDERS } from "../../../../types.js";
-import { CardIcon } from "../shared/card-icon.js";
-import { IconButton } from "../shared/icon-button.js";
+import { ProviderFormShell } from "../shared/provider-form-shell.js";
 import { MODES, stripWhitespace } from "./modes.js";
 
 const OPENAI_DISPLAY_NAME = PROVIDERS.openai.displayName;
@@ -53,50 +50,39 @@ export function OpenAIForm({
   });
 
   return (
-    <Card className="anim-in">
-      <form onSubmit={onSubmit} className="flex flex-col gap-4 p-5">
-        <div className="flex items-center gap-3">
-          <CardIcon provider="openai" />
-          <div className="flex-1 min-w-0">
-            <div className="text-[15px] font-bold text-foreground">
-              {OPENAI_DISPLAY_NAME}
-            </div>
-            <div className="text-[12px] text-muted-foreground">
-              {isEdit
-                ? "Paste a new API key to replace the existing one."
-                : "Powers Codex agents and any harness that reads OPENAI_API_KEY."}
-            </div>
+    <ProviderFormShell
+      provider="openai"
+      title={OPENAI_DISPLAY_NAME}
+      description={
+        isEdit
+          ? "Paste a new API key to replace the existing one."
+          : "Powers Codex agents and any harness that reads OPENAI_API_KEY."
+      }
+      onSubmit={onSubmit}
+      onCancel={onCancel}
+    >
+      <div className="flex gap-3">
+        <Input
+          type="password"
+          autoComplete="off"
+          data-1p-ignore
+          data-lpignore="true"
+          data-form-type="other"
+          placeholder={MODES["api-key"].placeholder}
+          {...register("value")}
+        />
+        <Button type="submit" disabled={submitDisabled} className="shrink-0">
+          {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
+        </Button>
+      </div>
+
+      {errors.value &&
+        value.length > 0 &&
+        errors.value.message !== "Required" && (
+          <div className="text-[12px] font-medium text-destructive">
+            {errors.value.message}
           </div>
-          {onCancel && (
-            <IconButton onClick={onCancel} title="Cancel" hoverTone="neutral">
-              <X size={13} />
-            </IconButton>
-          )}
-        </div>
-
-        <div className="flex gap-3">
-          <Input
-            type="password"
-            autoComplete="off"
-            data-1p-ignore
-            data-lpignore="true"
-            data-form-type="other"
-            placeholder={MODES["api-key"].placeholder}
-            {...register("value")}
-          />
-          <Button type="submit" disabled={submitDisabled} className="shrink-0">
-            {isSubmitting ? "..." : isEdit ? "Replace" : "Save"}
-          </Button>
-        </div>
-
-        {errors.value &&
-          value.length > 0 &&
-          errors.value.message !== "Required" && (
-            <div className="text-[12px] font-medium text-destructive">
-              {errors.value.message}
-            </div>
-          )}
-      </form>
-    </Card>
+        )}
+    </ProviderFormShell>
   );
 }

--- a/packages/ui/src/modules/settings/components/shared/card-icon.tsx
+++ b/packages/ui/src/modules/settings/components/shared/card-icon.tsx
@@ -43,6 +43,12 @@ const STYLES: Record<
   },
 };
 
+const TILE_SIZE_CLASS: Record<"lg" | "md" | "sm", string> = {
+  lg: "w-[68px] h-[68px]",
+  md: "w-10 h-10",
+  sm: "w-7 h-7",
+};
+
 const LARGE_ICON_CLASS: Record<ProviderPresetType, string> = {
   anthropic: "!w-8 !h-8",
   openai: "!w-8 !h-8",
@@ -67,11 +73,7 @@ export function CardIcon({
     <div
       className={cn(
         "shrink-0 rounded-lg flex items-center justify-center",
-        size === "lg"
-          ? "w-[68px] h-[68px]"
-          : size === "sm"
-            ? "w-7 h-7"
-            : "w-10 h-10",
+        TILE_SIZE_CLASS[size],
         style.bg,
       )}
     >

--- a/packages/ui/src/modules/settings/components/shared/card-icon.tsx
+++ b/packages/ui/src/modules/settings/components/shared/card-icon.tsx
@@ -43,31 +43,43 @@ const STYLES: Record<
   },
 };
 
+const LARGE_ICON_CLASS: Record<ProviderPresetType, string> = {
+  anthropic: "!w-8 !h-8",
+  openai: "!w-8 !h-8",
+  "ibm-litellm": "!text-[40px]",
+  bob: "!w-10 !h-10",
+};
+
 export function CardIcon({
   provider,
   size = "md",
 }: {
   provider: ProviderPresetType;
-  /** "md" = 40×40 (default, used in provider cards). "sm" = 28×28
-   *  (compact use inside dropdown rows / inline labels). The brand mark
-   *  inside scales proportionally so it stays centered. */
-  size?: "md" | "sm";
+  /** "lg" = 68×68 (provider connect modal header). "md" = 40×40 (default,
+   *  used in provider cards). "sm" = 28×28 (compact use inside dropdown rows /
+   *  inline labels). The brand mark inside scales proportionally so it stays
+   *  centered. */
+  size?: "lg" | "md" | "sm";
 }) {
   const style = STYLES[provider];
   const Icon = style.Icon;
-  const small = size === "sm";
   return (
     <div
       className={cn(
         "shrink-0 rounded-lg flex items-center justify-center",
-        small ? "w-7 h-7" : "w-10 h-10",
+        size === "lg"
+          ? "w-[68px] h-[68px]"
+          : size === "sm"
+            ? "w-7 h-7"
+            : "w-10 h-10",
         style.bg,
       )}
     >
       <Icon
         className={cn(
           style.iconClass,
-          small &&
+          size === "lg" && LARGE_ICON_CLASS[provider],
+          size === "sm" &&
             (provider === "ibm-litellm" ? "!text-[16px]" : "!w-3.5 !h-3.5"),
         )}
       />

--- a/packages/ui/src/modules/settings/components/shared/icon-button.tsx
+++ b/packages/ui/src/modules/settings/components/shared/icon-button.tsx
@@ -13,11 +13,13 @@ export function IconButton({
   onClick,
   title,
   hoverTone,
+  className,
   children,
 }: {
   onClick: () => void | Promise<void>;
   title: string;
   hoverTone: "accent" | "danger" | "neutral";
+  className?: string;
   children: ReactNode;
 }) {
   const tone =
@@ -33,7 +35,7 @@ export function IconButton({
       size="icon"
       onClick={onClick}
       title={title}
-      className={cn("h-7 w-7", tone)}
+      className={cn("h-7 w-7", tone, className)}
     >
       {children}
     </Button>

--- a/packages/ui/src/modules/settings/components/shared/provider-form-shell.tsx
+++ b/packages/ui/src/modules/settings/components/shared/provider-form-shell.tsx
@@ -1,0 +1,51 @@
+import { X } from "lucide-react";
+import type { FormEventHandler, ReactNode } from "react";
+
+import { Card } from "@/components/ui/card";
+
+import type { ProviderPresetType } from "../../../../types.js";
+import { CardIcon } from "./card-icon.js";
+import { IconButton } from "./icon-button.js";
+
+export function ProviderFormShell({
+  provider,
+  title,
+  description,
+  onSubmit,
+  onCancel,
+  children,
+}: {
+  provider: ProviderPresetType;
+  title: string;
+  description: ReactNode;
+  onSubmit: FormEventHandler<HTMLFormElement>;
+  onCancel?: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <Card className="anim-in">
+      <form onSubmit={onSubmit} className="flex flex-col gap-6 p-6">
+        <div className="flex items-center gap-3">
+          <CardIcon provider={provider} size="lg" />
+          <div className="min-w-0 flex-1">
+            <div className="text-[18px] font-bold text-foreground">{title}</div>
+            <div className="text-[14px] text-muted-foreground">
+              {description}
+            </div>
+          </div>
+          {onCancel && (
+            <IconButton
+              onClick={onCancel}
+              title="Cancel"
+              hoverTone="neutral"
+              className="self-start"
+            >
+              <X size={13} />
+            </IconButton>
+          )}
+        </div>
+        {children}
+      </form>
+    </Card>
+  );
+}


### PR DESCRIPTION
## What

Configuring the IBM LiteLLM ETE Proxy provider requires generating an API key first, and several users (including the dev team) got stuck at that step with no in-product guidance. This adds a **"Need an API key?"** callout to the LiteLLM provider form linking straight to the key-generation guide, so users can obtain and paste a token without leaving setup. It shows in both the sandbox-creation wizard and the configure page.

Along the way, the four provider connect forms (Anthropic, OpenAI, Bob, IBM LiteLLM) are unified onto a single shared layout component, so they share one header treatment, type scale, icon size, and dialog width instead of each rolling their own.

Closes #886