### PR TITLE
feat(deploy): DAM-in-DAM inner-cluster build+deploy from agent pod (dam-kt9)

### DIFF
--- a/deploy/helm/platform/values-inner.yaml
+++ b/deploy/helm/platform/values-inner.yaml
@@ -1,0 +1,110 @@
+# DAM-in-DAM (dam-kt9): images are built by the outer agent via buildkit and
+# pushed to the inner cluster's registry, then pulled by the inner node. Unlike
+# values-local.yaml (Never + local containerd side-load), every ref points at the
+# shared registry hostname and uses Always so a rebuild+push is picked up on the
+# next pod start.
+#
+# Used via: helm ... -f values-inner.yaml  (after -f values-local.yaml so these win)
+
+ui:
+  image:
+    repository: inner-registry:25000/platform-ui
+    tag: latest
+    pullPolicy: Always
+
+apiServer:
+  image:
+    repository: inner-registry:25000/platform-api-server
+    tag: latest
+    pullPolicy: Always
+
+controller:
+  image:
+    repository: inner-registry:25000/platform-controller
+    tag: latest
+    pullPolicy: Always
+  logLevel: debug
+  agent:
+    base:
+      storageClass: platform-rwx
+    templateDefaults:
+      imagePullPolicy: Always
+
+nfsProvisioner:
+  enabled: true
+
+agentTemplates:
+  - name: claude-code
+    enabled: true
+    description: "Default Claude Code agent"
+    image:
+      repository: inner-registry:25000/platform-claude-code
+      tag: latest
+    storageSize: "5Gi"
+
+  - name: codex
+    enabled: false
+    description: "OpenAI Codex coding agent"
+    image:
+      repository: inner-registry:25000/platform-codex
+      tag: latest
+    storageSize: "5Gi"
+
+  - name: pi-agent
+    enabled: false
+    description: "Pi coding agent with multi-LLM support"
+    image:
+      repository: inner-registry:25000/platform-pi-agent
+      tag: latest
+    storageSize: "2Gi"
+
+  - name: bob
+    enabled: false
+    description: "Bob shell agent"
+    image:
+      repository: inner-registry:25000/platform-bob
+      tag: latest
+    storageSize: "2Gi"
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+
+  - name: mock
+    enabled: true
+    description: "Scripted mock agent (E2E test fixture)"
+    image:
+      repository: inner-registry:25000/platform-mock
+      tag: latest
+    storageSize: "1Gi"
+    env:
+      - name: MOCK_DEFAULT_REPLY
+        value: "Hello from the mock agent."
+
+ingress:
+  catchAllAppHost: true
+
+keycloak:
+  admin:
+    password: admin
+  image:
+    repository: inner-registry:25000/platform-keycloak
+    tag: latest
+    pullPolicy: Always
+  testUser:
+    enabled: true
+    username: dev
+    password: dev
+  extraRedirectUris:
+    - "*"
+  extraWebOrigins:
+    - "*"
+  log:
+    consoleOutput: "default"
+
+terms:
+  version: dev
+  text: "Dev placeholder Terms of Use. See ADR-047."

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -22,6 +22,13 @@ controller:
   agent:
     base:
       storageClass: platform-rwx
+      # DAM-in-DAM (dam-kt9): let agents reach the inner cluster's Kubernetes
+      # API (26444) and buildkit daemon (21234) across the lima host gateway.
+      # Install-wide — every agent gets the allowance; harmless when no inner
+      # VM is running (nothing listens on those ports).
+      extraEgress:
+        - cidr: 192.168.5.2/32
+          ports: [26444, 21234]
     templateDefaults:
       imagePullPolicy: IfNotPresent
 
@@ -82,6 +89,30 @@ agentTemplates:
     env:
       - name: MOCK_DEFAULT_REPLY
         value: "Hello from the mock agent."
+
+  # DAM-in-DAM dev loop (dam-kt9). Runs in THIS (outer) cluster; rebuilds
+  # platform images via the inner cluster's buildkit and deploys them into
+  # the inner cluster. On for local dev — cluster:install builds
+  # platform-dev-agent; the build+deploy loop additionally needs the inner VM
+  # plus the extraEgress allowance above. NO_PROXY pins the inner API +
+  # buildkit to direct egress: the controller routes all other traffic
+  # through the paired gateway, which can't proxy raw TCP (buildkit) or the
+  # IP-literal inner API.
+  - name: dev-agent
+    enabled: true
+    description: "DAM-in-DAM dev loop (build + deploy into the inner cluster)"
+    image:
+      repository: platform-dev-agent
+      tag: latest
+    storageSize: "10Gi"
+    init: dev-bootstrap
+    env:
+      - name: NO_PROXY
+        value: "192.168.5.2"
+      - name: no_proxy
+        value: "192.168.5.2"
+      - name: REPO_REF
+        value: "feat/dam-in-dam"
 
 # Local dev convenience: route requests with any Host header (including
 # IP literals like 127.0.0.1) to the app, so the cluster is reachable

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -98,6 +98,10 @@ agentTemplates:
   # buildkit to direct egress: the controller routes all other traffic
   # through the paired gateway, which can't proxy raw TCP (buildkit) or the
   # IP-literal inner API.
+  #
+  # No `init:` — init containers get only HOME (no HTTPS_PROXY / CA), so a
+  # git clone there can't reach github. Run `dev-bootstrap` (on PATH) at
+  # session start inside the main container, which has the proxy + CA.
   - name: dev-agent
     enabled: true
     description: "DAM-in-DAM dev loop (build + deploy into the inner cluster)"
@@ -105,7 +109,6 @@ agentTemplates:
       repository: platform-dev-agent
       tag: latest
     storageSize: "10Gi"
-    init: dev-bootstrap
     env:
       - name: NO_PROXY
         value: "192.168.5.2"

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -572,6 +572,15 @@ controller:
       # Gated by top-level `probes.enabled`.
       probes: {}
 
+      # Extra IP-CIDR egress allowances added to every agent's per-pair
+      # NetworkPolicy, on top of the paired gateway. These bypass the
+      # gateway's L7 ext_authz gate, so they are operator policy for
+      # cluster-integration destinations the gateway can't proxy (raw TCP).
+      # Empty in production. The DAM-in-DAM dev loop sets it in
+      # values-local.yaml to reach the inner cluster's API + buildkit.
+      # Each entry: {cidr: "<ip>/<prefix>", ports: [<int>, ...]}.
+      extraEgress: []
+
       # ━━━ SECURITY DEFAULTS — DO NOT CHANGE WITHOUT REVIEW ━━━
       # These ship the cluster-enforced sandbox boundary the platform relies on.
       # Relaxing them gives the agent container privileges that bypass the

--- a/deploy/inner/buildkit-registry.yaml
+++ b/deploy/inner/buildkit-registry.yaml
@@ -1,0 +1,97 @@
+# Build plane for the INNER cluster (DAM-in-DAM, dam-kt9).
+#
+# registry: holds images the outer agent builds; exposed on the node loopback
+#   (hostPort 5000) so registries.yaml's inner-registry:5000 mirror resolves it,
+#   and forwarded to host :5000 so the outer agent can push.
+# buildkitd: OCI worker (the supported config — the containerd-worker direct-to-
+#   store path fails the RUN executor when buildkitd runs as a pod). Listens on
+#   tcp :1234 (hostPort + host forward) so the outer agent runs buildctl as a
+#   thin client; the privileged daemon lives here, where privilege is acceptable.
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: dam-inner
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: registry
+  namespace: dam-inner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: registry
+  template:
+    metadata:
+      labels:
+        app: registry
+    spec:
+      # hostNetwork (not hostPort): lima's guest-agent forwards real listening
+      # sockets, but hostPort is CNI iptables DNAT with no socket, so lima never
+      # sees it. hostNetwork binds the node's 0.0.0.0:5000 directly, which lima
+      # then forwards to the host, and which registries.yaml reaches at 127.0.0.1:5000.
+      hostNetwork: true
+      containers:
+        - name: registry
+          image: registry:2
+          env:
+            # Listen on the same port the shared image name uses (25000), so the
+            # ref inner-registry:25000 resolves identically for the outer agent
+            # (via the host gateway), this node (registries.yaml mirror), and
+            # buildkitd (hostAlias -> 127.0.0.1). host :5000 is taken on macOS.
+            - name: REGISTRY_HTTP_ADDR
+              value: ":25000"
+          ports:
+            - containerPort: 25000
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/registry
+      volumes:
+        - name: data
+          hostPath:
+            path: /var/lib/dam-inner-registry
+            type: DirectoryOrCreate
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: buildkitd
+  namespace: dam-inner
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: buildkitd
+  template:
+    metadata:
+      labels:
+        app: buildkitd
+    spec:
+      hostNetwork: true
+      # buildkitd performs the push (not the client), so the shared name must
+      # resolve here too: inner-registry -> the node loopback where the registry
+      # listens. The outer agent only talks to buildkitd's :1234; it never
+      # resolves inner-registry itself.
+      hostAliases:
+        - ip: "127.0.0.1"
+          hostnames:
+            - inner-registry
+      containers:
+        - name: buildkitd
+          image: moby/buildkit:latest
+          args:
+            - --addr=tcp://0.0.0.0:1234
+          ports:
+            - containerPort: 1234
+          securityContext:
+            privileged: true
+          readinessProbe:
+            exec:
+              command: ["buildctl", "--addr", "tcp://127.0.0.1:1234", "debug", "workers"]
+            initialDelaySeconds: 3
+            periodSeconds: 5

--- a/deploy/inner/buildkit-registry.yaml
+++ b/deploy/inner/buildkit-registry.yaml
@@ -55,6 +55,21 @@ spec:
             path: /var/lib/dam-inner-registry
             type: DirectoryOrCreate
 ---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: buildkitd-config
+  namespace: dam-inner
+data:
+  # The agent images (FROM ${BASE_IMAGE}=inner-registry:25000/platform-base) make
+  # buildkitd PULL from the inner registry, which is plain HTTP on the node
+  # loopback (hostAlias inner-registry -> 127.0.0.1). buildkitd defaults to HTTPS,
+  # so without this the FROM resolve fails. (Push insecurity is handled per-build
+  # by the output's registry.insecure=true; pulls need daemon config.)
+  buildkitd.toml: |
+    [registry."inner-registry:25000"]
+      http = true
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -86,6 +101,7 @@ spec:
           image: moby/buildkit:latest
           args:
             - --addr=tcp://0.0.0.0:1234
+            - --config=/etc/buildkit/buildkitd.toml
           ports:
             - containerPort: 1234
           securityContext:
@@ -95,3 +111,10 @@ spec:
               command: ["buildctl", "--addr", "tcp://127.0.0.1:1234", "debug", "workers"]
             initialDelaySeconds: 3
             periodSeconds: 5
+          volumeMounts:
+            - name: config
+              mountPath: /etc/buildkit
+      volumes:
+        - name: config
+          configMap:
+            name: buildkitd-config

--- a/deploy/lima-k3s-inner.yaml
+++ b/deploy/lima-k3s-inner.yaml
@@ -7,8 +7,8 @@
 #   2. /etc/rancher/k3s/registries.yaml mirrors the shared image hostname
 #      `inner-registry:25000` to the in-cluster registry on the node loopback, so
 #      push (from the outer agent) and pull (this node) agree on one image ref.
-#   3. Host port forwards for the API, registry, and buildkit endpoints, all to
-#      host loopback (reachable from outer pods via 192.168.5.2 — validated).
+#   3. Host port forwards for the API, registry, and buildkit endpoints bound on
+#      0.0.0.0 so outer pods can reach them via the lima host gateway (192.168.5.2).
 #
 # Host ports (26444/25000/21234/24445) sit in a high free range so they never
 # clobber the outer VM's forwards (which already include 16443/16444/4444/4445).
@@ -98,15 +98,23 @@ copyToHost:
 # (26444/25000/21234) that the outer VM never touches. The image-name port equals
 # the registry host-forward port (25000) because buildctl derives the push target
 # from the ref — hence the shared hostname inner-registry:25000.
+#
+# hostIP: 0.0.0.0 is required so the forwarded ports bind on all host interfaces,
+# including 192.168.5.2 (the lima host gateway). Without it lima defaults to
+# 127.0.0.1, which is unreachable from outer agent pods.
 portForwards:
   - guestPort: 16444
     hostPort: 26444
+    hostIP: "0.0.0.0"
   - guestPort: 25000
     hostPort: 25000
+    hostIP: "0.0.0.0"
   - guestPort: 1234
     hostPort: 21234
+    hostIP: "0.0.0.0"
   - guestPort: 4445
     hostPort: 24445
+    hostIP: "0.0.0.0"
   - guestIP: 0.0.0.0
     proto: any
     ignore: true

--- a/deploy/lima-k3s-inner.yaml
+++ b/deploy/lima-k3s-inner.yaml
@@ -1,0 +1,117 @@
+# Lima VM template for the INNER platform k3s cluster (DAM-in-DAM, dam-kt9).
+#
+# This is the target an agent pod (running in the OUTER cluster) builds into and
+# deploys to. It differs from lima-k3s.yaml in three ways:
+#   1. k3s API on 16444 (not 16443) + tls-san 192.168.5.2 so the outer agent pod
+#      can reach it through the lima host gateway without a cert mismatch.
+#   2. /etc/rancher/k3s/registries.yaml mirrors the shared image hostname
+#      `inner-registry:25000` to the in-cluster registry on the node loopback, so
+#      push (from the outer agent) and pull (this node) agree on one image ref.
+#   3. Host port forwards for the API, registry, and buildkit endpoints, all to
+#      host loopback (reachable from outer pods via 192.168.5.2 — validated).
+#
+# Host ports (26444/25000/21234/24445) sit in a high free range so they never
+# clobber the outer VM's forwards (which already include 16443/16444/4444/4445).
+
+images:
+  - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-arm64.img
+    arch: aarch64
+  - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
+    arch: x86_64
+
+cpus: 4
+memory: 8GiB
+disk: 200GiB
+
+containerd:
+  system: false
+  user: false
+
+provision:
+  - mode: system
+    script: |
+      #!/bin/sh
+      set -e
+      echo "[inner-provision] Installing nfs-common (required for platform-rwx NFS mounts)..."
+      DEBIAN_FRONTEND=noninteractive apt-get update
+      DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends nfs-common
+      echo "[inner-provision] mount.nfs4: $(command -v mount.nfs4 || echo MISSING)"
+      mkdir -p /etc/rancher/k3s
+      cat > /etc/rancher/k3s/config.yaml << 'EOF'
+      kubelet-arg:
+        - "container-log-max-size=10Mi"
+        - "container-log-max-files=3"
+      EOF
+      # Shared-hostname registry mirror (k3d-style): both the outer agent (push)
+      # and this node (pull) reference images as inner-registry:5000/...; the node
+      # rewrites that to the in-cluster registry exposed on loopback:5000.
+      cat > /etc/rancher/k3s/registries.yaml << 'EOF'
+      mirrors:
+        "inner-registry:25000":
+          endpoint:
+            - "http://127.0.0.1:25000"
+      configs:
+        "127.0.0.1:25000":
+          tls:
+            insecure_skip_verify: true
+      EOF
+      if [ ! -d /var/lib/rancher/k3s ]; then
+        curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644 --https-listen-port 16444 --tls-san 192.168.5.2" sh -
+      fi
+      mkdir -p /var/lib/rancher/k3s/server/manifests
+      cat > /var/lib/rancher/k3s/server/manifests/traefik-config.yaml << 'EOF'
+      apiVersion: helm.cattle.io/v1
+      kind: HelmChartConfig
+      metadata:
+        name: traefik
+        namespace: kube-system
+      spec:
+        valuesContent: |
+          ports:
+            platform:
+              port: 4445
+              expose:
+                default: true
+              exposedPort: 4445
+              protocol: TCP
+      EOF
+
+probes:
+  - mode: readiness
+    description: k3s is ready
+    script: |
+      #!/bin/bash
+      set -eux -o pipefail
+      if ! timeout 30s bash -c "until test -f /etc/rancher/k3s/k3s.yaml; do sleep 3; done"; then
+        echo >&2 "k3s is not running yet"
+        exit 1
+      fi
+
+copyToHost:
+  - guest: /etc/rancher/k3s/k3s.yaml
+    host: "{{.Dir}}/copied-from-guest/kubeconfig.yaml"
+    deleteOnStop: true
+
+# Host ports deliberately offset from the defaults: the OUTER VM's guest-agent
+# auto-forwards its own guest 127.0.0.1 listeners to same-numbered host ports and
+# already squats 16444/4445/5000, so the inner VM forwards to a high free range
+# (26444/25000/21234) that the outer VM never touches. The image-name port equals
+# the registry host-forward port (25000) because buildctl derives the push target
+# from the ref — hence the shared hostname inner-registry:25000.
+portForwards:
+  - guestPort: 16444
+    hostPort: 26444
+  - guestPort: 25000
+    hostPort: 25000
+  - guestPort: 1234
+    hostPort: 21234
+  - guestPort: 4445
+    hostPort: 24445
+  - guestIP: 0.0.0.0
+    proto: any
+    ignore: true
+
+message: |
+  Inner k3s ready (DAM-in-DAM target).
+  KUBECONFIG: {{.Dir}}/copied-from-guest/kubeconfig.yaml
+  API on host :26444, registry on host :25000, buildkit on host :21234.

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -54,7 +54,7 @@ esac
 # upgrade: assumes VM/k3s exists, uses helm upgrade
 
 ["cluster:install"]
-description = "Create k3s cluster, build images, install cert-manager + Platform chart. Options: --vm-name=NAME --lima-template=PATH --helm-values=PATH --set=key=val --no-restart"
+description = "Create k3s cluster, build images, install cert-manager + Platform chart. Options: --vm-name=NAME --lima-template=PATH --helm-values=PATH --set=key=val --no-restart --external-kubeconfig=PATH"
 depends = ["controller:image", "api-server:image", "ui:image", "keycloak-theme:image"]
 dir = "{{config_root}}"
 raw = true
@@ -68,6 +68,7 @@ HELM_VALUES=""
 HELM_EXTRA_ARGS=()
 NO_RESTART=false
 DEV_VALUES="deploy/helm/platform/values-dev.yaml"
+EXTERNAL_KUBECONFIG=""
 for arg in "$@"; do
   case "$arg" in
     --vm-name=*) LIMA_INSTANCE="${arg#--vm-name=}" ;;
@@ -75,13 +76,29 @@ for arg in "$@"; do
     --helm-values=*) HELM_VALUES="${arg#--helm-values=}" ;;
     --set=*) HELM_EXTRA_ARGS+=("$arg") ;;
     --no-restart) NO_RESTART=true ;;
+    --external-kubeconfig=*) EXTERNAL_KUBECONFIG="${arg#--external-kubeconfig=}" ;;
   esac
 done
+
+# External-kubeconfig mode (dam-o3w): target an already-running cluster (the inner
+# DAM cluster). Skip every VM/sandbox step — provisioning, k3s log-rotation, the
+# btrfs probe, the image-store prune — they all shell into lima/the sandbox host.
+# Force SKIP_IMAGE_LOAD (images come from the inner registry, pushed by
+# `inner:build`, not the local containerd) and layer values-inner so its registry
+# refs + Always pull policy win. The caller sets SKIP_IMAGE_BUILD when there's no
+# Docker daemon (the dev-agent pod); the depends: image tasks honor it.
+EXTERNAL=false
+INNER_VALUES=""
+if [ -n "$EXTERNAL_KUBECONFIG" ]; then
+  EXTERNAL=true
+  SKIP_IMAGE_LOAD=1
+  INNER_VALUES="deploy/helm/platform/values-inner.yaml"
+fi
 
 # Resolve the optional personal overlay (values-dev.yaml, gitignored) up front so
 # the agent render in step 3 sees the same values the install uses. Committed dev
 # defaults (terms.*, keycloak admin) live in values-local.yaml.
-if [ -z "$HELM_VALUES" ] && [ -f "$DEV_VALUES" ]; then
+if [ "$EXTERNAL" != true ] && [ -z "$HELM_VALUES" ] && [ -f "$DEV_VALUES" ]; then
   HELM_VALUES="$DEV_VALUES"
   echo "Using dev overrides: $DEV_VALUES"
 fi
@@ -92,7 +109,10 @@ AGENT_VALUE_FLAGS=()
 AGENT_VALUE_FLAGS+=("${HELM_EXTRA_ARGS[@]}")
 
 # 1. Provision cluster and set KUBECONFIG
-if [ -n "${IS_SANDBOX:-}" ]; then
+if [ "$EXTERNAL" = true ]; then
+  echo "Targeting external cluster via kubeconfig: $EXTERNAL_KUBECONFIG"
+  KUBECONFIG="$EXTERNAL_KUBECONFIG"
+elif [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
   if [ ! -d /var/lib/rancher/k3s ]; then
     echo "Provisioning k3s on host (sandbox mode)..."
@@ -150,7 +170,9 @@ K3S_CONFIG_YAML='kubelet-arg:
   - "container-log-max-size=10Mi"
   - "container-log-max-files=3"
 '
-if [ -n "${IS_SANDBOX:-}" ]; then
+if [ "$EXTERNAL" = true ]; then
+  echo "Skipping k3s log-rotation config (external cluster owns its k3s config)"
+elif [ -n "${IS_SANDBOX:-}" ]; then
   if ! sudo grep -q container-log-max-size /etc/rancher/k3s/config.yaml 2>/dev/null; then
     echo "Configuring k3s container log rotation (issue #244)..."
     sudo mkdir -p /etc/rancher/k3s
@@ -409,7 +431,9 @@ fi
 # against a btrfs export (userspace ganesha hits ENOSYS on handle-based
 # syscalls). Switch to the cluster's default RWO local-path instead.
 # ext4/xfs hosts (lima Ubuntu and most production storage) are unaffected.
-if [ -n "${IS_SANDBOX:-}" ]; then
+if [ "$EXTERNAL" = true ]; then
+  ROOT_FSTYPE=""  # can't probe an external node's fs from here; assume the standard RWX path
+elif [ -n "${IS_SANDBOX:-}" ]; then
   ROOT_FSTYPE=$(df -T / 2>/dev/null | awk 'NR==2 {print $2}')
 else
   ROOT_FSTYPE=$(limactl shell "$LIMA_INSTANCE" df -T / 2>/dev/null | awk 'NR==2 {print $2}')
@@ -437,7 +461,7 @@ kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=60
 # --force-conflicts: Helm v4 applies server-side; field drift on a chart-managed
 # object (a stray kubectl patch/rollout, another controller) otherwise hard-fails
 # the upgrade with an ownership conflict. The chart is the source of truth here.
-helm --kubeconfig="$KUBECONFIG" upgrade --install platform deploy/helm/platform -f deploy/helm/platform/values-local.yaml --timeout 15m --force-conflicts ${HELM_VALUES:+-f "$HELM_VALUES"} "${HELM_EXTRA_ARGS[@]}"
+helm --kubeconfig="$KUBECONFIG" upgrade --install platform deploy/helm/platform -f deploy/helm/platform/values-local.yaml ${INNER_VALUES:+-f "$INNER_VALUES"} --timeout 15m --force-conflicts ${HELM_VALUES:+-f "$HELM_VALUES"} "${HELM_EXTRA_ARGS[@]}"
 
 # 5. Restart pods to pick up new local images (dev only — :latest tags don't trigger rollout)
 if [ "$NO_RESTART" = true ]; then
@@ -460,12 +484,16 @@ kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Available deployment --a
 # `<none>:<none>`. Drop only those — `crictl rmi --prune` would also wipe
 # tagged-but-unpinned images like the agent ones we just loaded (no
 # instance pods exist yet to pin them).
-echo "Pruning dangling images..."
-PRUNE_DANGLING='sudo k3s crictl images 2>/dev/null | sed -nE "s/^<none>[[:space:]]+<none>[[:space:]]+([^[:space:]]+).*/\\1/p" | xargs -r sudo k3s crictl rmi >/dev/null 2>&1 || true'
-if [ -n "${IS_SANDBOX:-}" ]; then
-  bash -c "$PRUNE_DANGLING"
+if [ "$EXTERNAL" = true ]; then
+  echo "Skipping image prune (external cluster manages its own image store)"
 else
-  limactl shell "$LIMA_INSTANCE" bash -c "$PRUNE_DANGLING"
+  echo "Pruning dangling images..."
+  PRUNE_DANGLING='sudo k3s crictl images 2>/dev/null | sed -nE "s/^<none>[[:space:]]+<none>[[:space:]]+([^[:space:]]+).*/\\1/p" | xargs -r sudo k3s crictl rmi >/dev/null 2>&1 || true'
+  if [ -n "${IS_SANDBOX:-}" ]; then
+    bash -c "$PRUNE_DANGLING"
+  else
+    limactl shell "$LIMA_INSTANCE" bash -c "$PRUNE_DANGLING"
+  fi
 fi
 
 echo ""
@@ -542,6 +570,80 @@ echo "Registry: 127.0.0.1:25000  (push images as inner-registry:25000/...)"
 echo "Buildkit: 127.0.0.1:21234  / 192.168.5.2:21234 (from outer pods)"
 echo ""
 "${INNER_KUBECTL[@]}" -n dam-inner get pods
+'''
+
+# Build every Platform image straight into the inner registry via the inner
+# cluster's buildkitd — no local Docker daemon. The client (buildctl) ships the
+# build context over TCP; buildkitd builds and pushes. This replaces the outer
+# loop's `docker build` + `docker save` + `k3s ctr images import` with a single
+# push-to-registry per component (values-inner points every ref at the registry).
+["inner:build"]
+description = "Build all Platform images via the inner buildkitd (no Docker daemon) and push to the inner registry. DAM-in-DAM (dam-kt9). BUILDKIT_HOST overrides the daemon address (default tcp://127.0.0.1:21234; outer agent pods use tcp://192.168.5.2:21234)."
+dir = "{{config_root}}"
+depends = ["keycloak-theme:build"]
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+# buildctl talks to the inner buildkitd over TCP; the daemon does the push
+# (resolving inner-registry -> 127.0.0.1 via its hostAlias), so the client needs
+# neither Docker nor registry DNS. Default to the host forward; an outer agent pod
+# exports BUILDKIT_HOST=tcp://192.168.5.2:21234.
+: "${BUILDKIT_HOST:=tcp://127.0.0.1:21234}"
+export BUILDKIT_HOST
+REGISTRY="inner-registry:25000"
+BASE_REF="$REGISTRY/platform-base:latest"
+
+# buildctl is a host prerequisite (like docker/kubectl — not mise-managed); the
+# dev-agent image bundles it, on a dev box install moby/buildkit (e.g. `brew
+# install buildkit`).
+if ! command -v buildctl >/dev/null 2>&1; then
+  echo "FATAL: buildctl not found on PATH. Install moby/buildkit (brew install buildkit)." >&2
+  exit 1
+fi
+
+echo "buildkitd: $BUILDKIT_HOST  ->  registry: $REGISTRY"
+buildctl debug workers >/dev/null  # fail fast if the daemon is unreachable
+
+# build <image-name> <context-dir> <dockerfile-dir> [BUILD_ARG=value ...]
+# Pushes $REGISTRY/<image-name>:latest. registry.insecure=true covers the push
+# over plain HTTP; the FROM-pull insecurity is handled by buildkitd.toml in the
+# build plane (deploy/inner/buildkit-registry.yaml).
+build() {
+  local name="$1" context="$2" dfdir="$3"; shift 3
+  local opts=()
+  local a
+  for a in "$@"; do opts+=(--opt "build-arg:$a"); done
+  echo ">>> building $name"
+  buildctl build \
+    --frontend dockerfile.v0 \
+    --local context="$context" \
+    --local dockerfile="$dfdir" \
+    --opt filename=Dockerfile \
+    "${opts[@]}" \
+    --output "type=image,name=$REGISTRY/$name:latest,push=true,registry.insecure=true"
+}
+
+# platform-base FIRST — the agent images do `FROM ${BASE_IMAGE}` and pull it back
+# from the registry, so it has to exist there before they build.
+build platform-base        .                           packages/platform-base
+
+# Core components: own base images (Red Hat UBI / keycloak), root or package
+# context — mirrors the *:image tasks (api-server, ui, controller, keycloak).
+build platform-api-server  .                           packages/api-server
+build platform-ui          .                           packages/ui
+build platform-controller  packages/controller         packages/controller
+build platform-keycloak    .                           packages/keycloak-theme
+
+# Agents: FROM the platform-base we just pushed. This covers values-inner's
+# enabled templates (claude-code + mock); add codex / pi-agent / bob here when
+# enabling them in values-inner.
+build platform-claude-code packages/agents/claude-code packages/agents/claude-code BASE_IMAGE="$BASE_REF"
+build platform-mock        .                           packages/e2e/agents/mock     BASE_IMAGE="$BASE_REF"
+
+echo ""
+echo "=== All images pushed to $REGISTRY ==="
+echo "Deploy with: SKIP_IMAGE_BUILD=1 mise run cluster:install --external-kubeconfig=<inner kubeconfig>"
 '''
 
 ["cluster:build-apiserver"]

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -484,6 +484,66 @@ run = '''
 exec env SKIP_IMAGE_BUILD=1 SKIP_IMAGE_LOAD=1 mise run cluster:install "$@"
 '''
 
+# -- DAM-in-DAM inner cluster (dam-kt9) --
+#
+# The INNER cluster is the target an agent pod in the OUTER cluster builds into
+# and deploys to. This task only provisions the VM and the build plane (registry
+# + buildkitd); cert-manager/Istio/helm come later via cluster:install in
+# external-kubeconfig mode (dam-o3w). Lima-only — the inner cluster is never the
+# sandbox host, so there is no IS_SANDBOX branch.
+["cluster:inner:install"]
+description = "Provision the inner DAM cluster VM (platform-k3s-inner) and stand up its build plane (registry + buildkitd). DAM-in-DAM (dam-kt9)."
+dir = "{{config_root}}"
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+
+LIMA_INSTANCE="platform-k3s-inner"
+LIMA_TEMPLATE="deploy/lima-k3s-inner.yaml"
+BUILD_PLANE="deploy/inner/buildkit-registry.yaml"
+
+# 1. Provision / start the inner VM (mirrors cluster:install step 1).
+if ! limactl list -q 2>/dev/null | grep -qx "$LIMA_INSTANCE"; then
+  echo "Creating inner k3s VM ($LIMA_INSTANCE)..."
+  limactl create --name="$LIMA_INSTANCE" "$LIMA_TEMPLATE" --tty=false
+fi
+STATUS=$(limactl list --json | python3 -c "import sys,json; [print(json.loads(l)['status']) for l in sys.stdin if json.loads(l)['name']=='$LIMA_INSTANCE']" 2>/dev/null || echo "Stopped")
+if [ "$STATUS" != "Running" ]; then
+  echo "Starting inner k3s VM..."
+  limactl start "$LIMA_INSTANCE"
+fi
+
+# All kubectl runs guest-side via `limactl shell ... sudo k3s kubectl`. The
+# copied-out kubeconfig points at 127.0.0.1:16444, but on the host that port is
+# the OUTER VM's auto-forwarded API (different CA) — talking to it fails with a
+# cert error and would hit the wrong cluster. The guest's own k3s kubeconfig has
+# no such collision. (Outer pods reach this API at 192.168.5.2:26444; the host
+# forward is 127.0.0.1:26444.)
+INNER_KUBECTL=(limactl shell "$LIMA_INSTANCE" sudo k3s kubectl)
+
+# 2. Wait for k3s to be ready.
+echo "Waiting for inner k3s to be ready..."
+for _ in $(seq 1 60); do "${INNER_KUBECTL[@]}" get nodes -o name 2>/dev/null | grep -q . && break; sleep 2; done
+"${INNER_KUBECTL[@]}" wait --for=condition=Ready node --all --timeout=120s
+
+# 3. Apply the build plane (registry + buildkitd), piped guest-side.
+echo "Applying build plane (registry + buildkitd)..."
+"${INNER_KUBECTL[@]}" apply -f - < "$BUILD_PLANE"
+
+# 4. Wait for the build plane to come up.
+echo "Waiting for build plane to be ready..."
+"${INNER_KUBECTL[@]}" -n dam-inner rollout status deploy/registry --timeout=120s
+"${INNER_KUBECTL[@]}" -n dam-inner rollout status deploy/buildkitd --timeout=120s
+
+echo ""
+echo "=== Inner build plane ready ==="
+echo "API:      127.0.0.1:26444 (host) / 192.168.5.2:26444 (from outer pods)"
+echo "Registry: 127.0.0.1:25000  (push images as inner-registry:25000/...)"
+echo "Buildkit: 127.0.0.1:21234  / 192.168.5.2:21234 (from outer pods)"
+echo ""
+"${INNER_KUBECTL[@]}" -n dam-inner get pods
+'''
+
 ["cluster:build-apiserver"]
 description = "Build and load API server image into k3s, restart apiserver pod"
 depends = ["api-server:image"]

--- a/mise.toml
+++ b/mise.toml
@@ -49,6 +49,7 @@ includes = [
     "packages/agents/bob/tasks.toml",
     "packages/agents/claude-code/tasks.toml",
     "packages/agents/codex/tasks.toml",
+    "packages/agents/dev-agent/tasks.toml",
     "packages/agents/pi-agent/tasks.toml",
     "packages/agents/tasks.toml",
     "packages/api-server-api/tasks.toml",

--- a/packages/agents/dev-agent/Dockerfile
+++ b/packages/agents/dev-agent/Dockerfile
@@ -1,0 +1,32 @@
+ARG BASE_IMAGE=platform-claude-code
+FROM ${BASE_IMAGE}
+
+USER root
+
+COPY scripts/install-pnpm.sh /usr/local/bin/install-pnpm
+COPY package.json /tmp/install-pnpm/package.json
+RUN --mount=type=cache,target=/root/.npm \
+    install-pnpm /tmp/install-pnpm/package.json &&\
+    rm -rf /tmp/install-pnpm &&\
+    mise reshim
+
+RUN printf '%s\n' \
+      '' \
+      'java = "21"' \
+      'maven = "latest"' \
+      'helm = "4.2.0"' \
+      'kubectl = "latest"' \
+      '"aqua:moby/buildkit" = "latest"' \
+      >> /app/working-dir/.config/mise/config.toml &&\
+    export MISE_GLOBAL_CONFIG_FILE=/app/working-dir/.config/mise/config.toml &&\
+    mise install &&\
+    mise reshim &&\
+    chown -R 65532:0 /app/working-dir/.config
+
+COPY --chmod=0755 packages/agents/dev-agent/dev-bootstrap.sh /usr/local/bin/dev-bootstrap
+
+ENV BUILDKIT_HOST=tcp://192.168.5.2:21234
+
+COPY --chown=65532:0 packages/agents/dev-agent/workspace/ /app/working-dir/
+
+USER 65532

--- a/packages/agents/dev-agent/dev-bootstrap.sh
+++ b/packages/agents/dev-agent/dev-bootstrap.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_URL="${REPO_URL:-https://github.com/dam-agents/dam.git}"
+REPO_REF="${REPO_REF:-feat/dam-in-dam}"
+REPO_DIR="${REPO_DIR:-$HOME/platform}"
+
+if [ -d "$REPO_DIR/.git" ]; then
+  git -C "$REPO_DIR" fetch --depth 1 origin "$REPO_REF"
+  git -C "$REPO_DIR" checkout -f FETCH_HEAD
+else
+  git clone --depth 1 --branch "$REPO_REF" "$REPO_URL" "$REPO_DIR"
+fi
+
+mise trust "$REPO_DIR/mise.toml" >/dev/null 2>&1 || true
+
+cat <<EOF
+dev-agent ready: $REPO_DIR @ $REPO_REF
+  build inner images:  cd $REPO_DIR && mise run inner:build
+  deploy to inner:     cd $REPO_DIR && SKIP_IMAGE_BUILD=1 mise run cluster:install --external-kubeconfig="\${INNER_KUBECONFIG:-\$HOME/.kube/inner.yaml}"
+EOF

--- a/packages/agents/dev-agent/tasks.toml
+++ b/packages/agents/dev-agent/tasks.toml
@@ -1,0 +1,33 @@
+["agents:dev-agent:image"]
+description = "Build the dev-agent image (DAM-in-DAM inner-cluster dev loop, dam-kt9)"
+dir = "{{config_root}}"
+depends = ["agents:claude-code:image"]
+run = '''
+#!/usr/bin/env bash
+[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
+docker build -f packages/agents/dev-agent/Dockerfile -t platform-dev-agent:latest .
+'''
+
+["agents:dev-agent:scan"]
+depends = ["agents:dev-agent:scan:*"]
+
+["agents:dev-agent:scan:trivy"]
+dir = "{{config_root}}"
+usage = '''
+flag "--json" help="Emit Trivy JSON (exit 0) instead of failing on findings"
+flag "--tag <tag>" help="Scan quay.io/dam-agents/dev-agent:<tag> instead of building locally"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${usage_tag:-}" ]; then
+  image="quay.io/dam-agents/dev-agent:${usage_tag}"
+else
+  {{ mise_bin }} run agents:dev-agent:image
+  image="platform-dev-agent:latest"
+fi
+if [[ "${usage_json:-false}" == "true" ]]; then
+  exec trivy image --quiet --format json "$image"
+fi
+exec trivy image --quiet --exit-code 1 "$image"
+'''

--- a/packages/agents/dev-agent/workspace/.agents/skills/inner-cluster-dev-loop/SKILL.md
+++ b/packages/agents/dev-agent/workspace/.agents/skills/inner-cluster-dev-loop/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: inner-cluster-dev-loop
+description: >
+  How to build and deploy the platform into the separate INNER cluster from inside this agent pod. Use whenever the task is to rebuild platform images, deploy a code change, or test the platform running on the platform (dogfooding) — i.e. any "build and deploy", "ship this to the inner cluster", "rebuild the api-server/ui/controller image", or "install the chart into the inner cluster" request. This pod has no Docker daemon and cannot run lima; the only supported build+deploy path is the one described here.
+---
+
+You are a dev-agent running inside the **outer** platform cluster. Your job is to edit platform source, rebuild images, and deploy them into a **separate inner platform cluster** on the same host. There is no Docker daemon here and you cannot nest lima — do not reach for `docker build`, `docker save`, `k3s`, `limactl`, or `kubectl apply` of raw images. The flow below is the only one that works.
+
+## Topology
+
+- **Outer cluster** (VM `platform-k3s`): where you run, right now, as an agent pod.
+- **Inner cluster** (VM `platform-k3s-inner`): the target you build into and deploy to.
+- A buildkit daemon + an in-cluster image registry live in the inner cluster. You ship build context to buildkitd over TCP; it builds (no Docker daemon) and pushes to the registry; the inner k3s pulls from that registry via a configured mirror.
+
+You reach the inner cluster across VMs through the lima host gateway `192.168.5.2`.
+
+| What | Endpoint |
+| --- | --- |
+| Inner buildkit daemon | `tcp://192.168.5.2:21234` (preset in `$BUILDKIT_HOST`) |
+| Inner Kubernetes API | `https://192.168.5.2:26444` |
+| Inner image registry (ref used everywhere) | `inner-registry:25000` |
+
+## The loop
+
+The repo is cloned at session start (default `$HOME/platform`). Run everything with `mise run` from the repo root — never invoke `go`, `pnpm`, `helm`, `kubectl`, or `buildctl` directly.
+
+```sh
+cd "$HOME/platform"
+
+# 1. Build every platform image via the inner buildkitd and push to the inner registry.
+#    BUILDKIT_HOST is already set to tcp://192.168.5.2:21234.
+mise run inner:build
+
+# 2. Deploy the chart into the inner cluster. SKIP_IMAGE_BUILD because there is no
+#    local Docker daemon; --external-kubeconfig targets the inner API and forces
+#    the registry image refs + Always pull policy (values-inner).
+SKIP_IMAGE_BUILD=1 mise run cluster:install \
+  --external-kubeconfig="${INNER_KUBECONFIG:-$HOME/.kube/inner.yaml}"
+```
+
+`inner:build` builds `platform-base` first (the agent images do `FROM` it), then the core components and the enabled agent images. A single `mise run inner:build` is the whole rebuild step — it replaces the outer loop's `docker build` + `docker save` + image import with one push-to-registry per component.
+
+To iterate on a single component, edit the source and re-run `mise run inner:build` (buildkit layer-caches unchanged stages), then re-run the `cluster:install` step to roll the deployment.
+
+## Gotchas
+
+- **apiserver restarts right after install** while it waits for postgres — this is a known startup race that self-heals. Give it a minute before treating it as a failure.
+- **Inner UI login may bounce to the outer keycloak.** Known gap: the inner public URLs are not yet re-pointed at the inner ingress. The cluster is healthy even when browser login misbehaves; verify via pod/deployment status, not the login page.
+- **Build plane choice is settled.** The inner buildkitd uses the OCI worker plus an in-cluster registry. The containerd-worker "build straight into the k3s image store" path is unsupported when buildkitd runs as a pod (the RUN executor fails on an empty rootfs). Do not try to switch it.
+- **First-ever install** of a brand-new inner cluster also applies cert-manager and the Gateway API from github.com. A warm inner cluster already has these and the steps are skipped, so the steady-state loop only needs the inner API and buildkit.
+
+## When something is unreachable
+
+- `mise run inner:build` failing to connect → the inner buildkitd at `192.168.5.2:21234` is down or egress is blocked. `buildctl debug workers` (from the repo root) probes it.
+- `cluster:install` failing to reach the API → the inner API at `192.168.5.2:26444` is down, or the kubeconfig is missing/points at the wrong server. The kubeconfig server must be `https://192.168.5.2:26444`.

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -83,6 +83,24 @@ type AgentBase struct {
 	// agent's main container on egress NetworkPolicy being verifiably
 	// enforced. Used where IptablesInit can't run.
 	NPGateInit *AgentNPGateInit `json:"npGateInit,omitempty"`
+
+	// ExtraEgress adds chart-defined IP-CIDR allowances to every agent's
+	// per-pair egress NetworkPolicy, on top of the paired gateway. These
+	// bypass the gateway's L7 ext_authz gate, so they are operator policy
+	// (chart-only) for cluster-integration destinations the gateway can't
+	// proxy. Empty in production; the DAM-in-DAM dev loop (dam-kt9) sets it
+	// so agents reach the inner cluster's Kubernetes API and buildkit daemon
+	// across the lima host gateway.
+	ExtraEgress []EgressPeer `json:"extraEgress,omitempty"`
+}
+
+// EgressPeer is a chart-defined IP-CIDR + TCP-port egress allowance added
+// verbatim to every agent's per-pair NetworkPolicy. It bypasses the paired
+// gateway, so it is operator policy used for destinations the gateway can't
+// proxy (e.g. a raw TCP buildkit daemon).
+type EgressPeer struct {
+	CIDR  string `json:"cidr"`
+	Ports []int  `json:"ports,omitempty"`
 }
 
 type AgentIptablesInit struct {

--- a/packages/controller/pkg/reconciler/iptables_init.go
+++ b/packages/controller/pkg/reconciler/iptables_init.go
@@ -17,8 +17,9 @@ import (
 const iptablesInitContainerName = "egress-lockdown"
 
 // buildIptablesInitContainer pins the agent pod's OUTPUT chain to
-// "loopback + ESTABLISHED + paired gateway only". Returns nil when the
-// feature is off, the image is unset, or the gateway IP isn't known yet.
+// "loopback + ESTABLISHED + paired gateway (+ chart-defined ExtraEgress)
+// only". Returns nil when the feature is off, the image is unset, or the
+// gateway IP isn't known yet.
 //
 // Targets the SIG Release `registry.k8s.io/build-image/distroless-iptables`
 // image, which ships both `iptables-nft` and `iptables-legacy`. We
@@ -48,6 +49,19 @@ func buildIptablesInitContainer(cfg *config.Config, gatewayClusterIP string) *co
 	// both backends are unusable: defense-in-depth is the whole point of
 	// this container, so the pod must not silently fall back to
 	// NetworkPolicy-only.
+	// Chart-defined ExtraEgress opens direct IPv4 egress to specific
+	// CIDR:port pairs, bypassing the gateway (the DAM-in-DAM dev loop's
+	// inner API + buildkit). These ACCEPTs must mirror the per-pair
+	// NetworkPolicy's extra rules (BuildAgentEgressNetworkPolicy) — both
+	// layers gate the same hop, so a rule in one without the other still
+	// drops. Empty in production. IPv6 stays drop-all (inner is IPv4).
+	extraRules := ""
+	for _, peer := range cfg.AgentBase.ExtraEgress {
+		for _, p := range peer.Ports {
+			extraRules += fmt.Sprintf("\"$IPT\" -A OUTPUT -d %s -p tcp --dport %d -j ACCEPT\n", peer.CIDR, p)
+		}
+	}
+
 	script := `set -eu
 echo "egress-lockdown: gateway=$GATEWAY_IP:$ENVOY_PORT"
 if iptables-nft -nL OUTPUT >/dev/null 2>&1; then
@@ -64,11 +78,11 @@ echo "egress-lockdown: backend=$IPT"
 "$IPT" -A OUTPUT -o lo -j ACCEPT
 "$IPT" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 "$IPT" -A OUTPUT -d "$GATEWAY_IP" -p tcp --dport "$ENVOY_PORT" -j ACCEPT
-"$IPT" -A OUTPUT -j DROP
+` + extraRules + `"$IPT" -A OUTPUT -j DROP
 "$IP6T" -A OUTPUT -o lo -j ACCEPT
 "$IP6T" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT
 "$IP6T" -A OUTPUT -j DROP
-echo "egress-lockdown: gateway-only IPv4 + IPv6 drop applied"
+echo "egress-lockdown: gateway + extra-egress IPv4 ACCEPT, IPv6 drop applied"
 `
 
 	// Needs root + NET_ADMIN/NET_RAW for the netfilter ops. K8s/containerd

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -1,6 +1,7 @@
 package reconciler
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -102,6 +103,31 @@ func TestBuildIptablesInitContainer_AllowListScript(t *testing.T) {
 	assert.Contains(t, script, `"$IP6T" -A OUTPUT -o lo -j ACCEPT`, "IPv6 loopback must be admitted")
 	assert.Contains(t, script, `"$IP6T" -A OUTPUT -m conntrack --ctstate ESTABLISHED,RELATED -j ACCEPT`)
 	assert.Contains(t, script, `"$IP6T" -A OUTPUT -j DROP`, "IPv6 terminal catch-all DROP")
+}
+
+// Chart-defined ExtraEgress adds IPv4 ACCEPTs (one per CIDR×port) that must
+// mirror the per-pair NetworkPolicy and land BEFORE the terminal DROP —
+// the DAM-in-DAM dev loop reaching the inner API + buildkit. Both
+// enforcement layers gate the same hop, so a rule in one without the other
+// still drops.
+func TestBuildIptablesInitContainer_ExtraEgress(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.IptablesInit = &config.AgentIptablesInit{Enabled: true, Image: "registry.k8s.io/build-image/distroless-iptables:v0.9.2"}
+	cfg.AgentBase.ExtraEgress = []config.EgressPeer{
+		{CIDR: "192.168.5.2/32", Ports: []int{26444, 21234}},
+	}
+	ic := buildIptablesInitContainer(&cfg, "10.96.42.42")
+	require.NotNil(t, ic)
+	script := ic.Command[2]
+
+	api := `"$IPT" -A OUTPUT -d 192.168.5.2/32 -p tcp --dport 26444 -j ACCEPT`
+	buildkit := `"$IPT" -A OUTPUT -d 192.168.5.2/32 -p tcp --dport 21234 -j ACCEPT`
+	assert.Contains(t, script, api, "inner API CIDR:port must be admitted")
+	assert.Contains(t, script, buildkit, "inner buildkit CIDR:port must be admitted")
+
+	// Ordering is load-bearing: an ACCEPT after the terminal DROP never matches.
+	assert.Less(t, strings.Index(script, api), strings.Index(script, `"$IPT" -A OUTPUT -j DROP`),
+		"extra-egress ACCEPT must precede the terminal DROP")
 }
 
 // PoC: with `iptablesInit.enabled: true` the egress-lockdown init container

--- a/packages/controller/pkg/reconciler/network_policy.go
+++ b/packages/controller/pkg/reconciler/network_policy.go
@@ -21,6 +21,11 @@ import (
 // chart-rendered namespace-scope deny-all baseline, the agent's only
 // admitted destination is its paired gateway. All other egress —
 // external, harness, ext-authz — flows through the gateway (ADR-035).
+//
+// AgentBase.ExtraEgress adds chart-defined IP-CIDR allowances on top of
+// the gateway rule, for cluster-integration destinations the gateway can't
+// proxy (the DAM-in-DAM dev loop's inner API + buildkit). Empty in
+// production.
 
 // BuildAgentEgressNetworkPolicy renders the per-pair egress NP for the
 // agent pod of `pairKey`. Long-lived pairs use the instance name;
@@ -49,6 +54,21 @@ func BuildAgentEgressNetworkPolicy(pairKey string, cfg *config.Config, ownerRef 
 			{Protocol: &tcp, Port: &envoyPort},
 		},
 	}}
+
+	// Chart-defined extra egress (operator policy, ADR-038). Each peer is a
+	// raw IP-CIDR + TCP ports the agent may reach directly, bypassing the
+	// gateway. Empty unless an install opts in (e.g. DAM-in-DAM).
+	for _, peer := range cfg.AgentBase.ExtraEgress {
+		ports := make([]networkingv1.NetworkPolicyPort, 0, len(peer.Ports))
+		for _, p := range peer.Ports {
+			port := intstr.FromInt(p)
+			ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &port})
+		}
+		egress = append(egress, networkingv1.NetworkPolicyEgressRule{
+			To:    []networkingv1.NetworkPolicyPeer{{IPBlock: &networkingv1.IPBlock{CIDR: peer.CIDR}}},
+			Ports: ports,
+		})
+	}
 
 	return &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{

--- a/packages/controller/pkg/reconciler/network_policy_test.go
+++ b/packages/controller/pkg/reconciler/network_policy_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
+
+	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
 
 // Per-pair NP admits exactly the paired gateway on the Envoy port —
@@ -78,6 +80,32 @@ func TestBuildAgentEgressNetworkPolicy_NoHBONE(t *testing.T) {
 				"egress rule %d must not admit HBONE 15008", i)
 		}
 	}
+}
+
+// Chart-defined ExtraEgress (AgentBase) appends IP-CIDR allowances on top
+// of the gateway rule — the DAM-in-DAM dev loop reaches the inner cluster's
+// API (26444) + buildkit (21234) across the lima host gateway. Empty in
+// production, so the gateway-only invariant above still holds by default.
+func TestBuildAgentEgressNetworkPolicy_ExtraEgress(t *testing.T) {
+	cfg := *testConfig
+	cfg.AgentBase.ExtraEgress = []config.EgressPeer{
+		{CIDR: "192.168.5.2/32", Ports: []int{26444, 21234}},
+	}
+	np := BuildAgentEgressNetworkPolicy("my-instance", &cfg, configMapOwnerRef(testOwnerCM))
+
+	require.Len(t, np.Spec.Egress, 2, "paired gateway rule + one extra-egress peer")
+
+	extra := np.Spec.Egress[1]
+	require.Len(t, extra.To, 1)
+	require.NotNil(t, extra.To[0].IPBlock, "extra egress is an IP-CIDR peer, not a pod selector")
+	assert.Nil(t, extra.To[0].PodSelector)
+	assert.Equal(t, "192.168.5.2/32", extra.To[0].IPBlock.CIDR)
+
+	require.Len(t, extra.Ports, 2)
+	assert.Equal(t, int32(26444), extra.Ports[0].Port.IntVal)
+	assert.Equal(t, int32(21234), extra.Ports[1].Port.IntVal)
+	require.NotNil(t, extra.Ports[0].Protocol)
+	assert.Equal(t, corev1.ProtocolTCP, *extra.Ports[0].Protocol)
 }
 
 // Label-managed-by lets operators bulk-list controller-managed NPs and


### PR DESCRIPTION
Overarching PR for the DAM-in-DAM epic (dam-kt9).

GOAL: let a Claude agent in an OUTER dam install (agent pod, VM `platform-k3s`) edit dam source, rebuild images without a Docker daemon, and deploy into a separate INNER dam cluster (VM `platform-k3s-inner`) on the same host. Unblocks dogfooding dam-on-dam; the blocker was lima-in-lima (agent pods cannot nest lima).

## Topology

```
VM#1 platform-k3s        outer dam; agent pod runs here, Claude inside
VM#2 platform-k3s-inner  inner dam target (build into + deploy to)
```

agent pod (VM#1) --buildctl--> buildkitd (VM#2, OCI worker) builds + pushes --> in-cluster registry (VM#2) <-- k3s pulls via `registries.yaml` mirror. Agent also runs helm/kubectl against the VM#2 API. Cross-VM reachability via the lima host gateway (192.168.5.2); VM#2 forwards API/registry/buildkit to host loopback on offset ports 26444/25000/21234.

## Work (dam-kt9 children)

- [x] dam-8yk Commit inner artifacts (lima template, build-plane manifest, `values-inner` overlay) + `cluster:inner:install`
- [x] dam-6jq `inner:build` mise task (buildctl push per component)
- [x] dam-o3w `cluster:install --external-kubeconfig` mode
- [x] dam-fgq Validate full inner-DAM install (real images) into VM#2
- [x] dam-853 dev-agent image (toolchain + git clone bootstrap)
- [x] dam-3bo Agent egress NetworkPolicy + wire dev-agent as agentTemplate
- [ ] dam-mef Deliver inner kubeconfig into the dev-agent pod
- [ ] dam-57d Validate the loop fully in-pod (dev-agent runs build+deploy)
- [ ] dam-i48 Architecture doc for the dev loop

## Key decisions

- OCI-worker buildkitd + in-cluster registry (k3d-style). Rejected containerd-worker direct-to-store: unsupported when buildkitd is a pod (RUN executor fails on empty rootfs).
- hostNetwork (not hostPort): lima forwards listening sockets, not CNI DNAT. Singletons use Recreate.
- Registry ref consistent at `inner-registry:25000` everywhere (buildkitd does the push, hostAlias `inner-registry`->127.0.0.1).
- Inner k3s: `--https-listen-port 16444 --tls-san 192.168.5.2`.
- Agent egress (dam-3bo): install-wide controller knob `AgentBase.ExtraEgress` adds IPBlock rules to the per-pair egress NetworkPolicy, on top of the paired gateway. `values-local` opens the inner API (26444) + buildkit (21234) on 192.168.5.2; empty in production. The dev-agent template sets `NO_PROXY=192.168.5.2` so kubectl/helm/buildctl reach the inner cluster directly instead of through the gateway proxy (which can't proxy raw TCP or the IP-literal API). dev-agent is `enabled: true` for local dev.

## Validation

Real images, end-to-end (dam-fgq): `inner:build` pushed all 8 platform images to `inner-registry:25000`; `SKIP_IMAGE_BUILD=1 cluster:install --external-kubeconfig` + `values-inner` brought up cert-manager + Istio ambient + the dam chart in VM#2. All 5 platform deployments Available (apiserver/controller/ui/keycloak/waypoint), postgres/redis/nfs/keycloak Running, UI HTTP 200 on the inner ingress (host 24445), apiserver 401 (auth required). No Dockerfile / build-context issues surfaced. The earlier busybox pipeline also passed.

This validation was run from the HOST. The in-pod path (dev-agent running the loop itself) is verified at the render/unit level (controller tests + helm render) but not yet end-to-end — tracked by dam-57d.

## Known gaps (tracked separately)

- **In-pod kubeconfig delivery (dam-mef):** `dev-bootstrap` only clones the repo; it does not provision the inner kubeconfig, so in-pod `cluster:install --external-kubeconfig` has no target. Host-side runs supply the kubeconfig manually. Blocks closing the loop from inside the pod.
- **Inner UI login (not blocking):** browser login bounces to `keycloak.localhost:4444` (the outer cluster). `values-inner` sets `catchAllAppHost` + wildcard redirect URIs but never re-points the public URLs (`UI_BASE_URL`, `KEYCLOAK_EXTERNAL_URL`) at the inner port 24445.
