### PR TITLE
refactor(ui): migrate the API keys feature to shared primitives

### DIFF
--- a/packages/ui/src/modules/api-keys/components/api-key-row.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-key-row.tsx
@@ -1,6 +1,8 @@
 import type { ApiKeyView } from "api-server-api";
 import { KeyRound, Trash2 } from "lucide-react";
 
+import { Button } from "@/components/ui/button";
+
 interface Props {
   apiKey: ApiKeyView;
   onRevoke: (id: string, name: string) => void;
@@ -16,17 +18,19 @@ export function ApiKeyRow({ apiKey, onRevoke, revoking }: Props) {
       : `${agentIds.length} agent${agentIds.length === 1 ? "" : "s"}`;
 
   return (
-    <li className="flex items-start gap-3 p-4 rounded-xl border-2 border-border-light bg-surface">
-      <KeyRound size={20} className="text-text-muted mt-0.5 shrink-0" />
+    <li className="flex items-start gap-3 p-4 rounded-xl border border-border bg-card">
+      <KeyRound size={20} className="text-muted-foreground mt-0.5 shrink-0" />
       <div className="flex-1 min-w-0">
         <div className="flex items-baseline gap-2">
           <span className="text-[14px] font-semibold truncate">{name}</span>
-          <span className="text-[11px] text-text-muted font-mono">{id}</span>
+          <span className="text-[11px] text-muted-foreground font-mono">
+            {id}
+          </span>
         </div>
-        <div className="text-[12px] text-text-secondary mt-1">
+        <div className="text-[12px] text-muted-foreground mt-1">
           {scopes.join(", ")} · {binding}
         </div>
-        <div className="text-[11px] text-text-muted mt-0.5">
+        <div className="text-[11px] text-muted-foreground mt-0.5">
           created {new Date(createdAt).toLocaleDateString()}
           {expiresAt &&
             ` · expires ${new Date(expiresAt).toLocaleDateString()}`}
@@ -35,14 +39,17 @@ export function ApiKeyRow({ apiKey, onRevoke, revoking }: Props) {
             : " · never used"}
         </div>
       </div>
-      <button
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        tone="danger"
         onClick={() => onRevoke(id, name)}
         disabled={revoking}
-        className="px-2 py-1.5 text-[13px] text-text-secondary hover:text-danger rounded-lg hover:bg-danger-light transition-colors disabled:opacity-50"
+        className="shrink-0 text-muted-foreground"
         title="Revoke"
       >
         <Trash2 size={14} />
-      </button>
+      </Button>
     </li>
   );
 }

--- a/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
@@ -28,24 +28,27 @@ export function ApiKeysList() {
 
   return (
     <div className="anim-in">
-      <div className="flex items-start justify-between mb-1">
-        <h2 className="text-[18px] font-bold">API Keys</h2>
-        <Button onClick={() => setCreateOpen(true)}>Create key</Button>
-      </div>
-      <p className="text-[14px] text-text-secondary mb-6">
+      <h2 className="text-[18px] font-bold mb-1">API Keys</h2>
+      <p className="text-[14px] text-muted-foreground mb-4">
         Long-lived tokens for headless / CI use. Pass the value as a bearer
         credential when calling the API. Plaintext is shown once on creation and
         never recoverable.
       </p>
 
-      {isLoading && <p className="text-[13px] text-text-muted">Loading…</p>}
+      <div className="flex justify-end mb-4">
+        <Button onClick={() => setCreateOpen(true)}>Create key</Button>
+      </div>
+
+      {isLoading && (
+        <p className="text-[13px] text-muted-foreground">Loading…</p>
+      )}
 
       {isError && (
         <div className="p-4 rounded-xl border-2 border-danger-light bg-danger-light">
           <p className="text-[13px] text-danger font-semibold mb-1">
             Couldn't load API keys
           </p>
-          <p className="text-[12px] text-text-secondary">
+          <p className="text-[12px] text-muted-foreground">
             The server returned an error. Try again or check your network
             connection.
           </p>
@@ -53,9 +56,9 @@ export function ApiKeysList() {
       )}
 
       {!isLoading && !isError && keys && keys.length === 0 && (
-        <div className="flex flex-col items-center gap-3 p-8 rounded-xl border-2 border-dashed border-border-light bg-surface">
-          <KeyRound size={32} className="text-text-muted" />
-          <p className="text-[13px] text-text-secondary">
+        <div className="flex flex-col items-center gap-3 p-8 rounded-xl border border-dashed border-border bg-card">
+          <KeyRound size={32} className="text-muted-foreground" />
+          <p className="text-[13px] text-muted-foreground">
             No API keys yet. Create one to authenticate the CLI without a
             browser.
           </p>

--- a/packages/ui/src/modules/api-keys/components/confirm-revoke-dialog.tsx
+++ b/packages/ui/src/modules/api-keys/components/confirm-revoke-dialog.tsx
@@ -1,5 +1,7 @@
 import type { ApiKeyView } from "api-server-api";
 
+import { Button } from "@/components/ui/button";
+
 import {
   DialogBody,
   DialogFooter,
@@ -26,31 +28,28 @@ export function ConfirmRevokeDialog({
         <h2 className="text-[18px] font-bold">Revoke API key?</h2>
       </DialogHeader>
       <DialogBody>
-        <p className="text-[13px] text-text-secondary mb-2">
-          The key <span className="font-semibold text-text">{apiKey.name}</span>{" "}
-          (<code className="text-[12px]">{apiKey.id}</code>) will stop working
+        <p className="text-[13px] text-muted-foreground mb-2">
+          The key{" "}
+          <span className="font-semibold text-foreground">{apiKey.name}</span> (
+          <code className="text-[12px]">{apiKey.id}</code>) will stop working
           immediately on every running CLI and integration that uses it.
         </p>
-        <p className="text-[13px] text-text-secondary">
+        <p className="text-[13px] text-muted-foreground">
           This cannot be undone — to restore access, create a new key.
         </p>
       </DialogBody>
       <DialogFooter>
-        <button
-          type="button"
-          onClick={onCancel}
-          className="px-3 py-1.5 text-[13px] font-semibold rounded-lg text-text-secondary hover:bg-surface-raised"
-        >
+        <Button type="button" variant="outline" onClick={onCancel}>
           Cancel
-        </button>
-        <button
+        </Button>
+        <Button
           type="button"
+          variant="destructive"
           onClick={onConfirm}
           disabled={pending}
-          className="px-3 py-1.5 text-[13px] font-semibold rounded-lg bg-danger text-white hover:bg-danger/90 disabled:opacity-50"
         >
           {pending ? "Revoking…" : "Revoke"}
-        </button>
+        </Button>
       </DialogFooter>
     </Modal>
   );

--- a/packages/ui/src/modules/api-keys/components/create-api-key-dialog/agent-binding-field.tsx
+++ b/packages/ui/src/modules/api-keys/components/create-api-key-dialog/agent-binding-field.tsx
@@ -1,3 +1,5 @@
+import { SectionLabel } from "@/components/ui/section-label";
+
 import { cn } from "../../../../lib/utils.js";
 import { useAgentsList } from "../../../agents/api/queries.js";
 
@@ -25,10 +27,8 @@ export function AgentBindingField({
 
   return (
     <div className="mb-4">
-      <span className="text-[13px] font-semibold block mb-1.5">
-        Agent access
-      </span>
-      <p className="text-[12px] text-text-muted mb-2">
+      <SectionLabel className="mb-1 block">Agent access</SectionLabel>
+      <p className="text-[12px] text-muted-foreground mb-2">
         {lockedToAll ? (
           <>
             <code>agents:manage</code> keys must cover every agent — per-agent
@@ -59,7 +59,7 @@ export function AgentBindingField({
       {effectiveMode === "specific" && (
         <div className="mt-2 ml-6 space-y-1.5">
           {agents.length === 0 ? (
-            <p className="text-[12px] text-text-muted">
+            <p className="text-[12px] text-muted-foreground">
               You have no agents yet — create one first, or choose “All agents”.
             </p>
           ) : (
@@ -104,7 +104,7 @@ function BindingModeOption({
         "flex items-start gap-2 p-2 rounded-lg",
         disabled
           ? "opacity-50 cursor-not-allowed"
-          : "hover:bg-surface-raised cursor-pointer",
+          : "hover:bg-muted/40 cursor-pointer",
       )}
     >
       <input
@@ -116,7 +116,7 @@ function BindingModeOption({
       />
       <div className="flex-1">
         <span className="text-[13px] font-semibold">{label}</span>
-        <span className="text-[12px] text-text-secondary block">
+        <span className="text-[12px] text-muted-foreground block">
           {description}
         </span>
       </div>

--- a/packages/ui/src/modules/api-keys/components/create-api-key-dialog/create-form.tsx
+++ b/packages/ui/src/modules/api-keys/components/create-api-key-dialog/create-form.tsx
@@ -1,6 +1,10 @@
 import { AGENT_SCOPES, CREDENTIAL_SCOPES, type Scope } from "api-server-api";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SectionLabel } from "@/components/ui/section-label";
+
 import {
   DialogBody,
   DialogFooter,
@@ -81,32 +85,32 @@ export function CreateApiKeyForm({ onCreated, onCancel }: Props) {
         <h2 className="text-[18px] font-bold">Create API key</h2>
       </DialogHeader>
       <DialogBody>
-        <label className="block mb-4">
-          <span className="text-[13px] font-semibold block mb-1.5">Name</span>
-          <input
+        <div className="mb-4">
+          <SectionLabel className="mb-1 block">Name</SectionLabel>
+          <Input
             type="text"
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="e.g. CI release pipeline"
             autoFocus
             maxLength={100}
-            className="w-full px-3 py-2 text-[14px] rounded-lg border-2 border-border-light bg-surface focus:border-accent outline-none"
+            aria-label="Name"
           />
-        </label>
+        </div>
 
         <div className="mb-4">
-          <span className="text-[13px] font-semibold block mb-1.5">Scopes</span>
-          <p className="text-[12px] text-text-muted mb-2">
+          <SectionLabel className="mb-1 block">Scopes</SectionLabel>
+          <p className="text-[12px] text-muted-foreground mb-2">
             Pick the narrowest scope that satisfies your use case. An
             exfiltrated key with only <code>agents:read</code> cannot change
             anything or run an agent.
           </p>
-          <div className="space-y-3">
+          <div className="space-y-4 rounded-lg border border-border p-4">
             {SCOPE_GROUPS.map((group) => (
               <div key={group.label}>
-                <span className="text-[11px] font-semibold uppercase tracking-wide text-text-muted block mb-1">
+                <SectionLabel className="mb-1.5 block">
                   {group.label}
-                </span>
+                </SectionLabel>
                 <div className="space-y-2">
                   {group.scopes.map((scope) => (
                     <ScopeOption
@@ -133,20 +137,12 @@ export function CreateApiKeyForm({ onCreated, onCancel }: Props) {
         )}
       </DialogBody>
       <DialogFooter>
-        <button
-          type="button"
-          onClick={onCancel}
-          className="px-3 py-1.5 text-[13px] font-semibold rounded-lg text-text-secondary hover:bg-surface-raised"
-        >
+        <Button type="button" variant="outline" onClick={onCancel}>
           Cancel
-        </button>
-        <button
-          type="submit"
-          disabled={submitDisabled}
-          className="px-3 py-1.5 text-[13px] font-semibold rounded-lg bg-accent text-white hover:bg-accent-hover disabled:opacity-50"
-        >
+        </Button>
+        <Button type="submit" disabled={submitDisabled}>
           {createApiKey.isPending ? "Creating…" : "Create"}
-        </button>
+        </Button>
       </DialogFooter>
     </form>
   );
@@ -160,7 +156,7 @@ interface ScopeOptionProps {
 
 function ScopeOption({ scope, checked, onToggle }: ScopeOptionProps) {
   return (
-    <label className="flex items-start gap-2 p-2 rounded-lg hover:bg-surface-raised cursor-pointer">
+    <label className="flex items-start gap-2 p-2 rounded-lg hover:bg-muted/40 cursor-pointer">
       <input
         type="checkbox"
         checked={checked}
@@ -169,7 +165,7 @@ function ScopeOption({ scope, checked, onToggle }: ScopeOptionProps) {
       />
       <div className="flex-1">
         <code className="text-[13px] font-semibold">{scope}</code>
-        <span className="text-[12px] text-text-secondary block">
+        <span className="text-[12px] text-muted-foreground block">
           {scopeDescription(scope)}
         </span>
       </div>

--- a/packages/ui/src/modules/api-keys/components/create-api-key-dialog/reveal-token.tsx
+++ b/packages/ui/src/modules/api-keys/components/create-api-key-dialog/reveal-token.tsx
@@ -1,6 +1,8 @@
 import { Check, Copy } from "lucide-react";
 import { useState } from "react";
 
+import { Button } from "@/components/ui/button";
+
 import {
   DialogBody,
   DialogFooter,
@@ -37,28 +39,30 @@ export function RevealToken({ plaintext, onClose }: Props) {
         <h2 className="text-[18px] font-bold">Save this token now</h2>
       </DialogHeader>
       <DialogBody>
-        <p className="text-[13px] text-text-secondary mb-4">
+        <p className="text-[13px] text-muted-foreground mb-4">
           This is the only time the token will be shown. If you lose it, revoke
           this key and create a new one.
         </p>
-        <div className="flex items-stretch gap-2 p-3 rounded-lg bg-surface-raised border border-border-light font-mono text-[12px]">
+        <div className="flex items-center gap-2 p-3 rounded-lg bg-muted border border-border font-mono text-[12px]">
           <code className="flex-1 break-all">{plaintext}</code>
-          <button
+          <Button
             type="button"
+            variant="ghost"
+            size="icon-sm"
             onClick={handleCopy}
             aria-label={
               copyState === "copied"
                 ? "Copied to clipboard"
                 : "Copy to clipboard"
             }
-            className="shrink-0 px-2 py-1 rounded hover:bg-surface text-text-secondary"
+            className="shrink-0 text-muted-foreground"
           >
             {copyState === "copied" ? (
               <Check size={16} aria-hidden />
             ) : (
               <Copy size={16} aria-hidden />
             )}
-          </button>
+          </Button>
         </div>
         {copyState === "failed" && (
           <p className="text-[12px] text-danger mt-2">
@@ -66,19 +70,15 @@ export function RevealToken({ plaintext, onClose }: Props) {
             manually.
           </p>
         )}
-        <p className="text-[12px] text-text-muted mt-3">
+        <p className="text-[12px] text-muted-foreground mt-3">
           Use as the bearer credential when calling the API. See the CLI
           documentation for the exact environment variable name.
         </p>
       </DialogBody>
       <DialogFooter>
-        <button
-          type="button"
-          onClick={onClose}
-          className="px-3 py-1.5 text-[13px] font-semibold rounded-lg bg-accent text-white hover:bg-accent-hover"
-        >
+        <Button type="button" onClick={onClose}>
           Done
-        </button>
+        </Button>
       </DialogFooter>
     </>
   );


### PR DESCRIPTION
## What

Brings the API keys settings tab in line with the redesigned UI.

- Replace raw `<input>`/`<button>` with the shared `Input` and `Button` primitives across the list, rows, create form, revoke dialog, and token reveal.
- Use `SectionLabel` for all field labels (Name, Scopes, Agent access) and the Agents/Credentials sub-groups; wrap the scopes block in a border so the Scopes → group hierarchy reads, mirroring "Network access" on the sandbox configure page.
- Move the "Create key" action onto its own row directly above the list.
- Replace leftover pre-redesign tokens (`text-text-*`, `bg-surface*`, `border-border-light`, `bg-accent`) with the standard tokens.

Purely presentational; no behavior change.

## Stacked PR

> [!NOTE]
> Based on #1271 (SectionLabel consolidation). GitHub will retarget this to `main` automatically once #1271 merges. Review the **last commit only**, or merge #1271 first.

## Test plan
- `mise run ui:check` (eslint + prettier + tsc) — clean
- `mise run ui:test` — 44 passing