### PR TITLE
feat(helm): predefine external agents as selectable UI templates

### DIFF
--- a/deploy/helm/platform/templates/agent-template-pull-secrets.yaml
+++ b/deploy/helm/platform/templates/agent-template-pull-secrets.yaml
@@ -1,0 +1,33 @@
+{{/*
+Per-template image pull secrets. For each enabled `.Values.agentTemplates`
+entry that declares `imagePullSecret` (server/username/password), render one
+kubernetes.io/dockerconfigjson Secret in `agentNamespace` — the namespace where
+agent pods run, so kubelet can read it at pull time.
+
+The api-server stamps the matching `imagePullSecretRef` onto the agent spec
+(see agent-templates.yaml), and the controller adds it to the pod's
+imagePullSecrets. This lets operators predefine experimental external agents
+(private-registry images) that users just pick from the template list — no
+manual "Private registry" credential entry needed.
+
+Secret name MUST match the reference rendered in agent-templates.yaml.
+*/}}
+{{- range $tmpl := .Values.agentTemplates }}
+{{- if and $tmpl.enabled $tmpl.imagePullSecret }}
+{{- $cred := $tmpl.imagePullSecret }}
+{{- $auth := printf "%s:%s" $cred.username $cred.password | b64enc }}
+{{- $dockercfg := dict "auths" (dict $cred.server (dict "auth" $auth)) | toJson }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $tmpl.name | quote }}
+  namespace: {{ $.Values.agentNamespace }}
+  labels:
+    {{- include "platform.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: agent-template-pull-secret
+type: kubernetes.io/dockerconfigjson
+stringData:
+  .dockerconfigjson: {{ $dockercfg | quote }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -37,6 +37,9 @@ data:
     {{- with $tmpl.storageSize }}
     storageSize: {{ . | quote }}
     {{- end }}
+    {{- if $tmpl.imagePullSecret }}
+    imagePullSecretRef: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $tmpl.name | quote }}
+    {{- end }}
     {{- with $tmpl.resources }}
     resources:
       {{- toYaml . | nindent 6 }}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -732,6 +732,23 @@ controller:
 # override the chart-wide default for agents created from this template.
 # `$HOME` in mount paths is substituted at chart render time
 # using this entry's `agentHome` if set, else `templateDefaults.agentHome`.
+#
+# To predefine an *experimental external agent* (a private-registry image users
+# just pick from the template list, with no manual "Private registry" entry),
+# add an entry with `imagePullSecret`:
+#
+#   - name: bugstone
+#     enabled: true
+#     description: "Experimental DAM bug-hunting agent"
+#     image:
+#       repository: icr.io/dam-agents/bugstone
+#       tag: ""
+#     storageSize: "5Gi"
+#     imagePullSecret:                 # renders a dockerconfigjson Secret in agentNamespace
+#       server: icr.io
+#       username: iamapikey
+#       password: "<registry-api-key>" # keep out of plaintext values in prod (sealed/SOPS/external secret)
+#
 agentTemplates:
   - name: claude-code
     enabled: true

--- a/packages/api-server-api/src/modules/templates/schemas.ts
+++ b/packages/api-server-api/src/modules/templates/schemas.ts
@@ -39,6 +39,11 @@ export const templateSpecSchema = z
     env: z.array(envVarConfigMapSchema).optional(),
     resources: resourcesSchema.optional(),
     imagePullPolicy: z.string().optional(),
+    // Names a kubernetes.io/dockerconfigjson Secret in the agent namespace,
+    // pre-created by the chart for templates that pull from a private registry
+    // (e.g. experimental external agents). Carried onto the agent spec so the
+    // pod can pull the image without the user entering registry credentials.
+    imagePullSecretRef: z.string().optional(),
     storageSize: z.string().optional(),
     skillSources: z.array(skillSourceSeedSchema).optional(),
   })

--- a/packages/api-server-api/src/modules/templates/types.ts
+++ b/packages/api-server-api/src/modules/templates/types.ts
@@ -38,6 +38,11 @@ export interface TemplateSpec {
   /** Overrides `controller.agent.templateDefaults.imagePullPolicy` for
    *  instances created from this template. Empty = inherit. */
   imagePullPolicy?: string;
+  /** Names a kubernetes.io/dockerconfigjson Secret in the agent namespace,
+   *  pre-created by the chart for templates pulling from a private registry.
+   *  Carried onto the agent spec so the pod pulls without the user supplying
+   *  registry credentials. Empty = none. */
+  imagePullSecretRef?: string;
   /** Overrides `controller.agent.templateDefaults.storageSize` for the
    *  persistent home mount. Per-mount `size` (if set) wins over this. */
   storageSize?: string;

--- a/packages/api-server/src/modules/agents/domain/spec-assembly.ts
+++ b/packages/api-server/src/modules/agents/domain/spec-assembly.ts
@@ -16,6 +16,7 @@ export function assembleSpecFromTemplate(
     env: tmplSpec.env,
     resources: tmplSpec.resources,
     imagePullPolicy: tmplSpec.imagePullPolicy,
+    imagePullSecretRef: tmplSpec.imagePullSecretRef,
     storageSize: tmplSpec.storageSize,
   };
 }


### PR DESCRIPTION
## What

Adds a `values.yaml` way to predefine **experimental external agents** — private-registry images like `icr.io/dam-agents/bugstone` — so users just pick them from the existing "From Template" list. No manual *Custom* image entry, no manual *Private registry* credentials.

## Why

Today onboarding a custom DAM agent requires the user to paste the image, flip on "Private registry", and enter server/username/password by hand. This lets operators ship that once in the chart.

## How

- `agentTemplates[]` entries gain an optional `imagePullSecret` (`server`/`username`/`password`).
- New `agent-template-pull-secrets.yaml` renders a `kubernetes.io/dockerconfigjson` Secret per such template into `agentNamespace` (where pods pull).
- `agent-templates.yaml` stamps the matching `imagePullSecretRef` onto the rendered template spec.
- `templateSpecSchema` / `TemplateSpec` carry `imagePullSecretRef`; `assembleSpecFromTemplate` forwards it onto the agent spec. The controller already wires `spec.imagePullSecretRef` into the pod's `imagePullSecrets` (gen 2, #930/#932) — no controller change.
- `values.yaml` documents the field with a commented `bugstone` example.

No UI changes: predefined agents flow through the existing template picker.

## Example

```yaml
agentTemplates:
  - name: bugstone
    enabled: true
    description: "Experimental DAM bug-hunting agent"
    image:
      repository: icr.io/dam-agents/bugstone
      tag: ""
    storageSize: "5Gi"
    imagePullSecret:
      server: icr.io
      username: iamapikey
      password: "<registry-api-key>"  # use sealed/SOPS/external secret in prod
```

## Notes / follow-ups

- Plaintext creds in values are fine for local/dev; prod should source `password` via sealed secrets / SOPS / external-secrets.
- Helm render verification was interrupted before completion — please confirm `mise run helm:check:render` / `helm:check:lint` in CI.