### PR TITLE
refactor(ui): consolidate section labels into one SectionLabel primitive

### DIFF
--- a/packages/ui/src/components/ui/section-label.tsx
+++ b/packages/ui/src/components/ui/section-label.tsx
@@ -2,6 +2,11 @@ import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 
+/**
+ * The project's section/field label. Once the redesign lands, this should
+ * replace the Radix `Label` primitive (`@/components/ui/label`) everywhere so
+ * there is a single label component across the app.
+ */
 export function SectionLabel({
   className,
   children,

--- a/packages/ui/src/components/ui/section-label.tsx
+++ b/packages/ui/src/components/ui/section-label.tsx
@@ -9,15 +9,18 @@ import { cn } from "@/lib/utils";
  */
 export function SectionLabel({
   className,
+  spaced = false,
   children,
 }: {
   className?: string;
+  spaced?: boolean;
   children: ReactNode;
 }) {
   return (
     <span
       className={cn(
         "text-[11px] font-medium uppercase leading-[17.05px] tracking-[1.65px] text-muted-foreground",
+        spaced && "mb-3 block",
         className,
       )}
     >

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -1,5 +1,7 @@
 import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
-import { type ReactNode, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+
+import { SectionLabel } from "@/components/ui/section-label";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useStartOAuth } from "../api/mutations.js";
@@ -71,7 +73,7 @@ export function ConnectionTemplatesSection() {
 
       {!loading && conns.length > 0 && (
         <div className="mb-8">
-          <SectionLabel>My connections</SectionLabel>
+          <SectionLabel className="mb-3 block">My connections</SectionLabel>
           <div className="flex flex-col gap-3">
             {conns.map((c) => (
               <ConnectionRow
@@ -104,7 +106,9 @@ export function ConnectionTemplatesSection() {
             if (list.length === 0) return null;
             return (
               <div key={cat}>
-                <SectionLabel>{CATEGORY_LABEL[cat]}</SectionLabel>
+                <SectionLabel className="mb-3 block">
+                  {CATEGORY_LABEL[cat]}
+                </SectionLabel>
                 <div className="flex flex-col gap-3">
                   {list.map((t) => (
                     <ConnectionCatalogRow
@@ -163,13 +167,5 @@ function ConnectionActions({
         disabled={deleting}
       />
     </div>
-  );
-}
-
-function SectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-      {children}
-    </p>
   );
 }

--- a/packages/ui/src/modules/connections/components/templates-section.tsx
+++ b/packages/ui/src/modules/connections/components/templates-section.tsx
@@ -73,7 +73,7 @@ export function ConnectionTemplatesSection() {
 
       {!loading && conns.length > 0 && (
         <div className="mb-8">
-          <SectionLabel className="mb-3 block">My connections</SectionLabel>
+          <SectionLabel spaced>My connections</SectionLabel>
           <div className="flex flex-col gap-3">
             {conns.map((c) => (
               <ConnectionRow
@@ -106,9 +106,7 @@ export function ConnectionTemplatesSection() {
             if (list.length === 0) return null;
             return (
               <div key={cat}>
-                <SectionLabel className="mb-3 block">
-                  {CATEGORY_LABEL[cat]}
-                </SectionLabel>
+                <SectionLabel spaced>{CATEGORY_LABEL[cat]}</SectionLabel>
                 <div className="flex flex-col gap-3">
                   {list.map((t) => (
                     <ConnectionCatalogRow

--- a/packages/ui/src/modules/sandboxes/components/connections-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/connections-section.tsx
@@ -72,7 +72,7 @@ export function ConnectionsSection({
   return (
     <>
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">My connections</SectionLabel>
+        <SectionLabel spaced>My connections</SectionLabel>
         {connections.length > 0 ? (
           <CardList>
             {connections.map((c) => (
@@ -116,9 +116,7 @@ export function ConnectionsSection({
           if (list.length === 0) return null;
           return (
             <section key={cat} className="mb-8">
-              <SectionLabel className="mb-3 block">
-                {CATEGORY_LABEL[cat]}
-              </SectionLabel>
+              <SectionLabel spaced>{CATEGORY_LABEL[cat]}</SectionLabel>
               <CardList>
                 {list.map((t) => (
                   <ConnectionCatalogRow

--- a/packages/ui/src/modules/sandboxes/components/connections-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/connections-section.tsx
@@ -2,6 +2,8 @@ import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
 import { ChevronDown, ChevronUp } from "lucide-react";
 import { useMemo, useState } from "react";
 
+import { SectionLabel } from "@/components/ui/section-label";
+
 import {
   useAppConnections,
   useConnectionTemplates,
@@ -19,7 +21,6 @@ import {
 } from "../../connections/internal-only.js";
 import { PROVIDER_TEMPLATE_IDS } from "../../connections/lib/provider-templates.js";
 import { CardList } from "./card-list.js";
-import { WizardSectionLabel } from "./wizard-section-label.js";
 
 const NO_TEMPLATES: ConnectionTemplateView[] = [];
 const NO_CONNECTIONS: ConnectionView[] = [];
@@ -71,7 +72,7 @@ export function ConnectionsSection({
   return (
     <>
       <section className="mb-8">
-        <WizardSectionLabel>My connections</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">My connections</SectionLabel>
         {connections.length > 0 ? (
           <CardList>
             {connections.map((c) => (
@@ -115,7 +116,9 @@ export function ConnectionsSection({
           if (list.length === 0) return null;
           return (
             <section key={cat} className="mb-8">
-              <WizardSectionLabel>{CATEGORY_LABEL[cat]}</WizardSectionLabel>
+              <SectionLabel className="mb-3 block">
+                {CATEGORY_LABEL[cat]}
+              </SectionLabel>
               <CardList>
                 {list.map((t) => (
                   <ConnectionCatalogRow

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -114,7 +114,7 @@ export function ConnectionsStep({
 
       {connections.length > 0 && (
         <section className="mb-8">
-          <SectionLabel className="mb-3 block">My connections</SectionLabel>
+          <SectionLabel spaced>My connections</SectionLabel>
           <CardList>
             {connections.map((c) => (
               <ConnectionRow
@@ -148,9 +148,7 @@ export function ConnectionsStep({
         if (list.length === 0) return null;
         return (
           <section key={cat} className="mb-8">
-            <SectionLabel className="mb-3 block">
-              {CATEGORY_LABEL[cat]}
-            </SectionLabel>
+            <SectionLabel spaced>{CATEGORY_LABEL[cat]}</SectionLabel>
             <CardList>
               {list.map((t) => (
                 <ConnectionCatalogRow

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -2,6 +2,7 @@ import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { SectionLabel } from "@/components/ui/section-label";
 
 import {
   useAppConnections,
@@ -26,7 +27,6 @@ import {
 } from "../../lib/wizard-snapshot.js";
 import { CardList } from "../card-list.js";
 import { StepHeader } from "../step-header.js";
-import { WizardSectionLabel } from "../wizard-section-label.js";
 
 const NO_TEMPLATES: ConnectionTemplateView[] = [];
 
@@ -114,7 +114,7 @@ export function ConnectionsStep({
 
       {connections.length > 0 && (
         <section className="mb-8">
-          <WizardSectionLabel>My connections</WizardSectionLabel>
+          <SectionLabel className="mb-3 block">My connections</SectionLabel>
           <CardList>
             {connections.map((c) => (
               <ConnectionRow
@@ -148,7 +148,9 @@ export function ConnectionsStep({
         if (list.length === 0) return null;
         return (
           <section key={cat} className="mb-8">
-            <WizardSectionLabel>{CATEGORY_LABEL[cat]}</WizardSectionLabel>
+            <SectionLabel className="mb-3 block">
+              {CATEGORY_LABEL[cat]}
+            </SectionLabel>
             <CardList>
               {list.map((t) => (
                 <ConnectionCatalogRow

--- a/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
@@ -41,9 +41,7 @@ export function ImageStep({
       />
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">
-          Pick a pre-built image
-        </SectionLabel>
+        <SectionLabel spaced>Pick a pre-built image</SectionLabel>
         <CardList>
           {loading ? (
             <ListSkeleton rows={4} rowHeight={64} />
@@ -62,9 +60,7 @@ export function ImageStep({
       </section>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">
-          Or bring your own image
-        </SectionLabel>
+        <SectionLabel spaced>Or bring your own image</SectionLabel>
         <CardList>
           <CustomImageCard
             value={customImage}

--- a/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
@@ -3,13 +3,13 @@ import { ArrowRight } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
 import { ListSkeleton } from "../../../../components/list-skeleton.js";
 import type { TemplateView } from "../../../../types.js";
 import { CardList } from "../card-list.js";
 import { StepHeader } from "../step-header.js";
-import { WizardSectionLabel } from "../wizard-section-label.js";
 
 interface Props {
   templates: TemplateView[];
@@ -41,7 +41,9 @@ export function ImageStep({
       />
 
       <section className="mb-8">
-        <WizardSectionLabel>Pick a pre-built image</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">
+          Pick a pre-built image
+        </SectionLabel>
         <CardList>
           {loading ? (
             <ListSkeleton rows={4} rowHeight={64} />
@@ -60,7 +62,9 @@ export function ImageStep({
       </section>
 
       <section className="mb-8">
-        <WizardSectionLabel>Or bring your own image</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">
+          Or bring your own image
+        </SectionLabel>
         <CardList>
           <CustomImageCard
             value={customImage}

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -75,7 +75,7 @@ export function SetupStep({
       />
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Name</SectionLabel>
+        <SectionLabel spaced>Name</SectionLabel>
         <FormField>
           <Input
             autoFocus
@@ -87,7 +87,7 @@ export function SetupStep({
       </section>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Provider</SectionLabel>
+        <SectionLabel spaced>Provider</SectionLabel>
         <ProviderSection
           selectedSecretId={providerSecretId}
           onSelect={(secretId) => update({ providerSecretId: secretId })}
@@ -101,7 +101,7 @@ export function SetupStep({
       </section>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Network access</SectionLabel>
+        <SectionLabel spaced>Network access</SectionLabel>
         <CardList>
           {NETWORK_PRESETS.map((preset) => (
             <NetworkPresetRow

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -2,6 +2,7 @@ import { ArrowRight } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
 import { ProviderSection } from "../../../providers/components/provider-section.js";
@@ -17,7 +18,6 @@ import {
   registryFilledCount,
 } from "../registry-credential-section.js";
 import { StepHeader } from "../step-header.js";
-import { WizardSectionLabel } from "../wizard-section-label.js";
 
 const NETWORK_PRESETS: { value: EgressPreset; label: string; help: string }[] =
   [
@@ -75,7 +75,7 @@ export function SetupStep({
       />
 
       <section className="mb-8">
-        <WizardSectionLabel>Name</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Name</SectionLabel>
         <FormField>
           <Input
             autoFocus
@@ -87,7 +87,7 @@ export function SetupStep({
       </section>
 
       <section className="mb-8">
-        <WizardSectionLabel>Provider</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Provider</SectionLabel>
         <ProviderSection
           selectedSecretId={providerSecretId}
           onSelect={(secretId) => update({ providerSecretId: secretId })}
@@ -101,7 +101,7 @@ export function SetupStep({
       </section>
 
       <section className="mb-8">
-        <WizardSectionLabel>Network access</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Network access</SectionLabel>
         <CardList>
           {NETWORK_PRESETS.map((preset) => (
             <NetworkPresetRow

--- a/packages/ui/src/modules/sandboxes/components/wizard-section-label.tsx
+++ b/packages/ui/src/modules/sandboxes/components/wizard-section-label.tsx
@@ -1,7 +1,0 @@
-import type { ReactNode } from "react";
-
-import { SectionLabel } from "@/components/ui/section-label";
-
-export function WizardSectionLabel({ children }: { children: ReactNode }) {
-  return <SectionLabel className="mb-3 block">{children}</SectionLabel>;
-}

--- a/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
@@ -47,7 +47,7 @@ export function SandboxSettingsView() {
       </h1>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Name</SectionLabel>
+        <SectionLabel spaced>Name</SectionLabel>
         <FormField>
           <Input disabled={f.saving} {...f.register("name")} />
         </FormField>
@@ -55,7 +55,7 @@ export function SandboxSettingsView() {
       </section>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Image</SectionLabel>
+        <SectionLabel spaced>Image</SectionLabel>
         {/* Read-only: image/template are create-only — changing them would mean
             delete+recreate, destroying the workspace PVC. */}
         <FormField>
@@ -73,7 +73,7 @@ export function SandboxSettingsView() {
       </section>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Provider</SectionLabel>
+        <SectionLabel spaced>Provider</SectionLabel>
         <ProviderSection
           variant="collapsible"
           listClassName="md:-ml-4"
@@ -95,7 +95,7 @@ export function SandboxSettingsView() {
       />
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Network access</SectionLabel>
+        <SectionLabel spaced>Network access</SectionLabel>
         <FormField className="rounded-lg border border-border p-4">
           <AgentEgressEditor
             agentId={agent.id}
@@ -106,7 +106,7 @@ export function SandboxSettingsView() {
       </section>
 
       <section className="mb-8">
-        <SectionLabel className="mb-3 block">Environment</SectionLabel>
+        <SectionLabel spaced>Environment</SectionLabel>
         <FormField className="rounded-lg border border-border p-4">
           <Controller
             control={f.control}

--- a/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
@@ -3,6 +3,7 @@ import { Controller } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { SectionLabel } from "@/components/ui/section-label";
 
 import { FormError } from "../../../components/form-error.js";
 import { EnvTab } from "../../agents/components/configure-agent/env-tab.js";
@@ -10,7 +11,6 @@ import { AgentEgressEditor } from "../../egress-rules/components/agent-egress-ed
 import { ProviderSection } from "../../providers/components/provider-section.js";
 import { ConnectionsSection } from "../components/connections-section.js";
 import { FormField } from "../components/form-field.js";
-import { WizardSectionLabel } from "../components/wizard-section-label.js";
 import { useSandboxSettingsForm } from "../hooks/use-sandbox-settings-form.js";
 
 const READ_ONLY_FIELD =
@@ -47,7 +47,7 @@ export function SandboxSettingsView() {
       </h1>
 
       <section className="mb-8">
-        <WizardSectionLabel>Name</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Name</SectionLabel>
         <FormField>
           <Input disabled={f.saving} {...f.register("name")} />
         </FormField>
@@ -55,7 +55,7 @@ export function SandboxSettingsView() {
       </section>
 
       <section className="mb-8">
-        <WizardSectionLabel>Image</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Image</SectionLabel>
         {/* Read-only: image/template are create-only — changing them would mean
             delete+recreate, destroying the workspace PVC. */}
         <FormField>
@@ -73,7 +73,7 @@ export function SandboxSettingsView() {
       </section>
 
       <section className="mb-8">
-        <WizardSectionLabel>Provider</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Provider</SectionLabel>
         <ProviderSection
           variant="collapsible"
           listClassName="md:-ml-4"
@@ -95,7 +95,7 @@ export function SandboxSettingsView() {
       />
 
       <section className="mb-8">
-        <WizardSectionLabel>Network access</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Network access</SectionLabel>
         <FormField className="rounded-lg border border-border p-4">
           <AgentEgressEditor
             agentId={agent.id}
@@ -106,7 +106,7 @@ export function SandboxSettingsView() {
       </section>
 
       <section className="mb-8">
-        <WizardSectionLabel>Environment</WizardSectionLabel>
+        <SectionLabel className="mb-3 block">Environment</SectionLabel>
         <FormField className="rounded-lg border border-border p-4">
           <Controller
             control={f.control}

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
 import { getUser, logout } from "../../../auth.js";
@@ -156,9 +157,7 @@ export function SettingsView() {
               Manage your account and session.
             </p>
 
-            <p className="mb-3 text-[11px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
-              Profile
-            </p>
+            <SectionLabel className="mb-3 block">Profile</SectionLabel>
             <Card className="flex items-center gap-4 p-4">
               <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold text-[16px]">
                 {(user?.profile.preferred_username ??

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -157,7 +157,7 @@ export function SettingsView() {
               Manage your account and session.
             </p>
 
-            <SectionLabel className="mb-3 block">Profile</SectionLabel>
+            <SectionLabel spaced>Profile</SectionLabel>
             <Card className="flex items-center gap-4 p-4">
               <div className="h-10 w-10 rounded-full bg-primary/10 flex items-center justify-center text-primary font-bold text-[16px]">
                 {(user?.profile.preferred_username ??


### PR DESCRIPTION
## What

There were three copies of the same section-label idea floating around:
- `components/ui/section-label.tsx` — the `SectionLabel` primitive
- `sandboxes/.../wizard-section-label.tsx` — `WizardSectionLabel` (= SectionLabel + `mb-3 block`)
- `connections/.../templates-section.tsx` — a hand-rolled duplicate `SectionLabel`

This unifies them on the single `SectionLabel` primitive:
- Remove the duplicate in `templates-section`.
- Remove `WizardSectionLabel`; its 5 consumers (sandbox wizard steps + settings view) now use `SectionLabel` directly with the margin applied at the call site.
- Add a note on the primitive that it should replace the Radix `Label` once the redesign lands, so the app converges on one label component.

Purely presentational; no behavior change.

## Test plan
- `mise run ui:check` (eslint + prettier + tsc) — clean
- `mise run ui:test` — 44 passing