### PR TITLE
fix(ui): post-redesign polish (login widow, LiteLLM tile, Create key button)

### DIFF
--- a/packages/keycloak-theme/src/login/Template.tsx
+++ b/packages/keycloak-theme/src/login/Template.tsx
@@ -87,7 +87,7 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
                 <span className="block">Agents</span>
                 <span className="block">Massively</span>
               </h2>
-              <p className="text-muted-foreground text-xl leading-relaxed">
+              <p className="text-muted-foreground text-xl leading-relaxed text-pretty">
                 Run agent harnesses like Claude Code headless in the cloud, on a
                 schedule, connected to your tools — without exposing your
                 tokens.

--- a/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
@@ -2,6 +2,8 @@ import type { ApiKeyView } from "api-server-api";
 import { KeyRound } from "lucide-react";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import { useRevokeApiKey } from "../api/mutations.js";
 import { useApiKeys } from "../api/queries.js";
 import { ApiKeyRow } from "./api-key-row.js";
@@ -28,12 +30,7 @@ export function ApiKeysList() {
     <div className="anim-in">
       <div className="flex items-start justify-between mb-1">
         <h2 className="text-[18px] font-bold">API Keys</h2>
-        <button
-          onClick={() => setCreateOpen(true)}
-          className="px-3 py-1.5 text-[13px] font-semibold rounded-lg bg-accent text-white hover:bg-accent-hover"
-        >
-          Create key
-        </button>
+        <Button onClick={() => setCreateOpen(true)}>Create key</Button>
       </div>
       <p className="text-[14px] text-text-secondary mb-6">
         Long-lived tokens for headless / CI use. Pass the value as a bearer

--- a/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
@@ -67,7 +67,7 @@ export function IbmLitellmForm({
         href={KEY_GUIDE_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary hover:bg-muted"
+        className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary"
       >
         <div className="flex flex-col gap-0.5">
           <span className="text-[14px] font-bold text-foreground">

--- a/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
@@ -67,7 +67,7 @@ export function IbmLitellmForm({
         href={KEY_GUIDE_URL}
         target="_blank"
         rel="noopener noreferrer"
-        className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:border-primary"
+        className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-muted/40"
       >
         <div className="flex flex-col gap-0.5">
           <span className="text-[14px] font-bold text-foreground">


### PR DESCRIPTION
Small UI polish fixes:

- **#1097** — Login page: the marketing description no longer drops its last word ("tokens.") to a line of its own at full viewport. Uses `text-wrap: pretty`, so it holds at any width.
- **#1100** — LiteLLM provider modal: the "Need an API key?" tile now uses the same row-style hover as the cards elsewhere (`hover:bg-muted/40`).
- **#1101** — API Keys settings page: the "Create key" button now uses the shared `Button` component, matching the primary-action styling used across the app instead of a hand-rolled accent button.

Closes #1097
Closes #1100
Closes #1101