### PR TITLE
test(e2e): swap egress echo to httpbingo.org

### DIFF
--- a/packages/e2e/playwright/src/lib/fixtures.ts
+++ b/packages/e2e/playwright/src/lib/fixtures.ts
@@ -1,10 +1,10 @@
 export const harnessName = "mock";
 export const agentName = "e2e-agent";
 export const connectionName = "e2e-connection";
-export const connectionHost = "httpbin.org";
+export const connectionHost = "httpbingo.org";
 export const headerName = "x-api-key";
 export const valueFormat = "{value}";
 export const envName = "E2E_INJECTED_KEY";
 export const sentinel = "e2e-injected-secret-7f3a9c1";
 export const placeholder = "dummy-placeholder";
-export const echoUrl = "https://httpbin.org/headers";
+export const echoUrl = "https://httpbingo.org/headers";

--- a/packages/e2e/playwright/src/tests/05-injection.spec.ts
+++ b/packages/e2e/playwright/src/tests/05-injection.spec.ts
@@ -59,7 +59,8 @@ test("connection injects the credential (env placeholder + egress after Envoy)",
         {
           timeout: 120_000,
           intervals: [3_000],
-          message: "httpbin did not echo the injected credential after Envoy",
+          message:
+            "echo endpoint did not return the injected credential after Envoy",
         },
       )
       .toContain(sentinel);


### PR DESCRIPTION
## Why

The injection egress test (`05-injection.spec.ts`) hits `https://httpbin.org/headers` to verify the credential gets injected after Envoy. httpbin.org returns intermittent `503 Service Temporarily Unavailable`, which flakes the test (e.g. run 27606126960). The 503 comes back as a real HTML body through the full egress path, so the injection plumbing works fine, the external echo is just unreliable.

## What

Swap the echo endpoint to `httpbingo.org` (the go-httpbin public instance). Same `/headers` path and JSON shape, so the assertion is unchanged. Also renamed the timeout message off "httpbin" so a future failure does not mislead.

## Caveat

Still a third-party dependency, just a sturdier one. A hard httpbingo.org outage would flake the same way. The outage-proof fix is an in-cluster echo (cert-manager cert with a SAN matching the connection host, since the gateway Envoy re-originates TLS with SAN-bound validation), tracked separately if this recurs.