### PR TITLE
fix(agents): prevent model-gateway crash on client disconnect

### DIFF
--- a/packages/agents/claude-code/model-gateway.mjs
+++ b/packages/agents/claude-code/model-gateway.mjs
@@ -196,8 +196,11 @@ async function proxy(req, res) {
   }
 
   res.writeHead(r.status, keepHeaders([...r.headers], RES_DROP));
-  if (r.body) Readable.fromWeb(r.body).pipe(res);
-  else res.end();
+  if (r.body) {
+    const upstream = Readable.fromWeb(r.body);
+    upstream.on("error", () => res.destroy());
+    upstream.pipe(res);
+  } else res.end();
 }
 
 const server = http.createServer((req, res) => {


### PR DESCRIPTION
May fix #1444.

## Problem

Long-running agent tasks get interrupted: the agent appears to end its turn mid-work and background processes die, consistent with the pod restarting. Captured agent logs show the `model-gateway` process crashing with an unhandled `'error'` event (`DOMException [AbortError]`), after which `pod-service` restarts it (`exited (code 1) ... restarting in 1000ms`).

## Root cause

In `packages/agents/claude-code/model-gateway.mjs`, the proxy aborts the upstream `fetch` when the client disconnects mid-response (`res` `close` with `writableEnded === false`). The response body is streamed via `Readable.fromWeb(r.body).pipe(res)`. Aborting makes that source Readable emit an `'error'` event — but `.pipe()` does **not** forward source errors and there was no `'error'` handler, so Node throws on the unhandled event and the whole gateway process dies, taking the agent's in-flight turn and background processes with it.

This reproduces under real streaming LLM workloads (e.g. BugStone) but not trivial tasks like `sleep`, which make no model calls.

## Fix

Attach an `'error'` handler to the source stream so an aborted/errored stream just tears down the response (`res.destroy()`) instead of throwing.

## Testing

Requires an agent image rebuild (`mise run cluster:build-agent`) to land in a running cluster.