### PR TITLE
fix(api-server): wake hibernated agent before proxying trpc calls

### DIFF
--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -410,6 +410,15 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       );
     }
 
+    try {
+      await agentsRepo.ensureReady(agentId);
+    } catch (err) {
+      process.stderr.write(
+        `[trpc-proxy] ensureReady failed for ${agentId}: ${(err as Error).message}\n`,
+      );
+      return c.json({ error: "agent unreachable" }, 502);
+    }
+
     // No Bearer swap needed: ownership is verified above, and the agent
     // pod's NetworkPolicy admits ingress only from the api-server pod —
     // the kernel-level gate is the auth boundary on this hop.


### PR DESCRIPTION
## Problem

`dam ssh connect <agent>` did not wake a hibernating agent — it failed instead of resuming it.

## Root cause

The agent trpc proxy (`/api/agents/:id/trpc/*` in `app.ts`) forwarded directly to the in-pod agent-runtime **without** waking the agent. A hibernated (scaled-to-zero) agent therefore returned `502` for every proxied call.

The CLI's SSH `_proxy` registers the SSH public key via `ssh.authorizeKey` — routed through this proxy — **before** opening the tunnel. Against a hibernated agent that key-registration call failed, so the CLI aborted with *"could not register SSH key with agent"* before ever reaching `connectRawBridge`, which is the only path that woke the agent (via `ensureReady` in the SSH relay).

## Fix

Call `ensureReady()` at the top of the trpc proxy handler, mirroring the existing import-proxy pattern. Since this proxy only ever targets the in-pod runtime (which requires a running pod), waking on any proxied call is correct, and it specifically unblocks the `authorizeKey` step that gates `dam ssh connect`.

## Testing

- `mise run api-server:check` — lint, format, tsc all pass.
- Verified on local k3s: backdated an agent's `last-activity` annotation, confirmed the idle checker hibernated it (`Ready=False, reason=Hibernated`, both StatefulSets scaled to zero).