### PR TITLE
feat(ui): sandbox wizard + configure-page polish

### DIFF
--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     data-slot="card"
-    className={cn("rounded-lg bg-card text-card-foreground shadow", className)}
+    className={cn("rounded-lg bg-card text-card-foreground border", className)}
     {...props}
   />
 ));

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -13,8 +13,9 @@ const inputVariants = cva(
         invalid: "border-destructive focus-visible:ring-destructive",
       },
       size: {
-        default: "h-10 px-3 py-2 text-sm",
+        default: "h-10 px-4 py-2 text-sm",
         sm: "h-8 px-3 text-xs",
+        xs: "h-7 px-3 text-xs",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/ui/input.tsx
+++ b/packages/ui/src/components/ui/input.tsx
@@ -14,8 +14,8 @@ const inputVariants = cva(
       },
       size: {
         default: "h-10 px-4 py-2 text-sm",
-        sm: "h-8 px-3 text-xs",
-        xs: "h-7 px-3 text-xs",
+        sm: "h-8 px-3 text-[12px]",
+        xs: "h-7 px-3 text-[12px]",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/ui/section-label.tsx
+++ b/packages/ui/src/components/ui/section-label.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function SectionLabel({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      className={cn(
+        "text-[11px] font-medium uppercase leading-[17.05px] tracking-[1.65px] text-muted-foreground",
+        className,
+      )}
+    >
+      {children}
+    </span>
+  );
+}

--- a/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
+++ b/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
@@ -1,6 +1,7 @@
 import { AlertTriangle, KeyRound, Lock } from "lucide-react";
 
 import { SectionLabel } from "@/components/ui/section-label";
+import { cn } from "@/lib/utils";
 
 import { EnvVarsEditor } from "../../../../components/env-vars-editor.js";
 import type { EnvVar } from "../../../../types.js";
@@ -107,7 +108,7 @@ function InheritedEnvRow({ entry }: { entry: InheritedEnv }) {
   return (
     <div className="group flex items-center gap-2 rounded-md border px-3 py-1.5 text-[12px]">
       <span
-        className={`shrink-0 ${isSystem && "text-text-muted"}`}
+        className={cn("shrink-0", isSystem && "text-text-muted")}
         title={isSystem ? "Platform-managed" : `From connection: ${sourceName}`}
       >
         {isSystem ? <Lock size={12} /> : <KeyRound size={12} />}

--- a/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
+++ b/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
@@ -1,5 +1,7 @@
 import { AlertTriangle, KeyRound, Lock } from "lucide-react";
 
+import { SectionLabel } from "@/components/ui/section-label";
+
 import { EnvVarsEditor } from "../../../../components/env-vars-editor.js";
 import type { EnvVar } from "../../../../types.js";
 
@@ -45,8 +47,8 @@ export function EnvTab({
 }) {
   const warnings = shadowWarnings(envVars, inherited);
   return (
-    <>
-      <p className="text-[12px] text-text-muted">
+    <div className="flex flex-col gap-6">
+      <p className="text-[14px] text-muted-foreground">
         Applied to every instance of this agent. Restart the instance pod to
         pick up changes.
       </p>
@@ -54,12 +56,7 @@ export function EnvTab({
       {inherited.length > 0 && (
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2">
-            <span className="text-[10px] font-bold text-text-muted uppercase tracking-[0.05em]">
-              Inherited
-            </span>
-            <span className="text-[10px] text-text-muted">
-              · managed elsewhere
-            </span>
+            <SectionLabel>Inherited</SectionLabel>
           </div>
           <div className="flex flex-col gap-1">
             {inherited.map((e, i) => (
@@ -70,9 +67,7 @@ export function EnvTab({
       )}
 
       <div className="flex flex-col gap-2">
-        <span className="text-[10px] font-bold text-text-muted uppercase tracking-[0.05em]">
-          Custom
-        </span>
+        <SectionLabel>Custom</SectionLabel>
         {warnings.length > 0 && (
           <div className="flex flex-col gap-1 rounded-md border-2 border-warning bg-warning-light px-3 py-2 text-[12px]">
             <div className="flex items-center gap-2 text-warning">
@@ -97,7 +92,7 @@ export function EnvTab({
           disabled={saving}
         />
       </div>
-    </>
+    </div>
   );
 }
 
@@ -110,9 +105,9 @@ function InheritedEnvRow({ entry }: { entry: InheritedEnv }) {
         ? entry.source.secretName
         : entry.source.appLabel;
   return (
-    <div className="group flex items-center gap-2 rounded-md border-2 border-border-light bg-surface-raised px-3 py-1.5 text-[12px]">
+    <div className="group flex items-center gap-2 rounded-md border px-3 py-1.5 text-[12px]">
       <span
-        className={`shrink-0 ${isSystem ? "text-text-muted" : "text-accent"}`}
+        className={`shrink-0 ${isSystem && "text-text-muted"}`}
         title={isSystem ? "Platform-managed" : `From connection: ${sourceName}`}
       >
         {isSystem ? <Lock size={12} /> : <KeyRound size={12} />}
@@ -122,13 +117,13 @@ function InheritedEnvRow({ entry }: { entry: InheritedEnv }) {
       </span>
       <span className="text-text-muted">=</span>
       <span
-        className="font-mono text-text-muted truncate flex-1"
+        className="font-mono text-muted-foreground truncate flex-1"
         title={entry.value}
       >
         {entry.value}
       </span>
       {!isSystem && (
-        <span className="text-[10px] text-text-muted italic truncate max-w-[160px]">
+        <span className="text-[14px] text-muted-foreground italic truncate max-w-[160px]">
           {sourceName}
         </span>
       )}

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -233,7 +233,7 @@ export function AgentEgressEditor({
 
   return (
     <div className="flex flex-col gap-4">
-      <p className="text-[12px] text-muted-foreground leading-relaxed max-w-prose">
+      <p className="text-[14px] text-muted-foreground max-w-prose">
         Rules decide which outbound HTTP requests this agent can make. The
         most-specific rule wins; <code>*</code> in <em>method</em> or
         <em>path</em> matches any value. Without a matching rule, the request
@@ -286,7 +286,7 @@ export function AgentEgressEditor({
               onChange={(e) => setDraft({ ...draft, host: e.target.value })}
               onKeyDown={onInputKeyDown}
               placeholder="api.anthropic.com"
-              className="h-7 text-[12px]"
+              size="xs"
             />
           </Field>
           <Field label="Method" widthClass="w-[100px]">
@@ -317,7 +317,8 @@ export function AgentEgressEditor({
               }
               onKeyDown={onInputKeyDown}
               placeholder="*  or  /v1/messages*"
-              className="h-7 text-[12px] font-mono"
+              size="xs"
+              variant="monospace"
             />
           </Field>
           <Field label="Verdict" widthClass="w-[100px]">
@@ -341,6 +342,7 @@ export function AgentEgressEditor({
             className="h-7 text-[11px]"
             onClick={onAddRule}
             disabled={!canAdd}
+            variant="outline"
           >
             <Plus size={11} /> Add rule
           </Button>

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -13,6 +13,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
+import { SectionLabel } from "@/components/ui/section-label";
 
 import {
   useApplyEgressPreset,
@@ -242,9 +243,7 @@ export function AgentEgressEditor({
 
       <Card className="px-3 py-3 flex flex-wrap items-end gap-2">
         <div className="flex flex-col gap-1 flex-1 min-w-[260px]">
-          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-            {stagedMode ? "Preset" : "Apply preset"}
-          </span>
+          <SectionLabel>{stagedMode ? "Preset" : "Apply preset"}</SectionLabel>
           <select
             value={dropdownValue}
             onChange={(e) => onPresetSelect(e.target.value as EgressPreset)}
@@ -269,7 +268,7 @@ export function AgentEgressEditor({
             Apply
           </Button>
         )}
-        <p className="basis-full text-[11px] text-muted-foreground">
+        <p className="basis-full text-[14px] text-muted-foreground">
           {stagedMode
             ? presetPending
               ? `Save will replace existing preset rules with "${staged.preset}". Manual and connection-derived rules are preserved.`
@@ -444,9 +443,7 @@ function Field({
 }) {
   return (
     <label className={`flex flex-col gap-1 ${widthClass}`}>
-      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
-        {label}
-      </span>
+      <SectionLabel>{label}</SectionLabel>
       {children}
     </label>
   );

--- a/packages/ui/src/modules/sandboxes/components/card-list.tsx
+++ b/packages/ui/src/modules/sandboxes/components/card-list.tsx
@@ -2,13 +2,6 @@ import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
-/**
- * Vertical stack of selectable cards/rows under a WizardSectionLabel. The
- * desktop-only negative left margin (matched to the cards' p-4) bleeds the card
- * surface leftward so the card *content* lines up with the section label, while
- * the right edge stays on the content column so trailing action buttons still
- * align with the cards. Disabled on mobile, where the gutter can't absorb it.
- */
 export function CardList({
   children,
   className,

--- a/packages/ui/src/modules/sandboxes/components/card-list.tsx
+++ b/packages/ui/src/modules/sandboxes/components/card-list.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
+import { FormField } from "./form-field.js";
+
 export function CardList({
   children,
   className,
@@ -10,8 +12,8 @@ export function CardList({
   className?: string;
 }) {
   return (
-    <div className={cn("flex flex-col gap-3 md:-ml-4", className)}>
+    <FormField className={cn("flex flex-col gap-3", className)}>
       {children}
-    </div>
+    </FormField>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/connections-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/connections-section.tsx
@@ -18,6 +18,7 @@ import {
   isShowInternalConnectionsEnabled,
 } from "../../connections/internal-only.js";
 import { PROVIDER_TEMPLATE_IDS } from "../../connections/lib/provider-templates.js";
+import { CardList } from "./card-list.js";
 import { WizardSectionLabel } from "./wizard-section-label.js";
 
 const NO_TEMPLATES: ConnectionTemplateView[] = [];
@@ -72,7 +73,7 @@ export function ConnectionsSection({
       <section className="mb-8">
         <WizardSectionLabel>My connections</WizardSectionLabel>
         {connections.length > 0 ? (
-          <div className="flex flex-col gap-3">
+          <CardList>
             {connections.map((c) => (
               <ConnectionRow
                 key={c.id}
@@ -92,7 +93,7 @@ export function ConnectionsSection({
                 />
               </ConnectionRow>
             ))}
-          </div>
+          </CardList>
         ) : (
           <p className="text-[13px] text-muted-foreground">
             No connections yet.
@@ -101,7 +102,7 @@ export function ConnectionsSection({
         <button
           type="button"
           onClick={() => setShowCatalog((v) => !v)}
-          className="mt-3 inline-flex items-center gap-1 text-[13px] font-medium text-muted-foreground hover:text-foreground"
+          className="mt-3 inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
         >
           {showCatalog ? "Show less" : "Show all"}
           {showCatalog ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
@@ -115,7 +116,7 @@ export function ConnectionsSection({
           return (
             <section key={cat} className="mb-8">
               <WizardSectionLabel>{CATEGORY_LABEL[cat]}</WizardSectionLabel>
-              <div className="flex flex-col gap-3">
+              <CardList>
                 {list.map((t) => (
                   <ConnectionCatalogRow
                     key={t.id}
@@ -123,7 +124,7 @@ export function ConnectionsSection({
                     onConnect={() => setCreating(t)}
                   />
                 ))}
-              </div>
+              </CardList>
             </section>
           );
         })}

--- a/packages/ui/src/modules/sandboxes/components/form-field.tsx
+++ b/packages/ui/src/modules/sandboxes/components/form-field.tsx
@@ -1,0 +1,13 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function FormField({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return <div className={cn("md:-ml-4", className)}>{children}</div>;
+}

--- a/packages/ui/src/modules/sandboxes/components/provider-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/provider-section.tsx
@@ -155,7 +155,7 @@ function ProviderDropdown({
       <DropdownMenuTrigger asChild>
         <button
           type="button"
-          className="flex h-10 w-full items-center gap-3 rounded-md border border-input bg-background px-3 text-sm text-foreground transition-colors hover:bg-muted/30"
+          className="flex h-10 w-full items-center gap-3 rounded-md border border-input bg-background px-4 text-sm text-foreground transition-colors hover:bg-muted/30"
         >
           {selected ? (
             <>

--- a/packages/ui/src/modules/sandboxes/components/sandbox-wizard-shell.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-wizard-shell.tsx
@@ -5,6 +5,7 @@ import { WizardStepIndicator } from "./wizard-step-indicator.js";
 
 interface Props {
   step: WizardStep;
+  maxStep: WizardStep;
   imageLabel: string | null;
   onNavigate: (step: WizardStep) => void;
   children: ReactNode;
@@ -12,6 +13,7 @@ interface Props {
 
 export function SandboxWizardShell({
   step,
+  maxStep,
   imageLabel,
   onNavigate,
   children,
@@ -21,6 +23,7 @@ export function SandboxWizardShell({
       <div className="flex flex-col gap-6 md:flex-row md:gap-10">
         <WizardStepIndicator
           step={step}
+          maxStep={maxStep}
           imageLabel={imageLabel}
           onNavigate={onNavigate}
         />

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -160,19 +160,8 @@ export function ConnectionsStep({
       })}
 
       <div className="flex justify-end gap-3">
-        {selected.size === 0 && (
-          <Button variant="outline" onClick={onFinish} disabled={finishing}>
-            Skip this step
-          </Button>
-        )}
         <Button onClick={onFinish} disabled={finishing}>
-          {selected.size > 0 ? (
-            "Create sandbox"
-          ) : (
-            <>
-              Continue <ArrowRight size={16} />
-            </>
-          )}
+          Create sandbox
         </Button>
       </div>
 

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -1,5 +1,4 @@
 import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
-import { ArrowRight } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";

--- a/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
@@ -66,6 +66,9 @@ export function ImageStep({
             value={customImage}
             selected={customImage.trim().length > 0}
             onChange={onCustomImageChange}
+            onSubmit={() => {
+              if (canContinue) onContinue();
+            }}
           />
         </CardList>
       </section>
@@ -114,10 +117,12 @@ function CustomImageCard({
   value,
   selected,
   onChange,
+  onSubmit,
 }: {
   value: string;
   selected: boolean;
   onChange: (value: string) => void;
+  onSubmit: () => void;
 }) {
   return (
     <div
@@ -142,6 +147,9 @@ function CustomImageCard({
         <Input
           value={value}
           onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onSubmit();
+          }}
           placeholder="ghcr.io/org/agent:latest"
           variant="monospace"
         />

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -9,6 +9,7 @@ import type {
   WizardSnapshot,
 } from "../../lib/wizard-snapshot.js";
 import { CardList } from "../card-list.js";
+import { FormField } from "../form-field.js";
 import { ProviderSection } from "../provider-section.js";
 import {
   type RegistryCredential,
@@ -75,14 +76,14 @@ export function SetupStep({
 
       <section className="mb-8">
         <WizardSectionLabel>Name</WizardSectionLabel>
-        <div className="md:-ml-3">
+        <FormField>
           <Input
             autoFocus
             value={name}
             onChange={(event) => update({ name: event.target.value })}
             placeholder="my-sandbox"
           />
-        </div>
+        </FormField>
       </section>
 
       <section className="mb-8">

--- a/packages/ui/src/modules/sandboxes/components/wizard-section-label.tsx
+++ b/packages/ui/src/modules/sandboxes/components/wizard-section-label.tsx
@@ -1,9 +1,7 @@
 import type { ReactNode } from "react";
 
+import { SectionLabel } from "@/components/ui/section-label";
+
 export function WizardSectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-      {children}
-    </p>
-  );
+  return <SectionLabel className="mb-3 block">{children}</SectionLabel>;
 }

--- a/packages/ui/src/modules/sandboxes/components/wizard-step-indicator.tsx
+++ b/packages/ui/src/modules/sandboxes/components/wizard-step-indicator.tsx
@@ -10,11 +10,17 @@ const STEPS = [
 
 interface Props {
   step: WizardStep;
+  maxStep: WizardStep;
   imageLabel: string | null;
   onNavigate: (step: WizardStep) => void;
 }
 
-export function WizardStepIndicator({ step, imageLabel, onNavigate }: Props) {
+export function WizardStepIndicator({
+  step,
+  maxStep,
+  imageLabel,
+  onNavigate,
+}: Props) {
   return (
     <nav
       aria-label="Wizard steps"
@@ -26,7 +32,11 @@ export function WizardStepIndicator({ step, imageLabel, onNavigate }: Props) {
           label={item.label}
           annotation={item.n === 1 ? imageLabel : null}
           state={
-            item.n === step ? "active" : item.n < step ? "visited" : "upcoming"
+            item.n === step
+              ? "active"
+              : item.n <= maxStep
+                ? "visited"
+                : "upcoming"
           }
           onClick={() => onNavigate(item.n as WizardStep)}
         />

--- a/packages/ui/src/modules/sandboxes/hooks/use-sandbox-wizard.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-sandbox-wizard.ts
@@ -20,6 +20,12 @@ export function useSandboxWizard(): SandboxWizard {
   const update = useCallback((patch: Partial<WizardSnapshot>) => {
     setSnapshot((prev) => {
       const next = { ...prev, ...patch };
+      if (patch.step !== undefined) {
+        next.maxStep = Math.max(
+          prev.maxStep || prev.step,
+          patch.step,
+        ) as WizardSnapshot["step"];
+      }
       saveSnapshot(next);
       return next;
     });

--- a/packages/ui/src/modules/sandboxes/lib/wizard-snapshot.ts
+++ b/packages/ui/src/modules/sandboxes/lib/wizard-snapshot.ts
@@ -8,6 +8,7 @@ export type EgressPreset = z.infer<typeof egressPresetSchema>;
 /** Persisted wizard state — ids and pick-state only, never secret values. */
 export const wizardSnapshotSchema = z.object({
   step: z.union([z.literal(1), z.literal(2), z.literal(3)]),
+  maxStep: z.union([z.literal(1), z.literal(2), z.literal(3)]).default(1),
   templateId: z.string().nullable(),
   customImage: z.string(),
   name: z.string(),
@@ -22,6 +23,7 @@ export type WizardStep = WizardSnapshot["step"];
 
 export const EMPTY_SNAPSHOT: WizardSnapshot = {
   step: 1,
+  maxStep: 1,
   templateId: null,
   customImage: "",
   name: "",
@@ -36,7 +38,11 @@ export function loadSnapshot(): WizardSnapshot {
   if (!raw) return EMPTY_SNAPSHOT;
   try {
     const parsed = wizardSnapshotSchema.safeParse(JSON.parse(raw));
-    return parsed.success ? parsed.data : EMPTY_SNAPSHOT;
+    if (!parsed.success) return EMPTY_SNAPSHOT;
+    return {
+      ...parsed.data,
+      maxStep: Math.max(parsed.data.maxStep, parsed.data.step) as WizardStep,
+    };
   } catch {
     return EMPTY_SNAPSHOT;
   }

--- a/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
@@ -8,12 +8,13 @@ import { FormError } from "../../../components/form-error.js";
 import { EnvTab } from "../../agents/components/configure-agent/env-tab.js";
 import { AgentEgressEditor } from "../../egress-rules/components/agent-egress-editor.js";
 import { ConnectionsSection } from "../components/connections-section.js";
+import { FormField } from "../components/form-field.js";
 import { ProviderSection } from "../components/provider-section.js";
 import { WizardSectionLabel } from "../components/wizard-section-label.js";
 import { useSandboxSettingsForm } from "../hooks/use-sandbox-settings-form.js";
 
 const READ_ONLY_FIELD =
-  "flex h-10 w-full items-center rounded-md border border-input bg-muted/40 px-3 text-sm text-muted-foreground";
+  "flex h-10 w-full items-center rounded-md border border-input bg-muted/40 px-4 text-sm text-muted-foreground";
 
 export function SandboxSettingsView() {
   const f = useSandboxSettingsForm();
@@ -41,13 +42,15 @@ export function SandboxSettingsView() {
   return (
     <div className="mx-auto w-full max-w-[666px]">
       <BackLink onClick={f.goBack} />
-      <h1 className="mb-8 mt-2 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
+      <h1 className="mb-8 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
         {agent.name}
       </h1>
 
       <section className="mb-8">
         <WizardSectionLabel>Name</WizardSectionLabel>
-        <Input disabled={f.saving} {...f.register("name")} />
+        <FormField>
+          <Input disabled={f.saving} {...f.register("name")} />
+        </FormField>
         <FormError message={f.errors.name?.message} />
       </section>
 
@@ -55,11 +58,13 @@ export function SandboxSettingsView() {
         <WizardSectionLabel>Image</WizardSectionLabel>
         {/* Read-only: image/template are create-only — changing them would mean
             delete+recreate, destroying the workspace PVC. */}
-        <div className={READ_ONLY_FIELD}>
-          <span className={`truncate ${agent.templateId ? "" : "font-mono"}`}>
-            {f.templateName ?? agent.image}
-          </span>
-        </div>
+        <FormField>
+          <div className={READ_ONLY_FIELD}>
+            <span className={`truncate ${agent.templateId ? "" : "font-mono"}`}>
+              {f.templateName ?? agent.image}
+            </span>
+          </div>
+        </FormField>
         {agent.templateId && (
           <p className="mt-1.5 truncate font-mono text-[12px] text-muted-foreground">
             {agent.image}
@@ -69,12 +74,14 @@ export function SandboxSettingsView() {
 
       <section className="mb-8">
         <WizardSectionLabel>Provider</WizardSectionLabel>
-        <ProviderSection
-          variant="dropdown"
-          selectedSecretId={f.selectedProviderSecretId}
-          onSelect={f.selectProvider}
-          onProviderRemoved={f.dropProviderGrant}
-        />
+        <FormField>
+          <ProviderSection
+            variant="dropdown"
+            selectedSecretId={f.selectedProviderSecretId}
+            onSelect={f.selectProvider}
+            onProviderRemoved={f.dropProviderGrant}
+          />
+        </FormField>
         <p className="mt-3 text-[12px] text-muted-foreground">
           Changing the provider swaps this sandbox's model credential. A
           cross-family switch (e.g. Anthropic → OpenAI on a Claude image) can
@@ -90,27 +97,31 @@ export function SandboxSettingsView() {
 
       <section className="mb-8">
         <WizardSectionLabel>Network access</WizardSectionLabel>
-        <AgentEgressEditor
-          agentId={agent.id}
-          currentPreset={f.currentPreset}
-          staged={f.egressStaged}
-        />
+        <FormField className="rounded-lg border border-border p-4">
+          <AgentEgressEditor
+            agentId={agent.id}
+            currentPreset={f.currentPreset}
+            staged={f.egressStaged}
+          />
+        </FormField>
       </section>
 
       <section className="mb-8">
         <WizardSectionLabel>Environment</WizardSectionLabel>
-        <Controller
-          control={f.control}
-          name="envVars"
-          render={({ field }) => (
-            <EnvTab
-              inherited={f.inheritedEnvs}
-              envVars={field.value}
-              setEnvVars={field.onChange}
-              saving={f.saving}
-            />
-          )}
-        />
+        <FormField className="rounded-lg border border-border p-4">
+          <Controller
+            control={f.control}
+            name="envVars"
+            render={({ field }) => (
+              <EnvTab
+                inherited={f.inheritedEnvs}
+                envVars={field.value}
+                setEnvVars={field.onChange}
+                saving={f.saving}
+              />
+            )}
+          />
+        </FormField>
       </section>
 
       <div className="flex items-center justify-end gap-3 pb-4">
@@ -139,9 +150,9 @@ function BackLink({ onClick }: { onClick: () => void }) {
       variant="ghost"
       size="sm"
       onClick={onClick}
-      className="-ml-2 h-auto self-start px-2 py-1 text-[12px] text-muted-foreground hover:text-foreground"
+      className="-ml-2 h-auto self-start px-2 py-1 text-[16px] leading-[22.75px] text-muted-foreground hover:text-foreground font-normal"
     >
-      <ArrowLeft size={12} /> Back to Sandboxes
+      <ArrowLeft size={16} /> Back to Sandboxes
     </Button>
   );
 }

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -113,6 +113,7 @@ export function SandboxWizardView() {
   return (
     <SandboxWizardShell
       step={snapshot.step}
+      maxStep={snapshot.maxStep || snapshot.step}
       imageLabel={imageLabel}
       onNavigate={goToStep}
     >


### PR DESCRIPTION
Follow-up UI polish on the sandbox creation wizard and the configure-sandbox page (after #1040).

**Wizard**
- Visited steps stay navigable — going back to an earlier step no longer disables the ones you've already reached; steps beyond the furthest reached stay locked.
- The image step gets its own Continue button (picking an image selects rather than auto-advancing), and the custom-image input submits on Enter.

**Configure page + shared form polish**
- Section content (name, image, provider, connections, network, environment) aligns with its label via a shared offset; Network and Environment sit in bordered boxes.
- One shared `SectionLabel` for all uppercase section labels, and one `FormField` for the content offset.
- Standard input padding bumped to 16px so content lines up; small/compact inputs keep 12px and gain a dedicated size. Cards use a border instead of a shadow. Back link adopts the larger type.

Scope note: a couple of the underlying changes (input padding, Card border) are design-system level and affect inputs/cards app-wide.