### PR TITLE
feat(agents): add Nous hypothesis-driven experimentation agent

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -280,6 +280,91 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "$IMAGE@sha256:%s " *)
 
+  build-nous:
+    # nous builds FROM claude-code (not platform-base), so it runs after the
+    # agent manifests are merged and pulls its base by the same per-commit tag.
+    needs: [merge-agents]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: packages/agents/nous
+          file: packages/agents/nous/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/nous,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ github.sha }}
+          cache-from: type=gha,scope=nous-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=nous-${{ matrix.arch }}
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-nous-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  merge-nous:
+    name: merge multi-arch nous manifest
+    needs: [build-nous, appversion]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: digests-nous-*
+          path: /tmp/digests
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/nous
+          tags: |
+            type=sha,prefix=,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ needs.appversion.outputs.composite }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      - name: Create manifest list and push
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/nous
+        run: |
+          set -euo pipefail
+          cd /tmp/digests
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "$IMAGE@sha256:%s " *)
+
   build-mock:
     name: build mock (e2e fixture)
     needs: [merge-images]
@@ -356,7 +441,7 @@ jobs:
           if-no-files-found: ignore
 
   publish:
-    needs: [merge-agents, appversion]
+    needs: [merge-agents, merge-nous, appversion]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -609,7 +694,7 @@ jobs:
 
   container-scan:
     name: mise run ${{ matrix.task }}
-    needs: [trivy-tasks, merge-images, merge-agents]
+    needs: [trivy-tasks, merge-images, merge-agents, merge-nous]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -72,6 +72,23 @@ agentTemplates:
         cpu: "2"
         memory: "4Gi"
 
+  - name: nous
+    enabled: true
+    category: harness
+    experimental: true
+    description: "Nous hypothesis-driven experimentation agent"
+    image:
+      repository: platform-nous
+      tag: latest
+    storageSize: "10Gi"
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+
   - name: mock
     enabled: true
     description: "Scripted mock agent (E2E test fixture)"

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -922,6 +922,27 @@ agentTemplates:
         cpu: "2"
         memory: "4Gi"
 
+  # Published by CI (build-nous / merge-nous in cd.yml). Experimental: the
+  # harness drives long-running Nous campaigns — see packages/agents/nous/README.md.
+  - name: nous
+    enabled: true
+    category: harness
+    experimental: true
+    description: "Nous hypothesis-driven experimentation agent"
+    image:
+      repository: quay.io/dam-agents/nous
+      tag: ""
+    # Campaigns clone, build, and run target systems (plus per-arm git
+    # worktrees and a Python venv), so give it more disk than a chat agent.
+    storageSize: "10Gi"
+    resources:
+      requests:
+        cpu: "500m"
+        memory: "1Gi"
+      limits:
+        cpu: "2"
+        memory: "4Gi"
+
   # Test-only mock agent. Scripted ACP emitter; receives prompts
   # into an in-pod buffer and emits a pre-set sequence of session/update
   # frames in response. Default off — flipped on by the e2e/local install.

--- a/mise.toml
+++ b/mise.toml
@@ -49,6 +49,7 @@ includes = [
     "packages/agents/bob/tasks.toml",
     "packages/agents/claude-code/tasks.toml",
     "packages/agents/codex/tasks.toml",
+    "packages/agents/nous/tasks.toml",
     "packages/agents/pi-agent/tasks.toml",
     "packages/agents/tasks.toml",
     "packages/api-server-api/tasks.toml",

--- a/packages/agents/nous/AGENTS.md
+++ b/packages/agents/nous/AGENTS.md
@@ -1,0 +1,278 @@
+# Agent pod environment — Nous
+
+You are running inside an isolated **Nous** agent pod on the platform. Your job
+is to do **Nous-related work**: drive the `nous` CLI to investigate software
+systems with the scientific method — author campaigns, run them, monitor and
+resume them, and report findings. You are not a general-purpose coding agent;
+keep the work centered on running and interpreting Nous campaigns.
+
+Your home directory and workspace are persistent; the rest of the filesystem is
+reset on pod restart. Network egress is proxied through the platform's
+credential gateway, so `git`, `gh`, and the Claude API all work **without any
+API key in this pod** — never ask the user for one, and never write credentials
+to disk.
+
+## What Nous is
+
+Nous runs the scientific method on software systems: it forms a falsifiable
+hypothesis about a target system, designs a controlled experiment, executes it,
+and extracts reusable principles. A deterministic Python orchestrator (the
+`nous` CLI) drives two Claude agent roles through a structured loop. You drive
+`nous`; Nous drives the experiment.
+
+**The `nous` skill is your reference** for the full CLI surface and campaign
+authoring (`locked_parameters`, `ground_truth`, the five hypothesis arms,
+rehearsal-vs-real iterations, `nous schema campaign`). Consult it whenever you
+author a campaign or reach for a subcommand. This file is the *how-to-operate-in-
+this-pod* layer.
+
+## Tools
+
+- `nous` — the Nous orchestrator CLI (pre-installed, on `PATH`). Do **not**
+  reinstall it.
+- `claude` — Claude Code CLI; Nous's Agent SDK calls shell out to it, authed
+  through the gateway.
+- `git`, `gh`, `node`/`npm`, `rg`, `fd`, `jq`, `uv`/`uvx`, `curl`, `tar`.
+
+## Starting a conversation
+
+At the **start of every new conversation**, before anything else, list the
+existing campaigns and offer to act on them. Scan `$NOUS_CAMPAIGN_PARENT`
+(`~/nous-campaigns`) for campaign directories (each has a `campaign.yaml`) and
+classify each as:
+
+- **running** — its `run.pid` names a live process (`kill -0 "$(cat run.pid)"`).
+- **not running** — no live process (finished, stopped, or paused by a pod
+  hibernation — see below).
+
+Present the grouped list, then ask whether they want a status pull on one or to
+resume one. When you pull detail, run `nous status <run_id> --line` and say
+whether a not-running campaign is **done** (state `DONE`) or **resumable**
+(checkpointed mid-run). If the user instead opens with a concrete task (e.g.
+"run a campaign on X"), do that task — but still mention any currently-running
+campaign in one line.
+
+## Running a campaign
+
+**Pre-flight checklist — do all of these before `nous run`:**
+
+1. **Detect channels.** Call `describe_channel` for `slack` and `telegram`; if
+   one is bound, wire `channels:` + start the bridge so progress reports flow to
+   the user's thread (see "Reporting progress"). This is easy to forget — it's
+   not optional when a channel is bound.
+2. **State the keep-awake tradeoff up front** (see "Surviving hibernation").
+   Before launching, tell the user the rough wall-clock and that an idle session
+   hibernates the pod — so either they keep a terminal/SSH session open for an
+   uninterrupted run, or you'll resume after each idle gap and it stretches out.
+   Say this *first*, not after the first death.
+3. **Author a lean, fast `campaign.yaml`** — declare `observable_metrics` and
+   schedule a rehearsal iteration (below); both cut DESIGN time and cost.
+4. **Discover gateway models** and pin `models:` (see "Pin models the gateway serves").
+
+Give **every campaign its own directory** under `$NOUS_CAMPAIGN_PARENT`, and
+clone the target repo **inside** it. Never create campaign files or clone repos
+in the pod's home root or any unrelated directory.
+
+1. **Pick a unique `run_id`.** Derive a concise, web-safe slug from the target
+   repo name plus the research question (lowercase; non-alphanumerics → `-`;
+   collapse repeats; trim; cap ~50 chars), e.g.
+   `inference-sim-latency-bottleneck`. **Guarantee uniqueness**: if
+   `$NOUS_CAMPAIGN_PARENT/<run_id>` already exists, append `-2`, `-3`, … until
+   it doesn't. The `run_id` is also the directory name and Nous's work-dir.
+
+2. **Create the directory and clone the target into `repo/`:**
+
+   ```sh
+   dir="$NOUS_CAMPAIGN_PARENT/<run_id>"
+   mkdir -p "$dir"
+   git clone <target-repo-url> "$dir/repo"      # skip for a live_target campaign
+   ```
+
+3. **Author `campaign.yaml` in that directory** (see the `nous` skill +
+   `nous schema campaign`). It MUST set:
+   - `run_id: <run_id>`
+   - `repo_path: <dir>/repo` (absolute), or `target_system.live_target: true`
+     with no clone for a running-system probe.
+   - **`locked_parameters`** — non-negotiable. Auto-approve refuses a campaign
+     with no locks, so front-load every knob whose deviation would invalidate
+     the experiment. Add `ground_truth` too.
+   - **`models`** — also non-negotiable here (see next section). Nous's hardcoded
+     defaults (`claude-opus-4-6`/`claude-sonnet-4-6`) are usually **absent** from
+     this pod's gateway, and a campaign that requests a missing model **hangs**.
+   - **`channels`** — if a Slack/Telegram channel is bound to this agent, add the
+     block automatically (see "Reporting progress"). Detect with `describe_channel`
+     first; omit it when nothing is bound.
+   - **`observable_metrics`** — declare them (e.g. `[ttft_p50_ms, throughput, …]`).
+     Omitting them makes the DESIGN phase spend extra Opus time exploring the repo
+     to discover what the target emits.
+   - **`iterations: [{mode: rehearsal}, {mode: real}]`** — schedule iter-1 as a
+     cheap rehearsal (apparatus + regime sanity check) before the full real
+     matrix. Catches parse/regime issues without paying for the whole seed sweep.
+
+4. **Run it auto-approved, in the background** (next section).
+
+## Pin models the gateway serves
+
+Always write an explicit `models:` block. The model gateway fronts a specific
+upstream whose catalog rarely matches Nous's built-in defaults — request a model
+it doesn't serve and the run gets stuck. **Discover the catalog at author time**
+and map it:
+
+```sh
+# Newest opus + sonnet the gateway resolves (set in this harness's env):
+echo "opus=$ANTHROPIC_DEFAULT_OPUS_MODEL  sonnet=$ANTHROPIC_DEFAULT_SONNET_MODEL"
+# Authoritative full catalog (works even if those vars are unset):
+curl --noproxy '*' -fsS 'http://127.0.0.1:24180/v1/models?limit=1000' | jq -r '.data[].id'
+```
+
+Map by tier, then drop straight into `campaign.yaml` (use the IDs verbatim — they
+may be namespaced, e.g. `claude/aws/claude-opus-4-8`):
+
+- `design` → the newest **opus** id,
+- `execute_analyze` and `report` → the newest **sonnet** id.
+
+If a tier is missing, fall back to another available model (prefer the most
+capable: opus → sonnet → whatever the catalog lists). Example for a gateway
+serving `claude/aws/claude-opus-4-8` + `claude/aws/claude-sonnet-4-6`:
+
+```yaml
+models:
+  design: "claude/aws/claude-opus-4-8"
+  execute_analyze: "claude/aws/claude-sonnet-4-6"
+  report: "claude/aws/claude-sonnet-4-6"
+```
+
+## Always auto-approve, always background
+
+- **Always pass `--auto-approve`.** Both human gates auto-pass
+  (`NOUS_ALLOW_AUTO_APPROVE=1` is set in this image). If `nous` ever asks for an
+  approval, approve it. Auto-approve is why `locked_parameters` is mandatory.
+- **Always launch the campaign as a background process** so you stay responsive
+  to the user and can query state with `nous` while it runs. Keep the PID and
+  the log in the campaign directory:
+
+  ```sh
+  cd "$NOUS_CAMPAIGN_PARENT/<run_id>"
+  nohup nous run campaign.yaml --auto-approve --max-iterations <N> \
+    > campaign.log 2>&1 &
+  echo $! > run.pid
+  ```
+
+  Then report status without blocking: `nous status <run_id> --line` (see
+  "Monitoring" for the right liveness signals). Use `nous stop <run_id>` to halt
+  cleanly.
+
+## Surviving hibernation (resume-on-wake)
+
+The pod **scales to zero when the session goes idle** — no active turn, no
+queued prompt, no open terminal/SSH session. That kills any background
+`nous run`. Campaign artifacts live on the persistent `$HOME`, so the run is
+recoverable but **does not progress while you're not engaged**.
+
+Therefore, **at the start of every turn**, for each campaign the user cares
+about (or any you launched this session): if `run.pid` is dead but
+`nous status` shows the campaign is not `DONE`, resume it in the background:
+
+```sh
+cd "$NOUS_CAMPAIGN_PARENT/<run_id>"
+nohup nous resume campaign.yaml --auto-approve >> campaign.log 2>&1 &
+echo $! > run.pid
+```
+
+**Keep-awake escape hatch:** for a long campaign that must progress
+continuously (e.g. overnight), tell the user to keep a **terminal or SSH session
+open** to this agent — an open session pins the pod awake, so a backgrounded
+`nous run` runs to completion without hibernation interruptions.
+
+## Monitoring a running campaign
+
+A campaign doesn't advance faster because you look at it more, and phases are
+long (DESIGN alone can be ~10–15 min). Poll **infrequently, with wide spacing**,
+and read the right signals:
+
+- **Use `nous status <run_id> --line`** for phase/iteration. For finer liveness,
+  check the freshness (mtime) of the executor log under `runs/iter-N/` (e.g.
+  `runs/iter-N/inputs/executor_log.jsonl`) and the count of result files — those
+  move continuously during EXECUTE_ANALYZE.
+- **Do NOT judge progress by `campaign.log`.** It only writes at phase
+  transitions, so it looks frozen for many minutes while real work is happening.
+- **`STUCK` means "look closer," not "dead."** It's a ~5-min-silence heuristic
+  and fires during legitimate long batches. Confirm with the signals above before
+  reacting.
+- **Poll without long foreground `sleep`s** — they overflow the turn window and
+  get auto-backgrounded. Use background polls on a consistent, wide cadence (or
+  just check less often).
+
+## Reporting progress to Slack/Telegram (auto when a channel is bound)
+
+If a Slack or Telegram channel is **bound to this agent**, report campaign
+progress there automatically — don't wait to be asked. This uses Nous's native
+`channels:` feature pointed at the in-pod **channel bridge**, which relays each
+gate summary to the bound thread via the platform (no external egress, no webhook
+secret on disk).
+
+**Before launching any campaign, detect a bound channel** with the
+`describe_channel` MCP tool (always registered in chat mode). Call it for
+`slack` and `telegram`; a channel is bound if it returns a non-empty `chats`
+list (a "channel type … not available" error means it isn't):
+
+- **A channel is bound** → wire reporting in automatically:
+  1. Ensure the shared bridge is running (one per pod, idempotent). The probe
+     tests whether anything is *listening* (a live bridge answers the empty body
+     with 400 — that still means "up"); only a refused connection starts one:
+     ```sh
+     curl -s -o /dev/null --max-time 2 -X POST http://127.0.0.1:8765/gate -d '{}' || \
+       { nohup nous-channel-bridge > "$NOUS_CAMPAIGN_PARENT/.bridge.log" 2>&1 & \
+         echo $! > "$NOUS_CAMPAIGN_PARENT/.bridge.pid"; }
+     ```
+     A race (two launches at once) is harmless: the loser hits the in-use port
+     and exits cleanly.
+  2. Add a `channels:` block to `campaign.yaml`, with `channel=` set to the bound
+     type (`slack` or `telegram`):
+     ```yaml
+     channels:
+       - kind: webhook
+         url: http://127.0.0.1:8765/gate?channel=slack
+     ```
+  3. Tell the user you've wired progress reporting to their <slack|telegram> thread.
+- **No channel bound** → skip silently (no `channels:` block, no bridge). Don't
+  mention it unless the user asks about messenger reporting — then point them at
+  binding a channel in the platform UI.
+
+Nous then POSTs a markdown summary at every DESIGN/FINDINGS gate — **including
+under `--auto-approve`** (the notify fires before the gate auto-passes) — and the
+bridge relays it to the thread. Delivery is best-effort: a bridge or channel
+hiccup logs a warning and never blocks the campaign.
+
+**Resume-on-wake:** the bridge dies with the pod on hibernation, like the
+campaign. When you resume a campaign that uses channels, re-run the bridge check.
+
+## After a campaign: harvest knowledge into the wiki
+
+When a campaign reaches `DONE`, offer to index it into the cross-campaign
+**wiki** (`~/.nous/wiki/`) so findings compound across runs — run
+`/post-campaign ~/nous-campaigns/<run_id>`. Use `/visualize-registry` for the
+cross-campaign knowledge graph and `/suggest-next <repo> "<question>"` to
+recommend high-value next experiments. When the user is scoping a *new*
+campaign on a repo that already has indexed history, consider `/suggest-next`
+first. These slash commands ship with the agent (`~/.claude/commands/`); the
+`nous` skill documents them.
+
+## Where things live
+
+- **Per-campaign directory** = `$NOUS_CAMPAIGN_PARENT/<run_id>/` (`~/nous-campaigns`,
+  on persistent `$HOME`). Holds `campaign.yaml`, the `repo/` clone, `run.pid`,
+  `campaign.log`, and Nous's own artifacts (`state.json`, `principles.json`,
+  `ledger.json`, `runs/iter-N/…`, `meta_findings.json`).
+- **Experiment worktrees** for per-arm experiments are created by Nous under the
+  target clone (`repo/.nous-experiments/`) — that's by design; they're code for
+  the target.
+
+## Notes for this environment
+
+- For a *running* target (a cluster, a deployed service, a non-git dataset)
+  rather than a repo, set `target_system.live_target: true` so arms are probes
+  and no worktree is created. The target must be reachable from this pod's
+  egress rules.
+- Long campaigns can run for hours; rely on resume-on-wake (above) when the user
+  is intermittently engaged, or the keep-awake escape hatch for uninterrupted runs.

--- a/packages/agents/nous/Dockerfile
+++ b/packages/agents/nous/Dockerfile
@@ -1,0 +1,78 @@
+# Nous agent — the Nous hypothesis-driven experimentation orchestrator, layered
+# on the claude-code image. Building FROM claude-code is deliberate: Nous drives
+# Claude through the Claude Agent SDK, which shells out to the `claude` CLI. By
+# inheriting that CLI plus the model gateway and CA trust, Nous's LLM calls
+# authenticate through the platform's Envoy credential gateway — the pod holds
+# no Anthropic key, exactly like the Claude Code harness.
+#
+# Nous is installed straight from its public GitHub repo with pip (no vendoring):
+# `mise run agents:nous:image` is a plain `docker build`. Override the pinned
+# release with `--build-arg NOUS_REF=<tag|branch|sha>`.
+ARG BASE_IMAGE=platform-claude-code
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Pinned Nous release. Bump here (or pass --build-arg NOUS_REF=...) to upgrade.
+ARG NOUS_REF=v0.4.0
+
+# uv-managed Python in a shared location so the agent user (uid 65532) can use
+# it at runtime. UV_PYTHON_INSTALL_DIR keeps interpreters out of root's $HOME.
+# uv itself is provided by the mise-managed base image.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    NOUS_VENV=/opt/nous-venv
+
+# Python 3.11 + Nous (and its claude-agent-sdk dependency) from GitHub, in a
+# dedicated venv. The repo is public, so the install needs no credentials.
+RUN uv python install 3.11 &&\
+    uv venv --python 3.11 "$NOUS_VENV" &&\
+    uv pip install --python "$NOUS_VENV/bin/python" \
+      "git+https://github.com/AI-native-Systems-Research/agentic-strategy-evolution.git@${NOUS_REF}" &&\
+    chown -R 65532:0 /opt/nous-venv /opt/uv
+
+# Put the venv (and thus `nous`, `python`, `pip`) ahead of the base tools.
+ENV PATH="/opt/nous-venv/bin:${PATH}"
+
+# Every campaign in this pod runs `--auto-approve`; some Nous versions gate that
+# behind this env. Setting it here makes unattended/background runs unconditional
+# (the design/findings human gates auto-pass). `locked_parameters` is still
+# required per campaign — see AGENTS.md / the nous skill.
+ENV NOUS_ALLOW_AUTO_APPROVE=1
+
+# Never proxy localhost. The pod's HTTP(S)_PROXY points at the egress gateway;
+# without this, Nous's gate-notification POST to the in-pod channel bridge
+# (http://127.0.0.1:…) would be sent to the gateway instead of staying local.
+# In-cluster hosts (e.g. the MCP endpoint) are NOT exempted, so the bridge's own
+# call still routes through the gateway like the harness's MCP calls.
+ENV NO_PROXY=127.0.0.1,localhost,::1 \
+    no_proxy=127.0.0.1,localhost,::1
+
+# Channel bridge: re-targets Nous's native `channels:` webhook at the platform's
+# per-agent `send_channel_message` MCP tool, so gate summaries land in the
+# agent's bound Slack/Telegram thread (no external egress, no webhook secret on
+# disk). See AGENTS.md / the nous skill. Shebang resolves to the venv python on
+# PATH; the pod has no extra runtime deps, so the bridge is pure stdlib.
+COPY --chmod=0755 nous-channel-bridge.py /usr/local/bin/nous-channel-bridge
+
+# Campaign artifacts on the persistent workspace, kept out of target repos
+# (Nous issue #239). $HOME (/home/agent) is the persist:true mount; /app/working-dir
+# is ephemeral image content that the agent init seeds into $HOME on first boot,
+# so we create the dir under the seed and point the env at the persisted path.
+# The template/agent env can override NOUS_CAMPAIGN_PARENT.
+ENV NOUS_CAMPAIGN_PARENT=/home/agent/nous-campaigns
+RUN mkdir -p /app/working-dir/nous-campaigns &&\
+    chown -R 65532:0 /app/working-dir/nous-campaigns
+
+# Nous-oriented system context for chat-mode (Claude Code, driving `nous`).
+# claude-code symlinks /etc/claude-code/CLAUDE.md -> /etc/AGENTS.md.
+# Both harnesses (chat and terminal) are inherited unchanged from the
+# claude-code base — nous customizes behavior via AGENTS.md + the skill, not
+# the harness scripts.
+COPY AGENTS.md /etc/AGENTS.md
+
+# Ship the `nous` skill (CLI + campaign-authoring reference) into the workspace.
+# The claude-code base already symlinks .claude/skills -> .agents/skills, and the
+# agent init seeds /app/working-dir into $HOME on first boot.
+COPY --chown=65532:0 workspace/ /app/working-dir/
+
+USER 65532

--- a/packages/agents/nous/README.md
+++ b/packages/agents/nous/README.md
@@ -1,0 +1,128 @@
+# Nous agent
+
+Runs [**Nous**](https://github.com/AI-native-Systems-Research/agentic-strategy-evolution)
+— a hypothesis-driven experimentation framework — as a platform agent type.
+Nous is a deterministic Python orchestrator (`nous run campaign.yaml`) that
+drives two Claude agent roles through a structured experiment loop against a
+target system it clones, builds, patches, and measures.
+
+## Why this maps cleanly onto the platform
+
+Nous's own docs ask you to run it "inside a network-namespaced container" with
+bounded egress and authenticated Claude access. The platform *is* that
+container: the agent pod holds **no** credentials, and Nous's Claude Agent SDK
+calls authenticate through the Envoy credential gateway — the same keyless path
+the `claude-code` harness uses. `git`/`gh` for cloning and publishing target
+repos go through the same gateway. The per-agent PVC persists campaign state
+across hibernation, so `nous resume` recovers a long run.
+
+## Image
+
+Built **FROM the `claude-code` image** (`ARG BASE_IMAGE=platform-claude-code`)
+so it inherits the `claude` CLI, the model gateway, and CA trust. On top it adds:
+
+- Python 3.11 + the `nous` package in a venv at `/opt/nous-venv`, installed with
+  `uv` **straight from the public GitHub repo** (pinned via `ARG NOUS_REF`,
+  default `v0.4.0`), with the venv on `PATH`. No source vendoring.
+- `NOUS_ALLOW_AUTO_APPROVE=1` so `--auto-approve` runs are unconditional in this
+  pod (the design/findings human gates auto-pass).
+- `NOUS_CAMPAIGN_PARENT=/home/agent/nous-campaigns` (on the persist:true `$HOME`
+  mount) so campaign artifacts survive hibernation and stay out of target repos
+  (Nous issue #239).
+- A Nous-oriented [`AGENTS.md`](./AGENTS.md) as the chat-mode system context,
+  plus the [`nous` skill](./workspace/.agents/skills/nous/SKILL.md) (CLI +
+  campaign-authoring reference) shipped into the workspace.
+- The Nous **wiki** slash commands (`post-campaign`, `index-wiki`,
+  `visualize-campaign`, `visualize-registry`, `suggest-next`) vendored verbatim
+  from the upstream repo into `~/.claude/commands/`, with their render scripts in
+  `~/scripts/`. They turn finished campaigns' `ledger.json`/`principles.json`
+  into a cross-campaign knowledge graph under `~/.nous/wiki/` so findings
+  compound across runs.
+
+## How the agent operates (chat mode)
+
+Both harnesses are inherited unchanged from the claude-code base; nous
+customizes behavior through [`AGENTS.md`](./AGENTS.md) + the skill, not the
+harness scripts. The chat harness drives `nous` per `AGENTS.md`:
+
+- **New conversation** → lists existing campaigns (running / not running) and
+  offers a status pull or a resume.
+- **Per campaign** → its own directory under `$NOUS_CAMPAIGN_PARENT`, named by a
+  unique web-safe `run_id` (repo + question, `-2`/`-3` on collision); the target
+  repo is cloned into `<run_id>/repo`, never in the pod root. `campaign.yaml`
+  always declares `locked_parameters`.
+- **Every run** → `nous run --auto-approve` launched as a **background process**
+  (PID in `run.pid`, output in `campaign.log`) so the agent stays conversational
+  and can poll `nous status` while it runs.
+
+### Hibernation & resume
+
+The pod scales to zero when the session goes idle (no active turn, queued
+prompt, or open terminal/SSH session — see
+[agent-lifecycle](../../../docs/architecture/agent-lifecycle.md)), which kills a
+background `nous run`. Artifacts persist on `$HOME`, so the agent **resumes on
+the next turn** (`nous resume --auto-approve`) when it finds a dead `run.pid`
+whose campaign isn't `DONE`. For uninterrupted long runs, keep a **terminal or
+SSH session open** — that pins the pod awake so the background run completes
+without hibernation gaps.
+
+### Progress to Slack/Telegram — the channel bridge
+
+[`nous-channel-bridge.py`](./nous-channel-bridge.py) (shipped to
+`/usr/local/bin/nous-channel-bridge`) lets a campaign report into the agent's
+bound Slack/Telegram thread using Nous's **own** `channels:` feature — without
+external egress or a webhook secret on disk. Nous's gate notifier POSTs each
+DESIGN/FINDINGS summary (it fires even under `--auto-approve`) to a `webhook`
+channel at `http://127.0.0.1:8765/gate?channel=slack`; the bridge relays it to
+the platform's per-agent `send_channel_message` MCP tool. It works because the
+image sets `NO_PROXY=127.0.0.1` (so Nous's POST stays local), the bridge's MCP
+call routes back through the egress gateway like the harness's own MCP calls, and
+the per-agent MCP endpoint authorizes by the pod's **mesh identity** (no token —
+ADR-041). Stdlib-only; the agent launches it on demand (see `AGENTS.md`). Needs a
+channel bound to the agent; delivery is best-effort.
+
+## Harness modes
+
+| Mode | Entrypoint | Behavior |
+|---|---|---|
+| **chat** | inherited claude-code (`claude-agent-acp`) | Claude Code with `nous` installed, the `nous` skill, and the Nous-oriented `AGENTS.md` — chat "run a campaign on …" and Claude drives the `nous` CLI (auto-approve, background, resume-on-wake). The primary path. |
+| **terminal** | inherited claude-code | The Claude Code TUI in a terminal (same harness as the base image). For a hands-on shell, use **SSH** — it drops into a plain login shell with `nous` on `PATH`. An open terminal or SSH session also pins the pod awake, useful for uninterrupted long runs. |
+
+## Build
+
+```sh
+mise run agents:nous:image          # plain docker build (pip-installs nous from GitHub)
+mise run cluster:build-agent        # rebuild + restart agent pods in the dev cluster
+```
+
+The build pip-installs Nous from its public GitHub repo — no local clone or
+vendoring. Override the pinned release with `NOUS_REF`:
+
+```sh
+NOUS_REF=main mise run agents:nous:image     # track a branch
+NOUS_REF=v0.4.1 mise run agents:nous:image   # or a different tag
+```
+
+`values-local.yaml` enables the nous template against the locally-built
+`platform-nous:latest`.
+
+## CI / publishing
+
+The nous image is published by CI (`.github/workflows/cd.yml`): `build-nous`
+(per-arch) runs after `merge-agents` — nous builds `FROM` claude-code, so it
+pulls its base by the same per-commit tag — and `merge-nous` publishes the
+multi-arch manifest to `quay.io/dam-agents/nous`. The `publish` (Helm) job waits
+on `merge-nous`. The template is enabled by default in `values.yaml`
+(`experimental: true`).
+
+## Known follow-ups (not yet wired)
+
+- **Schedule-driven unattended resume**: today a long campaign progresses while
+  the session is engaged (resume-on-wake) or while a terminal/SSH session pins
+  the pod awake. Mapping a platform *schedule trigger* → a "resume any running
+  campaigns" turn would give true overnight progress across hibernations; Nous
+  also ships a stubbed "Routines" payload builder for this.
+- **MCP**: Nous ships a read-only MCP server (`bin/nous-mcp`). Registering it in
+  the chat harness would make campaign data `@`-referenceable; left out of this
+  cut to avoid perturbing Claude Code startup. (The campaign-authoring/CLI
+  reference is already shipped as the `nous` skill.)

--- a/packages/agents/nous/nous-channel-bridge.py
+++ b/packages/agents/nous/nous-channel-bridge.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Localhost bridge: Nous native channel webhook -> platform `send_channel_message`.
+
+Nous (``orchestrator/channels.py``) POSTs a markdown gate summary to each
+configured channel at every DESIGN/FINDINGS gate — and it does so even under
+``--auto-approve`` (the notify fires before the gate decision). Point a campaign
+at this bridge:
+
+    channels:
+      - kind: webhook
+        url: http://127.0.0.1:8765/gate?channel=slack
+
+and the bridge forwards each summary to the platform's per-agent MCP
+``send_channel_message`` tool, which delivers it into the agent's bound
+Slack/Telegram thread. The campaign keeps using Nous's *own* channel feature;
+this just re-targets it at the platform's messaging instead of an external
+webhook — so no external egress and no webhook secret on disk.
+
+Why this works in the pod (all verified against a live agent):
+  * Auth is mesh-based — a process inside the agent pod inherits the pod's
+    mesh identity, which the api-server waypoint accepts for
+    ``/api/agents/<id>/mcp`` (ADR-041). No token needed.
+  * The MCP endpoint URL is injected as ``PLATFORM_MCP_URL``.
+  * The MCP call must traverse the egress gateway (the pod's NetworkPolicy
+    routes all egress through it); urllib's default opener honors ``HTTP_PROXY``
+    and the in-cluster MCP host is not in ``NO_PROXY``, so it does.
+  * Nous's POST to 127.0.0.1 must NOT be proxied — the image sets
+    ``NO_PROXY=127.0.0.1,localhost,::1`` so localhost bypasses the gateway.
+
+stdlib only — runs on the agent image's venv python; the pod has no extra tools
+(not even ``awk``).
+"""
+from __future__ import annotations
+
+import errno
+import json
+import logging
+import os
+import sys
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+MCP_URL = os.environ.get("PLATFORM_MCP_URL", "")
+DEFAULT_CHANNEL = os.environ.get("NOUS_BRIDGE_CHANNEL", "slack")
+PORT = int(os.environ.get("NOUS_BRIDGE_PORT", "8765"))
+PROTOCOL_VERSION = "2025-06-18"
+TIMEOUT_SECONDS = 15
+
+logging.basicConfig(level=logging.INFO, format="[nous-bridge] %(levelname)s %(message)s")
+log = logging.getLogger("nous-bridge")
+
+
+def _first_jsonrpc(raw: bytes, content_type: str) -> dict | None:
+    """Parse the first JSON-RPC object from an MCP response (SSE or plain JSON)."""
+    text = raw.decode("utf-8", "replace")
+    if "text/event-stream" in (content_type or ""):
+        for line in text.splitlines():
+            line = line.strip()
+            if line.startswith("data:"):
+                return json.loads(line[len("data:"):].strip())
+        return None
+    return json.loads(text) if text.strip() else None
+
+
+def _mcp_post(payload: dict, session_id: str | None):
+    """POST one JSON-RPC message to the MCP endpoint. Returns (headers, parsed)."""
+    headers = {
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    if session_id:
+        headers["mcp-session-id"] = session_id
+    req = urllib.request.Request(
+        MCP_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        headers=headers,
+        method="POST",
+    )
+    # Default opener honors HTTP_PROXY/NO_PROXY. The in-cluster MCP host is not
+    # in NO_PROXY, so this routes through the egress gateway, exactly like the
+    # harness's own MCP calls.
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SECONDS) as resp:
+        body = resp.read()
+        return resp.headers, _first_jsonrpc(body, resp.headers.get("Content-Type", ""))
+
+
+def send_channel_message(channel: str, text: str, chat_id: str | None) -> None:
+    """Run the MCP handshake and call send_channel_message."""
+    if not MCP_URL:
+        raise RuntimeError("PLATFORM_MCP_URL not set — not inside a platform agent pod?")
+    # 1. initialize -> mints the session id (returned in the mcp-session-id header).
+    headers, _ = _mcp_post(
+        {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": {"name": "nous-channel-bridge", "version": "1"},
+            },
+        },
+        None,
+    )
+    sid = headers.get("mcp-session-id")
+    # 2. initialized notification (the transport expects it before tool calls).
+    _mcp_post({"jsonrpc": "2.0", "method": "notifications/initialized"}, sid)
+    # 3. the actual tool call.
+    args: dict = {"channel": channel, "text": text}
+    if chat_id:
+        args["chatId"] = chat_id
+    _, parsed = _mcp_post(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "send_channel_message", "arguments": args},
+        },
+        sid,
+    )
+    result = (parsed or {}).get("result", {})
+    if result.get("isError"):
+        detail = " ".join(c.get("text", "") for c in result.get("content", []))
+        raise RuntimeError(f"send_channel_message rejected: {detail or 'unknown error'}")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, *_args):  # silence default access logging
+        pass
+
+    def do_POST(self):
+        try:
+            length = int(self.headers.get("Content-Length", 0) or 0)
+            raw = self.rfile.read(length) if length else b"{}"
+            body = json.loads(raw or b"{}")
+            # Nous `webhook` kind -> {"markdown": ...}; `slack` kind -> {"text": ...}.
+            text = (body.get("markdown") or body.get("text") or "").strip()
+            qs = parse_qs(urlparse(self.path).query)
+            channel = qs.get("channel", [DEFAULT_CHANNEL])[0]
+            chat_id = qs.get("chatId", [None])[0]
+            if not text:
+                self._reply(400, {"ok": False, "error": "empty message"})
+                return
+            send_channel_message(channel, text, chat_id)
+            log.info("forwarded gate notification to channel %r", channel)
+            self._reply(200, {"ok": True})
+        except Exception as exc:  # never hard-fail; Nous's notifier is best-effort
+            log.warning("forward failed: %s", exc)
+            self._reply(502, {"ok": False, "error": str(exc)})
+
+    def _reply(self, code: int, obj: dict) -> None:
+        data = json.dumps(obj).encode("utf-8")
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def main() -> int:
+    if not MCP_URL:
+        log.error("PLATFORM_MCP_URL not set; the bridge cannot reach the platform. Exiting.")
+        return 1
+    try:
+        server = ThreadingHTTPServer(("127.0.0.1", PORT), Handler)
+    except OSError as exc:
+        if exc.errno == errno.EADDRINUSE:
+            # Another bridge in this pod already owns the port. One shared bridge
+            # serves every campaign/session here (it's stateless per request), so
+            # a duplicate launch is a no-op — exit cleanly instead of crash-looping.
+            log.info("port %d already in use; another bridge is running — nothing to do.", PORT)
+            return 0
+        raise
+    log.info(
+        "listening on http://127.0.0.1:%d/gate -> %s (default channel: %s)",
+        PORT, MCP_URL, DEFAULT_CHANNEL,
+    )
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/agents/nous/tasks.toml
+++ b/packages/agents/nous/tasks.toml
@@ -1,0 +1,86 @@
+["agents:nous:image"]
+description = "Build the nous agent image (Nous orchestrator on the claude-code base)"
+dir = "{{config_root}}"
+depends = ["agents:claude-code:image"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
+
+# Nous installs from its public GitHub repo at build time (no vendoring). The
+# Dockerfile pins a default release; override it here with NOUS_REF=<tag|branch|sha>.
+build_args=()
+[ -n "${NOUS_REF:-}" ] && build_args+=(--build-arg "NOUS_REF=${NOUS_REF}")
+
+# ${build_args[@]+...} guards the empty-array expansion under `set -u` (bash 3.2 on macOS).
+docker build ${build_args[@]+"${build_args[@]}"} -t platform-nous:latest packages/agents/nous
+'''
+
+["agents:nous:sync-commands"]
+description = "Refresh workspace/.claude/commands from the Nous upstream repo, replacing each file by name"
+dir = "{{config_root}}"
+usage = '''
+flag "--ref <ref>" help="Upstream git ref (tag|branch|sha) to sync from (default: main)"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+ref="${usage_ref:-main}"
+repo="AI-native-Systems-Research/agentic-strategy-evolution"
+src=".claude/commands"
+dst="packages/agents/nous/workspace/.claude/commands"
+
+mkdir -p "$dst"
+
+# List the upstream command files. `gh` handles GitHub auth and JSON parsing; it
+# is the managed tool the repo already uses for the GitHub API.
+names="$(gh api "repos/${repo}/contents/${src}?ref=${ref}" \
+  --jq '.[] | select(.type == "file") | .name')"
+
+if [ -z "$names" ]; then
+  echo "No command files found at ${repo}@${ref}:${src}" >&2
+  exit 1
+fi
+
+# Overwrite each local command with its upstream counterpart name-by-name. We do
+# not wipe the directory, so any local-only files are left untouched. The heredoc
+# (not a pipe) keeps the loop in this shell so `count` survives — and avoids
+# `mapfile`, which the default macOS bash 3.2 lacks.
+count=0
+while IFS= read -r name; do
+  [ -z "$name" ] && continue
+  echo "↻ ${name}"
+  gh api "repos/${repo}/contents/${src}/${name}?ref=${ref}" \
+    -H "Accept: application/vnd.github.raw" >"${dst}/${name}"
+  count=$((count + 1))
+done <<EOF
+${names}
+EOF
+
+echo "Synced ${count} command(s) from ${repo}@${ref} into ${dst}"
+'''
+
+["agents:nous:scan"]
+depends = ["agents:nous:scan:*"]
+
+["agents:nous:scan:trivy"]
+dir = "{{config_root}}"
+usage = '''
+flag "--json" help="Emit Trivy JSON (exit 0) instead of failing on findings"
+flag "--tag <tag>" help="Scan quay.io/dam-agents/nous:<tag> instead of building locally"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${usage_tag:-}" ]; then
+  image="quay.io/dam-agents/nous:${usage_tag}"
+else
+  {{ mise_bin }} run agents:nous:image
+  image="platform-nous:latest"
+fi
+if [[ "${usage_json:-false}" == "true" ]]; then
+  exec trivy image --quiet --format json "$image"
+fi
+exec trivy image --quiet --exit-code 1 "$image"
+'''

--- a/packages/agents/nous/workspace/.agents/skills/nous/SKILL.md
+++ b/packages/agents/nous/workspace/.agents/skills/nous/SKILL.md
@@ -1,0 +1,433 @@
+---
+name: nous
+description: >-
+  Drive Nous, the hypothesis-driven experimentation framework, to investigate
+  software systems with the scientific method via the `nous` CLI. Use when the
+  user wants to run a Nous campaign, author or scaffold a campaign.yaml, kick
+  off / monitor / resume / stop / report on hypothesis-driven experiments, or
+  systematically investigate why a system (LLM server, DB optimizer, scheduler,
+  router, cache) behaves the way it does through controlled experiments.
+---
+
+# Nous — hypothesis-driven experimentation
+
+Nous runs the **scientific method on software systems**. An AI planner formulates
+falsifiable hypotheses about a target system, designs controlled experiments,
+an executor runs them, and Nous extracts reusable **principles** from the
+results — whether the hypothesis is confirmed or refuted. Knowledge accumulates
+across iterations so the same mistake is not repeated.
+
+It fits systems with **observable metrics, controllable knobs, reproducible
+execution, and decomposable mechanisms**: LLM serving, query optimizers,
+schedulers, routers, caches, load balancers.
+
+> Repo: https://github.com/AI-native-Systems-Research/agentic-strategy-evolution
+
+## This is a Nous agent pod
+
+`nous` is **pre-installed** in this pod (pinned, on `PATH`) and `claude` is
+authenticated through the platform's credential gateway — Nous's Claude Agent
+SDK calls work **with no API key in this pod**. Never ask the user for a
+credential, never write one to disk, and never `pip install` Nous yourself.
+
+The pod-level workflow (per-campaign directories, unique run ids, always
+`--auto-approve`, running campaigns in the background, resume-on-wake) is
+defined in this pod's system context (`AGENTS.md`). **This skill is the CLI and
+campaign-authoring reference**; follow `AGENTS.md` for *how* to drive a campaign
+in this environment.
+
+## The loop
+
+Each iteration is a deterministic state machine; the LLM only acts inside the
+phases, never the orchestration:
+
+```
+INIT → DESIGN → HUMAN_DESIGN_GATE → EXECUTE_ANALYZE → HUMAN_FINDINGS_GATE → DONE → (next iteration)
+```
+
+- **DESIGN** (planner, Opus by default) — authors a `bundle.yaml`: a hypothesis
+  with multiple falsifiable arms (see below) plus an experiment plan.
+- **HUMAN_DESIGN_GATE** — approve the design before expensive compute runs.
+- **EXECUTE_ANALYZE** (executor, Sonnet by default) — runs each arm in an
+  isolated git worktree, collects metrics, classifies prediction errors.
+- **HUMAN_FINDINGS_GATE** — approve findings before they enter the knowledge base.
+
+In this pod we always run with `--auto-approve` (both gates auto-pass), so
+front-loading `locked_parameters` is what keeps a run defensible — see below.
+
+## Quick start (full workflow)
+
+```bash
+# 0. Verify the CLI (already installed and gateway-authenticated here).
+nous --help
+
+# NOTE: NOUS_CAMPAIGN_PARENT is already exported in this pod (campaign artifacts
+# land on the persistent $HOME). Per AGENTS.md, give each campaign its own
+# directory under it and clone the target repo inside that directory.
+
+# 1. Scaffold a heavily-commented starting campaign.
+nous create-campaign --to ./campaign.yaml \
+  --target-name "Your System" \
+  --research-question "What mechanism drives the primary bottleneck?" \
+  --target-repo-path ./repo
+
+# 2. (Edit campaign.yaml — see "Authoring a campaign" below, and `nous schema`.)
+nous schema campaign            # authoritative field reference
+
+# 3. Run it (auto-approve; backgrounded per AGENTS.md).
+nous run campaign.yaml --auto-approve --max-iterations 3
+
+# 4. Watch progress live.
+nous status campaign.yaml --watch
+
+# 5. After it finishes: report, cost, and a paper-grade artifact tarball.
+nous report campaign.yaml
+nous cost   campaign.yaml --cache-stats
+nous package campaign.yaml
+```
+
+## Worked example: a BLIS campaign end-to-end
+
+A concrete campaign against **BLIS** (the `inference-sim` discrete-event
+LLM-serving simulator) — the whole arc: clone, author, run, then harvest the
+findings into the wiki.
+
+```bash
+# 1. Per-campaign dir + clone the target into it (see AGENTS.md for the convention).
+run_id="blis-prefix-ttft"
+dir="$NOUS_CAMPAIGN_PARENT/$run_id"
+mkdir -p "$dir"
+git clone https://github.com/inference-sim/inference-sim.git "$dir/repo"   # BLIS
+```
+
+`$dir/campaign.yaml`:
+
+```yaml
+research_question: >
+  With total input length held fixed, does increasing the prefix portion
+  (cached tokens) reduce TTFT under moderate load?
+
+run_id: blis-prefix-ttft
+max_iterations: 2
+
+target_system:
+  name: "BLIS — LLM Inference Serving Simulator"
+  description: >
+    BLIS is a discrete-event simulator for LLM inference serving.
+    It models request arrivals, scheduling, and KV-cache management.
+  repo_path: /home/agent/nous-campaigns/blis-prefix-ttft/repo   # the clone above (absolute)
+  # Declare what the target emits — omitting this makes DESIGN burn extra Opus
+  # time exploring the repo to discover the metrics.
+  observable_metrics: [ttft_p50_ms, throughput, scheduling_delay_p99_ms]
+  controllable_knobs: [prefix_fraction, concurrency, cache_policy]
+
+# Cheap rehearsal first (apparatus + regime sanity), then the full real matrix —
+# catches parse/regime issues before paying for the whole seed sweep.
+iterations:
+  - mode: rehearsal
+  - mode: real
+
+# Required for this pod's auto-approved runs — hard-pin what would invalidate the
+# experiment (see "Authoring a campaign"). Without it the run refuses to start.
+locked_parameters:
+  model: meta-llama/Llama-3-8B
+  concurrency_per_tenant: 8
+  duration_seconds: 120
+  warmup_seconds: 20
+
+ground_truth:
+  pre_registered: true
+  primary_metric: "P50(ttft)"
+  direction_claim: "P50(ttft) decreases as prefix fraction increases at fixed total length"
+  pass_condition: "direction holds in median across seeds AND in >=7 of 10 seeds"
+  seeds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+# Pin models the GATEWAY serves — discover them, don't trust Nous's defaults
+# (which usually aren't in the catalog, and a missing model hangs the run).
+# These IDs are illustrative; resolve the real ones per "Selecting models".
+models:
+  design: "claude/aws/claude-opus-4-8"            # opus
+  execute_analyze: "claude/aws/claude-sonnet-4-6" # sonnet
+  report: "claude/aws/claude-sonnet-4-6"          # sonnet
+
+prompts:
+  methodology_layer: "prompts/methodology"
+  domain_adapter_layer: null
+```
+
+```bash
+# 2. Run it auto-approved, in the background (see AGENTS.md), and follow progress.
+cd "$dir"
+nohup nous run campaign.yaml --auto-approve --max-iterations 2 > campaign.log 2>&1 &
+echo $! > run.pid
+nous status "$run_id" --watch
+
+# 3. When it finishes, harvest the findings into the wiki (see "Post-campaign knowledge").
+/post-campaign "$dir"
+```
+
+## Authoring a campaign
+
+`nous schema campaign` is the single source of truth. The **minimal** required
+shape:
+
+```yaml
+research_question: >
+  One falsifiable sentence. e.g. "With total input length fixed, does increasing
+  the cached prefix portion reduce TTFT under moderate load?"
+
+run_id: my-campaign           # working-dir name under $NOUS_CAMPAIGN_PARENT
+max_iterations: 2
+
+target_system:
+  name: "My System"
+  description: >              # THIS field is substituted into the LLM's prompts.
+    What the system does, its architecture, exact paths, baselines, data-schema
+    gotchas, and statistical guardrails. Put domain context HERE.
+  repo_path: ./repo           # experiments run in isolated worktrees off this
+  observable_metrics: [latency, throughput, error_rate]   # optional, auto-discovered if omitted
+  controllable_knobs: [batch_size, cache_policy]          # optional
+
+prompts:
+  methodology_layer: "prompts/methodology"   # generic Nous methodology prompts
+  domain_adapter_layer: null                 # NOT IMPLEMENTED — leave null; put domain context in target_system.description
+```
+
+Key authoring discipline (see [`reference/campaign-schema.md`](reference/campaign-schema.md) for the full field list):
+
+- **`locked_parameters`** / **`locked_workload`** — hard-pin every knob whose
+  deviation would invalidate the experiment (model, concurrency, duration,
+  warmup, KV blocks, workload distributions). Mismatches are hard validation
+  failures **even under `--auto-approve`**. In this pod every campaign runs
+  auto-approved, so this inventory is mandatory — a campaign with no
+  `locked_parameters` will refuse to run. Front-load it; adding locks reactively
+  after each review round turns a 2-week campaign into a 5-round dance.
+- **`iterations: [{mode: rehearsal}, {mode: real}]`** — schedule iter-1 as a
+  cheap *rehearsal* (does the apparatus parse? does the regime engage the
+  mechanism?) and iter-2+ as full *real* runs.
+- **`live_target: true`** (under `target_system`) — for probing a *running*
+  system (cluster, service, non-git dataset) with no code to evolve. No
+  per-iteration worktree; bundles must contain no `code_changes` arms. The
+  target must be reachable from this pod's egress rules.
+- **`ground_truth`** — pre-register `direction_claim`, `pass_condition`,
+  `primary_metric`, and `seeds` before any iteration so the agent can't move the goalposts.
+- **`models`** — **always set this explicitly** (see below). Per-phase:
+  `design`, `execute_analyze`, `report`.
+
+### Selecting models (don't trust the defaults)
+
+Nous's built-in defaults are `claude-opus-4-6` / `claude-sonnet-4-6`, but the
+model gateway in this pod fronts a specific upstream whose catalog usually
+**doesn't** include those exact IDs — and a campaign that requests a model the
+gateway can't serve **hangs**. So discover the catalog and pin `models:` to it:
+
+```sh
+# Newest opus + sonnet the gateway resolves (exported into this harness's env):
+echo "opus=$ANTHROPIC_DEFAULT_OPUS_MODEL  sonnet=$ANTHROPIC_DEFAULT_SONNET_MODEL"
+# Authoritative full catalog (works even if those vars are unset):
+curl --noproxy '*' -fsS 'http://127.0.0.1:24180/v1/models?limit=1000' | jq -r '.data[].id'
+```
+
+Use the IDs **verbatim** (they may be namespaced, e.g.
+`claude/aws/claude-opus-4-8`): `design` → newest **opus**, `execute_analyze` and
+`report` → newest **sonnet**. If a tier is absent, fall back to the most capable
+model the catalog does list (opus → sonnet → anything).
+
+When the user asks to author a campaign, **read [`reference/campaign-schema.md`](reference/campaign-schema.md)**
+for the complete field set, then walk them through research question →
+target_system.description → what to lock.
+
+## The five hypothesis arms
+
+Every DESIGN bundle tests one mechanism from multiple angles:
+
+| Arm | Purpose |
+|---|---|
+| `H-main` | Validates the primary mechanism |
+| `H-ablation` | Isolates individual component contributions |
+| `H-super-additivity` | Detects interaction effects between components |
+| `H-control-negative` | Confirms specificity (the effect shouldn't appear here) |
+| `H-robustness` | Tests generalization across conditions |
+
+Fast-fail rules skip wasted compute on ablations/robustness when `H-main` is refuted.
+
+## Running, monitoring, controlling
+
+```bash
+# Unattended run — REQUIRES locked_parameters declared (safety precondition).
+# This is the default in this pod; NOUS_ALLOW_AUTO_APPROVE=1 is set in the image.
+nous run campaign.yaml --auto-approve --max-iterations 10 --timeout 1800 --max-cli-retries 50
+
+# Skip DESIGN with a pre-authored hypothesis bundle.
+nous run campaign.yaml --bundle ./bundle.yaml --auto-approve
+
+# Resume an interrupted campaign (timeout/crash/hibernation) at the last checkpoint.
+nous resume campaign.yaml --auto-approve
+
+# Live status (STUCK marker after ~5 min silence); single-line for prompts.
+nous status campaign.yaml --watch
+nous status campaign.yaml --line
+
+# Halt a running campaign cleanly at the next phase boundary.
+nous stop campaign.yaml --reason "regime looks wrong"
+nous stop campaign.yaml --immediate     # abort mid-turn within seconds
+
+# Cost / cache analytics, regenerate the report.
+nous cost   campaign.yaml --cache-stats
+nous report campaign.yaml
+```
+
+Notes:
+- `--agent sdk` is the **default** backend (Claude Agent SDK, gateway-authenticated
+  here). `--agent inline` emits prompts to stdout for an enclosing agent framework.
+- Default per-phase timeout is 1800s (30 min); `--max-cli-retries` default 10,
+  `-1` = unbounded.
+- If `--auto-approve` refuses to proceed, the run is missing required
+  `locked_parameters` — declare the locks first. (`NOUS_ALLOW_AUTO_APPROVE=1` is
+  already set in this image, so that gate is not the cause here.)
+
+**Reading liveness (don't be fooled):** `nous status --line` gives phase/iteration;
+for fine-grained progress watch the executor log mtime under `runs/iter-N/` (e.g.
+`runs/iter-N/inputs/executor_log.jsonl`) and the result-file count — they advance
+continuously during EXECUTE_ANALYZE. A backgrounded run's `campaign.log` only
+writes at phase transitions, so it looks frozen mid-phase — don't read "no new log
+lines" as "stuck". The `STUCK` marker is a ~5-min-silence heuristic that fires
+during legitimate long batches: treat it as "look closer", not "it died". Phases
+are long (DESIGN ~10–15 min) — poll infrequently with wide spacing; looking more
+often doesn't make it go faster.
+
+## Reporting progress to Slack/Telegram (the channel bridge)
+
+Nous's native `channels:` feature POSTs a markdown summary at every DESIGN/FINDINGS
+gate — and it fires **even under `--auto-approve`** (the notify runs before the
+gate auto-passes), so it doubles as unattended progress reporting. In this pod,
+don't point it at an external webhook (that needs egress allowlisting + a secret
+on disk); point it at the in-pod **channel bridge**, which relays each summary to
+the agent's bound Slack/Telegram thread via the platform's `send_channel_message`
+— no external egress, no secret.
+
+The agent wires this in **automatically when a channel is bound** to the agent
+(it checks `describe_channel` before each run); you don't have to ask. See
+`AGENTS.md` for the operate-in-this-pod steps (incl. resume-on-wake).
+
+One bridge serves the whole pod — it's stateless per request (each POST carries
+its own `channel` + text and does a fresh MCP call), so every campaign and
+session shares the single `127.0.0.1:8765` listener. Launches are idempotent and
+a duplicate start is a harmless no-op (the bridge exits cleanly if the port is
+already taken). Bridges in *other* agent pods are isolated — `127.0.0.1` is
+pod-local, and each posts only to its own agent's bound channel.
+
+```bash
+# Start the shared bridge (idempotent — one per pod):
+nohup nous-channel-bridge > "$NOUS_CAMPAIGN_PARENT/.bridge.log" 2>&1 &
+```
+
+```yaml
+# …then in campaign.yaml (channel=slack or channel=telegram to match the binding):
+channels:
+  - kind: webhook
+    url: http://127.0.0.1:8765/gate?channel=slack
+```
+
+How it holds together: `NO_PROXY=127.0.0.1` (set in the image) keeps Nous's POST
+local; the bridge's own call to the MCP endpoint routes back out through the
+egress gateway and is authorized by the pod's mesh identity (no token). Delivery
+is best-effort — a hiccup logs a warning and never blocks the campaign. See
+`AGENTS.md` for the operate-in-this-pod steps (incl. resume-on-wake).
+
+## Output artifacts
+
+Under `$NOUS_CAMPAIGN_PARENT/<run_id>/`:
+
+- `state.json` — orchestrator checkpoint (drives `resume`)
+- `principles.json` — accumulated, reusable knowledge across iterations
+- `ledger.json` — decision/event ledger; `handoff.md` — human-readable summary
+- `runs/iter-N/bundle.yaml` — the iteration's hypothesis + experiment plan
+- `runs/iter-N/findings.json` — results, validation, prediction-error taxonomy
+- `meta_findings.json` — cross-iteration synthesis & deployment recommendation
+
+## Post-campaign knowledge (the wiki)
+
+When a campaign finishes, harvest its `ledger.json` / `principles.json` into a
+cross-campaign **wiki** at `~/.nous/wiki/` so knowledge compounds across runs.
+These are Claude Code slash commands shipped with this agent (in
+`~/.claude/commands/`); the rendering scripts live at `~/scripts/`:
+
+```bash
+# Extract knowledge, index it into the registry, generate an interactive HTML viz.
+/post-campaign ~/nous-campaigns/<run_id>
+
+# Re-render one campaign's interactive HTML knowledge graph.
+/visualize-campaign <campaign-name>
+
+# Render the cross-campaign knowledge graph — campaigns, entities, concepts,
+# entity clusters, heuristic opportunity scores. Deterministic, no LLM calls.
+/visualize-registry
+
+# Recommend high-value next experiments from everything indexed so far.
+/suggest-next <repo-path-or-name> "your research question"
+```
+
+The wiki commands turn raw `ledger.json` / `principles.json` into structured
+knowledge — **dead-ends** (refuted approaches), **frontiers** (boundary
+conditions), and untested **interactions** — plus interactive HTML
+visualizations. Knowledge **compounds**: `/suggest-next` draws on findings from
+*all* indexed campaigns to point the next campaign at the highest-value open
+questions.
+
+> The viz commands invoke `python scripts/<name>.py`; run them from `$HOME`
+> (where the shipped `scripts/` live) or call `~/scripts/<name>.py` directly.
+> The scripts read/write only under `~/.nous/wiki/`.
+
+## Full CLI surface (13 subcommands)
+
+Run `nous <cmd> --help` for exact flags. Grouped by purpose:
+
+**Lifecycle — run & control**
+- `nous run <campaign>` — run end-to-end. Flags: `--max-iterations`, `--model`,
+  `--run-id`, `--auto-approve`, `--timeout` (default 1800s), `--max-cli-retries`
+  (default 10, `-1`=unbounded), `--agent {sdk,inline}` (default `sdk`),
+  `--sandbox {bypass,default}`, `--bundle` (skip DESIGN), `--problem-md`, `--handoff-md`.
+- `nous resume <target>` — pick up an interrupted run at the last checkpoint
+  (`--max-iterations`, `--model`, `--auto-approve`, `--timeout`, `--max-cli-retries`, `--agent`).
+- `nous stop <target>` — halt cleanly at the next phase boundary; `--reason`,
+  `--immediate` (abort mid-turn within seconds).
+
+**Author & inspect**
+- `nous create-campaign --to <path>` — scaffold a commented `campaign.yaml`
+  (`--target-name`, `--target-description`, `--research-question`, `--run-id`,
+  `--target-repo-path`, `--force`).
+- `nous schema [campaign|bundle|findings]` — print the authoritative artifact
+  schema (`--format {md,json,yaml}`).
+- `nous validate {design|execution} --dir <DIR>` — validate a work-dir against
+  the schema (the same gate the orchestrator runs internally).
+
+**Monitor & report**
+- `nous status <target>` — phase/iteration/principles snapshot; `--watch`,
+  `--line`, `--interval`.
+- `nous cost <target>` — token/cost totals; `--cache-stats` for cache hit-rate.
+- `nous report <target>` — (re)generate the **LLM** markdown findings report
+  (`--model`, `--agent`, `--timeout`; costs tokens).
+- `nous reports <target>` — re-emit `meta_findings.json` **deterministically,
+  zero LLM tokens**; works on legacy/aborted runs. (Note the trailing `s` — different command.)
+
+**Provenance & reproducibility**
+- `nous lineage <target>` — derivation chain + per-iteration `cumulative.patch`
+  availability (what `derived_from` inherited); `--json`.
+- `nous replay <target> --iter <N>` — replay a specific recorded iteration from its artifacts.
+- `nous package <target>` — tarball work_dir + `reproduce.sh` + Dockerfile +
+  README for paper artifact evaluation; `--output`.
+
+**Housekeeping**
+- `nous clean` — remove stale `nous-exp-*` worktrees/branches. `--orphaned`
+  (default: prune worktrees whose owning run is dead), `--target-repo`,
+  `--campaign`, `--dry-run`.
+
+`<target>` is generally a `campaign.yaml`, a work_dir, or a `run_id` resolvable
+under `$NOUS_CAMPAIGN_PARENT`.
+
+## When NOT to use Nous
+
+Skip it for one-off tweaks, systems with no observable metrics, or
+non-reproducible environments. Nous pays off when the question is a real
+*mechanism* question and you want defensible, cumulative findings.

--- a/packages/agents/nous/workspace/.agents/skills/nous/reference/campaign-schema.md
+++ b/packages/agents/nous/workspace/.agents/skills/nous/reference/campaign-schema.md
@@ -1,0 +1,182 @@
+# Campaign.yaml — full field reference
+
+This is a curated copy of `nous schema campaign`. The **live CLI output is
+authoritative** — run `nous schema campaign` (or `--format yaml`/`--format json`)
+to confirm against the installed version before relying on a field. Unknown
+top-level properties are rejected.
+
+There are two other artifact schemas: `nous schema bundle` (a DESIGN hypothesis
+bundle) and `nous schema findings` (EXECUTE_ANALYZE results).
+
+## Required fields
+
+- **`research_question`** _string_ — the guiding, falsifiable question.
+- **`target_system`** _object_
+  - `name` _string_ (required) — human-readable system name.
+  - `description` _string_ (required) — **this field is substituted into the
+    LLM's prompts.** Put all domain context here: architecture, exact paths,
+    baselines, data-schema gotchas, statistical guardrails.
+  - `repo_path` _string|null_ — target git repo; experiments run in isolated
+    worktrees off it.
+  - `observable_metrics` _array_ — measurable outputs (latency, throughput, error rate).
+  - `controllable_knobs` _array_ — what can be changed (algorithms, configs, limits).
+  - `live_target` _bool_ — if true, run directly in `repo_path` with **no**
+    per-iteration worktree. For probing a running system/dataset with no code to
+    evolve; bundles must contain no `code_changes` arms.
+  - `worktree_extras` _array_ — relative paths to symlink into each experiment
+    worktree (gitignored assets the executor needs: venvs, prefetched data,
+    build artifacts, prior-iteration outputs).
+- **`prompts`** _object_
+  - `methodology_layer` _string_ (required) — path to generic Nous methodology prompts.
+  - `domain_adapter_layer` _string|null_ — **NOT IMPLEMENTED (#89).** Setting it
+    warns and is ignored. Put domain context in `target_system.description` instead.
+
+## Spec-fidelity (front-load these for defensible, auto-approvable runs)
+
+- **`locked_parameters`** _object_ — `key: value` knobs hard-pinned for the
+  campaign. Each MUST appear identically in `bundle.experiment_spec.verified_parameters`;
+  mismatch is a hard validation failure **regardless of `--auto-approve`**.
+  Idiomatic keys: `model`, `concurrency_per_tenant`, `duration_seconds`,
+  `warmup_seconds`, `total_kv_blocks`, plus anything whose deviation invalidates
+  the experiment.
+- **`locked_workload`** _object_ — canonical workload structure that
+  `bundle.inputs/<workload>.yaml` must match (per-tenant input/output
+  distributions, concurrency). Same hard-fail semantics. Deliberate deviations
+  require `bundle.workload_changes_from_canonical`.
+- **`ground_truth`** _object_ — pre-registered, immutable claim:
+  `direction_claim`, `pass_condition`, `primary_metric`, `baselines`, `seeds`,
+  `workload`, `pre_registered`. Rendered into the agent's prompt so it can't move goalposts.
+- **`theory_references`** _array_ — external theorems/laws/identities used to
+  ground the ground truth (the "independent thermometer").
+
+## Iteration & scheduling
+
+- **`max_iterations`** _int_ — cap (default 10; CLI `--max-iterations` overrides).
+- **`iterations`** _array_ — per-iteration overrides consulted by index. v1
+  supports `mode`: `rehearsal` (minimal-scope apparatus + feasibility check,
+  surfaces friction as `brief_amendments.md`) vs `real` (full run). Idiom:
+  iter-1 rehearsal, iter-2+ real.
+- **`max_turns`** _object_ — per-phase tool-use turn cap: `design` (default 80),
+  `execute_analyze` (default 120), `report` (default 25).
+
+## Models & SDK
+
+- **`models`** _object_ — per-phase model: `design` (default `claude-opus-4-6`),
+  `execute_analyze` (default `claude-sonnet-4-6`), `report` (default `claude-sonnet-4-6`).
+  **In this pod, do not rely on those defaults** — the model gateway fronts an
+  upstream whose catalog usually doesn't include them, and a missing model hangs
+  the run. Always set `models` explicitly to gateway-served IDs; see "Selecting
+  models" in `SKILL.md`.
+- **`sandbox`** _string_ — `bypass` (default; needed because campaigns write
+  outside the launched cwd) or `default` (only if the campaign lives entirely
+  under the launched cwd — rare).
+- **`sdk_options`** _object_ — per-phase reasoning effort (`design`,
+  `execute_analyze`); omit to use SDK default ("high").
+- **`sdk_timeouts`** _object_ — `silence_threshold_seconds` (default 600) and
+  `turn_silence_threshold_seconds` (scalar or per-phase map
+  `{design:600, execute_analyze:120, report:240}`) for the hung-subprocess watchdog.
+
+## Async notifications (channels)
+
+- **`channels`** _array_ — **Phase A (Phase B reply-parsing planned).** Route
+  human gate notifications to external platforms. Each iteration, at each gate
+  (DESIGN and FINDINGS), Nous posts a markdown summary card so reviewers can
+  monitor progress without sitting at the terminal. The gate still blocks on
+  terminal input (Phase B will accept Slack replies). Configuration:
+
+  ```yaml
+  channels:
+    - kind: slack
+      webhook_url: https://hooks.slack.com/services/YOUR/WEBHOOK/URL
+    
+    - kind: webhook
+      url: https://example.com/nous/gate
+      headers:
+        Authorization: Bearer YOUR_TOKEN
+  ```
+  
+  - `slack` — POST to Slack webhook (`text` field contains markdown).
+  - `webhook` — generic HTTP POST (`{"markdown": "..."}` body + custom headers).
+  - Best-effort: timeouts, 5xx, DNS failures log warnings but **do NOT** break
+    the gate or campaign. Notification is supplemental.
+
+## Scoring & reproducibility
+
+- **`objective`** _object_ — composite scoring: `weights` (metric→weight, sum 1.0),
+  `metric_extractors`, `deploy_threshold` (default 0.1). Drives the deployment
+  recommendation in `meta_findings.json`.
+- **`objective_preset`** _string_ — `compound-return-style` | `latency-style`
+  (mutually exclusive with `objective`).
+- **`plot_specs`** _array_ — declarative figure scripts run after `findings.json`;
+  read `NOUS_RESULTS_DIR`, write `NOUS_FIGURES_DIR`.
+- **`pre_work_script`** _string_ — deterministic exploration run before iter-1
+  DESIGN; stdout JSON → `pre_work.json` context for the designer.
+- **`reproducibility_metadata`** _object_ — **auto-populated at INIT** (repo
+  commit, hardware-config sha, language versions, lockfile shas, gpu mem util).
+  User-readable, not user-set; to pin a commit, check it out before running.
+
+## Knowledge inheritance & misc
+
+- **`warm_start`** _object_ — inherit `principles.json` + `handoff.md` from a
+  prior campaign on the same repo (`prior_run_id`), with drift detection.
+- **`derived_from`** _object_ — inherit a prior campaign's worktree code state
+  (`campaign`, `iteration`=`final` or N) by applying its `cumulative.patch` as a
+  preflight to every experiment worktree.
+- **`validation`** _object_ — `iter_root_extensions` (extra allowed files at iter
+  root) and `required_iter_root` (files that MUST exist after EXECUTE_ANALYZE).
+- **`metadata`** _object_ — user tags/goal, copied to the work dir at init.
+- **`run_id`** _string_ — work-dir name (CLI `--run-id` overrides).
+
+---
+
+## Starter campaign.yaml (annotated)
+
+```yaml
+research_question: >
+  With total input length held fixed, does increasing the cached prefix portion
+  reduce TTFT under moderate load?
+
+run_id: blis-fast
+max_iterations: 2
+
+target_system:
+  name: "BLIS — LLM Inference Serving Simulator"
+  description: >
+    BLIS is a discrete-event simulator for LLM inference serving. It models
+    request arrivals, scheduling, and KV-cache management. Baselines, exact CLI
+    args, metric definitions, and statistical guardrails go here.
+  repo_path: ./repo
+  observable_metrics: [ttft, throughput, p95_latency]
+  controllable_knobs: [prefix_fraction, concurrency, cache_policy]
+
+# Schedule a cheap rehearsal first, then the real run.
+iterations:
+  - mode: rehearsal
+  - mode: real
+
+# Hard-pin everything whose deviation would invalidate the experiment.
+locked_parameters:
+  model: meta-llama/Llama-3-8B
+  concurrency_per_tenant: 8
+  duration_seconds: 120
+  warmup_seconds: 20
+  total_kv_blocks: 4096
+
+ground_truth:
+  pre_registered: true
+  primary_metric: "P50(ttft)"
+  direction_claim: "P50(ttft) decreases as prefix_fraction increases at fixed total length"
+  pass_condition: "direction holds in median across 10 seeds AND in >=7 of 10 seeds"
+  seeds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+
+# Pin to gateway-served IDs — discover them, don't trust the defaults above
+# (see "Selecting models" in SKILL.md). IDs here are illustrative.
+models:
+  design: "claude/aws/claude-opus-4-8"
+  execute_analyze: "claude/aws/claude-sonnet-4-6"
+  report: "claude/aws/claude-sonnet-4-6"
+
+prompts:
+  methodology_layer: "prompts/methodology"
+  domain_adapter_layer: null
+```

--- a/packages/agents/nous/workspace/.claude/commands/index-wiki.md
+++ b/packages/agents/nous/workspace/.claude/commands/index-wiki.md
@@ -1,0 +1,107 @@
+Merge a single campaign's extracted knowledge into the cross-campaign registry.
+
+## Usage
+
+`/index-wiki <campaign-name>` — indexes one campaign into registry.json
+
+## Steps
+
+1. **Resolve campaign**: Use `$ARGUMENTS` as the campaign name. Verify `~/.nous/wiki/campaigns/<campaign-name>/concepts.json` exists.
+
+2. **Read per-campaign files**: From `~/.nous/wiki/campaigns/<campaign-name>/`:
+   - `concepts.json` — contains `repo_path`, `system_name`, `research_question`, `campaign_name`, `date`, plus `entities`, `concepts`, `parameters`
+   - `principles.json` — full principle definitions (extract IDs for the registry)
+   - `dead-ends.json` — refuted approaches
+   - `frontiers.json` — boundary conditions
+   - `interactions.json` — untested combinations
+
+3. **Load existing registry**: Read `~/.nous/wiki/registry.json`. If it doesn't exist, initialize:
+   ```json
+   {"version": 1, "projects": {}}
+   ```
+
+4. **Idempotency check**: Look for this campaign in `projects[repo_path].campaigns[]` by name. If already present, report "Campaign already in registry — skipping" and stop.
+
+5. **Find or create project**: Look up `projects[repo_path]`. If not present, create:
+   ```json
+   {
+     "name": "<system_name from concepts.json>",
+     "campaigns": [],
+     "entities": []
+   }
+   ```
+
+6. **Process entities**: For each entity in `concepts.json`:
+   - Normalize the name (lowercase, strip content in parentheses) for matching
+   - Check if an entity with the same normalized name exists in `projects[repo_path].entities[]`
+     - If yes: add this campaign name to its `campaigns[]` array (if not already there)
+     - If no: assign new ID `E-{max_entity_id + 1}`, create entry:
+       ```json
+       {"id": "E-N", "name": "<entity name>", "aliases": [], "campaigns": ["<campaign-name>"]}
+       ```
+   - Track the max entity ID across all projects globally (IDs are globally unique)
+
+7. **Build campaign object**: Create the campaign entry for the registry:
+   ```json
+   {
+     "name": "<campaign_name>",
+     "date": "<date>",
+     "research_question": "<research_question>",
+     "concepts": [],
+     "parameters": [],
+     "principles": [],
+     "dead_ends": [],
+     "frontiers": [],
+     "interactions": []
+   }
+   ```
+
+   - **Concepts**: For each concept in `concepts.json`, assign ID `C-{max+1}` and add `{"id": "C-N", "name": "<concept name>"}` to the campaign's `concepts[]`
+   - **Parameters**: For each parameter in `concepts.json`, assign ID `P-{max+1}` and add `{"id": "P-N", "name": "<parameter name>"}` to the campaign's `parameters[]`
+   - **Principles**: Read `principles.json`, add each principle's ID string (e.g., "RP-1") to the campaign's `principles[]` array
+   - **Dead-ends**: For each entry in `dead-ends.json`, assign ID `DE-{max+1}` and add `{"id": "DE-N", "title": "<title>"}` to the campaign's `dead_ends[]`
+   - **Frontiers**: For each entry in `frontiers.json`, assign ID `F-{max+1}` and add `{"id": "F-N", "title": "<title>"}` to the campaign's `frontiers[]`
+   - **Interactions**: For each entry in `interactions.json`, assign ID `I-{max+1}` and add `{"id": "I-N", "title": "<title>"}` to the campaign's `interactions[]`
+
+8. **Add campaign to project**: Append the campaign object to `projects[repo_path].campaigns[]`.
+
+9. **Recompute entity clusters**: Using ALL entities in `projects[repo_path].entities[]` and their definitions from per-campaign `concepts.json` files:
+
+   a. For each entity, gather its definition from the campaign(s) that define it (read `~/.nous/wiki/campaigns/<campaign>/concepts.json` → `entities[]` → match by name). If an entity appears in multiple campaigns, concatenate definitions with ` | `.
+
+   b. Semantically group entities by functional role/purpose into clusters. Rules:
+      - Min 2 entities per cluster, max 10
+      - Max 20 clusters total per project — if grouping would exceed 20, merge the smallest/most-similar clusters
+      - Each entity belongs to at most one cluster (singletons are valid — omit them)
+      - Labels: 2-4 words, Title Case, describe the functional group
+
+   c. Assign sequential IDs `EC-1`, `EC-2`, etc. Set `projects[repo_path].entity_clusters` to:
+      ```json
+      [{"id": "EC-1", "label": "...", "entities": ["E-4", "E-5", "E-6"]}, ...]
+      ```
+
+   d. **CRITICAL**: This step ONLY writes the `entity_clusters` field. Do NOT modify `name`, `campaigns`, `entities`, or any other field on the project or registry.
+
+10. **Write registry.json**: Write the updated registry to `~/.nous/wiki/registry.json` with 2-space indentation.
+
+11. **Report**: Print the registry path and a summary of what was added (counts of entities, concepts, parameters, principles, dead-ends, frontiers, interactions).
+
+## ID Assignment Rules
+
+- IDs are **globally unique** across all projects and campaigns
+- To find the next ID for a type (e.g., "C-"), scan ALL projects and campaigns in the registry for the maximum existing ID of that type, then increment
+- Entity IDs (E-N) are unique per-project in practice but globally unique in assignment
+- Principle IDs (RP-N) are NOT reassigned — they keep their original campaign-local IDs
+
+## Deduplication Rules
+
+- **Entities**: Match by normalized name (lowercase, strip parenthetical suffixes). If matched, add campaign to existing entity's `campaigns[]` array.
+- **Everything else** (concepts, parameters, dead-ends, frontiers, interactions): Always create new entries. Different campaigns may have similar-sounding entries that are contextually distinct. Never deduplicate these across campaigns.
+
+## Important Rules
+
+- This skill only reads from `~/.nous/wiki/campaigns/` — it never reaches back to source repos
+- This is the ONLY skill that writes to `registry.json`
+- All metadata (`repo_path`, `system_name`, `research_question`) comes from the per-campaign `concepts.json`, which was populated by `/post-campaign` from the source `campaign.yaml`
+- Process one campaign at a time (read registry → modify → write) to prevent conflicts
+- `entity_clusters` is the ONLY registry field that is recomputed (not appended). It is fully replaced each time a new campaign is indexed. All other data is strictly append-only.

--- a/packages/agents/nous/workspace/.claude/commands/post-campaign.md
+++ b/packages/agents/nous/workspace/.claude/commands/post-campaign.md
@@ -1,0 +1,309 @@
+Index a completed Nous campaign into the shared wiki and generate a visualization.
+
+## Steps
+
+1. **Find the campaign**: If `$ARGUMENTS` is provided, use it as the path to the `.nous/<campaign>/` directory. Otherwise, search for directories containing both `ledger.json` and `principles.json` under `.nous/` paths in the project or `~/Downloads/`, and ask the user which to index.
+
+   **Style passthrough**: If `$ARGUMENTS` contains `::`, split on the **first** occurrence only. The left side is the campaign path (used for indexing steps 2-10). The right side is the style intent — it is ignored during indexing and only forwarded to `/visualize-campaign` in step 11. The campaign **name** (derived from the path's directory name) is what gets passed to `/visualize-campaign`, not the full path.
+2. **Read campaign artifacts**: Read `ledger.json`, `principles.json`, and `campaign.yaml` from the campaign directory. Extract:
+   - Campaign name (directory name)
+   - Campaign date (earliest non-baseline timestamp from ledger iterations)
+   - **Campaign context** from `campaign.yaml`:
+     - `research_question` — the overarching question being investigated
+     - `target_system.name` — the system under test
+     - `target_system.description` — what the system does
+     - `target_system.repo_path` — path to the target repository
+   - **Runtime metadata** from `campaign.yaml` (under `runtime:` block, if present):
+     - `runtime.target_commit` — git SHA of target repo at campaign start
+     - `runtime.target_repo` — org/repo identifier
+     - `runtime.nous_version` — Nous version used
+     - `runtime.started_at` — ISO timestamp of campaign initialization
+   - All iterations with their outcomes (`h_main_result`), families, and prediction accuracy
+   - All principles with full fields (statement, confidence, regime, mechanism, applicability_bounds, contradicts, superseded_by, status)
+
+   If `campaign.yaml` doesn't exist in the campaign directory, check for `report.md` and extract the research question from its opening section. If neither exists, ask the user for the campaign context.
+
+   The campaign context will be embedded in JSON metadata for each output file.
+
+3. **Check idempotency**: Check if `~/.nous/wiki/campaigns/<campaign-name>/concepts.json` exists. If it does, report "Campaign already indexed — skipping to visualization" and jump to step 11.
+
+4. **Write dead-ends.json**: Write a JSON array to `~/.nous/wiki/campaigns/<campaign-name>/dead-ends.json`.
+
+   Dead-ends are approaches that were tested and conclusively don't work. Each entry must be **self-contained**: another agent reading this should understand what was tried, why it failed, and when to avoid it — without looking at any other file.
+
+   For each iteration where `h_main_result == "REFUTED"`:
+   - Find the principles extracted in that iteration
+   - Synthesize a self-contained explanation of the failure
+
+   ```json
+   [
+     {
+       "id": "DE-1",
+       "title": "<descriptive title of what was attempted>",
+       "iteration": "iter-N",
+       "what_was_tried": "<1-2 sentences: the specific approach/configuration, with concrete values>",
+       "why_it_failed": "<1-2 sentences: the causal mechanism>",
+       "avoid_when": "<specific conditions under which this fails>"
+     }
+   ]
+   ```
+
+   Number IDs sequentially starting from DE-1 within this campaign.
+
+5. **Write frontiers.json**: Write a JSON array to `~/.nous/wiki/campaigns/<campaign-name>/frontiers.json`.
+
+   Frontiers are the edges of what this campaign explored — where knowledge ends and the next experiment begins. Each frontier must be **self-contained**: a reader should understand it without looking at principles.json or the Principles tab.
+
+   Identify frontiers by looking for **high-confidence** principles only:
+   - High-confidence principles from PARTIALLY_CONFIRMED iterations (boundary was actively hit)
+   - High-confidence principles whose `applicability_bounds` explicitly mentions untested territory
+   - High-confidence confirmed principles that were tested under narrow conditions (specific rates, cluster sizes, durations) where adjacent conditions remain unexplored
+
+   **Skip all medium and low confidence principles** — they aren't established enough to define meaningful boundaries.
+
+   ```json
+   [
+     {
+       "id": "F-1",
+       "title": "<descriptive title of the frontier — what's at the edge>",
+       "what_was_tried": "<1-2 sentences: the specific experiment/configuration that was run, using concrete values>",
+       "what_was_left_untried": "<1-2 sentences: the adjacent territory not explored>",
+       "what_to_try_next": "<1 sentence: a concrete, actionable experiment>",
+       "related_principles": ["RP-5", "RP-18"]
+     }
+   ]
+   ```
+
+   Write 5-10 frontiers per campaign. Prioritize frontiers where the next experiment is clearly actionable. **Only include frontiers based on high-confidence principles.**
+
+6. **Write interactions.json**: Write a JSON array to `~/.nous/wiki/campaigns/<campaign-name>/interactions.json`.
+
+   Interactions are untested combinations of independently-validated approaches that might compound, conflict, or reveal new behavior when used together. Each entry must be **self-contained**: another agent should understand what the two approaches do individually, why combining them is interesting, and what experiment to run — without looking at any other file.
+
+   Identify interactions by:
+   - Looking for pairs of CONFIRMED principles that address different mechanisms and were never validated together
+   - Focusing on approaches that operate in adjacent or overlapping conditions
+   - Limit to 3-5 most interesting interactions to avoid noise
+
+   ```json
+   [
+     {
+       "id": "I-1",
+       "title": "<descriptive title of the combination>",
+       "approach_a": "<1-2 sentences: what the first approach does, under what conditions, what it achieves>",
+       "approach_b": "<1-2 sentences: what the second approach does, under what conditions, what it achieves>",
+       "why_combine": "<1-2 sentences: why these together might produce better results>",
+       "experiment_to_run": "<1 sentence: a concrete, actionable experiment configuration>",
+       "related_principles": ["RP-8", "RP-17", "RP-18"]
+     }
+   ]
+   ```
+
+7. **Write campaign summary**: Write `~/.nous/wiki/campaigns/<campaign-name>/summary.md` (create directory if needed). Skip if the file already exists.
+
+    Read the campaign's `report.md` if it exists for additional context. Generate:
+
+    ```
+    # <campaign-name>
+
+    **Date:** <date>
+    **Iterations:** <count of non-baseline iterations>
+    **Key question:** <from report.md opening or inferred from iteration families>
+
+    ## Outcome
+    <2-3 sentence answer based on the pattern of confirmations/refutations>
+
+    ## Iteration arc
+    <Brief narrative: what families were explored, which confirmed/refuted, key pivots>
+
+    ## Key principles
+    <Bulleted list of 5-10 most important high-confidence principles with IDs>
+
+    ## Open questions
+    <Bulleted list of frontiers and untested territory>
+    ```
+
+8. **Copy principles.json**: Copy the source campaign's `principles.json` to `~/.nous/wiki/campaigns/<campaign-name>/principles.json`.
+
+9. **Copy llm_metrics.jsonl**: If `llm_metrics.jsonl` exists in the campaign directory, copy it to `~/.nous/wiki/campaigns/<campaign-name>/llm_metrics.jsonl`. This preserves per-iteration LLM cost data (model, cost, duration, turns) for the visualization's cost chart.
+
+10. **Generate visualization data files**: Generate JSON files that feed the interactive graph. Save to `~/.nous/wiki/campaigns/<campaign-name>/` (create directory if needed).
+
+    **a) `concepts.json`** — structured JSON for the Knowledge tab and Iterations sub-nodes.
+
+    Index the campaign's vocabulary into three categories with strict ownership semantics:
+
+    **The directed ownership graph**: `Entity ←(operates_on)← Concept →(owns)→ Parameter`
+    - Entities are leaf nodes (no outgoing ownership edges)
+    - Concepts are the central nodes connecting entities to parameters
+    - Parameters are leaf nodes owned by exactly one concept
+    - Every concept MUST point to ≥1 entity and 0+ parameters
+    - Every parameter MUST point back to exactly 1 concept
+    - **A parameter appears in exactly ONE concept's `parameters` array** — the concept that INTRODUCED and OWNS the knob. Other concepts that merely USE or are AFFECTED BY the parameter do NOT list it. "Uses" ≠ "owns."
+
+    **Category definitions:**
+    - **Concept**: A reusable algorithm, theory, or technique that Nous discovered and validated during this campaign. Must be self-contained — understandable and applicable without campaign-specific context. Concepts are transferable across campaigns (e.g., "Slope-Based Saturation Detection" is a concept; "iter-3 config" is not). A concept operates on one or more entities and owns zero or more parameters as its tweakable knobs. Did NOT exist before Nous ran.
+    - **Parameter**: A numeric knob or threshold belonging to exactly ONE concept that was actively tuned during experimentation. The parameter's meaning derives entirely from its parent concept — it cannot exist independently. If you can't name which concept owns it, either the concept is missing or the parameter is misclassified.
+    - **Entity**: A component that ALREADY EXISTED in the project's source code BEFORE this campaign ran. Entities are the pre-existing infrastructure that concepts operate ON — e.g., a scheduler, dispatcher, router, queue, or gateway that was already in the codebase. If the campaign INTRODUCED or CREATED a component (like a new detector, a new algorithm, a new module), that is a **Concept**, NOT an entity. The test: "Did this exist in the codebase before the campaign started?" If yes → Entity. If no → Concept. NOT model profiles, workload configurations, benchmark inputs, hardware specs, or experiment design choices. Entities do NOT own parameters — only concepts do.
+
+    **Include metadata at top level:**
+    ```json
+    {
+      "campaign_name": "<campaign-name>",
+      "date": "<campaign date>",
+      "repo_path": "<target_system.repo_path from campaign.yaml>",
+      "system_name": "<target_system.name> — <target_system.description>",
+      "research_question": "<research_question from campaign.yaml>",
+      "target_commit": "<runtime.target_commit from campaign.yaml, or null>",
+      "target_repo": "<runtime.target_repo from campaign.yaml, or null>",
+      "nous_version": "<runtime.nous_version from campaign.yaml, or null>",
+      "started_at": "<runtime.started_at from campaign.yaml, or null>",
+      "concepts": [...],
+      "parameters": [...],
+      "entities": [...]
+    }
+    ```
+
+    **Item schemas (MUST match exactly — the visualization script reads these field names):**
+
+    ```json
+    // Concept item:
+    {
+      "name": "Descriptive Name",
+      "definition": "1-3 sentence explanation of what this is and how it works.",
+      "principles": ["RP-1", "RP-7", "RP-10"],
+      "operates_on": ["EntityName1", "EntityName2"],
+      "parameters": ["paramName1", "paramName2"]
+    }
+
+    // Parameter item:
+    {
+      "name": "parameterName",
+      "definition": "What this knob controls and its effect.",
+      "principles": ["RP-7", "RP-10"],
+      "parent_concept": "Concept Name That Owns This Parameter",
+      "evolution": [
+        {"iter": "iter-3", "value": "0.1", "outcome": "confirmed", "note": "Eliminated false positives at rate=20"},
+        {"iter": "iter-10", "value": "0.05", "outcome": "confirmed", "note": "2.6% incremental critical gain"}
+      ]
+    }
+
+    // Entity item:
+    {
+      "name": "ComponentName",
+      "source": "path/to/file.go::TypeName",
+      "definition": "What this pre-existing component does in the system.",
+      "principles": ["RP-2", "RP-15"]
+    }
+    ```
+
+    **Relationship field requirements (explicit edges — authoritative for knowledge graph):**
+    - Every concept MUST have `operates_on` (array of ≥1 entity name) and `parameters` (array of 0+ parameter names)
+    - Every parameter MUST have `parent_concept` (string — exactly 1 concept name that owns this parameter)
+    - Names in `operates_on` MUST exactly match names in this file's `entities` array
+    - Names in `parameters` MUST exactly match names in this file's `parameters` array
+    - The `parent_concept` value MUST exactly match a name in this file's `concepts` array
+    - These relationship fields are the authoritative graph edges — `principles` arrays are supplementary (used for iteration-linking and cross-campaign principle queries)
+
+    **Relationship integrity checklist (run mentally before writing the file):**
+    1. For each parameter P: can you name exactly one concept that P belongs to? If not, add the missing concept.
+    2. For each concept C: does C.parameters list every parameter in the file whose parent_concept == C.name? (Bidirectional consistency)
+    3. **Does any parameter name appear in MORE THAN ONE concept's `parameters` array?** This is always wrong. A parameter has one owner. If concept A introduced the knob and concept B merely uses it, only A lists it.
+    4. For each concept C: does every name in C.operates_on appear in the entities array? If not, add the missing entity or fix the name.
+    5. Is any parameter orphaned (not listed in ANY concept's `parameters` array)? Fix by adding it to its parent concept.
+    6. Is any entity unreachable (not referenced by ANY concept's `operates_on`)? Either add a concept that operates on it, or remove the entity.
+
+    **Field name requirements (visualization contract):**
+    - Use `definition` (NOT `description`) — displayed in tooltip and detail panel
+    - Use `principles` (NOT `related_principles`) — array of RP-IDs that reference this item; used to compute graph edges between items and to connect items to iterations
+    - For `evolution`: use `iter` (NOT `iteration`), `value`, `outcome` (lowercase status: "confirmed"/"refuted"/"partially_confirmed"/"baseline"), `note` (explanation text)
+    - Every concept, parameter, AND entity MUST have a `principles` array — this is how the graph determines which items share connections and which iterations they belong to
+
+    Guidelines:
+    - Extract 5-15 concepts, 3-10 parameters, and 5-10 entities per campaign.
+    - Only include parameters that were actively varied during the campaign.
+    - Skip common industry terms (TTFT, LLM, GPU, p99, etc.). Focus on campaign-specific vocabulary.
+    - Every active principle MUST be referenced by at least one concept, parameter, or entity. The validator will reject dangling principles (present in principles.json but not referenced by any node). If a principle has no natural home, either create a concept that captures the pattern it describes, or attach it to the most relevant existing entity/concept.
+    - The `evolution` array for parameters should include every iteration where the parameter's value was meaningfully varied.
+
+    **Entity validation (mandatory):** After drafting the entity list, verify each entity is truly pre-existing — NOT something the campaign introduced. You cannot rely on git history (campaign code may not be committed). Instead, use these sources of truth:
+
+    1. **campaign.yaml is the ground truth for what pre-existed.** The `target_system.description` and any `reference_code_paths` describe the system AS IT WAS before the campaign. Components mentioned there are entities.
+    2. **Principles describe what the campaign CREATED.** Read principles.json — any algorithm, detector, technique, or module described as something the campaign implemented, discovered, or introduced is a Concept, never an Entity. If a principle says "we built X" or "X was introduced to improve Y", then X is a Concept.
+    3. **The litmus test:** Could you describe this component in a sentence that makes sense WITHOUT mentioning this campaign? "The gateway queue dispatches requests to instances" → Entity (it's infrastructure). "The TTFT slope detector fires when latency slope exceeds a threshold" → Concept (the campaign created it to test a hypothesis).
+
+    Remove or reclassify as Concept anything that fails this check. For each validated entity, note which part of `target_system` in campaign.yaml references it.
+
+    **Entity name grounding (mandatory):** Entity names MUST come from the actual source code, not from human-readable paraphrasing. For each validated entity, do a **single targeted search** in `<repo_path>` to find the primary type/class/struct name. Detect the language from file extensions in the repo and search accordingly:
+
+    ```bash
+    # Go:
+    grep -r "type <YourGuess>" <repo_path> --include="*.go" -l
+    # Python:
+    grep -r "class <YourGuess>" <repo_path> --include="*.py" -l
+    # Rust:
+    grep -r "struct <YourGuess>\|impl <YourGuess>" <repo_path> --include="*.rs" -l
+    # TypeScript/JavaScript:
+    grep -r "class <YourGuess>\|interface <YourGuess>" <repo_path> --include="*.ts" --include="*.js" -l
+    ```
+
+    - Use the **actual type name** from source as the entity `name` (e.g., `FlowControlFilter`, not "Gateway Queue")
+    - Set `source` to `<relative-path>::<TypeName>` where `<relative-path>` is relative to `repo_path` (e.g., `pkg/epp/handlers/flowcontrol.go::FlowControlFilter`). The validator will check that `<repo_path>/<relative-path>` exists on disk — so the path must resolve to a real file.
+    - If multiple types compose one logical entity, pick the primary orchestrating type
+    - If you cannot find a matching type after 2-3 searches, use the best name from `campaign.yaml`'s `target_system` description and leave `source` as `null`
+
+    **Scope guard:** This is a naming step, not a research step. Do NOT read function bodies, trace call graphs, or explore the codebase beyond finding the type declaration. Spend at most 1-2 searches per entity.
+
+    **Graph validation (mandatory — must pass before proceeding):** After writing concepts.json, run:
+    ```bash
+    python scripts/validate_concepts.py ~/.nous/wiki/campaigns/<campaign-name>/concepts.json
+    ```
+    If the script exits with errors, fix concepts.json and re-run until it passes. Common fixes:
+    - "owned by multiple concepts" → remove the parameter from all but its true owner's `parameters` array
+    - "orphaned parameter" → add it to the owning concept's `parameters` array
+    - "unreachable entity" → either add an `operates_on` reference from a concept, or remove the entity
+    - "unknown entity/parameter/concept" → fix the spelling to match exactly
+    - "dangling principles" → add the principle ID to the `principles` array of the most relevant entity, concept, or parameter. If no existing node fits, create a new concept that captures the pattern the principle describes.
+
+    Do NOT proceed to step 10b until `validate_concepts.py` exits 0.
+
+    **b) `summaries.json`** — iteration summaries for the detail panel:
+    ```json
+    {
+      "iter-0": {
+        "what_was_tried": "<1-2 sentences: experimental setup>",
+        "what_was_found": "<1-2 sentences: key result, include CONFIRMED/REFUTED/PARTIALLY_CONFIRMED>",
+        "why_it_matters": "<1 sentence: significance for the campaign's evolution>"
+      },
+      "iter-1": { ... },
+      ...
+    }
+    ```
+    Write a summary for EVERY iteration (including baseline). These appear in the side panel when a user clicks an iteration node. Keep concise but informative.
+
+11. **Generate visualization and open**: Only after ALL indexing steps (4-10) are complete, invoke `/visualize-campaign` to generate and open the HTML.
+
+    If `$ARGUMENTS` contained a `::` delimiter (style intent), pass it through:
+    - Without style: invoke `/visualize-campaign <campaign-name>`
+    - With style: invoke `/visualize-campaign <campaign-name> :: <style intent>`
+
+    The visualization skill handles running the script, applying any style, and opening the browser.
+12. **Invoke /index-wiki**: After visualization is generated, invoke `/index-wiki <campaign-name>` to merge this campaign's data into the cross-campaign registry.
+
+13. **Report**: Print all output paths and confirm the visualization opened:
+    - `~/.nous/wiki/campaigns/<name>/dead-ends.json`
+    - `~/.nous/wiki/campaigns/<name>/frontiers.json`
+    - `~/.nous/wiki/campaigns/<name>/interactions.json`
+    - `~/.nous/wiki/campaigns/<name>/principles.json`
+    - `~/.nous/wiki/campaigns/<name>/llm_metrics.jsonl`
+    - `~/.nous/wiki/campaigns/<name>/summary.md`
+    - `~/.nous/wiki/campaigns/<name>/concepts.json`
+    - `~/.nous/wiki/campaigns/<name>/summaries.json`
+    - `~/.nous/wiki/viz/<name>.html`
+    - `~/.nous/wiki/registry.json`
+
+## Important Rules
+
+- **Read-only inputs**: Never modify the campaign's own files (ledger.json, principles.json, etc.).
+- **Per-campaign isolation**: Each campaign's structured data lives in `~/.nous/wiki/campaigns/<name>/`. No shared markdown files.
+- **Idempotent**: If the campaign is already indexed (step 3 check), skip indexing and only regenerate the visualization (steps 11-12).

--- a/packages/agents/nous/workspace/.claude/commands/suggest-next.md
+++ b/packages/agents/nous/workspace/.claude/commands/suggest-next.md
@@ -1,0 +1,344 @@
+Given a user's research intent, retrieve prior knowledge from the cross-campaign registry and recommend how to frame a new campaign.
+
+## Usage
+
+`/suggest-next <repo_path_or_project_name> <intent>`
+
+Examples:
+- `/suggest-next /path/to/inference-sim "improve admission control fairness across priority bands"`
+- `/suggest-next inference-sim "reduce tail latency under burst workloads"`
+- `/suggest-next` (no arguments — list available projects and ask)
+
+## Argument Parsing
+
+- If `$ARGUMENTS` is empty, read `~/.nous/wiki/registry.json`, list all projects (by name and path), and ask the user which project and what their research intent is.
+- If `$ARGUMENTS` starts with a path (contains `/`) or matches a project name in the registry, use it as the project filter. Everything after it is the intent.
+- If `$ARGUMENTS` doesn't match any project, treat the entire argument as the intent and ask the user which project to use.
+
+## Algorithm
+
+The algorithm has five phases: **A: Retrieval** (script-driven, deterministic), **B: Synthesis** (LLM reasoning over the retrieved context), **C: Output** (write markdown), **D: Format** (file structure), and **E: Campaign Generation** (interactive YAML creation). The LLM selects what to retrieve; the script does the mechanical graph traversal and filtering.
+
+---
+
+### Phase A: Retrieval
+
+#### A1. Load Registry and Match Project
+
+Read `~/.nous/wiki/registry.json`. Find the project entry matching the user's repo path or project name:
+- Try exact path match against `projects` keys
+- Try substring match (user might give just the repo name, match against the end of each key)
+- Try fuzzy match against project `name` fields
+
+If not found, report: "No prior knowledge for this system. Available projects:" and list them. **STOP.**
+
+#### A2. Select Campaigns and Entities (LLM judgment)
+
+From the matched project's registry entry, select:
+
+- **Exactly 3 campaign names** (or all campaigns if fewer than 3 exist) — rank by relevance to the user's intent using `research_question`, `concepts[].name`, and `frontiers[].title`
+- **Exactly 6 entity names** (or all entities if fewer than 6 exist) — from the project-level `entities` array, pick those whose `name` or `aliases` relate to the user's intent. Also include entities that appear in the selected campaigns if their role is relevant.
+
+#### A3. Run Retrieval Script
+
+Call the retrieval script with the selected campaigns and entities:
+
+```bash
+python scripts/retrieve_wiki_context.py \
+  -c <campaign-1> <campaign-2> ... \
+  -e "<Entity Name 1>" "<Entity Name 2>" ... \
+  -i "<user's research intent>"
+```
+
+The script:
+1. Builds a knowledge graph from each campaign's `concepts.json` (nodes = entities/concepts/parameters, edges = shared principles)
+2. Extracts the subgraph reachable from the specified entities (1-hop via principle overlap)
+3. Loads principles from `principles.json` — only those referenced by the subgraph
+4. Loads all dead-ends from `dead-ends.json`
+5. Loads frontiers and interactions filtered by the scoped principle IDs
+6. Outputs a structured context block to stdout
+
+#### A4. Read Script Output
+
+Capture the script's stdout. This is the **Retrieved Context** block that feeds Phase B.
+
+---
+
+### Phase B: Synthesis
+
+Using the assembled context block from Phase A, generate **top 3 recommended campaign framings**. For each recommendation:
+
+1. **Score it** on five dimensions:
+   - **Novelty (weight 0.25):** How far is this from known dead-ends? Does it explore genuinely new territory?
+   - **Foundation (weight 0.20):** How many scoped principles does it build upon? Stronger foundation = higher confidence.
+   - **Impact (weight 0.25):** Based on related results, what's the estimated effect size? Prioritize high-impact experiments.
+   - **Testability (weight 0.15):** Can this be validated in a single campaign run? Concrete, bounded experiments score higher.
+   - **Efficiency (weight 0.15):** How cost-effective is this experiment predicted to be? Score based on:
+     - Predicted cost relative to predicted impact (low cost + high impact = high efficiency)
+     - Whether the experiment can reuse cached context from prior runs (cache reads reduce cost)
+     - Whether a cheaper model configuration could work (e.g., Sonnet-only for refinement campaigns vs Opus+Sonnet for exploratory)
+     - Fewer predicted iterations = higher efficiency
+
+2. **For each recommendation, provide:**
+   - A suggested `research_question` (1-2 sentences, phrased as a testable question)
+   - Which entities/concepts from the context block it builds on (with brief context)
+   - Which frontiers it addresses (by ID and title)
+   - Which interactions it could test (by ID and title)
+   - Which dead-ends to explicitly avoid (by ID and brief reason)
+   - Score breakdown (Novelty/Foundation/Impact/Testability/Efficiency + weighted total)
+   - Predicted cost (iterations × cost/iter, with basis for estimate)
+   - Suggested model configuration (which models for design/execute phases, with rationale)
+
+### Phase C: Output File
+
+Write the full recommendation to a markdown file at:
+
+```
+~/.nous/wiki/suggestions/<YYYY-MM-DD>-<slugified-intent>.md
+```
+
+- Create the `~/.nous/wiki/suggestions/` directory if it doesn't exist.
+- Slugify the intent: lowercase, replace spaces with `-`, strip non-alphanumeric characters, truncate to 50 chars.
+- If the file already exists (same date + intent), append a numeric suffix (`-2`, `-3`, etc.).
+
+After writing the file, print a short summary to the terminal:
+
+```
+Wrote: ~/.nous/wiki/suggestions/<filename>.md
+
+Top recommendations:
+  1. <title> — score: <total>/1.0
+  2. <title> — score: <total>/1.0
+  3. <title> — score: <total>/1.0
+```
+
+### Phase D: File Format
+
+The markdown file should follow this structure. The scoring table is **required** for every recommendation — it is the primary decision-making artifact.
+
+```markdown
+# Suggest-Next: <project name>
+
+**Date:** <YYYY-MM-DD>
+**Research intent:** "<user's intent>"
+**Prior campaigns:** <count>
+**Total confirmed principles:** <count>
+**Campaigns consulted:** <comma-separated names>
+**Entities scoped:** <comma-separated names>
+
+---
+
+## Scoring Summary
+
+| # | Recommendation | Novelty | Foundation | Impact | Testability | Efficiency | **Total** |
+|---|---------------|---------|-----------|--------|-------------|------------|-----------|
+| 1 | <short title> | X.XX | X.XX | X.XX | X.XX | X.XX | **X.XX** |
+| 2 | <short title> | X.XX | X.XX | X.XX | X.XX | X.XX | **X.XX** |
+| 3 | <short title> | X.XX | X.XX | X.XX | X.XX | X.XX | **X.XX** |
+
+*Weights: Novelty 0.25, Foundation 0.20, Impact 0.25, Testability 0.15, Efficiency 0.15*
+
+---
+
+## Recommendation 1: <short title>
+
+**Suggested research question:**
+> <1-2 sentence testable question>
+
+### Score Breakdown
+
+**Weighted total: X.XX/1.0**
+
+| Dimension    | Weight | Score | Rationale |
+|-------------|--------|-------|-----------|
+| Novelty     | 0.25   | X.XX  | <brief — what makes this novel or not> |
+| Foundation  | 0.20   | X.XX  | <brief — which principles it builds on> |
+| Impact      | 0.25   | X.XX  | <brief — expected effect size and why> |
+| Testability | 0.15   | X.XX  | <brief — how bounded/measurable it is> |
+| Efficiency  | 0.15   | X.XX  | <brief — cost/impact ratio reasoning> |
+
+### Builds on
+- <Entity/Concept name> — <how it's relevant>
+- ...
+
+### Addresses frontiers
+- F-N: <title> — <how this experiment would push the boundary>
+- ...
+
+### Tests interactions
+- I-N: <title> — <what combining these would reveal>
+- ...
+
+### Avoid (dead-ends)
+- DE-N: <title> — <why this failed before>
+- ...
+
+### Predicted cost
+
+| Metric | Estimate | Basis |
+|--------|----------|-------|
+| Iterations | N-M | <reasoning: refinement/exploratory, builds on N principles, etc.> |
+| Cost/iter | ~$X.XX | Project historical average (adjusted if applicable) |
+| Total | $XX-YY | iterations × cost/iter |
+| Duration | ~Xh | Based on avg duration/iter from similar campaigns |
+
+### Model configuration
+- Design phase: <model> (<rationale>)
+- Execute phase: <model> (<rationale>)
+- Alternative: <cheaper/costlier option with savings estimate>
+
+**Efficiency note:** <1 sentence on why this cost is justified relative to expected impact>
+
+---
+
+## Recommendation 2: <short title>
+
+<same structure as Recommendation 1>
+
+---
+
+## Recommendation 3: <short title>
+
+<same structure as Recommendation 1>
+
+---
+
+## Next Steps
+
+To start a campaign from these recommendations, use the interactive generator below or manually:
+1. Select recommendations to generate `campaign.yaml` files (Phase E prompt follows)
+2. Review and adjust the generated config if needed
+3. Run: `nous run <path-to-campaign.yaml>`
+4. After completion, run `/post-campaign` to feed results back into the registry
+```
+
+### Phase E: Interactive Campaign Generation
+
+After printing the terminal summary (end of Phase C), offer to generate executable `campaign.yaml` files from the recommendations.
+
+#### E1. Ask the User
+
+Use AskUserQuestion to present choices:
+
+**Question:** "Which recommendations would you like to generate campaign.yaml files for?"
+
+**Options:**
+- "1" — Generate for recommendation 1 only
+- "2" — Generate for recommendation 2 only
+- "3" — Generate for recommendation 3 only
+- "All" — Generate for all recommendations
+- "None" — Skip campaign generation
+
+Allow multi-select (the user can pick e.g. "1" and "3").
+
+If the user selects "None", print `No campaigns generated.` and **STOP**.
+
+#### E2. Generate campaign.yaml for Each Selected Recommendation
+
+For each selected recommendation, produce a YAML document with these field mappings:
+
+| campaign.yaml field | Source |
+|---|---|
+| `research_question` | Recommendation's suggested research question (verbatim from the `> <question>` block) |
+| `run_id` | Slugified recommendation title (lowercase, hyphens, ≤50 chars) |
+| `max_iterations` | Upper bound from the "Iterations" row in the Predicted cost table (e.g., "6-8" → 8) |
+| `target_system.name` | From registry `projects[key].name` |
+| `target_system.description` | Synthesized from registry project description + recommendation context |
+| `target_system.repo_path` | The project key (path) from the registry |
+| `target_system.observable_metrics` | Inferred from recommendation's Impact rationale (omit field entirely if not confidently inferable) |
+| `target_system.controllable_knobs` | Parameter names from "Builds on" section (omit field entirely if not confidently inferable) |
+| `prompts.methodology_layer` | `"prompts/methodology"` (standard default) |
+| `prompts.domain_adapter_layer` | `null` |
+| `models.design` | From recommendation's "Model configuration → Design phase" model name |
+| `models.execute_analyze` | From recommendation's "Model configuration → Execute phase" model name |
+| `metadata` | Traceability block (see E3) |
+
+**Schema compliance rules:**
+- Do NOT include any fields not in `orchestrator/schemas/campaign.schema.yaml`
+- Root object: only `research_question`, `run_id`, `max_iterations`, `target_system`, `prompts`, `models`, `metadata`
+- `target_system`: only `name`, `description`, `repo_path`, `observable_metrics`, `controllable_knobs`, `live_target`
+- `prompts`: only `methodology_layer`, `domain_adapter_layer`
+- `models`: only `design`, `execute_analyze`, `report`
+- Omit optional fields rather than including empty values
+- Model values default: `claude-opus-4-6` (design), `claude-sonnet-4-6` (execute_analyze)
+
+#### E3. Metadata Traceability Block
+
+Include a `metadata` section for provenance tracking:
+
+```yaml
+metadata:
+  source_suggestion: "<YYYY-MM-DD>-<slug>.md"
+  recommendation_rank: <1|2|3>
+  research_intent: "<user's original intent verbatim>"
+  builds_on_frontiers: ["F-1", "F-3"]
+  tests_interactions: ["I-2"]
+  avoids_dead_ends: ["DE-1", "DE-4"]
+  foundation_principles: ["RP-5", "RP-12"]
+  composite_score: 0.XX
+```
+
+- Use the actual IDs from the recommendation's "Addresses frontiers", "Tests interactions", "Avoid (dead-ends)" sections
+- `foundation_principles`: principle IDs referenced in the Foundation score rationale
+- `composite_score`: the weighted total from the scoring table
+
+#### E4. Write Files
+
+Write each generated YAML to:
+
+```
+~/.nous/wiki/suggestions/campaigns/<YYYY-MM-DD>-<slugified-intent>-<N>.yaml
+```
+
+Where `<N>` is the recommendation number (1, 2, or 3).
+
+- The `<YYYY-MM-DD>-<slugified-intent>` prefix matches the suggestion markdown filename (without `.md`)
+- If the file already exists, append a numeric suffix before `.yaml` (e.g., `-1-2.yaml`)
+- Create `~/.nous/wiki/suggestions/campaigns/` if it doesn't exist
+
+#### E5. Print Execution Instructions
+
+After writing all campaign files, print:
+
+```
+Generated campaign files:
+  <N>. ~/.nous/wiki/suggestions/campaigns/<filename>.yaml
+     Run: nous run <full-path>
+
+  ...
+```
+
+Example:
+```
+Generated campaign files:
+  1. ~/.nous/wiki/suggestions/campaigns/2026-06-03-improve-fairness-1.yaml
+     Run: nous run ~/.nous/wiki/suggestions/campaigns/2026-06-03-improve-fairness-1.yaml
+  3. ~/.nous/wiki/suggestions/campaigns/2026-06-03-improve-fairness-3.yaml
+     Run: nous run ~/.nous/wiki/suggestions/campaigns/2026-06-03-improve-fairness-3.yaml
+```
+
+---
+
+## Model Configuration Guidance
+
+When suggesting models for a recommendation, use the **Cost Context** section from the retrieved context and apply these heuristics:
+
+- **Opus design + Sonnet execute** (default): For campaigns exploring new territory, combining multiple approaches, or where the design phase needs to reason about complex interactions. Historical cost: ~$5.50-6.00/iter.
+- **Sonnet design + Sonnet execute** (cheaper, ~45% savings): For campaigns that are narrow refinements of known-good configurations — the design space is well-constrained by prior principles. Historical cost: ~$3.00-3.50/iter estimate.
+- **Opus both** (expensive, ~80% increase): Only for campaigns that need deep analysis in the execute phase (e.g., debugging subtle failures where Sonnet might miss root causes). Historical cost: ~$10-11/iter estimate.
+
+Iteration count heuristics:
+- **Refinement** (builds on 3+ confirmed principles, narrow scope): 4-6 iterations
+- **Exploratory** (new territory, tests interactions, <2 confirmed principles to build on): 8-12 iterations
+- **Standard** (mix of known and new): 6-8 iterations
+
+## Important Rules
+
+- This skill **writes files only to `~/.nous/wiki/suggestions/`** — the suggestion markdown at the top level, and optionally campaign YAML files in the `campaigns/` subdirectory. It never modifies registry files, campaign data, or any other existing files.
+- All reasoning happens in-context using the LLM's judgment — no external scripts beyond `retrieve_wiki_context.py`.
+- If the registry is empty or the project has no campaigns, say so clearly and suggest the user run their first campaign manually.
+- Always ground recommendations in specific prior data (principle IDs, frontier IDs, dead-end IDs). Never hallucinate IDs that don't exist in the loaded files.
+- Keep recommendations actionable — each should be concrete enough to immediately write a `campaign.yaml` from.
+- Prefer recommendations that combine insights from multiple campaigns over those that just extend a single campaign.
+- Always use the Cost Context section to ground cost predictions in real data — never invent cost numbers without historical basis.
+- **Scoring transparency is non-negotiable** — every recommendation must include its full score breakdown table with per-dimension rationale. The summary table at the top lets users compare at a glance.

--- a/packages/agents/nous/workspace/.claude/commands/visualize-campaign.md
+++ b/packages/agents/nous/workspace/.claude/commands/visualize-campaign.md
@@ -1,0 +1,194 @@
+Visualize a Nous campaign as an interactive knowledge graph.
+
+## Arguments
+
+`$ARGUMENTS` format: `<campaign-name>` or `<campaign-name> :: <style intent>`
+
+- **Campaign name** (required): The name of an indexed campaign (must exist under `~/.nous/wiki/campaigns/`)
+- **Style intent** (optional): Everything after `::`. When present, all visible text in the visualization is restyled to match this tone/style. The canonical wiki data is NOT modified.
+
+Examples:
+- `/visualize-campaign epp-ttft-slope-detector`
+- `/visualize-campaign epp-ttft-slope-detector :: explain like I'm a novice`
+- `/visualize-campaign blis-search-algo2 :: brief and technical, no jargon expansion`
+
+## Steps
+
+1. **Parse arguments**: Split `$ARGUMENTS` on the **first** occurrence of `::` only.
+   - Left side (trimmed) = campaign name. If empty, STOP and tell the user: "Please provide a campaign name. Usage: `/visualize-campaign <name>` or `/visualize-campaign <name> :: <style>`"
+   - Right side (trimmed, if present) = style intent. Everything after the first `::` is the style, including any subsequent `::` characters. If no `::` in arguments, style = None. If `::` is present but the right side is empty/whitespace after trimming, treat as no style and warn: "Found `::` but no style intent after it. Proceeding without style."
+
+2. **Resolve paths**:
+   - `wiki_dir` = `~/.nous/wiki`
+   - `campaign_dir` = `~/.nous/wiki/campaigns/<campaign-name>`
+
+3. **Verify data files exist**: Check that ALL of the following exist:
+   - `<campaign_dir>/summaries.json`
+   - `<campaign_dir>/concepts.json`
+   - `<campaign_dir>/dead-ends.json`
+
+   If ANY are missing, **STOP** and tell the user:
+   > "This campaign hasn't been fully indexed yet. Run `/post-campaign <path>` first, then re-run `/visualize-campaign`."
+
+   Do NOT proceed. Do NOT attempt to generate or fix any data yourself.
+
+4. **Find the campaign source path**: Look for a directory containing `ledger.json` and `principles.json` that matches the campaign name. Search in:
+   - `.nous/<campaign-name>/` relative to the current project
+   - `~/Downloads/**/.nous/<campaign-name>/`
+   - If not found, ask the user for the campaign source path.
+
+5. **If no style intent** → go directly to step 7.
+
+6. **Restyle text fields** (only when style intent is present):
+
+   **Prepare temp directory**: Delete `/tmp/nous-viz-styled-<campaign-name>/` if it exists, then recreate it fresh. This prevents stale files from prior runs contaminating output.
+
+   Read the canonical files:
+   - `<campaign_dir>/concepts.json`
+   - `<campaign_dir>/summaries.json`
+   - `<campaign_dir>/dead-ends.json`
+   - `<campaign_dir>/frontiers.json` (if exists)
+   - `<campaign_dir>/interactions.json` (if exists)
+   - `<campaign_dir>/summary.md` (if exists)
+
+   Make **5 parallel LLM calls** to restyle text. For each call, use structured output (provide a response schema) so the LLM can ONLY fill in text strings — the structure is locked.
+
+   **Call 1 — Concepts/Entities/Parameters definitions:**
+
+   Prompt:
+   ```
+   Rewrite each "definition" field to match this style: "<style intent>"
+
+   Keep the name fields exactly as-is. Only rewrite the definition strings.
+   Preserve technical accuracy — change tone/vocabulary/depth, not meaning.
+   ```
+
+   Response schema (construct from the canonical concepts.json):
+   ```json
+   {
+     "entities": [{"name": "<exact name>", "definition": "string"}],
+     "concepts": [{"name": "<exact name>", "definition": "string"}],
+     "parameters": [{"name": "<exact name>", "definition": "string"}]
+   }
+   ```
+
+   Provide the original definitions as context so the LLM knows what to restyle.
+
+   **Call 2 — Iteration summaries:**
+
+   Prompt:
+   ```
+   Rewrite each narrative field to match this style: "<style intent>"
+
+   Keep iter keys exactly as-is. Only rewrite the three text fields per iteration.
+   Preserve technical accuracy.
+   ```
+
+   Response schema (construct from canonical summaries.json):
+   ```json
+   {
+     "<iter-key>": {"what_was_tried": "string", "what_was_found": "string", "why_it_matters": "string"}
+   }
+   ```
+
+   **Call 3 — Dead-ends:**
+
+   Prompt:
+   ```
+   Rewrite the text fields to match this style: "<style intent>"
+
+   Keep id and iteration fields exactly as-is. Only rewrite title, what_was_tried, why_it_failed, avoid_when.
+   ```
+
+   Response schema:
+   ```json
+   [{"id": "<exact>", "title": "string", "what_was_tried": "string", "why_it_failed": "string", "avoid_when": "string"}]
+   ```
+
+   **Call 4 — Frontiers + Interactions:**
+
+   Prompt:
+   ```
+   Rewrite the text fields to match this style: "<style intent>"
+
+   Keep id and related_principles fields exactly as-is.
+   ```
+
+   Response schema for frontiers:
+   ```json
+   [{"id": "<exact>", "title": "string", "what_was_tried": "string", "what_was_left_untried": "string", "what_to_try_next": "string"}]
+   ```
+
+   Response schema for interactions:
+   ```json
+   [{"id": "<exact>", "title": "string", "approach_a": "string", "approach_b": "string", "why_combine": "string", "experiment_to_run": "string"}]
+   ```
+
+   (If either file doesn't exist, skip that part of the call.)
+
+   **Call 5 — Summary.md:**
+
+   Prompt:
+   ```
+   Rewrite this campaign summary markdown to match this style: "<style intent>"
+
+   Preserve the heading structure (# headings). Change the prose tone/vocabulary/depth.
+   ```
+
+   Response: a single markdown string.
+
+   **Merge and write temp files:**
+
+   For each successful call:
+   - Deep copy the canonical file
+   - Replace only the text fields with the restyled versions (matched by `name` for concepts, by `id` for insights, by key for summaries). If a returned `name` or `id` does not match any entry in the canonical file, skip that entry and keep canonical text.
+   - All structural fields (`principles`, `operates_on`, `parent_concept`, `parameters`, `evolution`, `source`, `related_principles`, `iteration`) remain unchanged
+   - Write to `/tmp/nous-viz-styled-<campaign-name>/`
+
+   **Assemble `insights.json`**: The script's `--insights` flag expects a single JSON object with keys `dead_ends`, `frontiers`, and `interactions`. After Calls 3 and 4 complete, combine the restyled arrays into:
+   ```json
+   {
+     "dead_ends": [<restyled dead-ends array>],
+     "frontiers": [<restyled frontiers array, or empty if file didn't exist>],
+     "interactions": [<restyled interactions array, or empty if file didn't exist>]
+   }
+   ```
+   Write this combined object to `/tmp/nous-viz-styled-<campaign-name>/insights.json`.
+
+   **Failure handling:**
+   - If a call fails or returns unexpected structure (e.g., array length mismatch, missing fields), use the canonical data for that component. Never partial-restyle within a single file — either fully restyled or fully canonical.
+   - Print a visible warning: "WARNING: Could not restyle <component> (<reason>). Showing original text for this section."
+   - If ALL 5 restyle calls fail, STOP and ask the user: "All style calls failed. Would you like to open the canonical (unstyled) visualization instead, or retry?"
+
+7. **Run the visualization script**:
+
+   If style was applied (step 6 completed):
+   ```bash
+   python scripts/visualize_campaign.py "<campaign_source_path>" \
+     --concepts /tmp/nous-viz-styled-<campaign-name>/concepts.json \
+     --summaries /tmp/nous-viz-styled-<campaign-name>/summaries.json \
+     --insights /tmp/nous-viz-styled-<campaign-name>/insights.json \
+     --summary-md /tmp/nous-viz-styled-<campaign-name>/summary.md
+   ```
+
+   If no style (canonical):
+   ```bash
+   python scripts/visualize_campaign.py "<campaign_source_path>" \
+     --summaries ~/.nous/wiki/campaigns/<campaign-name>/summaries.json \
+     --concepts ~/.nous/wiki/campaigns/<campaign-name>/concepts.json
+   ```
+
+8. **Open the HTML**:
+   ```bash
+   open ~/.nous/wiki/viz/<campaign-name>.html
+   ```
+
+9. **Report** the output path.
+
+## Important
+
+- This skill does NOT modify any wiki files or registry data.
+- Style restyling is ephemeral — it only affects the generated HTML, not the stored JSON.
+- If style is present, the 5 LLM calls are independent and can be made in parallel (i.e., as separate tool calls in a single response) for speed.
+- If any restyle call fails, that file falls back to canonical text with a visible warning.
+- Campaign names must not contain `::`. If a campaign directory name contains double colons, rename it before using this skill.

--- a/packages/agents/nous/workspace/.claude/commands/visualize-registry.md
+++ b/packages/agents/nous/workspace/.claude/commands/visualize-registry.md
@@ -1,0 +1,42 @@
+Render the cross-campaign knowledge graph from the Nous wiki registry.
+
+This skill verifies prerequisites and runs `visualize_registry.py` to produce an interactive HTML page showing campaigns, entities, concepts, entity clusters, and heuristic opportunity scores — all computed directly from registry data without any LLM calls.
+
+## Steps
+
+1. **Verify registry exists**: Check that `~/.nous/wiki/registry.json` exists and is non-empty.
+
+   If missing, **STOP** and tell the user:
+
+   > "No registry found. Run `/post-campaign <path>` on at least one campaign first, then re-run `/visualize-registry`."
+
+   Do NOT proceed. Do NOT attempt to generate or fix any data yourself.
+
+2. **Run the visualization script**:
+   ```bash
+   python scripts/visualize_registry.py
+   ```
+
+   The script:
+   - Reads `registry.json` and per-campaign wiki files
+   - Builds a force-directed graph with campaigns, entities, concepts, and parameters as nodes
+   - Computes cross-node edges from explicit relationship fields (operates_on, parent_concept, shared principles)
+   - Computes heuristic opportunity scores per entity cluster from frontier/interaction/dead-end counts
+   - Renders the Opportunities tab showing per-cluster research potential with copyable `/suggest-next` commands
+   - Writes `~/.nous/wiki/viz/registry.html`
+
+3. **Open the HTML**:
+   ```bash
+   open ~/.nous/wiki/viz/registry.html
+   ```
+
+4. **Report** the output path and a brief summary of what's in the graph (number of campaigns, entities, concepts, clusters).
+
+## Important
+
+- This skill does NOT modify registry.json, campaign data, or any existing wiki files.
+- The ONLY file this skill writes is `~/.nous/wiki/viz/registry.html` (via the Python script).
+- Entity clusters are pre-computed at index time by `/index-wiki` and stored in `registry.json`. The script reads them directly.
+- No LLM calls are made. All scoring is heuristic (frontier count, interaction count, recency, dead-end density).
+- The Opportunities tab helps users identify where to focus research, then run `/suggest-next` themselves for detailed recommendations.
+- If the script fails, report the error output verbatim.

--- a/packages/agents/nous/workspace/scripts/validate_concepts.py
+++ b/packages/agents/nous/workspace/scripts/validate_concepts.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Validate a concepts.json file for relationship integrity.
+
+Checks:
+  1. Every concept has operates_on (≥1) and parameters (≥0)
+  2. Every parameter has parent_concept (exactly 1)
+  3. No parameter appears in more than one concept's parameters array
+  4. All names in operates_on exist in the entities array
+  5. All names in concept.parameters exist in the parameters array
+  6. Every parent_concept value matches a concept name
+  7. Bidirectional consistency: concept.parameters ↔ parameter.parent_concept
+  8. No orphaned parameters (not in any concept's parameters array)
+  9. No unreachable entities (not in any concept's operates_on)
+  10. No dangling principles (in principles.json but not referenced by any node)
+
+Usage:
+    python scripts/validate_concepts.py <path-to-concepts.json>
+    python scripts/validate_concepts.py ~/.nous/wiki/campaigns/*/concepts.json
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def validate(path: Path) -> list[str]:
+    """Return a list of error strings. Empty = valid."""
+    with open(path) as f:
+        data = json.load(f)
+
+    errors = []
+
+    concept_names = {c["name"] for c in data.get("concepts", [])}
+    param_names = {p["name"] for p in data.get("parameters", [])}
+    entity_names = {e["name"] for e in data.get("entities", [])}
+
+    # Track which parameters are claimed by concepts
+    param_owners = {}  # param_name → list of concept names
+
+    for concept in data.get("concepts", []):
+        name = concept["name"]
+
+        # Check operates_on exists and is non-empty
+        operates_on = concept.get("operates_on")
+        if operates_on is None:
+            errors.append(f"concept '{name}': missing operates_on field")
+        elif len(operates_on) == 0:
+            errors.append(f"concept '{name}': operates_on is empty (need ≥1 entity)")
+        else:
+            for entity in operates_on:
+                if entity not in entity_names:
+                    errors.append(f"concept '{name}': operates_on references unknown entity '{entity}'")
+
+        # Check parameters field exists
+        params = concept.get("parameters")
+        if params is None:
+            errors.append(f"concept '{name}': missing parameters field")
+        else:
+            for p in params:
+                if p not in param_names:
+                    errors.append(f"concept '{name}': parameters references unknown parameter '{p}'")
+                param_owners.setdefault(p, []).append(name)
+
+    # Check for multi-ownership
+    for p, owners in param_owners.items():
+        if len(owners) > 1:
+            errors.append(f"parameter '{p}': owned by multiple concepts: {owners}")
+
+    for param in data.get("parameters", []):
+        name = param["name"]
+
+        # Check parent_concept exists
+        parent = param.get("parent_concept")
+        if parent is None:
+            errors.append(f"parameter '{name}': missing parent_concept field")
+        elif parent not in concept_names:
+            errors.append(f"parameter '{name}': parent_concept '{parent}' not found in concepts")
+
+        # Bidirectional check: parent concept should list this param
+        if parent and parent in concept_names:
+            parent_concept = next(c for c in data["concepts"] if c["name"] == parent)
+            if name not in parent_concept.get("parameters", []):
+                errors.append(f"parameter '{name}': parent_concept is '{parent}' but that concept doesn't list it in parameters")
+
+    # Orphaned parameters
+    claimed_params = set(param_owners.keys())
+    for p in param_names:
+        if p not in claimed_params:
+            errors.append(f"parameter '{p}': orphaned — not in any concept's parameters array")
+
+    # Unreachable entities
+    referenced_entities = set()
+    for concept in data.get("concepts", []):
+        referenced_entities.update(concept.get("operates_on", []))
+    for e in entity_names:
+        if e not in referenced_entities:
+            errors.append(f"entity '{e}': unreachable — not in any concept's operates_on")
+
+    # Entity source grounding
+    repo_path = data.get("repo_path")
+    for entity in data.get("entities", []):
+        source = entity.get("source")
+        if not source:
+            errors.append(f"entity '{entity['name']}': missing source field (not grounded to code)")
+        elif repo_path:
+            # source format: "relative/path/to/file.go::TypeName"
+            file_part = source.split("::")[0]
+            full_path = Path(repo_path) / file_part
+            if not full_path.exists():
+                errors.append(f"entity '{entity['name']}': source file not found: {full_path}")
+
+    # Dangling principles: every active principle in principles.json must be
+    # referenced by at least one entity, concept, or parameter in concepts.json
+    principles_path = path.parent / "principles.json"
+    if principles_path.exists():
+        try:
+            with open(principles_path) as f:
+                principles_data = json.load(f)
+        except json.JSONDecodeError as e:
+            errors.append(f"principles.json contains invalid JSON: {e}")
+            principles_data = None
+        except OSError as e:
+            errors.append(f"principles.json could not be read: {e}")
+            principles_data = None
+
+        if principles_data is not None:
+            if not isinstance(principles_data, dict):
+                errors.append(
+                    f"principles.json has invalid structure: expected a JSON object, "
+                    f"got {type(principles_data).__name__}"
+                )
+            else:
+                all_principle_ids = {
+                    p["id"]
+                    for p in principles_data.get("principles", [])
+                    if isinstance(p, dict) and "id" in p and p.get("status", "active") == "active"
+                }
+                referenced_principle_ids = set()
+                for entity in data.get("entities", []):
+                    referenced_principle_ids.update(entity.get("principles") or [])
+                for concept in data.get("concepts", []):
+                    referenced_principle_ids.update(concept.get("principles") or [])
+                for param in data.get("parameters", []):
+                    referenced_principle_ids.update(param.get("principles") or [])
+
+                dangling = sorted(all_principle_ids - referenced_principle_ids)
+                if dangling:
+                    errors.append(
+                        f"dangling principles (in principles.json but not referenced by any "
+                        f"entity/concept/parameter): {dangling}"
+                    )
+
+    return errors
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python scripts/validate_concepts.py <concepts.json> [...]", file=sys.stderr)
+        sys.exit(1)
+
+    all_valid = True
+    for arg in sys.argv[1:]:
+        path = Path(arg)
+        if not path.exists():
+            print(f"SKIP {path} (not found)")
+            continue
+
+        errors = validate(path)
+        if errors:
+            all_valid = False
+            print(f"FAIL {path} ({len(errors)} errors):")
+            for e in errors:
+                print(f"  - {e}")
+        else:
+            print(f"OK   {path}")
+
+    sys.exit(0 if all_valid else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agents/nous/workspace/scripts/visualize_campaign.py
+++ b/packages/agents/nous/workspace/scripts/visualize_campaign.py
@@ -1,0 +1,2473 @@
+#!/usr/bin/env python3
+"""Generate an interactive D3.js knowledge graph for a single Nous campaign.
+
+Reads ledger.json and principles.json from a campaign's .nous/ directory,
+produces a self-contained HTML file with a force-directed graph.
+
+Three views:
+  - Iterations View: timeline of iterations with outcomes and principle sub-nodes
+  - Principles View: principle-centric graph showing relationships and origins
+  - Insights View: dead-ends, frontiers, and interactions from wiki (HTML cards)
+
+Usage:
+    python scripts/visualize_campaign.py <campaign_path> [--output <path>] [--wiki <path>]
+
+    campaign_path: path to the .nous/<campaign-name>/ directory
+    --output: optional output path (default: ~/.nous/wiki/viz/<campaign-name>.html)
+    --wiki: path to wiki directory (default: ~/.nous/wiki/)
+"""
+
+import argparse
+import json
+import re
+import sys
+import webbrowser
+from datetime import datetime, timezone
+from pathlib import Path
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>{title}</title>
+<style>
+  body {{ margin: 0; background: #1a1a2e; font-family: -apple-system, system-ui, sans-serif; }}
+  body > svg {{ width: 100vw; height: 100vh; }}
+  .legend svg {{ width: auto; height: auto; display: inline-block; vertical-align: middle; }}
+  .iteration-node {{ cursor: pointer; }}
+  .principle-node {{ cursor: pointer; opacity: 0; transition: opacity 0.3s; }}
+  .principle-node.visible {{ opacity: 1; }}
+  .link {{ stroke-opacity: 0.6; }}
+  .principle-link {{ stroke-opacity: 0; transition: stroke-opacity 0.3s; }}
+  .principle-link.visible {{ stroke-opacity: 0.6; }}
+  .label {{ font-size: 11px; fill: #e0e0e0; pointer-events: none; text-anchor: middle; }}
+  .tooltip {{
+    position: absolute; background: #16213e; border: 1px solid #0f3460;
+    border-radius: 6px; padding: 10px; color: #e0e0e0; font-size: 12px;
+    max-width: 400px; pointer-events: none; display: none; z-index: 100;
+  }}
+  .legend {{
+    position: absolute; top: 16px; left: 16px; background: #16213e;
+    border: 1px solid #0f3460; border-radius: 6px; padding: 12px;
+    color: #e0e0e0; font-size: 12px; z-index: 50;
+  }}
+  .legend-item {{ display: flex; align-items: center; margin: 4px 0; }}
+  .legend-dot {{ width: 12px; height: 12px; border-radius: 50%; margin-right: 8px; flex-shrink: 0; }}
+  .campaign-objective {{
+    position: absolute; top: 16px; left: 50%; transform: translateX(-50%);
+    background: #16213e;
+    border: 1px solid #0f3460; border-radius: 6px; padding: 12px 14px;
+    color: #e0e0e0; font-size: 12px; z-index: 50; max-width: 480px;
+  }}
+  .campaign-objective.collapsed {{ padding: 6px 12px; }}
+  .campaign-objective .obj-header {{
+    display: flex; align-items: center; justify-content: space-between;
+    gap: 12px; cursor: pointer; user-select: none;
+  }}
+  .campaign-objective .obj-label {{
+    color: #888; font-size: 10px; text-transform: uppercase;
+    letter-spacing: 0.8px;
+  }}
+  .campaign-objective:not(.collapsed) .obj-header {{ margin-bottom: 6px; }}
+  .campaign-objective .obj-toggle {{
+    color: #888; font-size: 10px; transition: transform 0.15s;
+    transform: rotate(180deg);
+  }}
+  .campaign-objective.collapsed .obj-toggle {{ transform: rotate(0deg); }}
+  .campaign-objective .obj-header:hover .obj-label,
+  .campaign-objective .obj-header:hover .obj-toggle {{ color: #ccc; }}
+  .campaign-objective.collapsed .obj-body {{ display: none; }}
+  .campaign-objective .obj-question {{
+    color: #ccc; font-style: italic; line-height: 1.5; margin-bottom: 6px;
+  }}
+  .campaign-objective .obj-meta {{
+    color: #777; font-size: 11px; display: flex; gap: 4px; align-items: center;
+  }}
+  .campaign-objective .obj-meta code {{
+    background: #0a1628; padding: 1px 5px; border-radius: 3px;
+    font-size: 10px; color: #b39ddb; border: 1px solid #1a2a4a;
+    font-family: "SF Mono", "Fira Code", monospace;
+  }}
+  .view-toggle {{
+    position: absolute; top: 16px; right: 16px; z-index: 50;
+    display: flex; gap: 0;
+  }}
+  .view-btn {{
+    background: #16213e; border: 1px solid #0f3460; color: #e0e0e0;
+    padding: 8px 16px; cursor: pointer; font-size: 12px; transition: all 0.2s;
+  }}
+  .view-btn:first-child {{ border-radius: 6px 0 0 6px; }}
+  .view-btn:last-child {{ border-radius: 0 6px 6px 0; }}
+  .view-btn:not(:first-child):not(:last-child) {{ border-radius: 0; }}
+  .view-btn.active {{ background: #0f3460; color: #fff; font-weight: bold; }}
+  .view-btn:hover:not(.active) {{ background: #1a2a4a; }}
+  #iter-detail-panel {{
+    position: absolute; top: 0; right: 0; width: 380px; height: 100vh;
+    background: #16213e; border-left: 1px solid #0f3460;
+    overflow-y: auto; padding: 60px 20px 20px; box-sizing: border-box;
+    display: none; z-index: 60; color: #e0e0e0; font-size: 13px; line-height: 1.6;
+  }}
+  #iter-detail-panel.open {{ display: block; }}
+  #iter-detail-panel .panel-close {{
+    position: absolute; top: 12px; right: 16px; background: none;
+    border: none; color: #888; font-size: 20px; cursor: pointer;
+  }}
+  #iter-detail-panel .panel-close:hover {{ color: #fff; }}
+  #iter-detail-panel .panel-header {{
+    display: flex; align-items: center; gap: 10px; margin-bottom: 16px;
+    padding-bottom: 12px; border-bottom: 1px solid #0f3460;
+  }}
+  #iter-detail-panel .panel-header .outcome-dot {{
+    width: 12px; height: 12px; border-radius: 50%; flex-shrink: 0;
+  }}
+  #iter-detail-panel .panel-header h3 {{ margin: 0; font-size: 15px; }}
+  #iter-detail-panel .panel-outcome {{
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.8px;
+    font-weight: 600; margin-bottom: 16px;
+  }}
+  #iter-detail-panel .panel-summary {{ color: #ccc; margin-bottom: 16px; }}
+  #iter-detail-panel .panel-field {{
+    margin: 10px 0;
+  }}
+  #iter-detail-panel .panel-field-label {{
+    color: #8899aa; font-size: 10px; text-transform: uppercase;
+    letter-spacing: 0.8px; margin-bottom: 3px;
+  }}
+  #iter-detail-panel .panel-field-value {{ color: #ccc; }}
+  #iter-detail-panel .panel-principles {{
+    margin-top: 16px; padding-top: 12px; border-top: 1px solid #0f3460;
+  }}
+  #iter-detail-panel .panel-principle-tag {{
+    display: inline-block; background: #0f3460; border-radius: 4px;
+    padding: 3px 8px; font-size: 11px; color: #b39ddb; margin: 3px 3px 3px 0;
+  }}
+  .chip-btn {{
+    border: 1px solid #333; border-radius: 14px; padding: 4px 12px;
+    font-size: 11px; cursor: pointer; background: #1a1a2e;
+    transition: all 0.15s; font-family: inherit;
+  }}
+  .chip-btn:hover {{ filter: brightness(1.3); transform: scale(1.03); }}
+  .chip-concept {{ color: #9fa8da; border-color: #5c6bc0; }}
+  .chip-param {{ color: #ce93d8; border-color: #7b1fa2; }}
+  .chip-entity {{ color: #a5d6a7; border-color: #388e3c; }}
+  #insights-container {{
+    display: none; padding: 80px 40px 40px; height: 100vh; overflow-y: auto;
+    box-sizing: border-box;
+  }}
+  #summary-container {{
+    display: none; padding: 80px 40px 60px; height: 100vh; overflow-y: auto;
+    box-sizing: border-box; max-width: 780px; margin: 0 auto;
+  }}
+  #summary-container .summary-inner {{
+    background: #16213e; border-radius: 12px; padding: 36px 40px 40px;
+    border: 1px solid #0f3460;
+  }}
+  #summary-container h1 {{
+    color: #fff; font-size: 20px; margin: 0 0 8px; font-weight: 700;
+    letter-spacing: -0.3px;
+  }}
+  #summary-container .summary-meta {{
+    display: flex; gap: 16px; flex-wrap: wrap; margin-bottom: 28px;
+    padding-bottom: 16px; border-bottom: 1px solid #0f3460;
+  }}
+  #summary-container .summary-meta span {{
+    color: #888; font-size: 12px;
+  }}
+  #summary-container .summary-meta strong {{ color: #b0bec5; font-weight: 600; }}
+  #summary-container .summary-question {{
+    color: #9fa8da; font-style: italic; line-height: 1.6; font-size: 13px;
+    margin: 0 0 28px; padding: 12px 16px;
+    background: rgba(79, 91, 213, 0.08); border-radius: 6px;
+    border-left: 3px solid #5c6bc0;
+  }}
+  #summary-container h2 {{
+    font-size: 13px; margin: 28px 0 12px; padding: 0;
+    text-transform: uppercase; letter-spacing: 1px; font-weight: 700;
+  }}
+  #summary-container h2.outcome-heading {{ color: #4caf50; }}
+  #summary-container h2.arc-heading {{ color: #64b5f6; }}
+  #summary-container h2.principles-heading {{ color: #b39ddb; }}
+  #summary-container h2.questions-heading {{ color: #ffb74d; }}
+  #summary-container p {{
+    color: #ccc; line-height: 1.75; margin: 8px 0; font-size: 13.5px;
+  }}
+  #summary-container ul, #summary-container ol {{
+    color: #ccc; line-height: 1.8; padding-left: 20px; margin: 8px 0;
+  }}
+  #summary-container li {{
+    margin: 6px 0; font-size: 13px; padding-left: 4px;
+  }}
+  #summary-container li::marker {{ color: #555; }}
+  #summary-container strong {{ color: #e0e0e0; font-weight: 600; }}
+  #summary-container code {{
+    background: #0a1628; padding: 2px 7px; border-radius: 3px;
+    font-size: 12px; color: #b39ddb; border: 1px solid #1a2a4a;
+  }}
+  .summary-fallback {{ color: #888; font-size: 14px; text-align: center; padding: 80px 20px; font-style: italic; }}
+  .insights-nav {{
+    display: flex; gap: 0; max-width: 1100px; margin: 0 auto 24px;
+    border-radius: 8px; overflow: hidden; border: 1px solid #0f3460;
+  }}
+  .insights-nav-btn {{
+    flex: 1; padding: 12px 16px; background: #16213e; border: none;
+    color: #888; font-size: 13px; cursor: pointer; transition: all 0.2s;
+    display: flex; flex-direction: column; align-items: center; gap: 4px;
+    border-right: 1px solid #0f3460;
+  }}
+  .insights-nav-btn:last-child {{ border-right: none; }}
+  .insights-nav-btn:hover:not(.active) {{ background: #1a2a4a; color: #aaa; }}
+  .insights-nav-btn.active {{ background: #0f3460; }}
+  .insights-nav-btn .nav-title {{ font-weight: 700; font-size: 13px; }}
+  .insights-nav-btn .nav-desc {{ font-size: 10px; opacity: 0.7; }}
+  .insights-nav-btn .nav-count {{
+    font-size: 10px; opacity: 0.5; margin-top: 2px;
+  }}
+  .insights-sections {{
+    max-width: 1100px; margin: 0 auto; display: flex; flex-direction: column; gap: 40px;
+  }}
+  .insights-section {{ margin: 0; display: none; }}
+  .insights-section.active {{ display: block; }}
+  .insights-cards {{
+    display: flex; flex-wrap: wrap; gap: 16px;
+  }}
+  .insight-card {{
+    flex: 1 1 300px; max-width: 500px;
+  }}
+  .insight-card {{
+    background: #16213e; border-radius: 10px; padding: 20px 24px;
+    border-left: 4px solid #555; color: #e0e0e0; font-size: 13px; line-height: 1.7;
+    word-wrap: break-word; overflow-wrap: break-word;
+  }}
+  .insight-card h4 {{
+    margin: 0 0 14px; font-size: 15px; font-weight: 600;
+    line-height: 1.4;
+  }}
+  .insight-card .field {{
+    margin: 10px 0; padding: 0;
+  }}
+  .insight-card .field-label {{
+    color: #8899aa; font-weight: 600; font-size: 10px;
+    text-transform: uppercase; letter-spacing: 0.8px;
+    margin-bottom: 3px; display: block;
+  }}
+  .insight-card .field-value {{
+    color: #ccc; display: block;
+  }}
+  .insight-card--dead-end {{ border-left-color: #f44336; }}
+  .insight-card--dead-end h4 {{ color: #ef5350; }}
+  .insight-card--frontier {{ border-left-color: #ff9800; }}
+  .insight-card--frontier h4 {{ color: #ffb74d; }}
+  .insight-card--interaction {{ border-left-color: #2196f3; }}
+  .insight-card--interaction h4 {{ color: #64b5f6; }}
+  .insights-fallback {{
+    color: #888; font-size: 14px; text-align: center; padding: 80px 20px;
+    font-style: italic;
+  }}
+  /* Timeline animation controls */
+  #timeline-controls {{
+    position: absolute; bottom: 16px; right: 16px; z-index: 50;
+    display: none; align-items: center; gap: 10px;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 8px;
+    padding: 10px 16px;
+  }}
+  #timeline-controls.visible {{ display: flex; }}
+  #timeline-play-btn {{
+    background: none; border: 1px solid #0f3460; color: #e0e0e0;
+    width: 32px; height: 32px; border-radius: 50%; cursor: pointer;
+    font-size: 14px; display: flex; align-items: center; justify-content: center;
+    transition: all 0.2s;
+  }}
+  #timeline-play-btn:hover {{ background: #0f3460; }}
+  #timeline-slider {{
+    width: 200px; accent-color: #5c6bc0; cursor: pointer;
+  }}
+  #timeline-label {{
+    color: #e0e0e0; font-size: 12px; min-width: 50px; text-align: center;
+  }}
+  #timeline-dismiss {{
+    background: none; border: none; color: #666; font-size: 16px;
+    cursor: pointer; padding: 0 4px; margin-left: 4px;
+  }}
+  #timeline-dismiss:hover {{ color: #e0e0e0; }}
+  #timeline-trigger {{
+    position: absolute; bottom: 16px; right: 16px; z-index: 50;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 6px;
+    padding: 8px 14px; color: #e0e0e0; font-size: 12px; cursor: pointer;
+    transition: all 0.2s; display: none;
+  }}
+  #timeline-trigger:hover {{ background: #0f3460; }}
+  #timeline-trigger.visible {{ display: block; }}
+  #timeline-narrative {{
+    position: absolute; bottom: 70px; right: 16px; z-index: 50;
+    max-width: 360px; display: none;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 8px;
+    padding: 10px 14px; font-size: 12px; line-height: 1.5;
+    color: #e0e0e0; transition: opacity 0.3s;
+  }}
+  #timeline-narrative.visible {{ display: block; }}
+  #timeline-narrative .narr-title {{ font-weight: 600; margin-bottom: 4px; }}
+  #timeline-narrative .narr-family {{
+    font-size: 10px; color: #888; text-transform: uppercase; letter-spacing: 0.5px;
+  }}
+  .revisit-arc {{ stroke-dasharray: 6,3; fill: none; pointer-events: none; }}
+  /* Cost bar chart */
+  #cost-chart {{
+    position: absolute; left: 16px; z-index: 50;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 6px;
+    padding: 12px; display: none; box-sizing: border-box;
+  }}
+  #cost-chart.visible {{ display: block; }}
+  #cost-chart .cost-title {{
+    color: #888; font-size: 10px; text-transform: uppercase;
+    letter-spacing: 0.8px; margin-bottom: 8px;
+  }}
+  #cost-chart .cost-total {{
+    color: #e0e0e0; font-size: 12px; margin-bottom: 10px;
+  }}
+  #cost-chart .cost-bars {{
+    display: flex; align-items: flex-end; gap: 4px; height: 140px;
+  }}
+  #cost-chart .cost-bar-group {{
+    display: flex; flex-direction: column; align-items: center; gap: 0;
+    flex: 1; min-width: 0;
+  }}
+  #cost-chart .cost-bar-stack {{
+    display: flex; flex-direction: column; justify-content: flex-end;
+    width: 100%; height: 140px; border-radius: 2px 2px 0 0; overflow: hidden;
+  }}
+  #cost-chart .cost-bar-design {{
+    background: #ef6c00; width: 100%;
+  }}
+  #cost-chart .cost-bar-execute {{
+    background: #00acc1; width: 100%;
+  }}
+  #cost-chart .cost-bar-label {{
+    color: #888; font-size: 8px; margin-top: 3px; white-space: nowrap;
+    overflow: hidden; text-overflow: ellipsis; max-width: 100%; text-align: center;
+  }}
+  #cost-chart .cost-legend {{
+    display: flex; gap: 12px; margin-top: 8px; font-size: 10px; color: #888;
+  }}
+  #cost-chart .cost-legend-item {{
+    display: flex; align-items: center; gap: 4px;
+  }}
+  #cost-chart .cost-legend-dot {{
+    width: 8px; height: 8px; border-radius: 2px;
+  }}
+  /* Hypothesis arms in panel */
+  .hyp-arms {{ margin-top: 16px; padding-top: 12px; border-top: 1px solid #0f3460; }}
+  .hyp-arms-label {{ color: #888; font-size: 10px; text-transform: uppercase; letter-spacing: 0.8px; margin-bottom: 8px; }}
+  .hyp-arm {{
+    margin: 8px 0; padding: 8px 10px; border-radius: 6px;
+    background: rgba(255,255,255,0.03); border-left: 3px solid #555;
+    cursor: pointer; transition: background 0.15s;
+  }}
+  .hyp-arm:hover {{ background: rgba(255,255,255,0.06); }}
+  .hyp-arm-header {{ display: flex; align-items: center; gap: 8px; }}
+  .hyp-arm-type {{ font-size: 11px; font-weight: 600; color: #ccc; }}
+  .hyp-arm-status {{
+    font-size: 9px; font-weight: 700; padding: 1px 6px;
+    border-radius: 3px; text-transform: uppercase; letter-spacing: 0.5px;
+  }}
+  .hyp-arm-detail {{
+    display: none; margin-top: 8px; font-size: 11px; line-height: 1.6;
+  }}
+  .hyp-arm.expanded .hyp-arm-detail {{ display: block; }}
+  .hyp-arm-detail .hyp-field {{ margin: 4px 0; }}
+  .hyp-arm-detail .hyp-field-label {{ color: #8899aa; font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; }}
+  .hyp-arm-detail .hyp-field-value {{ color: #bbb; }}
+</style>
+</head>
+<body>
+<div class="view-toggle">
+  <button class="view-btn active" onclick="switchView('iterations')">Iterations</button>
+  <button class="view-btn" onclick="switchView('principles')">Knowledge</button>
+  <button class="view-btn" onclick="switchView('insights')">Insights</button>
+  <button class="view-btn" onclick="switchView('summary')">Summary</button>
+</div>
+
+<div class="legend" id="legend-iterations">
+    <strong style="margin-bottom:8px;display:block;">{title}</strong>
+    <div style="margin-bottom:8px;border-bottom:1px solid #0f3460;padding-bottom:8px;">
+      <div style="color:#888;font-size:10px;margin-bottom:4px;">NODES</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#4caf50"></div>Confirmed hypothesis</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#f44336"></div>Refuted hypothesis</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#ff9800"></div>Partially confirmed</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#9e9e9e"></div>Baseline</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#5c6bc0;border-radius:3px;width:10px;height:10px"></div>Concept (click iteration)</div>
+      <div class="legend-item"><svg width="14" height="14" style="margin-right:8px;"><polygon points="7,2 12,12 2,12" fill="#4a148c" stroke="#ce93d8" stroke-width="1.5"/></svg>Parameter (click iteration)</div>
+      <div class="legend-item"><div class="legend-dot" style="background:#66bb6a;transform:rotate(45deg);border-radius:2px;width:9px;height:9px"></div>Entity (click iteration)</div>
+    </div>
+    <div style="margin-bottom:8px;border-bottom:1px solid #0f3460;padding-bottom:8px;">
+      <div style="color:#888;font-size:10px;margin-bottom:4px;">EDGES</div>
+      <div class="legend-item"><svg width="24" height="12"><line x1="0" y1="6" x2="24" y2="6" stroke="#555" stroke-width="2" stroke-dasharray="4,4"/></svg><span style="margin-left:8px;">Timeline sequence</span></div>
+      <div class="legend-item"><svg width="24" height="12"><line x1="0" y1="6" x2="24" y2="6" stroke="#5c6bc0" stroke-width="1"/></svg><span style="margin-left:8px;">Concept/entity link</span></div>
+      <div class="legend-item"><svg width="24" height="12"><path d="M0,10 Q12,0 24,10" fill="none" stroke="#ffb74d" stroke-width="1.5" stroke-dasharray="3,2"/></svg><span style="margin-left:8px;">Revisited earlier idea</span></div>
+    </div>
+    <div>
+      <div style="color:#888;font-size:10px;margin-bottom:4px;">INTERACTIONS</div>
+      <div style="color:#aaa;font-size:11px;line-height:1.5;">
+        <strong>Click</strong> iteration &rarr; show/hide concepts<br>
+        <strong>Hover</strong> any node &rarr; see details<br>
+        <strong>Drag</strong> node &rarr; rearrange<br>
+        <strong>Scroll</strong> &rarr; zoom &bull; <strong>Drag bg</strong> &rarr; pan<br>
+        <strong>Play timeline</strong> &rarr; animate graph evolution
+      </div>
+    </div>
+</div>
+
+<div class="legend" id="legend-principles" style="display:none;">
+  <strong style="margin-bottom:8px;display:block;">{title} &mdash; Knowledge Graph</strong>
+  <div style="margin-bottom:8px;border-bottom:1px solid #0f3460;padding-bottom:8px;">
+    <div style="color:#888;font-size:10px;margin-bottom:4px;">NODES</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#1a237e;border:2px solid #5c6bc0;border-radius:3px;width:12px;height:12px"></div>Concept (technique/algorithm)</div>
+    <div class="legend-item"><svg width="14" height="14" style="margin-right:8px;"><polygon points="7,1 13,12 1,12" fill="#4a148c" stroke="#ce93d8" stroke-width="1.5"/></svg>Parameter (config knob)</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#1b5e20;border:2px solid #66bb6a;transform:rotate(45deg);border-radius:2px;width:10px;height:10px"></div>Entity (system component)</div>
+  </div>
+  <div style="margin-bottom:8px;border-bottom:1px solid #0f3460;padding-bottom:8px;">
+    <div style="color:#888;font-size:10px;margin-bottom:4px;">EDGES</div>
+    <div class="legend-item"><svg width="24" height="12"><line x1="0" y1="6" x2="24" y2="6" stroke="rgba(255,255,255,0.3)" stroke-width="2"/></svg><span style="margin-left:8px;">Shared principles (thicker = more)</span></div>
+  </div>
+  <div style="margin-bottom:8px;border-bottom:1px solid #0f3460;padding-bottom:8px;">
+    <div style="color:#888;font-size:10px;margin-bottom:4px;">PRINCIPLE CONFIDENCE</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#4caf50;width:8px;height:8px;border-radius:50%;"></div>High</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#ff9800;width:8px;height:8px;border-radius:50%;"></div>Medium</div>
+    <div class="legend-item"><div class="legend-dot" style="background:#f44336;width:8px;height:8px;border-radius:50%;"></div>Low</div>
+  </div>
+  <div>
+    <div style="color:#888;font-size:10px;margin-bottom:4px;">INTERACTIONS</div>
+    <div style="color:#aaa;font-size:11px;line-height:1.5;">
+      <strong>Click</strong> node &rarr; see definition + principles<br>
+      <strong>Hover</strong> node &rarr; quick info<br>
+      <strong>Drag</strong> node &rarr; rearrange<br>
+      <strong>Scroll</strong> &rarr; zoom &bull; <strong>Drag bg</strong> &rarr; pan<br>
+      <strong>Node size</strong> = connections to other concepts
+    </div>
+  </div>
+</div>
+
+<div class="campaign-objective" id="campaign-objective-box" style="display:none;"></div>
+
+<div id="insights-container"></div>
+<div id="summary-container"></div>
+<div id="iter-detail-panel">
+  <button class="panel-close" onclick="closeIterPanel()">&times;</button>
+  <div id="iter-detail-content"></div>
+</div>
+<div id="cost-chart"></div>
+<div class="tooltip" id="tooltip"></div>
+<div id="timeline-narrative"></div>
+<button id="timeline-trigger" onclick="startTimeline()">&#9654; Play timeline</button>
+<div id="timeline-controls">
+  <button id="timeline-play-btn" onclick="toggleTimelinePlay()">&#9654;</button>
+  <input type="range" id="timeline-slider" min="0" max="1" value="0" oninput="scrubTimeline(this.value)">
+  <span id="timeline-label">0 / 0</span>
+  <button id="timeline-dismiss" onclick="dismissTimeline()">&times;</button>
+</div>
+<script src="d3.v7.min.js"></script>
+<script>if(typeof d3==="undefined")document.write('<script src="https://d3js.org/d3.v7.min.js"><\\/script>')</script>
+<script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+<script>
+const iterData = {iter_data_json};
+const princData = {princ_data_json};
+const insightsData = {insights_data_json};
+const iterSummaries = {iter_summaries_json};
+const campaignContext = {campaign_context_json};
+const conceptsData = {concepts_data_json};
+const summaryMd = {summary_md_json};
+const knowledgeGraph = {knowledge_graph_json};
+const findingsData = {findings_data_json};
+const narrativesData = {narratives_data_json};
+const llmMetrics = {llm_metrics_json};
+
+let currentView = "iterations";
+
+// Render campaign objective box (top-center). Collapsible; persists across reloads via localStorage.
+const OBJECTIVE_COLLAPSED_KEY = "nous-viz-objective-collapsed";
+function toggleObjective() {{
+  const box = document.getElementById("campaign-objective-box");
+  if (!box) return;
+  const nowCollapsed = !box.classList.contains("collapsed");
+  box.classList.toggle("collapsed", nowCollapsed);
+  try {{ localStorage.setItem(OBJECTIVE_COLLAPSED_KEY, nowCollapsed ? "1" : "0"); }} catch (e) {{}}
+}}
+if (campaignContext && (campaignContext.research_question || campaignContext.target_commit)) {{
+  const box = document.getElementById("campaign-objective-box");
+  if (box) {{
+    let bodyHtml = '';
+    if (campaignContext.research_question) {{
+      bodyHtml += '<div class="obj-question">' + campaignContext.research_question + '</div>';
+    }}
+    const metaParts = [];
+    if (campaignContext.target_commit) {{
+      const shortSha = campaignContext.target_commit.substring(0, 7);
+      const repoLabel = campaignContext.target_repo || "";
+      metaParts.push('<span class="obj-meta-item" title="' + campaignContext.target_commit + '">commit <code>' + shortSha + '</code>' + (repoLabel ? ' on ' + repoLabel : '') + '</span>');
+    }}
+    if (campaignContext.nous_version) {{
+      const shortVer = campaignContext.nous_version.length > 12 ? campaignContext.nous_version.substring(0, 7) : campaignContext.nous_version;
+      metaParts.push('<span class="obj-meta-item">nous <code>' + shortVer + '</code></span>');
+    }}
+    if (metaParts.length > 0) {{
+      bodyHtml += '<div class="obj-meta">' + metaParts.join(' &middot; ') + '</div>';
+    }}
+    box.innerHTML =
+      '<div class="obj-header" onclick="toggleObjective()">' +
+        '<span class="obj-label">Research Objective</span>' +
+        '<span class="obj-toggle">&#9662;</span>' +
+      '</div>' +
+      '<div class="obj-body">' + bodyHtml + '</div>';
+    let startCollapsed = true;
+    try {{
+      const stored = localStorage.getItem(OBJECTIVE_COLLAPSED_KEY);
+      if (stored === "0") startCollapsed = false;
+    }} catch (e) {{}}
+    box.classList.toggle("collapsed", startCollapsed);
+    box.style.display = "block";
+  }}
+}}
+
+// --- Cost bar chart ---
+function renderCostChart() {{
+  const chart = document.getElementById("cost-chart");
+  if (!llmMetrics || Object.keys(llmMetrics).length === 0) {{
+    chart.classList.remove("visible");
+    return;
+  }}
+
+  const iterIds = Object.keys(llmMetrics).sort((a, b) =>
+    parseInt(a.replace("iter-", "")) - parseInt(b.replace("iter-", ""))
+  );
+  const maxCost = Math.max(...iterIds.map(id => llmMetrics[id].total_cost));
+  const totalCampaignCost = iterIds.reduce((sum, id) => sum + llmMetrics[id].total_cost, 0);
+
+  let html = '<div class="cost-title">Cost per Iteration</div>';
+  html += `<div class="cost-total">Campaign total: <strong style="color:#fff">$${{totalCampaignCost.toFixed(2)}}</strong></div>`;
+  html += '<div class="cost-bars">';
+
+  iterIds.forEach(id => {{
+    const m = llmMetrics[id];
+    const designCost = m.design ? m.design.cost_usd : 0;
+    const execCost = m.execute ? m.execute.cost_usd : 0;
+    const designH = maxCost > 0 ? (designCost / maxCost) * 140 : 0;
+    const executeH = maxCost > 0 ? (execCost / maxCost) * 140 : 0;
+    const label = id.replace("iter-", "");
+    const tooltipText = `$${{m.total_cost.toFixed(2)}} (design: $${{designCost.toFixed(2)}}, exec: $${{execCost.toFixed(2)}})`;
+    html += `<div class="cost-bar-group">`;
+    html += `<div class="cost-bar-stack" title="${{tooltipText}}">`;
+    html += `<div class="cost-bar-design" style="height:${{designH}}px"></div>`;
+    html += `<div class="cost-bar-execute" style="height:${{executeH}}px"></div>`;
+    html += `</div>`;
+    html += `<div class="cost-bar-label">${{label}}</div>`;
+    html += `</div>`;
+  }});
+
+  html += '</div>';
+  html += '<div class="cost-legend">';
+  html += '<div class="cost-legend-item"><div class="cost-legend-dot" style="background:#ef6c00"></div>Design (Opus)</div>';
+  html += '<div class="cost-legend-item"><div class="cost-legend-dot" style="background:#00acc1"></div>Execute (Sonnet)</div>';
+  html += '</div>';
+
+  chart.innerHTML = html;
+  chart.classList.add("visible");
+  // Position below the visible legend, match its width
+  const legend = document.getElementById("legend-iterations");
+  if (legend && legend.style.display !== "none") {{
+    chart.style.top = (legend.offsetTop + legend.offsetHeight + 12) + "px";
+    chart.style.width = legend.offsetWidth + "px";
+  }} else {{
+    chart.style.top = "16px";
+  }}
+}}
+
+let simulation, svg, g;
+
+function switchView(view) {{
+  if (view === currentView) return;
+  currentView = view;
+  document.querySelectorAll(".view-btn").forEach(b => b.classList.remove("active"));
+  document.querySelector(`.view-btn[onclick="switchView('${{view}}')"]`).classList.add("active");
+  document.getElementById("legend-iterations").style.display = view === "iterations" ? "block" : "none";
+  document.getElementById("legend-principles").style.display = view === "principles" ? "block" : "none";
+  const objBox = document.getElementById("campaign-objective-box");
+  if (objBox && objBox.innerHTML) {{
+    objBox.style.display = (view === "iterations" || view === "principles") ? "block" : "none";
+  }}
+  // Cost chart: only visible in iterations view
+  const costChart = document.getElementById("cost-chart");
+  if (view === "iterations") {{
+    renderCostChart();
+  }} else {{
+    costChart.classList.remove("visible");
+  }}
+  // Timeline controls: dismiss when leaving iterations, show trigger when entering
+  if (view !== "iterations") {{
+    if (timelineActive) dismissTimeline();
+    document.getElementById("timeline-trigger").classList.remove("visible");
+    document.getElementById("timeline-controls").classList.remove("visible");
+  }} else {{
+    if (!timelineActive) document.getElementById("timeline-trigger").classList.add("visible");
+  }}
+  const insightsEl = document.getElementById("insights-container");
+  const summaryEl = document.getElementById("summary-container");
+  if (view === "insights") {{
+    // Hide SVG graph, show insights
+    const svgEl = document.querySelector("body > svg");
+    if (svgEl) svgEl.style.display = "none";
+    insightsEl.style.display = "block";
+    summaryEl.style.display = "none";
+    renderInsights();
+  }} else if (view === "summary") {{
+    const svgEl = document.querySelector("body > svg");
+    if (svgEl) svgEl.style.display = "none";
+    insightsEl.style.display = "none";
+    summaryEl.style.display = "block";
+    renderSummary();
+  }} else {{
+    insightsEl.style.display = "none";
+    summaryEl.style.display = "none";
+    render(view === "iterations" ? iterData : princData, view);
+  }}
+}}
+
+function renderSummary() {{
+  const container = document.getElementById("summary-container");
+  if (!summaryMd) {{
+    container.innerHTML = '<div class="summary-fallback">No summary available. Run /post-campaign to generate summary.md.</div>';
+    return;
+  }}
+  // Parse markdown and wrap in styled container
+  let html = marked.parse(summaryMd);
+
+  // Extract metadata lines (Date, Iterations, Key question) into a styled header
+  const metaRegex = /<p><strong>(.+?)<\/strong>\s*(.+?)<br>\s*<strong>(.+?)<\/strong>\s*(.+?)<br>\s*<strong>(.+?)<\/strong>\s*([\s\S]*?)<\/p>/;
+  const metaMatch = html.match(metaRegex);
+  if (metaMatch) {{
+    const metaHtml = `<div class="summary-meta"><span><strong>${{metaMatch[1]}}</strong> ${{metaMatch[2]}}</span><span><strong>${{metaMatch[3]}}</strong> ${{metaMatch[4]}}</span></div>`
+      + `<div class="summary-question">${{metaMatch[6].trim()}}</div>`;
+    html = html.replace(metaMatch[0], metaHtml);
+  }}
+
+  // Add semantic classes to h2 headings based on content
+  html = html.replace(/<h2[^>]*>Outcome<\/h2>/i, '<h2 class="outcome-heading">Outcome</h2>');
+  html = html.replace(/<h2[^>]*>Iteration arc<\/h2>/i, '<h2 class="arc-heading">Iteration Arc</h2>');
+  html = html.replace(/<h2[^>]*>Key principles<\/h2>/i, '<h2 class="principles-heading">Key Principles</h2>');
+  html = html.replace(/<h2[^>]*>Open questions<\/h2>/i, '<h2 class="questions-heading">Open Questions</h2>');
+
+  container.innerHTML = '<div class="summary-inner">' + html + '</div>';
+}}
+
+function renderInsights() {{
+  const container = document.getElementById("insights-container");
+  const sections = [
+    {{ key: "dead_ends", title: "Dead Ends", cssClass: "dead-end", color: "#f44336",
+       desc: "Approaches that were tested and conclusively don't work",
+       fields: [["what_was_tried", "What was tried"], ["why_it_failed", "Why it failed"], ["avoid_when", "Avoid when"]] }},
+    {{ key: "frontiers", title: "Frontiers", cssClass: "frontier", color: "#ff9800",
+       desc: "Edges of exploration — what was tried, what wasn't, and what to try next",
+       fields: [["what_was_tried", "What was tried"], ["what_was_left_untried", "Left untried"], ["what_to_try_next", "Try next"]] }},
+    {{ key: "interactions", title: "Interactions", cssClass: "interaction", color: "#2196f3",
+       desc: "Untested combinations of validated approaches — experiments to run next",
+       fields: [["approach_a", "Approach A"], ["approach_b", "Approach B"], ["why_combine", "Why combine"], ["experiment_to_run", "Experiment"]] }},
+  ];
+
+  const hasAny = sections.some(s => insightsData[s.key]);
+  if (!hasAny) {{
+    container.innerHTML = '<div class="insights-fallback">Run /post-campaign to generate insights</div>';
+    return;
+  }}
+
+  function renderMarkdownInline(text) {{
+    return text.replace(/\\*\\*(.+?)\\*\\*/g, '<strong style="color:#e0e0e0">$1</strong>');
+  }}
+
+  function renderBulletLine(line) {{
+    const cleaned = line.replace(/^[-*]\\s*/, "").trim();
+    const fieldMatch = cleaned.match(/^\\*\\*(.+?):?\\*\\*:?\\s*(.*)/);
+    if (fieldMatch) {{
+      const label = fieldMatch[1].replace(/:$/, "");
+      const value = fieldMatch[2];
+      if (value) {{
+        return `<div class="field"><span class="field-label">${{label}}</span><span class="field-value">${{renderMarkdownInline(value)}}</span></div>`;
+      }} else {{
+        return `<div class="field"><span class="field-value" style="color:#e0e0e0;font-weight:600">${{label}}</span></div>`;
+      }}
+    }}
+    return `<div class="field"><span class="field-value">${{renderMarkdownInline(cleaned)}}</span></div>`;
+  }}
+
+  function renderJsonEntry(entry, fieldDefs) {{
+    let body = "";
+    for (const [key, label] of fieldDefs) {{
+      const value = entry[key];
+      if (value) {{
+        body += `<div class="field"><span class="field-label">${{label}}</span><span class="field-value">${{value}}</span></div>`;
+      }}
+    }}
+    if (entry.related_principles && entry.related_principles.length) {{
+      body += `<div class="field"><span class="field-label">Related</span><span class="field-value">${{entry.related_principles.join(", ")}}</span></div>`;
+    }}
+    return body;
+  }}
+
+  function getCount(data) {{
+    if (!data) return 0;
+    if (Array.isArray(data)) return data.length;
+    if (typeof data === "string") return (data.match(/^### /gm) || []).length;
+    return 0;
+  }}
+
+  // Build nav bar
+  let html = '<div class="insights-nav">';
+  for (let i = 0; i < sections.length; i++) {{
+    const section = sections[i];
+    const data = insightsData[section.key];
+    const count = getCount(data);
+    const activeClass = i === 0 ? " active" : "";
+    html += `<button class="insights-nav-btn${{activeClass}}" style="color:${{i === 0 ? section.color : ''}}" onclick="switchInsightTab(${{i}})" data-idx="${{i}}" data-color="${{section.color}}">`;
+    html += `<span class="nav-title">${{section.title}}</span>`;
+    html += `<span class="nav-desc">${{section.desc}}</span>`;
+    html += `<span class="nav-count">${{count}} item${{count !== 1 ? "s" : ""}}</span>`;
+    html += `</button>`;
+  }}
+  html += '</div>';
+
+  // Build section panels
+  html += '<div class="insights-sections">';
+  for (let i = 0; i < sections.length; i++) {{
+    const section = sections[i];
+    const data = insightsData[section.key];
+    const activeClass = i === 0 ? " active" : "";
+    html += `<div class="insights-section${{activeClass}}" data-section="${{i}}">`;
+
+    if (!data) {{
+      html += `<div class="insight-card insight-card--${{section.cssClass}}"><p style="color:#666;font-style:italic;margin:0;">No data available</p></div>`;
+    }} else if (Array.isArray(data)) {{
+      // New JSON array format
+      html += `<div class="insights-cards">`;
+      for (const entry of data) {{
+        const title = entry.title || "Untitled";
+        const iterTag = entry.iteration ? ` <span style="color:#888;font-size:0.8em">(${{entry.iteration}})</span>` : "";
+        const body = renderJsonEntry(entry, section.fields);
+        html += `<div class="insight-card insight-card--${{section.cssClass}}"><h4>${{title}}${{iterTag}}</h4>${{body}}</div>`;
+      }}
+      html += `</div>`;
+    }} else {{
+      // Legacy markdown string format (backward compatibility)
+      html += `<div class="insights-cards">`;
+      const chunks = data.split(/^### /m).filter(c => c.trim());
+      for (const chunk of chunks) {{
+        const lines = chunk.split("\\n");
+        const title = lines[0].trim();
+        if (!title || !lines.slice(1).some(l => /^[-*]\\s/.test(l.trim()))) continue;
+        const bodyLines = lines.slice(1).filter(l => l.trim());
+        const body = bodyLines.map(l => renderBulletLine(l)).join("");
+        html += `<div class="insight-card insight-card--${{section.cssClass}}"><h4>${{renderMarkdownInline(title)}}</h4>${{body}}</div>`;
+      }}
+      html += `</div>`;
+    }}
+    html += `</div>`;
+  }}
+  html += '</div>';
+  container.innerHTML = html;
+}}
+
+function showIterPanel(d) {{
+  resetEdgeHighlights();
+  const panel = document.getElementById("iter-detail-panel");
+  const content = document.getElementById("iter-detail-content");
+  const colorMap = {{ "CONFIRMED": "#4caf50", "REFUTED": "#f44336", "PARTIALLY_CONFIRMED": "#ff9800", "BASELINE": "#9e9e9e" }};
+  const color = colorMap[d.outcome] || "#9e9e9e";
+  const summary = iterSummaries[d.id];
+
+  let html = `<div class="panel-header">`;
+  html += `<div class="outcome-dot" style="background:${{color}}"></div>`;
+  html += `<h3>${{d.label}}</h3>`;
+  html += `</div>`;
+  html += `<div class="panel-outcome" style="color:${{color}}">${{d.outcome || "BASELINE"}}</div>`;
+
+  if (summary) {{
+    html += `<div class="panel-field"><div class="panel-field-label">What was tried</div><div class="panel-field-value">${{summary.what_was_tried || "—"}}</div></div>`;
+    html += `<div class="panel-field"><div class="panel-field-label">What was found</div><div class="panel-field-value">${{summary.what_was_found || "—"}}</div></div>`;
+    html += `<div class="panel-field"><div class="panel-field-label">Why it matters</div><div class="panel-field-value">${{summary.why_it_matters || "—"}}</div></div>`;
+  }} else {{
+    html += `<div class="panel-summary" style="color:#666;font-style:italic;">No summary available. Run /visualize-campaign to generate.</div>`;
+  }}
+
+  // Show hypothesis arms from findings
+  const arms = findingsData[d.id];
+  if (arms && arms.length > 0) {{
+    const statusColors = {{ "CONFIRMED": "#4caf50", "REFUTED": "#f44336", "PARTIALLY_CONFIRMED": "#ff9800" }};
+    const armLabels = {{ "h-main": "Main Hypothesis", "h-control-negative": "Negative Control", "h-robustness": "Robustness", "h-ablation": "Ablation" }};
+    function escHtml(str) {{
+      return str.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+    }}
+    html += `<div class="hyp-arms"><div class="hyp-arms-label">Hypothesis Arms</div>`;
+    arms.forEach((arm, idx) => {{
+      const sc = statusColors[arm.status] || "#9e9e9e";
+      const label = armLabels[arm.arm_type] || arm.arm_type;
+      const bgColor = arm.status === "CONFIRMED" ? "rgba(76,175,80,0.15)" : arm.status === "REFUTED" ? "rgba(244,67,54,0.15)" : "rgba(255,152,0,0.15)";
+      html += `<div class="hyp-arm" style="border-left-color:${{sc}}" onclick="this.classList.toggle('expanded')">`;
+      html += `<div class="hyp-arm-header"><span class="hyp-arm-type">${{label}}</span>`;
+      html += `<span class="hyp-arm-status" style="color:${{sc}};background:${{bgColor}}">${{arm.status}}</span></div>`;
+      html += `<div class="hyp-arm-detail">`;
+      if (arm.predicted) html += `<div class="hyp-field"><div class="hyp-field-label">Predicted</div><div class="hyp-field-value">${{escHtml(arm.predicted)}}</div></div>`;
+      if (arm.observed) html += `<div class="hyp-field"><div class="hyp-field-label">Observed</div><div class="hyp-field-value">${{escHtml(arm.observed)}}</div></div>`;
+      if (arm.diagnostic_note) html += `<div class="hyp-field"><div class="hyp-field-label">Diagnostic</div><div class="hyp-field-value">${{escHtml(arm.diagnostic_note)}}</div></div>`;
+      html += `</div></div>`;
+    }});
+    html += `</div>`;
+  }}
+
+  // Show related concepts and entities (by principle overlap OR summary mention)
+  if (conceptsData) {{
+    const iterPrinciples = d.principles || [];
+    const summaryText = (function() {{
+      const s = iterSummaries[d.id];
+      if (!s) return "";
+      return [s.what_was_tried || "", s.what_was_found || "", s.why_it_matters || ""].join(" ").toLowerCase();
+    }})();
+    function panelMentions(name) {{
+      const terms = [name.toLowerCase()];
+      const pm = name.match(/^([^(]+)\s*\(/);
+      if (pm) terms.push(pm[1].trim().toLowerCase());
+      const am = name.match(/\(([^)]+)\)/);
+      if (am) terms.push(am[1].trim().toLowerCase());
+      return terms.some(t => summaryText.includes(t));
+    }}
+    const relatedConcepts = (conceptsData.concepts || []).filter(c =>
+      c.principles.some(pid => iterPrinciples.includes(pid)) || panelMentions(c.name)
+    );
+    const relatedParams = (conceptsData.parameters || []).filter(p =>
+      p.principles.some(pid => iterPrinciples.includes(pid)) || panelMentions(p.name)
+    );
+    const relatedEntities = (conceptsData.entities || []).filter(ent =>
+      ent.principles.some(pid => iterPrinciples.includes(pid)) || panelMentions(ent.name)
+    );
+    if (relatedConcepts.length > 0 || relatedParams.length > 0 || relatedEntities.length > 0) {{
+      html += `<div class="panel-principles" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;">`;
+      if (relatedConcepts.length > 0) {{
+        html += `<div class="panel-field-label" style="margin-bottom:6px;">Concepts</div>`;
+        html += `<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;">`;
+        relatedConcepts.forEach(c => {{
+          const cid = "concept-" + c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+          html += `<button class="chip-btn chip-concept" onclick="openChipPanel('${{cid}}', 'concept')">${{c.name}}</button>`;
+        }});
+        html += `</div>`;
+      }}
+      if (relatedParams.length > 0) {{
+        html += `<div class="panel-field-label" style="margin-bottom:6px;">Parameters</div>`;
+        html += `<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;">`;
+        relatedParams.forEach(p => {{
+          const pid = "param-" + p.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+          html += `<button class="chip-btn chip-param" onclick="openChipPanel('${{pid}}', 'parameter')">${{p.name}}</button>`;
+        }});
+        html += `</div>`;
+      }}
+      if (relatedEntities.length > 0) {{
+        html += `<div class="panel-field-label" style="margin-bottom:6px;">Entities</div>`;
+        html += `<div style="display:flex;flex-wrap:wrap;gap:6px;margin-bottom:10px;">`;
+        relatedEntities.forEach(ent => {{
+          const eid = "entity-" + ent.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+          html += `<button class="chip-btn chip-entity" onclick="openChipPanel('${{eid}}', 'entity')">${{ent.name}}</button>`;
+        }});
+        html += `</div>`;
+      }}
+      html += `</div>`;
+    }}
+  }}
+
+  // LLM cost breakdown section
+  if (llmMetrics && llmMetrics[d.id]) {{
+    const m = llmMetrics[d.id];
+    html += `<div class="panel-principles" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;">`;
+    html += `<div class="panel-field-label" style="margin-bottom:8px;">LLM Cost</div>`;
+    html += `<div style="display:flex;gap:12px;margin-bottom:8px;">`;
+    // Mini stacked bar
+    const maxBarW = 120;
+    const totalCost = m.total_cost || 0.01;
+    const designW = m.design ? (m.design.cost_usd / totalCost) * maxBarW : 0;
+    const execW = m.execute ? (m.execute.cost_usd / totalCost) * maxBarW : 0;
+    html += `<div style="display:flex;align-items:center;gap:4px;">`;
+    html += `<div style="display:flex;height:12px;border-radius:3px;overflow:hidden;">`;
+    if (designW > 0) html += `<div style="width:${{designW}}px;background:#ef6c00;"></div>`;
+    if (execW > 0) html += `<div style="width:${{execW}}px;background:#00acc1;"></div>`;
+    html += `</div>`;
+    html += `<span style="color:#ffab40;font-weight:600;font-size:13px;">$${{totalCost.toFixed(2)}}</span>`;
+    html += `</div></div>`;
+    // Detail rows
+    if (m.design) {{
+      html += `<div style="display:flex;justify-content:space-between;padding:4px 0;font-size:11px;">`;
+      html += `<span style="color:#ef6c00;">Design (${{m.design.model.replace("claude-", "")}})</span>`;
+      html += `<span style="color:#aaa;">$${{m.design.cost_usd.toFixed(2)}} &middot; ${{m.design.num_turns}} turns &middot; ${{(m.design.duration_ms / 60000).toFixed(1)}}m</span>`;
+      html += `</div>`;
+    }}
+    if (m.execute) {{
+      html += `<div style="display:flex;justify-content:space-between;padding:4px 0;font-size:11px;">`;
+      html += `<span style="color:#00acc1;">Execute (${{m.execute.model.replace("claude-", "")}})</span>`;
+      html += `<span style="color:#aaa;">$${{m.execute.cost_usd.toFixed(2)}} &middot; ${{m.execute.num_turns}} turns &middot; ${{(m.execute.duration_ms / 60000).toFixed(1)}}m</span>`;
+      html += `</div>`;
+    }}
+    html += `<div style="display:flex;justify-content:space-between;padding:6px 0 0;font-size:11px;border-top:1px solid #0f3460;margin-top:4px;">`;
+    html += `<span style="color:#e0e0e0;">Total</span>`;
+    html += `<span style="color:#e0e0e0;">${{m.total_turns}} turns &middot; ${{(m.total_duration_ms / 60000).toFixed(1)}} min</span>`;
+    html += `</div>`;
+    html += `</div>`;
+  }}
+
+  // Campaign provenance footer
+  if (campaignContext && campaignContext.target_commit) {{
+    html += `<div class="panel-principles" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;">`;
+    html += `<div class="panel-field-label" style="margin-bottom:6px;">Campaign Provenance</div>`;
+    const shortSha = campaignContext.target_commit.substring(0, 7);
+    html += `<div style="font-size:11px;color:#888;">`;
+    html += `<span title="${{campaignContext.target_commit}}">Target commit: <code style="background:#0a1628;padding:1px 5px;border-radius:3px;font-size:10px;color:#b39ddb;border:1px solid #1a2a4a;">${{shortSha}}</code></span>`;
+    if (campaignContext.target_repo) html += ` <span style="color:#666;">(${{campaignContext.target_repo}})</span>`;
+    html += `</div>`;
+    if (campaignContext.started_at) {{
+      const dt = new Date(campaignContext.started_at);
+      html += `<div style="font-size:11px;color:#666;margin-top:4px;">Started: ${{dt.toLocaleDateString()}} ${{dt.toLocaleTimeString([], {{hour:"2-digit",minute:"2-digit"}})}}</div>`;
+    }}
+    html += `</div>`;
+  }}
+
+  content.innerHTML = html;
+  panel.classList.add("open");
+}}
+
+function resetEdgeHighlights() {{
+  d3.selectAll("line.link").each(function(d) {{
+    const el = d3.select(this);
+    if (d.type === "shared-principles") {{
+      el.attr("stroke", "rgba(255,255,255,0.3)").attr("stroke-width", Math.min(d.weight || 1, 5)).attr("stroke-opacity", 0.6);
+    }} else {{
+      el.attr("stroke-opacity", 0.6).attr("stroke-width", 2);
+    }}
+  }});
+}}
+
+function closeIterPanel() {{
+  document.getElementById("iter-detail-panel").classList.remove("open");
+  resetEdgeHighlights();
+}}
+
+function openChipPanel(nodeId, nodeType, viewCtx) {{
+  // Build a minimal node-like object to pass to showConceptPanel
+  const fakeNode = {{ id: nodeId, nodeType: nodeType }};
+  showConceptPanel(fakeNode, viewCtx || "iterations");
+}}
+
+function showPrinciplePanel(principleId) {{
+  const panel = document.getElementById("iter-detail-panel");
+  const content = document.getElementById("iter-detail-content");
+  const princNodes = princData.nodes || [];
+  const pNode = princNodes.find(n => n.id === principleId);
+  if (!pNode) return;
+
+  const confColors = {{ high: "#4caf50", medium: "#ff9800", low: "#f44336" }};
+  const col = confColors[pNode.confidence] || "#666";
+
+  let html = `<div class="panel-header">`;
+  html += `<div class="outcome-dot" style="background:${{col}}"></div>`;
+  html += `<h3>${{principleId}}</h3>`;
+  html += `</div>`;
+  html += `<div class="panel-outcome" style="color:${{col}}">${{(pNode.confidence || "unknown").toUpperCase()}} CONFIDENCE</div>`;
+  html += `<div class="panel-field"><div class="panel-field-label">Statement</div><div class="panel-field-value">${{pNode.statement || "—"}}</div></div>`;
+  if (pNode.regime) html += `<div class="panel-field"><div class="panel-field-label">When it applies</div><div class="panel-field-value">${{pNode.regime}}</div></div>`;
+  if (pNode.mechanism) html += `<div class="panel-field"><div class="panel-field-label">Mechanism</div><div class="panel-field-value">${{pNode.mechanism}}</div></div>`;
+
+  content.innerHTML = html;
+  panel.classList.add("open");
+
+  // Dim all edges, then highlight edges connecting nodes that share this principle
+  d3.selectAll("line.link").each(function(link) {{
+    const el = d3.select(this);
+    const srcNode = (typeof link.source === "object") ? link.source : null;
+    const tgtNode = (typeof link.target === "object") ? link.target : null;
+    if (srcNode && tgtNode && srcNode.principles && tgtNode.principles &&
+        srcNode.principles.includes(principleId) && tgtNode.principles.includes(principleId)) {{
+      el.attr("stroke", "#fff").attr("stroke-width", 2.5).attr("stroke-opacity", 1);
+    }} else {{
+      el.attr("stroke-opacity", 0.1);
+    }}
+  }});
+}}
+
+function renderRelationshipChips(d, item, viewContext) {{
+  let html = "";
+  const ctx = viewContext;
+  if (d.nodeType === "concept") {{
+    const ownedParams = (item.parameters || []).map(pName =>
+      (conceptsData.parameters || []).find(p => p.name === pName)).filter(Boolean);
+    if (ownedParams.length > 0) {{
+      html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label" style="margin-bottom:6px;">Parameters</div>`;
+      html += `<div style="display:flex;flex-wrap:wrap;gap:6px;">`;
+      ownedParams.forEach(p => {{
+        const pid = "param-" + p.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+        html += `<button class="chip-btn chip-param" onclick="openChipPanel('${{pid}}', 'parameter', '${{ctx}}')">${{p.name}}</button>`;
+      }});
+      html += `</div></div>`;
+    }}
+    const operatesOn = (item.operates_on || []).map(eName =>
+      (conceptsData.entities || []).find(e => e.name === eName)).filter(Boolean);
+    if (operatesOn.length > 0) {{
+      html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label" style="margin-bottom:6px;">Operates on</div>`;
+      html += `<div style="display:flex;flex-wrap:wrap;gap:6px;">`;
+      operatesOn.forEach(e => {{
+        const eid = "entity-" + e.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+        html += `<button class="chip-btn chip-entity" onclick="openChipPanel('${{eid}}', 'entity', '${{ctx}}')">${{e.name}}</button>`;
+      }});
+      html += `</div></div>`;
+    }}
+  }} else if (d.nodeType === "parameter") {{
+    const parentName = item.parent_concept;
+    if (parentName) {{
+      const parentConcept = (conceptsData.concepts || []).find(c => c.name === parentName);
+      if (parentConcept) {{
+        html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label" style="margin-bottom:6px;">Parent concept</div>`;
+        const cid = "concept-" + parentConcept.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+        html += `<button class="chip-btn chip-concept" onclick="openChipPanel('${{cid}}', 'concept', '${{ctx}}')">${{parentConcept.name}}</button>`;
+        html += `</div>`;
+      }}
+    }}
+  }} else if (d.nodeType === "entity") {{
+    const actingConcepts = (conceptsData.concepts || []).filter(c =>
+      (c.operates_on || []).includes(item.name));
+    if (actingConcepts.length > 0) {{
+      html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label" style="margin-bottom:6px;">Concepts that act on this</div>`;
+      html += `<div style="display:flex;flex-wrap:wrap;gap:6px;">`;
+      actingConcepts.forEach(c => {{
+        const cid = "concept-" + c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+        html += `<button class="chip-btn chip-concept" onclick="openChipPanel('${{cid}}', 'concept', '${{ctx}}')">${{c.name}}</button>`;
+      }});
+      html += `</div></div>`;
+    }}
+  }}
+  return html;
+}}
+
+function showConceptPanel(d, viewContext) {{
+  resetEdgeHighlights();
+  const panel = document.getElementById("iter-detail-panel");
+  const content = document.getElementById("iter-detail-content");
+  const colorMap = {{ concept: "#5c6bc0", parameter: "#ce93d8", entity: "#66bb6a" }};
+  const labelMap = {{ concept: "CONCEPT", parameter: "PARAMETER", entity: "ENTITY" }};
+  const color = colorMap[d.nodeType] || "#9e9e9e";
+  const typeLabel = labelMap[d.nodeType] || "UNKNOWN";
+  const isKnowledge = viewContext === "knowledge";
+
+  // Find the full data from conceptsData
+  const sourceListMap = {{ concept: conceptsData.concepts || [], parameter: conceptsData.parameters || [], entity: conceptsData.entities || [] }};
+  const prefixMap = {{ concept: "concept-", parameter: "param-", entity: "entity-" }};
+  const sourceList = sourceListMap[d.nodeType] || [];
+  const prefix = prefixMap[d.nodeType] || "";
+  const item = sourceList.find(c => {{
+    const id = prefix + c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    return id === d.id;
+  }});
+
+  const displayName = d.label || (item && item.name) || d.id;
+  let html = `<div class="panel-header">`;
+  html += `<div class="outcome-dot" style="background:${{color}}"></div>`;
+  html += `<h3>${{displayName}}</h3>`;
+  html += `</div>`;
+  html += `<div class="panel-outcome" style="color:${{color}}">${{typeLabel}}</div>`;
+
+  if (item) {{
+    // Definition
+    html += `<div class="panel-field"><div class="panel-field-label">What it is</div><div class="panel-field-value">${{item.definition}}</div></div>`;
+
+    // Render relationship chips (shared logic for both Knowledge and Iterations tabs)
+    html += renderRelationshipChips(d, item, viewContext);
+
+    if (isKnowledge) {{
+      // Knowledge tab: show principles as clickable buttons for concepts
+      if (d.nodeType === "concept") {{
+        const princNodes = princData.nodes || [];
+        const allPrincs = item.principles.map(pid => {{
+          const pNode = princNodes.find(n => n.id === pid);
+          return {{ id: pid, statement: pNode ? pNode.statement : null, confidence: pNode ? pNode.confidence : null }};
+        }});
+        if (allPrincs.length > 0) {{
+          const confColors = {{ high: "#4caf50", medium: "#ff9800", low: "#f44336" }};
+          html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label">Principles</div>`;
+          html += `<div style="display:flex;flex-wrap:wrap;gap:4px;margin-top:4px;">`;
+          allPrincs.forEach(p => {{
+            const col = confColors[p.confidence] || "#666";
+            html += `<button style="display:inline-block;padding:2px 7px;border-radius:4px;font-size:10px;font-weight:600;color:${{col}};border:1px solid ${{col}};background:transparent;cursor:pointer;font-family:inherit;transition:all 0.15s;" onmouseenter="this.style.background='rgba(255,255,255,0.08)'" onmouseleave="this.style.background='transparent'" onclick="showPrinciplePanel('${{p.id}}')">${{p.id}}</button>`;
+          }});
+          html += `</div></div>`;
+        }}
+      }}
+      // Knowledge tab: show evolution timeline for parameters
+      if (d.nodeType === "parameter") {{
+        const evolution = item.evolution || [];
+        if (evolution.length > 0) {{
+          html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label">Value across iterations</div>`;
+          const outcomeColors = {{ "confirmed": "#4caf50", "refuted": "#f44336", "partially_confirmed": "#ff9800", "baseline": "#9e9e9e" }};
+          evolution.forEach(ev => {{
+            const oc = outcomeColors[(ev.outcome || "").toLowerCase()] || "#9e9e9e";
+            html += `<div style="margin:6px 0;border-left:3px solid ${{oc}};padding-left:8px;"><span style="color:#ccc;font-weight:600;font-size:11px;">${{ev.iter}}</span> <span style="color:#7986cb;font-size:11px;">= ${{ev.value}}</span><br><span style="color:#999;font-size:10px;">${{ev.note || ""}}</span></div>`;
+          }});
+          html += `</div>`;
+        }}
+      }}
+    }} else {{
+      // Which iterations involve this item
+      const iterNodes = iterData.nodes.filter(n => n.nodeType === "iteration");
+      const connectedIters = iterNodes.filter(iterNode => {{
+        const iterPrinciples = iterNode.principles || [];
+        return item.principles.some(pid => iterPrinciples.includes(pid));
+      }});
+      if (connectedIters.length > 0) {{
+        html += `<div class="panel-field" style="margin-top:12px;padding-top:12px;border-top:1px solid #0f3460;"><div class="panel-field-label" style="margin-bottom:6px;">Appears in iterations</div>`;
+        html += `<div style="display:flex;flex-wrap:wrap;gap:6px;">`;
+        connectedIters.forEach(iter => {{
+          const colorMap = {{ "CONFIRMED": "#4caf50", "REFUTED": "#f44336", "PARTIALLY_CONFIRMED": "#ff9800", "BASELINE": "#9e9e9e" }};
+          const c = colorMap[iter.outcome] || "#9e9e9e";
+          html += `<button class="chip-btn" style="color:${{c}};border-color:${{c}};" onclick="showIterPanel(iterData.nodes.find(n=>n.id==='${{iter.id}}'))">${{iter.label}}</button>`;
+        }});
+        html += `</div></div>`;
+      }}
+    }}
+  }}
+
+  content.innerHTML = html;
+  panel.classList.add("open");
+}}
+
+function switchInsightTab(idx) {{
+  document.querySelectorAll(".insights-nav-btn").forEach(btn => {{
+    btn.classList.remove("active");
+    btn.style.color = "";
+  }});
+  const activeBtn = document.querySelector(`.insights-nav-btn[data-idx="${{idx}}"]`);
+  activeBtn.classList.add("active");
+  activeBtn.style.color = activeBtn.dataset.color;
+  document.querySelectorAll(".insights-section").forEach(s => s.classList.remove("active"));
+  document.querySelector(`.insights-section[data-section="${{idx}}"]`).classList.add("active");
+}}
+
+function render(data, viewType) {{
+  // Clear existing
+  d3.select("body > svg").remove();
+  if (simulation) simulation.stop();
+
+  const width = window.innerWidth;
+  const height = window.innerHeight;
+
+  svg = d3.select("body").append("svg")
+    .attr("viewBox", [0, 0, width, height])
+    .call(d3.zoom().on("zoom", (e) => g.attr("transform", e.transform)))
+    .on("click", (e) => {{
+      if (e.target.tagName === "svg") {{ resetEdgeHighlights(); }}
+    }});
+
+  g = svg.append("g");
+
+  let nodes = data.nodes.map(d => ({{...d}}));
+  let links = data.links.map(d => ({{...d}}));
+
+  // In principles view: use pre-computed knowledge graph from Python
+  if (viewType === "principles" && knowledgeGraph && knowledgeGraph.nodes.length > 0) {{
+    // Clear all principle nodes and links — use pre-computed concept/entity graph
+    nodes = [];
+    links = [];
+
+    // Map pre-computed nodes
+    knowledgeGraph.nodes.forEach(n => {{
+      const sharedCount = knowledgeGraph.edges.filter(e => e.source === n.id || e.target === n.id).length;
+      const radius = Math.min(8 + sharedCount * 1.5, 18);
+      nodes.push({{
+        id: n.id, label: n.name, nodeType: n.type,
+        tooltip: `<strong>${{n.name}}</strong><br>${{n.definition}}<br><br><em>${{n.principles.length}} principles</em>`,
+        radius, principles: n.principles, definition: n.definition
+      }});
+    }});
+
+    // Map pre-computed edges
+    knowledgeGraph.edges.forEach(e => {{
+      links.push({{ source: e.source, target: e.target, type: "shared-principles", weight: e.shared_principles.length }});
+    }});
+  }}
+
+  // Inject concept/entity sub-nodes for iterations view (replaces principle sub-nodes)
+  if (viewType === "iterations" && conceptsData) {{
+    // Remove principle sub-nodes — concepts/entities replace them
+    nodes = nodes.filter(n => n.nodeType !== "principle");
+    links = links.filter(l => l.type !== "principle-of");
+
+    // Helper: check if a concept/entity name is mentioned in an iteration's summary
+    function summaryMentions(iterNode, name) {{
+      const summary = iterSummaries[iterNode.id];
+      if (!summary) return false;
+      const text = [summary.what_was_tried || "", summary.what_was_found || "", summary.why_it_matters || ""].join(" ").toLowerCase();
+      // Extract search terms: full name + each word/abbreviation before parentheses
+      const terms = [name.toLowerCase()];
+      const parenMatch = name.match(/^([^(]+)\s*\(/);
+      if (parenMatch) terms.push(parenMatch[1].trim().toLowerCase());
+      const abbrevMatch = name.match(/\(([^)]+)\)/);
+      if (abbrevMatch) terms.push(abbrevMatch[1].trim().toLowerCase());
+      return terms.some(term => text.includes(term));
+    }}
+
+    // Helper: check if iteration is connected to a concept/entity
+    function iterConnected(iterNode, item) {{
+      const iterPrinciples = iterNode.principles || [];
+      return item.principles.some(pid => iterPrinciples.includes(pid)) || summaryMentions(iterNode, item.name);
+    }}
+
+    // Shared concept/parameter/entity nodes — only add if linked to at least one iteration
+    const iterNodes = nodes.filter(n => n.nodeType === "iteration");
+
+    (conceptsData.concepts || []).forEach(c => {{
+      const id = "concept-" + c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      const connectedIters = iterNodes.filter(iterNode => iterConnected(iterNode, c));
+      if (connectedIters.length > 0) {{
+        nodes.push({{ id, label: c.name, nodeType: "concept",
+          tooltip: `<strong>${{c.name}}</strong><br>${{c.definition}}` }});
+        connectedIters.forEach(iterNode => {{
+          links.push({{ source: iterNode.id, target: id, type: "concept-of" }});
+        }});
+      }}
+    }});
+
+    (conceptsData.parameters || []).forEach(p => {{
+      const id = "param-" + p.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      const connectedIters = iterNodes.filter(iterNode => iterConnected(iterNode, p));
+      if (connectedIters.length > 0) {{
+        nodes.push({{ id, label: p.name, nodeType: "parameter",
+          tooltip: `<strong>${{p.name}}</strong><br>${{p.definition}}` }});
+        connectedIters.forEach(iterNode => {{
+          links.push({{ source: iterNode.id, target: id, type: "concept-of" }});
+        }});
+      }}
+    }});
+
+    (conceptsData.entities || []).forEach(ent => {{
+      const id = "entity-" + ent.name.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+      const connectedIters = iterNodes.filter(iterNode => iterConnected(iterNode, ent));
+      if (connectedIters.length > 0) {{
+        nodes.push({{ id, label: ent.name, nodeType: "entity",
+          tooltip: `<strong>${{ent.name}}</strong><br>${{ent.definition}}` }});
+        connectedIters.forEach(iterNode => {{
+          links.push({{ source: iterNode.id, target: id, type: "concept-of" }});
+        }});
+      }}
+    }});
+  }}
+
+  simulation = d3.forceSimulation(nodes)
+    .force("link", d3.forceLink(links).id(d => d.id).distance(d => {{
+      if (viewType === "iterations") return (d.type === "principle-of" || d.type === "concept-of") ? 40 : 280;
+      if (viewType === "principles") return d.weight ? Math.max(80, 200 / d.weight) : 140;
+      return 80;
+    }}))
+    .force("charge", d3.forceManyBody().strength(d => {{
+      if (viewType === "iterations") return (d.nodeType === "principle" || d.nodeType === "concept" || d.nodeType === "entity" || d.nodeType === "parameter") ? -15 : -600;
+      if (viewType === "principles") return -400;
+      return -80;
+    }}))
+    .force("center", d3.forceCenter(width / 2, height / 2))
+    .force("x", viewType === "principles" ? d3.forceX(width / 2).strength(0.08) : null)
+    .force("y", viewType === "principles" ? d3.forceY(height / 2).strength(0.08) : null)
+    .force("collision", d3.forceCollide().radius(d => {{
+      if (viewType === "iterations") return (d.nodeType === "principle" || d.nodeType === "concept" || d.nodeType === "entity") ? 18 : 50;
+      if (viewType === "principles") return (d.radius || 16) + 8;
+      return (d.radius || 14) + 4;
+    }}));
+
+  const link = g.append("g").selectAll("line")
+    .data(links)
+    .join("line")
+    .attr("class", d => {{
+      if (viewType === "iterations" && (d.type === "principle-of" || d.type === "concept-of")) return "principle-link link";
+      return "link";
+    }})
+    .attr("stroke", d => {{
+      if (viewType === "iterations") {{
+        if (d.type === "led-to") return "#555";
+        if (d.type === "concept-of") return "#5c6bc0";
+        return "#7c4dff";
+      }} else {{
+        if (d.type === "shared-principles") return "rgba(255,255,255,0.3)";
+        if (d.type === "contradicts") return "#f44336";
+        if (d.type === "supersedes") return "#ff9800";
+        if (d.type === "co-extracted") return "rgba(255,255,255,0.08)";
+        if (d.type === "concept-link") return "rgba(92,107,192,0.4)";
+        return "#555";
+      }}
+    }})
+    .attr("stroke-width", d => {{
+      if (d.type === "principle-of" || d.type === "extracted-from") return 1;
+      if (d.type === "shared-principles") return Math.min(d.weight || 1, 5);
+      return 2;
+    }})
+    .attr("stroke-dasharray", d => {{
+      if (d.type === "led-to" || d.type === "supersedes") return "4,4";
+      return null;
+    }})
+    .attr("stroke-opacity", d => {{
+      if (viewType === "iterations" && (d.type === "principle-of" || d.type === "concept-of")) return 0;
+      return 0.6;
+    }});
+
+  const node = g.append("g").selectAll("g")
+    .data(nodes)
+    .join("g")
+    .attr("class", d => {{
+      if (viewType === "iterations") {{
+        if (d.nodeType === "principle" || d.nodeType === "concept" || d.nodeType === "parameter" || d.nodeType === "entity") return "principle-node";
+        return "iteration-node";
+      }}
+      return "iteration-node";
+    }})
+    .call(d3.drag()
+      .on("start", (e, d) => {{ if (!e.active) simulation.alphaTarget(0.3).restart(); d.fx = d.x; d.fy = d.y; }})
+      .on("drag", (e, d) => {{ d.fx = e.x; d.fy = e.y; }})
+      .on("end", (e, d) => {{ if (!e.active) simulation.alphaTarget(0); d.fx = null; d.fy = null; }}));
+
+  if (viewType === "iterations") {{
+    // Iteration view rendering
+    const iterColorMap = {{ "CONFIRMED": "#4caf50", "REFUTED": "#f44336", "PARTIALLY_CONFIRMED": "#ff9800", "BASELINE": "#9e9e9e" }};
+
+    node.filter(d => d.nodeType === "iteration")
+      .append("circle")
+      .attr("r", 20)
+      .attr("fill", d => iterColorMap[d.outcome] || "#9e9e9e")
+      .attr("stroke", "#fff")
+      .attr("stroke-width", 2);
+
+    node.filter(d => d.nodeType === "principle")
+      .append("circle")
+      .attr("r", 6)
+      .attr("fill", "#7c4dff")
+      .attr("stroke", "#fff")
+      .attr("stroke-width", 1);
+
+    node.filter(d => d.nodeType === "principle")
+      .append("text")
+      .attr("class", "label")
+      .attr("dy", 16)
+      .style("font-size", "9px")
+      .text(d => d.label);
+
+    // Concept sub-nodes (small squares) in iterations view — no labels, tooltip only
+    node.filter(d => d.nodeType === "concept")
+      .style("cursor", "pointer")
+      .append("rect")
+      .attr("width", 14).attr("height", 14)
+      .attr("x", -7).attr("y", -7)
+      .attr("rx", 3).attr("ry", 3)
+      .attr("fill", "#1a237e")
+      .attr("stroke", "#5c6bc0")
+      .attr("stroke-width", 1.5);
+
+    // Parameter sub-nodes (small triangles) in iterations view — no labels, tooltip only
+    node.filter(d => d.nodeType === "parameter")
+      .style("cursor", "pointer")
+      .append("polygon")
+      .attr("points", "0,-8 7,6 -7,6")
+      .attr("fill", "#4a148c")
+      .attr("stroke", "#ce93d8")
+      .attr("stroke-width", 1.5);
+
+    // Entity sub-nodes (small diamonds) in iterations view — no labels, tooltip only
+    node.filter(d => d.nodeType === "entity")
+      .style("cursor", "pointer")
+      .append("polygon")
+      .attr("points", "-7,0 0,-7 7,0 0,7")
+      .attr("fill", "#1b5e20")
+      .attr("stroke", "#66bb6a")
+      .attr("stroke-width", 1.5);
+
+    // Cost bars to the right of iteration nodes (stacked: design=blue, execute=green)
+    if (llmMetrics && Object.keys(llmMetrics).length > 0) {{
+      const maxCost = Math.max(...Object.values(llmMetrics).map(m => m.total_cost || 0));
+      const barMaxHeight = 30;
+      const barWidth = 6;
+
+      const iterCostGroup = node.filter(d => d.nodeType === "iteration" && llmMetrics[d.id])
+        .append("g")
+        .attr("class", "cost-bar")
+        .attr("transform", `translate(24, -${{barMaxHeight / 2}})`);
+
+      // Design phase bar (blue) - top portion
+      iterCostGroup.append("rect")
+        .attr("width", barWidth)
+        .attr("height", d => {{
+          const m = llmMetrics[d.id];
+          return m.design ? (m.design.cost_usd / maxCost) * barMaxHeight : 0;
+        }})
+        .attr("y", d => {{
+          const m = llmMetrics[d.id];
+          const designH = m.design ? (m.design.cost_usd / maxCost) * barMaxHeight : 0;
+          const execH = m.execute ? (m.execute.cost_usd / maxCost) * barMaxHeight : 0;
+          return barMaxHeight - designH - execH;
+        }})
+        .attr("rx", 1)
+        .attr("fill", "#ef6c00")
+        .attr("opacity", 0.85);
+
+      // Execute phase bar (cyan) - bottom portion
+      iterCostGroup.append("rect")
+        .attr("width", barWidth)
+        .attr("height", d => {{
+          const m = llmMetrics[d.id];
+          return m.execute ? (m.execute.cost_usd / maxCost) * barMaxHeight : 0;
+        }})
+        .attr("y", d => {{
+          const m = llmMetrics[d.id];
+          const execH = m.execute ? (m.execute.cost_usd / maxCost) * barMaxHeight : 0;
+          return barMaxHeight - execH;
+        }})
+        .attr("rx", 1)
+        .attr("fill", "#00acc1")
+        .attr("opacity", 0.85);
+    }}
+
+    node.filter(d => d.nodeType === "iteration")
+      .append("text")
+      .attr("class", "label")
+      .attr("dy", 35)
+      .text(d => d.label);
+  }} else {{
+    // Principles view — concept/entity knowledge graph
+    // Truncate labels: use abbreviation if present, otherwise shorten
+    function shortLabel(name, max) {{
+      const abbrev = name.match(/\(([^)]+)\)/);
+      if (abbrev && abbrev[1].length <= max) return abbrev[1];
+      const base = name.replace(/\s*\([^)]*\)\s*/g, "").trim();
+      return base.length <= max ? base : base.slice(0, max - 1) + "\u2026";
+    }}
+
+    node.filter(d => d.nodeType === "concept")
+      .style("cursor", "pointer")
+      .append("rect")
+      .attr("width", d => Math.max(d.radius * 2, 32))
+      .attr("height", d => Math.max(d.radius * 2, 32))
+      .attr("x", d => -Math.max(d.radius, 16))
+      .attr("y", d => -Math.max(d.radius, 16))
+      .attr("rx", 6).attr("ry", 6)
+      .attr("fill", "#1a237e")
+      .attr("stroke", "#5c6bc0")
+      .attr("stroke-width", 2);
+
+    node.filter(d => d.nodeType === "concept")
+      .append("text")
+      .attr("class", "label")
+      .attr("dy", d => Math.max(d.radius, 16) + 14)
+      .style("fill", "#9fa8da")
+      .style("font-weight", "600")
+      .style("font-size", "10px")
+      .text(d => shortLabel(d.label, 18));
+
+    node.filter(d => d.nodeType === "entity")
+      .style("cursor", "pointer")
+      .append("polygon")
+      .attr("points", d => {{
+        const r = Math.max(d.radius, 16);
+        return `-${{r}},0 0,-${{r}} ${{r}},0 0,${{r}}`;
+      }})
+      .attr("fill", "#1b5e20")
+      .attr("stroke", "#66bb6a")
+      .attr("stroke-width", 2);
+
+    node.filter(d => d.nodeType === "entity")
+      .append("text")
+      .attr("class", "label")
+      .attr("dy", d => Math.max(d.radius, 16) + 14)
+      .style("fill", "#a5d6a7")
+      .style("font-weight", "600")
+      .style("font-size", "10px")
+      .text(d => shortLabel(d.label, 18));
+
+    // Parameter nodes (triangles, smaller) in knowledge graph
+    node.filter(d => d.nodeType === "parameter")
+      .style("cursor", "pointer")
+      .append("polygon")
+      .attr("points", d => {{
+        const r = Math.max(d.radius * 0.6, 10);
+        return `0,-${{r}} ${{r}},${{r * 0.75}} -${{r}},${{r * 0.75}}`;
+      }})
+      .attr("fill", "#4a148c")
+      .attr("stroke", "#ce93d8")
+      .attr("stroke-width", 1.5);
+
+    node.filter(d => d.nodeType === "parameter")
+      .append("text")
+      .attr("class", "label")
+      .attr("dy", d => Math.max(d.radius * 0.6, 10) + 12)
+      .style("fill", "#ce93d8")
+      .style("font-weight", "600")
+      .style("font-size", "9px")
+      .text(d => shortLabel(d.label, 16));
+  }}
+
+  // Tooltip
+  const tooltip = d3.select("#tooltip");
+  node.on("mouseover", (e, d) => {{
+    let html = d.tooltip;
+    // Enrich iteration tooltips with cost data
+    if (d.nodeType === "iteration" && llmMetrics && llmMetrics[d.id]) {{
+      const m = llmMetrics[d.id];
+      html += `<br><hr style="border-color:#0f3460;margin:6px 0;">`;
+      html += `<span style="color:#ffab40;">Cost: $$${{m.total_cost.toFixed(2)}}</span>`;
+      if (m.design) html += `<br><span style="color:#ef6c00;">Design:</span> $$${{m.design.cost_usd.toFixed(2)}} (${{m.design.model.replace("claude-", "")}}, ${{m.design.num_turns}} turns)`;
+      if (m.execute) html += `<br><span style="color:#00acc1;">Execute:</span> $$${{m.execute.cost_usd.toFixed(2)}} (${{m.execute.model.replace("claude-", "")}}, ${{m.execute.num_turns}} turns)`;
+      const durationMin = (m.total_duration_ms / 60000).toFixed(1);
+      html += `<br>Duration: ${{durationMin}} min`;
+    }}
+    tooltip.style("display", "block")
+      .html(html)
+      .style("left", (e.pageX + 12) + "px")
+      .style("top", (e.pageY - 12) + "px");
+  }})
+  .on("mouseout", () => tooltip.style("display", "none"));
+
+  // Click to show detail panel + expand sub-nodes (iterations view only)
+  if (viewType === "iterations") {{
+    node.filter(d => d.nodeType === "iteration")
+      .on("click", (e, d) => {{
+        if (conceptsData) {{
+          // Hide all concept/entity nodes and links first
+          g.selectAll("g.principle-node").classed("visible", false);
+          link.filter(l => l.type === "concept-of").classed("visible", false);
+
+          // Show only the ones for this iteration (unless clicking the same node again)
+          const relevantIds = new Set();
+          (conceptsData.concepts || []).forEach(c => {{
+            if (iterConnected(d, c)) {{
+              relevantIds.add("concept-" + c.name.toLowerCase().replace(/[^a-z0-9]+/g, "-"));
+            }}
+          }});
+          (conceptsData.parameters || []).forEach(p => {{
+            if (iterConnected(d, p)) {{
+              relevantIds.add("param-" + p.name.toLowerCase().replace(/[^a-z0-9]+/g, "-"));
+            }}
+          }});
+          (conceptsData.entities || []).forEach(ent => {{
+            if (iterConnected(d, ent)) {{
+              relevantIds.add("entity-" + ent.name.toLowerCase().replace(/[^a-z0-9]+/g, "-"));
+            }}
+          }});
+
+          if (d._lastClicked) {{
+            // Clicking same node again — hide (already hidden above)
+            d._lastClicked = false;
+          }} else {{
+            // Clear flag on all nodes, set on this one
+            nodes.forEach(n => n._lastClicked = false);
+            d._lastClicked = true;
+            g.selectAll("g.principle-node")
+              .filter(p => relevantIds.has(p.id))
+              .classed("visible", true);
+            link.filter(l => l.type === "concept-of" && l.source.id === d.id)
+              .classed("visible", true);
+          }}
+        }} else {{
+          // Fallback: show principle sub-nodes
+          const principleIds = links
+            .filter(l => l.type === "principle-of" && l.source.id === d.id)
+            .map(l => l.target.id);
+          const pNodes = g.selectAll("g.principle-node")
+            .filter(p => principleIds.includes(p.id));
+          const isVisible = pNodes.classed("visible");
+          pNodes.classed("visible", !isVisible);
+          link.filter(l => l.type === "principle-of" && l.source.id === d.id)
+            .classed("visible", !isVisible);
+        }}
+        // Show detail panel
+        showIterPanel(d);
+      }});
+
+    // Click concept/parameter/entity sub-nodes to show their detail panel (iterations context)
+    node.filter(d => d.nodeType === "concept" || d.nodeType === "parameter" || d.nodeType === "entity")
+      .on("click", (e, d) => {{
+        showConceptPanel(d, "iterations");
+      }});
+  }}
+
+  // Click handler for principles (knowledge graph) view
+  if (viewType === "principles") {{
+    node.on("click", (e, d) => {{
+      showConceptPanel(d, "knowledge");
+    }});
+  }}
+
+  // Compute and draw permanent revisit arcs for iterations view
+  let revisitArcsData = [];
+  if (viewType === "iterations" && conceptsData) {{
+    const iterNodesOnly = nodes.filter(n => n.nodeType === "iteration")
+      .sort((a, b) => parseInt(a.id.replace("iter-", "")) - parseInt(b.id.replace("iter-", "")));
+    // For each iteration, find which sub-node IDs it connects to
+    const iterSubMap = {{}};
+    links.forEach(l => {{
+      if (l.type === "concept-of") {{
+        const srcId = (typeof l.source === "object") ? l.source.id : l.source;
+        const tgtId = (typeof l.target === "object") ? l.target.id : l.target;
+        if (!iterSubMap[srcId]) iterSubMap[srcId] = new Set();
+        iterSubMap[srcId].add(tgtId);
+      }}
+    }});
+    // Find revisit pairs: iter-N shares 2+ concepts with iter-M (M < N-1)
+    // Only keep the strongest match per iteration (most shared concepts)
+    for (let n = 2; n < iterNodesOnly.length; n++) {{
+      const curId = iterNodesOnly[n].id;
+      const curSubs = iterSubMap[curId] || new Set();
+      if (curSubs.size === 0) continue;
+      const prevSubs = iterSubMap[iterNodesOnly[n - 1].id] || new Set();
+      let bestMatch = null;
+      for (let m = 0; m < n - 1; m++) {{
+        const earlierId = iterNodesOnly[m].id;
+        const earlierSubs = iterSubMap[earlierId] || new Set();
+        let shared = 0;
+        curSubs.forEach(s => {{ if (earlierSubs.has(s)) shared++; }});
+        if (shared >= 2) {{
+          let prevShared = 0;
+          curSubs.forEach(s => {{ if (prevSubs.has(s)) prevShared++; }});
+          if (shared > prevShared && (!bestMatch || shared > bestMatch.shared)) {{
+            bestMatch = {{ fromId: earlierId, toId: curId, shared: shared }};
+          }}
+        }}
+      }}
+      if (bestMatch) revisitArcsData.push(bestMatch);
+    }}
+  }}
+
+  // Draw revisit arcs as SVG paths (start hidden, fade in after simulation settles)
+  const revisitPaths = g.append("g").attr("class", "revisit-arcs-permanent")
+    .selectAll("path")
+    .data(revisitArcsData)
+    .join("path")
+    .attr("class", "revisit-arc")
+    .attr("stroke", "#ffb74d")
+    .attr("stroke-width", 1.5)
+    .attr("stroke-dasharray", "6,3")
+    .attr("opacity", 0)
+    .attr("fill", "none");
+
+  let tickCount = 0;
+  simulation.on("tick", () => {{
+    tickCount++;
+    link.attr("x1", d => d.source.x).attr("y1", d => d.source.y)
+        .attr("x2", d => d.target.x).attr("y2", d => d.target.y);
+    node.attr("transform", d => `translate(${{d.x}},${{d.y}})`);
+    // Update revisit arc paths every tick
+    if (revisitArcsData.length > 0) {{
+      revisitPaths.attr("d", arc => {{
+        const fromNode = nodes.find(n => n.id === arc.fromId);
+        const toNode = nodes.find(n => n.id === arc.toId);
+        if (!fromNode || !toNode) return "";
+        const midX = (fromNode.x + toNode.x) / 2;
+        const midY = Math.min(fromNode.y, toNode.y) - 60 - arc.shared * 10;
+        return `M${{fromNode.x}},${{fromNode.y}} Q${{midX}},${{midY}} ${{toNode.x}},${{toNode.y}}`;
+      }});
+      // Fade in arcs after layout stabilizes (~120 ticks), and only when not in timeline mode
+      if (tickCount === 120) {{
+        revisitPaths.transition().duration(800)
+          .attr("opacity", d => timelineActive ? 0 : 0.5);
+      }}
+    }}
+  }});
+}}
+
+// --- Timeline animation ---
+let timelineActive = false;
+let timelinePlaying = false;
+let timelineInterval = null;
+let timelineStep = 0;
+let timelineMaxSteps = 0;
+
+function getIterationNodes() {{
+  return iterData.nodes.filter(n => n.nodeType === "iteration")
+    .sort((a, b) => {{
+      const numA = parseInt(a.id.replace("iter-", ""));
+      const numB = parseInt(b.id.replace("iter-", ""));
+      return numA - numB;
+    }});
+}}
+
+function startTimeline() {{
+  if (currentView !== "iterations") return;
+  const iterNodes = getIterationNodes();
+  timelineMaxSteps = iterNodes.length - 1;
+  if (timelineMaxSteps < 1) return;
+
+  timelineActive = true;
+  timelineStep = 0;
+  timelinePlaying = true;
+
+  const slider = document.getElementById("timeline-slider");
+  slider.max = timelineMaxSteps;
+  slider.value = 0;
+
+  document.getElementById("timeline-trigger").classList.remove("visible");
+  document.getElementById("timeline-controls").classList.add("visible");
+  document.getElementById("timeline-play-btn").innerHTML = "&#9646;&#9646;";
+
+  applyTimelineFilter(0);
+  timelineInterval = setInterval(() => {{
+    if (timelineStep < timelineMaxSteps) {{
+      timelineStep++;
+      document.getElementById("timeline-slider").value = timelineStep;
+      applyTimelineFilter(timelineStep);
+    }} else {{
+      pauseTimeline();
+    }}
+  }}, 1500);
+}}
+
+function toggleTimelinePlay() {{
+  if (timelinePlaying) {{
+    pauseTimeline();
+  }} else {{
+    resumeTimeline();
+  }}
+}}
+
+function pauseTimeline() {{
+  timelinePlaying = false;
+  if (timelineInterval) clearInterval(timelineInterval);
+  timelineInterval = null;
+  document.getElementById("timeline-play-btn").innerHTML = "&#9654;";
+}}
+
+function resumeTimeline() {{
+  if (timelineStep >= timelineMaxSteps) timelineStep = 0;
+  timelinePlaying = true;
+  document.getElementById("timeline-play-btn").innerHTML = "&#9646;&#9646;";
+  timelineInterval = setInterval(() => {{
+    if (timelineStep < timelineMaxSteps) {{
+      timelineStep++;
+      document.getElementById("timeline-slider").value = timelineStep;
+      applyTimelineFilter(timelineStep);
+    }} else {{
+      pauseTimeline();
+    }}
+  }}, 1500);
+}}
+
+function scrubTimeline(val) {{
+  timelineStep = parseInt(val);
+  applyTimelineFilter(timelineStep);
+  if (timelinePlaying) pauseTimeline();
+}}
+
+function dismissTimeline() {{
+  pauseTimeline();
+  timelineActive = false;
+  document.getElementById("timeline-controls").classList.remove("visible");
+  document.getElementById("timeline-trigger").classList.add("visible");
+  document.getElementById("timeline-narrative").classList.remove("visible");
+  // Restore full visibility
+  d3.selectAll("g.iteration-node, g.principle-node").style("opacity", null).style("pointer-events", null);
+  d3.selectAll("line.link").style("opacity", null);
+  // Remove animation-only revisit arcs and restore permanent ones
+  d3.selectAll(".revisit-arc-anim").remove();
+  d3.selectAll(".revisit-arcs-permanent path").transition().duration(400).attr("opacity", 0.5);
+}}
+
+function computeRevisitArcs(step, iterNodes) {{
+  // A "revisit" is when iter-N shares concept sub-nodes with iter-M (M < N-1)
+  // indicating the researcher went back to an earlier idea
+  const arcs = [];
+  if (step < 2) return arcs;
+  const currentId = iterNodes[step].id;
+  // Get concept-of links from the current iteration
+  const currentSubIds = new Set();
+  d3.selectAll("line.link").each(function(l) {{
+    const srcId = (typeof l.source === "object") ? l.source.id : l.source;
+    const tgtId = (typeof l.target === "object") ? l.target.id : l.target;
+    if (l.type === "concept-of" && srcId === currentId) currentSubIds.add(tgtId);
+  }});
+  if (currentSubIds.size === 0) return arcs;
+  // Check earlier non-adjacent iterations (skip step-1, that's sequential)
+  for (let i = 0; i < step - 1; i++) {{
+    const earlierId = iterNodes[i].id;
+    let shared = 0;
+    d3.selectAll("line.link").each(function(l) {{
+      const srcId = (typeof l.source === "object") ? l.source.id : l.source;
+      const tgtId = (typeof l.target === "object") ? l.target.id : l.target;
+      if (l.type === "concept-of" && srcId === earlierId && currentSubIds.has(tgtId)) shared++;
+    }});
+    // Only show if significant overlap (2+ shared concepts) and the immediately
+    // previous iteration does NOT share those same concepts (true revisit)
+    if (shared >= 2) {{
+      const prevId = iterNodes[step - 1].id;
+      let prevShared = 0;
+      d3.selectAll("line.link").each(function(l) {{
+        const srcId = (typeof l.source === "object") ? l.source.id : l.source;
+        const tgtId = (typeof l.target === "object") ? l.target.id : l.target;
+        if (l.type === "concept-of" && srcId === prevId && currentSubIds.has(tgtId)) prevShared++;
+      }});
+      if (shared > prevShared) {{
+        arcs.push({{ from: earlierId, to: currentId, shared: shared }});
+      }}
+    }}
+  }}
+  return arcs;
+}}
+
+function drawRevisitArcs(arcs) {{
+  // Remove old animation-only arcs (not permanent ones)
+  d3.selectAll(".revisit-arc-anim").remove();
+  if (!g || arcs.length === 0) return;
+  // Draw curved arcs between non-adjacent iterations
+  const arcGroup = g.append("g").attr("class", "revisit-arc-anim");
+  arcs.forEach(arc => {{
+    // Find node positions from the simulation
+    const fromNode = d3.selectAll("g.iteration-node").filter(d => d.id === arc.from).datum();
+    const toNode = d3.selectAll("g.iteration-node").filter(d => d.id === arc.to).datum();
+    if (!fromNode || !toNode) return;
+    // Draw a quadratic bezier arc above the nodes
+    const midX = (fromNode.x + toNode.x) / 2;
+    const midY = Math.min(fromNode.y, toNode.y) - 80;
+    const pathD = `M${{fromNode.x}},${{fromNode.y}} Q${{midX}},${{midY}} ${{toNode.x}},${{toNode.y}}`;
+    arcGroup.append("path")
+      .attr("d", pathD)
+      .attr("stroke", "#ffb74d")
+      .attr("stroke-width", 2)
+      .attr("stroke-dasharray", "6,3")
+      .attr("fill", "none")
+      .attr("opacity", 0)
+      .transition().duration(600)
+      .attr("opacity", 0.8);
+  }});
+}}
+
+function applyTimelineFilter(step) {{
+  const iterNodes = getIterationNodes();
+  const currentIterId = iterNodes[step].id;
+  const visibleIterIds = new Set(iterNodes.slice(0, step + 1).map(n => n.id));
+
+  document.getElementById("timeline-label").textContent =
+    iterNodes[step].label + " / " + iterNodes[iterNodes.length - 1].label;
+
+  // --- Narrative annotation ---
+  const narrative = narrativesData[currentIterId];
+  const summary = iterSummaries[currentIterId];
+  const narrEl = document.getElementById("timeline-narrative");
+  const narrText = summary ? summary.what_was_tried : (narrative ? narrative.title : "");
+  if (narrText) {{
+    const curOutcome = iterNodes[step].outcome;
+    const outcomeColors = {{ "CONFIRMED": "#4caf50", "REFUTED": "#f44336", "PARTIALLY_CONFIRMED": "#ff9800" }};
+    const borderColor = outcomeColors[curOutcome] || "#0f3460";
+    // Preamble: why this iteration exists (based on previous outcome)
+    let preamble = "";
+    if (step > 0) {{
+      const prevOutcome = iterNodes[step - 1].outcome;
+      if (prevOutcome === "CONFIRMED") preamble = "Built on success";
+      else if (prevOutcome === "REFUTED") preamble = "Pivoted after failure";
+      else if (prevOutcome === "PARTIALLY_CONFIRMED") preamble = "Refined partial result";
+    }}
+    let narrHtml = `<div style="font-size:9px;color:${{borderColor}};font-weight:600;margin-bottom:4px;">${{iterNodes[step].label}}${{preamble ? " — " + preamble : ""}}</div>`;
+    narrHtml += `<div class="narr-title" style="border-left:3px solid ${{borderColor}};padding-left:8px;">${{narrText}}</div>`;
+    narrEl.innerHTML = narrHtml;
+    narrEl.classList.add("visible");
+  }} else {{
+    narrEl.classList.remove("visible");
+  }}
+
+  // Permanent revisit arcs are shown/hidden at the end of this function
+
+  // --- Node/edge visibility ---
+  // Determine visible sub-node IDs: those connected to a visible iteration
+  const visibleSubIds = new Set();
+  d3.selectAll("line.link").each(function(l) {{
+    const srcId = (typeof l.source === "object") ? l.source.id : l.source;
+    const tgtId = (typeof l.target === "object") ? l.target.id : l.target;
+    if (l.type === "concept-of" && visibleIterIds.has(srcId)) {{
+      visibleSubIds.add(tgtId);
+    }}
+  }});
+
+  // Apply visibility to iteration nodes
+  d3.selectAll("g.iteration-node").each(function(d) {{
+    const visible = visibleIterIds.has(d.id);
+    d3.select(this)
+      .transition().duration(400)
+      .style("opacity", visible ? 1 : 0.08)
+      .style("pointer-events", visible ? "all" : "none");
+  }});
+
+  // Apply visibility to sub-nodes (concepts, params, entities)
+  d3.selectAll("g.principle-node").each(function(d) {{
+    const visible = visibleSubIds.has(d.id);
+    d3.select(this)
+      .transition().duration(400)
+      .style("opacity", visible ? 0.9 : 0.05)
+      .style("pointer-events", visible ? "all" : "none");
+  }});
+
+  // Apply visibility to edges
+  d3.selectAll("line.link").each(function(l) {{
+    const srcId = (typeof l.source === "object") ? l.source.id : l.source;
+    const tgtId = (typeof l.target === "object") ? l.target.id : l.target;
+    let visible = false;
+    if (l.type === "led-to") {{
+      visible = visibleIterIds.has(srcId) && visibleIterIds.has(tgtId);
+    }} else if (l.type === "concept-of") {{
+      visible = visibleIterIds.has(srcId) && visibleSubIds.has(tgtId);
+    }} else {{
+      visible = visibleIterIds.has(srcId) || visibleIterIds.has(tgtId);
+    }}
+    d3.select(this)
+      .transition().duration(400)
+      .style("opacity", visible ? null : 0.05);
+  }});
+
+  // Hide/show permanent revisit arcs based on endpoint visibility
+  d3.selectAll(".revisit-arcs-permanent path").each(function() {{
+    const d = d3.select(this).datum();
+    const bothVisible = visibleIterIds.has(d.fromId) && visibleIterIds.has(d.toId);
+    d3.select(this).transition().duration(400).attr("opacity", bothVisible ? 0.5 : 0);
+  }});
+}}
+
+// Initial render
+render(iterData, "iterations");
+renderCostChart();
+
+// Show timeline trigger if there are at least 2 iterations
+if (getIterationNodes().length >= 2) {{
+  document.getElementById("timeline-trigger").classList.add("visible");
+}}
+</script>
+</body>
+</html>"""
+
+
+def load_campaign(campaign_path: Path):
+    """Load ledger.json and principles.json from campaign directory."""
+    ledger_path = campaign_path / "ledger.json"
+    principles_path = campaign_path / "principles.json"
+
+    if not ledger_path.exists():
+        sys.exit(f"Error: {ledger_path} not found")
+    if not principles_path.exists():
+        sys.exit(f"Error: {principles_path} not found")
+
+    with open(ledger_path) as f:
+        ledger = json.load(f)
+    with open(principles_path) as f:
+        principles = json.load(f)
+
+    return ledger, principles
+
+
+def load_llm_metrics(campaign_path: Path, ledger: dict) -> dict:
+    """Load LLM cost metrics from llm_metrics.jsonl and group by iteration.
+
+    Returns a dict keyed by iteration ID (e.g., "iter-1") with cost breakdowns.
+    Each iteration has two phases: design (planner) and execute-analyze (executor).
+    Handles retries correctly by assigning entries to iterations based on
+    timestamps rather than assuming strict design/execute pairs.
+    """
+    metrics_path = campaign_path / "llm_metrics.jsonl"
+    if not metrics_path.exists():
+        return {}
+
+    entries = []
+    with open(metrics_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+
+    if not entries:
+        return {}
+
+    iterations = ledger.get("iterations", [])
+    result = {}
+
+    # Include all iterations with a timestamp (excludes only baseline iter-0).
+    # FAILED iterations are included so their costs aren't misattributed to neighbors.
+    non_baseline = [
+        it for it in iterations
+        if isinstance(it.get("iteration"), int) and it["iteration"] > 0 and it.get("timestamp")
+    ]
+    if not non_baseline:
+        return {}
+
+    def parse_ts(ts_str):
+        if not ts_str:
+            return None
+        try:
+            dt = datetime.fromisoformat(ts_str)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=timezone.utc)
+            return dt
+        except (ValueError, TypeError):
+            return None
+
+    # Build sorted iteration end-timestamps for bucketing metrics entries.
+    iter_boundaries = []
+    for it in non_baseline:
+        end_ts = parse_ts(it.get("timestamp"))
+        if end_ts is None:
+            continue
+        iter_boundaries.append({
+            "iter_id": f"iter-{it['iteration']}",
+            "end_ts": end_ts,
+        })
+    iter_boundaries.sort(key=lambda b: b["end_ts"])
+
+    if not iter_boundaries:
+        return {}
+
+    # Assign each metrics entry to the first iteration whose end_ts >= entry_ts.
+    iter_entries = {b["iter_id"]: [] for b in iter_boundaries}
+    for entry in entries:
+        entry_ts = parse_ts(entry.get("timestamp"))
+        if entry_ts is None:
+            continue
+        assigned = None
+        for b in iter_boundaries:
+            if entry_ts <= b["end_ts"]:
+                assigned = b["iter_id"]
+                break
+        if assigned is None:
+            # Entry after last completed iteration (e.g., failed/in-progress subsequent iter)
+            assigned = iter_boundaries[-1]["iter_id"]
+        iter_entries[assigned].append(entry)
+
+    # Aggregate per iteration: sum all design entries and all execute entries.
+    for b in iter_boundaries:
+        iter_id = b["iter_id"]
+        entries_for_iter = iter_entries[iter_id]
+
+        design_entries = [e for e in entries_for_iter if e.get("role") == "planner"]
+        execute_entries = [e for e in entries_for_iter if e.get("role") == "executor"]
+
+        iter_metrics = {"design": None, "execute": None, "total_cost": 0, "total_duration_ms": 0, "total_turns": 0}
+
+        if design_entries:
+            iter_metrics["design"] = {
+                "model": design_entries[-1].get("model", "unknown"),
+                "cost_usd": sum(e.get("cost_usd") or 0 for e in design_entries),
+                "duration_ms": sum(e.get("duration_ms") or 0 for e in design_entries),
+                "num_turns": sum(e.get("num_turns") or 0 for e in design_entries),
+                "input_tokens": sum(e.get("input_tokens") or 0 for e in design_entries),
+                "output_tokens": sum(e.get("output_tokens") or 0 for e in design_entries),
+            }
+
+        if execute_entries:
+            iter_metrics["execute"] = {
+                "model": execute_entries[-1].get("model", "unknown"),
+                "cost_usd": sum(e.get("cost_usd") or 0 for e in execute_entries),
+                "duration_ms": sum(e.get("duration_ms") or 0 for e in execute_entries),
+                "num_turns": sum(e.get("num_turns") or 0 for e in execute_entries),
+                "input_tokens": sum(e.get("input_tokens") or 0 for e in execute_entries),
+                "output_tokens": sum(e.get("output_tokens") or 0 for e in execute_entries),
+            }
+
+        for phase in ["design", "execute"]:
+            if iter_metrics[phase]:
+                iter_metrics["total_cost"] += iter_metrics[phase]["cost_usd"]
+                iter_metrics["total_duration_ms"] += iter_metrics[phase]["duration_ms"]
+                iter_metrics["total_turns"] += iter_metrics[phase]["num_turns"]
+
+        result[iter_id] = iter_metrics
+
+    return result
+
+
+def build_iterations_graph(ledger: dict, principles: dict) -> dict:
+    """Build nodes and links for the iterations-centric D3 graph."""
+    nodes = []
+    links = []
+    iterations = ledger.get("iterations", [])
+    all_principles = {p["id"]: p for p in principles.get("principles", [])}
+
+    # Build iteration nodes
+    for it in iterations:
+        iteration_id = f"iter-{it['iteration']}"
+        outcome = it.get("h_main_result") or "BASELINE"
+        accuracy = it.get("prediction_accuracy")
+        acc_str = f"{accuracy['accuracy_pct']}% ({accuracy['arms_correct']}/{accuracy['arms_total']})" if accuracy else "N/A"
+
+        tooltip = (
+            f"<strong>{it.get('family', iteration_id)}</strong><br>"
+            f"Iteration: {it['iteration']}<br>"
+            f"Outcome: {outcome}<br>"
+            f"Prediction accuracy: {acc_str}<br>"
+            f"Principles extracted: {len(it.get('principles_extracted', []))}"
+        )
+
+        nodes.append({
+            "id": iteration_id,
+            "nodeType": "iteration",
+            "label": f"iter-{it['iteration']}",
+            "family": it.get("family", ""),
+            "outcome": outcome,
+            "tooltip": tooltip,
+            "principles": [pe["id"] for pe in it.get("principles_extracted", [])],
+        })
+
+    # Sequential "led-to" edges
+    for i in range(len(iterations) - 1):
+        links.append({
+            "source": f"iter-{iterations[i]['iteration']}",
+            "target": f"iter-{iterations[i+1]['iteration']}",
+            "type": "led-to",
+        })
+
+    # Build principle sub-nodes and link to parent iteration
+    for it in iterations:
+        iteration_id = f"iter-{it['iteration']}"
+        for pe in it.get("principles_extracted", []):
+            pid = pe["id"]
+            principle = all_principles.get(pid)
+            if not principle:
+                continue
+
+            principle_node_id = f"{iteration_id}-{pid}"
+            tooltip = (
+                f"<strong>{pid}</strong><br>"
+                f"{principle['statement'][:150]}...<br>"
+                f"Confidence: {principle.get('confidence', 'unknown')}<br>"
+                f"Regime: {principle.get('regime', 'N/A')[:80]}"
+            )
+
+            nodes.append({
+                "id": principle_node_id,
+                "nodeType": "principle",
+                "label": pid,
+                "tooltip": tooltip,
+            })
+
+            links.append({
+                "source": iteration_id,
+                "target": principle_node_id,
+                "type": "principle-of",
+            })
+
+    return {"nodes": nodes, "links": links}
+
+
+def build_principles_graph(ledger: dict, principles: dict) -> dict:
+    """Build principle node data for panel lookups (statement, confidence, regime, mechanism).
+
+    The Knowledge tab uses concept/parameter/entity nodes instead of principle nodes,
+    but panels still need to look up principle details by ID.
+    """
+    nodes = []
+    links = []
+    iterations = ledger.get("iterations", [])
+    all_principles = {p["id"]: p for p in principles.get("principles", [])}
+
+    # Track which iterations extracted each principle
+    principle_iterations = {}  # pid -> list of iteration numbers
+    for it in iterations:
+        for pe in it.get("principles_extracted", []):
+            pid = pe["id"]
+            if pid not in principle_iterations:
+                principle_iterations[pid] = []
+            if it["iteration"] not in principle_iterations[pid]:
+                principle_iterations[pid].append(it["iteration"])
+
+    # Build principle nodes
+    for pid, principle in all_principles.items():
+        iters = principle_iterations.get(pid, [])
+
+        nodes.append({
+            "id": pid,
+            "nodeType": "principle",
+            "label": pid,
+            "statement": principle["statement"][:200],
+            "confidence": principle.get("confidence", "unknown"),
+            "regime": principle.get("regime", ""),
+            "mechanism": principle.get("mechanism", ""),
+        })
+
+    # Build principle-to-principle edges from contradicts/superseded_by
+    for pid, principle in all_principles.items():
+        for contra_id in principle.get("contradicts", []):
+            if contra_id in all_principles:
+                edge = {"source": pid, "target": contra_id, "type": "contradicts"}
+                reverse = {"source": contra_id, "target": pid, "type": "contradicts"}
+                if edge not in links and reverse not in links:
+                    links.append(edge)
+
+        superseded_by = principle.get("superseded_by")
+        if superseded_by and superseded_by in all_principles:
+            links.append({
+                "source": pid,
+                "target": superseded_by,
+                "type": "supersedes",
+            })
+
+    return {"nodes": nodes, "links": links}
+
+
+def load_findings(campaign_path: Path, ledger: dict) -> dict:
+    """Load findings.json from each iteration's run directory.
+
+    Returns a dict keyed by iter-N with the arms array from findings.json.
+    """
+    findings = {}
+    for it in ledger.get("iterations", []):
+        iter_num = it["iteration"]
+        iter_id = f"iter-{iter_num}"
+        findings_path = campaign_path / "runs" / iter_id / "findings.json"
+        if findings_path.exists():
+            try:
+                data = json.loads(findings_path.read_text())
+                findings[iter_id] = data.get("arms", [])
+            except (json.JSONDecodeError, KeyError):
+                pass
+    return findings
+
+
+def load_iter_narratives(campaign_path: Path, ledger: dict) -> dict:
+    """Load iteration narrative data: problem.md title and family transitions.
+
+    Returns a dict keyed by iter-N with:
+      - title: first heading from problem.md (stripped of "# Problem Framing — " prefix)
+      - family: the experiment family name
+    """
+    narratives = {}
+    iterations = ledger.get("iterations", [])
+    for i, it in enumerate(iterations):
+        iter_num = it["iteration"]
+        iter_id = f"iter-{iter_num}"
+        family = it.get("family", "")
+
+        # Extract title from problem.md
+        title = ""
+        problem_path = campaign_path / "runs" / iter_id / "problem.md"
+        if problem_path.exists():
+            first_line = problem_path.read_text().split("\n", 1)[0]
+            # Strip markdown heading and common prefixes
+            title = re.sub(r"^#\s*", "", first_line)
+            title = re.sub(r"^Problem Framing\s*[—–-]\s*", "", title, flags=re.IGNORECASE)
+            title = re.sub(r"^Iter(ation)?\s*-?\d+:?\s*", "", title, flags=re.IGNORECASE)
+            title = title.strip()
+
+        narratives[iter_id] = {
+            "title": title,
+            "family": family,
+        }
+    return narratives
+
+
+def build_insights_data(wiki_dir: Path, campaign_name: str) -> dict:
+    """Build insights data from per-campaign JSON files."""
+    campaign_dir = wiki_dir / "campaigns" / campaign_name
+    result = {}
+
+    # Read dead-ends.json
+    dead_ends_path = campaign_dir / "dead-ends.json"
+    if dead_ends_path.exists():
+        with open(dead_ends_path) as f:
+            result["dead_ends"] = json.load(f)
+
+    # Read frontiers.json
+    frontiers_path = campaign_dir / "frontiers.json"
+    if frontiers_path.exists():
+        with open(frontiers_path) as f:
+            result["frontiers"] = json.load(f)
+
+    # Read interactions.json
+    interactions_path = campaign_dir / "interactions.json"
+    if interactions_path.exists():
+        with open(interactions_path) as f:
+            result["interactions"] = json.load(f)
+
+    return result
+
+
+def _make_kg_id(node_type: str, name: str) -> str:
+    """Generate a stable node ID from type and name.
+
+    Must match the JS slug algorithm: replace all non-[a-z0-9] with dashes.
+    """
+    import re
+    slug = re.sub(r"[^a-z0-9]+", "-", name.lower()).strip("-")
+    return f"{node_type}-{slug}"
+
+
+def _build_knowledge_graph(concepts_data: dict) -> dict:
+    """Build nodes+edges for the Knowledge tab from explicit relationship fields."""
+    if not concepts_data:
+        return {"nodes": [], "edges": []}
+
+    nodes = []
+    for concept in concepts_data.get("concepts", []):
+        nodes.append({
+            "id": _make_kg_id("concept", concept["name"]),
+            "name": concept["name"],
+            "type": "concept",
+            "definition": concept.get("definition", ""),
+            "principles": concept.get("principles", []),
+        })
+    for param in concepts_data.get("parameters", []):
+        nodes.append({
+            "id": _make_kg_id("param", param["name"]),
+            "name": param["name"],
+            "type": "parameter",
+            "definition": param.get("definition", ""),
+            "principles": param.get("principles", []),
+            "evolution": param.get("evolution", []),
+        })
+    for entity in concepts_data.get("entities", []):
+        nodes.append({
+            "id": _make_kg_id("entity", entity["name"]),
+            "name": entity["name"],
+            "type": "entity",
+            "definition": entity.get("definition", ""),
+            "principles": entity.get("principles", []),
+        })
+
+    node_index = {n["id"]: n for n in nodes}
+    edges = []
+
+    for concept in concepts_data.get("concepts", []):
+        concept_id = _make_kg_id("concept", concept["name"])
+        for entity_name in concept.get("operates_on", []):
+            entity_id = _make_kg_id("entity", entity_name)
+            if entity_id in node_index:
+                shared = set(concept.get("principles", [])) & set(node_index[entity_id].get("principles", []))
+                edges.append({"source": concept_id, "target": entity_id, "shared_principles": sorted(shared), "edge_type": "operates_on"})
+
+    # Derive has_param edges from parameter-side parent_concept (guarantees single owner)
+    for param in concepts_data.get("parameters", []):
+        parent_name = param.get("parent_concept")
+        if not parent_name:
+            continue
+        concept_id = _make_kg_id("concept", parent_name)
+        param_id = _make_kg_id("param", param["name"])
+        if concept_id in node_index and param_id in node_index:
+            shared = set(node_index[concept_id].get("principles", [])) & set(param.get("principles", []))
+            edges.append({"source": concept_id, "target": param_id, "shared_principles": sorted(shared), "edge_type": "has_param"})
+
+    # Entity↔Entity edges from principle overlap (≥2 shared)
+    entity_nodes = [n for n in nodes if n["type"] == "entity"]
+    for i in range(len(entity_nodes)):
+        for j in range(i + 1, len(entity_nodes)):
+            shared = set(entity_nodes[i]["principles"]) & set(entity_nodes[j]["principles"])
+            if len(shared) >= 2:
+                edges.append({"source": entity_nodes[i]["id"], "target": entity_nodes[j]["id"], "shared_principles": sorted(shared), "edge_type": "interacts"})
+
+    return {"nodes": nodes, "edges": edges}
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Visualize a Nous campaign as a knowledge graph")
+    parser.add_argument("campaign_path", help="Path to .nous/<campaign-name>/ directory")
+    parser.add_argument("--output", "-o", help="Output HTML file path")
+    parser.add_argument("--wiki", "-w", default=str(Path.home() / ".nous" / "wiki"),
+                        help="Path to wiki directory (default: ~/.nous/wiki/)")
+    parser.add_argument("--insights", help="JSON file with pre-summarized insights (overrides wiki extraction)")
+    parser.add_argument("--summaries", "-s", help="JSON file with iteration summaries (keyed by iter-N)")
+    parser.add_argument("--concepts", help="JSON file with concepts and entities for the Knowledge tab")
+    parser.add_argument("--no-open", action="store_true", help="Don't open browser")
+    parser.add_argument("--summary-md", help="Markdown file for the Summary tab (overrides wiki lookup)")
+    args = parser.parse_args()
+
+    campaign_path = Path(args.campaign_path).resolve()
+    campaign_name = campaign_path.name
+
+    # Default output location
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        viz_dir = Path.home() / ".nous" / "wiki" / "viz"
+        viz_dir.mkdir(parents=True, exist_ok=True)
+        output_path = viz_dir / f"{campaign_name}.html"
+
+    ledger, principles = load_campaign(campaign_path)
+    iter_graph = build_iterations_graph(ledger, principles)
+    princ_graph = build_principles_graph(ledger, principles)
+
+    # Build insights: use pre-summarized file if provided, else extract raw from wiki
+    if args.insights:
+        with open(args.insights) as f:
+            insights = json.load(f)
+    else:
+        wiki_dir = Path(args.wiki)
+        insights = build_insights_data(wiki_dir, campaign_name)
+
+    # Load iteration summaries
+    if args.summaries:
+        with open(args.summaries) as f:
+            iter_summaries = json.load(f)
+    else:
+        iter_summaries = {}
+
+    # Load concepts/entities and pre-compute knowledge graph
+    if args.concepts:
+        with open(args.concepts) as f:
+            concepts_data = json.load(f)
+    else:
+        concepts_data = None
+
+    knowledge_graph_data = _build_knowledge_graph(concepts_data) if concepts_data else {"nodes": [], "edges": []}
+
+    # Load findings, narratives, and LLM cost metrics from run directories
+    findings_data = load_findings(campaign_path, ledger)
+    narratives_data = load_iter_narratives(campaign_path, ledger)
+    llm_metrics = load_llm_metrics(campaign_path, ledger)
+
+    # Load campaign context from campaign.yaml
+    campaign_context = {}
+    campaign_yaml_path = campaign_path / "campaign.yaml"
+    if campaign_yaml_path.exists():
+        import yaml
+        campaign_config = yaml.safe_load(campaign_yaml_path.read_text()) or {}
+        campaign_context["research_question"] = campaign_config.get("research_question", "").strip()
+        # Extract runtime metadata (target_commit, target_repo, nous_version, started_at)
+        runtime = campaign_config.get("runtime") or {}
+        if runtime.get("target_commit"):
+            campaign_context["target_commit"] = runtime["target_commit"]
+        if runtime.get("target_repo"):
+            campaign_context["target_repo"] = runtime["target_repo"]
+        if runtime.get("nous_version"):
+            campaign_context["nous_version"] = runtime["nous_version"]
+        if runtime.get("started_at"):
+            campaign_context["started_at"] = runtime["started_at"]
+
+    # Load summary.md for the Summary tab
+    if args.summary_md:
+        summary_md_path = Path(args.summary_md)
+        if not summary_md_path.exists():
+            print(f"Error: --summary-md file not found: {args.summary_md}", file=sys.stderr)
+            sys.exit(1)
+        summary_md = summary_md_path.read_text()
+    else:
+        summary_md = ""
+        wiki_campaigns_dir = Path.home() / ".nous" / "wiki" / "campaigns" / campaign_name
+        summary_md_path = wiki_campaigns_dir / "summary.md"
+        if summary_md_path.exists():
+            summary_md = summary_md_path.read_text()
+
+    html = HTML_TEMPLATE.format(
+        title=campaign_name,
+        iter_data_json=json.dumps(iter_graph, indent=2),
+        princ_data_json=json.dumps(princ_graph, indent=2),
+        insights_data_json=json.dumps(insights),
+        iter_summaries_json=json.dumps(iter_summaries),
+        campaign_context_json=json.dumps(campaign_context),
+        concepts_data_json=json.dumps(concepts_data),
+        findings_data_json=json.dumps(findings_data),
+        narratives_data_json=json.dumps(narratives_data),
+        summary_md_json=json.dumps(summary_md),
+        knowledge_graph_json=json.dumps(knowledge_graph_data),
+        llm_metrics_json=json.dumps(llm_metrics),
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html)
+    print(f"Generated: {output_path}")
+
+    if not args.no_open:
+        webbrowser.open(f"file://{output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/agents/nous/workspace/scripts/visualize_registry.py
+++ b/packages/agents/nous/workspace/scripts/visualize_registry.py
@@ -1,0 +1,2038 @@
+#!/usr/bin/env python3
+"""Generate an interactive D3.js cross-campaign knowledge graph from the Nous wiki registry.
+
+Reads ~/.nous/wiki/registry.json and per-campaign files to produce a self-contained
+HTML visualization showing campaigns, entities, concepts, and parameters as an
+interconnected force-directed graph.
+
+Usage:
+    python scripts/visualize_registry.py [--wiki <path>] [--output <path>] [--no-open]
+
+    --wiki: path to wiki directory (default: ~/.nous/wiki/)
+    --output: output HTML file path (default: ~/.nous/wiki/viz/registry.html)
+    --no-open: don't open browser after generation
+"""
+
+import argparse
+import json
+import sys
+import webbrowser
+from pathlib import Path
+
+
+HTML_TEMPLATE = """<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>Nous Registry — Cross-Campaign Knowledge Graph</title>
+<style>
+  * {{ box-sizing: border-box; }}
+  body {{ margin: 0; background: #1a1a2e; font-family: -apple-system, system-ui, sans-serif; overflow: hidden; }}
+  #graph {{ width: 100vw; height: 100vh; display: block; }}
+
+  .node {{ cursor: pointer; }}
+  .node:hover {{ filter: brightness(1.3); }}
+  .link {{ stroke-opacity: 0.5; fill: none; }}
+  .link:hover {{ stroke-opacity: 1; }}
+
+  .label {{
+    font-size: 10px; fill: #e0e0e0; pointer-events: none;
+    text-anchor: middle; dominant-baseline: middle;
+  }}
+  .label-campaign {{ font-size: 12px; font-weight: 600; fill: #fff; }}
+
+  /* Tooltip */
+  .tooltip {{
+    position: absolute; background: #16213e; border: 1px solid #0f3460;
+    border-radius: 8px; padding: 14px; color: #e0e0e0; font-size: 12px;
+    max-width: 420px; pointer-events: none; display: none; z-index: 200;
+    line-height: 1.5; box-shadow: 0 4px 20px rgba(0,0,0,0.5);
+  }}
+  .tooltip h3 {{ margin: 0 0 6px; font-size: 14px; color: #fff; }}
+  .tooltip .tt-type {{ color: #888; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; }}
+  .tooltip .tt-field {{ margin-top: 8px; }}
+  .tooltip .tt-label {{ color: #888; font-size: 10px; }}
+  .tooltip .tt-value {{ color: #ccc; margin-top: 2px; }}
+
+  /* Detail panel */
+  .detail-panel {{
+    position: absolute; top: 16px; right: 16px; width: 360px;
+    max-height: calc(100vh - 32px); overflow-y: auto;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 8px;
+    padding: 20px; color: #e0e0e0; font-size: 12px; z-index: 100;
+    display: none; box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+  }}
+  .detail-panel.visible {{ display: block; }}
+  .detail-panel h2 {{ margin: 0 0 4px; font-size: 16px; color: #fff; }}
+  .detail-panel .panel-type {{ color: #888; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 12px; }}
+  .detail-panel .panel-section {{ margin-top: 14px; padding-top: 12px; border-top: 1px solid #0f3460; }}
+  .detail-panel .panel-section-title {{ color: #888; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px; margin-bottom: 6px; }}
+  .detail-panel .panel-item {{ margin: 4px 0; padding: 4px 8px; background: rgba(255,255,255,0.03); border-radius: 4px; }}
+  .detail-panel .panel-close {{
+    position: absolute; top: 12px; right: 12px; background: none;
+    border: none; color: #888; font-size: 18px; cursor: pointer; padding: 4px 8px;
+  }}
+  .detail-panel .panel-close:hover {{ color: #fff; }}
+  .detail-panel .campaign-date {{ color: #7986cb; font-size: 11px; }}
+
+
+
+  /* Rendered markdown in panels */
+  .panel-summary {{ color: #ccc; line-height: 1.6; }}
+  .md-section-title {{
+    color: #90a4ae; font-size: 11px; font-weight: 600;
+    text-transform: uppercase; letter-spacing: 0.5px;
+    margin-top: 14px; margin-bottom: 6px; padding-top: 10px;
+    border-top: 1px solid #0f3460;
+  }}
+  .md-section-title:first-child {{ border-top: none; margin-top: 0; padding-top: 0; }}
+  .md-para {{ margin: 6px 0; font-size: 12px; color: #ccc; line-height: 1.6; }}
+  .md-list {{ margin: 4px 0; padding-left: 16px; }}
+  .md-list li {{ margin: 4px 0; font-size: 11px; color: #bbb; line-height: 1.5; }}
+  .md-list li strong {{ color: #e0e0e0; }}
+  .md-kv {{ margin: 3px 0; font-size: 11px; color: #bbb; }}
+  .md-kv strong {{ color: #90a4ae; }}
+
+  /* View toggle */
+  .view-toggle {{
+    position: absolute; top: 16px; left: 50%; transform: translateX(-50%); z-index: 70;
+    display: flex; gap: 0;
+  }}
+  .view-btn {{
+    background: #16213e; border: 1px solid #0f3460; color: #e0e0e0;
+    padding: 8px 16px; cursor: pointer; font-size: 12px; transition: all 0.2s;
+  }}
+  .view-btn:first-child {{ border-radius: 6px 0 0 6px; }}
+  .view-btn:last-child {{ border-radius: 0 6px 6px 0; }}
+  .view-btn.active {{ background: #0f3460; color: #fff; font-weight: 600; }}
+
+  /* Cost badge on campaign nodes */
+  .cost-badge {{
+    font-size: 9px; fill: #ffab40; font-weight: 600;
+    text-anchor: middle; pointer-events: none;
+  }}
+
+  /* Opportunities list view */
+  #opp-list-container {{
+    position: absolute; top: 0; left: 0; right: 0; bottom: 0;
+    overflow-y: auto; padding: 60px 32px 24px;
+    background: #1a1a2e; z-index: 40;
+  }}
+  .opp-header {{
+    color: #888; font-size: 10px; text-transform: uppercase;
+    letter-spacing: 0.8px; margin-bottom: 16px; padding-bottom: 8px;
+    border-bottom: 1px solid #0f3460;
+    display: flex; align-items: center; gap: 16px;
+  }}
+  .opp-cluster-bar {{
+    display: flex; gap: 8px; flex-wrap: wrap; align-items: center;
+    padding: 12px 0 16px; border-bottom: 1px solid #0f3460; margin-bottom: 16px;
+  }}
+  .opp-cluster-bar-label {{
+    color: #888; font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+    margin-right: 4px;
+  }}
+  .opp-cluster-btn {{
+    background: #0d1b2a; border: 1px solid #0f3460; color: #aaa;
+    padding: 6px 14px; border-radius: 5px; font-size: 11px; cursor: pointer;
+    transition: all 0.15s; font-weight: 500;
+  }}
+  .opp-cluster-btn:hover {{ border-color: #5c6bc0; color: #ccc; }}
+  .opp-cluster-btn.active {{ border-color: var(--btn-color, #66bb6a); color: #fff; background: rgba(255,255,255,0.08); font-weight: 600; }}
+  .opp-cluster-btn .cluster-dot-inline {{
+    display: inline-block; width: 8px; height: 8px; border-radius: 2px; margin-right: 6px;
+  }}
+  .opp-header .opp-total-cost {{
+    float: right; color: #ffab40; font-size: 12px; font-weight: 600;
+    text-transform: none; letter-spacing: normal;
+  }}
+  .opp-card {{
+    background: #16213e; border: 1px solid #0f3460; border-radius: 8px;
+    padding: 16px 20px; margin-bottom: 12px; transition: border-color 0.2s;
+    cursor: pointer;
+  }}
+  .opp-card:hover {{ border-color: #5c6bc0; }}
+  .opp-card-header {{
+    display: flex; align-items: center; gap: 10px; margin-bottom: 8px;
+  }}
+  .opp-card-type {{
+    font-size: 9px; font-weight: 700; text-transform: uppercase;
+    letter-spacing: 0.5px; padding: 2px 8px; border-radius: 3px;
+  }}
+  .opp-card-type.frontier {{ background: #e65100; color: #fff; }}
+  .opp-card-type.interaction {{ background: #00695c; color: #fff; }}
+  .opp-card-title {{
+    font-size: 14px; font-weight: 600; color: #fff; flex: 1;
+  }}
+  .opp-card-cost {{
+    font-size: 13px; font-weight: 700; color: #ffab40;
+    white-space: nowrap;
+  }}
+  .opp-card-meta {{
+    display: flex; gap: 16px; font-size: 11px; color: #888; margin-bottom: 10px;
+  }}
+  .opp-card-body {{
+    font-size: 12px; color: #ccc; line-height: 1.6;
+  }}
+  .opp-card-principles {{
+    margin-top: 10px; display: flex; flex-wrap: wrap; gap: 4px;
+  }}
+  .opp-card-principles .principle-tag {{
+    font-size: 9px; background: rgba(121,134,203,0.15); color: #7986cb;
+    padding: 2px 6px; border-radius: 3px; font-weight: 600;
+  }}
+  .opp-card-detail {{
+    display: none; margin-top: 12px; padding-top: 12px;
+    border-top: 1px solid #0f3460; font-size: 11px; color: #aaa; line-height: 1.6;
+  }}
+  .opp-card.expanded .opp-card-detail {{ display: block; }}
+  .opp-card-detail .detail-section {{
+    margin-bottom: 10px;
+  }}
+  .opp-card-detail .detail-label {{
+    color: #888; font-size: 9px; text-transform: uppercase;
+    letter-spacing: 0.5px; margin-bottom: 4px;
+  }}
+  .opp-card-detail .detail-value {{ color: #ccc; }}
+
+  /* Stats bar */
+  .stats-bar {{
+    position: absolute; bottom: 16px; left: 16px; background: #16213e;
+    border: 1px solid #0f3460; border-radius: 8px; padding: 10px 14px;
+    color: #e0e0e0; font-size: 11px; z-index: 50; display: flex; gap: 16px;
+  }}
+  .stats-bar .stat-value {{ font-size: 14px; font-weight: 600; color: #fff; }}
+  .stats-bar .stat-label {{ color: #888; font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px; }}
+
+  .node-glow {{
+    filter: drop-shadow(0 0 6px rgba(255, 215, 0, 0.8));
+  }}
+
+  /* Filter panel */
+  .filter-panel {{
+    position: absolute; top: 16px; left: 16px; width: 260px;
+    max-height: calc(100vh - 32px); overflow-y: auto;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 8px;
+    padding: 16px; color: #e0e0e0; font-size: 11px; z-index: 60;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+  }}
+  .filter-panel h4 {{
+    margin: 0 0 8px; font-size: 12px; color: #fff; text-transform: uppercase;
+    letter-spacing: 0.5px;
+  }}
+  .filter-step {{ margin-bottom: 14px; }}
+  .filter-step-label {{
+    color: #888; font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px;
+    margin-bottom: 6px; display: flex; align-items: center; gap: 6px;
+  }}
+  .filter-step-num {{
+    display: inline-flex; align-items: center; justify-content: center;
+    width: 16px; height: 16px; border-radius: 50%; background: #0f3460;
+    color: #5c6bc0; font-size: 9px; font-weight: 700;
+  }}
+  .filter-step-num.done {{ background: #1b5e20; color: #66bb6a; }}
+  .filter-select {{
+    width: 100%; background: #0d1b2a; border: 1px solid #0f3460; color: #e0e0e0;
+    padding: 6px 8px; border-radius: 5px; font-size: 11px; cursor: pointer;
+  }}
+  .filter-select:focus {{ outline: none; border-color: #5c6bc0; }}
+  .entity-chips {{
+    display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px;
+  }}
+  .entity-chip {{
+    background: #0d1b2a; border: 1px solid #0f3460; color: #aaa;
+    padding: 4px 8px; border-radius: 4px; font-size: 10px; cursor: pointer;
+    transition: all 0.15s;
+  }}
+  .entity-chip:hover {{ border-color: #66bb6a; color: #ccc; }}
+  .entity-chip.selected {{ background: #1b5e20; border-color: #66bb6a; color: #fff; }}
+
+  /* Cluster groups in filter panel */
+  .cluster-group {{
+    margin-bottom: 8px; border: 1px solid #0f3460; border-radius: 6px;
+    overflow: hidden; transition: border-color 0.2s;
+  }}
+  .cluster-group.selected {{ border-color: var(--cluster-color, #66bb6a); }}
+  .cluster-header {{
+    display: flex; align-items: center; gap: 8px; padding: 8px 10px;
+    cursor: pointer; transition: background 0.2s;
+  }}
+  .cluster-header:hover {{ background: rgba(255,255,255,0.03); }}
+  .cluster-dot {{
+    width: 10px; height: 10px; border-radius: 2px; flex-shrink: 0;
+  }}
+  .cluster-name {{
+    flex: 1; font-size: 11px; color: #ccc; font-weight: 600;
+  }}
+  .cluster-count {{
+    font-size: 9px; color: #888; background: #0d1b2a; padding: 2px 6px;
+    border-radius: 3px;
+  }}
+  .cluster-entities {{
+    padding: 0 10px 8px; display: flex; flex-wrap: wrap; gap: 3px;
+  }}
+  .filter-btn {{
+    width: 100%; background: transparent; border: 1px solid #0f3460; color: #888;
+    padding: 8px; border-radius: 5px; font-size: 11px; font-weight: 600;
+    cursor: pointer; text-transform: uppercase; letter-spacing: 0.5px;
+    margin-top: 10px; transition: all 0.2s;
+  }}
+  .filter-btn:hover {{ border-color: #f44336; color: #f44336; }}
+  .scope-summary {{
+    margin-top: 10px; padding: 8px; background: rgba(255,255,255,0.03);
+    border-radius: 5px; font-size: 10px; color: #aaa; line-height: 1.6;
+  }}
+  .scope-summary .scope-count {{ color: #fff; font-weight: 600; }}
+
+  /* Legend panel */
+  .legend-panel {{
+    position: absolute; bottom: 16px; right: 16px;
+    background: #16213e; border: 1px solid #0f3460; border-radius: 8px;
+    padding: 14px 16px; color: #e0e0e0; font-size: 11px; z-index: 50;
+    box-shadow: 0 4px 20px rgba(0,0,0,0.4); min-width: 200px;
+  }}
+  .legend-panel.collapsed {{
+    padding: 8px 12px; min-width: auto;
+  }}
+  .legend-panel.collapsed .legend-body {{ display: none; }}
+  .legend-toggle {{
+    background: none; border: none; color: #888; font-size: 10px;
+    cursor: pointer; text-transform: uppercase; letter-spacing: 0.5px;
+    padding: 0; display: flex; align-items: center; gap: 6px;
+  }}
+  .legend-toggle:hover {{ color: #fff; }}
+  .legend-section-title {{
+    color: #888; font-size: 9px; text-transform: uppercase; letter-spacing: 0.5px;
+    margin: 10px 0 6px; padding-top: 8px; border-top: 1px solid #0f3460;
+  }}
+  .legend-section-title:first-child {{ border-top: none; margin-top: 4px; padding-top: 0; }}
+  .legend-row {{
+    display: flex; align-items: center; gap: 8px; margin: 5px 0;
+  }}
+  .legend-row span {{ color: #ccc; font-size: 11px; }}
+</style>
+</head>
+<body>
+<div class="view-toggle">
+  <button class="view-btn active" id="btn-knowledge" onclick="switchView('knowledge')">Knowledge</button>
+  <button class="view-btn" id="btn-opportunities" onclick="switchView('opportunities')">Opportunities</button>
+</div>
+<div id="opp-list-container" style="display:none;"></div>
+<div class="tooltip" id="tooltip"></div>
+<div class="detail-panel" id="detail-panel">
+  <button class="panel-close" onclick="closePanel()">&times;</button>
+  <div id="panel-content"></div>
+</div>
+<div class="filter-panel" id="filter-panel">
+  <h4>Registry Explorer</h4>
+  <div class="filter-step" id="step-project">
+    <div class="filter-step-label"><span class="filter-step-num" id="step1-num">1</span> Project</div>
+    <select class="filter-select" id="project-select" onchange="onProjectSelect()">
+      <option value="">Select project...</option>
+    </select>
+  </div>
+  <div class="filter-step" id="step-entities" style="display:none;">
+    <div class="filter-step-label"><span class="filter-step-num" id="step2-num">2</span> Select entity cluster</div>
+    <div id="cluster-groups"></div>
+  </div>
+  <div id="scope-summary" style="display:none;"></div>
+  <button class="filter-btn reset" id="reset-btn" style="display:none;" onclick="resetFilter()">Reset</button>
+</div>
+<div class="stats-bar" id="stats-bar"></div>
+<div class="legend-panel" id="legend-panel">
+  <button class="legend-toggle" id="legend-toggle" onclick="toggleLegend()">
+    <span id="legend-arrow">&#9662;</span> Legend
+  </button>
+  <div class="legend-body" id="legend-body">
+    <div class="legend-section-title">Nodes</div>
+    <div class="legend-row">
+      <svg width="16" height="16"><circle cx="8" cy="8" r="6" fill="#78909c" stroke="#b0bec5" stroke-width="1.5"/></svg>
+      <span>Campaign</span>
+    </div>
+    <div class="legend-row">
+      <svg width="16" height="16"><polygon points="8,2 14,8 8,14 2,8" fill="#1b5e20" stroke="#66bb6a" stroke-width="1.5"/></svg>
+      <span>Entity (colored by cluster)</span>
+    </div>
+    <div class="legend-row">
+      <svg width="16" height="16"><rect x="2" y="2" width="12" height="12" rx="3" ry="3" fill="#1a237e" stroke="#5c6bc0" stroke-width="1.5"/></svg>
+      <span>Concept</span>
+    </div>
+    <div class="legend-row">
+      <svg width="16" height="16"><polygon points="8,2 14,13 2,13" fill="#4a148c" stroke="#ce93d8" stroke-width="1.5"/></svg>
+      <span>Parameter</span>
+    </div>
+    <div class="legend-section-title">Edges</div>
+    <div class="legend-row">
+      <svg width="30" height="8"><line x1="0" y1="4" x2="30" y2="4" stroke="#5c6bc0" stroke-width="1.5"/></svg>
+      <span>campaign &rarr; concept</span>
+    </div>
+    <div class="legend-row">
+      <svg width="30" height="8"><line x1="0" y1="4" x2="30" y2="4" stroke="#66bb6a" stroke-width="1.5" stroke-dasharray="4,3"/></svg>
+      <span>campaign &rarr; entity</span>
+    </div>
+    <div class="legend-row">
+      <svg width="30" height="8"><line x1="0" y1="4" x2="30" y2="4" stroke="#80cbc4" stroke-width="1.5" stroke-dasharray="2,2"/></svg>
+      <span>concept operates_on entity</span>
+    </div>
+    <div class="legend-row">
+      <svg width="30" height="8"><line x1="0" y1="4" x2="30" y2="4" stroke="#ce93d8" stroke-width="1.5" stroke-dasharray="3,2"/></svg>
+      <span>concept has_param</span>
+    </div>
+    <div class="legend-row">
+      <svg width="30" height="8"><line x1="0" y1="4" x2="30" y2="4" stroke="#90a4ae" stroke-width="1.5" stroke-dasharray="4,2"/></svg>
+      <span>entity &harr; entity (interacts)</span>
+    </div>
+    <div class="legend-row">
+      <svg width="30" height="8"><line x1="0" y1="4" x2="30" y2="4" stroke="#ffab40" stroke-width="1.5" stroke-dasharray="6,2"/></svg>
+      <span>shared principles</span>
+    </div>
+  </div>
+</div>
+<svg id="graph"></svg>
+
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script>
+// --- Data injected by Python ---
+const registryData = {registry_data_json};
+const campaignDetails = {campaign_details_json};
+const crossEdges = {cross_edges_json};
+const retrievalScopes = {retrieval_scopes_json};
+const campaignCosts = {campaign_costs_json};
+const entityClusters = {entity_clusters_json};
+
+// --- Cluster color palette and mapping ---
+const clusterColors = ["#66bb6a", "#42a5f5", "#ffca28", "#ef5350", "#ab47bc", "#26c6da", "#ff7043"];
+const clusterFills = ["#1b5e20", "#0d47a1", "#5d4037", "#b71c1c", "#4a148c", "#004d40", "#bf360c"];
+
+// Build node_id → cluster index map
+const entityClusterMap = {{}};
+entityClusters.forEach(cluster => {{
+  cluster.node_ids.forEach(nid => {{
+    entityClusterMap[nid] = cluster.id;
+  }});
+}});
+
+function entityClusterColor(nodeId) {{
+  const idx = entityClusterMap[nodeId];
+  if (idx == null) return "#66bb6a";
+  return clusterColors[idx % clusterColors.length];
+}}
+
+function entityClusterFill(nodeId) {{
+  const idx = entityClusterMap[nodeId];
+  if (idx == null) return "#1b5e20";
+  return clusterFills[idx % clusterFills.length];
+}}
+
+// --- Graph construction ---
+const nodes = [];
+const links = [];
+const nodeIndex = {{}};
+
+function addNode(id, data) {{
+  if (nodeIndex[id]) return nodeIndex[id];
+  const node = {{ id, ...data }};
+  nodes.push(node);
+  nodeIndex[id] = node;
+  return node;
+}}
+
+function addLink(source, target, data) {{
+  links.push({{ source, target, ...data }});
+}}
+
+// Build graph from registry
+Object.entries(registryData.projects || {{}}).forEach(([repoPath, project]) => {{
+  const campaigns = project.campaigns || [];
+  const entities = project.entities || [];
+
+  // Sort campaigns by date for timeline positioning
+  const sorted = [...campaigns].sort((a, b) => (a.date || "").localeCompare(b.date || ""));
+
+  // Add campaign nodes
+  sorted.forEach((campaign, idx) => {{
+    const cId = `campaign-${{campaign.name}}`;
+    addNode(cId, {{
+      type: "campaign",
+      label: campaign.name,
+      date: campaign.date,
+      research_question: campaign.research_question,
+      timeIndex: idx,
+      totalCampaigns: sorted.length,
+      conceptCount: (campaign.concepts || []).length,
+      paramCount: (campaign.parameters || []).length,
+      deadEndCount: (campaign.dead_ends || []).length,
+      frontierCount: (campaign.frontiers || []).length,
+    }});
+
+    // Add concept nodes and edges
+    (campaign.concepts || []).forEach(concept => {{
+      const nId = `concept-${{concept.id}}`;
+      addNode(nId, {{
+        type: "concept",
+        label: concept.name,
+        conceptId: concept.id,
+        campaign: campaign.name,
+      }});
+      addLink(cId, nId, {{ edgeType: "concept" }});
+    }});
+
+    // Add parameter nodes (no direct campaign link — connected via shared-principle edges)
+    (campaign.parameters || []).forEach(param => {{
+      const nId = `param-${{param.id}}`;
+      addNode(nId, {{
+        type: "parameter",
+        label: param.name,
+        paramId: param.id,
+        campaign: campaign.name,
+      }});
+    }});
+
+  }});
+
+  // Add entity nodes — these connect to multiple campaigns
+  entities.forEach(entity => {{
+    const eId = `entity-${{entity.id}}`;
+    addNode(eId, {{
+      type: "entity",
+      label: entity.name,
+      entityId: entity.id,
+      campaigns: entity.campaigns || [],
+      campaignCount: (entity.campaigns || []).length,
+    }});
+
+    // Link entity to each campaign that studied it
+    (entity.campaigns || []).forEach(campName => {{
+      const cId = `campaign-${{campName}}`;
+      if (nodeIndex[cId]) {{
+        addLink(cId, eId, {{ edgeType: "entity" }});
+      }}
+    }});
+  }});
+}});
+
+// --- Cross-node edges (from explicit relationship fields in concepts.json) ---
+crossEdges.forEach(e => {{
+  if (nodeIndex[e.source] && nodeIndex[e.target]) {{
+    addLink(e.source, e.target, {{ edgeType: e.edgeType, strength: e.strength }});
+  }}
+}});
+
+// Stats bar — hidden until retrieval scope is shown
+document.getElementById("stats-bar").style.display = "none";
+
+// --- Filter-driven retrieval (uses pre-computed scopes from Python) ---
+// retrievalScopes: entityName -> [nodeId, ...] — computed by retrieve_wiki_context logic
+
+const projectEntities = {{}};
+const projectNames = [];
+Object.entries(registryData.projects || {{}}).forEach(([repoPath, project]) => {{
+  projectNames.push(repoPath);
+  projectEntities[repoPath] = (project.entities || []).map(e => ({{
+    name: e.name,
+    id: e.id,
+    campaigns: e.campaigns || [],
+    campaignCount: (e.campaigns || []).length,
+  }}));
+}});
+
+// Populate project dropdown
+const projectSelect = document.getElementById("project-select");
+projectNames.forEach(name => {{
+  const opt = document.createElement("option");
+  opt.value = name;
+  opt.textContent = name.split("/").pop() || name;
+  projectSelect.appendChild(opt);
+}});
+
+let selectedProject = null;
+let selectedEntityNames = new Set();
+let filterScopeNodeIds = new Set();
+let filterActive = false;
+
+function onProjectSelect() {{
+  const val = projectSelect.value;
+  if (!val) {{
+    document.getElementById("step-entities").style.display = "none";
+    filterActive = false;
+    applyFilterVisuals();
+    document.getElementById("stats-bar").style.display = "none";
+    return;
+  }}
+  selectedProject = val;
+  selectedEntityNames.clear();
+  document.getElementById("step1-num").classList.add("done");
+  document.getElementById("step-entities").style.display = "block";
+  document.getElementById("scope-summary").style.display = "none";
+  document.getElementById("reset-btn").style.display = "none";
+
+  // Render cluster groups
+  const container = document.getElementById("cluster-groups");
+  container.innerHTML = "";
+  const projectEntityNames = new Set((projectEntities[val] || []).map(e => e.name));
+
+  entityClusters.forEach(cluster => {{
+    // Only show clusters that have entities in this project
+    const clusterEntitiesInProject = cluster.entities.filter(e => projectEntityNames.has(e));
+    if (clusterEntitiesInProject.length === 0) return;
+
+    const color = clusterColors[cluster.id % clusterColors.length];
+    const group = document.createElement("div");
+    group.className = "cluster-group";
+    group.style.setProperty("--cluster-color", color);
+    group.dataset.clusterId = cluster.id;
+
+    // Header (click to select/deselect all entities in cluster)
+    const header = document.createElement("div");
+    header.className = "cluster-header";
+    header.innerHTML = `
+      <span class="cluster-dot" style="background:${{color}}"></span>
+      <span class="cluster-name">${{cluster.label}}</span>
+      <span class="cluster-count">${{clusterEntitiesInProject.length}}</span>
+    `;
+    header.onclick = () => toggleCluster(cluster.id, clusterEntitiesInProject, group);
+    group.appendChild(header);
+
+    // Individual entity chips within cluster
+    const chipsDiv = document.createElement("div");
+    chipsDiv.className = "cluster-entities";
+    clusterEntitiesInProject.forEach(name => {{
+      const chip = document.createElement("span");
+      chip.className = "entity-chip";
+      chip.textContent = name;
+      chip.dataset.name = name;
+      chip.onclick = (evt) => {{
+        evt.stopPropagation();
+        toggleEntityChip(chip, name);
+        updateClusterGroupState(group, clusterEntitiesInProject);
+      }};
+      chipsDiv.appendChild(chip);
+    }});
+    group.appendChild(chipsDiv);
+
+    container.appendChild(group);
+  }});
+
+  // Show unclustered entities as individual chips below clusters
+  const clusteredNames = new Set();
+  entityClusters.forEach(c => c.entities.forEach(e => clusteredNames.add(e)));
+  const unclustered = [...projectEntityNames].filter(n => !clusteredNames.has(n)).sort();
+  if (unclustered.length > 0) {{
+    const uDiv = document.createElement("div");
+    uDiv.style.cssText = "margin-top:8px;padding-top:8px;border-top:1px solid #0f3460;";
+    const uLabel = document.createElement("div");
+    uLabel.style.cssText = "font-size:9px;color:#888;text-transform:uppercase;letter-spacing:0.5px;margin-bottom:6px;";
+    uLabel.textContent = "Unclustered entities";
+    uDiv.appendChild(uLabel);
+    const uChips = document.createElement("div");
+    uChips.className = "cluster-entities";
+    unclustered.forEach(name => {{
+      const chip = document.createElement("span");
+      chip.className = "entity-chip";
+      chip.textContent = name;
+      chip.dataset.name = name;
+      chip.onclick = (evt) => {{
+        evt.stopPropagation();
+        toggleEntityChip(chip, name);
+      }};
+      uChips.appendChild(chip);
+    }});
+    uDiv.appendChild(uChips);
+    container.appendChild(uDiv);
+  }}
+
+  filterActive = false;
+  applyFilterVisuals();
+  document.getElementById("stats-bar").style.display = "none";
+}}
+
+function toggleCluster(clusterId, entityNames, groupEl) {{
+  // Check if all entities in this cluster are already selected
+  const allSelected = entityNames.every(n => selectedEntityNames.has(n));
+
+  if (allSelected) {{
+    // Deselect all
+    entityNames.forEach(n => selectedEntityNames.delete(n));
+    groupEl.classList.remove("selected");
+    groupEl.querySelectorAll(".entity-chip").forEach(c => c.classList.remove("selected"));
+  }} else {{
+    // Select all
+    entityNames.forEach(n => selectedEntityNames.add(n));
+    groupEl.classList.add("selected");
+    groupEl.querySelectorAll(".entity-chip").forEach(c => c.classList.add("selected"));
+  }}
+
+  if (selectedEntityNames.size > 0) {{
+    runRetrieval();
+  }} else {{
+    filterActive = false;
+    applyFilterVisuals();
+    document.getElementById("stats-bar").style.display = "none";
+    document.getElementById("scope-summary").style.display = "none";
+    document.getElementById("reset-btn").style.display = "none";
+  }}
+}}
+
+function updateClusterGroupState(groupEl, clusterEntityNames) {{
+  const allSelected = clusterEntityNames.every(n => selectedEntityNames.has(n));
+  if (allSelected) {{
+    groupEl.classList.add("selected");
+  }} else {{
+    groupEl.classList.remove("selected");
+  }}
+}}
+
+function toggleEntityChip(chip, name) {{
+  if (selectedEntityNames.has(name)) {{
+    selectedEntityNames.delete(name);
+    chip.classList.remove("selected");
+  }} else {{
+    selectedEntityNames.add(name);
+    chip.classList.add("selected");
+  }}
+  if (selectedEntityNames.size > 0) {{
+    runRetrieval();
+  }} else {{
+    filterActive = false;
+    applyFilterVisuals();
+    document.getElementById("stats-bar").style.display = "none";
+    document.getElementById("scope-summary").style.display = "none";
+    document.getElementById("reset-btn").style.display = "none";
+  }}
+}}
+
+function runRetrieval() {{
+  // Union pre-computed scopes for all selected entities
+  filterScopeNodeIds = new Set();
+  selectedEntityNames.forEach(name => {{
+    const scope = retrievalScopes[name] || [];
+    scope.forEach(id => filterScopeNodeIds.add(id));
+  }});
+
+  filterActive = true;
+  applyFilterVisuals();
+
+  // Count node types in scope
+  const scopeEntities = [...filterScopeNodeIds].filter(id => id.startsWith("entity-"));
+  const scopeConcepts = [...filterScopeNodeIds].filter(id => id.startsWith("concept-"));
+  const scopeParams = [...filterScopeNodeIds].filter(id => id.startsWith("param-"));
+  const scopeCampaigns = [...filterScopeNodeIds].filter(id => id.startsWith("campaign-"));
+
+  const statsBar = document.getElementById("stats-bar");
+  statsBar.style.display = "flex";
+  statsBar.innerHTML = `
+    <div><div class="stat-value">${{scopeEntities.length}}</div><div class="stat-label">Entities</div></div>
+    <div><div class="stat-value">${{scopeConcepts.length}}</div><div class="stat-label">Concepts</div></div>
+    <div><div class="stat-value">${{scopeParams.length}}</div><div class="stat-label">Parameters</div></div>
+    <div><div class="stat-value">${{scopeCampaigns.length}}</div><div class="stat-label">Campaigns</div></div>
+  `;
+
+  const summary = document.getElementById("scope-summary");
+  summary.style.display = "block";
+  summary.className = "scope-summary";
+  summary.innerHTML = `
+    <div><span class="scope-count">${{scopeEntities.length}}</span> entities</div>
+    <div><span class="scope-count">${{scopeConcepts.length}}</span> concepts (operates_on)</div>
+    <div><span class="scope-count">${{scopeParams.length}}</span> parameters (parent_concept)</div>
+    <div><span class="scope-count">${{scopeCampaigns.length}}</span> campaigns</div>
+  `;
+  document.getElementById("reset-btn").style.display = "block";
+
+  zoomToFitScope();
+}}
+
+function zoomToFitScope() {{
+  // Compute bounding box of in-scope nodes
+  let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+  let count = 0;
+  nodes.forEach(d => {{
+    if (filterScopeNodeIds.has(d.id) && d.x != null && d.y != null) {{
+      const r = nodeRadius(d);
+      minX = Math.min(minX, d.x - r);
+      minY = Math.min(minY, d.y - r);
+      maxX = Math.max(maxX, d.x + r);
+      maxY = Math.max(maxY, d.y + r);
+      count++;
+    }}
+  }});
+  if (count === 0) return;
+
+  const padding = 60;
+  const bw = maxX - minX + padding * 2;
+  const bh = maxY - minY + padding * 2;
+  const midX = (minX + maxX) / 2;
+  const midY = (minY + maxY) / 2;
+  const scale = Math.min(1.2, 0.7 / Math.max(bw / width, bh / height));
+  const translate = [width / 2 - scale * midX, height / 2 - scale * midY];
+
+  svg.transition().duration(600).call(
+    zoom.transform,
+    d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale)
+  );
+}}
+
+function applyFilterVisuals() {{
+  if (!filterActive) {{
+    // Show all nodes and links when no filter is active
+    node.style("display", null);
+    node.selectAll("circle, rect, polygon").attr("opacity", 1);
+    node.selectAll("text").attr("opacity", 1);
+    link.style("display", null);
+    link.attr("stroke-opacity", 0.5);
+    return;
+  }}
+
+  // Show only nodes in the retrieval scope
+  node.each(function(d) {{
+    const el = d3.select(this);
+    if (filterScopeNodeIds.has(d.id)) {{
+      el.style("display", null);
+      el.selectAll("circle, rect, polygon").attr("opacity", 1);
+      el.selectAll("text").attr("opacity", 1);
+    }} else {{
+      el.style("display", "none");
+    }}
+  }});
+
+  // Show only edges where both endpoints are in scope
+  link.each(function(d) {{
+    const el = d3.select(this);
+    const srcId = d.source.id || d.source;
+    const tgtId = d.target.id || d.target;
+    if (filterScopeNodeIds.has(srcId) && filterScopeNodeIds.has(tgtId)) {{
+      el.style("display", null);
+      el.attr("stroke-opacity", 0.7);
+    }} else {{
+      el.style("display", "none");
+    }}
+  }});
+}}
+
+function resetFilter() {{
+  filterActive = false;
+  filterScopeNodeIds.clear();
+  selectedEntityNames.clear();
+  applyFilterVisuals();
+
+  // Reset UI
+  document.getElementById("stats-bar").style.display = "none";
+  document.getElementById("scope-summary").style.display = "none";
+  document.getElementById("reset-btn").style.display = "none";
+  document.getElementById("step2-num").classList.remove("done");
+  document.querySelectorAll(".entity-chip").forEach(c => c.classList.remove("selected"));
+  document.querySelectorAll(".cluster-group").forEach(g => g.classList.remove("selected"));
+}}
+
+// --- Markdown renderer ---
+function renderMarkdown(md) {{
+  if (!md) return "";
+  // Remove the top-level H1 title (campaign name) — we already show it in the panel header
+  let lines = md.split("\\n");
+  if (lines[0] && lines[0].startsWith("# ")) lines = lines.slice(1);
+  md = lines.join("\\n").trim();
+
+  // Process block-level elements
+  let html = "";
+  const blocks = md.split(/\\n{{2,}}/);
+  for (let block of blocks) {{
+    block = block.trim();
+    if (!block) continue;
+
+    // H2 headings → styled section headers
+    if (block.startsWith("## ")) {{
+      const title = block.replace(/^## /, "");
+      html += `<div class="md-section-title">${{inlineFormat(title)}}</div>`;
+      continue;
+    }}
+
+    // Bullet lists
+    if (/^[-*] /.test(block)) {{
+      const items = block.split(/\\n/).filter(l => l.trim());
+      html += `<ul class="md-list">`;
+      items.forEach(item => {{
+        const text = item.replace(/^[-*] /, "");
+        html += `<li>${{inlineFormat(text)}}</li>`;
+      }});
+      html += `</ul>`;
+      continue;
+    }}
+
+    // Key-value lines (like **Date:** value)
+    if (/^[*][*][^*]+:[*][*]/.test(block)) {{
+      const kvLines = block.split("\\n").filter(l => l.trim());
+      kvLines.forEach(line => {{
+        html += `<div class="md-kv">${{inlineFormat(line)}}</div>`;
+      }});
+      continue;
+    }}
+
+    // Regular paragraph
+    html += `<p class="md-para">${{inlineFormat(block.replace(/\\n/g, " "))}}</p>`;
+  }}
+  return html;
+}}
+
+function inlineFormat(text) {{
+  // Bold: **text**
+  text = text.replace(/[*][*]([^*]+)[*][*]/g, '<strong>$1</strong>');
+  // Italic: *text*
+  text = text.replace(/[*]([^*]+)[*]/g, '<em>$1</em>');
+  // Inline code: `text`
+  text = text.replace(/`([^`]+)`/g, '<code style="background:rgba(255,255,255,0.08);padding:1px 4px;border-radius:3px;font-size:11px;">$1</code>');
+  // RP-N references highlighted
+  text = text.replace(/\\b(RP-\\d+)\\b/g, '<span style="color:#7986cb;font-weight:600;">$1</span>');
+  return text;
+}}
+
+// --- D3 visualization ---
+const width = window.innerWidth;
+const height = window.innerHeight;
+
+const svg = d3.select("#graph")
+  .attr("width", width)
+  .attr("height", height);
+
+
+// Zoom behavior
+const g = svg.append("g");
+const zoom = d3.zoom()
+  .scaleExtent([0.2, 4])
+  .on("zoom", (event) => g.attr("transform", event.transform));
+svg.call(zoom);
+
+// Color and size scales (synced with visualize_campaign.py)
+const typeColors = {{
+  campaign: "#78909c",
+  concept: "#5c6bc0",
+  parameter: "#ce93d8",
+  entity: "#66bb6a",
+}};
+
+function nodeRadius(d) {{
+  if (d.type === "campaign") return 22;
+  if (d.type === "entity") return 8 + (d.campaignCount || 1) * 4;
+  if (d.type === "concept") return 7;
+  if (d.type === "parameter") return 5;
+  return 6;
+}}
+
+// Entity box dimensions (width x height) based on campaignCount
+function nodeColor(d) {{
+  return typeColors[d.type] || "#999";
+}}
+
+function linkColor(d) {{
+  if (d.edgeType === "entity") return "#66bb6a";
+  if (d.edgeType === "concept") return "#5c6bc0";
+  if (d.edgeType === "operates_on") return "#80cbc4";
+  if (d.edgeType === "has_param") return "#ce93d8";
+  if (d.edgeType === "interacts") return "#90a4ae";
+  if (d.edgeType === "shared_principles") return "#ffab40";
+  if (d.edgeType === "related") return "#616161";
+  return "#555";
+}}
+
+function linkDash(d) {{
+  if (d.edgeType === "entity") return "4,3";
+  if (d.edgeType === "operates_on") return "2,2";
+  if (d.edgeType === "has_param") return "3,2";
+  if (d.edgeType === "interacts") return "4,2";
+  if (d.edgeType === "shared_principles") return "6,2";
+  if (d.edgeType === "related") return "2,3";
+  return "none";
+}}
+
+function linkWidth(d) {{
+  if (d.edgeType === "entity") return 1.5;
+  if (d.edgeType === "concept") return 1.2;
+  if (d.edgeType === "operates_on") return 1.2;
+  if (d.edgeType === "has_param") return 0.8;
+  if (d.edgeType === "interacts") return 1.5;
+  if (d.edgeType === "shared_principles") return Math.min(0.8 + (d.strength || 1) * 0.4, 3);
+  if (d.edgeType === "related") return 0.6;
+  return 1;
+}}
+
+// Force simulation
+const simulation = d3.forceSimulation(nodes)
+  .force("link", d3.forceLink(links).id(d => d.id).distance(d => {{
+    if (d.edgeType === "entity") return 120;
+    if (d.edgeType === "concept") return 70;
+    if (d.edgeType === "operates_on") return 60;
+    if (d.edgeType === "has_param") return 40;
+    if (d.edgeType === "interacts") return 80;
+    if (d.edgeType === "shared_principles") return 100;
+    if (d.edgeType === "related") return 70;
+    return 55;
+  }}).strength(d => {{
+    if (d.edgeType === "entity") return 0.3;
+    if (d.edgeType === "operates_on") return 0.4;
+    if (d.edgeType === "has_param") return 0.5;
+    if (d.edgeType === "interacts") return 0.2;
+    if (d.edgeType === "shared_principles") return 0.15;
+    if (d.edgeType === "related") return 0.15;
+    return 0.5;
+  }}))
+  .force("charge", d3.forceManyBody().strength(d => {{
+    if (d.type === "campaign") return -400;
+    if (d.type === "entity") return -100;
+    return -40;
+  }}))
+  .force("center", d3.forceCenter(width / 2, height / 2))
+  .force("collision", d3.forceCollide().radius(d => nodeRadius(d) + 4))
+  .force("x", d3.forceX(d => {{
+    // Position campaigns in a timeline row
+    if (d.type === "campaign" && d.totalCampaigns > 1) {{
+      const padding = 200;
+      const span = width - padding * 2;
+      return padding + (d.timeIndex / (d.totalCampaigns - 1)) * span;
+    }}
+    // Position entities by cluster (spread across X axis)
+    if (d.type === "entity") {{
+      const clusterIdx = entityClusterMap[d.id];
+      if (clusterIdx != null) {{
+        const numClusters = entityClusters.length;
+        const padding = 150;
+        const span = width - padding * 2;
+        return padding + (clusterIdx / Math.max(numClusters - 1, 1)) * span;
+      }}
+    }}
+    return width / 2;
+  }}).strength(d => {{
+    if (d.type === "campaign") return 0.3;
+    if (d.type === "entity") return 0.08;
+    return 0.02;
+  }}))
+  .force("y", d3.forceY(d => {{
+    if (d.type === "campaign") return height * 0.35;
+    if (d.type === "entity") return height * 0.2;
+    if (d.type === "concept" || d.type === "parameter") return height * 0.55;
+    return height * 0.55;
+  }}).strength(d => {{
+    if (d.type === "campaign") return 0.2;
+    if (d.type === "entity" && d.campaignCount > 1) return 0.1;
+    return 0.03;
+  }}));
+
+// Draw links
+const link = g.append("g")
+  .selectAll("line")
+  .data(links)
+  .join("line")
+  .attr("class", "link")
+  .attr("stroke", linkColor)
+  .attr("stroke-dasharray", linkDash)
+  .attr("stroke-width", linkWidth);
+
+// Draw nodes
+const node = g.append("g")
+  .selectAll("g")
+  .data(nodes)
+  .join("g")
+  .attr("class", "node")
+  .call(d3.drag()
+    .on("start", dragstarted)
+    .on("drag", dragged)
+    .on("end", dragended));
+
+// Node shapes by type (synced with visualize_campaign.py):
+// Campaigns → circles (grey, with border)
+node.filter(d => d.type === "campaign")
+  .append("circle")
+  .attr("r", nodeRadius)
+  .attr("fill", nodeColor)
+  .attr("stroke", "#b0bec5")
+  .attr("stroke-width", 2.5);
+
+// Concepts → rounded squares (indigo fill, blue stroke)
+node.filter(d => d.type === "concept")
+  .append("rect")
+  .attr("width", d => nodeRadius(d) * 2)
+  .attr("height", d => nodeRadius(d) * 2)
+  .attr("x", d => -nodeRadius(d))
+  .attr("y", d => -nodeRadius(d))
+  .attr("rx", 4).attr("ry", 4)
+  .attr("fill", "#1a237e")
+  .attr("stroke", "#5c6bc0")
+  .attr("stroke-width", 2);
+
+// Parameters → triangles (purple fill, pink stroke)
+node.filter(d => d.type === "parameter")
+  .append("polygon")
+  .attr("points", d => {{
+    const r = nodeRadius(d);
+    return `0,-${{r}} ${{r}},${{r * 0.75}} -${{r}},${{r * 0.75}}`;
+  }})
+  .attr("fill", "#4a148c")
+  .attr("stroke", "#ce93d8")
+  .attr("stroke-width", 1.5);
+
+// Entities → diamonds (cluster-colored fill and stroke)
+node.filter(d => d.type === "entity")
+  .append("polygon")
+  .attr("points", d => {{
+    const r = nodeRadius(d) * 1.2;
+    return `-${{r}},0 0,-${{r}} ${{r}},0 0,${{r}}`;
+  }})
+  .attr("fill", d => entityClusterFill(d.id))
+  .attr("stroke", d => entityClusterColor(d.id))
+  .attr("stroke-width", d => d.campaignCount > 1 ? 2.5 : 1.5);
+
+
+// Labels (only for campaigns and multi-campaign entities)
+node.filter(d => d.type === "campaign" || (d.type === "entity" && d.campaignCount > 1))
+  .append("text")
+  .attr("class", d => `label ${{d.type === "campaign" ? "label-campaign" : ""}}`)
+  .attr("dy", d => {{
+    if (d.type === "entity") return nodeRadius(d) * 1.2 + 14;
+    return nodeRadius(d) + 14;
+  }})
+  .text(d => {{
+    if (d.type === "campaign") {{
+      const name = d.label || "";
+      return name.length > 25 ? name.substring(0, 22) + "..." : name;
+    }}
+    return d.label;
+  }});
+
+// Cost badges on campaign nodes
+node.filter(d => d.type === "campaign" && campaignCosts[d.label])
+  .append("text")
+  .attr("class", "cost-badge")
+  .attr("dy", d => -(nodeRadius(d) + 6))
+  .text(d => `$${{campaignCosts[d.label].toFixed(0)}}`);
+
+// Show all nodes by default — filter hides them only when user selects a scope
+node.style("display", null);
+link.style("display", null);
+
+// Tooltip
+const tooltip = d3.select("#tooltip");
+
+node.on("mouseover", (event, d) => {{
+  const typeLabels = {{ campaign: "Campaign", entity: "Entity", concept: "Concept", parameter: "Parameter" }};
+  let html = `<div class="tt-type">${{typeLabels[d.type] || d.type}}</div>`;
+  html += `<h3>${{d.label}}</h3>`;
+
+  if (d.type === "campaign") {{
+    html += `<div class="tt-field"><div class="tt-label">Date</div><div class="tt-value">${{d.date || "unknown"}}</div></div>`;
+    html += `<div class="tt-field"><div class="tt-label">Research Question</div><div class="tt-value">${{d.research_question || ""}}</div></div>`;
+    html += `<div class="tt-field"><div class="tt-label">Scope</div><div class="tt-value">${{d.conceptCount}} concepts, ${{d.paramCount}} params</div></div>`;
+    if (campaignCosts[d.label]) {{
+      html += `<div class="tt-field"><div class="tt-label">LLM Cost</div><div class="tt-value" style="color:#ffab40;">$${{campaignCosts[d.label].toFixed(2)}}</div></div>`;
+    }}
+  }} else if (d.type === "entity") {{
+    html += `<div class="tt-field"><div class="tt-label">Campaigns</div><div class="tt-value">${{(d.campaigns || []).join(", ")}}</div></div>`;
+  }} else {{
+    html += `<div class="tt-field"><div class="tt-label">Campaign</div><div class="tt-value">${{d.campaign || ""}}</div></div>`;
+  }}
+
+  tooltip.html(html).style("display", "block");
+  // Highlight connected edges
+  link.attr("stroke-opacity", l =>
+    (l.source.id === d.id || l.target.id === d.id) ? 1 : 0.15
+  );
+  node.each(function(n) {{
+    const opac = (n.id === d.id || links.some(l =>
+      (l.source.id === d.id && l.target.id === n.id) ||
+      (l.target.id === d.id && l.source.id === n.id)
+    )) ? 1 : 0.3;
+    d3.select(this).selectAll("circle, rect, polygon").attr("opacity", opac);
+  }});
+}})
+.on("mousemove", (event) => {{
+  tooltip.style("left", (event.pageX + 12) + "px")
+    .style("top", (event.pageY - 10) + "px");
+}})
+.on("mouseout", () => {{
+  tooltip.style("display", "none");
+  applyFilterVisuals();
+}})
+.on("click", (event, d) => {{
+  event.stopPropagation();
+  if (d.type === "campaign") {{
+    window.open(d.label + ".html", "_blank");
+  }} else {{
+    showDetailPanel(d);
+  }}
+}});
+
+svg.on("click", () => closePanel());
+
+// Detail panel
+function showDetailPanel(d) {{
+  const panel = document.getElementById("detail-panel");
+  const content = document.getElementById("panel-content");
+  let html = "";
+
+  if (d.type === "campaign") {{
+    html += `<h2>${{d.label}}</h2>`;
+    html += `<div class="panel-type">Campaign &mdash; <span class="campaign-date">${{d.date || ""}}</span></div>`;
+    html += `<p style="color:#ccc;font-style:italic;line-height:1.5;">${{d.research_question || ""}}</p>`;
+    if (campaignCosts[d.label]) {{
+      html += `<div style="margin:8px 0;padding:8px 12px;background:rgba(255,171,64,0.1);border-radius:6px;border-left:3px solid #ffab40;">`;
+      html += `<span style="color:#888;font-size:10px;text-transform:uppercase;letter-spacing:0.5px;">Total LLM Cost</span>`;
+      html += `<div style="color:#ffab40;font-size:18px;font-weight:700;margin-top:4px;">$${{campaignCosts[d.label].toFixed(2)}}</div>`;
+      html += `</div>`;
+    }}
+
+    // Show summary from campaignDetails (rendered as HTML)
+    const details = campaignDetails[d.label];
+    if (details && details.summary) {{
+      html += `<div class="panel-section panel-summary">${{renderMarkdown(details.summary)}}</div>`;
+    }}
+
+    // Connected entities
+    const connEnts = links.filter(l => l.source.id === d.id && l.edgeType === "entity")
+      .map(l => nodeIndex[l.target.id] || nodeIndex[l.target]);
+    if (connEnts.length > 0) {{
+      html += `<div class="panel-section"><div class="panel-section-title">Entities Studied</div>`;
+      connEnts.forEach(e => {{
+        html += `<div class="panel-item">${{e.label}}</div>`;
+      }});
+      html += `</div>`;
+    }}
+
+    // Connected concepts
+    const connConcepts = links.filter(l => l.source.id === d.id && l.edgeType === "concept")
+      .map(l => nodeIndex[l.target.id] || nodeIndex[l.target])
+      .filter(Boolean);
+    if (connConcepts.length > 0) {{
+      html += `<div class="panel-section"><div class="panel-section-title">Concepts Discovered</div>`;
+      connConcepts.forEach(c => {{
+        html += `<div class="panel-item">${{c.label}}</div>`;
+      }});
+      html += `</div>`;
+    }}
+
+    // Dead-ends (from campaignDetails, not graph nodes)
+    const details_de = campaignDetails[d.label];
+    if (details_de && details_de.dead_ends && details_de.dead_ends.length > 0) {{
+      html += `<div class="panel-section"><div class="panel-section-title" style="color:#f44336;">Dead-ends (avoid)</div>`;
+      details_de.dead_ends.forEach(de => {{
+        html += `<div class="panel-item" style="border-left:3px solid #f44336;padding-left:8px;">${{de.title}}</div>`;
+      }});
+      html += `</div>`;
+    }}
+
+    // Frontiers (from campaignDetails, not graph nodes)
+    if (details_de && details_de.frontiers && details_de.frontiers.length > 0) {{
+      html += `<div class="panel-section"><div class="panel-section-title" style="color:#ff9800;">Frontiers (opportunities)</div>`;
+      details_de.frontiers.forEach(fr => {{
+        html += `<div class="panel-item" style="border-left:3px solid #ff9800;padding-left:8px;">${{fr.title}}</div>`;
+      }});
+      html += `</div>`;
+    }}
+
+  }} else if (d.type === "entity") {{
+    html += `<h2>${{d.label}}</h2>`;
+    html += `<div class="panel-type">Entity &mdash; Pre-existing infrastructure</div>`;
+    html += `<p style="color:#aaa;">Studied in ${{d.campaignCount}} campaign${{d.campaignCount > 1 ? "s" : ""}}:</p>`;
+    (d.campaigns || []).forEach(cName => {{
+      html += `<div class="panel-item" style="cursor:pointer;" onclick="focusCampaign('${{cName}}')">${{cName}}</div>`;
+    }});
+
+    // Show definition if available from details
+    for (const [campName, details] of Object.entries(campaignDetails)) {{
+      if (details.entities) {{
+        const ent = details.entities.find(e => e.name === d.label);
+        if (ent) {{
+          html += `<div class="panel-section"><div class="panel-section-title">Definition (from ${{campName}})</div>`;
+          html += `<div style="color:#ccc;line-height:1.5;">${{ent.definition || ""}}</div></div>`;
+          break;
+        }}
+      }}
+    }}
+
+  }} else if (d.type === "concept") {{
+    html += `<h2>${{d.label}}</h2>`;
+    html += `<div class="panel-type" style="color:#66bb6a">Concept &mdash; ${{d.campaign}}</div>`;
+
+    const details = campaignDetails[d.campaign];
+    if (details && details.concepts) {{
+      const concept = details.concepts.find(c => c.name === d.label);
+      if (concept) {{
+        html += `<div class="panel-section"><div class="panel-section-title">Definition</div><div style="color:#ccc;line-height:1.5;">${{concept.definition || ""}}</div></div>`;
+      }}
+    }}
+
+  }} else if (d.type === "parameter") {{
+    html += `<h2>${{d.label}}</h2>`;
+    html += `<div class="panel-type">Parameter &mdash; ${{d.campaign}}</div>`;
+
+    const details = campaignDetails[d.campaign];
+    if (details && details.parameters) {{
+      const param = details.parameters.find(p => p.name === d.label);
+      if (param) {{
+        html += `<div class="panel-section"><div class="panel-section-title">Definition</div><div style="color:#ccc;line-height:1.5;">${{param.definition || ""}}</div></div>`;
+        if (param.evolution && param.evolution.length > 0) {{
+          html += `<div class="panel-section"><div class="panel-section-title">Evolution</div>`;
+          const outcomeColors = {{ "confirmed": "#4caf50", "refuted": "#f44336", "partially_confirmed": "#ff9800", "baseline": "#9e9e9e" }};
+          param.evolution.forEach(ev => {{
+            const oc = outcomeColors[(ev.outcome || "").toLowerCase()] || "#9e9e9e";
+            html += `<div style="margin:6px 0;border-left:3px solid ${{oc}};padding-left:8px;">`;
+            html += `<span style="color:#ccc;font-weight:600;">${{ev.iter}}</span> `;
+            html += `<span style="color:#7986cb;">= ${{ev.value}}</span><br>`;
+            html += `<span style="color:#999;font-size:10px;">${{ev.note || ""}}</span></div>`;
+          }});
+          html += `</div>`;
+        }}
+      }}
+    }}
+  }}
+
+  content.innerHTML = html;
+  panel.classList.add("visible");
+}}
+
+function closePanel() {{
+  document.getElementById("detail-panel").classList.remove("visible");
+}}
+
+function focusCampaign(name) {{
+  const cNode = nodes.find(n => n.type === "campaign" && n.label === name);
+  if (cNode) showDetailPanel(cNode);
+}}
+
+// Drag behavior
+function dragstarted(event, d) {{
+  if (!event.active) simulation.alphaTarget(0.3).restart();
+  d.fx = d.x; d.fy = d.y;
+}}
+function dragged(event, d) {{
+  d.fx = event.x; d.fy = event.y;
+}}
+function dragended(event, d) {{
+  if (!event.active) simulation.alphaTarget(0);
+  d.fx = null; d.fy = null;
+}}
+
+// Tick
+simulation.on("tick", () => {{
+  link
+    .attr("x1", d => d.source.x)
+    .attr("y1", d => d.source.y)
+    .attr("x2", d => d.target.x)
+    .attr("y2", d => d.target.y);
+  node.attr("transform", d => `translate(${{d.x}},${{d.y}})`);
+}});
+
+// Initial zoom to fit
+setTimeout(() => {{
+  const bounds = g.node().getBBox();
+  const fullWidth = bounds.width;
+  const fullHeight = bounds.height;
+  const midX = bounds.x + fullWidth / 2;
+  const midY = bounds.y + fullHeight / 2;
+  const scale = Math.min(0.85, 0.85 / Math.max(fullWidth / width, fullHeight / height));
+  const translate = [width / 2 - scale * midX, height / 2 - scale * midY];
+  svg.transition().duration(750).call(
+    zoom.transform,
+    d3.zoomIdentity.translate(translate[0], translate[1]).scale(scale)
+  );
+}}, 2000);
+
+// Legend toggle
+function toggleLegend() {{
+  const panel = document.getElementById("legend-panel");
+  const arrow = document.getElementById("legend-arrow");
+  panel.classList.toggle("collapsed");
+  arrow.innerHTML = panel.classList.contains("collapsed") ? "&#9656;" : "&#9662;";
+}}
+
+// --- Opportunities View (Heuristic-scored, no LLM calls) ---
+let currentView = "knowledge";
+
+let oppClusterFilter = null;  // null = show all
+
+function setOppClusterFilter(clusterId) {{
+  oppClusterFilter = (oppClusterFilter === clusterId) ? null : clusterId;
+  renderOpportunities();
+}}
+
+// Compute heuristic opportunity score for a cluster from registry data.
+// Only counts frontiers/interactions whose related_principles overlap with
+// the principles of entities in the cluster (principle-based relevance).
+function computeClusterScore(cluster) {{
+  const clusterEntities = new Set(cluster.entities);
+  let frontierCount = 0;
+  let interactionCount = 0;
+  let deadEndCount = 0;
+  let campaignCount = 0;
+  let latestDate = "";
+  const relatedCampaigns = [];
+  const frontierTitles = [];
+  const interactionTitles = [];
+  const deadEndTitles = [];
+
+  Object.values(registryData.projects || {{}}).forEach(project => {{
+    project.campaigns.forEach(campaign => {{
+      const details = campaignDetails[campaign.name] || {{}};
+      const campaignEntities = details.entities || [];
+      const touches = campaignEntities.some(e => clusterEntities.has(e.name));
+      if (!touches) return;
+
+      // Build the set of principles linked to entities in THIS cluster
+      const clusterPrinciples = new Set();
+      campaignEntities.forEach(e => {{
+        if (clusterEntities.has(e.name)) {{
+          (e.principles || []).forEach(p => clusterPrinciples.add(p));
+        }}
+      }});
+
+      campaignCount++;
+      relatedCampaigns.push(campaign.name);
+      if (campaign.date > latestDate) latestDate = campaign.date;
+
+      // Count frontiers — only if related_principles overlap with cluster
+      (details.frontiers || []).forEach(f => {{
+        const related = f.related_principles || [];
+        if (related.some(p => clusterPrinciples.has(p))) {{
+          frontierCount++;
+          frontierTitles.push(`${{f.id || "?"}}: ${{f.title || ""}}`);
+        }}
+      }});
+      // Count interactions — only if related_principles overlap with cluster
+      (details.interactions || []).forEach(i => {{
+        const related = i.related_principles || [];
+        if (related.some(p => clusterPrinciples.has(p))) {{
+          interactionCount++;
+          interactionTitles.push(`${{i.id || "?"}}: ${{i.title || ""}}`);
+        }}
+      }});
+      // Dead-ends lack related_principles — count all from touching campaigns
+      // (conservative: over-counting dead-ends penalizes the score)
+      (details.dead_ends || []).forEach(d => {{
+        deadEndCount++;
+        deadEndTitles.push(`${{d.id || "?"}}: ${{d.title || ""}}`);
+      }});
+    }});
+  }});
+
+  // Raw score: more frontiers + interactions = more opportunity
+  // Dead-ends reduce score slightly (territory is more constrained)
+  const rawScore = (frontierCount * 2) + (interactionCount * 3) - (deadEndCount * 0.5);
+
+  return {{
+    rawScore,
+    frontierCount,
+    interactionCount,
+    deadEndCount,
+    campaignCount,
+    latestDate,
+    relatedCampaigns,
+    frontierTitles: frontierTitles.slice(0, 5),
+    interactionTitles: interactionTitles.slice(0, 5),
+    deadEndTitles: deadEndTitles.slice(0, 5),
+  }};
+}}
+
+// Copy text to clipboard
+function copyToClipboard(text, btn) {{
+  navigator.clipboard.writeText(text).then(() => {{
+    const orig = btn.textContent;
+    btn.textContent = "Copied!";
+    setTimeout(() => {{ btn.textContent = orig; }}, 1500);
+  }});
+}}
+
+function renderOpportunities() {{
+  const container = document.getElementById("opp-list-container");
+
+  if (!entityClusters || entityClusters.length === 0) {{
+    container.innerHTML = `<div style="color:#888;text-align:center;padding:60px;font-size:13px;">No entity clusters found.<br>Run <code>/index-wiki</code> on at least two campaigns to generate clusters.</div>`;
+    return;
+  }}
+
+  // Compute raw scores for all clusters, then normalize adaptively
+  const rawScored = entityClusters.map(cluster => ({{
+    ...cluster,
+    ...computeClusterScore(cluster),
+  }}));
+  const maxRaw = Math.max(...rawScored.map(c => c.rawScore), 1);
+  const scored = rawScored.map(c => ({{
+    ...c,
+    score: Math.max(0, c.rawScore / maxRaw),
+  }}));
+  scored.sort((a, b) => b.score - a.score);
+  scored.splice(20); // Cap at 20 clusters
+
+  // Filter
+  const filtered = oppClusterFilter == null
+    ? scored
+    : scored.filter(c => c.id === oppClusterFilter);
+
+  // Cluster filter bar
+  let html = `<div class="opp-cluster-bar">`;
+  html += `<span class="opp-cluster-bar-label">Filter by entity cluster:</span>`;
+  scored.forEach(cluster => {{
+    const color = clusterColors[cluster.id % clusterColors.length];
+    const active = oppClusterFilter === cluster.id ? "active" : "";
+    html += `<button class="opp-cluster-btn ${{active}}" style="--btn-color:${{color}}" onclick="setOppClusterFilter(${{cluster.id}})">`;
+    html += `<span class="cluster-dot-inline" style="background:${{color}}"></span>${{cluster.label}}`;
+    html += `</button>`;
+  }});
+  const allActive = oppClusterFilter == null ? "active" : "";
+  html += `<button class="opp-cluster-btn ${{allActive}}" style="--btn-color:#78909c" onclick="setOppClusterFilter(null)">All</button>`;
+  html += `</div>`;
+
+  // Explainer banner
+  html += `<div style="background:rgba(121,134,203,0.08);border:1px solid rgba(121,134,203,0.25);border-radius:6px;padding:12px 16px;margin-bottom:16px;font-size:11px;color:#aaa;line-height:1.6;">`;
+  html += `<strong style="color:#b39ddb;">Research landscape</strong> — entity clusters ranked by open research territory. `;
+  html += `<span style="color:#ff9800;">Frontiers</span> and <span style="color:#26c6da;">interactions</span> are matched via principle overlap with the cluster's entities.<br>`;
+  html += `To get detailed recommendations, run: `;
+  html += `<code style="background:#0a1628;padding:4px 8px;border-radius:3px;color:#7986cb;display:inline-block;margin-top:4px;">/suggest-next &lt;project&gt; "your research question"</code>`;
+  html += `</div>`;
+
+  // Header
+  html += `<div class="opp-header">`;
+  html += `<span>${{filtered.length}} entity clusters</span>`;
+  html += `</div>`;
+
+  // Render cluster cards
+  filtered.forEach(cluster => {{
+    const color = clusterColors[cluster.id % clusterColors.length];
+
+    html += `<div class="opp-card" onclick="this.classList.toggle('expanded')">`;
+
+    // Header: label
+    html += `<div class="opp-card-header">`;
+    html += `<span style="display:inline-block;width:10px;height:10px;border-radius:3px;background:${{color}};margin-right:4px;"></span>`;
+    html += `<span class="opp-card-title">${{cluster.label}}</span>`;
+    html += `</div>`;
+
+    // Summary metrics
+    html += `<div class="opp-card-meta" style="margin-top:6px;">`;
+    html += `<span style="color:#ff9800;">${{cluster.frontierCount}} frontiers</span>`;
+    html += `<span style="color:#26c6da;">${{cluster.interactionCount}} interactions</span>`;
+    html += `<span style="color:#f44336;">${{cluster.deadEndCount}} dead-ends</span>`;
+    html += `<span>${{cluster.campaignCount}} campaigns</span>`;
+    if (cluster.latestDate) html += `<span style="color:#666;">Last: ${{cluster.latestDate}}</span>`;
+    html += `</div>`;
+
+    // Entities
+    html += `<div style="margin-top:8px;display:flex;flex-wrap:wrap;gap:4px;">`;
+    cluster.entities.forEach(name => {{
+      html += `<span style="font-size:10px;background:rgba(255,255,255,0.05);border:1px solid #0f3460;padding:2px 8px;border-radius:3px;color:#ccc;">${{name}}</span>`;
+    }});
+    html += `</div>`;
+
+    // Expandable detail
+    html += `<div class="opp-card-detail">`;
+
+    // Frontiers
+    if (cluster.frontierTitles.length > 0) {{
+      html += `<div class="detail-section"><div class="detail-label" style="color:#ff9800;">Open Frontiers</div>`;
+      cluster.frontierTitles.forEach(f => {{
+        html += `<div style="margin:4px 0;color:#ccc;font-size:11px;border-left:2px solid #ff9800;padding-left:8px;">${{f}}</div>`;
+      }});
+      if (cluster.frontierCount > 5) html += `<div style="color:#666;font-size:10px;margin-top:4px;">...and ${{cluster.frontierCount - 5}} more</div>`;
+      html += `</div>`;
+    }}
+
+    // Interactions
+    if (cluster.interactionTitles.length > 0) {{
+      html += `<div class="detail-section"><div class="detail-label" style="color:#26c6da;">Untested Interactions</div>`;
+      cluster.interactionTitles.forEach(i => {{
+        html += `<div style="margin:4px 0;color:#ccc;font-size:11px;border-left:2px solid #26c6da;padding-left:8px;">${{i}}</div>`;
+      }});
+      if (cluster.interactionCount > 5) html += `<div style="color:#666;font-size:10px;margin-top:4px;">...and ${{cluster.interactionCount - 5}} more</div>`;
+      html += `</div>`;
+    }}
+
+    // Dead-ends
+    if (cluster.deadEndTitles.length > 0) {{
+      html += `<div class="detail-section"><div class="detail-label" style="color:#f44336;">Known Dead-Ends</div>`;
+      cluster.deadEndTitles.forEach(d => {{
+        html += `<div style="margin:4px 0;color:#999;font-size:11px;border-left:2px solid #f44336;padding-left:8px;">${{d}}</div>`;
+      }});
+      if (cluster.deadEndCount > 5) html += `<div style="color:#666;font-size:10px;margin-top:4px;">...and ${{cluster.deadEndCount - 5}} more</div>`;
+      html += `</div>`;
+    }}
+
+    // Suggest-next command
+    const entityList = cluster.entities.map(e => `"${{e}}"`).join(" ");
+    const repoPath = Object.keys(registryData.projects || {{}})[0] || "<repo-path>";
+    const suggestCmd = `/suggest-next ${{repoPath}} "explore ${{cluster.label.toLowerCase()}} opportunities"`;
+
+    html += `<div class="detail-section" style="padding-top:14px;">`;
+    html += `<div class="detail-label">Get detailed recommendations</div>`;
+    html += `<div style="background:#0a1628;border:1px solid #1a2a4a;border-radius:5px;padding:10px 12px;margin-top:6px;font-family:'SF Mono','Fira Code',monospace;font-size:11px;color:#7986cb;word-break:break-all;">`;
+    html += suggestCmd;
+    html += `</div>`;
+    html += `<button onclick="event.stopPropagation(); copyToClipboard('${{suggestCmd.replace(/'/g, "\\\\'")}}', this)" style="margin-top:8px;background:#1a2a4a;border:1px solid #0f3460;color:#aaa;padding:6px 12px;border-radius:4px;font-size:10px;cursor:pointer;transition:all 0.2s;">`;
+    html += `Copy command</button>`;
+    html += `<span style="color:#555;font-size:10px;margin-left:8px;">Runs /suggest-next scoped to this cluster's entities</span>`;
+    html += `</div>`;
+
+    html += `</div>`; // end detail
+    html += `</div>`; // end card
+  }});
+
+  container.innerHTML = html;
+}}
+
+
+// --- View switching ---
+function switchView(view) {{
+  if (view === currentView) return;
+  currentView = view;
+
+  document.querySelectorAll(".view-btn").forEach(b => b.classList.remove("active"));
+  document.getElementById(`btn-${{view}}`).classList.add("active");
+
+  const oppContainer = document.getElementById("opp-list-container");
+  const graphEl = document.getElementById("graph");
+
+  if (view === "knowledge") {{
+    // Show knowledge graph, hide opportunities list
+    oppContainer.style.display = "none";
+    graphEl.style.display = "block";
+    g.style("display", null);
+    svg.call(zoom.on("zoom", (event) => g.attr("transform", event.transform)));
+    applyFilterVisuals();
+    document.getElementById("filter-panel").style.display = "block";
+    document.getElementById("legend-panel").style.display = "block";
+    if (filterActive) document.getElementById("stats-bar").style.display = "flex";
+  }} else if (view === "opportunities") {{
+    // Hide knowledge graph, show pre-computed opportunities
+    graphEl.style.display = "none";
+    oppContainer.style.display = "block";
+    document.getElementById("filter-panel").style.display = "none";
+    document.getElementById("legend-panel").style.display = "none";
+    document.getElementById("stats-bar").style.display = "none";
+    closePanel();
+    renderOpportunities();
+  }}
+}}
+</script>
+</body>
+</html>"""
+
+
+def load_registry(wiki_dir: Path) -> dict:
+    """Load the cross-campaign registry."""
+    registry_path = wiki_dir / "registry.json"
+    if not registry_path.exists():
+        print(f"Error: registry.json not found at {registry_path}", file=sys.stderr)
+        print("Run /post-campaign and /index-wiki first to build the registry.", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        with open(registry_path) as f:
+            return json.load(f)
+    except (json.JSONDecodeError, ValueError) as e:
+        print(f"Error: registry.json is corrupted: {e}", file=sys.stderr)
+        print(f"Path: {registry_path}", file=sys.stderr)
+        print("Try re-running /index-wiki to rebuild the registry.", file=sys.stderr)
+        sys.exit(1)
+
+
+def load_campaign_details(wiki_dir: Path, registry: dict) -> dict:
+    """Load per-campaign detail files (concepts, dead-ends, frontiers, summaries).
+
+    Returns a dict keyed by campaign name with detail data for the panel.
+    """
+    details = {}
+
+    for repo_path, project in registry.get("projects", {}).items():
+        for campaign in project.get("campaigns", []):
+            name = campaign["name"]
+            campaign_dir = wiki_dir / "campaigns" / name
+            entry = {}
+
+            # Load summary.md
+            summary_path = campaign_dir / "summary.md"
+            if summary_path.exists():
+                entry["summary"] = summary_path.read_text()
+
+            # Load concepts.json for definitions
+            concepts_path = campaign_dir / "concepts.json"
+            if concepts_path.exists():
+                try:
+                    with open(concepts_path) as f:
+                        concepts_data = json.load(f)
+                    entry["concepts"] = concepts_data.get("concepts", [])
+                    entry["parameters"] = concepts_data.get("parameters", [])
+                    entry["entities"] = concepts_data.get("entities", [])
+                except (json.JSONDecodeError, ValueError) as e:
+                    print(f"Warning: skipping corrupted {concepts_path}: {e}", file=sys.stderr)
+
+            # Load dead-ends.json
+            dead_ends_path = campaign_dir / "dead-ends.json"
+            if dead_ends_path.exists():
+                try:
+                    with open(dead_ends_path) as f:
+                        entry["dead_ends"] = json.load(f)
+                except (json.JSONDecodeError, ValueError) as e:
+                    print(f"Warning: skipping corrupted {dead_ends_path}: {e}", file=sys.stderr)
+
+            # Load frontiers.json
+            frontiers_path = campaign_dir / "frontiers.json"
+            if frontiers_path.exists():
+                try:
+                    with open(frontiers_path) as f:
+                        entry["frontiers"] = json.load(f)
+                except (json.JSONDecodeError, ValueError) as e:
+                    print(f"Warning: skipping corrupted {frontiers_path}: {e}", file=sys.stderr)
+
+            # Load interactions.json
+            interactions_path = campaign_dir / "interactions.json"
+            if interactions_path.exists():
+                try:
+                    with open(interactions_path) as f:
+                        entry["interactions"] = json.load(f)
+                except (json.JSONDecodeError, ValueError) as e:
+                    print(f"Warning: skipping corrupted {interactions_path}: {e}", file=sys.stderr)
+
+            details[name] = entry
+
+    return details
+
+
+def build_cross_edges(registry: dict, campaign_details: dict) -> list:
+    """Build cross-node edges directly from explicit relationship fields.
+
+    Reads operates_on/parameters from concepts.json data and translates
+    to registry-level node IDs.
+
+    Returns a list of edge dicts: {source, target, edgeType, strength}
+    """
+    edges = []
+    seen = set()
+
+    for repo_path, project in registry.get("projects", {}).items():
+        # Build name→registry_node_id maps for this project
+        concept_name_to_id = {}
+        param_name_to_id = {}
+        entity_name_to_id = {}
+
+        for campaign in project.get("campaigns", []):
+            camp_name = campaign["name"]
+            for c in campaign.get("concepts", []):
+                concept_name_to_id[(camp_name, c["name"])] = f"concept-{c['id']}"
+            for p in campaign.get("parameters", []):
+                param_name_to_id[(camp_name, p["name"])] = f"param-{p['id']}"
+
+        for e in project.get("entities", []):
+            entity_name_to_id[e["name"]] = f"entity-{e['id']}"
+
+        # For each campaign, read explicit relationships directly
+        for campaign in project.get("campaigns", []):
+            camp_name = campaign["name"]
+            details = campaign_details.get(camp_name, {})
+
+            for concept in details.get("concepts", []):
+                concept_id = concept_name_to_id.get((camp_name, concept["name"]))
+                if not concept_id:
+                    continue
+
+                # Concept → Entity (operates_on)
+                for entity_name in concept.get("operates_on", []):
+                    entity_id = entity_name_to_id.get(entity_name)
+                    if not entity_id:
+                        continue
+                    pair_key = tuple(sorted([concept_id, entity_id]))
+                    if pair_key in seen:
+                        continue
+                    seen.add(pair_key)
+                    edges.append({
+                        "source": concept_id,
+                        "target": entity_id,
+                        "edgeType": "operates_on",
+                        "strength": 1,
+                    })
+
+            # Parameter → parent concept (has_param) — derived from parameter side
+            # to guarantee single ownership (parent_concept is a string, not array)
+            for param in details.get("parameters", []):
+                parent_name = param.get("parent_concept")
+                if not parent_name:
+                    continue
+                concept_id = concept_name_to_id.get((camp_name, parent_name))
+                param_id = param_name_to_id.get((camp_name, param["name"]))
+                if not concept_id or not param_id:
+                    continue
+                pair_key = tuple(sorted([concept_id, param_id]))
+                if pair_key in seen:
+                    continue
+                seen.add(pair_key)
+                edges.append({
+                    "source": concept_id,
+                    "target": param_id,
+                    "edgeType": "has_param",
+                    "strength": 1,
+                })
+
+            # Entity↔Entity edges: principle overlap (≥2 shared)
+            entity_nodes = [
+                (entity_name_to_id[e["name"]], set(e.get("principles", [])))
+                for e in details.get("entities", [])
+                if e["name"] in entity_name_to_id
+            ]
+            for i in range(len(entity_nodes)):
+                for j in range(i + 1, len(entity_nodes)):
+                    shared = entity_nodes[i][1] & entity_nodes[j][1]
+                    if len(shared) >= 2:
+                        pair_key = tuple(sorted([entity_nodes[i][0], entity_nodes[j][0]]))
+                        if pair_key in seen:
+                            continue
+                        seen.add(pair_key)
+                        edges.append({
+                            "source": entity_nodes[i][0],
+                            "target": entity_nodes[j][0],
+                            "edgeType": "interacts",
+                            "strength": len(shared),
+                        })
+
+        # Cross-campaign concept↔concept edges: concepts from DIFFERENT campaigns
+        # sharing ≥2 principles indicate they study the same underlying behavior.
+        concept_nodes_with_principles = []
+        for campaign in project.get("campaigns", []):
+            camp_name = campaign["name"]
+            details = campaign_details.get(camp_name, {})
+            for concept in details.get("concepts", []):
+                concept_id = concept_name_to_id.get((camp_name, concept["name"]))
+                if not concept_id:
+                    continue
+                principles = set(concept.get("principles", []))
+                if principles:
+                    concept_nodes_with_principles.append(
+                        (concept_id, camp_name, principles)
+                    )
+
+        for i in range(len(concept_nodes_with_principles)):
+            for j in range(i + 1, len(concept_nodes_with_principles)):
+                # Only cross-campaign pairs
+                if concept_nodes_with_principles[i][1] == concept_nodes_with_principles[j][1]:
+                    continue
+                shared = concept_nodes_with_principles[i][2] & concept_nodes_with_principles[j][2]
+                if len(shared) >= 2:
+                    pair_key = tuple(sorted([
+                        concept_nodes_with_principles[i][0],
+                        concept_nodes_with_principles[j][0],
+                    ]))
+                    if pair_key in seen:
+                        continue
+                    seen.add(pair_key)
+                    edges.append({
+                        "source": concept_nodes_with_principles[i][0],
+                        "target": concept_nodes_with_principles[j][0],
+                        "edgeType": "shared_principles",
+                        "strength": len(shared),
+                    })
+
+    return edges
+
+
+def load_campaign_costs(wiki_dir: Path, registry: dict) -> dict:
+    """Load total LLM cost per campaign from llm_metrics.jsonl files.
+
+    Returns: {campaign_name: total_cost_usd}
+    """
+    costs = {}
+    for repo_path, project in registry.get("projects", {}).items():
+        for campaign in project.get("campaigns", []):
+            name = campaign["name"]
+            metrics_path = wiki_dir / "campaigns" / name / "llm_metrics.jsonl"
+            if metrics_path.exists():
+                total = 0.0
+                with open(metrics_path) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            entry = json.loads(line)
+                            total += entry.get("cost_usd") or 0
+                        except (json.JSONDecodeError, ValueError):
+                            continue  # skip malformed lines
+                costs[name] = total
+    return costs
+
+
+def build_entity_clusters(registry: dict) -> list:
+    """Read pre-computed entity clusters from the registry.
+
+    Clusters are assigned at index time by /index-wiki using semantic
+    analysis of entity definitions. This function maps stored entity IDs
+    to names and node_ids for the HTML visualization.
+    """
+    clusters = []
+    cluster_idx = 0
+
+    for project in registry.get("projects", {}).values():
+        id_to_name = {e["id"]: e["name"] for e in project.get("entities", [])}
+
+        for stored in project.get("entity_clusters", []):
+            names = []
+            node_ids = []
+            for eid in stored.get("entities", []):
+                name = id_to_name.get(eid)
+                if name:
+                    names.append(name)
+                    node_ids.append(f"entity-{eid}")
+            if len(names) < 2:
+                continue
+            clusters.append({
+                "id": cluster_idx,
+                "label": stored.get("label", f"Cluster {cluster_idx}"),
+                "entities": sorted(names),
+                "node_ids": sorted(node_ids),
+            })
+            cluster_idx += 1
+
+    return clusters
+
+
+def build_retrieval_scopes(registry: dict, campaign_details: dict) -> dict:
+    """Pre-compute retrieval scope per entity using retrieve_wiki_context.py logic.
+
+    For each entity, walks: entity → operates_on → concepts → parent_concept → params,
+    collecting graph node IDs that would be in scope. This is the exact same walk as
+    retrieve_wiki_context.retrieve_context().
+
+    Returns: {entity_name: [list of graph node IDs in scope]}
+    """
+    scopes = {}
+
+    for repo_path, project in registry.get("projects", {}).items():
+        # Build name→node_id maps
+        concept_name_to_id = {}
+        param_name_to_id = {}
+        entity_name_to_id = {}
+
+        for campaign in project.get("campaigns", []):
+            camp_name = campaign["name"]
+            for c in campaign.get("concepts", []):
+                concept_name_to_id[(camp_name, c["name"])] = f"concept-{c['id']}"
+            for p in campaign.get("parameters", []):
+                param_name_to_id[(camp_name, p["name"])] = f"param-{p['id']}"
+
+        for e in project.get("entities", []):
+            entity_name_to_id[e["name"]] = f"entity-{e['id']}"
+
+        # For each entity, compute its retrieval scope
+        for entity in project.get("entities", []):
+            entity_name = entity["name"]
+            entity_id = entity_name_to_id[entity_name]
+            scope_node_ids = {entity_id}
+
+            # Walk all campaigns (same as retrieve_wiki_context with all campaigns)
+            for campaign in project.get("campaigns", []):
+                camp_name = campaign["name"]
+                details = campaign_details.get(camp_name, {})
+
+                # Find concepts whose operates_on includes this entity
+                matched_concept_names = set()
+                for concept in details.get("concepts", []):
+                    if entity_name in concept.get("operates_on", []):
+                        concept_id = concept_name_to_id.get(
+                            (camp_name, concept["name"])
+                        )
+                        if concept_id:
+                            scope_node_ids.add(concept_id)
+                            matched_concept_names.add(concept["name"])
+
+                # Find parameters whose parent_concept is a matched concept
+                for param in details.get("parameters", []):
+                    if param.get("parent_concept") in matched_concept_names:
+                        param_id = param_name_to_id.get(
+                            (camp_name, param["name"])
+                        )
+                        if param_id:
+                            scope_node_ids.add(param_id)
+
+            # Add campaign nodes that own any scope node
+            for campaign in project.get("campaigns", []):
+                camp_name = campaign["name"]
+                camp_id = f"campaign-{camp_name}"
+                for c in campaign.get("concepts", []):
+                    if f"concept-{c['id']}" in scope_node_ids:
+                        scope_node_ids.add(camp_id)
+                        break
+
+            scopes[entity_name] = sorted(scope_node_ids)
+
+    return scopes
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate cross-campaign knowledge graph visualization"
+    )
+    parser.add_argument(
+        "--wiki", "-w",
+        default=str(Path.home() / ".nous" / "wiki"),
+        help="Path to wiki directory (default: ~/.nous/wiki/)",
+    )
+    parser.add_argument(
+        "--output", "-o",
+        help="Output HTML file path (default: ~/.nous/wiki/viz/registry.html)",
+    )
+    parser.add_argument(
+        "--no-open",
+        action="store_true",
+        help="Don't open browser after generation",
+    )
+    parser.add_argument(
+        "--list-clusters",
+        action="store_true",
+        help="Output entity clusters as JSON to stdout and exit (for skill integration)",
+    )
+    args = parser.parse_args()
+
+    wiki_dir = Path(args.wiki)
+
+    # Load data
+    registry = load_registry(wiki_dir)
+    campaign_details = load_campaign_details(wiki_dir, registry)
+
+    # Pre-compute cross-node edges
+    cross_edges = build_cross_edges(registry, campaign_details)
+
+    # Read pre-computed entity clusters from registry
+    entity_clusters = build_entity_clusters(registry)
+
+    # If --list-clusters, output clusters and exit
+    if args.list_clusters:
+        print(json.dumps(entity_clusters, indent=2))
+        sys.exit(0)
+
+    # Pre-compute retrieval scopes per entity (using retrieve_wiki_context logic)
+    retrieval_scopes = build_retrieval_scopes(registry, campaign_details)
+
+    # Load per-campaign cost data
+    campaign_costs = load_campaign_costs(wiki_dir, registry)
+
+    # Determine output path
+    if args.output:
+        output_path = Path(args.output)
+    else:
+        viz_dir = wiki_dir / "viz"
+        viz_dir.mkdir(parents=True, exist_ok=True)
+        output_path = viz_dir / "registry.html"
+
+    # Render HTML — escape </ sequences to prevent breaking <script> blocks
+    def safe_json(obj, **kwargs):
+        return json.dumps(obj, **kwargs).replace("</", r"<\/")
+
+    html = HTML_TEMPLATE.format(
+        registry_data_json=safe_json(registry, indent=2),
+        campaign_details_json=safe_json(campaign_details),
+        cross_edges_json=safe_json(cross_edges),
+        retrieval_scopes_json=safe_json(retrieval_scopes),
+        campaign_costs_json=safe_json(campaign_costs),
+        entity_clusters_json=safe_json(entity_clusters),
+    )
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(html)
+    print(f"Generated: {output_path}")
+
+    if not args.no_open:
+        webbrowser.open(f"file://{output_path}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Adds **Nous** — a hypothesis-driven experimentation framework — as a platform agent type, layered on the `claude-code` image. Nous drives the scientific method on software systems via the `nous` CLI (DESIGN → EXECUTE_ANALYZE → findings), with all Claude calls authenticated through the platform credential gateway (no API key in the pod).

## What's included

- **Install via pip, no vendoring** — `Dockerfile` pip-installs Nous from its public GitHub repo (`ARG NOUS_REF`, default `v0.4.0`) into a venv built with the mise-provided `uv`.
- **Behavioral layer (`AGENTS.md`)** — per-campaign directories, unique web-safe `run_id`s, mandatory `locked_parameters`, always `--auto-approve` (`NOUS_ALLOW_AUTO_APPROVE=1`), background runs with **resume-on-wake** across hibernation, gateway model pinning, a **pre-flight checklist**, and monitoring guidance.
- **`nous` skill** — full CLI + campaign-authoring reference (`workspace/.agents/skills/nous/`), plus a worked BLIS example.
- **Wiki slash commands** — `post-campaign`, `index-wiki`, `visualize-campaign`, `visualize-registry`, `suggest-next` (vendored verbatim from upstream) and their stdlib render scripts, turning finished campaigns into a cross-campaign knowledge graph.
- **Channel bridge (`nous-channel-bridge.py`)** — relays Nous's native `channels:` gate notifications to the agent's bound Slack/Telegram thread via the per-agent `send_channel_message` MCP tool. Mesh-authorized, routed through the egress gateway; `NO_PROXY=127.0.0.1` keeps Nous's POST local. No external egress, no webhook secret on disk. Auto-wired when a channel is bound (`describe_channel`); duplicate launches are safe no-ops.
- **CI** — `build-nous` + `merge-nous` jobs (FROM `claude-code`, gated after `merge-agents`); `publish` and `container-scan` wait on `merge-nous`. Template enabled in `values.yaml` / `values-local.yaml`.

## Testing

- Built and deployed to a local k3s cluster; ran the BLIS example end-to-end (campaign completed, post-campaign indexing validated).
- Channel bridge verified in-pod: full MCP handshake (`initialize` → `tools/call send_channel_message`) reaches the platform and is mesh-authorized; concurrency hardening (`EADDRINUSE` → clean no-op) verified with concurrent launches.
- `mise run check` passes; `mise run helm:check:lint` / `helm:check:render` clean; `cd.yml` job graph validated.

## Follow-ups (not in this PR)

- Schedule-driven unattended resume (cron trigger → "resume running campaigns") for true overnight progress across hibernation.
- Optionally register Nous's read-only MCP server in the chat harness.
