### PR TITLE
feat(keycloak): allow OpenTelemetry config via chart passthrough

### DIFF
--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -58,7 +58,7 @@ spec:
         - name: keycloak
           image: "{{ .Values.keycloak.image.repository }}:{{ .Values.keycloak.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.keycloak.image.pullPolicy | default "IfNotPresent" }}
-          args: [{{ if eq .Values.scheme "https" }}"start"{{ else }}"start-dev"{{ end }}, "--features=token-exchange,admin-fine-grained-authz:v1"]
+          args: [{{ if eq .Values.scheme "https" }}"start"{{ else }}"start-dev"{{ end }}, "--features=token-exchange,admin-fine-grained-authz:v1{{ range .Values.keycloak.extraFeatures }},{{ . }}{{ end }}"]
           ports:
             - containerPort: {{ .Values.keycloak.port }}
               name: http
@@ -102,6 +102,9 @@ spec:
             {{- if eq .Values.scheme "https" }}
             - name: KC_HTTP_ENABLED
               value: "true"
+            {{- end }}
+            {{- with .Values.keycloak.extraEnv }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
           {{- if .Values.probes.enabled }}
           readinessProbe:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -175,6 +175,13 @@ keycloak:
   configCliImage: quay.io/adorsys/keycloak-config-cli:latest-26.5.4
   port: 8080
 
+  # -- Additional Keycloak server features. The chart always enables a required
+  # base — `token-exchange` (the API server depends on it) and
+  # `admin-fine-grained-authz:v1` — and appends these to it, rendered into the
+  # single `--features=` arg (a second `--features` would override, not merge).
+  # List only extras here, e.g. `opentelemetry-logs` to enable OTLP log export.
+  extraFeatures: []
+
   # -- Admin credentials (for Keycloak admin console)
   admin:
     user: admin
@@ -244,6 +251,23 @@ keycloak:
     # Local dev overrides this to `default` in `values-local.yaml` for
     # readable `kubectl logs`.
     consoleOutput: "json"
+
+  # -- Extra environment variables appended verbatim to the Keycloak container.
+  # The chart does not model Keycloak's still-evolving OpenTelemetry options, so
+  # wire observability here. All signals push over OTLP to a collector — traces,
+  # metrics, and logs share one endpoint and one auth header:
+  #   extraEnv:
+  #     - name: KC_TRACING_ENABLED
+  #       value: "true"
+  #     - name: KC_TRACING_ENDPOINT
+  #       value: "http://otel-collector:4317"
+  #     - name: KC_TELEMETRY_HEADER_AUTHORIZATION  # token from a Secret, never inline
+  #       valueFrom:
+  #         secretKeyRef: { name: otel-creds, key: authorization }
+  # Each entry is a raw corev1.EnvVar (name/value or name/valueFrom). Appended
+  # after the chart's own env, so an entry reusing a built-in KC_ name overrides
+  # it (Kubernetes env is last-wins).
+  extraEnv: []
 
   # -- Test user bootstrapped via realm import.
   # DISABLED by default — production deployments must not ship a known credential.


### PR DESCRIPTION
## What

Lets the Helm chart configure Keycloak's OpenTelemetry — traces, logs, and metrics — without the chart hardcoding Keycloak's still-evolving `telemetry-*` option names. Nothing is enabled by default; rendered output is unchanged until configured.

## Why

Keycloak 26.6.3 (Quarkus) has native OTel: tracing is a stable knob (`KC_TRACING_ENABLED`), OTLP log/metrics export are newer (`KC_TELEMETRY_LOGS_ENABLED` / `KC_TELEMETRY_METRICS_ENABLED`, logs preview-gated behind `--features=opentelemetry-logs`). It needs **no** operator `inject-java` agent — that would double-instrument. All signals push over OTLP to a collector and share one endpoint + one auth header. But the chart hardcoded the env list and `--features` arg with no way to set any of it.

## Changes

- `values.yaml` → `keycloak.features` (list) — replaces the hardcoded `--features=` literal; defaults to `token-exchange` + `admin-fine-grained-authz:v1`. Add `opentelemetry-logs` here to enable OTLP log export.
- `values.yaml` → `keycloak.extraEnv` (list of raw `EnvVar`) — passthrough for `KC_TRACING_*` / `KC_TELEMETRY_*` / `KC_METRICS_*`, with a worked OTLP example (incl. a secret-backed `KC_TELEMETRY_HEADER_AUTHORIZATION`) in the values comment.
- `templates/keycloak/app.yaml` — renders the features list into the single `--features` arg and appends `extraEnv` after the built-in env.

## Design note

`features` is modeled as a list (not a generic `extraArgs`) on purpose: a second `--features` flag **overrides** rather than merges, so passing `opentelemetry-logs` via a raw arg passthrough would silently drop `token-exchange` (which the API server relies on).

## Verification

- `mise run helm:check:lint` + `mise run helm:check:render` (kubeconform) pass.
- Default render is byte-identical: `args: ["start-dev", "--features=token-exchange,admin-fine-grained-authz:v1"]`, same KC_ env set.
- With overrides: `--features=...,opentelemetry-logs` (token-exchange preserved) and `extraEnv` appended with `KC_TELEMETRY_HEADER_AUTHORIZATION` resolving via `secretKeyRef`.

## Out of scope

Actually enabling tracing/logs/metrics (needs a deployed OTLP collector endpoint) — this PR only makes it configurable.