### PR TITLE
feat(controller): emit JSON logs, ready for OTel zero-code instrumentation

### DIFF
--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Last verified: 2026-06-15
+Last verified: 2026-06-19
 
 ## Overview
 
@@ -47,3 +47,11 @@ Two disjoint mechanisms feed the one logger:
 - **Single process, single stdout.** The public API, harness, and ext-authz gRPC apps run in one process, so one logger configuration and one stream cover the whole api-server.
 - **Once per replica.** The domain bus is in-process; each replica's saga logs only its own events. Moving domain events onto the cross-replica Redis bus would require dedup, or every replica would duplicate every line. The api-server runs single-replica today.
 - **Non-blocking.** The egress gate logs on the proxy's request-blocking hop; the writer must never block or throw into a request path.
+
+## Controller logging
+
+The controller logs through Go's standard-library `log/slog`, configured once at startup ([`packages/controller/main.go`](../../packages/controller/main.go), `setupLogger`). Output is one JSON object per line on **stderr** at the `LOG_LEVEL` level (`debug|info|warn|error`, default `info`); `debug` surfaces per-reconcile phase timing. As with the api-server, the level is the only knob — there is no per-feature toggle. The controller logs to stderr rather than stdout because its lines are pure diagnostics, not program output; Kubernetes merges both streams into the one container log, so a collector sees it either way.
+
+The controller carries **no audit trail**. It acts only under its own ServiceAccount against the K8s API, never on behalf of a user, so there is no real actor to attribute — the audit trail is solely an api-server concern.
+
+The controller wires up no in-process OpenTelemetry SDK and registers no global `TracerProvider`, which keeps it ready for **zero-code instrumentation**: the OpenTelemetry Operator injects an eBPF auto-instrumentation sidecar whose `log/slog` probe captures these JSON records and exports them with trace correlation (the Go counterpart of Pino log auto-instrumentation). Registering a `TracerProvider` in-process would conflict with the injected auto-SDK and break that correlation, so the binary deliberately stays free of OTel setup.

--- a/packages/controller/main.go
+++ b/packages/controller/main.go
@@ -96,8 +96,11 @@ func main() {
 	})
 }
 
-// setupLogger installs the slog handler at the LOG_LEVEL level (debug|info|warn|
-// error, default info) — debug surfaces the per-reconcile phase timing.
+// setupLogger installs the JSON slog handler at the LOG_LEVEL level (debug|info|
+// warn|error, default info) — debug surfaces the per-reconcile phase timing.
+// JSON on stderr keeps the controller ready for OTel zero-code instrumentation;
+// keep it free of an in-process OTel TracerProvider, which would conflict with
+// the Operator-injected eBPF auto-SDK.
 func setupLogger() {
 	level := slog.LevelInfo
 	if v := os.Getenv("LOG_LEVEL"); v != "" {
@@ -106,7 +109,7 @@ func setupLogger() {
 			level = slog.LevelInfo
 		}
 	}
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
+	slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: level})))
 }
 
 func run(ctx context.Context, client kubernetes.Interface, dynClient dynamic.Interface, cfg *config.Config) {


### PR DESCRIPTION
## What

The controller logged via `log/slog` with a **TextHandler** on stderr. This switches it to a **JSONHandler** (stream unchanged) so each line is a single machine-parseable JSON object, and leaves the controller ready for OpenTelemetry zero-code instrumentation.

## Why

We want the controller ready for the OTel Operator's injected auto-instrumentation sidecar (eBPF for Go — the [autosdk](https://opentelemetry.io/docs/zero-code/go/autosdk/) model). The controller wires up **no** OTel SDK itself; it only has to (a) emit structured logs and (b) stay compatible with the injected agent. The autosdk's one hard rule is *never register a global `TracerProvider`* — the controller has zero OTel code, so it's compliant by default, and it already uses `log/slog` (the agent's probe target) in a single-container Deployment (satisfies Go injection's no-multi-container limit). So JSON output was the only real change.

## Changes

- `packages/controller/main.go` — `setupLogger()` uses `slog.NewJSONHandler` instead of `slog.NewTextHandler`; comment records the no-`TracerProvider` invariant.
- `docs/architecture/logging.md` — added a "Controller logging" section (the page was api-server-only) and bumped `Last verified:`.

## Notes

- **Stream stays stderr** — logs are diagnostics, it's the Go/controller-runtime default, and K8s merges both streams so the eBPF agent / collectors see it regardless.
- Reconcile-timing **durations now render as integer nanoseconds** rather than `"1.5s"` strings — expected with JSON, machine-friendlier.
- OTel Operator injection annotations are intentionally **out of scope** — the operator isn't deployed yet, so shipping them now would be dead config. Enabling injection later is a one-annotation opt-in.

## Verification

- `mise run controller:test` — all packages pass.
- `go build` / `go vet` / `gofmt` — clean.
- `staticcheck` failure is **pre-existing and unrelated** (toolchain mismatch in the Go install's vendored stdlib: `fips140only_go1.26.go requires go1.26, app built with go1.25`); confirmed it fails identically on a clean tree without these changes.