### PR TITLE
feat(ui): group Step 1 images into harness/pre-configured categories

### DIFF
--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -31,6 +31,12 @@ data:
     image: "{{ $tmpl.image.repository }}:{{ $tmpl.image.tag | default $.Chart.AppVersion }}"
     description: {{ $tmpl.description | quote }}
     agentHome: {{ $home | quote }}
+    {{- with $tmpl.category }}
+    category: {{ . | quote }}
+    {{- end }}
+    {{- if $tmpl.experimental }}
+    experimental: true
+    {{- end }}
     {{- with $tmpl.image.pullPolicy }}
     imagePullPolicy: {{ . | quote }}
     {{- end }}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -732,6 +732,10 @@ controller:
 # override the chart-wide default for agents created from this template.
 # `$HOME` in mount paths is substituted at chart render time
 # using this entry's `agentHome` if set, else `templateDefaults.agentHome`.
+# `category` groups the entry in the creation wizard's Step 1: "harness"
+# (base coding harnesses; the default when omitted) or "preconfigured"
+# (curated workload images, e.g. Bugstone). `experimental: true` badges the
+# image as alpha in the wizard.
 #
 # To predefine an *experimental external agent* (a private-registry image users
 # just pick from the template list, with no manual "Private registry" entry),
@@ -739,6 +743,8 @@ controller:
 #
 #   - name: bugstone
 #     enabled: true
+#     category: preconfigured
+#     experimental: true
 #     description: "Experimental DAM bug-hunting agent"
 #     image:
 #       repository: icr.io/dam-agents/bugstone

--- a/packages/api-server-api/src/modules/templates/router.ts
+++ b/packages/api-server-api/src/modules/templates/router.ts
@@ -10,6 +10,8 @@ function toView(tmpl: Template) {
     name: tmpl.name,
     image: tmpl.spec.image,
     description: tmpl.spec.description,
+    category: tmpl.spec.category ?? "harness",
+    experimental: tmpl.spec.experimental ?? false,
   };
 }
 

--- a/packages/api-server-api/src/modules/templates/schemas.ts
+++ b/packages/api-server-api/src/modules/templates/schemas.ts
@@ -29,11 +29,17 @@ export const skillSourceSeedSchema = z.object({
   gitUrl: z.string(),
 });
 
+export const templateCategorySchema = z
+  .enum(["harness", "preconfigured"])
+  .default("harness");
+
 export const templateSpecSchema = z
   .object({
     version: z.string(),
     image: z.string(),
     description: z.string().optional(),
+    category: templateCategorySchema,
+    experimental: z.boolean().optional(),
     mounts: z.array(mountSchema).optional(),
     init: z.string().optional(),
     env: z.array(envVarConfigMapSchema).optional(),

--- a/packages/api-server-api/src/modules/templates/types.ts
+++ b/packages/api-server-api/src/modules/templates/types.ts
@@ -16,6 +16,8 @@ export interface Resources {
 
 export const SPEC_VERSION = "agent-platform.ai/v1";
 
+export type TemplateCategory = "harness" | "preconfigured";
+
 /** A {name, gitUrl} pair declared by the helm values (platform-wide) or by a
  *  template (per-agent). The same shape flows through every layer — helm
  *  values, rendered ConfigMap, TypeScript and Go types. */
@@ -31,6 +33,8 @@ export interface TemplateSpec {
   version: string;
   image: string;
   description?: string;
+  category?: TemplateCategory;
+  experimental?: boolean;
   mounts?: Mount[];
   init?: string;
   env?: EnvVar[];

--- a/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
@@ -32,6 +32,10 @@ export function ImageStep({
 }: Props) {
   const canContinue =
     selectedTemplateId !== null || customImage.trim().length > 0;
+  const harnessImages = templates.filter((t) => t.category === "harness");
+  const preconfiguredImages = templates.filter(
+    (t) => t.category === "preconfigured",
+  );
   return (
     <div>
       <StepHeader
@@ -41,16 +45,17 @@ export function ImageStep({
       />
 
       <section className="mb-8">
-        <SectionLabel spaced>Pick a pre-built image</SectionLabel>
+        <SectionLabel spaced>Harness Images</SectionLabel>
         <CardList>
           {loading ? (
             <ListSkeleton rows={4} rowHeight={64} />
           ) : (
-            templates.map((template) => (
+            harnessImages.map((template) => (
               <ImageCard
                 key={template.id}
                 name={template.name}
                 description={template.description}
+                experimental={template.experimental}
                 selected={template.id === selectedTemplateId}
                 onSelect={() => onPickTemplate(template.id)}
               />
@@ -59,8 +64,26 @@ export function ImageStep({
         </CardList>
       </section>
 
+      {!loading && preconfiguredImages.length > 0 && (
+        <section className="mb-8">
+          <SectionLabel spaced>Pre-configured Images</SectionLabel>
+          <CardList>
+            {preconfiguredImages.map((template) => (
+              <ImageCard
+                key={template.id}
+                name={template.name}
+                description={template.description}
+                experimental={template.experimental}
+                selected={template.id === selectedTemplateId}
+                onSelect={() => onPickTemplate(template.id)}
+              />
+            ))}
+          </CardList>
+        </section>
+      )}
+
       <section className="mb-8">
-        <SectionLabel spaced>Or bring your own image</SectionLabel>
+        <SectionLabel spaced>Custom Image</SectionLabel>
         <CardList>
           <CustomImageCard
             value={customImage}
@@ -85,11 +108,13 @@ export function ImageStep({
 function ImageCard({
   name,
   description,
+  experimental,
   selected,
   onSelect,
 }: {
   name: string;
   description?: string;
+  experimental?: boolean;
   selected: boolean;
   onSelect: () => void;
 }) {
@@ -105,7 +130,17 @@ function ImageCard({
           : "border-border bg-card hover:bg-muted/40",
       )}
     >
-      <p className="text-[16px] font-semibold text-foreground">{name}</p>
+      <div className="flex items-center gap-2">
+        <p className="text-[16px] font-semibold text-foreground">{name}</p>
+        {experimental && (
+          <Badge
+            variant="outline"
+            className="border-transparent bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
+          >
+            Alpha
+          </Badge>
+        )}
+      </div>
       {description && (
         <p className="mt-1 text-[14px] text-muted-foreground">{description}</p>
       )}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -98,6 +98,8 @@ export interface TemplateView {
   name: string;
   image: string;
   description?: string;
+  category: "harness" | "preconfigured";
+  experimental: boolean;
 }
 
 export type AgentState =


### PR DESCRIPTION
## Summary

Implements #1274. Reorganizes Step 1 of the agent creation wizard into three categories and adds support for categorizing agent templates.

## Changes

**Schema — categorize agents with a default**
- Add `category` (`harness` | `preconfigured`, defaults to `harness`) and `experimental` to the agent template spec.
- Plumbed through every layer: helm ConfigMap render → api-server zod schema/types → tRPC view → UI types.
- Existing/uncategorized templates fall into `harness` automatically.

**UI — three categories in Step 1**
- **Harness Images** — base coding harnesses (Claude, Bob, …).
- **Pre-configured Images** — curated workloads (`category: preconfigured`); section hidden when empty.
- **Custom Image** — user-supplied image (renamed from "Or bring your own image").
- Experimental images render an amber **Alpha** badge.

## Notes

- Per #1274, this PR covers only the UI grouping + categorization plumbing. Bugstone and other curated workloads (#938) are supplied as `category: preconfigured` entries in **deployment-specific** values, not in the checked-in defaults — so they appear under "Pre-configured Images" with the Alpha badge wherever they're provisioned.

Closes #1274