### PR TITLE
test(e2e): assert foreign-fork credential injected on egress

### DIFF
--- a/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
@@ -14,9 +14,10 @@ export interface ScriptedMockComposition {
 
 export function composeScriptedMock(): ScriptedMockComposition {
   const state = createInitialState();
+  const proxyFetch = createProxyFetch();
   const scriptedMock = createScriptedMockService({
     state,
-    proxyFetch: createProxyFetch(),
+    proxyFetch,
   });
   const stdio = createStdioChannel();
 
@@ -42,6 +43,7 @@ export function composeScriptedMock(): ScriptedMockComposition {
     channel: acpChannel,
     state,
     workspace: createWorkspaceWriter(process.cwd()),
+    proxyFetch,
   });
 
   return { scriptedMock };

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/acp-service.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/acp-service.ts
@@ -1,13 +1,16 @@
 import { randomUUID } from "node:crypto";
 import { isRequest, parseFrame, type JsonRpcId } from "../domain/frames.js";
 import type { MockState } from "../domain/state.js";
-import { recordPrompt } from "./control-service.js";
+import { recordPrompt, type ProxyFetch } from "./control-service.js";
 import type { AcpChannel, WorkspaceWriter } from "./ports.js";
+
+const FETCH_DIRECTIVE = /__FETCH__\s+(\S+)/;
 
 export interface AcpServiceDeps {
   channel: AcpChannel;
   state: MockState;
   workspace: WorkspaceWriter;
+  proxyFetch: ProxyFetch;
   now?: () => Date;
   sleep?: (ms: number) => Promise<void>;
   newSessionId?: () => string;
@@ -85,6 +88,13 @@ export function startAcpService(deps: AcpServiceDeps): void {
       prompt: promptPayload,
     });
 
+    const fetchUrl = FETCH_DIRECTIVE.exec(promptText(promptPayload))?.[1];
+    if (fetchUrl) {
+      await replyWithFetch(sid, fetchUrl);
+      respond(id, { stopReason: "end_turn" });
+      return;
+    }
+
     for (const file of deps.state.scriptFiles) {
       await deps.workspace.writeFile(file.path, file.content);
     }
@@ -98,6 +108,23 @@ export function startAcpService(deps: AcpServiceDeps): void {
     }
 
     respond(id, { stopReason: deps.state.scriptStopReason });
+  }
+
+  async function replyWithFetch(sid: string, url: string): Promise<void> {
+    let text: string;
+    try {
+      const { status, body } = await deps.proxyFetch({ url });
+      text = `[fetch ${status}] ${body}`;
+    } catch (err) {
+      text = `[fetch error] ${err instanceof Error ? err.message : String(err)}`;
+    }
+    notify("session/update", {
+      sessionId: sid,
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      },
+    });
   }
 
   function respondInitialize(id: JsonRpcId): void {
@@ -124,4 +151,16 @@ function extractSessionId(params: unknown): string | null {
   if (!params || typeof params !== "object") return null;
   const sid = (params as { sessionId?: unknown }).sessionId;
   return typeof sid === "string" ? sid : null;
+}
+
+function promptText(payload: unknown): string {
+  if (typeof payload === "string") return payload;
+  if (!Array.isArray(payload)) return "";
+  return payload
+    .map((block) =>
+      block && typeof block === "object" && "text" in block
+        ? String((block as { text?: unknown }).text ?? "")
+        : "",
+    )
+    .join("\n");
 }

--- a/packages/e2e/playwright/src/lib/auth.ts
+++ b/packages/e2e/playwright/src/lib/auth.ts
@@ -11,7 +11,9 @@ interface TokenResponse {
   expires_in: number;
 }
 
-export async function getAccessToken(): Promise<string> {
+export async function getAccessToken(
+  user: { username: string; password: string } = testUser,
+): Promise<string> {
   const url = `${keycloakUrl}/realms/${keycloakRealm}/protocol/openid-connect/token`;
   const res = await fetch(url, {
     method: "POST",
@@ -19,8 +21,8 @@ export async function getAccessToken(): Promise<string> {
     body: new URLSearchParams({
       grant_type: "password",
       client_id: keycloakClientId,
-      username: testUser.username,
-      password: testUser.password,
+      username: user.username,
+      password: user.password,
     }),
   });
   if (!res.ok) {

--- a/packages/e2e/playwright/src/lib/connections.ts
+++ b/packages/e2e/playwright/src/lib/connections.ts
@@ -44,3 +44,25 @@ export async function getConnectionId(
   if (!conn) throw new Error(`connection ${connectionName} not found`);
   return conn.id;
 }
+
+export async function ensureCustomHeaderConnection(
+  api: ApiClient,
+  input: CustomHeaderConnectionInput,
+): Promise<string> {
+  const existing = (await api.connections.list.query()).find(
+    (c) => c.name === input.name,
+  );
+  if (existing) return existing.id;
+
+  const { id } = await api.connections.create.mutate({
+    templateId: "custom-header",
+    authKind: "header",
+    name: input.name,
+    host: input.host,
+    headerName: input.headerName,
+    valueFormat: input.valueFormat,
+    value: input.value,
+    envName: input.envName,
+  });
+  return id;
+}

--- a/packages/e2e/playwright/src/lib/fixtures.ts
+++ b/packages/e2e/playwright/src/lib/fixtures.ts
@@ -8,3 +8,7 @@ export const envName = "E2E_INJECTED_KEY";
 export const sentinel = "e2e-injected-secret-7f3a9c1";
 export const placeholder = "dummy-placeholder";
 export const echoUrl = "https://httpbingo.org/headers";
+
+export const foreignConnectionName = "e2e-foreign-connection";
+export const foreignSentinel = "e2e-foreign-secret-2b8d4e6";
+export const foreignEnvName = "E2E_FOREIGN_INJECTED_KEY";

--- a/packages/e2e/playwright/src/tests/07-slack.spec.ts
+++ b/packages/e2e/playwright/src/tests/07-slack.spec.ts
@@ -4,7 +4,17 @@ import { baseUrl, testUser2 } from "../config.js";
 import { waitForAgentRunning } from "../lib/agents.js";
 import { createApiClient } from "../lib/api-client.js";
 import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { ensureCustomHeaderConnection } from "../lib/connections.js";
+import {
+  agentName,
+  connectionHost,
+  echoUrl,
+  foreignConnectionName,
+  foreignEnvName,
+  foreignSentinel,
+  headerName,
+  valueFormat,
+} from "../lib/fixtures.js";
 
 const slackChannelId = "C-E2E-TRACER";
 const foreignSlackUserId = "U-E2E-FOREIGN";
@@ -131,5 +141,56 @@ test("foreign user mention forks the agent and the reply lands back in the threa
         (r.kind === "message" && r.text.startsWith("Error:")),
     );
     expect(failures).toEqual([]);
+  });
+});
+
+test("foreign-user fork injects the foreign user's credential on egress", async () => {
+  test.setTimeout(420_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+  await waitForAgentRunning(api, agentName);
+
+  await test.step("foreign user creates their own credential connection", async () => {
+    const foreignApi = createApiClient(await getAccessToken(testUser2));
+    await ensureCustomHeaderConnection(foreignApi, {
+      name: foreignConnectionName,
+      host: connectionHost,
+      headerName,
+      valueFormat,
+      value: foreignSentinel,
+      envName: foreignEnvName,
+    });
+  });
+
+  await test.step("foreign mention forks and the fork egress carries the foreign credential", async () => {
+    await api.e2e.slackResetOutbound.mutate();
+    await api.e2e.slackFireMention.mutate({
+      user: foreignSlackUserId,
+      channel: slackChannelId,
+      ts: "1700000002.000100",
+      text: `__FETCH__ ${echoUrl}`,
+    });
+
+    let replyText = "";
+    await expect
+      .poll(
+        async () => {
+          const { records } = await api.e2e.slackReadOutbound.query();
+          const reply = records.find(
+            (r) => r.kind === "message" && r.text.includes("[fetch "),
+          );
+          replyText = reply && reply.kind === "message" ? reply.text : "";
+          return replyText !== "";
+        },
+        {
+          timeout: 300_000,
+          intervals: [5_000],
+          message: "fork did not post the egress result back to the thread",
+        },
+      )
+      .toBe(true);
+
+    expect(replyText).toContain(foreignSentinel);
   });
 });


### PR DESCRIPTION
Adds a CI guard that a non-owner Slack user's fork injects that user's own credential on outbound calls.

While building this I found #444 and #91 already appear to be resolved on main: the foreign fork resolves and injects the replier's own credential, so the behavior both tickets describe as broken now works. This PR just locks that in with a test, it is not a fix.

## What it does

- **Mock agent**: a `__FETCH__ <url>` prompt directive makes the mock perform an authenticated proxy fetch through its gateway Envoy during the turn, then reply with the echoed result. Without the directive it falls through to the existing static-script behavior, so the tracer and other specs are untouched.
- **07-slack**: the foreign user (dev2) creates their own httpbingo connection with a distinct sentinel, then a foreign mention `__FETCH__ <echoUrl>` forks the agent. The fork pair mounts the replier's own credential Secrets (`owner=<dev2-sub>`), so the echoed request headers must carry dev2's value. The assertion requires the foreign sentinel in the echoed headers.
- Mirrors the owner-path proof in 05-injection, but from a fork.

## Note

Originally written as a `test.fail()` repro for the foreign-fork egress gap. That path already works on main, so the assertion holds. Dropped the annotation so it stands as a passing regression guard.

## Validation

Relying on CI `mise run e2e` (the foreign sentinel comes back in the echoed headers). Not validated on a local cluster, since the e2e test VM can't bootstrap alongside the running dev clusters due to k3s host-port collisions.
