### PR TITLE
feat(ui): emit nginx access logs as JSON

### DIFF
--- a/deploy/helm/platform/templates/ui/app.yaml
+++ b/deploy/helm/platform/templates/ui/app.yaml
@@ -16,10 +16,28 @@ data:
         ''      '';
     }
 
+    # Structured JSON access log, one object per line on stdout.
+    log_format json_access escape=json
+        '{'
+        '"time":"$time_iso8601",'
+        '"remote_addr":"$remote_addr",'
+        '"method":"$request_method",'
+        '"uri":"$request_uri",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"request_time":$request_time,'
+        '"upstream_response_time":"$upstream_response_time",'
+        '"referer":"$http_referer",'
+        '"user_agent":"$http_user_agent",'
+        '"x_forwarded_for":"$http_x_forwarded_for"'
+        '}';
+
     server {
         listen {{ .Values.ui.port }};
         root /usr/share/nginx/html;
         index index.html;
+
+        access_log /dev/stdout json_access;
 
         location /api/ {
             proxy_pass http://{{ $apiserverName }}:{{ .Values.apiServer.port }};

--- a/packages/ui/default.conf
+++ b/packages/ui/default.conf
@@ -1,6 +1,22 @@
+# Structured JSON access log, one object per line on stdout.
+log_format json_access escape=json
+    '{'
+    '"time":"$time_iso8601",'
+    '"remote_addr":"$remote_addr",'
+    '"method":"$request_method",'
+    '"uri":"$request_uri",'
+    '"status":$status,'
+    '"body_bytes_sent":$body_bytes_sent,'
+    '"request_time":$request_time,'
+    '"referer":"$http_referer",'
+    '"user_agent":"$http_user_agent"'
+    '}';
+
 server {
     listen       8080;
     server_name  localhost;
+
+    access_log /dev/stdout json_access;
 
     location / {
         root  /usr/share/nginx/html;


### PR DESCRIPTION
## What

The UI is a static React SPA served by nginx — there's no application logger, so the only server logs are nginx's access/error logs, which were in the default plaintext `combined` format. This switches them to **structured JSON**, one object per line on stdout.

In-cluster the UI pod's nginx reverse-proxies same-origin `/api/` (tRPC + REST + WebSockets) to the api-server, so these access logs capture **all API traffic through the edge**, not just static-asset hits.

## Changes

- `deploy/helm/platform/templates/ui/app.yaml` (the live `*-ui-nginx` ConfigMap) — adds `log_format json_access escape=json` (http context, alongside the existing `map`) and `access_log /dev/stdout json_access;` in the server block. Fields: `time, remote_addr, method, uri, status, body_bytes_sent, request_time, upstream_response_time, referer, user_agent, x_forwarded_for`.
- `packages/ui/default.conf` (image-baked, used only outside k8s) — same format (minus the proxy-only fields), kept consistent to avoid drift.

## Notes

- **No `$otel_trace_id` field.** It requires a loaded nginx OTel module; referencing it with no module crashes nginx at startup. The JSON structure is in place so adding that one field is trivial later.
- **Trace propagation is intentionally out of scope.** The OTel Operator's `inject-nginx` uses a module supporting only nginx 1.22–1.23.1; our image is newer. Rather than downgrade or hand-bake the native `ngx_otel_module`, propagation waits until the operator supports this nginx version. (Tracking issue to follow.)

## Verification

- `mise run helm:check:lint` and `mise run helm:check:render` (kubeconform) pass; rendered ConfigMap confirmed correct (nginx `$vars` survive the YAML block scalar, upstream interpolates).
- nginx syntax not validatable locally (no binary/cached image); the authoritative check is `mise run cluster:build-ui` → confirm the pod starts and access lines are single JSON objects.