### PR TITLE
chore(deps): bump pi-coding-agent to 0.79.10; sort experimental templates last

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -50,7 +50,7 @@ agentTemplates:
     storageSize: "5Gi"
 
   - name: pi-agent
-    enabled: false
+    enabled: true
     description: "Pi coding agent with multi-LLM support"
     image:
       repository: platform-pi-agent

--- a/packages/agents/pi-agent/Dockerfile
+++ b/packages/agents/pi-agent/Dockerfile
@@ -19,3 +19,5 @@ ln -s ../../.agents/skills /app/working-dir/.pi/agent/skills
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
 USER 65532
+
+ENV PI_SKIP_VERSION_CHECK=1

--- a/packages/agents/pi-agent/workspace/.config/mise/config.toml
+++ b/packages/agents/pi-agent/workspace/.config/mise/config.toml
@@ -4,6 +4,6 @@ minimum_release_age = "7d"
 
 # keep pi-coding-agent in sync with the pi-dynamic-providers extension's devDependency
 [tools]
-"npm:@earendil-works/pi-coding-agent" = "0.79.9"
+"npm:@earendil-works/pi-coding-agent" = "0.79.10"
 "npm:pi-acp" = "0.0.28"
 "npm:@zhafron/pi-memory" = "1.0.2"

--- a/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-dynamic-providers/package.json
+++ b/packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-dynamic-providers/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.0",
   "description": "Local-only types for the pi-dynamic-providers extension. Not installed at runtime; @earendil-works/pi-coding-agent is provided globally by the agent image. Keep this version pinned to the same version installed in the pi-agent workspace mise config so the extension type-checks against the runtime it actually loads against.",
   "devDependencies": {
-    "@earendil-works/pi-coding-agent": "0.79.9",
+    "@earendil-works/pi-coding-agent": "0.79.10",
     "@types/node": "^24.0.0"
   }
 }

--- a/packages/ui/src/modules/templates/api/queries.ts
+++ b/packages/ui/src/modules/templates/api/queries.ts
@@ -1,10 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { trpc } from "../../../trpc.js";
+import type { TemplateView } from "../../../types.js";
+
+// Push experimental templates (e.g. nous) to the end of the catalogue so the
+// stable, generally-available harnesses lead the list. Stable sort preserves
+// the server's order within each group. Module-level so the `select` reference
+// stays stable across renders.
+function sortExperimentalLast(templates: TemplateView[]): TemplateView[] {
+  return [...templates].sort(
+    (a, b) => Number(a.experimental) - Number(b.experimental),
+  );
+}
 
 export function useTemplates() {
   return useQuery({
     ...trpc.templates.list.queryOptions(),
+    select: sortExperimentalLast,
     meta: { errorToast: "Couldn't load templates" },
   });
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,8 +140,8 @@ importers:
   packages/agents/pi-agent/workspace/.pi/agent/extensions/pi-dynamic-providers:
     devDependencies:
       '@earendil-works/pi-coding-agent':
-        specifier: 0.79.9
-        version: 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+        specifier: 0.79.10
+        version: 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       '@types/node':
         specifier: ^24.0.0
         version: 24.12.0
@@ -1381,22 +1381,22 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@earendil-works/pi-agent-core@0.79.9':
-    resolution: {integrity: sha512-GsFbPR85nhncKoU9++fTKa11PzwUkAmkrKXo97dBOzi10Td72rVV6vmfxKjwPLHTzRbJMa0byr12YhODZ59yLA==}
+  '@earendil-works/pi-agent-core@0.79.10':
+    resolution: {integrity: sha512-XKxgdjhcPuyjrthCOFSgfzT3xZ1uBrJ1IMVDxci1to6hIN6BIg9J5iY8q0pGXK1DLgATLP23da+1UyZLwA360Q==}
     engines: {node: '>=22.19.0'}
 
-  '@earendil-works/pi-ai@0.79.9':
-    resolution: {integrity: sha512-fHmgNMONwCCE7bQAKbcz76sgm3iQuA7km1mpIc4H5xXd9+zhPh/faULz6ARkgjQE0EufHnfZPJY39+lNf8Sa9g==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.79.9':
-    resolution: {integrity: sha512-8TZ796Zn0NE4vmhxG9hv4ZtJDGJzhqMjlmFg8ZkUKxfqB7LJa4ums2jSJKtnyAZfAamN6VzqzN0A82RNDqv8Ag==}
+  '@earendil-works/pi-ai@0.79.10':
+    resolution: {integrity: sha512-9jR23tOl0BIUdQMn70Gr72xYBpM7Xgl9Lyv7gAnU1USfkNRuYG/f/edLl+n/Dp/RafDW3JI4DF7y/GhgkORuew==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
-  '@earendil-works/pi-tui@0.79.9':
-    resolution: {integrity: sha512-XcqfoGyoX64OSMQklMR1vG2MRi1TCPSUERRCmPDvYKCK6LtZoBqJ6idNCLRklNYveCj4gHDOzOsLhGqn04jmYw==}
+  '@earendil-works/pi-coding-agent@0.79.10':
+    resolution: {integrity: sha512-YxaRhmgyDTvLDdGVbe7YzTHV80oL5mX5odg6EhGHz3w5Wu1Ix8DCw7bhtiOBLGQNFRcknia0zPmVWIj30XP1EA==}
+    engines: {node: '>=22.19.0'}
+    hasBin: true
+
+  '@earendil-works/pi-tui@0.79.10':
+    resolution: {integrity: sha512-FUVOjDn1DVwM1uHD5MNYboXQrXjIDbSt+BQ3py7nQWCY62tKfxgiM1OBMxTcwRWLfSdZHUPpV0hm1loIdUJnPw==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/runtime@1.9.2':
@@ -7825,9 +7825,9 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-agent-core@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
       ignore: 7.0.5
       typebox: 1.1.38
       yaml: 2.9.0
@@ -7839,7 +7839,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -7860,11 +7860,11 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-coding-agent@0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
+  '@earendil-works/pi-coding-agent@0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)':
     dependencies:
-      '@earendil-works/pi-agent-core': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.79.9(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.79.9
+      '@earendil-works/pi-agent-core': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.79.10(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.21.0)(zod@4.4.3)
+      '@earendil-works/pi-tui': 0.79.10
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       cross-spawn: 7.0.6
@@ -7890,7 +7890,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-tui@0.79.9':
+  '@earendil-works/pi-tui@0.79.10':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 18.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -54,19 +54,19 @@ minimumReleaseAgeExclude:
   # actually loads against them (issue #375). The fork ships its core/ai/tui
   # packages at the same version; bump all four together with the mise
   # config. Safe to drop from this list once the chosen version ages past 7 days.
-  - "@earendil-works/pi-coding-agent@0.79.9"
-  - "@earendil-works/pi-agent-core@0.79.9"
-  - "@earendil-works/pi-ai@0.79.9"
-  - "@earendil-works/pi-tui@0.79.9"
+  - "@earendil-works/pi-coding-agent@0.79.10"
+  - "@earendil-works/pi-agent-core@0.79.10"
+  - "@earendil-works/pi-ai@0.79.10"
+  - "@earendil-works/pi-tui@0.79.10"
   # form-data 4.0.6 fixes CVE-2026-12143 (HIGH), pulled in via the override
   # above; published <7 days ago. Safe to drop once it ages past 7 days.
   - "form-data@4.0.6"
   # undici 8.5.0 fixes the 8.x line of the undici advisory cluster (CVE-2026-12151
-  # HIGH et al.), pulled in by @earendil-works/pi-coding-agent@0.79.9; published
+  # HIGH et al.), pulled in by @earendil-works/pi-coding-agent@0.79.10; published
   # 2026-06-15 (<7 days). Safe to drop once it ages past 7 days.
   - "undici@8.5.0"
   # @mistralai/mistralai 2.2.6 is pulled in transitively by @earendil-works/pi-ai
-  # @0.79.9 (the pi-coding-agent bump above); published 2026-06-16 (<7 days).
+  # @0.79.10 (the pi-coding-agent bump above); published 2026-06-16 (<7 days).
   # Safe to drop once it ages past 7 days.
   - "@mistralai/mistralai@2.2.6"
 allowBuilds:


### PR DESCRIPTION
## Summary

### 1. Bump `pi-coding-agent` 0.79.9 → 0.79.10
Routine patch bump to the latest release (published 2026-06-22).

- `mise` pin in the pi-agent workspace, the `pi-dynamic-providers` extension devDependency, and all four fork packages (`pi-coding-agent`, `pi-agent-core`, `pi-ai`, `pi-tui`) in `minimumReleaseAgeExclude` bumped together.
- The version is <7 days old, so it stays in `minimumReleaseAgeExclude` to satisfy the 7-day release-age gate.
- Transitive `undici@8.5.0` and `@mistralai/mistralai@2.2.6` are unchanged, so their exclude entries remain valid; comments updated to reference 0.79.10.

**Verified:** `common:check:lockfile-age` passes; the extension type-checks cleanly against 0.79.10 (`tsc --noEmit` exit 0).

### 2. Sort experimental agent templates last in the UI
Templates are loaded from the `agent-templates` ConfigMap via `readdirSync` (effectively alphabetical), so experimental harnesses could sort ahead of generally-available ones — e.g. **nous** (experimental) appeared before **pi-agent**. A stable `select` in `useTemplates` now pushes experimental templates to the end of the catalogue, applied consistently across every consumer (Add Agent dialog, sandbox wizard, agents list).

**Verified:** `ui:fix` + `ui:check:tsc` pass.

### 3. Silence the pi runtime version-check nag
Set `PI_SKIP_VERSION_CHECK=1` in the pi-agent image. The image pins pi-coding-agent via mise, so the harness's "Update Available" check at startup is noise it can never act on.

### 4. Enable pi-agent across deployment environments
- `values.yaml` (base): already `enabled: true`; `values-dev.yaml` inherits it.
- `values-local.yaml`: flipped on in this PR.
- `values-e2e.yaml`: intentionally **left mock-only** — the e2e task builds only platform-base + mock images, so registering pi-agent would point the chart at an image not loaded in the test cluster.

## Test plan
- [ ] Open the Add Agent dialog → `pi-agent` (and other GA harnesses) lead the list; `nous` sorts last.
- [ ] Rebuild the pi-agent image and confirm the harness runs on 0.79.10 with no version-check nag.
- [ ] Confirm pi-agent appears in local/dev installs and e2e still runs mock-only.