### PR TITLE
bump: v0.2.6

### DIFF
--- a/deploy/helm/platform/Chart.yaml
+++ b/deploy/helm/platform/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: platform
 description: ADK — Secure Agent Execution Platform
 type: application
-version: 0.2.5
-appVersion: "0.2.5"
+version: 0.2.6
+appVersion: "0.2.6"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dam-agents/cli",
   "author": "IBM Corp.",
-  "version": "0.2.5",
+  "version": "0.2.6",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dam-agents/dam/tree/main/packages/cli#readme",


### PR DESCRIPTION
Bump pending version on `main` to 0.2.6 after opening `release-v0.2.5`.