### PR TITLE
fix(helm): zero-downtime UI rollout

### DIFF
--- a/deploy/helm/platform/templates/ui/app.yaml
+++ b/deploy/helm/platform/templates/ui/app.yaml
@@ -95,6 +95,11 @@ metadata:
   {{- include "platform.annotations" (dict "root" $ "component" .Values.ui) | nindent 2 }}
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/component: ui


### PR DESCRIPTION
## What

Add an explicit `RollingUpdate` strategy (`maxSurge: 1`, `maxUnavailable: 0`) to the UI Deployment so a new pod becomes Ready **before** the old one is torn down — no serving gap on `helm upgrade` / roll. Previously the UI relied on the implicit Kubernetes 25%/25% default, which at `replicas: 1` is ambiguous and not explicitly guaranteed to keep a pod serving throughout. This mirrors what the api-server Deployment already does.

## Why

Part of minimizing downtime/interruptions on redeployment. The UI's nginx also proxies the `/api` WebSocket relay (ACP + terminal) to the api-server, so a UI roll with a gap would needlessly drop those connections.

Two related findings from the same investigation were deliberately **not** changed:
- **api-server WS** — already zero-downtime for HTTP; WS interruptions are self-healing (UI auto-reconnects with backoff, agent-runtime replays state on reconnect). No change needed.
- **Keycloak `Recreate`** — kept as-is. Flipping it to RollingUpdate is unsafe for a single, un-clustered Keycloak (cache-isolated pods → broken in-flight logins/code-exchange; schema-migration races on version bumps).

## Verification

Deployed via `mise run cluster:install` and triggered a real roll:

```
t=02–04  pods=2  available=1   # surges to 2, old keeps serving
t=05+    pods=1  available=1   # old retired only after new Ready
```

`availableReplicas` never dropped below 1 across the entire rollout — confirmed zero serving gap. In-cluster strategy reads back as `{type: RollingUpdate, maxSurge: 1, maxUnavailable: 0}`.