### PR TITLE
feat(ui): open file previews fullscreen in a dialog

### DIFF
--- a/packages/ui/src/modules/files/components/file-preview-body.tsx
+++ b/packages/ui/src/modules/files/components/file-preview-body.tsx
@@ -1,0 +1,161 @@
+import { HighlightedCode } from "../../../components/highlighted-code.js";
+import { Markdown } from "../../../components/markdown.js";
+import type { FileContent } from "../api/queries.js";
+import { CodeEditor } from "./code-editor.js";
+
+interface Props {
+  file: FileContent;
+  editMode: boolean;
+  draft: string;
+  onDraftChange: (value: string) => void;
+  onSave: () => void;
+  renderSvg: boolean;
+  renderMd: boolean;
+  renderHtml: boolean;
+  /** Blob URL for PDF rendering; owned by the parent so it can revoke on change. */
+  pdfBlobUrl: string | null;
+  onOpenFile: (path: string) => void;
+}
+
+function hexDump(base64: string): string {
+  const raw = atob(base64);
+  const lines: string[] = [];
+  const maxBytes = Math.min(raw.length, 1024);
+  for (let off = 0; off < maxBytes; off += 16) {
+    const slice = raw.slice(off, Math.min(off + 16, maxBytes));
+    const hex = Array.from(slice)
+      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
+      .join(" ");
+    const ascii = Array.from(slice)
+      .map((c) => {
+        const code = c.charCodeAt(0);
+        return code >= 0x20 && code < 0x7f ? c : ".";
+      })
+      .join("");
+    lines.push(
+      `${off.toString(16).padStart(8, "0")}  ${hex.padEnd(47)}  ${ascii}`,
+    );
+  }
+  if (raw.length > maxBytes)
+    lines.push(`... ${raw.length - maxBytes} more bytes`);
+  return lines.join("\n");
+}
+
+function isImageMime(mime: string | undefined): boolean {
+  return !!mime && mime.startsWith("image/");
+}
+
+/** Renders a file's body — editor, rendered preview (image / PDF / SVG /
+ * markdown / HTML), hex dump, or syntax-highlighted source. Sizing fills the
+ * width of its container, so the same body works in the side panel and in the
+ * fullscreen dialog. */
+export function FilePreviewBody({
+  file,
+  editMode,
+  draft,
+  onDraftChange,
+  onSave,
+  renderSvg,
+  renderMd,
+  renderHtml,
+  pdfBlobUrl,
+  onOpenFile,
+}: Props) {
+  const { path, content, binary, mimeType: mime, tooLarge } = file;
+  const filename = path.split("/").pop();
+  const isSvg = mime === "image/svg+xml";
+  const isMarkdown = mime === "text/markdown";
+  const isHtml = mime === "text/html";
+  const isPdf = mime === "application/pdf";
+  const isBinaryImage = binary && content && isImageMime(mime) && !isSvg;
+
+  if (editMode) {
+    return (
+      <CodeEditor
+        value={draft}
+        path={path}
+        onChange={onDraftChange}
+        onSave={onSave}
+      />
+    );
+  }
+  if (isBinaryImage) {
+    return (
+      <div className="flex items-center justify-center">
+        <img
+          src={`data:${mime};base64,${content}`}
+          alt={filename ?? "image"}
+          className="max-w-full max-h-[calc(100dvh-200px)] object-contain rounded border border-border"
+        />
+      </div>
+    );
+  }
+  if (isPdf && pdfBlobUrl) {
+    return (
+      <iframe
+        src={pdfBlobUrl}
+        title={filename ?? "pdf"}
+        className="w-full h-[calc(100dvh-200px)] rounded border border-border bg-white"
+      />
+    );
+  }
+  // tooLarge must come before the `binary` arm: PAYLOAD_TOO_LARGE comes back with
+  // binary:true and content:"" so the hex-dump path would render an empty buffer.
+  if (tooLarge) {
+    return (
+      <div className="py-12 text-center text-[13px] text-muted-foreground">
+        <p>File too large to preview</p>
+        <p className="mt-1 text-[11px]">Files over 10 MB cannot be displayed</p>
+      </div>
+    );
+  }
+  if (binary) {
+    return (
+      <div>
+        <div className="mb-2 flex items-baseline gap-2">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
+            Binary file — hex dump
+          </p>
+          {mime && (
+            <p className="text-[11px] font-mono text-muted-foreground">
+              {mime}
+            </p>
+          )}
+        </div>
+        <p className="mb-3 text-[11px] text-muted-foreground">
+          This file is not directly viewable. The first bytes are shown below.
+        </p>
+        <pre className="text-[11px] font-mono leading-[1.6] text-foreground/80 whitespace-pre overflow-x-auto">
+          {hexDump(content)}
+        </pre>
+      </div>
+    );
+  }
+  if (isSvg && renderSvg) {
+    return (
+      <div className="flex items-center justify-center">
+        <img
+          src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(content)}`}
+          alt={filename ?? "image"}
+          className="max-w-full max-h-[calc(100dvh-200px)] object-contain rounded border border-border"
+        />
+      </div>
+    );
+  }
+  if (isMarkdown && renderMd) {
+    return <Markdown onFileClick={onOpenFile}>{content}</Markdown>;
+  }
+  if (isHtml && renderHtml) {
+    // `allow-scripts` without `allow-same-origin` runs the page's JS in an
+    // opaque origin, so agent-authored HTML can't reach the app's session.
+    return (
+      <iframe
+        srcDoc={content}
+        title={filename ?? "html"}
+        sandbox="allow-scripts"
+        className="w-full h-[calc(100dvh-200px)] rounded border border-border bg-white"
+      />
+    );
+  }
+  return <HighlightedCode code={content} path={path} />;
+}

--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -1,11 +1,9 @@
 import {
   ArrowLeft,
   Close as X,
-  Code,
   Download,
   Edit as Pencil,
   Save,
-  View as Eye,
 } from "@carbon/icons-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
@@ -23,6 +21,7 @@ import {
 } from "../api/queries.js";
 import { base64ToBlob, downloadFileContent } from "../lib/download.js";
 import { CodeEditor } from "./code-editor.js";
+import { RenderToggle } from "./render-toggle.js";
 
 interface Props {
   file: FileContent;
@@ -62,6 +61,7 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
   const { path, content, binary, mimeType: mime, tooLarge } = file;
   const isMarkdown = mime === "text/markdown";
   const isSvg = mime === "image/svg+xml";
+  const isHtml = mime === "text/html";
   const isBinaryImage = binary && content && isImageMime(mime) && !isSvg;
   const isPdf = mime === "application/pdf";
   const filename = path.split("/").pop();
@@ -75,6 +75,7 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
 
   const [renderMd, setRenderMd] = useState(true);
   const [renderSvg, setRenderSvg] = useState(true);
+  const [renderHtml, setRenderHtml] = useState(true);
   const [editMode, setEditMode] = useState(editable && openFileEdit);
   const [draft, setDraft] = useState(content);
   const [baseMtimeMs, setBaseMtimeMs] = useState<number | undefined>(
@@ -247,28 +248,28 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           </Button>
         )}
         {isSvg && !editMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${renderSvg ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
-            onClick={() => setRenderSvg((p) => !p)}
-            title={renderSvg ? "Show raw SVG" : "Render SVG"}
-          >
-            {renderSvg ? <Code size={11} /> : <Eye size={11} />}
-            {renderSvg ? "Raw" : "Render"}
-          </Button>
+          <RenderToggle
+            rendered={renderSvg}
+            onToggle={() => setRenderSvg((p) => !p)}
+            rawTitle="Show raw SVG"
+            renderTitle="Render SVG"
+          />
         )}
         {isMarkdown && !editMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${renderMd ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
-            onClick={() => setRenderMd((p) => !p)}
-            title={renderMd ? "Show raw" : "Render markdown"}
-          >
-            {renderMd ? <Code size={11} /> : <Eye size={11} />}
-            {renderMd ? "Raw" : "Render"}
-          </Button>
+          <RenderToggle
+            rendered={renderMd}
+            onToggle={() => setRenderMd((p) => !p)}
+            rawTitle="Show raw"
+            renderTitle="Render markdown"
+          />
+        )}
+        {isHtml && !editMode && (
+          <RenderToggle
+            rendered={renderHtml}
+            onToggle={() => setRenderHtml((p) => !p)}
+            rawTitle="Show raw HTML"
+            renderTitle="Render HTML"
+          />
         )}
       </div>
       <div
@@ -336,6 +337,15 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           </div>
         ) : isMarkdown && renderMd ? (
           <Markdown onFileClick={onOpenFile}>{content}</Markdown>
+        ) : isHtml && renderHtml ? (
+          // `allow-scripts` without `allow-same-origin` runs the page's JS in an
+          // opaque origin, so agent-authored HTML can't reach the app's session.
+          <iframe
+            srcDoc={content}
+            title={filename ?? "html"}
+            sandbox="allow-scripts"
+            className="w-full h-[calc(100dvh-200px)] rounded border border-border bg-white"
+          />
         ) : (
           <HighlightedCode code={content} path={path} />
         )}

--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -3,14 +3,13 @@ import {
   Close as X,
   Download,
   Edit as Pencil,
+  Maximize,
   Save,
 } from "@carbon/icons-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
-import { HighlightedCode } from "../../../components/highlighted-code.js";
-import { Markdown } from "../../../components/markdown.js";
 import { useUnsavedGuard } from "../../../hooks/use-unsaved-guard.js";
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
@@ -20,7 +19,8 @@ import {
   useFileWriteMutation,
 } from "../api/queries.js";
 import { base64ToBlob, downloadFileContent } from "../lib/download.js";
-import { CodeEditor } from "./code-editor.js";
+import { FilePreviewBody } from "./file-preview-body.js";
+import { FullscreenPreviewDialog } from "./fullscreen-preview-dialog.js";
 import { RenderToggle } from "./render-toggle.js";
 
 interface Props {
@@ -29,42 +29,14 @@ interface Props {
   onOpenFile: (path: string) => void;
 }
 
-function hexDump(base64: string): string {
-  const raw = atob(base64);
-  const lines: string[] = [];
-  const maxBytes = Math.min(raw.length, 1024);
-  for (let off = 0; off < maxBytes; off += 16) {
-    const slice = raw.slice(off, Math.min(off + 16, maxBytes));
-    const hex = Array.from(slice)
-      .map((c) => c.charCodeAt(0).toString(16).padStart(2, "0"))
-      .join(" ");
-    const ascii = Array.from(slice)
-      .map((c) => {
-        const code = c.charCodeAt(0);
-        return code >= 0x20 && code < 0x7f ? c : ".";
-      })
-      .join("");
-    lines.push(
-      `${off.toString(16).padStart(8, "0")}  ${hex.padEnd(47)}  ${ascii}`,
-    );
-  }
-  if (raw.length > maxBytes)
-    lines.push(`... ${raw.length - maxBytes} more bytes`);
-  return lines.join("\n");
-}
-
-function isImageMime(mime: string | undefined): boolean {
-  return !!mime && mime.startsWith("image/");
-}
-
 export function FileViewer({ file, onClose, onOpenFile }: Props) {
   const { path, content, binary, mimeType: mime, tooLarge } = file;
   const isMarkdown = mime === "text/markdown";
   const isSvg = mime === "image/svg+xml";
   const isHtml = mime === "text/html";
-  const isBinaryImage = binary && content && isImageMime(mime) && !isSvg;
   const isPdf = mime === "application/pdf";
-  const filename = path.split("/").pop();
+  const isBinaryImage =
+    binary && !!content && !!mime && mime.startsWith("image/") && !isSvg;
   const editable = !binary && !tooLarge;
 
   const selectedAgent = useStore((s) => s.selectedAgent);
@@ -76,6 +48,7 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
   const [renderMd, setRenderMd] = useState(true);
   const [renderSvg, setRenderSvg] = useState(true);
   const [renderHtml, setRenderHtml] = useState(true);
+  const [isExpanded, setIsExpanded] = useState(false);
   const [editMode, setEditMode] = useState(editable && openFileEdit);
   const [draft, setDraft] = useState(content);
   const [baseMtimeMs, setBaseMtimeMs] = useState<number | undefined>(
@@ -89,6 +62,9 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
       setOpenFileEdit(false);
     }
   }, [openFileEdit, editable, setOpenFileEdit]);
+
+  // Leaving fullscreen when the viewer switches to a different file.
+  useEffect(() => setIsExpanded(false), [path]);
 
   const dirty = editMode && draft !== content;
   useUnsavedGuard(dirty);
@@ -185,6 +161,31 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
 
   const pathLabel = useMemo(() => (dirty ? `● ${path}` : path), [dirty, path]);
 
+  // Whether the current view is a rendered preview (not source/editor/hex) and
+  // therefore worth offering at full size.
+  const isRenderedPreview =
+    !editMode &&
+    (isBinaryImage ||
+      (isPdf && !!pdfBlobUrl) ||
+      (isSvg && renderSvg) ||
+      (isMarkdown && renderMd) ||
+      (isHtml && renderHtml));
+
+  const previewBody = (
+    <FilePreviewBody
+      file={file}
+      editMode={editMode}
+      draft={draft}
+      onDraftChange={setDraft}
+      onSave={save}
+      renderSvg={renderSvg}
+      renderMd={renderMd}
+      renderHtml={renderHtml}
+      pdfBlobUrl={pdfBlobUrl}
+      onOpenFile={onOpenFile}
+    />
+  );
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <div className="flex items-center gap-2 px-3 h-9 border-b border-border shrink-0">
@@ -236,6 +237,17 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
             </Button>
           </>
         )}
+        {isRenderedPreview && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-primary"
+            onClick={() => setIsExpanded(true)}
+            title="Open fullscreen"
+          >
+            <Maximize size={11} /> Fullscreen
+          </Button>
+        )}
         {!tooLarge && !editMode && (
           <Button
             variant="ghost"
@@ -277,79 +289,22 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           editMode ? "flex-1 overflow-hidden p-2" : "flex-1 overflow-auto p-4"
         }
       >
-        {editMode ? (
-          <CodeEditor
-            value={draft}
-            path={path}
-            onChange={setDraft}
-            onSave={save}
-          />
-        ) : isBinaryImage ? (
-          <div className="flex items-center justify-center">
-            <img
-              src={`data:${mime};base64,${content}`}
-              alt={filename ?? "image"}
-              className="max-w-full max-h-[calc(100dvh-200px)] object-contain rounded border border-border"
-            />
+        {isExpanded ? (
+          <div className="flex h-full items-center justify-center text-[12px] text-muted-foreground">
+            Opened in fullscreen
           </div>
-        ) : isPdf && pdfBlobUrl ? (
-          <iframe
-            src={pdfBlobUrl}
-            title={filename ?? "pdf"}
-            className="w-full h-[calc(100dvh-200px)] rounded border border-border bg-white"
-          />
-        ) : /* tooLarge must come before the `binary` arm: PAYLOAD_TOO_LARGE
-           comes back with binary:true and content:"" so the hex-dump path
-           would otherwise render an empty buffer. */ tooLarge ? (
-          <div className="py-12 text-center text-[13px] text-muted-foreground">
-            <p>File too large to preview</p>
-            <p className="mt-1 text-[11px]">
-              Files over 10 MB cannot be displayed
-            </p>
-          </div>
-        ) : binary ? (
-          <div>
-            <div className="mb-2 flex items-baseline gap-2">
-              <p className="text-[11px] font-semibold uppercase tracking-[0.05em] text-muted-foreground">
-                Binary file — hex dump
-              </p>
-              {mime && (
-                <p className="text-[11px] font-mono text-muted-foreground">
-                  {mime}
-                </p>
-              )}
-            </div>
-            <p className="mb-3 text-[11px] text-muted-foreground">
-              This file is not directly viewable. The first bytes are shown
-              below.
-            </p>
-            <pre className="text-[11px] font-mono leading-[1.6] text-foreground/80 whitespace-pre overflow-x-auto">
-              {hexDump(content)}
-            </pre>
-          </div>
-        ) : isSvg && renderSvg ? (
-          <div className="flex items-center justify-center">
-            <img
-              src={`data:image/svg+xml;charset=utf-8,${encodeURIComponent(content)}`}
-              alt={filename ?? "image"}
-              className="max-w-full max-h-[calc(100dvh-200px)] object-contain rounded border border-border"
-            />
-          </div>
-        ) : isMarkdown && renderMd ? (
-          <Markdown onFileClick={onOpenFile}>{content}</Markdown>
-        ) : isHtml && renderHtml ? (
-          // `allow-scripts` without `allow-same-origin` runs the page's JS in an
-          // opaque origin, so agent-authored HTML can't reach the app's session.
-          <iframe
-            srcDoc={content}
-            title={filename ?? "html"}
-            sandbox="allow-scripts"
-            className="w-full h-[calc(100dvh-200px)] rounded border border-border bg-white"
-          />
         ) : (
-          <HighlightedCode code={content} path={path} />
+          previewBody
         )}
       </div>
+      {isExpanded && (
+        <FullscreenPreviewDialog
+          title={path}
+          onClose={() => setIsExpanded(false)}
+        >
+          {previewBody}
+        </FullscreenPreviewDialog>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/modules/files/components/fullscreen-preview-dialog.tsx
+++ b/packages/ui/src/modules/files/components/fullscreen-preview-dialog.tsx
@@ -1,0 +1,58 @@
+import { Close as X } from "@carbon/icons-react";
+import { type ReactNode, useEffect } from "react";
+import { createPortal } from "react-dom";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  title: string;
+  onClose: () => void;
+  children: ReactNode;
+}
+
+/** Full-viewport modal hosting a file preview at full size. Portaled to <body>
+ * so it escapes the file panel's layout; Escape or the close button dismisses
+ * it, and body scroll is locked while open. */
+export function FullscreenPreviewDialog({ title, onClose, children }: Props) {
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", onKey);
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = previousOverflow;
+    };
+  }, [onClose]);
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={title}
+      className="fixed inset-0 z-50 flex flex-col bg-background"
+    >
+      <div className="flex items-center gap-2 px-3 h-9 border-b border-border shrink-0">
+        <span
+          className="text-[12px] font-mono text-foreground/80 truncate flex-1"
+          title={title}
+        >
+          {title}
+        </span>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-primary"
+          onClick={onClose}
+          title="Exit fullscreen (Esc)"
+        >
+          <X size={11} /> Close
+        </Button>
+      </div>
+      <div className="flex-1 overflow-auto p-4">{children}</div>
+    </div>,
+    document.body,
+  );
+}

--- a/packages/ui/src/modules/files/components/render-toggle.tsx
+++ b/packages/ui/src/modules/files/components/render-toggle.tsx
@@ -1,0 +1,35 @@
+import { Code, View as Eye } from "@carbon/icons-react";
+
+import { Button } from "@/components/ui/button";
+
+interface Props {
+  /** True when the rendered view is showing; false shows the raw source. */
+  rendered: boolean;
+  onToggle: () => void;
+  /** Tooltip shown while rendered (i.e. the action switches to raw). */
+  rawTitle: string;
+  /** Tooltip shown while raw (i.e. the action switches to rendered). */
+  renderTitle: string;
+}
+
+/** Toolbar button that flips a previewable file between its rendered view and
+ * raw source. Shared by the SVG, markdown, and HTML file-viewer previews. */
+export function RenderToggle({
+  rendered,
+  onToggle,
+  rawTitle,
+  renderTitle,
+}: Props) {
+  return (
+    <Button
+      variant="ghost"
+      size="sm"
+      className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${rendered ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
+      onClick={onToggle}
+      title={rendered ? rawTitle : renderTitle}
+    >
+      {rendered ? <Code size={11} /> : <Eye size={11} />}
+      {rendered ? "Raw" : "Render"}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a **Fullscreen** action to the file viewer: any rendered preview (image, PDF, SVG, markdown, HTML) opens in a full-viewport dialog. Motivated by the Nous knowledge-graph visualizations, which are cramped in the narrow side panel.

> **Stacked on #1739** (render HTML in the file viewer). Base is `feat/file-viewer-html-render`; merge after #1739.

## Changes

- A **Fullscreen** toolbar button appears whenever a *rendered* preview is showing; it opens the preview in a self-contained portal dialog (Escape or Close to exit, body scroll locked while open).
- Extracted the preview render-chain into `FilePreviewBody` so the side panel and the dialog render from one implementation (DRY).
- No new dependency — the dialog is a `createPortal` overlay, not a new shared Dialog primitive.

## Testing

- `mise run ui:check` clean (eslint + tsc + prettier).
- Not visually verified in a running UI; reuses the same sandboxed iframe as #1739. Switching inline↔fullscreen reparents the iframe, so the page briefly reloads (the graph re-renders).

## Notes

- `file-viewer.tsx` now holds 8 `useState` (over the skill's ~5 guideline) — a `usePreviewControls` hook extraction is a reasonable follow-up, left out to keep this PR focused.
