### PR TITLE
fix(ui): GitHub App install URL for Enterprise + sandbox wizard

### DIFF
--- a/packages/ui/src/__tests__/unit/github-app-install-url.test.ts
+++ b/packages/ui/src/__tests__/unit/github-app-install-url.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test } from "vitest";
+
+import { githubAppInstallUrl } from "../../modules/connections/lib/github-app-install-url.js";
+
+describe("githubAppInstallUrl", () => {
+  test("github.com uses the /apps/ segment", () => {
+    expect(
+      githubAppInstallUrl({ templateId: "github", appSlug: "my-app" }),
+    ).toBe("https://github.com/apps/my-app/installations/new");
+  });
+
+  test("ignores host on a github.com connection", () => {
+    expect(
+      githubAppInstallUrl({
+        templateId: "github",
+        host: "ghe.acme.com",
+        appSlug: "my-app",
+      }),
+    ).toBe("https://github.com/apps/my-app/installations/new");
+  });
+
+  test("GitHub Enterprise Server uses the /github-apps/ segment on its host", () => {
+    expect(
+      githubAppInstallUrl({
+        templateId: "github-enterprise",
+        host: "ghe.acme.com",
+        appSlug: "my-app",
+      }),
+    ).toBe("https://ghe.acme.com/github-apps/my-app/installations/new");
+  });
+
+  test("returns null without an app slug", () => {
+    expect(githubAppInstallUrl({ templateId: "github" })).toBeNull();
+    expect(
+      githubAppInstallUrl({
+        templateId: "github-enterprise",
+        host: "ghe.acme.com",
+      }),
+    ).toBeNull();
+  });
+
+  test("returns null for an enterprise connection missing its host", () => {
+    expect(
+      githubAppInstallUrl({
+        templateId: "github-enterprise",
+        appSlug: "my-app",
+      }),
+    ).toBeNull();
+  });
+});

--- a/packages/ui/src/modules/connections/components/github-app-install-link.tsx
+++ b/packages/ui/src/modules/connections/components/github-app-install-link.tsx
@@ -1,0 +1,34 @@
+import type { ConnectionView } from "api-server-api";
+
+import { cn } from "@/lib/utils";
+
+import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
+
+// Installing the GitHub App is only meaningful once the connection is
+// authorized, so the link is gated on an active status.
+export function GithubAppInstallLink({
+  connection,
+  className,
+}: {
+  connection: Pick<
+    ConnectionView,
+    "templateId" | "host" | "appSlug" | "status"
+  >;
+  className?: string;
+}) {
+  const url = githubAppInstallUrl(connection);
+  if (!url || connection.status !== "active") return null;
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+      className={cn(
+        "shrink-0 text-[14px] font-normal text-foreground hover:underline",
+        className,
+      )}
+    >
+      Install on GitHub
+    </a>
+  );
+}

--- a/packages/ui/src/modules/connections/components/github-app-install-link.tsx
+++ b/packages/ui/src/modules/connections/components/github-app-install-link.tsx
@@ -1,20 +1,16 @@
 import type { ConnectionView } from "api-server-api";
 
-import { cn } from "@/lib/utils";
-
 import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
 
 // Installing the GitHub App is only meaningful once the connection is
 // authorized, so the link is gated on an active status.
 export function GithubAppInstallLink({
   connection,
-  className,
 }: {
   connection: Pick<
     ConnectionView,
     "templateId" | "host" | "appSlug" | "status"
   >;
-  className?: string;
 }) {
   const url = githubAppInstallUrl(connection);
   if (!url || connection.status !== "active") return null;
@@ -23,10 +19,7 @@ export function GithubAppInstallLink({
       href={url}
       target="_blank"
       rel="noreferrer noopener"
-      className={cn(
-        "shrink-0 text-[14px] font-normal text-foreground hover:underline",
-        className,
-      )}
+      className="shrink-0 text-[13px] font-medium text-foreground hover:underline"
     >
       Install on GitHub
     </a>

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -10,13 +10,13 @@ import {
   filterOfferedTemplates,
   isShowInternalConnectionsEnabled,
 } from "../internal-only.js";
-import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
 import { PROVIDER_TEMPLATE_IDS } from "../lib/provider-templates.js";
 import {
   ConnectionAction,
   ConnectionCatalogRow,
   ConnectionRow,
 } from "./connection-row.js";
+import { GithubAppInstallLink } from "./github-app-install-link.js";
 
 const NO_TEMPLATES: ConnectionTemplateView[] = [];
 const NO_CONNECTIONS: ConnectionView[] = [];
@@ -153,19 +153,12 @@ function ConnectionActions({
       />
     );
   }
-  const installUrl = githubAppInstallUrl(connection);
   return (
     <div className="flex shrink-0 items-center gap-4">
-      {installUrl && connection.status === "active" && (
-        <a
-          href={installUrl}
-          target="_blank"
-          rel="noreferrer noopener"
-          className="text-[13px] font-medium text-foreground hover:underline"
-        >
-          Install on GitHub
-        </a>
-      )}
+      <GithubAppInstallLink
+        connection={connection}
+        className="text-[13px] font-medium"
+      />
       <ConnectionAction
         label="Disconnect"
         tone="danger"

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -10,6 +10,7 @@ import {
   filterOfferedTemplates,
   isShowInternalConnectionsEnabled,
 } from "../internal-only.js";
+import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
 import { PROVIDER_TEMPLATE_IDS } from "../lib/provider-templates.js";
 import {
   ConnectionAction,
@@ -181,14 +182,4 @@ function SectionLabel({ children }: { children: ReactNode }) {
       {children}
     </p>
   );
-}
-
-function githubAppInstallUrl(connection: ConnectionView): string | null {
-  if (!connection.appSlug) return null;
-  const host =
-    connection.templateId === "github-enterprise"
-      ? (connection.host ?? null)
-      : "github.com";
-  if (!host) return null;
-  return `https://${host}/apps/${connection.appSlug}/installations/new`;
 }

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -155,10 +155,7 @@ function ConnectionActions({
   }
   return (
     <div className="flex shrink-0 items-center gap-4">
-      <GithubAppInstallLink
-        connection={connection}
-        className="text-[13px] font-medium"
-      />
+      <GithubAppInstallLink connection={connection} />
       <ConnectionAction
         label="Disconnect"
         tone="danger"

--- a/packages/ui/src/modules/connections/lib/github-app-install-url.ts
+++ b/packages/ui/src/modules/connections/lib/github-app-install-url.ts
@@ -1,0 +1,18 @@
+import type { ConnectionView } from "api-server-api";
+
+type GithubAppInstallInput = Pick<
+  ConnectionView,
+  "templateId" | "host" | "appSlug"
+>;
+
+// github.com serves App pages under /apps/; GitHub Enterprise Server uses /github-apps/.
+export function githubAppInstallUrl(
+  connection: GithubAppInstallInput,
+): string | null {
+  if (!connection.appSlug) return null;
+  const isEnterprise = connection.templateId === "github-enterprise";
+  const host = isEnterprise ? connection.host : "github.com";
+  if (!host) return null;
+  const segment = isEnterprise ? "github-apps" : "apps";
+  return `https://${host}/${segment}/${connection.appSlug}/installations/new`;
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -13,6 +13,7 @@ import {
   ConnectionCatalogRow,
   ConnectionRow,
 } from "../../../connections/components/connection-row.js";
+import { GithubAppInstallLink } from "../../../connections/components/github-app-install-link.js";
 import { TemplateCreateForm } from "../../../connections/forms/template-create-form.js";
 import { useDisconnectConnection } from "../../../connections/hooks/use-disconnect-connection.js";
 import {
@@ -128,12 +129,15 @@ export function ConnectionsStep({
                 onSelectedChange={(on) => toggle(c.id, on)}
                 testId={`connection-grant-${c.id}`}
               >
-                <ConnectionAction
-                  label="Disconnect"
-                  tone="danger"
-                  onClick={() => void disconnect(c.id, c.name)}
-                  disabled={deletingId === c.id}
-                />
+                <div className="flex shrink-0 items-center gap-4">
+                  <GithubAppInstallLink connection={c} />
+                  <ConnectionAction
+                    label="Disconnect"
+                    tone="danger"
+                    onClick={() => void disconnect(c.id, c.name)}
+                    disabled={deletingId === c.id}
+                  />
+                </div>
               </ConnectionRow>
             ))}
           </CardList>

--- a/packages/ui/src/modules/v2/components/wizard/github-step.tsx
+++ b/packages/ui/src/modules/v2/components/wizard/github-step.tsx
@@ -4,6 +4,7 @@ import { type ReactNode, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
 
 import { api } from "../../../../api.js";
+import { githubAppInstallUrl } from "../../../connections/lib/github-app-install-url.js";
 import {
   type GithubMode,
   useGithubConnect,
@@ -45,6 +46,11 @@ export function GithubStep({
     null,
   );
   const pendingTargetRef = useRef<Target | null>(null);
+
+  const installUrlFor = (mode: GithubMode, host: string): string | null => {
+    const existing = findExisting(mode, host);
+    return existing ? githubAppInstallUrl(existing) : null;
+  };
 
   const { open: openPopup, close: closePopup } = useOAuthPopup((result) => {
     const target = pendingTargetRef.current;
@@ -150,6 +156,7 @@ export function GithubStep({
           title="GitHub"
           description="Read + write repos, issues, and PRs on github.com."
           connected={snapshot.githubAuthorized && !!snapshot.githubConnectionId}
+          installUrl={installUrlFor("github", "")}
           authorizing={authorizingTarget === "github"}
           disabled={authorizingTarget !== null}
           onAuthorize={() => connect("github")}
@@ -172,6 +179,7 @@ export function GithubStep({
           description="Connect a self-hosted GitHub Enterprise host."
           connected={snapshot.gheAuthorized && !!snapshot.gheConnectionId}
           connectedLabel={`Connected to ${snapshot.gheHost}.`}
+          installUrl={installUrlFor("github-enterprise", snapshot.gheHost)}
           authorizing={authorizingTarget === "ghe"}
           disabled={authorizingTarget !== null}
           onAuthorize={() => connect("ghe")}
@@ -226,6 +234,7 @@ function ConnectionCard({
   description,
   connected,
   connectedLabel = "Connected to GitHub.",
+  installUrl,
   authorizing,
   disabled,
   onAuthorize,
@@ -236,6 +245,7 @@ function ConnectionCard({
   description: string;
   connected: boolean;
   connectedLabel?: string;
+  installUrl?: string | null;
   authorizing: boolean;
   disabled: boolean;
   onAuthorize: () => void;
@@ -250,6 +260,16 @@ function ConnectionCard({
         {connected ? (
           <div className="flex items-center gap-2 text-[13px] text-success">
             <Check size={15} /> {connectedLabel}
+            {installUrl && (
+              <a
+                href={installUrl}
+                target="_blank"
+                rel="noreferrer noopener"
+                className="ml-1 font-medium text-foreground hover:underline"
+              >
+                Install on GitHub
+              </a>
+            )}
             <button
               type="button"
               onClick={onChange}


### PR DESCRIPTION
## Summary

Fixes the "Install on GitHub" link for GitHub App connections in two places.

1. **Enterprise install path was wrong.** The link hardcoded the `/apps/` path segment, which is correct for github.com but 404s on GitHub Enterprise Server — GHES serves App pages under `/github-apps/`. The path segment is now chosen by host.
2. **Link was missing from the sandbox creation wizard.** The connections settings page (`/settings/connections`) surfaced an "Install on GitHub" link for connected App connections, but the sandbox wizard (`/sandboxes/new`) did not — so there was no way to install the App during first-run setup. The wizard now shows the same link on a connected card, for both github.com and Enterprise.

## Changes

- Extract `githubAppInstallUrl` out of `templates-section.tsx` into a pure, unit-tested helper in `connections/lib/`.
- Pick the path segment (`apps` vs `github-apps`) by host so the link resolves on both github.com and GHES.
- Reuse that single helper in the sandbox wizard's connection step, so the Enterprise path fix applies there automatically (no duplicated logic).
- Add unit coverage for both hosts and the missing-slug / missing-host cases.

## Notes

- The link only appears for platform-managed GitHub Apps (connections that carry an `appSlug`). Bring-your-own-app connections without an `appSlug` show no link — same behavior as before, in both locations.

## Testing

- `mise run ui:check` (lint + format + tsc) — clean
- `mise run ui:test` — 44 passed (5 new)