### PR TITLE
Fix misleading 'can't reach server' warnings on first run

### DIFF
--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -20,9 +20,6 @@ export default function App() {
   const view = useStore((s) => s.view);
   const theme = useStore((s) => s.theme);
 
-  useAgentCrashToasts();
-  useFirstRunRedirect();
-
   // Apply theme on mount + listen for system preference changes
   useEffect(() => {
     const apply = () => {
@@ -38,6 +35,16 @@ export default function App() {
     mq.addEventListener("change", apply);
     return () => mq.removeEventListener("change", apply);
   }, [theme]);
+
+  if (view === "terms") return <TermsView />;
+  return <MainApp />;
+}
+
+function MainApp() {
+  const view = useStore((s) => s.view);
+
+  useAgentCrashToasts();
+  useFirstRunRedirect();
 
   useEffect(() => {
     // The v2 wizard and the sandbox-creation wizard own their own OAuth-return
@@ -128,13 +135,6 @@ export default function App() {
         <ChatView />
         <DialogOverlay />
         <ConnectionBanner />
-      </>
-    );
-
-  if (view === "terms")
-    return (
-      <>
-        <TermsView />
       </>
     );
 

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -13,6 +13,7 @@ import { initAuth } from "./auth.js";
 import { applyBrand, loadBrand } from "./brand.js";
 import { preflightTermsGate } from "./modules/terms/lib/preflight.js";
 import { queryClient } from "./query-client.js";
+import { useStore } from "./store.js";
 
 async function main() {
   // Brand fetch is unauthenticated and runs in parallel with auth init so the
@@ -21,7 +22,10 @@ async function main() {
   const [user] = await Promise.all([initAuth(), loadBrand().then(applyBrand)]);
   if (!user) return; // Redirecting to Keycloak, don't render
 
-  if (!(await preflightTermsGate())) return;
+  if (!(await preflightTermsGate())) {
+    window.history.replaceState({}, "", "/terms");
+    useStore.setState({ view: "terms" });
+  }
 
   const { default: App } = await import("./app.js");
   createRoot(document.getElementById("root")!).render(

--- a/packages/ui/src/modules/terms/lib/on-terms-stale.ts
+++ b/packages/ui/src/modules/terms/lib/on-terms-stale.ts
@@ -1,8 +1,13 @@
 let redirecting = false;
+let termsStale = false;
 
-export function onTermsStale() {
-  if (redirecting) return;
-  if (window.location.pathname === "/terms") return;
+export function isTermsStale(): boolean {
+  return termsStale;
+}
+
+export function onTermsStale(): void {
+  termsStale = true;
+  if (redirecting || window.location.pathname === "/terms") return;
   redirecting = true;
   window.location.assign("/terms");
 }

--- a/packages/ui/src/modules/terms/lib/preflight.ts
+++ b/packages/ui/src/modules/terms/lib/preflight.ts
@@ -7,11 +7,7 @@ export async function preflightTermsGate(): Promise<boolean> {
       api.terms.current.query(),
       api.terms.latestAcceptance.query(),
     ]);
-    if (!latest || latest.version !== current.version) {
-      window.location.replace("/terms");
-      return false;
-    }
-    return true;
+    return !!latest && latest.version === current.version;
   } catch {
     return true;
   }

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -24,10 +24,17 @@ export function TermsView() {
 
   const doc = document.data;
   const acceptedCurrent = latest.data?.version === doc.version;
+  const isStaleReaccept = !!latest.data && latest.data.version !== doc.version;
 
   return (
     <div className="mx-auto w-full max-w-200 px-4 py-10">
       <h1 className="text-2xl font-semibold mb-2">Terms of Use</h1>
+      {isStaleReaccept && (
+        <p className="text-sm text-muted-foreground mb-4">
+          The Terms of Use have been updated — please review and accept to
+          continue.
+        </p>
+      )}
       <TermsMeta version={doc.version} accepted={latest.data} />
       <Markdown>{doc.text}</Markdown>
       <div className="mt-8 flex gap-3 items-center">
@@ -58,7 +65,7 @@ function TermsMeta({
 }) {
   const isCurrent = accepted?.version === version;
   return (
-    <div className="text-sm text-muted mb-6">
+    <div className="text-sm text-muted-foreground mb-6">
       Version <code>{version}</code>
       {isCurrent && accepted && (
         <>
@@ -101,7 +108,9 @@ function CenteredMessage({
 }) {
   return (
     <div className="mx-auto w-full max-w-200 px-4 py-10">
-      <div className={tone === "error" ? "text-red-600" : "text-muted"}>
+      <div
+        className={tone === "error" ? "text-red-600" : "text-muted-foreground"}
+      >
         {children}
       </div>
     </div>

--- a/packages/ui/src/query-client.ts
+++ b/packages/ui/src/query-client.ts
@@ -8,6 +8,7 @@ import {
 
 import { getApiHealthSnapshot, subscribeApiHealth } from "./lib/api-health.js";
 import { emitToast } from "./lib/toast.js";
+import { isTermsStale } from "./modules/terms/lib/on-terms-stale.js";
 
 declare module "@tanstack/react-query" {
   interface Register {
@@ -35,7 +36,8 @@ export const queryClient = new QueryClient({
       if (
         !toast ||
         notifiedOutages.has(query) ||
-        getApiHealthSnapshot() === "reconnecting"
+        getApiHealthSnapshot() === "reconnecting" ||
+        isTermsStale()
       )
         return;
       notifiedOutages.add(query);
@@ -54,7 +56,7 @@ export const queryClient = new QueryClient({
         );
       },
       onError: (error, _vars, _ctx, mutation) => {
-        if (getApiHealthSnapshot() === "reconnecting") return;
+        if (getApiHealthSnapshot() === "reconnecting" || isTermsStale()) return;
         const title = mutation.meta?.errorToast;
         const detail =
           error instanceof Error && error.message ? error.message : "";


### PR DESCRIPTION
## What

A brand-new user's very first screen used to show two misleading warnings — *"Can't reach the server — agent list may be stale"* and *"Couldn't load secrets"* — even though the server was perfectly healthy. It was simply declining to hand over app data until the Terms of Use were accepted, and the UI surfaced that expected state as a connectivity failure.

This makes "Terms not yet accepted" a normal state instead of an error:

- The Terms page no longer requests app data it isn't entitled to yet, so the two spurious warnings never appear for a new user.
- A returning user whose accepted Terms version is out of date is quietly routed to re-accept, with a clear "the Terms of Use have been updated" note.
- Genuine server outages still show the real connectivity warning — only the terms-gate case is treated as normal.
- The terms gate now appears without a second full-page reload, and its loading text is legible instead of near-invisible.

## Note

The original report also mentioned a blank screen during boot. A branded boot screen was prototyped but dropped: the empty page paints instantly and the app mounts quickly, and an inlined boot overlay introduced more jank than it removed. The fix focuses on the warnings and the in-app loading state instead.

Closes #1075