### PR TITLE
feat(helm): allow custom annotations on chart workloads

### DIFF
--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -56,6 +56,48 @@ imagePullSecrets:
 {{- end }}
 
 {{/*
+podAnnotations — merged pod-template annotations for a workload. This is the
+hook OpenTelemetry auto-instrumentation and similar injection operators key
+off of. Precedence, highest first: chart-internal (e.g. config checksums that
+must survive so a `helm upgrade` rolls the pod) > per-component
+(`<component>.podAnnotations`) > chart-wide (`.Values.commonPodAnnotations`).
+Renders an `annotations:` block, or nothing when the merged map is empty.
+
+Usage:
+  {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.apiServer "internal" $checksums) | nindent 6 }}
+  - root:      root context ($), for the chart-wide defaults
+  - component: component values subtree (may define `.podAnnotations`); optional
+  - internal:  chart-managed annotations that must always render; optional
+*/}}
+{{- define "platform.podAnnotations" -}}
+{{- $component := .component | default dict -}}
+{{- $internal := .internal | default dict -}}
+{{- $merged := merge (deepCopy $internal) ($component.podAnnotations | default dict) (.root.Values.commonPodAnnotations | default dict) -}}
+{{- with $merged }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
+annotations — merged workload object-metadata annotations (on the
+Deployment/StatefulSet/Job itself). Precedence, highest first: chart-internal
+(e.g. Helm hook directives) > per-component (`<component>.annotations`) >
+chart-wide (`.Values.commonAnnotations`). Renders an `annotations:` block, or
+nothing when the merged map is empty. Same `dict` arguments as
+`platform.podAnnotations`, reading `.annotations` instead of `.podAnnotations`.
+*/}}
+{{- define "platform.annotations" -}}
+{{- $component := .component | default dict -}}
+{{- $internal := .internal | default dict -}}
+{{- $merged := merge (deepCopy $internal) ($component.annotations | default dict) (.root.Values.commonAnnotations | default dict) -}}
+{{- with $merged }}
+annotations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{/*
 nameList — comma-separated .name values from a list of objects.
 Usage: {{ include "platform.nameList" .Values.someList }}
 */}}

--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -60,6 +60,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: apiserver
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.apiServer) | nindent 2 }}
 spec:
   replicas: 1
   strategy:
@@ -73,16 +74,17 @@ spec:
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
-      annotations:
-        # The api-server loads the mounted agent-templates once at boot,
-        # and K8s doesn't restart a pod when a mounted ConfigMap changes — so roll
-        # the pod when the rendered templates change, making `helm upgrade` of a
-        # template take effect instead of serving stale ones until the next restart.
-        checksum/agent-templates: {{ include (print $.Template.BasePath "/agent-templates.yaml") . | sha256sum }}
-        checksum/git-repos: {{ include (print $.Template.BasePath "/git-repos.yaml") . | sha256sum }}
       labels:
         {{- include "platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: apiserver
+      # The api-server loads the mounted agent-templates once at boot,
+      # and K8s doesn't restart a pod when a mounted ConfigMap changes — so roll
+      # the pod when the rendered templates change, making `helm upgrade` of a
+      # template take effect instead of serving stale ones until the next restart.
+      {{- $checksums := dict
+            "checksum/agent-templates" (include (print $.Template.BasePath "/agent-templates.yaml") . | sha256sum)
+            "checksum/git-repos" (include (print $.Template.BasePath "/git-repos.yaml") . | sha256sum) }}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.apiServer "internal" $checksums) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "platform.apiserver.serviceAccountName" . }}

--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -9,6 +9,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.controller) | nindent 2 }}
 spec:
   replicas: {{ .Values.controller.replicas | default 1 }}
   selector:
@@ -20,6 +21,7 @@ spec:
       labels:
         {{- include "platform.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: controller
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.controller) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "platform.controller.serviceAccountName" . }}

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -28,6 +28,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.keycloak) | nindent 2 }}
 spec:
   replicas: 1
   strategy:
@@ -41,7 +42,7 @@ spec:
       labels:
         {{- include "platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: keycloak
-      annotations: {}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.keycloak) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       initContainers:

--- a/deploy/helm/platform/templates/keycloak/provision-job.yaml
+++ b/deploy/helm/platform/templates/keycloak/provision-job.yaml
@@ -8,16 +8,18 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: keycloak-provision
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
-    helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded
-    helm.sh/hook-weight: "5"
+  {{- $hooks := dict
+        "helm.sh/hook" "post-install,post-upgrade"
+        "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded"
+        "helm.sh/hook-weight" "5" }}
+  {{- include "platform.annotations" (dict "root" $ "internal" $hooks) | nindent 2 }}
 spec:
   template:
     metadata:
       labels:
         {{- include "platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: keycloak-provision
+      {{- include "platform.podAnnotations" (dict "root" $) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       restartPolicy: OnFailure

--- a/deploy/helm/platform/templates/migrate-stale-netpols.yaml
+++ b/deploy/helm/platform/templates/migrate-stale-netpols.yaml
@@ -92,10 +92,11 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "platform.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: pre-upgrade
-    helm.sh/hook-weight: "1"
-    helm.sh/hook-delete-policy: hook-succeeded,before-hook-creation
+  {{- $hooks := dict
+        "helm.sh/hook" "pre-upgrade"
+        "helm.sh/hook-weight" "1"
+        "helm.sh/hook-delete-policy" "hook-succeeded,before-hook-creation" }}
+  {{- include "platform.annotations" (dict "root" $ "internal" $hooks) | nindent 2 }}
 spec:
   backoffLimit: 1
   ttlSecondsAfterFinished: 300
@@ -103,6 +104,7 @@ spec:
     metadata:
       labels:
         {{- include "platform.labels" . | nindent 8 }}
+      {{- include "platform.podAnnotations" (dict "root" $) | nindent 6 }}
     spec:
       serviceAccountName: {{ $jobName }}
       restartPolicy: OnFailure

--- a/deploy/helm/platform/templates/nfs-provisioner.yaml
+++ b/deploy/helm/platform/templates/nfs-provisioner.yaml
@@ -157,10 +157,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: nfs-provisioner
-  {{- with .Values.nfsProvisioner.annotations }}
-  annotations:
-    {{- toYaml . | nindent 4 }}
-  {{- end }}
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.nfsProvisioner) | nindent 2 }}
 spec:
   serviceName: {{ $name }}
   replicas: 1
@@ -173,10 +170,7 @@ spec:
       labels:
         {{- include "platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: nfs-provisioner
-      {{- with .Values.nfsProvisioner.podAnnotations }}
-      annotations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.nfsProvisioner) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ $name }}

--- a/deploy/helm/platform/templates/postgres.yaml
+++ b/deploy/helm/platform/templates/postgres.yaml
@@ -49,6 +49,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: postgres
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.postgres) | nindent 2 }}
 spec:
   serviceName: {{ $pgName }}
   replicas: 1
@@ -61,6 +62,7 @@ spec:
       labels:
         app.kubernetes.io/component: postgres
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.postgres) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       containers:

--- a/deploy/helm/platform/templates/redis.yaml
+++ b/deploy/helm/platform/templates/redis.yaml
@@ -54,6 +54,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: redis
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.redis) | nindent 2 }}
 spec:
   serviceName: {{ $redisName }}
   replicas: 1
@@ -66,6 +67,7 @@ spec:
       labels:
         app.kubernetes.io/component: redis
         app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.redis) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       containers:

--- a/deploy/helm/platform/templates/ui/app.yaml
+++ b/deploy/helm/platform/templates/ui/app.yaml
@@ -74,6 +74,7 @@ metadata:
   labels:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: ui
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.ui) | nindent 2 }}
 spec:
   replicas: 1
   selector:
@@ -85,8 +86,8 @@ spec:
       labels:
         {{- include "platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: ui
-      annotations:
-        checksum/nginx-config: {{ toYaml .Values.ui | sha256sum }}
+      {{- $checksums := dict "checksum/nginx-config" (toYaml .Values.ui | sha256sum) }}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.ui "internal" $checksums) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}
       containers:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -82,6 +82,20 @@ urls:
 #     - name: my-registry-secret
 imagePullSecrets: []
 
+# -- Annotations added to every chart-managed workload (Deployments,
+# StatefulSets and the setup/migration Jobs). Use for cluster-wide policy or
+# tooling that targets workload objects. Per-component `annotations` override
+# these on collision; chart-internal annotations (e.g. Helm hooks) always win.
+commonAnnotations: {}
+
+# -- Annotations added to the pod template of every chart-managed workload.
+# This is what injection operators read — e.g. set
+# `instrumentation.opentelemetry.io/inject-sdk: "true"` here to opt the whole
+# platform into OpenTelemetry auto-instrumentation. Per-component
+# `podAnnotations` override these; chart-internal annotations (config
+# checksums) always win.
+commonPodAnnotations: {}
+
 # -- Kubelet probes for chart-managed pods (api-server, ui, keycloak,
 # postgres, redis) AND controller-managed agent / fork pods. Set
 # `enabled: false` to drop all readiness/liveness/startup probes — escape
@@ -129,6 +143,10 @@ openshift:
 # Set enabled: false when using external/cloud DBs for all services.
 postgres:
   enabled: true
+  # -- Extra annotations for the StatefulSet object / its pod template
+  # (merged over commonAnnotations / commonPodAnnotations).
+  annotations: {}
+  podAnnotations: {}
   image: registry.access.redhat.com/hi/postgresql:18
   user: platform
   # password is auto-generated if not set
@@ -150,6 +168,10 @@ postgres:
 # the source of truth for anything durable).
 redis:
   enabled: true
+  # -- Extra annotations for the StatefulSet object / its pod template
+  # (merged over commonAnnotations / commonPodAnnotations).
+  annotations: {}
+  podAnnotations: {}
   image: registry.access.redhat.com/hi/valkey:9.0
   port: 6379
   storage: 1Gi
@@ -165,6 +187,10 @@ redis:
 # -- Keycloak (OIDC identity provider)
 keycloak:
   enabled: true
+  # -- Extra annotations for the Deployment object / its pod template
+  # (merged over commonAnnotations / commonPodAnnotations).
+  annotations: {}
+  podAnnotations: {}
   # The Keycloak image is a first-party build that bakes the
   # Keycloakify theme JAR on top of upstream Keycloak. The upstream
   # version is pinned in `packages/keycloak-theme/Dockerfile`.
@@ -330,6 +356,10 @@ ingress:
 
 # -- UI (nginx serving static SPA, reverse-proxies /api to API server)
 ui:
+  # -- Extra annotations for the Deployment object / its pod template
+  # (merged over commonAnnotations / commonPodAnnotations).
+  annotations: {}
+  podAnnotations: {}
   image:
     repository: quay.io/dam-agents/ui
     tag: "" # defaults to appVersion
@@ -345,6 +375,10 @@ ui:
 
 # -- API Server
 apiServer:
+  # -- Extra annotations for the Deployment object / its pod template
+  # (merged over commonAnnotations / commonPodAnnotations).
+  annotations: {}
+  podAnnotations: {}
   image:
     repository: quay.io/dam-agents/api-server
     tag: ""
@@ -526,6 +560,12 @@ apiServer:
 
 # -- Controller (Go reconciler + scheduler)
 controller:
+  # -- Extra annotations for the controller Deployment object / its pod
+  # template (merged over commonAnnotations / commonPodAnnotations). These
+  # apply to the controller pod itself, not the agent pods it launches (those
+  # have their own knobs under controller.agent).
+  annotations: {}
+  podAnnotations: {}
   image:
     repository: quay.io/dam-agents/controller
     tag: ""


### PR DESCRIPTION
Closes #1375

## Problem

The chart gave operators no way to annotate the workloads it deploys. The motivating case is **OpenTelemetry auto-instrumentation**, whose injection operator triggers on pod-template annotations — with nowhere to put them, the platform's services couldn't be auto-instrumented without forking the chart or hand-patching live resources. Only the NFS provisioner had annotation knobs; the primary services had none.

## Change

Two shared template helpers (`platform.podAnnotations`, `platform.annotations`) merge annotations from three layers and render the block only when non-empty:

- **`commonPodAnnotations` / `commonAnnotations`** (new, chart-wide) — applied to every workload's pod template / object metadata.
- **`<component>.podAnnotations` / `<component>.annotations`** (per-component override) — added to `apiServer`, `ui`, `controller`, `keycloak`, `postgres`, `redis` (NFS provisioner already had them, now routed through the helpers so the chart-wide defaults reach it too).
- **chart-internal** (highest precedence) — config checksums and Helm hook directives are passed through as `internal` so rollout-on-config-change and hook behavior are preserved.

Precedence, highest first: **internal > per-component > chart-wide**. All knobs default to `{}` — existing installs are unaffected.

Covers all 9 workloads: api-server, UI, controller, Keycloak, Postgres, Redis, NFS provisioner, and both setup/migration Jobs.

## Verification

`mise run helm:check:lint` and `mise run helm:check:render` (kubeconform) pass. Rendered-output checks:

| Scenario | Result |
|---|---|
| Defaults | Helm hooks + config checksums intact; no stray annotation blocks |
| Chart-wide defaults set | land on all 8 enabled workloads + their pod templates |
| Per-component override | wins on that component only |
| Chart-wide + per-component | both keys **merge** (correct precedence) |
| Hook Jobs + user annotation | keep every hook directive **and** gain the annotation |