### PR TITLE
feat(ui): render HTML files in the file viewer via a sandboxed iframe

### DIFF
--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -1,11 +1,9 @@
 import {
   ArrowLeft,
   Close as X,
-  Code,
   Download,
   Edit as Pencil,
   Save,
-  View as Eye,
 } from "@carbon/icons-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -23,6 +21,7 @@ import {
 } from "../api/queries.js";
 import { base64ToBlob, downloadFileContent } from "../lib/download.js";
 import { CodeEditor } from "./code-editor.js";
+import { RenderToggle } from "./render-toggle.js";
 
 interface Props {
   file: FileContent;
@@ -62,6 +61,7 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
   const { path, content, binary, mimeType: mime, tooLarge } = file;
   const isMarkdown = mime === "text/markdown";
   const isSvg = mime === "image/svg+xml";
+  const isHtml = mime === "text/html";
   const isBinaryImage = binary && content && isImageMime(mime) && !isSvg;
   const isPdf = mime === "application/pdf";
   const filename = path.split("/").pop();
@@ -75,6 +75,7 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
 
   const [renderMd, setRenderMd] = useState(true);
   const [renderSvg, setRenderSvg] = useState(true);
+  const [renderHtml, setRenderHtml] = useState(true);
   const [editMode, setEditMode] = useState(editable && openFileEdit);
   const [draft, setDraft] = useState(content);
   const [baseMtimeMs, setBaseMtimeMs] = useState<number | undefined>(
@@ -247,28 +248,28 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           </Button>
         )}
         {isSvg && !editMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${renderSvg ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
-            onClick={() => setRenderSvg((p) => !p)}
-            title={renderSvg ? "Show raw SVG" : "Render SVG"}
-          >
-            {renderSvg ? <Code size={11} /> : <Eye size={11} />}
-            {renderSvg ? "Raw" : "Render"}
-          </Button>
+          <RenderToggle
+            rendered={renderSvg}
+            onToggle={() => setRenderSvg((p) => !p)}
+            rawTitle="Show raw SVG"
+            renderTitle="Render SVG"
+          />
         )}
         {isMarkdown && !editMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${renderMd ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
-            onClick={() => setRenderMd((p) => !p)}
-            title={renderMd ? "Show raw" : "Render markdown"}
-          >
-            {renderMd ? <Code size={11} /> : <Eye size={11} />}
-            {renderMd ? "Raw" : "Render"}
-          </Button>
+          <RenderToggle
+            rendered={renderMd}
+            onToggle={() => setRenderMd((p) => !p)}
+            rawTitle="Show raw"
+            renderTitle="Render markdown"
+          />
+        )}
+        {isHtml && !editMode && (
+          <RenderToggle
+            rendered={renderHtml}
+            onToggle={() => setRenderHtml((p) => !p)}
+            rawTitle="Show raw HTML"
+            renderTitle="Render HTML"
+          />
         )}
       </div>
       <div
@@ -336,6 +337,15 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           </div>
         ) : isMarkdown && renderMd ? (
           <Markdown onFileClick={onOpenFile}>{content}</Markdown>
+        ) : isHtml && renderHtml ? (
+          // `allow-scripts` without `allow-same-origin` runs the page's JS in an
+          // opaque origin, so agent-authored HTML can't reach the app's session.
+          <iframe
+            srcDoc={content}
+            title={filename ?? "html"}
+            sandbox="allow-scripts"
+            className="w-full h-[calc(100dvh-200px)] rounded border border-border bg-white"
+          />
         ) : (
           <HighlightedCode code={content} path={path} />
         )}

--- a/packages/ui/src/modules/files/components/render-toggle.tsx
+++ b/packages/ui/src/modules/files/components/render-toggle.tsx
@@ -1,0 +1,35 @@
+import { Code, View as Eye } from "@carbon/icons-react";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  /** True when the rendered view is showing; false shows the raw source. */
+  rendered: boolean;
+  onToggle: () => void;
+  /** Tooltip shown while rendered (i.e. the action switches to raw). */
+  rawTitle: string;
+  /** Tooltip shown while raw (i.e. the action switches to rendered). */
+  renderTitle: string;
+}
+
+/** Toolbar button that flips a previewable file between its rendered view and
+ * raw source. Shared by the SVG, markdown, and HTML file-viewer previews. */
+export function RenderToggle({
+  rendered,
+  onToggle,
+  rawTitle,
+  renderTitle,
+}: Props) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${rendered ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
+      onClick={onToggle}
+      title={rendered ? rawTitle : renderTitle}
+    >
+      {rendered ? <Code size={11} /> : <Eye size={11} />}
+      {rendered ? "Raw" : "Render"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

Renders HTML files in the file panel instead of only showing their source, so agent-produced interactive pages — notably the **Nous** campaign knowledge-graph visualizations (`/visualize-campaign`, `/visualize-registry`) — can be viewed in-app without downloading.

Opening a `text/html` file now shows it in a **sandboxed iframe** with a **Raw / Render toggle** (matching the existing SVG and markdown toggles); it defaults to rendered, and flips to source on demand. The shared Raw/Render toolbar button was extracted into a small `RenderToggle` component now used by all three previews.

## Safety

The iframe uses `sandbox="allow-scripts"` **without** `allow-same-origin`, so the page's JS runs in an opaque origin and cannot reach the app's session, cookies, or DOM. The repo enforces no Content-Security-Policy, so self-contained pages (the Nous graphs are standalone) render with their inline scripts intact.

## Testing

- `mise run ui:check` clean (eslint + tsc + prettier).
- Confirmed `.html` is served as `text/html`/non-binary with the source in `content`, which the iframe consumes.
- **Not yet visually verified in a running UI** — reviewer/author should open a generated visualization and confirm the render. (Interactive D3 in the sandboxed frame.)

## Notes

- `file-viewer.tsx` is over the team's ~300-line component-split guideline; this PR stays focused (adds the branch + extracts the one shared toggle). A fuller split of the viewer is left as a separate refactor.

Closes #1415
