### PR TITLE
fix(keycloak-theme): pin React type resolution to v18

### DIFF
--- a/packages/keycloak-theme/tsconfig.json
+++ b/packages/keycloak-theme/tsconfig.json
@@ -7,7 +7,13 @@
     "allowImportingTsExtensions": true,
     "moduleDetection": "force",
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client"],
+    "paths": {
+      "react": ["./node_modules/@types/react"],
+      "react/*": ["./node_modules/@types/react/*"],
+      "react-dom": ["./node_modules/@types/react-dom"],
+      "react-dom/*": ["./node_modules/@types/react-dom/*"]
+    }
   },
   "include": ["src"]
 }


### PR DESCRIPTION
## Problem

After the UI bump to React 19, the keycloak-theme build intermittently fails type-checking:

```
src/login/pages/Error.tsx(15,6): error TS2786: 'Template' cannot be used as a JSX component.
  ...
  Type 'import(".../@types+react@19.2.17/.../react/index").ReactNode' is not assignable to type 'React.ReactNode'.
    Type 'bigint' is not assignable to type 'ReactNode'.
```

## Root cause

The React 19 bump added `@types/react@19` to the workspace, which pnpm **hoists** into the virtual store (`node_modules/.pnpm/node_modules/@types/react`). Keycloakify declares `react`/`@types/react` only as **devDependencies** (not peerDependencies), so pnpm never pins a React version for it. Its bundled `.d.ts` files therefore resolve `react` by walking up to the hoisted **v19** copy, while keycloak-theme's own sources resolve to the local **v18** copy. The two `ReactNode` types differ (v19's includes `bigint`), so `Template` fails the JSX-component check.

The intermittency comes from which `@types/react` version pnpm happens to hoist on a given install.

## Fix

Add tsconfig `paths` pinning `react`/`react-dom` type resolution to keycloak-theme's local v18 copy. `paths` apply program-wide — including to dependency `.d.ts` files — so keycloakify's types now resolve to v18 as well, making the build deterministic.

- Contained entirely to the keycloak-theme package
- Points at the pnpm-managed symlink (not a versioned `.pnpm` hash), so it survives dependency bumps
- Doesn't affect the runtime build — Vite/keycloakify resolve the real `react@18` package independently of tsconfig paths

## Verification

- `mise run keycloak-theme:check:tsc` — passes
- `mise run keycloak-theme:build` — full theme JAR builds successfully