### PR TITLE
test(e2e): click Continue on the wizard image step in agent spec

### DIFF
--- a/packages/e2e/playwright/src/tests/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-agent.spec.ts
@@ -46,6 +46,8 @@ test("create a mock agent with the connection attached", async ({ page }) => {
   await test.step("pick the mock image", async () => {
     await page.getByRole("button", { name: /create sandbox/i }).click();
     await page.getByText(harnessName, { exact: true }).click();
+    // The image step now only selects on click; advance with its Continue button.
+    await page.getByRole("button", { name: /continue/i }).click();
   });
 
   await test.step("name the sandbox and connect a provider", async () => {


### PR DESCRIPTION
## What

Fixes the failing `mise e2e` job on `main`. The agent spec (`03-agent.spec.ts`) was timing out and failing CI on every push.

## Root cause

```
✘ 03-agent.spec.ts:10 › create a mock agent with the connection attached (1.0m)
   Error: locator.fill: Test timeout of 60000ms exceeded.
   - waiting for getByPlaceholder('my-sandbox')
```

The sandbox wizard redesign (#1040) made the **image step select-only**: clicking a pre-built image now only *selects* it (`onSelect`) and you advance with a new **Continue** button — it no longer auto-advances to the setup step (`image-step.tsx`, wired to `step: 2` in `sandbox-wizard-view.tsx`).

The agent spec still assumed the old auto-advance: it picked the `mock` image and immediately waited for the `my-sandbox` name field, which lives on **step 2**. So it sat on step 1 and timed out. #1040 patched several other things in this spec (first-run suppression, template test-ids) but missed this click.

## Fix

Click the image step's **Continue** button after selecting the mock image, matching the Continue pattern already used in the spec's later steps. Verified against latest `main` (incl. the follow-up wizard PR #1078) — the pre-built `ImageCard` still only selects on click, so the explicit Continue is required.

## Testing

- `eslint` and `prettier --check` pass on the changed file.
- The full e2e suite requires a live k3s cluster (`mise run e2e`), which isn't available in my environment — relying on CI to run the suite on this PR.

Refs #896