### PR TITLE
fix(release): clear stale bump ref before creating bump/vX branch

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -512,7 +512,14 @@ set +x
 echo -e "\x1b[36m$release_branch\x1b[0m branch with pending version ${current_version}-rc1 created."
 
 bump_branch="bump/v$next_version"
+bump_namespace="${bump_branch%%/*}"
 set -x
+if git show-ref --verify --quiet "refs/heads/$bump_namespace"; then
+  git branch -D "$bump_namespace"
+fi
+if git ls-remote --exit-code --heads origin "$bump_namespace" >/dev/null 2>&1; then
+  git push origin --delete "$bump_namespace"
+fi
 git checkout -B "$bump_branch" main
 {{ mise_bin }} run release:set-version "$next_version"
 git push --force --set-upstream origin "$bump_branch"


### PR DESCRIPTION
## Problem
`release:new` failed at `git checkout -B bump/v$next_version main` with:

```
fatal: 'refs/heads/bump' exists; cannot create 'refs/heads/bump/v0.2.3'
```

A leftover plain `bump` branch (from the pre-PR direct-push release era, e.g. merged PR #796) can't coexist with the `bump/` namespace git now uses. This breaks both the `git checkout -B` and the subsequent push.

## Fix
Before creating the bump branch, clear any conflicting `bump` namespace ref, both local and remote, each guarded by an existence check so it's a no-op in the normal case.

## Validation
- `mise tasks info release:new` parses
- `bash -n` passes on the new logic