### PR TITLE
fix(ui): polish after redesign, unify status badges

### DIFF
--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -55,7 +55,7 @@ export function IconRail() {
   return (
     <>
       <nav
-        className="hidden md:flex flex-col items-center h-full w-[56px] bg-card border-r shrink-0"
+        className="hidden md:flex flex-col items-center h-full w-[56px] bg-card shrink-0"
         data-testid="app-sidebar"
       >
         <div className="flex items-center justify-center h-14">
@@ -92,7 +92,7 @@ function RailItem({ label, icon: Icon, active, badge, navigate }: Destination) {
       className={cn(
         "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
         active
-          ? "text-primary bg-primary/10"
+          ? "text-primary bg-muted"
           : "text-foreground/80 hover:text-foreground hover:bg-muted",
       )}
     >

--- a/packages/ui/src/components/status-indicator.tsx
+++ b/packages/ui/src/components/status-indicator.tsx
@@ -1,4 +1,6 @@
-import type { AgentDisplayState } from "../modules/agents/utils/agent-resolver.js";
+import { Badge, type BadgeProps } from "@/components/ui/badge";
+
+import type { AgentDisplayState } from "../modules/agents/utils/agent-resolver";
 
 const stateLabel: Record<AgentDisplayState, string> = {
   running: "Running",
@@ -9,57 +11,40 @@ const stateLabel: Record<AgentDisplayState, string> = {
   error: "Error",
 };
 
-const badgeColors: Record<AgentDisplayState, string> = {
-  running: "bg-success-light text-success border-success",
-  starting: "bg-warning-light text-warning border-warning",
-  preparing_workspace: "bg-warning-light text-warning border-warning",
-  hibernating: "bg-info-light text-info/50 border-info/25",
-  hibernated: "bg-info-light text-info/50 border-info/25",
-  error: "bg-danger-light text-danger border-danger",
+const stateVariant: Record<
+  AgentDisplayState,
+  NonNullable<BadgeProps["variant"]>
+> = {
+  running: "success",
+  starting: "warning",
+  preparing_workspace: "warning",
+  hibernating: "muted",
+  hibernated: "muted",
+  error: "danger",
 };
 
-const dotColors: Record<AgentDisplayState, string> = {
-  running: "bg-success",
-  starting: "bg-warning anim-pulse",
-  preparing_workspace: "bg-warning anim-pulse",
-  hibernating: "bg-info/50 anim-pulse",
-  hibernated: "bg-info/50",
-  error: "bg-danger",
-};
-
-/** Shared state pill used in the agents list and the chat header. `sm` matches
- *  the denser chat header treatment; `md` matches the agents-list card.
- *  When both `state` and an override (`label`/`colorClasses`/`dotColorClasses`)
- *  are passed, the overrides win — used for ad-hoc pills like "Busy" that sit
- *  outside the agent-state taxonomy. */
 export function StatusBadge({
   state,
-  size = "md",
   label,
   colorClasses,
-  dotColorClasses,
 }: {
   state?: AgentDisplayState;
   size?: "sm" | "md";
-  /** Override label + colors for ad-hoc pills (e.g. "Busy" on the chat header).
-   *  When provided, `state` is ignored. */
   label?: string;
   colorClasses?: string;
   dotColorClasses?: string;
 }) {
-  const border = size === "sm" ? "border" : "border-2";
-  const dot = size === "sm" ? "w-1.5 h-1.5" : "w-2.5 h-2.5";
   const resolvedLabel = label ?? (state ? stateLabel[state] : "");
-  const resolvedColors = colorClasses ?? (state ? badgeColors[state] : "");
-  const resolvedDot = dotColorClasses ?? (state ? dotColors[state] : "");
+  if (colorClasses) {
+    return (
+      <Badge variant="outline" className={colorClasses}>
+        {resolvedLabel}
+      </Badge>
+    );
+  }
   return (
-    <span
-      className={`inline-flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.03em] ${border} rounded-full px-2.5 py-0.5 ${resolvedColors}`}
-    >
-      <span
-        className={`inline-block ${dot} rounded-full shrink-0 ${resolvedDot}`}
-      />
+    <Badge variant={state ? stateVariant[state] : "outline"}>
       {resolvedLabel}
-    </span>
+    </Badge>
   );
 }

--- a/packages/ui/src/components/status-indicator.tsx
+++ b/packages/ui/src/components/status-indicator.tsx
@@ -1,6 +1,6 @@
 import { Badge, type BadgeProps } from "@/components/ui/badge";
 
-import type { AgentDisplayState } from "../modules/agents/utils/agent-resolver";
+import type { AgentDisplayState } from "../modules/agents/utils/agent-resolver.js";
 
 const stateLabel: Record<AgentDisplayState, string> = {
   running: "Running",
@@ -29,10 +29,8 @@ export function StatusBadge({
   colorClasses,
 }: {
   state?: AgentDisplayState;
-  size?: "sm" | "md";
   label?: string;
   colorClasses?: string;
-  dotColorClasses?: string;
 }) {
   const resolvedLabel = label ?? (state ? stateLabel[state] : "");
   if (colorClasses) {

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -15,7 +15,8 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
-        success: "border-transparent bg-success-light text-green-700",
+        success:
+          "border-transparent bg-success-light text-green-700 dark:text-success",
         warning: "border-transparent bg-warning/15 text-warning",
         danger: "border-transparent bg-danger-light text-danger",
         info: "border-transparent bg-info-light text-info",

--- a/packages/ui/src/components/ui/badge.tsx
+++ b/packages/ui/src/components/ui/badge.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 
 const badgeVariants = cva(
-  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs tracking-[0.338px] transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2",
+  "inline-flex items-center rounded-full border px-2.5 py-0.5 text-[12px] tracking-[0.338px] transition-colors focus:outline-hidden focus:ring-2 focus:ring-ring focus:ring-offset-2",
   {
     variants: {
       variant: {
@@ -15,6 +15,12 @@ const badgeVariants = cva(
         destructive:
           "border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80",
         outline: "text-foreground",
+        success: "border-transparent bg-success-light text-green-700",
+        warning: "border-transparent bg-warning/15 text-warning",
+        danger: "border-transparent bg-danger-light text-danger",
+        info: "border-transparent bg-info-light text-info",
+        muted: "border-transparent bg-muted text-muted-foreground",
+        accent: "border-transparent bg-accent-light text-accent",
       },
     },
     defaultVariants: {

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -29,14 +29,14 @@ const DropdownMenuContent = React.forwardRef<
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
 const dropdownMenuItemVariants = cva(
-  "flex h-9 w-full cursor-pointer select-none items-center gap-2 rounded-md px-3 text-sm font-medium outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+  "flex h-9 w-full cursor-pointer select-none items-center gap-2 rounded-md px-3 text-[14px] outline-none transition-colors data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
   {
     variants: {
       tone: {
         default:
           "data-[highlighted]:bg-muted data-[highlighted]:text-foreground",
         danger:
-          "data-[highlighted]:bg-danger-light data-[highlighted]:text-danger",
+          "data-[highlighted]:bg-danger-light data-[highlighted]:text-danger text-danger",
       },
     },
     defaultVariants: { tone: "default" },

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
@@ -77,6 +78,7 @@ export function AgentRow({
               <DropdownMenuItem onSelect={onConfigure}>
                 Configure
               </DropdownMenuItem>
+              <DropdownMenuSeparator />
               <DropdownMenuItem
                 tone="danger"
                 disabled={deletePending}

--- a/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
+++ b/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
@@ -127,7 +127,6 @@ export function AgentUnavailableOverlay({
           <StatusBadge
             label="Reconnecting"
             colorClasses="bg-warning-light text-warning border-warning"
-            dotColorClasses="bg-warning anim-pulse"
           />
         </div>
         <p className="max-w-105 text-[14px] text-text-secondary">

--- a/packages/ui/src/modules/agents/components/contribution-failures-badge.tsx
+++ b/packages/ui/src/modules/agents/components/contribution-failures-badge.tsx
@@ -4,10 +4,8 @@ import type { AgentView } from "../../../types.js";
 /** Degraded indicator: a running agent whose last settle left contributions unfinished. */
 export function ContributionFailuresBadge({
   failures,
-  size = "md",
 }: {
   failures: AgentView["contributionFailures"];
-  size?: "sm" | "md";
 }) {
   if (failures.length === 0) return null;
   const label =
@@ -18,10 +16,8 @@ export function ContributionFailuresBadge({
   return (
     <span title={detail}>
       <StatusBadge
-        size={size}
         label={label}
         colorClasses="bg-warning-light text-warning border-warning"
-        dotColorClasses="bg-warning"
       />
     </span>
   );

--- a/packages/ui/src/modules/connections/components/connection-row.tsx
+++ b/packages/ui/src/modules/connections/components/connection-row.tsx
@@ -1,7 +1,12 @@
-import type { AppConnectionView, ConnectionTemplateView } from "api-server-api";
+import type {
+  AppConnectionView,
+  ConnectionStatus,
+  ConnectionTemplateView,
+} from "api-server-api";
 import { Check } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { Badge, type BadgeProps } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 
 import { ConnectionIcon } from "./connection-icon.js";
@@ -136,32 +141,20 @@ export function ConnectionRow({
   );
 }
 
+const STATUS_BADGE: Record<
+  ConnectionStatus,
+  { label: string; variant: BadgeProps["variant"] }
+> = {
+  active: { label: "Connected", variant: "success" },
+  pending: { label: "Authorizing…", variant: "muted" },
+  expired: { label: "Expired", variant: "danger" },
+  disconnected: { label: "Disconnected", variant: "muted" },
+};
+
 function StatusBadge({ status }: { status?: AppConnectionView["status"] }) {
-  if (status === "active")
-    return (
-      <span className="rounded-full bg-success-light px-2.5 py-0.5 text-[12px] font-normal text-success">
-        Connected
-      </span>
-    );
-  if (status === "pending")
-    return (
-      <span className="rounded-full bg-muted px-2.5 py-0.5 text-[12px] font-normal text-muted-foreground">
-        Authorizing…
-      </span>
-    );
-  if (status === "expired")
-    return (
-      <span className="rounded-full bg-danger-light px-2.5 py-0.5 text-[12px] font-normal text-danger">
-        Expired
-      </span>
-    );
-  if (status === "disconnected")
-    return (
-      <span className="rounded-full bg-muted px-2.5 py-0.5 text-[12px] font-normal text-muted-foreground">
-        Disconnected
-      </span>
-    );
-  return null;
+  if (!status) return null;
+  const { label, variant } = STATUS_BADGE[status];
+  return <Badge variant={variant}>{label}</Badge>;
 }
 
 function SelectIndicator({ selected }: { selected: boolean }) {

--- a/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
+++ b/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
@@ -3,20 +3,17 @@ import { useIsImporting } from "../hooks/use-is-importing.js";
 
 interface Props {
   agentId: string | null;
-  size?: "sm" | "md";
 }
 
 /** Active indicator: a file upload/import is in flight for this agent. */
-export function ImportInProgressBadge({ agentId, size = "md" }: Props) {
+export function ImportInProgressBadge({ agentId }: Props) {
   const importing = useIsImporting(agentId);
   if (!importing) return null;
   return (
     <span title="Importing files into the agent">
       <StatusBadge
-        size={size}
         label="Importing…"
         colorClasses="bg-accent-light text-accent border-accent"
-        dotColorClasses="bg-accent anim-pulse"
       />
     </span>
   );

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -719,28 +719,21 @@ function ChatHeaderStatus({
     <>
       {busy ? (
         <StatusBadge
-          size="sm"
           label="Busy"
           colorClasses="bg-accent-light text-accent border-accent"
-          dotColorClasses="bg-accent anim-pulse"
         />
       ) : (
-        <StatusBadge size="sm" state={agent?.state ?? "starting"} />
+        <StatusBadge state={agent?.state ?? "starting"} />
       )}
       {reconnecting && (
         <StatusBadge
-          size="sm"
           label="Reconnecting"
           colorClasses="bg-warning-light text-warning border-warning"
-          dotColorClasses="bg-warning anim-pulse"
         />
       )}
-      <ImportInProgressBadge size="sm" agentId={selectedAgent} />
+      <ImportInProgressBadge agentId={selectedAgent} />
       {!busy && agent && (
-        <ContributionFailuresBadge
-          size="sm"
-          failures={agent.contributionFailures}
-        />
+        <ContributionFailuresBadge failures={agent.contributionFailures} />
       )}
     </>
   );

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -83,7 +83,7 @@ export function SettingsView() {
             className={cn(
               "px-3 py-2 text-[14px] font-medium rounded-lg text-left transition-colors",
               activeTab === tab.id
-                ? "text-primary bg-primary/10"
+                ? "text-primary bg-muted"
                 : "text-foreground/80 hover:text-foreground hover:bg-muted",
             )}
           >


### PR DESCRIPTION
Post-redesign UI polish, centered on unifying status badges.

## What

- Adds reusable **semantic color variants** to the shared Badge (`success`, `warning`, `danger`, `info`, `muted`, `accent`) in one consistent soft style, so status/label chips no longer need bespoke color classes.
- Restyles the **agent status badge** to use them — running shows as green, idle states (hibernated/hibernating) as muted grey, errors as danger, etc. — matching the connections-row look.
- Minor polish: a divider before the destructive "Delete sandbox" action in the sandbox row menu, danger dropdown items render in red, and active-state backgrounds in the icon rail and settings tabs use a muted fill.

Groundwork for #1152 (migrating the remaining scattered badges/pills onto these variants).