### PR TITLE
fix(ui): Environment section disclaimer, copy, and visual consistency

### DIFF
--- a/packages/ui/src/components/key-value-editor.tsx
+++ b/packages/ui/src/components/key-value-editor.tsx
@@ -58,6 +58,7 @@ export function KeyValueEditor({
           <div key={i} className="flex items-start gap-2">
             <div className="flex-1 flex flex-col gap-1">
               <Input
+                size="sm"
                 className={`font-mono ${invalid ? "border-destructive" : ""}`}
                 placeholder={keyPlaceholder}
                 value={row.key}
@@ -73,6 +74,7 @@ export function KeyValueEditor({
               )}
             </div>
             <Input
+              size="sm"
               className="flex-1 font-mono"
               placeholder={valuePlaceholder}
               value={row.value}
@@ -82,10 +84,11 @@ export function KeyValueEditor({
             <Button
               type="button"
               variant="outline"
-              size="icon"
+              tone="danger"
+              size="icon-sm"
               onClick={() => remove(i)}
               disabled={disabled}
-              className="shrink-0 text-muted-foreground hover:text-destructive hover:border-destructive"
+              className="shrink-0 text-muted-foreground"
               title="Remove"
             >
               <X size={13} />

--- a/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
+++ b/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
@@ -118,7 +118,7 @@ function InheritedEnvRow({ entry }: { entry: InheritedEnv }) {
       <span className="font-mono font-semibold text-text truncate">
         {entry.name}
       </span>
-      <span className="text-text-muted">=</span>
+      <span className="text-muted-foreground">=</span>
       <span
         className="font-mono text-muted-foreground truncate flex-1"
         title={entry.value}
@@ -126,7 +126,7 @@ function InheritedEnvRow({ entry }: { entry: InheritedEnv }) {
         {entry.value}
       </span>
       {!isSystem && (
-        <span className="text-[14px] text-muted-foreground italic truncate max-w-[160px]">
+        <span className="text-[12px] text-muted-foreground truncate max-w-[160px]">
           {sourceName}
         </span>
       )}

--- a/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
+++ b/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
@@ -49,9 +49,11 @@ export function EnvTab({
   const warnings = shadowWarnings(envVars, inherited);
   return (
     <div className="flex flex-col gap-6">
-      <p className="text-[14px] text-muted-foreground">
-        Applied to every instance of this agent. Restart the instance pod to
-        pick up changes.
+      <p className="text-[12px] text-muted-foreground">
+        Variables added here are sent directly to the agent as plaintext. Use
+        them only for non-sensitive stubs and config — never secrets, which
+        belong in Connections. Changes apply to this agent; restart it to pick
+        them up.
       </p>
 
       {inherited.length > 0 && (


### PR DESCRIPTION
Closes #1091

Fresh branch off latest `main` containing only the Environment-section UX work (the prior branch's history got tangled with an unrelated concurrent session; this is the clean home for the change).

## Issues addressed

**1. Copy + security disclaimer** (`env-tab.tsx`)

The subtext now warns that env vars are sent as plaintext and are for non-sensitive stubs/config only — secrets belong in Connections — and drops the stale "instance" language. Size aligned to `text-[12px]` to match the Provider/Network subtext.

> Variables added here are sent directly to the agent as plaintext. Use them only for non-sensitive stubs and config — never secrets, which belong in Connections. Changes apply to this agent; restart it to pick them up.

**2. Visual consistency of the Custom + Inherited rows** (`key-value-editor.tsx`, `env-tab.tsx`)

The editable Custom inputs previously towered over the compact read-only Inherited rows. Now:

- Custom key/value `<Input>`s use the `sm` size (`h-8`, 12px); the remove button uses `icon-sm` with the built-in `outline` + `danger` tone instead of hand-rolled hover classes.
- Inherited source label drops the oversized 14px italic for 12px; the `=` separator uses `text-muted-foreground` so all secondary text in the row shares one grey.

Class-only changes, no logic. `KeyValueEditor` is consumed only via `EnvVarsEditor` → `EnvTab`, so the sizing change is contained to this section.