### PR TITLE
fix(ui): verify MCP OAuth URL before opening the auth tab

### DIFF
--- a/packages/ui/src/__tests__/unit/mcp-url.test.ts
+++ b/packages/ui/src/__tests__/unit/mcp-url.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "vitest";
+
+import { validateMcpUrl } from "../../modules/connections/lib/mcp-url.js";
+
+describe("validateMcpUrl", () => {
+  test.each([
+    "https://mcp.example.com/sse",
+    "http://localhost:8080/mcp",
+    "https://mcp.example.com",
+  ])("accepts %s", (url) => {
+    expect(validateMcpUrl(url)).toBeNull();
+  });
+
+  test.each([
+    ["not-a-url", /valid URL/],
+    ["", /valid URL/],
+    ["mcp.example.com", /valid URL/],
+    ["ftp://mcp.example.com", /http or https/],
+    ["javascript:alert(1)", /http or https/],
+  ] as const)("rejects %s", (url, pattern) => {
+    expect(validateMcpUrl(url)).toMatch(pattern);
+  });
+});

--- a/packages/ui/src/modules/connections/forms/template-create-form.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form.tsx
@@ -20,8 +20,9 @@ import {
 } from "../../../components/modal.js";
 import { queryClient } from "../../../query-client.js";
 import { trpc } from "../../../trpc.js";
-import { useCreateConnection } from "../api/mutations.js";
+import { useCreateConnection, useDiscoverMcp } from "../api/mutations.js";
 import { useOAuthPopup } from "../hooks/use-oauth-popup.js";
+import { validateMcpUrl } from "../lib/mcp-url.js";
 
 export function TemplateCreateForm({
   template,
@@ -42,6 +43,7 @@ export function TemplateCreateForm({
   popupOAuth?: boolean;
 }) {
   const create = useCreateConnection();
+  const discover = useDiscoverMcp();
 
   const [name, setName] = useState(() => slugifyTemplateName(template.name));
   const [fields, setFields] = useState<Record<string, string>>(() => {
@@ -70,7 +72,7 @@ export function TemplateCreateForm({
   });
 
   const needsOAuth = template.authKind === "oauth";
-  const pending = create.isPending || authorizing;
+  const pending = create.isPending || authorizing || discover.isPending;
 
   const inputsByName = useMemo(() => {
     const map = new Map<string, ConnectionTemplateInput>();
@@ -172,6 +174,32 @@ export function TemplateCreateForm({
       return;
     }
     if (needsOAuth) {
+      // Custom MCP servers are reached by a user-typed URL. Verify it exposes
+      // OAuth discovery metadata before opening any tab, so an unreachable or
+      // non-OAuth URL fails inline here instead of flashing a popup that the
+      // create call would immediately close. Premade providers carry no `url`
+      // input and skip this, keeping their synchronous popup.
+      const mcpUrl = submittedValue("url");
+      if (mcpUrl) {
+        const urlError = validateMcpUrl(mcpUrl);
+        if (urlError) {
+          setError(urlError);
+          return;
+        }
+        try {
+          const { auth } = await discover.mutateAsync({ url: mcpUrl });
+          if (auth !== "oauth") {
+            setError(
+              "Couldn't find OAuth discovery metadata at this URL. Check that it points to an MCP server that supports OAuth (we look for /.well-known/oauth-* endpoints).",
+            );
+            return;
+          }
+        } catch {
+          // A transport/server failure is surfaced by the mutation's error toast.
+          return;
+        }
+      }
+
       // Open the popup synchronously (or it gets blocked); navigate it below.
       const popup = popupOAuth ? openPopup() : null;
       if (popup) {
@@ -308,13 +336,15 @@ export function TemplateCreateForm({
           disabled={pending}
           data-testid="connection-create-submit"
         >
-          {authorizing
-            ? "Redirecting…"
-            : pending
-              ? "…"
-              : needsOAuth
-                ? "Create + Authorize"
-                : "Create"}
+          {discover.isPending
+            ? "Verifying…"
+            : authorizing
+              ? "Redirecting…"
+              : pending
+                ? "…"
+                : needsOAuth
+                  ? "Create + Authorize"
+                  : "Create"}
         </Button>
       </DialogFooter>
     </Modal>

--- a/packages/ui/src/modules/connections/lib/mcp-url.ts
+++ b/packages/ui/src/modules/connections/lib/mcp-url.ts
@@ -1,0 +1,14 @@
+/** Validates a user-typed MCP server URL before OAuth discovery runs.
+ *  Returns an error message, or null when the URL is well-formed. */
+export function validateMcpUrl(value: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return "Enter a valid URL, e.g. https://mcp.example.com/sse.";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return "The MCP server URL must use http or https.";
+  }
+  return null;
+}


### PR DESCRIPTION
## Problem

In the sandbox creation wizard, adding a **Custom MCP server (OAuth)** connection and clicking **Create + Authorize** opened a new browser tab immediately — *before* the URL was checked at all. Validation existed only server-side, during the `create` call, which runs *after* the tab is already open. The result: a malformed or non-OAuth URL flashed a blank popup that was then closed.

Root cause: the popup is opened **synchronously** in the click handler (`openPopup()` runs before `await create.mutate(...)`), because browsers block `window.open` outside a user gesture. So the tab necessarily led the validation. Only the `popupOAuth` path (the wizard) was affected — the Settings → Connections path already navigates only after `create` succeeds.

## Fix

Before opening any tab, run a pre-flight check for OAuth templates that carry a user-typed `url` (custom MCP / dynamic registration):

1. Client-side URL format validation (`validateMcpUrl`).
2. The previously **unused** `discoverMcp` tRPC endpoint — confirms the server exposes OAuth discovery metadata (`/.well-known/oauth-*`) with DCR support.

If either fails, an inline error is shown and **no tab opens**. Only a verified URL proceeds to the OAuth flow.

- Premade providers (GitHub, etc.) have no `url` input, so they skip the check and keep their unchanged synchronous popup.
- For a verified custom-MCP URL the post-`await` popup may be blocked; the existing full-page-redirect fallback (already snapshot-safe in the wizard) handles that.
- Button now shows **Verifying…** during the pre-flight discovery.

## Tests

- New `validateMcpUrl` unit tests (accepts http/https, rejects malformed and non-http(s) schemes).
- `mise run ui:check` (lint + format + tsc) and `mise run ui:test` (47 tests) pass.

## Notes

UI-only change. No backend or contract changes — `discoverMcp` and the create-time discovery/DCR behavior are unchanged.