### PR TITLE
feat(ui): skip the empty state when no sandboxes exist

### DIFF
--- a/packages/ui/src/modules/sandboxes/hooks/use-first-run-redirect.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-first-run-redirect.ts
@@ -1,34 +1,23 @@
 import { useEffect } from "react";
 
 import { useStore } from "../../../store.js";
-import { isProviderPresetType } from "../../../types.js";
 import { useAgents } from "../../agents/api/queries.js";
-import { useSecrets } from "../../secrets/api/queries.js";
 
 const FIRST_RUN_FLAG = "platform-first-run-routed";
 
 export function useFirstRunRedirect(): void {
   const { data: agentsData, isSuccess: agentsLoaded } = useAgents();
-  const { data: secrets = [], isSuccess: secretsLoaded } = useSecrets();
   const view = useStore((s) => s.view);
   const navigateToCreateSandbox = useStore((s) => s.navigateToCreateSandbox);
 
   useEffect(() => {
-    if (!agentsLoaded || !secretsLoaded) return;
+    if (!agentsLoaded) return;
     // Set the flag unconditionally on the first loaded pass — even when not
     // routing — so a later delete-to-zero in this session never triggers it.
     if (sessionStorage.getItem(FIRST_RUN_FLAG)) return;
     sessionStorage.setItem(FIRST_RUN_FLAG, "1");
 
     const noSandboxes = (agentsData?.list.length ?? 0) === 0;
-    const noProvider = !secrets.some((s) => isProviderPresetType(s.type));
-    if (noSandboxes && noProvider && view === "list") navigateToCreateSandbox();
-  }, [
-    agentsLoaded,
-    secretsLoaded,
-    agentsData,
-    secrets,
-    view,
-    navigateToCreateSandbox,
-  ]);
+    if (noSandboxes && view === "list") navigateToCreateSandbox();
+  }, [agentsLoaded, agentsData, view, navigateToCreateSandbox]);
 }


### PR DESCRIPTION
When a user has no sandboxes, drop them straight into the create-sandbox flow on first load instead of showing the empty state with a "Create sandbox" button — saving a click on the most common first-run path.

A once-per-session guard means it fires at most once: backing out of the wizard (or deleting your last sandbox later in the session) lands you on the empty-state card rather than bouncing you back into the wizard.

Closes #1096