### PR TITLE
fix(ui): autogenerate default sandbox name on Step 2

### DIFF
--- a/packages/ui/src/modules/sandboxes/lib/sandbox-name.ts
+++ b/packages/ui/src/modules/sandboxes/lib/sandbox-name.ts
@@ -1,0 +1,60 @@
+const ADJECTIVES = [
+  "swift",
+  "calm",
+  "brave",
+  "clever",
+  "bright",
+  "gentle",
+  "bold",
+  "quiet",
+  "lucky",
+  "sunny",
+  "cosmic",
+  "amber",
+  "misty",
+  "nimble",
+  "mellow",
+  "stellar",
+  "crimson",
+  "golden",
+  "silent",
+  "breezy",
+  "frosty",
+  "jolly",
+  "rustic",
+  "velvet",
+] as const;
+
+const NOUNS = [
+  "otter",
+  "falcon",
+  "river",
+  "panda",
+  "maple",
+  "comet",
+  "willow",
+  "sparrow",
+  "cedar",
+  "harbor",
+  "meadow",
+  "badger",
+  "lynx",
+  "heron",
+  "ember",
+  "pebble",
+  "glacier",
+  "fern",
+  "robin",
+  "canyon",
+  "lantern",
+  "beacon",
+  "grove",
+  "summit",
+] as const;
+
+const pick = <T>(arr: readonly T[]): T =>
+  arr[Math.floor(Math.random() * arr.length)]!;
+
+export function generateSandboxName(): string {
+  return `${pick(ADJECTIVES)}-${pick(NOUNS)}`;
+}

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
@@ -14,6 +14,7 @@ import { ConnectionsStep } from "../components/steps/connections-step.js";
 import { ImageStep } from "../components/steps/image-step.js";
 import { SetupStep } from "../components/steps/setup-step.js";
 import { useSandboxWizard } from "../hooks/use-sandbox-wizard.js";
+import { generateSandboxName } from "../lib/sandbox-name.js";
 import { loadSnapshot, type WizardStep } from "../lib/wizard-snapshot.js";
 
 const NO_TEMPLATES: TemplateView[] = [];
@@ -72,6 +73,13 @@ export function SandboxWizardView() {
         });
     }
   }, [update]);
+
+  useLayoutEffect(() => {
+    if (snapshot.step === 2 && !snapshot.name.trim()) {
+      update({ name: generateSandboxName() });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [snapshot.step]);
 
   const goToStep = (step: WizardStep) => update({ step });
 


### PR DESCRIPTION
On Step 2 of sandbox setup, the **Continue** button stayed disabled until the sandbox was named, with nothing explaining why — and the `my-sandbox` placeholder read like a real, filled-in value, so it wasn't obvious the empty name field was the blocker.

Now the name field arrives **pre-filled with a friendly, editable default** (e.g. `golden-otter`) whenever you reach Step 2 with it empty, so Continue is ready immediately. You can rename it freely; if you clear it and come back later, a fresh default fills in again — so the field is never a silent dead end.

Closes #1098