### PR TITLE
fix(ui): replace provider dropdown in sandbox config with card picker

### DIFF
--- a/packages/ui/src/modules/providers/components/provider-section.tsx
+++ b/packages/ui/src/modules/providers/components/provider-section.tsx
@@ -1,23 +1,15 @@
-import { Check, ChevronDown } from "lucide-react";
+import { ChevronDown, ChevronUp } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
 import {
   bobPinsFromEnvMappings,
   type ProviderPresetType,
-  PROVIDERS,
   type SecretView,
 } from "../../../types.js";
 import { useSecrets } from "../../secrets/api/queries.js";
 import { detectMode, MODES } from "./anthropic/modes.js";
-import { CardIcon } from "./card-icon.js";
 import { ProviderConnectDialog } from "./provider-connect-dialog.js";
 import { ProviderRow } from "./provider-row.js";
 import { useProviderActions } from "./use-provider-actions.js";
@@ -66,7 +58,7 @@ interface Props {
   onSelect?: (secretId: string) => void;
   onProviderRemoved?: (secretId: string) => void;
   autoSelectFirst?: boolean;
-  variant?: "stacked" | "dropdown";
+  variant?: "stacked" | "collapsible";
   manage?: boolean;
   listClassName?: string;
 }
@@ -86,6 +78,7 @@ export function ProviderSection({
     provider: ProviderPresetType;
     secret?: SecretView;
   } | null>(null);
+  const [expanded, setExpanded] = useState(false);
 
   const secretByType = useMemo(
     () => new Map(secrets.map((s) => [s.type, s])),
@@ -102,54 +95,65 @@ export function ProviderSection({
     if (firstConnected) onSelect?.(firstConnected.id);
   }, [autoSelectFirst, selectedSecretId, secretByType, onSelect]);
 
-  const pick = (type: ProviderPresetType) => {
-    const secret = secretByType.get(type);
-    if (secret) onSelect?.(secret.id);
-    else setDialog({ provider: type });
+  const renderRow = (row: (typeof PROVIDER_ROWS)[number]) => {
+    const secret = secretByType.get(row.type);
+    return (
+      <ProviderRow
+        key={row.type}
+        type={row.type}
+        description={row.description}
+        subtitle={secret ? connectedSubtitle(row.type, secret) : undefined}
+        secret={secret}
+        selectable={!manage}
+        selected={!!secret && secret.id === selectedSecretId}
+        onConnect={() => setDialog({ provider: row.type })}
+        onSelect={() => secret && onSelect?.(secret.id)}
+        onEditKey={() => secret && setDialog({ provider: row.type, secret })}
+        onRemoveKey={() =>
+          secret &&
+          void providerActions.remove(secret.id, () =>
+            onProviderRemoved?.(secret.id),
+          )
+        }
+      />
+    );
   };
+
+  const connectedRows = PROVIDER_ROWS.filter((r) => secretByType.has(r.type));
+  const disconnectedRows = PROVIDER_ROWS.filter(
+    (r) => !secretByType.has(r.type),
+  );
+  // Connected providers stay visible; the rest hide behind "Show all". With
+  // nothing connected there's nothing to collapse, so reveal everything.
+  const collapsible =
+    variant === "collapsible" &&
+    connectedRows.length > 0 &&
+    disconnectedRows.length > 0;
+  const visibleRows =
+    variant === "collapsible"
+      ? [
+          ...connectedRows,
+          ...(collapsible && !expanded ? [] : disconnectedRows),
+        ]
+      : PROVIDER_ROWS;
 
   return (
     <>
-      {variant === "dropdown" ? (
-        <ProviderDropdown
-          secretByType={secretByType}
-          selectedSecretId={selectedSecretId}
-          onPick={pick}
-        />
-      ) : (
-        <div className={cn("flex flex-col gap-3", listClassName)}>
-          {isPending
-            ? PROVIDER_ROWS.map((row) => (
-                <ProviderRow.Skeleton key={row.type} />
-              ))
-            : PROVIDER_ROWS.map((row) => {
-                const secret = secretByType.get(row.type);
-                return (
-                  <ProviderRow
-                    key={row.type}
-                    type={row.type}
-                    description={row.description}
-                    subtitle={
-                      secret ? connectedSubtitle(row.type, secret) : undefined
-                    }
-                    secret={secret}
-                    selectable={!manage}
-                    selected={!!secret && secret.id === selectedSecretId}
-                    onConnect={() => setDialog({ provider: row.type })}
-                    onSelect={() => secret && onSelect?.(secret.id)}
-                    onEditKey={() =>
-                      secret && setDialog({ provider: row.type, secret })
-                    }
-                    onRemoveKey={() =>
-                      secret &&
-                      void providerActions.remove(secret.id, () =>
-                        onProviderRemoved?.(secret.id),
-                      )
-                    }
-                  />
-                );
-              })}
-        </div>
+      <div className={cn("flex flex-col gap-3", listClassName)}>
+        {isPending
+          ? PROVIDER_ROWS.map((row) => <ProviderRow.Skeleton key={row.type} />)
+          : visibleRows.map(renderRow)}
+      </div>
+
+      {!isPending && collapsible && (
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="mt-3 inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
+        >
+          {expanded ? "Show less" : "Show all"}
+          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+        </button>
       )}
 
       {dialog && (
@@ -164,70 +168,5 @@ export function ProviderSection({
         />
       )}
     </>
-  );
-}
-
-function ProviderDropdown({
-  secretByType,
-  selectedSecretId,
-  onPick,
-}: {
-  secretByType: Map<string, SecretView>;
-  selectedSecretId: string | null;
-  onPick: (type: ProviderPresetType) => void;
-}) {
-  const selected = PROVIDER_ROWS.find(
-    (r) => secretByType.get(r.type)?.id === selectedSecretId,
-  );
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          className="flex h-10 w-full items-center gap-3 rounded-md border border-input bg-background px-4 text-sm text-foreground transition-colors hover:bg-muted/30"
-        >
-          {selected ? (
-            <>
-              <CardIcon provider={selected.type} size="sm" />
-              <span>{PROVIDERS[selected.type].displayName}</span>
-            </>
-          ) : (
-            <span className="text-muted-foreground">Select a provider</span>
-          )}
-          <ChevronDown size={16} className="ml-auto text-muted-foreground" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent
-        align="start"
-        className="w-[var(--radix-dropdown-menu-trigger-width)]"
-      >
-        {PROVIDER_ROWS.map((row) => {
-          const secret = secretByType.get(row.type);
-          const isSelected = !!secret && secret.id === selectedSecretId;
-          return (
-            <DropdownMenuItem
-              key={row.type}
-              onSelect={() => onPick(row.type)}
-              className="h-10"
-            >
-              {isSelected ? (
-                <Check size={16} className="shrink-0" />
-              ) : (
-                <span className="w-4 shrink-0" />
-              )}
-              <CardIcon provider={row.type} size="sm" />
-              <span className="flex-1 truncate">
-                {PROVIDERS[row.type].displayName}
-              </span>
-              {secret && (
-                <span className="rounded-full bg-success-light px-2 py-0.5 text-[11px] font-medium text-success">
-                  Connected
-                </span>
-              )}
-            </DropdownMenuItem>
-          );
-        })}
-      </DropdownMenuContent>
-    </DropdownMenu>
   );
 }

--- a/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
@@ -74,14 +74,13 @@ export function SandboxSettingsView() {
 
       <section className="mb-8">
         <WizardSectionLabel>Provider</WizardSectionLabel>
-        <FormField>
-          <ProviderSection
-            variant="dropdown"
-            selectedSecretId={f.selectedProviderSecretId}
-            onSelect={f.selectProvider}
-            onProviderRemoved={f.dropProviderGrant}
-          />
-        </FormField>
+        <ProviderSection
+          variant="collapsible"
+          listClassName="md:-ml-4"
+          selectedSecretId={f.selectedProviderSecretId}
+          onSelect={f.selectProvider}
+          onProviderRemoved={f.dropProviderGrant}
+        />
         <p className="mt-3 text-[12px] text-muted-foreground">
           Changing the provider swaps this sandbox's model credential. A
           cross-family switch (e.g. Anthropic → OpenAI on a Claude image) can


### PR DESCRIPTION
## What

The provider picker on sandbox config was a dropdown, hiding all but the selected provider behind a click. A user with multiple connected providers couldn't see or compare their options at a glance.

This surfaces providers using the same card pattern used elsewhere (wizard, settings):

- New `collapsible` `ProviderSection` variant — connected providers render as the shared `ProviderRow` cards (always visible), with a **Show all / Show less** toggle (same pattern as `ConnectionsSection`) revealing the disconnected providers as Connect cards.
- Edge cases: nothing connected → everything shown, no toggle; everything connected → no toggle. The toggle only appears when there's something to collapse.
- The `stacked` variant (wizard + provider-management page) is unchanged, including its original fixed ordering — connected-first ordering applies only to `collapsible`.
- Removed the now-dead `ProviderDropdown` and its unused imports (net −62 lines).

The card list bleeds left via `listClassName="md:-ml-4"` (matching the wizard) so the toggle aligns with card content, the section label, and the help text — rather than the bleeding card edge.

## Test plan

- `mise run ui:check` (eslint + prettier + tsc) — clean
- `mise run ui:test` — 44 passing
- Manual visual check pending (no `platform` namespace installed locally at time of writing)

Closes #1099