### PR TITLE
fix(bob): handle chat file attachments

### DIFF
--- a/packages/agents/bob/README.md
+++ b/packages/agents/bob/README.md
@@ -7,7 +7,7 @@ Platform agent running [Bob Shell](https://internal.bob.ibm.com/docs/shell) — 
 | Component | Source | Purpose |
 |---|---|---|
 | Harness | `bobshell` (installed from `bob.ibm.com/download/bobshell.sh`) | Bob CLI in `--experimental-acp` mode + native TUI |
-| ACP bridge | `bob-acp-shim.mjs` (verbatim from upstream Bob) | Translates Bob's session/update events into the shape the platform UI expects; auto-approves `session/request_permission` (Bob's ACP doesn't actually issue per-tool HITL requests for built-in tools — see autonomy posture below) |
+| ACP bridge | `bob-acp-shim.mjs` | Translates Bob's session/update events into the shape the platform UI expects; auto-approves `session/request_permission` (Bob's ACP doesn't actually issue per-tool HITL requests for built-in tools — see autonomy posture below); stages chat attachments into the workspace so Bob can read them (it can't consume `resource_link` blocks in ACP mode) |
 | Storage | `/home/agent` PVC (ADR-027) | Bob's session index lives under `~/.bob/`; survives pod restarts |
 
 ## Authentication

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -62,8 +62,8 @@
 // Set BOB_SHIM_TRACE=1 to log every inbound and outbound frame to stderr.
 // ──────────────────────────────────────────────────────────────────────────
 import { spawn } from "node:child_process";
-import { promises as fsp } from "node:fs";
-import { dirname } from "node:path";
+import { copyFileSync, mkdirSync, promises as fsp } from "node:fs";
+import { basename, dirname, join } from "node:path";
 import readline from "node:readline";
 
 const TRACE = process.env.BOB_SHIM_TRACE === "1";
@@ -83,6 +83,8 @@ let currentModeId = (() => {
   return "ask";
 })();
 const pendingNewSessionIds = new Set();
+// Session workspace (ACP cwd); Bob's read guard allows only this dir + its temp.
+let sessionCwd = null;
 let pendingModeSwitch = null;
 
 // agent_message_chunk state machine. Bob wraps reasoning in <thinking>…
@@ -134,6 +136,7 @@ function handleClientLine(line) {
 
   if (isClientRequest && f.method === "session/new") {
     pendingNewSessionIds.add(f.id);
+    if (typeof f.params?.cwd === "string") sessionCwd = f.params.cwd;
     return forwardToBob(line);
   }
 
@@ -158,26 +161,52 @@ function handleClientLine(line) {
     return;
   }
 
-  // One-shot mode switch: prepend an instruction to the next prompt asking
-  // the LLM to call the switch-mode tool. Bob's system prompt teaches the
-  // exact XML form, so the LLM should comply, after which Bob's bundle
-  // updates its internal mode for subsequent turns.
-  if (isClientRequest && f.method === "session/prompt" && pendingModeSwitch) {
-    try {
-      const prompt = f.params?.prompt;
-      if (Array.isArray(prompt)) {
-        const firstText = prompt.find((p) => p?.type === "text" && typeof p?.text === "string");
-        if (firstText) {
-          const instruction = `[System: switch to ${pendingModeSwitch} mode now using the switch-mode tool, then continue.]\n\n`;
-          firstText.text = instruction + firstText.text;
-          pendingModeSwitch = null;
-          return forwardToBob(JSON.stringify(f));
-        }
+  if (isClientRequest && f.method === "session/prompt" && Array.isArray(f.params?.prompt)) {
+    // Bob rejects resource_link blocks (-32603, issue #441); stage each
+    // attachment and pass a text path pointer instead.
+    f.params.prompt = f.params.prompt.map((b) =>
+      b?.type === "resource_link" ? { type: "text", text: stageAttachment(b) } : b,
+    );
+    // One-shot mode switch: prepend an instruction so the LLM calls the
+    // switch-mode tool (Bob's system prompt teaches the XML form).
+    if (pendingModeSwitch) {
+      const firstText = f.params.prompt.find(
+        (p) => p?.type === "text" && typeof p?.text === "string",
+      );
+      if (firstText) {
+        firstText.text = `[System: switch to ${pendingModeSwitch} mode now using the switch-mode tool, then continue.]\n\n${firstText.text}`;
+        pendingModeSwitch = null;
       }
-    } catch { /* fall through */ }
+    }
+    return forwardToBob(JSON.stringify(f));
   }
 
   forwardToBob(line);
+}
+
+// Uploads land in $HOME/.uploads, which Bob can't read in ACP mode (read guard
+// is the workspace + temp, not widenable). Copy into the workspace and point
+// Bob there; on failure fall back to the original path.
+function stageAttachment(block) {
+  let src = typeof block.uri === "string" ? block.uri : "";
+  if (src.startsWith("file://")) {
+    try {
+      src = decodeURIComponent(new URL(src).pathname);
+    } catch {
+      /* keep raw uri */
+    }
+  }
+  const mime = block.mimeType ? ` (${block.mimeType})` : "";
+  try {
+    const destDir = join(sessionCwd || process.cwd(), ".attachments");
+    mkdirSync(destDir, { recursive: true });
+    const dest = join(destDir, basename(src));
+    copyFileSync(src, dest);
+    src = dest;
+  } catch (err) {
+    if (TRACE) process.stderr.write(`[bob-acp-shim] stage failed: ${err.message}\n`);
+  }
+  return `[Attached file${mime}: ${src}]`;
 }
 
 function sendToBob(frame) {

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -84,25 +84,20 @@ let currentModeId = (() => {
   return "ask";
 })();
 const pendingNewSessionIds = new Set();
-// Session workspace (ACP cwd); Bob's read guard allows only this dir + its
-// temp. Defaults to the harness's launch dir (the workspace) until session/new.
+// Session workspace (ACP cwd) — the only dir Bob's read guard allows; set on session/new.
 let sessionCwd = process.cwd();
-// Chat uploads land here; only files under it are staged into the workspace.
+// Chat uploads land here; only files under it get staged into the workspace.
 const UPLOADS_ROOT = resolve(process.env.HOME || "/home/agent", ".uploads");
 let pendingModeSwitch = null;
 
-// agent_message_chunk state machine. Bob wraps reasoning in <thinking>…
-// </thinking>; the actual user-facing text is whatever lives outside the
-// block. Default state is "inside" because bob skips the opening tag for
-// direct-answer turns. messageCarry retains the tail that might contain a
-// partial THINK_OPEN/THINK_CLOSE tag split across token boundaries.
+// agent_message_chunk state machine. Bob wraps reasoning in <thinking>…</thinking>;
+// user-facing text is what's outside. Default state is "inside" — Bob omits the
+// opening tag on direct-answer turns. messageCarry holds the tail in case a tag is
+// split across token boundaries.
 //
-// outsideBuf accumulates out-of-thinking text for meta-hint filtering.
-// Bob peppers "[using tool X: …]" status lines into the message stream,
-// which spread over many tokens (e.g. the closing "]" arrives several
-// chunks later, with real answer text in between). We strip complete
-// "[using tool … ]" segments and keep the tail whenever a still-unclosed
-// "[using tool" start is present so we don't ship partial meta to the UI.
+// outsideBuf accumulates out-of-thinking text for meta-hint filtering: Bob peppers
+// "[using tool X: …]" status lines across many tokens, so we strip complete
+// "[using tool … ]" segments and keep the tail while a "[using tool" is still open.
 const THINK_OPEN = "<thinking>";
 const THINK_CLOSE = "</thinking>";
 const META_COMPLETE = /\[using tool [^\]]*\]\n?/g;
@@ -166,13 +161,11 @@ function handleClientLine(line) {
   }
 
   if (isClientRequest && f.method === "session/prompt" && Array.isArray(f.params?.prompt)) {
-    // Bob rejects resource_link blocks (-32603, issue #441); stage each
-    // attachment and pass a text path pointer instead.
+    // Bob rejects resource_link blocks (#441); stage each and pass a text path pointer.
     f.params.prompt = f.params.prompt.map((b) =>
       b?.type === "resource_link" ? { type: "text", text: stageAttachment(b) } : b,
     );
-    // One-shot mode switch: prepend an instruction so the LLM calls the
-    // switch-mode tool (Bob's system prompt teaches the XML form).
+    // One-shot mode switch: prepend an instruction so the LLM calls the switch-mode tool.
     if (pendingModeSwitch) {
       const firstText = f.params.prompt.find(
         (p) => p?.type === "text" && typeof p?.text === "string",
@@ -188,22 +181,18 @@ function handleClientLine(line) {
   forwardToBob(line);
 }
 
-// Uploads land in $HOME/.uploads, which Bob can't read in ACP mode (read guard
-// is the workspace + temp, not widenable). Copy into the workspace and point
-// Bob there; on failure fall back to the original path.
+// Copy an upload into the workspace so Bob's read guard (workspace + temp only) can see it.
 function stageAttachment(block) {
   let src = typeof block.uri === "string" ? block.uri : "";
   if (src.startsWith("file://")) {
     try {
       src = fileURLToPath(src);
     } catch {
-      /* leave src as the raw uri */
+      /* keep the raw uri */
     }
   }
-  // Resolve before the containment check so `..` segments can't slip a path
-  // outside the upload dir past it — copying an arbitrary path into the
-  // workspace would smuggle a file past Bob's read guard. Other paths pass
-  // through for Bob's own guard to govern.
+  // Resolve before the containment check so `..` can't escape UPLOADS_ROOT and
+  // smuggle an arbitrary file past Bob's read guard.
   src = resolve(src);
   if (src === UPLOADS_ROOT || src.startsWith(UPLOADS_ROOT + sep)) {
     try {

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -84,8 +84,9 @@ let currentModeId = (() => {
   return "ask";
 })();
 const pendingNewSessionIds = new Set();
-// Session workspace (ACP cwd); Bob's read guard allows only this dir + its temp.
-let sessionCwd = null;
+// Session workspace (ACP cwd); Bob's read guard allows only this dir + its
+// temp. Defaults to the harness's launch dir (the workspace) until session/new.
+let sessionCwd = process.cwd();
 // Chat uploads land here; only files under it are staged into the workspace.
 const UPLOADS_ROOT = resolve(process.env.HOME || "/home/agent", ".uploads");
 let pendingModeSwitch = null;
@@ -199,12 +200,14 @@ function stageAttachment(block) {
       /* leave src as the raw uri */
     }
   }
-  // Only stage files from the upload dir — copying an arbitrary path into the
-  // workspace would let a crafted uri smuggle a file past Bob's read guard.
-  // Other paths pass through for Bob's own guard to govern.
+  // Resolve before the containment check so `..` segments can't slip a path
+  // outside the upload dir past it — copying an arbitrary path into the
+  // workspace would smuggle a file past Bob's read guard. Other paths pass
+  // through for Bob's own guard to govern.
+  src = resolve(src);
   if (src === UPLOADS_ROOT || src.startsWith(UPLOADS_ROOT + sep)) {
     try {
-      const destDir = join(sessionCwd || process.cwd(), ".attachments");
+      const destDir = join(sessionCwd, ".attachments");
       mkdirSync(destDir, { recursive: true });
       const dest = join(destDir, basename(src));
       copyFileSync(src, dest);

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -63,8 +63,9 @@
 // ──────────────────────────────────────────────────────────────────────────
 import { spawn } from "node:child_process";
 import { copyFileSync, mkdirSync, promises as fsp } from "node:fs";
-import { basename, dirname, join } from "node:path";
+import { basename, dirname, join, resolve, sep } from "node:path";
 import readline from "node:readline";
+import { fileURLToPath } from "node:url";
 
 const TRACE = process.env.BOB_SHIM_TRACE === "1";
 const thinkToolCallIds = new Set();
@@ -85,6 +86,8 @@ let currentModeId = (() => {
 const pendingNewSessionIds = new Set();
 // Session workspace (ACP cwd); Bob's read guard allows only this dir + its temp.
 let sessionCwd = null;
+// Chat uploads land here; only files under it are staged into the workspace.
+const UPLOADS_ROOT = resolve(process.env.HOME || "/home/agent", ".uploads");
 let pendingModeSwitch = null;
 
 // agent_message_chunk state machine. Bob wraps reasoning in <thinking>…
@@ -191,22 +194,28 @@ function stageAttachment(block) {
   let src = typeof block.uri === "string" ? block.uri : "";
   if (src.startsWith("file://")) {
     try {
-      src = decodeURIComponent(new URL(src).pathname);
+      src = fileURLToPath(src);
     } catch {
-      /* keep raw uri */
+      /* leave src as the raw uri */
     }
   }
-  const mime = block.mimeType ? ` (${block.mimeType})` : "";
-  try {
-    const destDir = join(sessionCwd || process.cwd(), ".attachments");
-    mkdirSync(destDir, { recursive: true });
-    const dest = join(destDir, basename(src));
-    copyFileSync(src, dest);
-    src = dest;
-  } catch (err) {
-    if (TRACE) process.stderr.write(`[bob-acp-shim] stage failed: ${err.message}\n`);
+  // Only stage files from the upload dir — copying an arbitrary path into the
+  // workspace would let a crafted uri smuggle a file past Bob's read guard.
+  // Other paths pass through for Bob's own guard to govern.
+  if (src === UPLOADS_ROOT || src.startsWith(UPLOADS_ROOT + sep)) {
+    try {
+      const destDir = join(sessionCwd || process.cwd(), ".attachments");
+      mkdirSync(destDir, { recursive: true });
+      const dest = join(destDir, basename(src));
+      copyFileSync(src, dest);
+      src = dest;
+    } catch (err) {
+      if (TRACE) process.stderr.write(`[bob-acp-shim] stage failed: ${err.message}\n`);
+    }
   }
-  return `[Attached file${mime}: ${src}]`;
+  const name = typeof block.name === "string" && block.name ? ` "${block.name}"` : "";
+  const mime = block.mimeType ? ` (${block.mimeType})` : "";
+  return `[Attached file${name}${mime}: ${src}]`;
 }
 
 function sendToBob(frame) {


### PR DESCRIPTION
Closes #441.

## Problem

Sending a non-image attachment (e.g. a PDF) to a **Bob** agent in chat failed with "Internal error" — even though the `files.upload` POST succeeded. Claude agents were unaffected.

## Root cause

The UI sends every non-image attachment as an ACP `resource_link` block. Bob routes `resource_link` to an internal `read_many_files` tool that **isn't registered in its experimental-ACP mode**, so the whole `session/prompt` rejects with `-32603` (`Error: read_many_files tool not found`). Claude reads `resource_link` natively, so the bug was Bob-only. Reproduced live against a Bob pod.

## Fix (in the Bob shim)

1. **Rewrite `resource_link` → text path pointer.** Stops the crash; Bob reads the file with its own tools.
2. **Stage the attachment into the workspace.** Bob's ACP read guard allows only the session workspace (`cwd`) + its temp dir, and that list can't be widened headless (`--include-directories` only enters the allow-list via an interactive trust prompt that never fires in ACP mode — verified in Bob's bundle). Uploads land in `$HOME/.uploads`, outside that list, so the shim copies each attachment into a `.attachments/` dir under the workspace and points Bob at the copy. This is what Bob would otherwise do itself (copy the file in), made deterministic. Falls back to the original path if the copy fails.

No cleanup of the staged copies: they share the lifecycle of the `.uploads` originals (persisted on the PVC, reclaimed when the agent is deleted). Pruning them would break "ask about that file later" back-references, which carry no new `resource_link` to re-stage.

## Verification

Reproduced and verified end-to-end against a live, rebuilt Bob pod:
- Before: `session/prompt` → `-32603 "Error: read_many_files tool not found"`.
- After: `session/prompt` → `stopReason: end_turn`; Bob reads the staged attachment in place (no "outside allowed workspace" error, no self-copy step) and answers from its contents.

A no-attachment control prompt and the staged-file path were both confirmed.