### PR TITLE
fix(agent-runtime): debounce idle ACP session reap

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
@@ -1024,6 +1024,52 @@ describe("createAcpRuntime", () => {
     expect((closeFrames[0] as any).params).toEqual({ sessionId: SID });
   });
 
+  it("debounces the idle reap and a new prompt within the window cancels it", () => {
+    vi.useFakeTimers();
+    try {
+      const fa = makeFakeAgent();
+      const runtime = createAcpRuntime({
+        spawnAgent: () => fa.agent,
+        workingDir: "/tmp",
+        idleReapDelayMs: 100,
+      });
+
+      const c = makeFakeChannel();
+      runtime.attach(c.channel);
+      c.pushMessage(initializeRequest(0));
+      fa.pushLine(initializeResponse(outboundId(fa.sent[0]), { close: {} }));
+      c.pushMessage(newSessionRequest(1));
+      fa.pushLine(newSessionResponse(outboundId(fa.sent[1])));
+
+      // Last viewer leaves → reap is scheduled, not immediate.
+      c.remoteClose();
+      vi.advanceTimersByTime(99);
+      expect(
+        fa.sent.filter((f: any) => f.method === "session/close"),
+      ).toHaveLength(0);
+
+      // A new prompt for the session arrives within the window → reap cancelled.
+      const c2 = makeFakeChannel();
+      runtime.attach(c2.channel);
+      c2.pushMessage(promptRequest(2));
+      vi.advanceTimersByTime(1000);
+      expect(
+        fa.sent.filter((f: any) => f.method === "session/close"),
+      ).toHaveLength(0);
+
+      // Prompt completes and that viewer leaves → reap fires after the window.
+      const promptOut = outboundId(fa.sent[fa.sent.length - 1]);
+      fa.pushLine(agentPromptResponse(promptOut));
+      c2.remoteClose();
+      vi.advanceTimersByTime(100);
+      const closes = fa.sent.filter((f: any) => f.method === "session/close");
+      expect(closes).toHaveLength(1);
+      expect((closes[0] as any).params).toEqual({ sessionId: SID });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("does not close a session with pending permission requests", () => {
     const fa = makeFakeAgent();
     const runtime = createAcpRuntime({

--- a/packages/agent-runtime/src/modules/acp/compose.ts
+++ b/packages/agent-runtime/src/modules/acp/compose.ts
@@ -37,6 +37,9 @@ export function composeAcp(opts: ComposeAcpOptions): {
     log: opts.log,
     // Warm restart (env on the PV) spawns now; cold boot gates until env arrives.
     envReadyAtBoot: opts.envReader.ready(),
+    // Let a turn's trailing work settle (and quick re-attaches reconnect)
+    // before reaping the harness subprocess.
+    idleReapDelayMs: 3_000,
   });
   const triggerDriver = createTriggerSessionDriver({ acpRuntime: runtime });
   return { runtime, triggerDriver };

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -80,6 +80,10 @@ export interface AcpRuntimeDeps {
   orphanTtlMs?: number;
   /** Override the env force-recycle bound — exposed for tests; default 60s. */
   envForceRecycleMs?: number;
+  /** Quiescence window before reaping an idle session's subprocess. 0 (default)
+   * reaps inline; production injects a few seconds so a turn's trailing work
+   * finishes and quick re-attaches keep the subprocess warm. */
+  idleReapDelayMs?: number;
   /** Env already on disk at boot → spawn now; false gates the first spawn until env arrives. Defaults true. */
   envReadyAtBoot?: boolean;
   /** Override the cold-boot warm-start bound — exposed for tests; default 15s. */
@@ -208,6 +212,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   const logBytesCap = deps.logBytesCap ?? DEFAULT_LOG_BYTES_CAP;
   const envForceRecycleMs =
     deps.envForceRecycleMs ?? DEFAULT_ENV_FORCE_RECYCLE_MS;
+  const idleReapDelayMs = deps.idleReapDelayMs ?? 0;
   const warmStartTimeoutMs =
     deps.warmStartTimeoutMs ?? DEFAULT_WARM_START_TIMEOUT_MS;
   // Cold-boot spawn gate: channels attaching before env lands buffer until it does.
@@ -267,6 +272,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   /** Per-session orphan timers. A session is orphaned when it has pending
    * agent-initiated requests but no channel engaged with it. */
   const orphanTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Per-session debounced idle-reap timers (see maybeCloseIdleSession). */
+  const idleReapTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   // ── Session log ──
 
@@ -607,6 +614,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
     bootstrapBySession.clear();
     for (const t of orphanTimers.values()) clearTimeout(t);
     orphanTimers.clear();
+    for (const t of idleReapTimers.values()) clearTimeout(t);
+    idleReapTimers.clear();
     pendingFromAgent.clear();
     activePromptBySession.clear();
     promptQueueBySession.clear();
@@ -698,6 +707,11 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
     }
     sessionLogs.delete(sessionId);
     for (const cursors of channelCursors.values()) cursors.delete(sessionId);
+    const reap = idleReapTimers.get(sessionId);
+    if (reap) {
+      clearTimeout(reap);
+      idleReapTimers.delete(sessionId);
+    }
   }
 
   /**
@@ -710,7 +724,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
    * `sessionCapabilities.close`: we can't tell the agent to drop the session,
    * so we also keep the cache so future resumes can still serve from memory.
    */
-  function maybeCloseIdleSession(sessionId: string): void {
+  function reapIdleSessionNow(sessionId: string): void {
+    idleReapTimers.delete(sessionId);
     if (!agent || agentExited) return;
     if (!sessionCloseSupported) return;
     if (hasEngagedChannel(sessionId)) return;
@@ -726,6 +741,27 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
 
     tearDownSession(sessionId);
     deps.log?.(`closing idle session ${sessionId}`);
+  }
+
+  // Defer the reap by a quiescence window: the harness can still be flushing
+  // a turn's trailing work (async post-tool hooks) after its prompt response
+  // lands, and a quick re-attach or the next queued prompt should keep the
+  // ~300MB subprocess warm rather than pay a cold respawn. The full guard is
+  // re-checked when the timer fires, so anything that re-engages in the window
+  // cancels the reap. Delay 0 (the library default, and tests) reaps inline,
+  // preserving the original synchronous behaviour. Ceiling: a fixed delay, not
+  // a true harness-idle signal.
+  function maybeCloseIdleSession(sessionId: string): void {
+    if (idleReapDelayMs <= 0) {
+      reapIdleSessionNow(sessionId);
+      return;
+    }
+    const existing = idleReapTimers.get(sessionId);
+    if (existing) clearTimeout(existing);
+    idleReapTimers.set(
+      sessionId,
+      setTimeout(() => reapIdleSessionNow(sessionId), idleReapDelayMs),
+    );
   }
 
   function sendErrorResponse(
@@ -1318,6 +1354,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       bootstrapBySession.clear();
       for (const t of orphanTimers.values()) clearTimeout(t);
       orphanTimers.clear();
+      for (const t of idleReapTimers.values()) clearTimeout(t);
+      idleReapTimers.clear();
       clearEnvForceTimer();
       if (warmTimer) clearTimeout(warmTimer);
       warmWaiters.clear();


### PR DESCRIPTION
## Problem

On every agent boot/turn we see this trio in the pod log:

```
[acp] closing idle session <id>
Error handling request … session/close … { code: -32603, details: 'Session not found' }
No onPostToolUseHook found for tool use ID: …   (×N)
```

The runtime reaps a chat session's harness subprocess the **instant** its `session/prompt` response lands (turn boundary, `acp-runtime.ts`) or its **last channel detaches** — with no grace period. But Claude Code keeps flushing a turn's trailing async work (post-tool hooks) *after* the prompt response, and a quick UI re-attach or the next queued prompt then pays a cold ~300 MB subprocess respawn. The orphaned `No onPostToolUseHook` lines are that trailing work arriving after teardown; the `Session not found` is a client's own `session/close` racing the reap (the existing code comments already flag this race).

This is independent of the liveness-probe fix (#1590) — it doesn't crash the pod, but it interrupts/strands work and spams the logs on every session.

## Change

Defer the reap by a **quiescence window** and re-check the full idle guard when the timer fires, so:
- a turn's trailing async work settles before `session/close`,
- a re-attach or next prompt within the window **cancels** the reap and keeps the subprocess warm.

Design:
- `idleReapDelayMs` is a new injected knob on the runtime. **Library default is `0` (inline reap)** — so every existing direct-construction test keeps its synchronous-reap contract untouched.
- Production injects `3_000` ms via `compose.ts` (the single production wiring point).
- Reap timers are cleared on teardown / env-recycle / shutdown to avoid leaks or double-reap.

**Ceiling (commented in code):** a fixed delay, not a true harness-idle signal. A turn whose trailing work exceeds the window can still orphan a hook; the clean fix is a harness "fully quiesced" signal, tracked separately.

## Testing
- New test: reap is deferred (not immediate), a new prompt within the window cancels it, and it fires once the session is genuinely idle past the window.
- `tsc` clean; eslint/prettier clean; **105/105 agent-runtime tests pass** (104 + the new one); all pre-existing reap tests unchanged and green.