### PR TITLE
feat(skills): recognize .claude/skills and .agents/skills source roots

### DIFF
--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Last verified: 2026-06-12
+Last verified: 2026-06-23
 
 ## Overview
 
@@ -93,6 +93,14 @@ Each per-agent Dockerfile ([`packages/agents/`](../../packages/agents/)) symlink
 
 Install writes the skill directory into **every** configured Skill Path; uninstall removes it from all of them. Scanning the disk for Local Skills walks every path in order and dedupes by directory name (first found wins).
 
+### Source Roots
+
+A scan reads a Source's repo from a fixed, ordered set of **source roots** — the directory layouts a repo may use to hold skills: `skills/`, then `.claude/skills/`, then `.agents/skills/`. A scan **unions** the skills found across all of them, so a repo that mixes layouts still surfaces every skill. Top-level `*` is a **fallback only** — consulted when none of the deliberate roots yielded a skill — so a repo that organizes under `skills/` is never polluted by unrelated top-level directories that happen to carry a `SKILL.md`. Discovery is one level deep per root; there is no recursive walk.
+
+The union is then **deduped by Skill name** (`name` frontmatter, else the directory basename — the same identity `agent_skills` and install key on), first-found-wins in root order. Name, not raw path, is the identity because the on-pod store is a flat name-keyed directory and the catalog row is keyed on name: two same-named directories are not separately representable, so the earlier root wins and the later one is dropped (and logged). This collapses the common case where a repo symlinks one root to another (e.g. `.claude/skills` → `.agents/skills`): both roots enumerate the same real skill, and dedupe yields a single entry. Per-skill symlinks are still skipped — only real directories are scanned.
+
+The ordering lives in one place shared by both scanners and the install-time resolver ([`packages/agent-runtime-api/`](../../packages/agent-runtime-api/)), so the api-server's public-archive scan, the agent-runtime clone scan, and install resolution can never disagree on precedence.
+
 ## Subsystems
 
 ### api-server skills service
@@ -101,7 +109,7 @@ Lives in [`packages/api-server/src/modules/skills/`](../../packages/api-server/s
 
 - The **Skill Source catalogue** — CRUD on user sources, merging in system seeds and template sources, dedupe and badge resolution.
 - The **scan cache** — per-`gitUrl`, 5-minute TTL, invalidated on `sources.refresh` or after a successful publish to that source.
-- **Public-archive scanning** — for `github.com` URLs, downloads `archive/HEAD.tar.gz` directly from GitHub, walks for `SKILL.md`, parses frontmatter, computes `contentHash`. No credentials required. This is the path that lets the catalog UI render even when no agent is running.
+- **Public-archive scanning** — for `github.com` URLs, downloads `archive/HEAD.tar.gz` directly from GitHub, enumerates skills across the [Source Roots](#source-roots), parses frontmatter, computes `contentHash`. No credentials required. This is the path that lets the catalog UI render even when no agent is running.
 - **Private / non-GitHub fallback** — falls through to the agent-runtime `skills.scan` over the harness port. Needs the credential path's paired gateway pod, so it **wakes a hibernated agent** via the shared `ensureReady` primitive rather than refusing (still requires an `agentId` to target).
 - **Install / uninstall orchestration** — wakes a hibernated agent before recording the change, then upserts the `agent_skills` row and bumps the outbox; the unified apply worker applies it onto the (now-warm) pod. The api-server is the only pod whose NetworkPolicy can reach the agent's tRPC listener; no Bearer token is sent.
 - **Publish orchestration** ([`publish-service`](../../packages/api-server/src/modules/skills/services/publish-service.ts)) — validates that the source is a GitHub URL (only host that supports publish), wakes a hibernated agent, calls agent-runtime, and on success writes the `agent_skill_publishes` row and invalidates the scan cache for that source.
@@ -115,8 +123,8 @@ Lives in [`packages/agent-runtime/src/modules/skills/`](../../packages/agent-run
 
 Three responsibilities:
 
-- **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The paired gateway pod injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the skill directory inside the fetch (`skills/<name>/` then top-level `<name>/`), copies it into every configured Skill Path, and returns the deterministic `contentHash`.
-- **Scan** — same fetch path; walks for `SKILL.md`, parses frontmatter, and returns `(name, description, version, contentHash)` for each.
+- **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The paired gateway pod injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the named skill's directory by walking the [Source Roots](#source-roots) in order (then top-level), copies it into every configured Skill Path, and returns the deterministic `contentHash`.
+- **Scan** — same fetch path; enumerates skills across the [Source Roots](#source-roots) (union, deduped by name, top-level fallback), parses frontmatter, and returns `(name, description, version, contentHash)` for each.
 - **Publish** — REST-only. Reads the local skill from disk (size-capped per file and per skill), creates blobs + tree + commit + branch + PR via the GitHub REST API, with author `Platform <platform-publish@users.noreply.github.com>`. Branch naming: `platform/publish-<name>-<timestamp>`. There is no `git push`.
 
 When env credentials arrive over the runtime channel, the agent-runtime reacts by running `gh auth setup-git`, so a private-repo `git clone` invoked from inside the pod also routes through `gh` (and therefore through the gateway pod's credential injector) instead of stalling on a username prompt. It deliberately does not run at boot, where credentials aren't available yet.

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -70,7 +70,7 @@ Pod-side operational view of skills. Distinct from the api-server's Skills conte
 | Skill | A directory containing `SKILL.md` (with `name`/`description` frontmatter); the unit of installation |
 | Skill Path | An absolute on-pod directory under which Skills are materialized; a Skill's identity within a path is the directory name |
 | Local Skill | A Skill present in some Skill Path on this pod, regardless of whether it was installed from a Source or authored in place |
-| Skill Source | A git repository URL that contains one or more Skills under `skills/*` or top-level `*` |
+| Skill Source | A git repository URL that contains one or more Skills |
 | Scanned Skill | A Skill discovered in a Source: `(source, name, description, version, contentHash)` where `version` is the Source's HEAD commit SHA at scan time |
 | Content Hash | Deterministic SHA-256 over a Skill directory's file contents (sorted-path order, NUL-delimited); the drift signal produced — but not compared — on this side |
 | Install | Materializing a Skill from a Source at a Version into one or more Skill Paths |

--- a/packages/agent-runtime-api/src/index.ts
+++ b/packages/agent-runtime-api/src/index.ts
@@ -44,6 +44,11 @@ export {
   skillScanInputSchema,
   skillUninstallInputSchema,
 } from "./modules/skills/schemas.js";
+export {
+  SKILL_SOURCE_ROOTS,
+  dedupeByName,
+} from "./modules/skills/source-roots.js";
+export type { DedupeByNameResult } from "./modules/skills/source-roots.js";
 export type { SshDomainError, SshService } from "./modules/ssh/types.js";
 export { sshAuthorizeKeyInputSchema } from "./modules/ssh/schemas.js";
 export { importBundleResultSchema } from "./modules/import/types.js";

--- a/packages/agent-runtime-api/src/modules/skills/source-roots.ts
+++ b/packages/agent-runtime-api/src/modules/skills/source-roots.ts
@@ -1,0 +1,27 @@
+export const SKILL_SOURCE_ROOTS = [
+  "skills",
+  ".claude/skills",
+  ".agents/skills",
+] as const;
+
+export interface DedupeByNameResult<T> {
+  kept: T[];
+  dropped: T[];
+}
+
+export function dedupeByName<T extends { name: string }>(
+  items: readonly T[],
+): DedupeByNameResult<T> {
+  const seen = new Set<string>();
+  const kept: T[] = [];
+  const dropped: T[] = [];
+  for (const item of items) {
+    if (seen.has(item.name)) {
+      dropped.push(item);
+    } else {
+      seen.add(item.name);
+      kept.push(item);
+    }
+  }
+  return { kept, dropped };
+}

--- a/packages/agent-runtime/src/modules/skills/compose.ts
+++ b/packages/agent-runtime/src/modules/skills/compose.ts
@@ -11,6 +11,7 @@ export interface ComposeSkillsOptions {
   /** Wall-clock provider. Defaults to `() => new Date()`. Tests inject a
    *  fixed clock to pin publish branch timestamps. */
   now?: () => Date;
+  log: (msg: string) => void;
 }
 
 export function composeSkills(opts: ComposeSkillsOptions): SkillsService {
@@ -29,5 +30,6 @@ export function composeSkills(opts: ComposeSkillsOptions): SkillsService {
     repo,
     skillPaths: skillPaths.value,
     now: opts.now ?? (() => new Date()),
+    log: opts.log,
   });
 }

--- a/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
@@ -9,7 +9,7 @@ import type {
   Result,
   SkillsDomainError,
 } from "agent-runtime-api";
-import { err, ok } from "agent-runtime-api";
+import { err, ok, SKILL_SOURCE_ROOTS } from "agent-runtime-api";
 import { parseFrontmatter } from "../domain/frontmatter.js";
 import type { SkillName } from "../domain/skill-name.js";
 import type { SkillPath } from "../domain/skill-path.js";
@@ -54,11 +54,12 @@ export interface LocalSkillRepository {
     opts: { stripComponents?: number },
   ) => Promise<void>;
   /** Walk a freshly-cloned/extracted repo and return every directory
-   *  (relative to `repoDir`) that contains a SKILL.md. Search order:
-   *  `skills/*` first, fall back to top-level `*`. */
+   *  (relative to `repoDir`) that contains a SKILL.md. Unions the deliberate
+   *  `SKILL_SOURCE_ROOTS` in order; top-level `*` only when none matched.
+   *  May contain same-name collisions — callers dedupe via `dedupeByName`. */
   findSkillDirsInClone: (repoDir: string) => Promise<string[]>;
   /** Resolve the directory inside a clone where the named skill lives.
-   *  Tries `skills/<name>/` first, then `<name>/`. */
+   *  Tries each `SKILL_SOURCE_ROOTS`/<name> in order, then top-level <name>. */
   resolveSkillDirInClone: (
     repoDir: string,
     name: SkillName,
@@ -251,35 +252,44 @@ function assertSafeTarEntry(entry: string): void {
 
 async function findSkillDirsInClone(repoDir: string): Promise<string[]> {
   const found: string[] = [];
-  const candidates = [path.join(repoDir, "skills"), repoDir];
-  for (const root of candidates) {
-    let entries: import("node:fs").Dirent[];
-    try {
-      entries = await fs.readdir(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const ent of entries) {
-      if (!ent.isDirectory() || ent.name.startsWith(".")) continue;
-      const dir = path.join(root, ent.name);
-      try {
-        await fs.access(path.join(dir, "SKILL.md"));
-        found.push(path.relative(repoDir, dir));
-      } catch {}
-    }
-    if (found.length > 0) return found;
+  for (const root of SKILL_SOURCE_ROOTS) {
+    found.push(...(await skillDirsUnder(repoDir, path.join(repoDir, root))));
   }
-  return found;
+  if (found.length > 0) return found;
+  return skillDirsUnder(repoDir, repoDir);
+}
+
+async function skillDirsUnder(
+  repoDir: string,
+  root: string,
+): Promise<string[]> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const ent of entries) {
+    if (!ent.isDirectory() || ent.name.startsWith(".")) continue;
+    const dir = path.join(root, ent.name);
+    try {
+      await fs.access(path.join(dir, "SKILL.md"));
+      out.push(path.relative(repoDir, dir));
+    } catch {}
+  }
+  return out;
 }
 
 async function resolveSkillDirInClone(
   repoDir: string,
   name: SkillName,
 ): Promise<Result<string, SkillsDomainError>> {
-  for (const candidate of [
-    path.join(repoDir, "skills", name),
+  const candidates = [
+    ...SKILL_SOURCE_ROOTS.map((root) => path.join(repoDir, root, name)),
     path.join(repoDir, name),
-  ]) {
+  ];
+  for (const candidate of candidates) {
     try {
       await fs.access(path.join(candidate, "SKILL.md"));
       return ok(candidate);

--- a/packages/agent-runtime/src/modules/skills/services/scan.ts
+++ b/packages/agent-runtime/src/modules/skills/services/scan.ts
@@ -5,7 +5,7 @@ import type {
   ScannedSkill,
   SkillsDomainError,
 } from "agent-runtime-api";
-import { err, ok } from "agent-runtime-api";
+import { dedupeByName, err, ok } from "agent-runtime-api";
 import {
   detectGithubOwnerRepo,
   type DetectedOwnerRepo,
@@ -18,6 +18,7 @@ export interface ScanDeps {
   github: GitHubRestClient;
   git: GitProtocolClient;
   repo: LocalSkillRepository;
+  log: (msg: string) => void;
 }
 
 /**
@@ -36,8 +37,17 @@ export async function runScan(
   input: SkillScanInput,
 ): Promise<Result<ScannedSkill[], SkillsDomainError>> {
   const host = detectGithubOwnerRepo(input.source);
-  if (host) return scanGithub(deps, input.source, host);
-  return scanGitClone(deps, input.source);
+  const res = host
+    ? await scanGithub(deps, input.source, host)
+    : await scanGitClone(deps, input.source);
+  if (!res.ok) return res;
+  const { kept, dropped } = dedupeByName(res.value);
+  for (const d of dropped) {
+    deps.log(
+      `scan ${input.source}: dropped same-name skill "${d.name}" from a later source root`,
+    );
+  }
+  return ok(kept);
 }
 
 async function scanGithub(

--- a/packages/agent-runtime/src/modules/skills/services/skills-service.ts
+++ b/packages/agent-runtime/src/modules/skills/services/skills-service.ts
@@ -27,6 +27,7 @@ export interface SkillsServiceDeps {
   skillPaths: SkillPath[];
   /** Wall-clock provider — used by publish for branch-name timestamps. */
   now: () => Date;
+  log: (msg: string) => void;
 }
 
 interface ValidatedNameAndPaths {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -73,6 +73,7 @@ const runtimeManifest = loadManifest(manifestPath);
 const filesService = createFilesService(homeDir);
 const skillsService = composeSkills({
   skillPaths: skillRefPaths(runtimeManifest, homeDir),
+  log: (msg) => process.stderr.write(`[skills] ${msg}\n`),
 });
 const sshService = createSshService(homeDir);
 const importHandlers = createImportHandlers(homeDir, workDir, (msg) =>

--- a/packages/api-server/src/modules/skills/infrastructure/public-archive-scanner.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/public-archive-scanner.ts
@@ -3,7 +3,9 @@ import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 import * as tar from "tar";
+import { dedupeByName, SKILL_SOURCE_ROOTS } from "agent-runtime-api";
 import type { Skill } from "api-server-api";
+import { getLogger } from "../../../core/logger.js";
 import { detectHost } from "./git-host.js";
 
 /**
@@ -116,27 +118,35 @@ export async function computeContentHash(absDir: string): Promise<string> {
 
 async function findSkillDirs(repoDir: string): Promise<string[]> {
   const found: string[] = [];
-  const candidates = [path.join(repoDir, "skills"), repoDir];
-  for (const root of candidates) {
-    let entries: import("node:fs").Dirent[];
-    try {
-      entries = await fs.readdir(root, { withFileTypes: true });
-    } catch {
-      continue;
-    }
-    for (const ent of entries) {
-      if (!ent.isDirectory() || ent.name.startsWith(".")) continue;
-      const dir = path.join(root, ent.name);
-      try {
-        await fs.access(path.join(dir, "SKILL.md"));
-        found.push(path.relative(repoDir, dir));
-      } catch {
-        /* no SKILL.md → not a skill dir */
-      }
-    }
-    if (found.length > 0) return found;
+  for (const root of SKILL_SOURCE_ROOTS) {
+    found.push(...(await skillDirsUnder(repoDir, path.join(repoDir, root))));
   }
-  return found;
+  if (found.length > 0) return found;
+  return skillDirsUnder(repoDir, repoDir);
+}
+
+async function skillDirsUnder(
+  repoDir: string,
+  root: string,
+): Promise<string[]> {
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const ent of entries) {
+    if (!ent.isDirectory() || ent.name.startsWith(".")) continue;
+    const dir = path.join(root, ent.name);
+    try {
+      await fs.access(path.join(dir, "SKILL.md"));
+      out.push(path.relative(repoDir, dir));
+    } catch {
+      /* no SKILL.md → not a skill dir */
+    }
+  }
+  return out;
 }
 
 /**
@@ -188,7 +198,7 @@ export async function scanPublicGithubArchive(
     const repoDir = path.join(tmp, extracted[0].name);
 
     const skillDirs = await findSkillDirs(repoDir);
-    const out = await Promise.all(
+    const scanned = await Promise.all(
       skillDirs.map(async (rel) => {
         const absDir = path.join(repoDir, rel);
         const content = await fs.readFile(
@@ -206,7 +216,14 @@ export async function scanPublicGithubArchive(
         };
       }),
     );
-    return out.sort((a, b) => a.name.localeCompare(b.name));
+    const { kept, dropped } = dedupeByName(scanned);
+    for (const d of dropped) {
+      getLogger().warn(
+        { source: gitUrl, name: d.name },
+        "skills scan: dropped same-name skill from a later source root",
+      );
+    }
+    return kept.sort((a, b) => a.name.localeCompare(b.name));
   } finally {
     await fs.rm(tmp, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Problem
Skill scan/import only recognized `skills/*` and top-level `*`. Repos that keep skills under `.claude/skills/` (Claude Code convention) reported no skills, so import silently failed. Ref #1637.

## Change
- Both scanners (api-server public-archive, agent-runtime clone) enumerate source roots in order `skills/` -> `.claude/skills/` -> `.agents/skills/` and union the results. Top-level `*` is consulted only as a fallback when no deliberate root matched.
- The union is deduped by skill name (frontmatter `name`, else basename, the install + `agent_skills` identity), first-found-wins. Dropped collisions are logged. This collapses a root-symlink pair (`.claude/skills` -> `.agents/skills`) to a single entry.
- Install resolver walks the same root order, so scan and install can never disagree on precedence.
- `SKILL_SOURCE_ROOTS` (ordered) and the pure `dedupeByName` helper live in `agent-runtime-api`, shared by both scanners and the resolver so the order cannot drift.
- Architecture doc updated with a Source Roots section.

## Out of scope
Recursive discovery, path-as-name, `.pi`/`.bob` roots, listLocal changes, "no skills found" messaging (#944).