### PR TITLE
fix(helm): default agent pull policy to Kubernetes' tag-based rule

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -748,7 +748,13 @@ controller:
       # api-server for pod-files producers (currently one global value).
       agentHome: /home/agent
 
-      imagePullPolicy: IfNotPresent
+      # Left unset so Kubernetes applies its native, tag-based pull policy:
+      # `Always` for a mutable `:latest` (so a repushed tag is actually
+      # re-pulled, not served stale from the node cache) and `IfNotPresent`
+      # for the immutable sha/digest tags the harness images use. Hardcoding a
+      # value here forces it for ALL tags and silently strands `:latest` agents
+      # on a cached image. A template or agent can still set its own override.
+      imagePullPolicy: ""
       storageSize: "10Gi"
       resources:
         requests:


### PR DESCRIPTION
## Problem

`controller.agent.templateDefaults.imagePullPolicy` was hardcoded to `IfNotPresent`. The controller passes that straight onto every agent pod (`resources.go`: `pullPolicy = agentSpec.ImagePullPolicy ?? defaults.ImagePullPolicy`), so it applied to **every** image regardless of tag — overriding Kubernetes' native behavior.

That's exactly what stranded the `bugstone` template (image `icr.io/dam-agents/bugstone:latest`): with `IfNotPresent` + a moving `:latest` tag, nodes served a cached old digest and never pulled a repushed `:latest`. Multiple deploy attempts all ran the same stale Jun-16 build.

## Fix

Leave `templateDefaults.imagePullPolicy` **unset** so Kubernetes applies its native, tag-based default:
- `:latest` (and untagged) → **Always** — a repushed tag is actually re-pulled
- immutable sha/digest tags (what the harness images use, e.g. `…:0.2.5-dev-<sha>`) → **IfNotPresent**

The controller already passes an empty policy through untouched, and `config.go` doesn't backfill a default — so no Go change is needed. A template or agent can still set an explicit `imagePullPolicy` override.

This is the principled version of the live hotfix applied to the dev cluster (which set `imagePullPolicy: Always` directly on the bugstone template) — it fixes the whole class, not just bugstone, with zero per-template overrides.

## Testing
- `mise run helm:check:lint` — 0 failed
- `mise run helm:check:render` — 43 valid / 0 invalid / 0 errors