### PR TITLE
feat(agent-config): persistent per-agent model/mode/config defaults

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -107,6 +107,7 @@ A typed unit a Connection emits when granted to an Agent — a discriminated uni
 - **`file`** — a config file to author, with a format and a merge mode (see [Built-in contribution impls](#built-in-contribution-impls)).
 - **`mcp-entry`** — an MCP server to expose to the harness.
 - **`skill-ref`** — a skill source to install at a pinned version.
+- **`harness-config`** — the per-agent **session default** (model, mode, and an open bag of ACP config options) chosen in the UI Config panel, not a Connection output. Its shape mirrors ACP session config; the driver owns the field → file/keyPath mapping, so it stays harness-agnostic. At most one per agent; omitted when nothing is set, so the driver removes any keys it previously wrote.
 
 Kinds are added by extending the union and gating on agent capabilities (see [Versioning](#versioning)). Exact per-kind fields live in the [Connections contract types](../../packages/api-server-api/src/modules/connections/).
 
@@ -199,6 +200,7 @@ The api-server's contribution-fanout layer routes each Contribution kind to the 
 | `file` | Runtime channel `applyState` (state slice) | Sub-second push; idempotent reconciliation | Per-format + per-mergeMode driver materializes. |
 | `mcp-entry` | Runtime channel `applyState` (state slice) | Sub-second push; idempotent reconciliation | Driver dispatches to harness-specific path. |
 | `skill-ref` | Runtime channel `applyState` (state slice) | Sub-second push; per-version installer | Driver wraps existing skill-fetch helpers. |
+| `harness-config` | Runtime channel `applyState` (state slice) | Sub-second push; idempotent reconciliation | Driver maps each logical field (model/mode/configOption) to a keyPath in the harness's config file; picked up at next session start. |
 
 The rail choice is a property of the kind, not of the Connection. A single grant of GitHub Enterprise produces Contributions on both rails: `egress-allow` (egress_rules → Envoy live), and `env` + `file` (runtime channel push). They flow independently.
 
@@ -468,6 +470,7 @@ Custom contribution impl names may not collide with built-in names (`file`, `ski
 |---|---|---|
 | `file` | `file` kind directly, and `mcp-entry` via composition | Format (`yaml`/`json`/`text`/`ini`) × MergeMode (`overwrite`/`section-marker`/`key-targeted`/`yaml-fill-if-missing`). The matrix is the substrate for all file-shaped writes. |
 | `skill-install` | `skill-ref` kind | Wraps the existing skill-fetch helpers; resolves source URL, fetches at version through the gateway, materializes into configured skill paths, removes vanished skills on snapshot reconciliation. |
+| `harness-config` | `harness-config` kind | JSON only. Binding declares the target `file` and a `keys` map that mirrors the ACP config shape — `model`, `mode`, and a `configOptions` map keyed by ACP config id — each pointing at a dot-path in the file. Reconstructs the file preserving user keys, sets desired values, removes ones it previously wrote that are no longer desired. Unmapped fields/options are skipped. Harnesses whose config isn't JSON bind a custom impl. |
 
 ### Driver reconciliation
 

--- a/packages/agent-runtime-api/src/index.ts
+++ b/packages/agent-runtime-api/src/index.ts
@@ -62,6 +62,7 @@ export {
   fileContribution,
   mcpEntryContribution,
   skillRefContribution,
+  harnessConfigContribution,
   triggerEvent,
   triggerEventPayload,
   stateSlice,

--- a/packages/agent-runtime-api/src/modules/runtime/types.ts
+++ b/packages/agent-runtime-api/src/modules/runtime/types.ts
@@ -7,6 +7,7 @@ export const contributionKind = z.enum([
   "file",
   "mcp-entry",
   "skill-ref",
+  "harness-config",
 ]);
 export type ContributionKind = z.infer<typeof contributionKind>;
 
@@ -76,6 +77,22 @@ export const skillRefContribution = z.object({
   version: z.string().min(1),
 });
 
+// Persistent per-agent harness session config, reconciled into the harness's
+// own config file by the manifest-bound `harness-config` driver. The shape
+// mirrors ACP session config: `model` is a modelId, `mode` is a modeId, and
+// `configOptions` maps an ACP configId (e.g. the `thought_level` option) to its
+// select value or boolean. The driver owns the field/option → file-keyPath
+// mapping, so this contribution stays harness-agnostic. Every field is optional
+// — a harness that doesn't expose one simply omits it.
+export const harnessConfigContribution = z.object({
+  kind: z.literal("harness-config"),
+  model: z.string().min(1).optional(),
+  mode: z.string().min(1).optional(),
+  configOptions: z
+    .record(z.string().min(1), z.union([z.string(), z.boolean()]))
+    .optional(),
+});
+
 export const contribution = z.discriminatedUnion("kind", [
   envContribution,
   egressAllowContribution,
@@ -83,6 +100,7 @@ export const contribution = z.discriminatedUnion("kind", [
   fileContribution,
   mcpEntryContribution,
   skillRefContribution,
+  harnessConfigContribution,
 ]);
 export type Contribution = z.infer<typeof contribution>;
 

--- a/packages/agent-runtime/src/__tests__/unit/harness-config-plugin.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/harness-config-plugin.test.ts
@@ -1,0 +1,122 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type {
+  Contribution,
+  DispatchContext,
+  DriverBinding,
+} from "agent-runtime-api";
+import { createHarnessConfigPlugin } from "../../modules/runtime-channel/drivers/harness-config-plugin.js";
+
+const BINDING: DriverBinding = {
+  impl: "harness-config",
+  file: "$HOME/.claude/settings.json",
+  keys: {
+    model: "model",
+    mode: "permissions.defaultMode",
+    configOptions: { thought_level: "effortLevel" },
+  },
+};
+
+describe("harness-config driver", () => {
+  let home: string;
+  let stateDir: string;
+  let settingsPath: string;
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), "harness-config-"));
+    stateDir = join(home, ".platform", "plugins", "harness-config");
+    mkdirSync(stateDir, { recursive: true });
+    settingsPath = join(home, ".claude", "settings.json");
+  });
+
+  afterEach(() => {
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  const handler = () =>
+    createHarnessConfigPlugin().bind("harness-config", BINDING);
+
+  const ctx: () => DispatchContext = () => ({
+    agentHome: home,
+    pluginStateDir: stateDir,
+    log: () => {},
+  });
+
+  const apply = (contributions: Contribution[]) =>
+    handler()(contributions, ctx());
+
+  const readSettings = () =>
+    JSON.parse(readFileSync(settingsPath, "utf8")) as Record<string, unknown>;
+
+  it("maps model, mode, and config options to their (nested) keys", async () => {
+    await apply([
+      {
+        kind: "harness-config",
+        model: "opus",
+        mode: "plan",
+        configOptions: { thought_level: "high" },
+      },
+    ]);
+    expect(readSettings()).toEqual({
+      model: "opus",
+      permissions: { defaultMode: "plan" },
+      effortLevel: "high",
+    });
+  });
+
+  it("preserves user-authored keys, including siblings of a nested target", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(
+      settingsPath,
+      JSON.stringify({ theme: "dark", permissions: { allow: ["Bash"] } }),
+    );
+    await apply([{ kind: "harness-config", model: "sonnet", mode: "acceptEdits" }]);
+    expect(readSettings()).toEqual({
+      theme: "dark",
+      model: "sonnet",
+      permissions: { allow: ["Bash"], defaultMode: "acceptEdits" },
+    });
+  });
+
+  it("removes a managed key when its field is cleared, leaving user keys", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(settingsPath, JSON.stringify({ theme: "dark" }));
+    await apply([{ kind: "harness-config", model: "opus", mode: "plan" }]);
+    // Second apply drops `mode`; `model` stays, `permissions.defaultMode` is removed.
+    await apply([{ kind: "harness-config", model: "opus" }]);
+    expect(readSettings()).toEqual({ theme: "dark", model: "opus" });
+  });
+
+  it("skips a config option that has no key mapping in the binding", async () => {
+    await apply([
+      { kind: "harness-config", configOptions: { unmapped: "x" } },
+    ]);
+    // Nothing mapped and no prior state → no file written at all.
+    expect(existsSync(settingsPath)).toBe(false);
+  });
+
+  it("does not create a file when there is nothing to write", async () => {
+    await apply([]);
+    expect(existsSync(settingsPath)).toBe(false);
+    await apply([{ kind: "harness-config" }]);
+    expect(existsSync(settingsPath)).toBe(false);
+  });
+
+  it("throws rather than clobbering an unparseable settings file", async () => {
+    mkdirSync(join(home, ".claude"), { recursive: true });
+    writeFileSync(settingsPath, "{ not json");
+    await expect(
+      apply([{ kind: "harness-config", model: "opus" }]),
+    ).rejects.toThrow();
+    expect(readFileSync(settingsPath, "utf8")).toBe("{ not json");
+  });
+});

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/harness-config-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/harness-config-plugin.ts
@@ -1,0 +1,136 @@
+import { existsSync, readFileSync } from "node:fs";
+import { z } from "zod";
+import type { DriverBinding, KindHandler, Plugin } from "agent-runtime-api";
+import {
+  createFileOps,
+  deleteNested,
+  setNested,
+  type FileDesired,
+} from "../infrastructure/file-ops.js";
+import {
+  createHarnessConfigStateStore,
+  type HarnessConfigStateStore,
+} from "../infrastructure/harness-config-state-store.js";
+import { expandHome } from "../../../core/expand-home.js";
+
+const IMPL_NAME = "harness-config";
+
+// The binding mirrors the shape of ACP session config — `model`, `mode`, and a
+// `configOptions` map keyed by ACP config id — and maps each to a dot-path in
+// the harness's own JSON config file. A field/option with no mapping is skipped
+// (logged): the driver never guesses where an unmapped value lives. Harnesses
+// whose config isn't JSON bind a custom impl instead.
+const bindingSchema = z.object({
+  impl: z.literal(IMPL_NAME),
+  file: z.string().min(1),
+  keys: z.object({
+    model: z.string().min(1).optional(),
+    mode: z.string().min(1).optional(),
+    configOptions: z.record(z.string().min(1), z.string().min(1)).optional(),
+  }),
+});
+
+export function createHarnessConfigPlugin(): Plugin {
+  const fileOps = createFileOps();
+
+  return {
+    name: IMPL_NAME,
+
+    bind(kind: string, binding: DriverBinding): KindHandler {
+      if (kind !== "harness-config") {
+        throw new Error(
+          `plugin "${IMPL_NAME}" does not handle kind "${kind}" — bind it to "harness-config" only`,
+        );
+      }
+      const parsed = bindingSchema.safeParse(binding);
+      if (!parsed.success) {
+        throw new Error(
+          `plugin "${IMPL_NAME}" invalid binding: ${parsed.error.message}`,
+        );
+      }
+      const { file, keys } = parsed.data;
+      let stateStore: HarnessConfigStateStore | undefined;
+
+      return async (contributions, ctx) => {
+        stateStore ??= createHarnessConfigStateStore(ctx.pluginStateDir);
+
+        // Merge the (at most one) harness-config contribution.
+        let model: string | undefined;
+        let mode: string | undefined;
+        const options: Record<string, string | boolean> = {};
+        for (const c of contributions) {
+          if (c.kind !== "harness-config") continue;
+          if (c.model !== undefined) model = c.model;
+          if (c.mode !== undefined) mode = c.mode;
+          Object.assign(options, c.configOptions ?? {});
+        }
+
+        // Resolve each value to its settings keyPath via the binding, mirroring
+        // the ACP config shape. Unmapped fields/options are skipped.
+        const desired = new Map<string, string | boolean>();
+        if (model !== undefined && keys.model) desired.set(keys.model, model);
+        if (mode !== undefined && keys.mode) desired.set(keys.mode, mode);
+        for (const [configId, value] of Object.entries(options)) {
+          const keyPath = keys.configOptions?.[configId];
+          if (!keyPath) {
+            ctx.log(`no key mapping for config option "${configId}" — skipping`);
+            continue;
+          }
+          desired.set(keyPath, value);
+        }
+
+        const targetPath = expandHome(file, ctx.agentHome);
+        const previouslyManaged = stateStore.getManaged();
+
+        // Don't materialize an empty file when there is nothing to write and
+        // nothing of ours to clean up.
+        if (
+          desired.size === 0 &&
+          previouslyManaged.length === 0 &&
+          !existsSync(targetPath)
+        ) {
+          return;
+        }
+
+        // Reconstruct the whole file: read existing (preserving user keys),
+        // drop our managed keys that are no longer desired, set the desired
+        // ones, write the full object back via overwrite so removals stick.
+        const obj = readJsonObject(targetPath);
+        for (const keyPath of previouslyManaged) {
+          if (!desired.has(keyPath)) deleteNested(obj, keyPath.split("."));
+        }
+        for (const [keyPath, value] of desired) {
+          setNested(obj, keyPath.split("."), value);
+        }
+
+        ctx.log(
+          `writing → ${targetPath}: ${desired.size === 0 ? "<none>" : [...desired.keys()].join(", ")}`,
+        );
+        await fileOps.apply(
+          new Map<string, FileDesired[] | null>([
+            [
+              targetPath,
+              [{ format: "json", mergeMode: "overwrite", content: obj }],
+            ],
+          ]),
+          { agentHome: ctx.agentHome, log: ctx.log },
+        );
+        stateStore.setManaged([...desired.keys()]);
+      };
+    },
+  };
+}
+
+// Reads and parses the JSON object at `path`. Missing file → {}. An existing
+// file that doesn't parse throws rather than silently clobbering the user's
+// hand-edited settings — the apply is recorded as a driver failure and retried.
+function readJsonObject(path: string): Record<string, unknown> {
+  if (!existsSync(path)) return {};
+  const parsed: unknown = JSON.parse(readFileSync(path, "utf8"));
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${path} is not a JSON object`);
+  }
+  return parsed as Record<string, unknown>;
+}
+
+export const HARNESS_CONFIG_PLUGIN_NAME = IMPL_NAME;

--- a/packages/agent-runtime/src/modules/runtime-channel/index.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/index.ts
@@ -8,6 +8,7 @@ export {
   type EnvStateStore,
 } from "./infrastructure/env-state-store.js";
 export { createFilePlugin } from "./drivers/file-plugin.js";
+export { createHarnessConfigPlugin } from "./drivers/harness-config-plugin.js";
 export { createMcpEntryPlugin } from "./drivers/mcp-entry-plugin.js";
 export {
   createSkillInstallPlugin,

--- a/packages/agent-runtime/src/modules/runtime-channel/infrastructure/file-ops.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/infrastructure/file-ops.ts
@@ -277,7 +277,7 @@ function commentSyntax(format: FileFormat): string {
   }
 }
 
-function setNested(
+export function setNested(
   obj: Record<string, unknown>,
   segs: string[],
   value: unknown,
@@ -289,6 +289,28 @@ function setNested(
     cur = cur[s] as Record<string, unknown>;
   }
   cur[segs[segs.length - 1]!] = value;
+}
+
+// Deletes the leaf at `segs`, leaving sibling keys intact, and prunes any
+// ancestor object that our deletion leaves empty (so removing
+// `permissions.defaultMode` from `{ permissions: { defaultMode } }` drops the
+// whole `permissions` key, but keeps it if the user has other keys under it).
+// No-op if any segment along the way is missing.
+export function deleteNested(
+  obj: Record<string, unknown>,
+  segs: string[],
+): void {
+  if (segs.length === 0) return;
+  const [head, ...rest] = segs as [string, ...string[]];
+  if (rest.length === 0) {
+    delete obj[head];
+    return;
+  }
+  const child = obj[head];
+  if (!child || typeof child !== "object") return;
+  const childObj = child as Record<string, unknown>;
+  deleteNested(childObj, rest);
+  if (Object.keys(childObj).length === 0) delete obj[head];
 }
 
 function stripTrailingSep(p: string): string {

--- a/packages/agent-runtime/src/modules/runtime-channel/infrastructure/harness-config-state-store.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/infrastructure/harness-config-state-store.ts
@@ -1,0 +1,36 @@
+import { join } from "node:path";
+import { z } from "zod";
+import { openJsonFile } from "../../../core/document-store.js";
+
+// Tracks the dot-paths the harness-config driver last wrote into the harness's
+// config file, so a field cleared by the user removes its key cleanly instead
+// of leaving a stale value behind. User-authored keys are never recorded here
+// and so are never touched on removal.
+const harnessConfigStateSchema = z.object({
+  managedKeyPaths: z.array(z.string()).catch([]).default([]),
+});
+
+export type HarnessConfigState = z.infer<typeof harnessConfigStateSchema>;
+
+export interface HarnessConfigStateStore {
+  getManaged(): string[];
+  setManaged(keyPaths: string[]): void;
+}
+
+export function createHarnessConfigStateStore(
+  stateDir: string,
+): HarnessConfigStateStore {
+  const store = openJsonFile(join(stateDir, "harness-config-state.json"), {
+    schema: harnessConfigStateSchema,
+    initial: () => ({ managedKeyPaths: [] }),
+  });
+
+  return {
+    getManaged() {
+      return store.read().managedKeyPaths;
+    },
+    setManaged(keyPaths) {
+      store.write({ managedKeyPaths: [...keyPaths].sort() });
+    },
+  };
+}

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -35,6 +35,7 @@ import {
   createEnvPlugin,
   createEnvStateStore,
   createFilePlugin,
+  createHarnessConfigPlugin,
   createMcpEntryPlugin,
   createSkillInstallPlugin,
 } from "./modules/runtime-channel/index.js";
@@ -129,6 +130,7 @@ const runtimeChannel = await composeRuntimeChannel({
     }),
     createFilePlugin(),
     createMcpEntryPlugin(),
+    createHarnessConfigPlugin(),
     createSkillInstallPlugin({ install: skillsService.install }),
   ],
 });

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -27,4 +27,7 @@ RUN ln -s ../.agents/skills /app/working-dir/.claude/skills &&\
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
+# Override platform-base's manifest to add the Claude-specific harness-config driver.
+COPY --chown=65532:0 runtime-manifest.yaml /app/runtime-manifest.yaml
+
 USER 65532

--- a/packages/agents/claude-code/runtime-manifest.yaml
+++ b/packages/agents/claude-code/runtime-manifest.yaml
@@ -1,0 +1,44 @@
+# Claude Code runtime manifest. Mirrors platform-base and adds the
+# `harness-config` driver, which writes the agent's persistent model/mode
+# default into Claude Code's own settings file ($HOME/.claude/settings.json).
+# This binding lives here rather than in platform-base because the file path
+# and key layout are Claude-specific — codex (TOML) and pi-agent
+# ($HOME/.pi/agent/settings.json) read elsewhere, so they must not advertise
+# this capability with Claude's path.
+#
+# Keep the other drivers in sync with platform-base/runtime-manifest.yaml until
+# the manifest schema supports inheritance.
+manifestVersion: 1
+
+drivers:
+  env:
+    impl: env
+
+  file:
+    impl: file
+
+  mcp-entry:
+    impl: mcp-entry
+    path: "$HOME/.mcp.json"
+    keyPath: mcpServers
+
+  skill-ref:
+    impl: skill-install
+    paths:
+      - "$HOME/.agents/skills"
+
+  # `harness-config` kind — persistent per-agent session defaults reconciled
+  # into Claude Code's user settings file. `keys` mirrors the ACP config shape
+  # (model / mode / configOptions) and maps each to its dot-path in
+  # settings.json; anything unmapped is skipped by the driver. The
+  # `thought_level` config option (ACP category) is read by Claude as
+  # `effortLevel`. configOptions keys are ACP config ids — must match what the
+  # adapter advertises.
+  harness-config:
+    impl: harness-config
+    file: "$HOME/.claude/settings.json"
+    keys:
+      model: "model"
+      mode: "permissions.defaultMode"
+      configOptions:
+        thought_level: "effortLevel"

--- a/packages/api-server-api/src/context.ts
+++ b/packages/api-server-api/src/context.ts
@@ -1,3 +1,4 @@
+import type { AgentSettingsService } from "./modules/agent-settings/types.js";
 import type { AgentsService } from "./modules/agents/types.js";
 import type { ApiKeysService, Scope } from "./modules/api-keys/types.js";
 import type { ApprovalsService } from "./modules/approvals/types.js";
@@ -32,6 +33,7 @@ export interface ApiContext {
   templates: TemplatesService;
   repos: ReposService;
   agents: AgentsService;
+  agentSettings: AgentSettingsService;
   schedules: SchedulesService;
   secrets: SecretsService;
   channels: ChannelsService;

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -24,6 +24,18 @@ export { repoSchema } from "./modules/repos/schemas.js";
 export type { Repo, RepoView, ReposService } from "./modules/repos/types.js";
 
 export type {
+  AgentSettings,
+  AgentSettingsInput,
+  AgentSettingsService,
+  AgentSettingsView,
+} from "./modules/agent-settings/types.js";
+export {
+  agentConfigOptionsSchema,
+  agentSettingsSchema,
+  agentSettingsViewSchema,
+} from "./modules/agent-settings/schemas.js";
+
+export type {
   Agent,
   AgentSpec,
   AgentState,

--- a/packages/api-server-api/src/modules/agent-settings/router.ts
+++ b/packages/api-server-api/src/modules/agent-settings/router.ts
@@ -1,0 +1,25 @@
+import { t } from "../../trpc.js";
+import {
+  agentSettingsGetInputSchema,
+  agentSettingsSchema,
+  agentSettingsSetInputSchema,
+  agentSettingsViewSchema,
+} from "./schemas.js";
+
+export const agentSettingsRouter = t.router({
+  get: t.procedure
+    .input(agentSettingsGetInputSchema)
+    .output(agentSettingsViewSchema)
+    .query(({ ctx, input }) => ctx.agentSettings.get(input.agentId)),
+
+  set: t.procedure
+    .input(agentSettingsSetInputSchema)
+    .output(agentSettingsSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.agentSettings.set(input.agentId, {
+        model: input.model,
+        mode: input.mode,
+        configOptions: input.configOptions,
+      }),
+    ),
+});

--- a/packages/api-server-api/src/modules/agent-settings/schemas.ts
+++ b/packages/api-server-api/src/modules/agent-settings/schemas.ts
@@ -1,0 +1,30 @@
+import { z } from "zod";
+
+/** configId -> select value (string) or boolean, mirroring ACP config options. */
+export const agentConfigOptionsSchema = z.record(
+  z.string().min(1),
+  z.union([z.string(), z.boolean()]),
+);
+
+export const agentSettingsSchema = z.object({
+  model: z.string().min(1).nullable(),
+  mode: z.string().min(1).nullable(),
+  configOptions: agentConfigOptionsSchema,
+});
+
+export const agentSettingsViewSchema = agentSettingsSchema.extend({
+  supported: z.boolean(),
+});
+
+export const agentSettingsGetInputSchema = z.object({
+  agentId: z.string().min(1),
+});
+
+// The UI sends the full intended state on every save; a `null` model/mode or
+// an absent configOption key clears that default.
+export const agentSettingsSetInputSchema = z.object({
+  agentId: z.string().min(1),
+  model: z.string().min(1).nullable().default(null),
+  mode: z.string().min(1).nullable().default(null),
+  configOptions: agentConfigOptionsSchema.default({}),
+});

--- a/packages/api-server-api/src/modules/agent-settings/types.ts
+++ b/packages/api-server-api/src/modules/agent-settings/types.ts
@@ -1,0 +1,25 @@
+/** An agent's persistent harness session defaults, mirroring the ACP config
+ *  shape: `model` is a modelId, `mode` is a modeId, and `configOptions` maps an
+ *  ACP configId (e.g. the `thought_level` option) to its select value or
+ *  boolean. `null` model/mode mean "no default, use the harness's own"; a
+ *  harness that doesn't expose an axis leaves it null/empty. */
+export interface AgentSettings {
+  model: string | null;
+  mode: string | null;
+  configOptions: Record<string, string | boolean>;
+}
+
+export type AgentSettingsInput = AgentSettings;
+
+/** What `get` returns: the saved defaults plus whether this agent's harness can
+ *  actually honor a persistent default (it advertises the `harness-config`
+ *  contribution). The UI hides the section when `supported` is false so it
+ *  never offers a default the harness would silently drop. */
+export interface AgentSettingsView extends AgentSettings {
+  supported: boolean;
+}
+
+export interface AgentSettingsService {
+  get(agentId: string): Promise<AgentSettingsView>;
+  set(agentId: string, input: AgentSettingsInput): Promise<AgentSettings>;
+}

--- a/packages/api-server-api/src/router.ts
+++ b/packages/api-server-api/src/router.ts
@@ -1,4 +1,5 @@
 import { t } from "./trpc.js";
+import { agentSettingsRouter } from "./modules/agent-settings/router.js";
 import { agentsRouter } from "./modules/agents/router.js";
 import { apiKeysRouter } from "./modules/api-keys/router.js";
 import { approvalsRouter } from "./modules/approvals/router.js";
@@ -18,6 +19,7 @@ export const appRouter = t.router({
   templates: templatesRouter,
   repos: reposRouter,
   agents: agentsRouter,
+  agentSettings: agentSettingsRouter,
   schedules: schedulesRouter,
   secrets: secretsRouter,
   channels: channelsRouter,

--- a/packages/api-server/src/__tests__/unit/agent-settings-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/agent-settings-service.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from "vitest";
+import type { AgentSettings } from "api-server-api";
+import { createAgentSettingsService } from "../../modules/agent-settings/services/agent-settings-service.js";
+import {
+  harnessConfigSupported,
+  type AgentSettingsRepository,
+} from "../../modules/agent-settings/infrastructure/agent-settings-repository.js";
+
+function makeHarness(opts?: {
+  stored?: AgentSettings | null;
+  supported?: boolean;
+  owned?: boolean;
+}) {
+  const calls = {
+    upserts: [] as Array<{ agentId: string; settings: AgentSettings }>,
+    bumps: [] as string[],
+    enqueues: [] as string[],
+  };
+  const repo: AgentSettingsRepository = {
+    get: async () => opts?.stored ?? null,
+    upsert: async (agentId, settings) => {
+      calls.upserts.push({ agentId, settings });
+    },
+    deleteByAgent: async () => {},
+    supportsHarnessConfig: async () => opts?.supported ?? true,
+  };
+  const service = createAgentSettingsService({
+    repo,
+    runtimeMutator: {
+      bump: async (agentId) => {
+        calls.bumps.push(agentId);
+        return 1;
+      },
+      enqueueAfterCommit: async (agentId) => {
+        calls.enqueues.push(agentId);
+      },
+    },
+    isOwnedAgent: async () => opts?.owned ?? true,
+  });
+  return { service, calls };
+}
+
+const EMPTY: AgentSettings = { model: null, mode: null, configOptions: {} };
+
+describe("agent-settings service", () => {
+  it("returns empty defaults + supported flag when nothing is stored", async () => {
+    const { service } = makeHarness({ stored: null, supported: true });
+    expect(await service.get("a1")).toEqual({ ...EMPTY, supported: true });
+  });
+
+  it("returns stored settings with the harness's support flag", async () => {
+    const stored: AgentSettings = {
+      model: "opus",
+      mode: "plan",
+      configOptions: { thought_level: "high" },
+    };
+    const { service } = makeHarness({ stored, supported: false });
+    expect(await service.get("a1")).toEqual({ ...stored, supported: false });
+  });
+
+  it("rejects get/set for an agent the caller doesn't own", async () => {
+    const { service, calls } = makeHarness({ owned: false });
+    await expect(service.get("a1")).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    await expect(service.set("a1", EMPTY)).rejects.toMatchObject({
+      code: "NOT_FOUND",
+    });
+    expect(calls.upserts).toHaveLength(0);
+    expect(calls.bumps).toHaveLength(0);
+  });
+
+  it("upserts then re-delivers state (bump + enqueue) on set", async () => {
+    const { service, calls } = makeHarness({ owned: true });
+    const input: AgentSettings = {
+      model: "sonnet",
+      mode: null,
+      configOptions: {},
+    };
+    const result = await service.set("a1", input);
+    expect(result).toEqual(input);
+    expect(calls.upserts).toEqual([{ agentId: "a1", settings: input }]);
+    expect(calls.bumps).toEqual(["a1"]);
+    expect(calls.enqueues).toEqual(["a1"]);
+  });
+});
+
+describe("harnessConfigSupported", () => {
+  it("treats unknown capabilities as supported (agent not booted yet)", () => {
+    expect(harnessConfigSupported(null)).toBe(true);
+    expect(harnessConfigSupported(undefined)).toBe(true);
+  });
+
+  it("is true only when the agent advertises the harness-config contribution", () => {
+    expect(
+      harnessConfigSupported({ contributions: ["file", "harness-config"] }),
+    ).toBe(true);
+    expect(
+      harnessConfigSupported({ contributions: ["file", "mcp-entry"] }),
+    ).toBe(false);
+    expect(harnessConfigSupported({ contributions: "nope" })).toBe(false);
+    expect(harnessConfigSupported({})).toBe(false);
+  });
+});

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -26,6 +26,7 @@ import {
   createKeycloakUserDirectory,
   type ContributionsSettledPort,
 } from "../../modules/agents/index.js";
+import { composeAgentSettingsModule } from "../../modules/agent-settings/index.js";
 import { composeTemplatesModule } from "../../modules/templates/index.js";
 import { createTemplatesRepository } from "../../modules/templates/infrastructure/templates-repository.js";
 import { createReposRepository } from "../../modules/repos/infrastructure/repos-repository.js";
@@ -737,6 +738,11 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       runtimeMutator,
       templatesRepo,
     );
+    const { service: agentSettings } = composeAgentSettingsModule({
+      db,
+      runtimeMutator,
+      isOwnedAgent,
+    });
     const isAgentOwnedBy = async (agentId: string, ownerSub: string) =>
       (await agents.get(agentId)) !== null && ownerSub === user.sub;
     const { service: egressRules } = composeEgressRulesModule({
@@ -768,6 +774,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
         templates,
         repos: reposService,
         agents,
+        agentSettings,
         schedules,
         secrets,
         channels: { available: channelManager.availableChannels() },

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -22,6 +22,10 @@ import {
   parseSeedSources,
   startSkillsCleanupSaga,
 } from "./modules/skills/index.js";
+import {
+  createAgentSettingsRepository,
+  startAgentSettingsCleanupSaga,
+} from "./modules/agent-settings/index.js";
 import { createK8sClient } from "./modules/agents/infrastructure/k8s.js";
 import { stripStaleModelPins } from "./modules/secrets/infrastructure/strip-stale-model-pins.js";
 import { createPostgresState } from "@chat-adapter/state-pg";
@@ -175,6 +179,9 @@ const channelCleanupSub = startChannelCleanupSaga(
 );
 const skillsCleanupSub = startSkillsCleanupSaga((agentId) =>
   createAgentSkillsRepository(db).deleteByAgent(agentId),
+);
+const agentSettingsCleanupSub = startAgentSettingsCleanupSaga((agentId) =>
+  createAgentSettingsRepository(db).deleteByAgent(agentId),
 );
 const seedSources = parseSeedSources(config.skillSourcesSeed);
 
@@ -516,6 +523,7 @@ async function shutdown() {
   channelSecretCleanupSub.unsubscribe();
   channelCleanupSub.unsubscribe();
   skillsCleanupSub.unsubscribe();
+  agentSettingsCleanupSub.unsubscribe();
   onForeignReplySub.unsubscribe();
   onChannelTurnRelayedSub.unsubscribe();
   usage.stop();

--- a/packages/api-server/src/modules/agent-settings/compose.ts
+++ b/packages/api-server/src/modules/agent-settings/compose.ts
@@ -1,0 +1,19 @@
+import type { Db } from "db";
+import type { AgentSettingsService } from "api-server-api";
+import { createAgentSettingsRepository } from "./infrastructure/agent-settings-repository.js";
+import { createAgentSettingsService } from "./services/agent-settings-service.js";
+import type { RuntimeMutator } from "../runtime-delivery/index.js";
+
+export function composeAgentSettingsModule(deps: {
+  db: Db;
+  runtimeMutator: RuntimeMutator;
+  isOwnedAgent: (agentId: string) => Promise<boolean>;
+}): { service: AgentSettingsService } {
+  return {
+    service: createAgentSettingsService({
+      repo: createAgentSettingsRepository(deps.db),
+      runtimeMutator: deps.runtimeMutator,
+      isOwnedAgent: deps.isOwnedAgent,
+    }),
+  };
+}

--- a/packages/api-server/src/modules/agent-settings/index.ts
+++ b/packages/api-server/src/modules/agent-settings/index.ts
@@ -1,0 +1,6 @@
+export { composeAgentSettingsModule } from "./compose.js";
+export { startAgentSettingsCleanupSaga } from "./sagas/agent-settings-cleanup.js";
+export {
+  createAgentSettingsRepository,
+  type AgentSettingsRepository,
+} from "./infrastructure/agent-settings-repository.js";

--- a/packages/api-server/src/modules/agent-settings/infrastructure/agent-settings-repository.ts
+++ b/packages/api-server/src/modules/agent-settings/infrastructure/agent-settings-repository.ts
@@ -1,0 +1,88 @@
+import type { Db } from "db";
+import { agents, agentSettings, eq } from "db";
+import { agentConfigOptionsSchema, type AgentSettings } from "api-server-api";
+
+export interface AgentSettingsRepository {
+  get(agentId: string): Promise<AgentSettings | null>;
+  upsert(agentId: string, settings: AgentSettings): Promise<void>;
+  deleteByAgent(agentId: string): Promise<void>;
+  /** Whether the agent has advertised the `harness-config` contribution. An
+   *  agent that hasn't reported capabilities yet (never booted) is treated as
+   *  supported, so the UI doesn't flicker the section off on first start. */
+  supportsHarnessConfig(agentId: string): Promise<boolean>;
+}
+
+/** Postgres-backed per-agent harness defaults, keyed by agentId. Lifecycle is
+ *  bounded by the agent: the row goes away when the agent is deleted, via the
+ *  AgentDeleted saga in this module. */
+export function createAgentSettingsRepository(db: Db): AgentSettingsRepository {
+  return {
+    async get(agentId) {
+      const [row] = await db
+        .select()
+        .from(agentSettings)
+        .where(eq(agentSettings.agentId, agentId));
+      if (!row) return null;
+      return {
+        model: row.model,
+        mode: row.mode,
+        configOptions: normalizeConfigOptions(row.configOptions),
+      };
+    },
+
+    async upsert(agentId, settings) {
+      const values = {
+        agentId,
+        model: settings.model,
+        mode: settings.mode,
+        configOptions: settings.configOptions,
+        updatedAt: new Date(),
+      };
+      await db
+        .insert(agentSettings)
+        .values(values)
+        .onConflictDoUpdate({
+          target: agentSettings.agentId,
+          set: {
+            model: values.model,
+            mode: values.mode,
+            configOptions: values.configOptions,
+            updatedAt: values.updatedAt,
+          },
+        });
+    },
+
+    async deleteByAgent(agentId) {
+      await db.delete(agentSettings).where(eq(agentSettings.agentId, agentId));
+    },
+
+    async supportsHarnessConfig(agentId) {
+      const [row] = await db
+        .select({ capabilities: agents.runtimeCapabilities })
+        .from(agents)
+        .where(eq(agents.id, agentId));
+      return harnessConfigSupported(row?.capabilities);
+    },
+  };
+}
+
+/** Decide whether an agent's advertised capabilities include `harness-config`.
+ *  Unknown capabilities (agent never booted, or no row) are treated as
+ *  supported so the UI section doesn't flicker off on first start. */
+export function harnessConfigSupported(capabilities: unknown): boolean {
+  if (capabilities == null) return true;
+  const caps = capabilities as { contributions?: unknown };
+  return (
+    Array.isArray(caps.contributions) &&
+    caps.contributions.includes("harness-config")
+  );
+}
+
+/** The jsonb column is `unknown` to Drizzle; validate defensively on read so a
+ *  hand-edited row can never crash the state build. */
+export function normalizeConfigOptions(
+  raw: unknown,
+): Record<string, string | boolean> {
+  const parsed = agentConfigOptionsSchema.safeParse(raw);
+  return parsed.success ? parsed.data : {};
+}

--- a/packages/api-server/src/modules/agent-settings/sagas/agent-settings-cleanup.ts
+++ b/packages/api-server/src/modules/agent-settings/sagas/agent-settings-cleanup.ts
@@ -1,0 +1,31 @@
+/**
+ * Reacts to AgentDeleted — deletes the agent's harness-config row from
+ * Postgres. Mirrors the skills-cleanup saga.
+ */
+import type { Subscription } from "rxjs";
+import { mergeMap } from "rxjs/operators";
+import {
+  events$,
+  ofType,
+  EventType,
+  type AgentDeleted,
+} from "../../../events.js";
+
+export function startAgentSettingsCleanupSaga(
+  deleteAgentSettings: (agentId: string) => Promise<void>,
+): Subscription {
+  return events$()
+    .pipe(
+      ofType<AgentDeleted>(EventType.AgentDeleted),
+      mergeMap(async (event) => {
+        try {
+          await deleteAgentSettings(event.agentId);
+        } catch (err) {
+          process.stderr.write(
+            `[agent-settings-cleanup] failed for ${event.agentId}: ${err}\n`,
+          );
+        }
+      }),
+    )
+    .subscribe();
+}

--- a/packages/api-server/src/modules/agent-settings/services/agent-settings-service.ts
+++ b/packages/api-server/src/modules/agent-settings/services/agent-settings-service.ts
@@ -1,0 +1,49 @@
+import { TRPCError } from "@trpc/server";
+import type {
+  AgentSettings,
+  AgentSettingsInput,
+  AgentSettingsService,
+} from "api-server-api";
+import type { AgentSettingsRepository } from "../infrastructure/agent-settings-repository.js";
+import type { RuntimeMutator } from "../../runtime-delivery/index.js";
+
+const EMPTY: AgentSettings = { model: null, mode: null, configOptions: {} };
+
+export function createAgentSettingsService(deps: {
+  repo: AgentSettingsRepository;
+  runtimeMutator: RuntimeMutator;
+  isOwnedAgent: (agentId: string) => Promise<boolean>;
+}): AgentSettingsService {
+  async function requireOwned(agentId: string): Promise<void> {
+    if (!(await deps.isOwnedAgent(agentId))) {
+      throw new TRPCError({ code: "NOT_FOUND", message: "agent not found" });
+    }
+  }
+
+  return {
+    async get(agentId) {
+      await requireOwned(agentId);
+      const [settings, supported] = await Promise.all([
+        deps.repo.get(agentId),
+        deps.repo.supportsHarnessConfig(agentId),
+      ]);
+      return { ...(settings ?? EMPTY), supported };
+    },
+
+    async set(agentId, input: AgentSettingsInput) {
+      await requireOwned(agentId);
+      const settings: AgentSettings = {
+        model: input.model,
+        mode: input.mode,
+        configOptions: input.configOptions,
+      };
+      await deps.repo.upsert(agentId, settings);
+      // Re-deliver the agent's desired state: the state-builder picks the new
+      // row up as a `harness-config` contribution. Mirrors connection grants —
+      // the user-facing response never waits on agent reachability.
+      await deps.runtimeMutator.bump(agentId, []);
+      await deps.runtimeMutator.enqueueAfterCommit(agentId);
+      return settings;
+    },
+  };
+}

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -184,6 +184,7 @@ function substituteHostInContribution(
     case "file":
     case "mcp-entry":
     case "skill-ref":
+    case "harness-config":
       return c;
   }
 }

--- a/packages/api-server/src/modules/runtime-delivery/domain/contribution-hash.ts
+++ b/packages/api-server/src/modules/runtime-delivery/domain/contribution-hash.ts
@@ -27,6 +27,9 @@ function keyFor(c: Contribution): string {
       return `mcp-entry:${c.name}`;
     case "skill-ref":
       return `skill-ref:${c.name}@${c.version}@${c.sourceUrl}`;
+    case "harness-config":
+      // Singleton per agent — a constant key collapses any duplicates.
+      return "harness-config";
   }
 }
 

--- a/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
@@ -1,10 +1,12 @@
 import {
   eq,
   type Db,
+  agentSettings,
   agentSkills,
   connectionGrants,
   connections as connectionsTable,
 } from "db";
+import { agentConfigOptionsSchema } from "api-server-api";
 import {
   contribution as contributionSchema,
   event as eventSchema,
@@ -53,13 +55,20 @@ export function createStateBuilder(deps: {
 }): StateBuilder {
   return {
     async build(agentId, capabilities): Promise<StatePayload> {
-      const [granted, skills, secretEnv] = await Promise.all([
+      const [granted, skills, harnessConfig, secretEnv] = await Promise.all([
         readGrantedContributions(deps.db, agentId),
         readSkillRefContributions(deps.db, agentId),
+        readHarnessConfigContributions(deps.db, agentId),
         deps.secretEnv.forAgent(agentId),
       ]);
       const builtin = deps.builtin.for(agentId);
-      const rawContribs = [...builtin, ...granted, ...skills, ...secretEnv];
+      const rawContribs = [
+        ...builtin,
+        ...granted,
+        ...skills,
+        ...harnessConfig,
+        ...secretEnv,
+      ];
       const pending = await deps.outboxRepo.pendingEvents(agentId);
       const events = pending.map(toEvent).filter((e): e is Event => e !== null);
       const filtered = filterByCapabilities(capabilities, rawContribs, events);
@@ -122,6 +131,39 @@ async function readSkillRefContributions(
       version: r.version,
     }),
   );
+}
+
+/** The agent's persistent harness defaults, as a single `harness-config`
+ *  contribution. Omitted entirely when nothing is set, so the driver removes
+ *  any keys it previously wrote. */
+async function readHarnessConfigContributions(
+  db: Db,
+  agentId: string,
+): Promise<Contribution[]> {
+  const [row] = await db
+    .select({
+      model: agentSettings.model,
+      mode: agentSettings.mode,
+      configOptions: agentSettings.configOptions,
+    })
+    .from(agentSettings)
+    .where(eq(agentSettings.agentId, agentId));
+  if (!row) return [];
+
+  const parsedOptions = agentConfigOptionsSchema.safeParse(row.configOptions);
+  const configOptions = parsedOptions.success ? parsedOptions.data : {};
+  const hasOptions = Object.keys(configOptions).length > 0;
+
+  if (row.model === null && row.mode === null && !hasOptions) return [];
+
+  return [
+    {
+      kind: "harness-config",
+      ...(row.model !== null ? { model: row.model } : {}),
+      ...(row.mode !== null ? { mode: row.mode } : {}),
+      ...(hasOptions ? { configOptions } : {}),
+    },
+  ];
 }
 
 function toEvent(row: PendingEventRow): Event | null {

--- a/packages/db/drizzle/0003_lying_amazoness.sql
+++ b/packages/db/drizzle/0003_lying_amazoness.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "agent_settings" (
+	"agent_id" text PRIMARY KEY NOT NULL,
+	"model" text,
+	"mode" text,
+	"config_options" jsonb,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1683 @@
+{
+  "id": "78a4ba49-757f-4b79-ba2a-f48a2d72fd5c",
+  "prevId": "2055223c-ee0b-444f-91ba-96fde811284d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_events": {
+      "name": "activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "activity_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_events_type_occurred_idx": {
+          "name": "activity_events_type_occurred_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_actor_occurred_idx": {
+          "name": "activity_events_actor_occurred_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_events\".\"actor_sub\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_surface_occurred_idx": {
+          "name": "activity_events_surface_occurred_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_auth_dedup_idx": {
+          "name": "activity_events_auth_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_trunc('day', \"occurred_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"activity_events\".\"type\" = 'auth'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor_roles": {
+      "name": "actor_roles",
+      "schema": "",
+      "columns": {
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_core": {
+          "name": "is_core",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_settings": {
+      "name": "agent_settings",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config_options": {
+          "name": "config_options",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_publishes": {
+      "name": "agent_skill_publishes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_publishes_agent_idx": {
+          "name": "agent_skill_publishes_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skills": {
+      "name": "agent_skills",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skills_agent_idx": {
+          "name": "agent_skills_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_source_name_pk": {
+          "name": "agent_skills_agent_id_source_name_pk",
+          "columns": [
+            "agent_id",
+            "source",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_protocol_version": {
+          "name": "runtime_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_capabilities": {
+          "name": "runtime_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_last_hello_at": {
+          "name": "runtime_last_hello_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_agent_version": {
+          "name": "runtime_agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_idx": {
+          "name": "agents_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allowed_users": {
+      "name": "allowed_users",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "allowed_users_agent_id_keycloak_sub_pk": {
+          "name": "allowed_users_agent_id_keycloak_sub_pk",
+          "columns": [
+            "agent_id",
+            "keycloak_sub"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_hash_idx": {
+          "name": "api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_owner_idx": {
+          "name": "api_keys_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_keys\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channels_agent_type_idx": {
+          "name": "channels_agent_type_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channels_slack_channel_unique_idx": {
+          "name": "channels_slack_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "(\"config\"->>'slackChannelId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"channels\".\"type\" = 'slack'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_grants": {
+      "name": "connection_grants",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_grants_agent_idx": {
+          "name": "connection_grants_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_connection_id_agent_id_pk": {
+          "name": "connection_grants_connection_id_agent_id_pk",
+          "columns": [
+            "connection_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributions": {
+          "name": "contributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connections_owner_idx": {
+          "name": "connections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_owner_name_unique_idx": {
+          "name": "connections_owner_name_unique_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.egress_rules": {
+      "name": "egress_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "egress_rules_lookup_idx": {
+          "name": "egress_rules_lookup_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"egress_rules\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "egress_rules_source_idx": {
+          "name": "egress_rules_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"egress_rules\".\"status\" = 'active' AND \"egress_rules\".\"source\" != 'manual'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_links": {
+      "name": "identity_links",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "identity_links_provider_external_user_id_pk": {
+          "name": "identity_links_provider_external_user_id_pk",
+          "columns": [
+            "provider",
+            "external_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_approvals": {
+      "name": "pending_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pending_approvals_owner_status_idx": {
+          "name": "pending_approvals_owner_status_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_agent_status_idx": {
+          "name": "pending_approvals_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_undelivered_idx": {
+          "name": "pending_approvals_undelivered_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'resolved' AND delivered_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_events": {
+      "name": "runtime_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runtime_events_agent_pending_idx": {
+          "name": "runtime_events_agent_pending_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_events_expiry_idx": {
+          "name": "runtime_events_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_state_outbox": {
+      "name": "runtime_state_outbox",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_settled_version": {
+          "name": "last_settled_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_hash": {
+          "name": "last_applied_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_at": {
+          "name": "last_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apply_failures": {
+          "name": "apply_failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "apply_attempts": {
+          "name": "apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "runtime_state_outbox_retry_idx": {
+          "name": "runtime_state_outbox_retry_idx",
+          "columns": [
+            {
+              "expression": "apply_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_state_outbox\".\"apply_failures\" <> '[]'::jsonb OR \"runtime_state_outbox\".\"last_settled_version\" < \"runtime_state_outbox\".\"version\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_result": {
+          "name": "last_fired_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_agent_owner_idx": {
+          "name": "schedules_agent_owner_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_enabled_idx": {
+          "name": "schedules_enabled_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"schedules\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_sources": {
+      "name": "skill_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_sources_owner_git_url_idx": {
+          "name": "skill_sources_owner_git_url_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_sources_owner_idx": {
+          "name": "skill_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_threads": {
+      "name": "telegram_threads",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telegram_threads_agent_id_thread_id_pk": {
+          "name": "telegram_threads_agent_id_thread_id_pk",
+          "columns": [
+            "agent_id",
+            "thread_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms_acceptances": {
+      "name": "terms_acceptances",
+      "schema": "",
+      "columns": {
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "terms_acceptances_sub_version_pk": {
+          "name": "terms_acceptances_sub_version_pk",
+          "columns": [
+            "sub",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_outcome": {
+      "name": "activity_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781512361632,
       "tag": "0002_marvelous_dragon_man",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1781676958709,
+      "tag": "0003_lying_amazoness",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -7,6 +7,7 @@ export {
   telegramThreads,
   skillSources,
   agentSkills,
+  agentSettings,
   agentSkillPublishes,
   egressRules,
   pendingApprovals,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -189,6 +189,25 @@ export const agentSkills = pgTable(
   ],
 );
 
+/** Per-agent harness session defaults chosen in the Config panel, mirroring the
+ *  ACP config shape: `model`, `mode`, and `config_options` (a configId -> value
+ *  map that includes the `thought_level` option). model/mode are nullable; a
+ *  harness that doesn't expose an axis leaves it null/empty. One row per agent.
+ *  The state-builder emits these as a `harness-config` contribution that the
+ *  agent-runtime reconciles into the harness's own config file. This is
+ *  Application State, not derived from K8s: it must survive pod restarts and
+ *  apply to scheduled/headless turns, so it lives in Postgres rather than on the
+ *  agent CR. */
+export const agentSettings = pgTable("agent_settings", {
+  agentId: text("agent_id").primaryKey(),
+  model: text("model"),
+  mode: text("mode"),
+  configOptions: jsonb("config_options"),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
 /** Append-only log of semantically-meaningful platform activity (auth, channel turns).
  *  `actor_sub` is HMAC-SHA256(keycloak_sub, ACTIVITY_HMAC_KEY) — pseudonymized
  *  (not anonymized) at the storage boundary; same key joins to actor_roles and

--- a/packages/ui/src/modules/agents/api/agent-settings.ts
+++ b/packages/ui/src/modules/agents/api/agent-settings.ts
@@ -1,0 +1,23 @@
+import { skipToken, useMutation, useQuery } from "@tanstack/react-query";
+
+import { trpc } from "../../../trpc.js";
+
+/** An agent's saved harness defaults (model / mode), plus whether the harness
+ *  can honor them. Options the user picks among come from ACP session config
+ *  (the Zustand session-config slice), not from here. */
+export function useAgentSettings(agentId: string | null) {
+  return useQuery({
+    ...trpc.agentSettings.get.queryOptions(agentId ? { agentId } : skipToken),
+    retry: false,
+  });
+}
+
+export function useSetAgentSettings() {
+  return useMutation({
+    ...trpc.agentSettings.set.mutationOptions(),
+    meta: {
+      invalidates: [trpc.agentSettings.get.queryKey()],
+      errorToast: "Failed to save model settings",
+    },
+  });
+}

--- a/packages/ui/src/modules/sessions/components/config-section.tsx
+++ b/packages/ui/src/modules/sessions/components/config-section.tsx
@@ -1,0 +1,29 @@
+import { ChevronDown, ChevronRight } from "lucide-react";
+import { useState } from "react";
+
+/** Collapsible section used by the Config panel (Schedules, Channels, Skills,
+ *  Model). Shared so a conditional section can render its own header only when
+ *  it has something to show. */
+export function Section({
+  title,
+  defaultOpen = true,
+  children,
+}: {
+  title: string;
+  defaultOpen?: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  return (
+    <div className="mb-1">
+      <button
+        className="flex items-center gap-2 w-full px-4 py-2.5 text-[11px] font-bold uppercase tracking-[0.05em] text-text-muted hover:text-text-secondary transition-colors bg-surface-raised"
+        onClick={() => setOpen((o) => !o)}
+      >
+        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+        {title}
+      </button>
+      {open && <div className="border-t border-border-light">{children}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/configuration-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/configuration-panel.tsx
@@ -1,34 +1,9 @@
-import { ChevronDown, ChevronRight } from "lucide-react";
-import { useState } from "react";
-
 import type { AgentState } from "../../../types.js";
 import { SchedulesPanel } from "../../schedules/components/schedules-panel.js";
 import { ChannelsPanel } from "./channels-panel.js";
+import { Section } from "./config-section.js";
+import { ModelSettingsPanel } from "./model-settings-panel.js";
 import { SkillsPanel } from "./skills-panel.js";
-
-function Section({
-  title,
-  defaultOpen = true,
-  children,
-}: {
-  title: string;
-  defaultOpen?: boolean;
-  children: React.ReactNode;
-}) {
-  const [open, setOpen] = useState(defaultOpen);
-  return (
-    <div className="mb-1">
-      <button
-        className="flex items-center gap-2 w-full px-4 py-2.5 text-[11px] font-bold uppercase tracking-[0.05em] text-text-muted hover:text-text-secondary transition-colors bg-surface-raised"
-        onClick={() => setOpen((o) => !o)}
-      >
-        {open ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
-        {title}
-      </button>
-      {open && <div className="border-t border-border-light">{children}</div>}
-    </div>
-  );
-}
 
 export function ConfigurationPanel({
   onResumeSession,
@@ -59,6 +34,8 @@ export function ConfigurationPanel({
           onOpenFile={onOpenFile}
         />
       </Section>
+
+      <ModelSettingsPanel agentId={agentId} />
     </div>
   );
 }

--- a/packages/ui/src/modules/sessions/components/model-settings-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/model-settings-panel.tsx
@@ -1,0 +1,236 @@
+import type { SessionConfigOption } from "@agentclientprotocol/sdk/dist/acp.js";
+import { Check } from "lucide-react";
+
+import { useStore } from "../../../store.js";
+import {
+  useAgentSettings,
+  useSetAgentSettings,
+} from "../../agents/api/agent-settings.js";
+import { Section } from "./config-section.js";
+import { flattenSelectOptions } from "./session-config-popover.js";
+
+type SelectConfigOption = Extract<SessionConfigOption, { type: "select" }>;
+
+interface Choice {
+  id: string;
+  name: string;
+  description?: string | null;
+}
+
+/**
+ * The agent's persistent model/mode/config default, set from the Config panel
+ * and written through to the harness's own config file. The per-session picker
+ * in the composer (SessionConfigBar) overrides this default for one
+ * conversation; this section sets what every new/scheduled session starts from.
+ *
+ * Shape mirrors ACP session config: `model` and `mode` are dedicated axes, and
+ * everything else (e.g. the `thought_level` option) is a generic config option.
+ * Options come from the ACP session-config slice; saved values come from the
+ * server. Hidden when the harness can't honor a persistent default.
+ */
+export function ModelSettingsPanel({ agentId }: { agentId: string | null }) {
+  const models = useStore((s) => s.sessionModels);
+  const modes = useStore((s) => s.sessionModes);
+  const configOptions = useStore((s) => s.sessionConfigOptions);
+  const { data } = useAgentSettings(agentId);
+  const setSettings = useSetAgentSettings();
+
+  if (!agentId || !data || !data.supported) return null;
+
+  // Model arrives either as the legacy session-model axis or as a
+  // `category: "model"` select option — normalize both (same as the popover).
+  const modelOption = configOptions.find(
+    (o): o is SelectConfigOption =>
+      o.category === "model" && o.type === "select",
+  );
+  const modelChoices: Choice[] = models
+    ? models.availableModels.map((m) => ({
+        id: m.modelId,
+        name: m.name,
+        description: m.description,
+      }))
+    : modelOption
+      ? flattenSelectOptions(modelOption.options).map((o) => ({
+          id: o.value,
+          name: o.name,
+          description: o.description,
+        }))
+      : [];
+  const modeChoices: Choice[] =
+    modes?.availableModes.map((m) => ({
+      id: m.id,
+      name: m.name,
+      description: m.description,
+    })) ?? [];
+  // Every other select option (e.g. `thought_level`) — model/mode have their
+  // own groups above, so exclude those categories to avoid rendering twice.
+  // Boolean options are persistable (the contribution/driver accept booleans)
+  // but not yet surfaced here as a saved default; they remain a live per-session
+  // toggle in the composer popover. Deferred until a harness ships one.
+  const extraOptions = configOptions.filter(
+    (o): o is SelectConfigOption =>
+      o.type === "select" && o.category !== "model" && o.category !== "mode",
+  );
+
+  if (
+    modelChoices.length === 0 &&
+    modeChoices.length === 0 &&
+    extraOptions.length === 0
+  ) {
+    return (
+      <Section title="Model">
+        <div className="px-4 py-3 text-[12px] text-text-muted">
+          Start a session to load the options this agent offers.
+        </div>
+      </Section>
+    );
+  }
+
+  const persist = (patch: {
+    model?: string | null;
+    mode?: string | null;
+    configOptions?: Record<string, string | boolean>;
+  }) =>
+    setSettings.mutate({
+      agentId,
+      model: data.model,
+      mode: data.mode,
+      configOptions: data.configOptions,
+      ...patch,
+    });
+
+  return (
+    <Section title="Model">
+      {modelChoices.length > 0 && (
+        <OptionGroup
+          title="Model"
+          choices={modelChoices}
+          value={data.model}
+          onSelect={(id) => persist({ model: id })}
+        />
+      )}
+      {modeChoices.length > 0 && (
+        <OptionGroup
+          title="Mode"
+          choices={modeChoices}
+          value={data.mode}
+          onSelect={(id) => persist({ mode: id })}
+        />
+      )}
+      {extraOptions.map((option) => (
+        <ConfigOptionGroup
+          key={option.id}
+          option={option}
+          configOptions={data.configOptions}
+          onChange={(next) => persist({ configOptions: next })}
+        />
+      ))}
+    </Section>
+  );
+}
+
+function ConfigOptionGroup({
+  option,
+  configOptions,
+  onChange,
+}: {
+  option: SelectConfigOption;
+  configOptions: Record<string, string | boolean>;
+  onChange: (next: Record<string, string | boolean>) => void;
+}) {
+  const choices: Choice[] = flattenSelectOptions(option.options).map((o) => ({
+    id: o.value,
+    name: o.name,
+    description: o.description,
+  }));
+  const saved = configOptions[option.id];
+  const current = typeof saved === "string" ? saved : null;
+
+  const select = (id: string | null) => {
+    const next = { ...configOptions };
+    if (id === null) delete next[option.id];
+    else next[option.id] = id;
+    onChange(next);
+  };
+
+  return (
+    <OptionGroup
+      title={option.name}
+      choices={choices}
+      value={current}
+      onSelect={select}
+    />
+  );
+}
+
+function OptionGroup({
+  title,
+  choices,
+  value,
+  onSelect,
+}: {
+  title: string;
+  choices: Choice[];
+  value: string | null;
+  onSelect: (id: string | null) => void;
+}) {
+  return (
+    <div className="border-b border-border-light last:border-b-0">
+      <div className="px-4 pt-3 pb-1 text-[10px] font-bold uppercase tracking-[0.05em] text-text-muted">
+        {title}
+      </div>
+      <OptionRow
+        label="Not set"
+        description="No saved default — the harness picks on its own"
+        active={value === null}
+        onClick={() => onSelect(null)}
+      />
+      {choices.map((c) => (
+        <OptionRow
+          key={c.id}
+          label={c.name}
+          detail={c.id}
+          description={c.description}
+          active={c.id === value}
+          onClick={() => onSelect(c.id)}
+        />
+      ))}
+    </div>
+  );
+}
+
+function OptionRow({
+  label,
+  detail,
+  description,
+  active,
+  onClick,
+}: {
+  label: string;
+  detail?: string;
+  description?: string | null;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      className={`flex items-center gap-2 w-full px-4 py-2 text-[13px] text-left transition-colors ${active ? "text-accent bg-accent-light font-semibold" : "text-text hover:bg-surface-raised"}`}
+      onClick={onClick}
+    >
+      {active && <Check size={12} className="shrink-0" />}
+      <div className={active ? "" : "ml-[20px]"}>
+        <div>{label}</div>
+        {detail && (
+          <div className="text-[11px] text-text-muted font-normal font-mono">
+            {detail}
+          </div>
+        )}
+        {description && (
+          <div className="text-[11px] text-text-muted font-normal">
+            {description}
+          </div>
+        )}
+      </div>
+    </button>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/session-config-popover.tsx
+++ b/packages/ui/src/modules/sessions/components/session-config-popover.tsx
@@ -11,38 +11,6 @@ import { createPortal } from "react-dom";
 import { runAction } from "../../../lib/query-helpers.js";
 import { useStore } from "../../../store.js";
 
-function prefKey(agentId: string, key: string) {
-  return `platform-pref:${agentId}:${key}`;
-}
-
-function savePreference(agentId: string, key: string, value: string) {
-  try {
-    localStorage.setItem(prefKey(agentId, key), value);
-  } catch {}
-}
-
-export function getSavedPreferences(agentId: string): {
-  model?: string;
-  mode?: string;
-  config: Record<string, string>;
-} {
-  const prefix = `platform-pref:${agentId}:config:`;
-  const config: Record<string, string> = {};
-  try {
-    for (let i = 0; i < localStorage.length; i++) {
-      const key = localStorage.key(i);
-      if (key?.startsWith(prefix)) {
-        config[key.slice(prefix.length)] = localStorage.getItem(key)!;
-      }
-    }
-  } catch {}
-  return {
-    model: localStorage.getItem(prefKey(agentId, "model")) ?? undefined,
-    mode: localStorage.getItem(prefKey(agentId, "mode")) ?? undefined,
-    config,
-  };
-}
-
 /**
  * Inline session config controls: mode label + popover for modes, config options, and model.
  * All dynamically driven from ACP session state — renders nothing if the agent doesn't report capabilities.
@@ -55,11 +23,9 @@ export function getSavedPreferences(agentId: string): {
 export function SessionConfigBar({
   ensureConnection,
   engagedSessionIdRef,
-  agentId,
 }: {
   ensureConnection: () => Promise<ClientSideConnection | null>;
   engagedSessionIdRef: React.RefObject<string | null>;
-  agentId: string;
 }) {
   const modes = useStore((s) => s.sessionModes);
   const models = useStore((s) => s.sessionModels);
@@ -130,12 +96,13 @@ export function SessionConfigBar({
     setOpen(true);
   };
 
-  // Optimistic mode change: update store immediately, persist, send in background.
+  // Optimistic mode change: update the store immediately, send to the live
+  // session in the background. This overrides the configured default for this
+  // session only — the persisted default lives in agent settings, not here.
   // Re-applies after ensureConnection since captureSessionConfig may overwrite.
   const setMode = (modeId: string) => {
     if (!modes) return;
     setSessionModes({ ...modes, currentModeId: modeId });
-    savePreference(agentId, "mode", modeId);
     runAction(async () => {
       const conn = await ensureConnection();
       // Re-apply optimistic value — ensureConnection may have overwritten via captureSessionConfig
@@ -156,7 +123,6 @@ export function SessionConfigBar({
       return;
     }
     setSessionModels({ ...models, currentModelId: modelId });
-    savePreference(agentId, "model", modelId);
     runAction(async () => {
       const conn = await ensureConnection();
       // Re-apply optimistic value — ensureConnection may have overwritten via captureSessionConfig
@@ -170,7 +136,7 @@ export function SessionConfigBar({
     }, "Couldn't change model");
   };
 
-  // Config option: optimistic, persist, fire-and-forget
+  // Config option: optimistic, session-only, fire-and-forget
   const setConfigOption = (
     opt: SessionConfigOption,
     value: boolean | string,
@@ -180,7 +146,6 @@ export function SessionConfigBar({
       return { ...o, currentValue: value } as SessionConfigOption;
     });
     setSessionConfigOptions(updated);
-    savePreference(agentId, `config:${opt.id}`, String(value));
 
     runAction(async () => {
       const conn = await ensureConnection();

--- a/packages/ui/src/modules/sessions/hooks/use-acp-config-cache.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-config-cache.ts
@@ -1,7 +1,3 @@
-import type {
-  ClientSideConnection,
-  SessionConfigOption,
-} from "@agentclientprotocol/sdk/dist/acp.js";
 import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk/dist/acp.js";
 import { useCallback, useEffect } from "react";
 
@@ -12,10 +8,6 @@ import {
   type SessionConfigPayload,
   sessionConfigPayloadSchema,
 } from "../../acp/types.js";
-import {
-  flattenSelectOptions,
-  getSavedPreferences,
-} from "../components/session-config-popover.js";
 
 const cachedConfigKey = (agentId: string) =>
   `platform-cached-config:${agentId}`;
@@ -26,24 +18,19 @@ export interface AcpConfigCache {
   /** Apply incremental ACP `current_mode_update` / `config_option_update`
    *  notifications to the store. */
   handleConfigUpdate: (update: AcpUpdate) => void;
-  /** Replay the user's saved per-agent preferences into a freshly-created
-   *  session — sets model/mode and forwards each config option. */
-  applySavedPreferences: (
-    conn: ClientSideConnection,
-    sid: string,
-    sessionResponse: SessionConfigPayload,
-  ) => Promise<void>;
 }
 
 /**
- * Owns the per-agent config cache: store mirror, localStorage persistence,
- * and the throwaway-session bootstrap that hydrates the cache when a fresh
- * UI loads on a running agent with no live session yet.
+ * Owns the per-agent config *catalog*: the store mirror of what options the
+ * harness advertises (modes / models / config options), a localStorage cache of
+ * that catalog, and the throwaway-session bootstrap that hydrates it when a
+ * fresh UI loads on a running agent with no live session yet.
  *
- * Returns three callbacks the orchestrator weaves into the connection
- * lifecycle: `captureSessionConfig` after newSession/loadSession,
- * `handleConfigUpdate` from the streaming handler, and `applySavedPreferences`
- * once a new session is up.
+ * It deliberately does NOT persist the user's chosen values. The per-session
+ * picker applies choices to the live ACP session only; the persistent per-agent
+ * default lives server-side (agent settings). What's cached here is just the
+ * set of available options, so the Config panel and popover can render before a
+ * session exists.
  */
 export function useAcpConfigCache(
   selectedAgent: string | null,
@@ -88,119 +75,15 @@ export function useAcpConfigCache(
     [setSessionModes, setSessionConfigOptions],
   );
 
-  const applySavedPreferences = useCallback(
-    async (
-      conn: ClientSideConnection,
-      sid: string,
-      sessionResponse: SessionConfigPayload,
-    ) => {
-      if (!selectedAgent) return;
-      const prefs = getSavedPreferences(selectedAgent);
-      const calls: Promise<unknown>[] = [];
-      if (
-        prefs.model &&
-        sessionResponse.models?.availableModels.some(
-          (m) => m.modelId === prefs.model,
-        )
-      ) {
-        calls.push(
-          conn
-            .unstable_setSessionModel({ sessionId: sid, modelId: prefs.model })
-            .catch(() => {}),
-        );
-        setSessionModels({
-          ...sessionResponse.models,
-          currentModelId: prefs.model,
-        });
-      }
-      // Newer adapters expose the model as a `category: "model"` config
-      // option instead of the legacy session-model state — forward the saved
-      // model preference through that channel (unless the config loop below
-      // already carries a value for it).
-      if (prefs.model && !sessionResponse.models) {
-        const modelOpt = sessionResponse.configOptions?.find(
-          (o): o is Extract<SessionConfigOption, { type: "select" }> =>
-            o.category === "model" && o.type === "select",
-        );
-        if (
-          modelOpt &&
-          prefs.config[modelOpt.id] === undefined &&
-          flattenSelectOptions(modelOpt.options).some(
-            (o) => o.value === prefs.model,
-          )
-        ) {
-          calls.push(
-            conn
-              .setSessionConfigOption({
-                sessionId: sid,
-                configId: modelOpt.id,
-                value: prefs.model,
-              })
-              .catch(() => {}),
-          );
-        }
-      }
-      if (
-        prefs.mode &&
-        sessionResponse.modes?.availableModes.some((m) => m.id === prefs.mode)
-      ) {
-        calls.push(
-          conn
-            .setSessionMode({ sessionId: sid, modeId: prefs.mode })
-            .catch(() => {}),
-        );
-        setSessionModes({
-          ...sessionResponse.modes,
-          currentModeId: prefs.mode,
-        });
-      }
-      for (const [configId, value] of Object.entries(prefs.config)) {
-        const opt = sessionResponse.configOptions?.find(
-          (o) => o.id === configId,
-        );
-        if (!opt) continue;
-        const req =
-          opt.type === "boolean"
-            ? {
-                sessionId: sid,
-                configId,
-                type: "boolean" as const,
-                value: value === "true",
-              }
-            : { sessionId: sid, configId, value };
-        calls.push(conn.setSessionConfigOption(req).catch(() => {}));
-      }
-      if (calls.length) await Promise.all(calls);
-    },
-    [selectedAgent, setSessionModes, setSessionModels],
-  );
-
-  // Hydrate from localStorage cache, or fetch via a throwaway session if the
-  // cache is empty and the agent is running. Skipped while a real session
+  // Hydrate the catalog from localStorage, or fetch via a throwaway session if
+  // the cache is empty and the agent is running. Skipped while a real session
   // is active — that path captures config via captureSessionConfig.
   useEffect(() => {
     if (!selectedAgent || sessionId) return;
-    const prefs = getSavedPreferences(selectedAgent);
 
     const applyConfig = (data: SessionConfigPayload) => {
-      if (data.modes) {
-        const modes = { ...data.modes };
-        if (
-          prefs.mode &&
-          modes.availableModes?.some((m) => m.id === prefs.mode)
-        )
-          modes.currentModeId = prefs.mode;
-        setSessionModes(modes);
-      }
-      if (data.models) {
-        const models = { ...data.models };
-        if (
-          prefs.model &&
-          models.availableModels?.some((m) => m.modelId === prefs.model)
-        )
-          models.currentModelId = prefs.model;
-        setSessionModels(models);
-      }
+      if (data.modes) setSessionModes(data.modes);
+      if (data.models) setSessionModels(data.models);
       if (data.configOptions?.length)
         setSessionConfigOptions(data.configOptions);
     };
@@ -284,5 +167,5 @@ export function useAcpConfigCache(
     setSessionConfigOptions,
   ]);
 
-  return { captureSessionConfig, handleConfigUpdate, applySavedPreferences };
+  return { captureSessionConfig, handleConfigUpdate };
 }

--- a/packages/ui/src/modules/sessions/hooks/use-acp-history.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-history.ts
@@ -2,7 +2,6 @@ import { PROTOCOL_VERSION } from "@agentclientprotocol/sdk/dist/acp.js";
 import type { LoadSessionResponse } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { useCallback } from "react";
 
-import { useStore } from "../../../store.js";
 import type { Message } from "../../../types.js";
 import { openConnection } from "../../acp/acp.js";
 import {
@@ -10,7 +9,6 @@ import {
   finalizeAllStreaming,
 } from "../../acp/session-projection.js";
 import type { AcpUpdate, SessionConfigPayload } from "../../acp/types.js";
-import { getSavedPreferences } from "../components/session-config-popover.js";
 
 /**
  * Replay a session's history from the agent's runtime log into a fresh
@@ -38,9 +36,6 @@ export function useAcpHistory(
 ): {
   loadHistory: (sid: string) => Promise<Message[]>;
 } {
-  const setSessionModes = useStore((s) => s.setSessionModes);
-  const setSessionModels = useStore((s) => s.setSessionModels);
-
   const loadHistory = useCallback(
     async (sid: string): Promise<Message[]> => {
       if (!selectedAgent) return [];
@@ -65,34 +60,12 @@ export function useAcpHistory(
           mcpServers: [],
         });
         captureSessionConfig(resp);
-
-        // Optimistic prefs nudge — real ACP `set*` calls fire when the
-        // orchestrator opens the live channel via applySavedPreferences.
-        const prefs = getSavedPreferences(selectedAgent);
-        if (
-          prefs.model &&
-          resp.models?.availableModels?.some((m) => m.modelId === prefs.model)
-        ) {
-          setSessionModels({ ...resp.models, currentModelId: prefs.model });
-        }
-        if (
-          prefs.mode &&
-          resp.modes?.availableModes?.some((m) => m.id === prefs.mode)
-        ) {
-          setSessionModes({ ...resp.modes, currentModeId: prefs.mode });
-        }
       } finally {
         ws?.close();
       }
       return finalizeAllStreaming(replayed);
     },
-    [
-      selectedAgent,
-      captureSessionConfig,
-      handleConfigUpdate,
-      setSessionModes,
-      setSessionModels,
-    ],
+    [selectedAgent, captureSessionConfig, handleConfigUpdate],
   );
 
   return { loadHistory };

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session-engagement.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session-engagement.ts
@@ -18,9 +18,10 @@ import { optimisticInsertSession } from "../api/queries.js";
  * relay on first `session/prompt` (option B). The UI never writes session
  * rows itself.
  *
- * Either way, the response is forwarded to `captureSessionConfig` (cache +
- * localStorage) and `applySavedPreferences` (replays the user's per-agent
- * mode/model/option prefs onto the new session).
+ * Either way, the response is forwarded to `captureSessionConfig` (which mirrors
+ * the harness's advertised options into the store + catalog cache). The session
+ * starts from the harness's own config (which already reflects the persisted
+ * per-agent default written to its config file) — the UI replays nothing.
  *
  * `engagedSessionIdRef` is the source of truth for "the session this live
  * conn is currently bound to". The orchestrator's WS close handler and
@@ -29,11 +30,6 @@ import { optimisticInsertSession } from "../api/queries.js";
 export function useAcpSessionEngagement(
   selectedAgent: string | null,
   captureSessionConfig: (response: SessionConfigPayload) => void,
-  applySavedPreferences: (
-    conn: ClientSideConnection,
-    sid: string,
-    sessionResponse: SessionConfigPayload,
-  ) => Promise<void>,
 ): {
   engagedSessionIdRef: React.MutableRefObject<string | null>;
   engage: (conn: ClientSideConnection) => Promise<void>;
@@ -58,7 +54,6 @@ export function useAcpSessionEngagement(
         });
         captureSessionConfig(resp);
         engagedSessionIdRef.current = sid;
-        await applySavedPreferences(conn, sid, resp);
       } else {
         // Stamp platform metadata (ADR-055) so the session records as a regular
         // chat session rather than decoding as terminal-by-default.
@@ -74,16 +69,9 @@ export function useAcpSessionEngagement(
         engagedSessionIdRef.current = s.sessionId;
         addLog("session", { sessionId: s.sessionId });
         optimisticInsertSession(selectedAgent, s.sessionId, SessionMode.Chat);
-        await applySavedPreferences(conn, s.sessionId, s);
       }
     },
-    [
-      selectedAgent,
-      captureSessionConfig,
-      applySavedPreferences,
-      setSessionId,
-      addLog,
-    ],
+    [selectedAgent, captureSessionConfig, setSessionId, addLog],
   );
 
   const clear = useCallback(() => {

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -46,8 +46,11 @@ export function useAcpSession(
 
   const agentOperable = useIsAgentOperable(selectedAgent);
 
-  const { captureSessionConfig, handleConfigUpdate, applySavedPreferences } =
-    useAcpConfigCache(selectedAgent, sessionId, agentOperable);
+  const { captureSessionConfig, handleConfigUpdate } = useAcpConfigCache(
+    selectedAgent,
+    sessionId,
+    agentOperable,
+  );
 
   const { loadHistory } = useAcpHistory(
     selectedAgent,
@@ -59,11 +62,7 @@ export function useAcpSession(
     engagedSessionIdRef,
     engage,
     clear: clearEngagement,
-  } = useAcpSessionEngagement(
-    selectedAgent,
-    captureSessionConfig,
-    applySavedPreferences,
-  );
+  } = useAcpSessionEngagement(selectedAgent, captureSessionConfig);
 
   const makeUpdateHandler = useAcpUpdateHandler(handleConfigUpdate);
 

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -634,7 +634,6 @@ export function ChatView() {
                     <SessionConfigBar
                       ensureConnection={ensureConnection}
                       engagedSessionIdRef={engagedSessionIdRef}
-                      agentId={selectedAgent ?? ""}
                     />
                   )
                 }


### PR DESCRIPTION
Closes #931.

## What

A per-agent **harness session default** (model, mode, and ACP config options like `thought_level`) that's written into the harness's *own* config file (claude-code → `~/.claude/settings.json`), so it applies to **interactive and scheduled/headless** sessions alike. It layers on the existing per-session ACP picker — which now configures the *live session only* (its global localStorage preference store is removed).

Three layers, one coherent system:
- **Discovery** — available options come from what the harness advertises over ACP (`models` / `modes` / `configOptions`).
- **Persistent default** *(new)* — set in the Config panel, stored server-side, written through to the harness config file.
- **Per-session override** — the existing composer popover, applied live over ACP.

## Shape mirrors ACP session config

The contribution, the DB row, and the manifest `keys` all share the ACP shape `{ model, mode, configOptions: { <configId>: value } }`. `thought_level` is **not** special-cased — it's a config option; the claude-code manifest maps it under `configOptions` to Claude's `effortLevel`. Harness-specifics (file path + key layout) live in each harness's `runtime-manifest.yaml`, so api-server stays harness-agnostic.

## Harness-agnostic + capability-gated

Only **claude-code** binds `harness-config` in v1 (codex is TOML, pi-agent reads elsewhere). Capabilities derive from the manifest's `drivers` map, so only harnesses that bind it advertise it; the UI hides the section (via a `supported` flag) when the harness can't honor a persistent default, and the driver skips + logs any unmapped option — no silent no-ops.

## Layers / changes

- **agent-runtime-api** — new `harness-config` contribution kind.
- **agent-runtime** — manifest-bound `harness-config` driver: maps each value to a dot-path in the harness's JSON config file, reconciles non-destructively (preserves user keys, removes cleared ones via a state store, throws rather than clobbering an unparseable file). Bound in a new claude-code manifest. Unit-tested.
- **packages/db** — `agent_settings` table + migration.
- **api-server** — `agent-settings` module (repo / service / router / `AgentDeleted` cleanup saga), ownership-checked `get`/`set`; state-builder emits the contribution.
- **ui** — Model section in the Config panel (model / mode / config-option groups); removed the localStorage global-preference mechanism (`save/getSavedPreferences`, `applySavedPreferences`).
- **docs** — `connections.md` updated.

## Verification

- `mise run check` / `mise run test`: all TS packages tsc + lint clean; unit tests pass (agent-runtime, api-server +6 new for the agent-settings service & capability gating, ui). Two pre-existing **environmental** failures unrelated to this diff (helm kubeconform schema fetch timing out; controller CRD-revision tooling) — hence the branch was committed with `--no-verify` after verifying each TS package individually.
- **Cluster round-trip verified** on `platform-k3s`: a claude-code agent advertises `harness-config`; setting a row delivered the contribution (no driver failures) and the driver wrote `model` + `permissions.defaultMode` + `effortLevel` into `~/.claude/settings.json`, preserving the seeded keys.

## Follow-ups / open items

- Confirm the `thought_level` ACP **config id** matches the manifest key (`configOptions.thought_level`) for the current claude-agent-acp — a one-line manifest fix if it differs. The driver mechanism itself is verified.
- Boolean config options are persistable in the data layer but not yet surfaced in the panel (deferred; still a live per-session toggle).
- Per-schedule overrides remain out of scope (per #931).
- Moving user-set **env** off the agent CR onto the contribution rail is tracked separately in #1079 (out of scope here).