### PR TITLE
feat(skills): load skills from a source subdirectory

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -962,14 +962,18 @@ e2e:
 
 # -- Platform-wide skill sources (shared catalog visible to all users).
 # Rendered into the api-server pod as SKILL_SOURCES_SEED. The same
-# `{name, gitUrl}` shape works for per-template sources under
-# `<templateKey>.skillSources`.
+# `{name, gitUrl, path?}` shape works for per-template sources under
+# `<templateKey>.skillSources`. `path` is an optional repo-relative
+# subdirectory to scan; omit it to scan `skills/` then the repo root.
 skills:
   skillSources: []
   # Example:
   # skillSources:
   #   - name: "Anthropic Skills"
   #     gitUrl: "https://github.com/anthropics/skills"
+  #   - name: "Acme Monorepo Skills"
+  #     gitUrl: "https://github.com/acme/monorepo"
+  #     path: ".claude/skills"
 
 # -- Curated catalog of public git repos an agent's working directory can be
 # seeded from at creation (cloned once into /home/agent/work, shortly after the

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Last verified: 2026-06-24
+Last verified: 2026-06-25
 
 ## Overview
 
@@ -127,7 +127,7 @@ Three responsibilities:
 
 - **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The paired gateway pod injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the named skill's directory from the source's `path/<name>/` when a [path](#skill-source) is set, else by walking the [Source Roots](#source-roots) in order (then top-level); copies it into every configured Skill Path, and returns the deterministic `contentHash`.
 - **Scan** — same fetch path; enumerates skills from the source's `path` exclusively when set, else across the [Source Roots](#source-roots) (union, deduped by name, top-level fallback); parses frontmatter, and returns `(name, description, version, contentHash)` for each.
-- **Publish** — REST-only. Reads the local skill from disk (size-capped per file and per skill), creates blobs + tree + commit + branch + PR via the GitHub REST API, with author `Platform <platform-publish@users.noreply.github.com>`. Branch naming: `platform/publish-<name>-<timestamp>`. There is no `git push`.
+- **Publish** — REST-only. Reads the local skill from disk (size-capped per file and per skill), creates blobs + tree + commit + branch + PR via the GitHub REST API, with author `Platform <platform-publish@users.noreply.github.com>`. Files land under the source's [`path`](#skill-source) subdir when set (so the same source's subdir-exclusive scan finds the published skill), else under `skills/`. Branch naming: `platform/publish-<name>-<timestamp>`. There is no `git push`.
 
 When env credentials arrive over the runtime channel, the agent-runtime reacts by running `gh auth setup-git`, so a private-repo `git clone` invoked from inside the pod also routes through `gh` (and therefore through the gateway pod's credential injector) instead of stalling on a username prompt. It deliberately does not run at boot, where credentials aren't available yet.
 

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -1,6 +1,6 @@
 # Skills
 
-Last verified: 2026-06-23
+Last verified: 2026-06-24
 
 ## Overview
 
@@ -70,7 +70,9 @@ A connection to an external git repository, addressable by id. Three kinds, all 
 - **System source** — a Helm-declared platform-wide entry from `skills.skillSources` ([`deploy/helm/platform/values.yaml`](../../deploy/helm/platform/values.yaml)). Loaded into api-server config from the `SKILL_SOURCES_SEED` env at boot, never persisted to Postgres. Marked `system: true` and protected from deletion. Badged "Platform".
 - **Template source** — declared on a template's `spec.skillSources`. Surfaced read-only on every agent derived from that template. Badged "Agent".
 
-Listing dedupes on `gitUrl` with first-wins precedence: user → template → system. A user creating a custom source for the same URL shadows the system entry; deleting the user row exposes the system entry again.
+Listing dedupes on `gitUrl` with first-wins precedence: user → system → template. A user creating a custom source for the same URL shadows the system entry; deleting the user row exposes the system entry again.
+
+A source may carry an optional repo-relative **path** — a subdirectory the scanner walks instead of the defaults. When set, that directory is scanned (and skills resolved) exclusively, bypassing the [Source Roots](#source-roots) union and top-level fallback; when absent, resolution is unchanged. Path is a property of the source, resolved server-side; it is denormalized onto each installed ref (`agent_skills`) so the apply path resolves the skill dir without re-reading the source. One path per `(owner, gitUrl)`; changing it is delete + re-add.
 
 ### Skill, Installed Skill Ref, Local Skill
 
@@ -109,7 +111,7 @@ Lives in [`packages/api-server/src/modules/skills/`](../../packages/api-server/s
 
 - The **Skill Source catalogue** — CRUD on user sources, merging in system seeds and template sources, dedupe and badge resolution.
 - The **scan cache** — per-`gitUrl`, 5-minute TTL, invalidated on `sources.refresh` or after a successful publish to that source.
-- **Public-archive scanning** — for `github.com` URLs, downloads `archive/HEAD.tar.gz` directly from GitHub, enumerates skills across the [Source Roots](#source-roots), parses frontmatter, computes `contentHash`. No credentials required. This is the path that lets the catalog UI render even when no agent is running.
+- **Public-archive scanning** — for `github.com` URLs, downloads `archive/HEAD.tar.gz` directly from GitHub, enumerates skills across the [Source Roots](#source-roots) (or the source's `path` when set), parses frontmatter, computes `contentHash`. No credentials required. This is the path that lets the catalog UI render even when no agent is running.
 - **Private / non-GitHub fallback** — falls through to the agent-runtime `skills.scan` over the harness port. Needs the credential path's paired gateway pod, so it **wakes a hibernated agent** via the shared `ensureReady` primitive rather than refusing (still requires an `agentId` to target).
 - **Install / uninstall orchestration** — wakes a hibernated agent before recording the change, then upserts the `agent_skills` row and bumps the outbox; the unified apply worker applies it onto the (now-warm) pod. The api-server is the only pod whose NetworkPolicy can reach the agent's tRPC listener; no Bearer token is sent.
 - **Publish orchestration** ([`publish-service`](../../packages/api-server/src/modules/skills/services/publish-service.ts)) — validates that the source is a GitHub URL (only host that supports publish), wakes a hibernated agent, calls agent-runtime, and on success writes the `agent_skill_publishes` row and invalidates the scan cache for that source.
@@ -123,8 +125,8 @@ Lives in [`packages/agent-runtime/src/modules/skills/`](../../packages/agent-run
 
 Three responsibilities:
 
-- **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The paired gateway pod injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the named skill's directory by walking the [Source Roots](#source-roots) in order (then top-level), copies it into every configured Skill Path, and returns the deterministic `contentHash`.
-- **Scan** — same fetch path; enumerates skills across the [Source Roots](#source-roots) (union, deduped by name, top-level fallback), parses frontmatter, and returns `(name, description, version, contentHash)` for each.
+- **Install** — fetches the source at the requested `version`. For GitHub URLs, uses the REST tarball endpoint (anonymous first, retry authenticated on 404 to distinguish "not found" from "private"); for everything else, shallow-clones via `git`. The paired gateway pod injects the owner's GitHub token on the wire when the request hits `api.github.com`. Resolves the named skill's directory from the source's `path/<name>/` when a [path](#skill-source) is set, else by walking the [Source Roots](#source-roots) in order (then top-level); copies it into every configured Skill Path, and returns the deterministic `contentHash`.
+- **Scan** — same fetch path; enumerates skills from the source's `path` exclusively when set, else across the [Source Roots](#source-roots) (union, deduped by name, top-level fallback); parses frontmatter, and returns `(name, description, version, contentHash)` for each.
 - **Publish** — REST-only. Reads the local skill from disk (size-capped per file and per skill), creates blobs + tree + commit + branch + PR via the GitHub REST API, with author `Platform <platform-publish@users.noreply.github.com>`. Branch naming: `platform/publish-<name>-<timestamp>`. There is no `git push`.
 
 When env credentials arrive over the runtime channel, the agent-runtime reacts by running `gh auth setup-git`, so a private-repo `git clone` invoked from inside the pod also routes through `gh` (and therefore through the gateway pod's credential injector) instead of stalling on a username prompt. It deliberately does not run at boot, where credentials aren't available yet.

--- a/packages/agent-runtime-api/src/modules/runtime/types.ts
+++ b/packages/agent-runtime-api/src/modules/runtime/types.ts
@@ -74,6 +74,7 @@ export const skillRefContribution = z.object({
   sourceUrl: z.string().min(1),
   name: z.string().min(1),
   version: z.string().min(1),
+  path: z.string().optional(),
 });
 
 export const contribution = z.discriminatedUnion("kind", [

--- a/packages/agent-runtime-api/src/modules/skills/schemas.ts
+++ b/packages/agent-runtime-api/src/modules/skills/schemas.ts
@@ -25,6 +25,9 @@ export const skillPublishInputSchema = z.object({
   repo: z.string().min(1),
   title: z.string().min(1),
   body: z.string(),
+  // Source subdir the skill is published into; mirrors the scanner so a
+  // subdir source's own scan finds what was published back to it.
+  path: z.string().optional(),
 });
 
 export const skillReadLocalInputSchema = z.object({

--- a/packages/agent-runtime-api/src/modules/skills/schemas.ts
+++ b/packages/agent-runtime-api/src/modules/skills/schemas.ts
@@ -5,6 +5,7 @@ export const skillInstallInputSchema = z.object({
   name: z.string().min(1),
   version: z.string().min(1),
   skillPaths: z.array(z.string().min(1)).min(1),
+  path: z.string().optional(),
 });
 
 export const skillUninstallInputSchema = z.object({
@@ -14,6 +15,7 @@ export const skillUninstallInputSchema = z.object({
 
 export const skillScanInputSchema = z.object({
   source: z.string().min(1),
+  path: z.string().optional(),
 });
 
 // No skillPaths: the agent-runtime resolves them from its manifest.

--- a/packages/agent-runtime/src/__tests__/unit/publish.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/publish.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { ok } from "agent-runtime-api";
+import type { SkillPublishInput } from "agent-runtime-api";
+import { runPublish } from "../../modules/skills/services/publish.js";
+import type { PublishDeps } from "../../modules/skills/services/publish.js";
+import type { GitHubRestClient } from "../../modules/skills/infrastructure/github-rest-client.js";
+import type { LocalSkillRepository } from "../../modules/skills/infrastructure/local-skill-repository.js";
+import type { SkillName } from "../../modules/skills/domain/skill-name.js";
+import type { SkillPath } from "../../modules/skills/domain/skill-path.js";
+
+/** Capture the tree paths runPublish asks GitHub to create. */
+function makeDeps(): { deps: PublishDeps; treePaths: () => string[] } {
+  let captured: string[] = [];
+  const github: GitHubRestClient = {
+    getRepo: async () => ok({ defaultBranch: "main" }),
+    getRef: async () => ok({ sha: "head-sha" }),
+    getCommitHead: async () => ok({ sha: "head-sha" }),
+    fetchTarball: async () => ok(new Uint8Array()),
+    createBlob: async () => ok({ sha: "blob-sha" }),
+    createTree: async (_host, body) => {
+      captured = body.tree.map((e) => e.path);
+      return ok({ sha: "tree-sha" });
+    },
+    createCommit: async () => ok({ sha: "commit-sha" }),
+    createRef: async () => ok({}),
+    createPullRequest: async () => ok({ htmlUrl: "https://example/pr/1" }),
+  };
+  const repo = {
+    readLocal: async () =>
+      ok({ files: [{ relPath: "SKILL.md", content: "# hi" }] }),
+  } as unknown as LocalSkillRepository;
+  return {
+    deps: { github, repo, now: () => new Date(0) },
+    treePaths: () => captured,
+  };
+}
+
+const input = (path?: string): SkillPublishInput => ({
+  name: "my-skill",
+  owner: "acme",
+  repo: "skills-repo",
+  title: "Add my-skill",
+  body: "",
+  ...(path !== undefined ? { path } : {}),
+});
+
+describe("runPublish blob paths", () => {
+  it("defaults to skills/ when the source has no configured path", async () => {
+    const { deps, treePaths } = makeDeps();
+    const res = await runPublish(
+      deps,
+      "my-skill" as SkillName,
+      ["/home/.claude/skills" as SkillPath],
+      input(),
+    );
+    expect(res.ok).toBe(true);
+    expect(treePaths()).toEqual(["skills/my-skill/SKILL.md"]);
+  });
+
+  it("publishes into the source's configured subdir", async () => {
+    const { deps, treePaths } = makeDeps();
+    const res = await runPublish(
+      deps,
+      "my-skill" as SkillName,
+      ["/home/.claude/skills" as SkillPath],
+      input(".claude/skills"),
+    );
+    expect(res.ok).toBe(true);
+    expect(treePaths()).toEqual([".claude/skills/my-skill/SKILL.md"]);
+  });
+});

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/skill-install-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/skill-install-plugin.ts
@@ -82,6 +82,7 @@ export function createSkillInstallPlugin(deps: {
             name: c.name,
             version: c.version,
             skillPaths,
+            ...(c.path !== undefined ? { path: c.path } : {}),
           };
           ctx.log(
             `install ${c.name}@${c.version} from ${c.sourceUrl} into ${skillPaths.length} path(s)`,

--- a/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
@@ -54,15 +54,21 @@ export interface LocalSkillRepository {
     opts: { stripComponents?: number },
   ) => Promise<void>;
   /** Walk a freshly-cloned/extracted repo and return every directory
-   *  (relative to `repoDir`) that contains a SKILL.md. Unions the deliberate
-   *  `SKILL_SOURCE_ROOTS` in order; top-level `*` only when none matched.
+   *  (relative to `repoDir`) that contains a SKILL.md. With `subPath`, scans
+   *  that subdir exclusively; otherwise unions the deliberate
+   *  `SKILL_SOURCE_ROOTS` in order, with top-level `*` only when none matched.
    *  May contain same-name collisions — callers dedupe via `dedupeByName`. */
-  findSkillDirsInClone: (repoDir: string) => Promise<string[]>;
-  /** Resolve the directory inside a clone where the named skill lives.
-   *  Tries each `SKILL_SOURCE_ROOTS`/<name> in order, then top-level <name>. */
+  findSkillDirsInClone: (
+    repoDir: string,
+    subPath?: string,
+  ) => Promise<string[]>;
+  /** Resolve the directory inside a clone where the named skill lives. With
+   *  `subPath`, looks at `<subPath>/<name>/` exclusively; otherwise tries each
+   *  `SKILL_SOURCE_ROOTS`/<name> in order, then top-level <name>. */
   resolveSkillDirInClone: (
     repoDir: string,
     name: SkillName,
+    subPath?: string,
   ) => Promise<Result<string, SkillsDomainError>>;
   /** Read SKILL.md frontmatter for a directory inside a clone. */
   readSkillManifest: (
@@ -250,7 +256,22 @@ function assertSafeTarEntry(entry: string): void {
   }
 }
 
-async function findSkillDirsInClone(repoDir: string): Promise<string[]> {
+/** A configured source subdir is api-server-validated, but guard at the join
+ *  site too so a stray `..`/absolute path can never escape the clone. */
+function subPathEscapes(subPath: string): boolean {
+  return subPath.startsWith("/") || subPath.split("/").includes("..");
+}
+
+async function findSkillDirsInClone(
+  repoDir: string,
+  subPath?: string,
+): Promise<string[]> {
+  if (subPath && subPathEscapes(subPath)) {
+    throw new Error(`skill source path rejected: ${subPath}`);
+  }
+  // An explicit subdir is scanned exclusively — no source-root union or root
+  // fallback, so the user gets exactly the directory they pointed at.
+  if (subPath) return skillDirsUnder(repoDir, path.join(repoDir, subPath));
   const found: string[] = [];
   for (const root of SKILL_SOURCE_ROOTS) {
     found.push(...(await skillDirsUnder(repoDir, path.join(repoDir, root))));
@@ -284,11 +305,17 @@ async function skillDirsUnder(
 async function resolveSkillDirInClone(
   repoDir: string,
   name: SkillName,
+  subPath?: string,
 ): Promise<Result<string, SkillsDomainError>> {
-  const candidates = [
-    ...SKILL_SOURCE_ROOTS.map((root) => path.join(repoDir, root, name)),
-    path.join(repoDir, name),
-  ];
+  if (subPath && subPathEscapes(subPath)) {
+    return err({ kind: "SkillNotFoundInSource", source: repoDir, name });
+  }
+  const candidates = subPath
+    ? [path.join(repoDir, subPath, name)]
+    : [
+        ...SKILL_SOURCE_ROOTS.map((root) => path.join(repoDir, root, name)),
+        path.join(repoDir, name),
+      ];
   for (const candidate of candidates) {
     try {
       await fs.access(path.join(candidate, "SKILL.md"));

--- a/packages/agent-runtime/src/modules/skills/services/install.ts
+++ b/packages/agent-runtime/src/modules/skills/services/install.ts
@@ -35,7 +35,11 @@ export async function runInstall(
     );
     if (!fetched.ok) return fetched;
 
-    const srcDirRes = await deps.repo.resolveSkillDirInClone(tmp, name);
+    const srcDirRes = await deps.repo.resolveSkillDirInClone(
+      tmp,
+      name,
+      input.path,
+    );
     if (!srcDirRes.ok) {
       // Re-tag with the original source URL — the tmpdir path inside the
       // repo's resolveSkillDirInClone result isn't useful to callers.

--- a/packages/agent-runtime/src/modules/skills/services/publish.ts
+++ b/packages/agent-runtime/src/modules/skills/services/publish.ts
@@ -52,6 +52,10 @@ export async function runPublish(
   if (!headRef.ok) return headRef;
   const headSha = headRef.value.sha;
 
+  // Publish back into the source's configured subdir so its scanner — which
+  // reads that subdir exclusively — finds the skill; default `skills/` when unset.
+  const baseDir = input.path && input.path.length > 0 ? input.path : "skills";
+
   // 1. Blob per file.
   const blobs: { path: string; sha: string }[] = [];
   for (const f of files) {
@@ -62,7 +66,10 @@ export async function runPublish(
         : { content: f.content, encoding: "utf-8" },
     );
     if (!blob.ok) return blob;
-    blobs.push({ path: `skills/${name}/${f.relPath}`, sha: blob.value.sha });
+    blobs.push({
+      path: `${baseDir}/${name}/${f.relPath}`,
+      sha: blob.value.sha,
+    });
   }
 
   // 2. Tree referencing the blobs, parented on the default-branch HEAD tree.

--- a/packages/agent-runtime/src/modules/skills/services/scan.ts
+++ b/packages/agent-runtime/src/modules/skills/services/scan.ts
@@ -38,8 +38,8 @@ export async function runScan(
 ): Promise<Result<ScannedSkill[], SkillsDomainError>> {
   const host = detectGithubOwnerRepo(input.source);
   const res = host
-    ? await scanGithub(deps, input.source, host)
-    : await scanGitClone(deps, input.source);
+    ? await scanGithub(deps, input.source, host, input.path)
+    : await scanGitClone(deps, input.source, input.path);
   if (!res.ok) return res;
   const { kept, dropped } = dedupeByName(res.value);
   for (const d of dropped) {
@@ -54,6 +54,7 @@ async function scanGithub(
   deps: ScanDeps,
   source: string,
   host: DetectedOwnerRepo,
+  subPath?: string,
 ): Promise<Result<ScannedSkill[], SkillsDomainError>> {
   // Anonymous preflight. The Envoy sidecar passes public repos through and
   // its credential_injector filter rewrites the sentinel for private repos
@@ -97,19 +98,20 @@ async function scanGithub(
     }
     const repoDir = path.join(tmp, extracted[0].name);
 
-    return collectSkills(deps, source, repoDir, version);
+    return collectSkills(deps, source, repoDir, version, subPath);
   });
 }
 
 async function scanGitClone(
   deps: ScanDeps,
   source: string,
+  subPath?: string,
 ): Promise<Result<ScannedSkill[], SkillsDomainError>> {
   return deps.repo.withTempDir("platform-skills-scan-", async (tmp) => {
     const cloned = await deps.git.cloneShallow(source, tmp, 50);
     if (!cloned.ok) return cloned;
 
-    const skillDirs = await deps.repo.findSkillDirsInClone(tmp);
+    const skillDirs = await deps.repo.findSkillDirsInClone(tmp, subPath);
     const out: ScannedSkill[] = [];
     for (const rel of skillDirs) {
       const absDir = path.join(tmp, rel);
@@ -134,8 +136,9 @@ async function collectSkills(
   source: string,
   repoDir: string,
   version: string,
+  subPath?: string,
 ): Promise<Result<ScannedSkill[], SkillsDomainError>> {
-  const skillDirs = await deps.repo.findSkillDirsInClone(repoDir);
+  const skillDirs = await deps.repo.findSkillDirsInClone(repoDir, subPath);
   const out = await Promise.all(
     skillDirs.map(async (rel) => {
       const absDir = path.join(repoDir, rel);

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -245,6 +245,7 @@ export {
   skillRefSchema,
   skillRefreshSourceInputSchema,
   skillSchema,
+  skillSourcePathSchema,
   skillSourceSchema,
   skillStateInputSchema,
   skillStateOutputSchema,

--- a/packages/api-server-api/src/modules/skills/schemas.ts
+++ b/packages/api-server-api/src/modules/skills/schemas.ts
@@ -1,5 +1,12 @@
 import { z } from "zod";
 
+/** A repo-relative subdirectory to scan for skills: relative, no `..`
+ *  traversal, surrounding slashes trimmed so `/foo/` and `foo` are equal. */
+export const skillSourcePathSchema = z
+  .string()
+  .transform((p) => p.trim().replace(/^\/+|\/+$/g, ""))
+  .refine((p) => !p.split("/").includes(".."), "path must not contain '..'");
+
 // --- Entity / output schemas ---
 
 /** A connected skill source (e.g. a public git repo). */
@@ -7,6 +14,7 @@ export const skillSourceSchema = z.object({
   id: z.string(),
   name: z.string(),
   gitUrl: z.string(),
+  path: z.string().optional(),
   /** True when the source is managed by the cluster admin
    *  (Helm-seeded). Users can't delete it. */
   system: z.boolean().optional(),
@@ -46,6 +54,9 @@ export const skillRefSchema = z.object({
    *  Optional for backward compatibility with installs that pre-date
    *  this field. */
   contentHash: z.string().optional(),
+  /** Source subdir the skill was installed from, denormalized so the apply
+   *  path resolves the skill dir without re-reading the source. */
+  path: z.string().optional(),
 });
 
 /** A skill authored directly on the instance's PVC (not installed
@@ -99,6 +110,7 @@ export const skillListSourcesInputSchema = z
 export const skillCreateSourceInputSchema = z.object({
   name: z.string().min(1).max(128),
   gitUrl: z.string().url(),
+  path: skillSourcePathSchema.optional(),
 });
 
 export const skillDeleteSourceInputSchema = z.object({

--- a/packages/api-server-api/src/modules/templates/schemas.ts
+++ b/packages/api-server-api/src/modules/templates/schemas.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { skillSourcePathSchema } from "../skills/schemas.js";
 
 export const templateGetInputSchema = z.object({
   id: z.string().min(1),
@@ -27,6 +28,7 @@ const envVarConfigMapSchema = z.object({
 export const skillSourceSeedSchema = z.object({
   name: z.string(),
   gitUrl: z.string(),
+  path: skillSourcePathSchema.optional(),
 });
 
 export const templateCategorySchema = z

--- a/packages/api-server-api/src/modules/templates/types.ts
+++ b/packages/api-server-api/src/modules/templates/types.ts
@@ -24,6 +24,7 @@ export type TemplateCategory = "harness" | "preconfigured";
 export interface SkillSourceSeed {
   name: string;
   gitUrl: string;
+  path?: string;
 }
 
 // An agent template's spec.yaml carries Layer B + C fields.

--- a/packages/api-server/src/__tests__/unit/public-archive-scanner.test.ts
+++ b/packages/api-server/src/__tests__/unit/public-archive-scanner.test.ts
@@ -165,4 +165,44 @@ describe("scanPublicGithubArchive", () => {
     ).rejects.toThrow(/only GitHub/);
     expect(fetchMock).not.toHaveBeenCalled();
   });
+
+  it("scans an explicit subPath exclusively, ignoring the standard source roots", async () => {
+    const sha = "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0";
+    const tarball = await makeTarball("acme-mono-a1b2c3d", {
+      "skills/root-skill/SKILL.md": "---\nname: root-skill\n---\nbody",
+      "packages/tools/skills/sub-skill/SKILL.md":
+        "---\nname: sub-skill\ndescription: From a subdir\n---\nbody",
+    });
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(
+        tarball,
+        `https://codeload.github.com/acme/mono/tar.gz/${sha}`,
+      ),
+    );
+
+    const skills = await scanPublicGithubArchive(
+      "https://github.com/acme/mono",
+      "packages/tools/skills",
+    );
+
+    // Only the subdir's skill — the standard `skills/` root is not consulted.
+    expect(skills.map((s) => s.name)).toEqual(["sub-skill"]);
+  });
+
+  it("rejects a traversal subPath", async () => {
+    const sha = "b0a9f8e7d6c5b4a3f2e1d0c9b8a7f6e5d4c3b2a1";
+    const tarball = await makeTarball("acme-mono-b0a9f8e", {
+      "skills/ok/SKILL.md": "---\nname: ok\n---\nbody",
+    });
+    fetchMock.mockResolvedValueOnce(
+      makeResponse(
+        tarball,
+        `https://codeload.github.com/acme/mono/tar.gz/${sha}`,
+      ),
+    );
+
+    await expect(
+      scanPublicGithubArchive("https://github.com/acme/mono", "../../etc"),
+    ).rejects.toThrow(/path rejected/);
+  });
 });

--- a/packages/api-server/src/modules/runtime-delivery/domain/contribution-hash.ts
+++ b/packages/api-server/src/modules/runtime-delivery/domain/contribution-hash.ts
@@ -26,7 +26,7 @@ function keyFor(c: Contribution): string {
     case "mcp-entry":
       return `mcp-entry:${c.name}`;
     case "skill-ref":
-      return `skill-ref:${c.name}@${c.version}@${c.sourceUrl}`;
+      return `skill-ref:${c.name}@${c.version}@${c.sourceUrl}@${c.path ?? ""}`;
   }
 }
 

--- a/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
@@ -138,6 +138,7 @@ async function readSkillRefContributions(
       source: agentSkills.source,
       name: agentSkills.name,
       version: agentSkills.version,
+      path: agentSkills.path,
     })
     .from(agentSkills)
     .where(eq(agentSkills.agentId, agentId));
@@ -147,6 +148,7 @@ async function readSkillRefContributions(
       sourceUrl: r.source,
       name: r.name,
       version: r.version,
+      ...(r.path !== null ? { path: r.path } : {}),
     }),
   );
 }

--- a/packages/api-server/src/modules/skills/compose.ts
+++ b/packages/api-server/src/modules/skills/compose.ts
@@ -20,33 +20,42 @@ interface CacheEntry {
 }
 
 /**
- * Cache shared across all users, keyed by gitUrl. A skill source returns the
- * same catalogue regardless of who's asking, so there's no owner-scoping.
- * The service is re-composed per request (context-scoped), so the cache must
- * live at module scope to persist across requests.
+ * Cache shared across all users, keyed by `(gitUrl, path)` — the same repo
+ * pointed at different subdirs yields different skills, but the result is
+ * independent of who's asking. The service is re-composed per request
+ * (context-scoped), so the cache must live at module scope to persist.
  */
 const sharedScanCache = new Map<string, CacheEntry>();
 
+function cacheKey(gitUrl: string, path: string | undefined): string {
+  // NUL separator can't appear in a URL or a validated path, so the key is
+  // collision-proof across (gitUrl, path) pairs.
+  return `${gitUrl}\0${path ?? ""}`;
+}
+
 async function scanWithCache(
   gitUrl: string,
+  path: string | undefined,
   scanner: (gitUrl: string) => Promise<Skill[]>,
 ): Promise<Skill[]> {
-  const hit = sharedScanCache.get(gitUrl);
+  const key = cacheKey(gitUrl, path);
+  const hit = sharedScanCache.get(key);
   if (hit && hit.expiresAt > Date.now()) {
-    process.stderr.write(`[skills] cache hit: ${gitUrl}\n`);
+    process.stderr.write(`[skills] cache hit: ${key}\n`);
     return hit.skills;
   }
-  process.stderr.write(`[skills] cache miss: ${gitUrl}\n`);
+  process.stderr.write(`[skills] cache miss: ${key}\n`);
   const skills = await scanner(gitUrl);
-  sharedScanCache.set(gitUrl, { skills, expiresAt: Date.now() + CACHE_TTL_MS });
+  sharedScanCache.set(key, { skills, expiresAt: Date.now() + CACHE_TTL_MS });
   return skills;
 }
 
-/** Drop the cached listing for a gitUrl so the next scan hits upstream.
- *  Called on successful publish + manual refresh. */
-function invalidateScanCache(gitUrl: string): void {
-  if (sharedScanCache.delete(gitUrl)) {
-    process.stderr.write(`[skills] cache invalidated: ${gitUrl}\n`);
+/** Drop the cached listing for a `(gitUrl, path)` so the next scan hits
+ *  upstream. Called on successful publish + manual refresh. */
+function invalidateScanCache(gitUrl: string, path: string | undefined): void {
+  const key = cacheKey(gitUrl, path);
+  if (sharedScanCache.delete(key)) {
+    process.stderr.write(`[skills] cache invalidated: ${key}\n`);
   }
 }
 

--- a/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
@@ -9,6 +9,7 @@ export interface PublishSkillCall {
   repo: string;
   title: string;
   body: string;
+  path?: string;
 }
 
 export interface PublishSkillResult {

--- a/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
@@ -37,7 +37,7 @@ export interface UpstreamGatewayError {
 export interface AgentRuntimeSkillsClient {
   listLocal(agentId: string): Promise<LocalSkill[]>;
   publish(agentId: string, body: PublishSkillCall): Promise<PublishSkillResult>;
-  scan(agentId: string, source: string): Promise<Skill[]>;
+  scan(agentId: string, source: string, path?: string): Promise<Skill[]>;
 }
 
 export class AgentRuntimeUpstreamError extends Error {
@@ -112,10 +112,14 @@ export function createAgentRuntimeSkillsClient(
       runWithUpstreamMapping(`agent-runtime publish ${agentId}`, () =>
         makeClient(agentId, namespace).skills.publish.mutate(body),
       ),
-    scan: async (agentId, source) => {
+    scan: async (agentId, source, path) => {
       const { skills } = await runWithUpstreamMapping(
         `agent-runtime scan ${agentId}`,
-        () => makeClient(agentId, namespace).skills.scan.mutate({ source }),
+        () =>
+          makeClient(agentId, namespace).skills.scan.mutate({
+            source,
+            ...(path !== undefined ? { path } : {}),
+          }),
       );
       return skills as Skill[];
     },

--- a/packages/api-server/src/modules/skills/infrastructure/agent-skills-repository.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/agent-skills-repository.ts
@@ -38,6 +38,7 @@ export function createAgentSkillsRepository(db: Db): AgentSkillsRepository {
         name: r.name,
         version: r.version,
         ...(r.contentHash !== null ? { contentHash: r.contentHash } : {}),
+        ...(r.path !== null ? { path: r.path } : {}),
       }));
     },
 
@@ -50,12 +51,14 @@ export function createAgentSkillsRepository(db: Db): AgentSkillsRepository {
           name: ref.name,
           version: ref.version,
           contentHash: ref.contentHash ?? null,
+          path: ref.path ?? null,
         })
         .onConflictDoUpdate({
           target: [agentSkills.agentId, agentSkills.source, agentSkills.name],
           set: {
             version: ref.version,
             contentHash: ref.contentHash ?? null,
+            path: ref.path ?? null,
           },
         });
     },

--- a/packages/api-server/src/modules/skills/infrastructure/public-archive-scanner.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/public-archive-scanner.ts
@@ -116,7 +116,24 @@ export async function computeContentHash(absDir: string): Promise<string> {
   return h.digest("hex");
 }
 
-async function findSkillDirs(repoDir: string): Promise<string[]> {
+function subPathEscapes(subPath: string): boolean {
+  return subPath.startsWith("/") || subPath.split("/").includes("..");
+}
+
+async function findSkillDirs(
+  repoDir: string,
+  subPath?: string,
+): Promise<string[]> {
+  // An explicit subdir is scanned exclusively — no source-root union or root
+  // fallback, so the user gets exactly the directory they pointed at. The path
+  // is api-validated at source creation; guard here too so a stray
+  // `..`/absolute path can never escape the extracted archive.
+  if (subPath) {
+    if (subPathEscapes(subPath)) {
+      throw new Error(`skill source path rejected: ${subPath}`);
+    }
+    return skillDirsUnder(repoDir, path.join(repoDir, subPath));
+  }
   const found: string[] = [];
   for (const root of SKILL_SOURCE_ROOTS) {
     found.push(...(await skillDirsUnder(repoDir, path.join(repoDir, root))));
@@ -156,6 +173,7 @@ async function skillDirsUnder(
  */
 export async function scanPublicGithubArchive(
   gitUrl: string,
+  subPath?: string,
 ): Promise<Skill[]> {
   const host = detectHost(gitUrl);
   if (!host)
@@ -197,7 +215,7 @@ export async function scanPublicGithubArchive(
       throw new Error("tarball contained no directories");
     const repoDir = path.join(tmp, extracted[0].name);
 
-    const skillDirs = await findSkillDirs(repoDir);
+    const skillDirs = await findSkillDirs(repoDir, subPath);
     const scanned = await Promise.all(
       skillDirs.map(async (rel) => {
         const absDir = path.join(repoDir, rel);

--- a/packages/api-server/src/modules/skills/infrastructure/seed-sources.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/seed-sources.ts
@@ -1,10 +1,11 @@
 import { z } from "zod/v4";
-import type { SkillSource } from "api-server-api";
+import { skillSourcePathSchema, type SkillSource } from "api-server-api";
 
 const seedSchema = z.array(
   z.object({
     name: z.string().min(1).max(128),
     gitUrl: z.url(),
+    path: skillSourcePathSchema.optional(),
   }),
 );
 
@@ -12,6 +13,7 @@ export interface SkillSourceSeed {
   id: string;
   name: string;
   gitUrl: string;
+  path?: string;
 }
 
 const SEED_ID_PREFIX = "skill-src-seed-";
@@ -76,6 +78,7 @@ export function parseSeedSources(raw: string | undefined): SkillSourceSeed[] {
       id: `${SEED_ID_PREFIX}${slug}`,
       name: entry.name,
       gitUrl: entry.gitUrl,
+      ...(entry.path ? { path: entry.path } : {}),
     };
   });
 }
@@ -83,5 +86,11 @@ export function parseSeedSources(raw: string | undefined): SkillSourceSeed[] {
 /** Surface seeds as `SkillSource` views, tagged `system: true` so the UI's
  *  "Platform" badge and the protected-source delete check both fall out. */
 export function seedToSkillSource(seed: SkillSourceSeed): SkillSource {
-  return { id: seed.id, name: seed.name, gitUrl: seed.gitUrl, system: true };
+  return {
+    id: seed.id,
+    name: seed.name,
+    gitUrl: seed.gitUrl,
+    system: true,
+    ...(seed.path !== undefined ? { path: seed.path } : {}),
+  };
 }

--- a/packages/api-server/src/modules/skills/infrastructure/skills-repository.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/skills-repository.ts
@@ -8,7 +8,7 @@ export interface SkillsRepository {
   list(owner: string): Promise<SkillSource[]>;
   get(id: string, owner: string): Promise<SkillSource | null>;
   create(
-    input: { name: string; gitUrl: string },
+    input: { name: string; gitUrl: string; path?: string },
     owner: string,
   ): Promise<SkillSource>;
   delete(id: string, owner: string): Promise<void>;
@@ -23,6 +23,20 @@ export class SkillSourceProtectedError extends Error {
 
 function generateId(): string {
   return `skill-src-${crypto.randomBytes(4).toString("hex")}`;
+}
+
+function rowToSource(r: {
+  id: string;
+  name: string;
+  gitUrl: string;
+  path: string | null;
+}): SkillSource {
+  return {
+    id: r.id,
+    name: r.name,
+    gitUrl: r.gitUrl,
+    ...(r.path !== null ? { path: r.path } : {}),
+  };
 }
 
 /** Postgres-backed user-source repo. System (admin-seeded) sources never live
@@ -45,7 +59,7 @@ export function createSkillsRepository(
         .select()
         .from(skillSources)
         .where(eq(skillSources.owner, owner));
-      return rows.map((r) => ({ id: r.id, name: r.name, gitUrl: r.gitUrl }));
+      return rows.map(rowToSource);
     },
 
     async get(id, owner) {
@@ -56,7 +70,7 @@ export function createSkillsRepository(
         .limit(1);
       const r = rows[0];
       if (!r) return null;
-      return { id: r.id, name: r.name, gitUrl: r.gitUrl };
+      return rowToSource(r);
     },
 
     async create(input, owner) {
@@ -66,8 +80,14 @@ export function createSkillsRepository(
         owner,
         name: input.name,
         gitUrl: input.gitUrl,
+        path: input.path || null,
       });
-      return { id, name: input.name, gitUrl: input.gitUrl };
+      return {
+        id,
+        name: input.name,
+        gitUrl: input.gitUrl,
+        ...(input.path ? { path: input.path } : {}),
+      };
     },
 
     async delete(id, owner) {

--- a/packages/api-server/src/modules/skills/services/publish-service.ts
+++ b/packages/api-server/src/modules/skills/services/publish-service.ts
@@ -75,6 +75,7 @@ export async function publishSkill(
       body:
         input.body?.trim() ||
         `Published from ${deps.brandName}.\n\n**Skill:** \`${input.name}\``,
+      ...(source.path !== undefined ? { path: source.path } : {}),
     });
   } catch (err) {
     if (err instanceof AgentRuntimeUpstreamError) {

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -62,18 +62,20 @@ export interface SkillsServiceDeps {
   runtimeClient: AgentRuntimeSkillsClient;
   runtimeMutator: RuntimeMutator;
   owner: string;
-  /** Scan via the provided scanner with a shared TTL cache. The cache key is
-   *  the gitUrl alone — results are user-independent. */
+  /** Scan via the provided scanner with a shared TTL cache, keyed by
+   *  `(gitUrl, path)` — the catalogue depends on both, and the cache is shared
+   *  across users who may point the same repo at different subdirs. */
   scanSource: (
     gitUrl: string,
+    path: string | undefined,
     scanner: (gitUrl: string) => Promise<Skill[]>,
   ) => Promise<Skill[]>;
-  invalidateScan: (gitUrl: string) => void;
+  invalidateScan: (gitUrl: string, path: string | undefined) => void;
   /** Scan a public GitHub repo directly from the api-server pod. Throws
    *  `PublicArchiveNotFoundError` when the archive endpoint returns 404 —
    *  signal to the caller to fall back to the agent-runtime path for
    *  private-repo auth (if the instance is running). */
-  scanPublic: (gitUrl: string) => Promise<Skill[]>;
+  scanPublic: (gitUrl: string, path?: string) => Promise<Skill[]>;
   /** Brand display name surfaced in publish-PR bodies. Sourced from runtime
    *  brand config so a deployment rebrand doesn't need a code change. */
   brandName: string;
@@ -113,6 +115,7 @@ async function loadTemplateSources(
     id: templateSourceId(template.id, seed.gitUrl),
     name: seed.name,
     gitUrl: seed.gitUrl,
+    ...(seed.path !== undefined ? { path: seed.path } : {}),
     fromTemplate: { templateId: template.id, templateName: template.name },
   }));
 }
@@ -138,6 +141,7 @@ async function resolveTemplateSource(
     id,
     name: seed.name,
     gitUrl: seed.gitUrl,
+    ...(seed.path !== undefined ? { path: seed.path } : {}),
     fromTemplate: { templateId: template.id, templateName: template.name },
   };
 }
@@ -190,6 +194,24 @@ function dedupeByGitUrl(list: SkillSource[]): SkillSource[] {
     out.push(s);
   }
   return out;
+}
+
+/** Recover a source's subdir from its gitUrl using the same merge + dedupe
+ *  precedence as listSources (user → system → template). Install carries the
+ *  gitUrl, not the source id, so this is how the path is found to denormalize
+ *  onto the installed ref. */
+async function resolveSourcePathByGitUrl(
+  deps: SkillsServiceDeps,
+  agentId: string,
+  gitUrl: string,
+): Promise<string | undefined> {
+  const [owned, template] = await Promise.all([
+    deps.repo.list(deps.owner),
+    loadTemplateSources(deps, agentId),
+  ]);
+  const seeds = deps.seedSources.map(seedToSkillSource);
+  const merged = dedupeByGitUrl([...owned, ...seeds, ...template]);
+  return merged.find((s) => s.gitUrl === gitUrl)?.path;
 }
 
 function upsertSkillRef(current: SkillRef[], next: SkillRef): SkillRef[] {
@@ -295,7 +317,9 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       // egress — it never touches the agent pod's per-grant gating.
       if (detectHost(src.gitUrl)) {
         try {
-          return await deps.scanSource(src.gitUrl, deps.scanPublic);
+          return await deps.scanSource(src.gitUrl, src.path, (gitUrl) =>
+            deps.scanPublic(gitUrl, src.path),
+          );
         } catch (err) {
           if (!(err instanceof PublicArchiveNotFoundError)) throw err;
           // 404 → repo is private (or nonexistent). Only the authenticated
@@ -316,8 +340,8 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       }
       await ensureAgentReachable(deps.agentsRepo, agentId, deps.owner);
       try {
-        return await deps.scanSource(src.gitUrl, (gitUrl) =>
-          deps.runtimeClient.scan(agentId, gitUrl),
+        return await deps.scanSource(src.gitUrl, src.path, (gitUrl) =>
+          deps.runtimeClient.scan(agentId, gitUrl, src.path),
         );
       } catch (err) {
         if (err instanceof AgentRuntimeUpstreamError) throw upstreamToTrpc(err);
@@ -328,6 +352,11 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
     async install(input: SkillInstallInput) {
       await ensureAgentReachable(deps.agentsRepo, input.agentId, deps.owner);
 
+      const path = await resolveSourcePathByGitUrl(
+        deps,
+        input.agentId,
+        input.source,
+      );
       const ref: SkillRef = {
         source: input.source,
         name: input.name,
@@ -335,6 +364,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
         ...(input.contentHash !== undefined
           ? { contentHash: input.contentHash }
           : {}),
+        ...(path !== undefined ? { path } : {}),
       };
       await deps.agentSkillsRepo.upsertSkill(input.agentId, ref);
       await deps.runtimeMutator.bump(input.agentId, []);
@@ -401,7 +431,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       // the merged PR (whenever that happens — we don't wait, we just stop
       // serving a stale snapshot).
       const source = await resolveSource(deps, input.sourceId);
-      if (source) deps.invalidateScan(source.gitUrl);
+      if (source) deps.invalidateScan(source.gitUrl, source.path);
       return result;
     },
 
@@ -412,7 +442,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
           code: "NOT_FOUND",
           message: "skill source not found",
         });
-      deps.invalidateScan(source.gitUrl);
+      deps.invalidateScan(source.gitUrl, source.path);
     },
 
     async listLocal(agentId: string): Promise<LocalSkill[]> {

--- a/packages/cli/src/modules/skill/commands/source-add.ts
+++ b/packages/cli/src/modules/skill/commands/source-add.ts
@@ -24,6 +24,10 @@ export function buildSourceAddCommand(deps: {
     .argument("<git-url>", "git URL of the skill source repository")
     .option("--name <name>", "source name (default: derived from the git URL)")
     .option(
+      "--path <path>",
+      "optional subdirectory within the repository to scan for skills",
+    )
+    .option(
       "--server <url>",
       "override the configured server URL for this call",
     )
@@ -35,12 +39,13 @@ export function buildSourceAddCommand(deps: {
         "uses shadows it — removing your source re-exposes the original.\n" +
         "\nExamples:\n" +
         "  dam skill source add https://github.com/anthropics/skills\n" +
-        "  dam skill source add https://github.com/acme/skills --name acme\n",
+        "  dam skill source add https://github.com/acme/skills --name acme\n" +
+        "  dam skill source add https://github.com/acme/monorepo --path .claude/skills\n",
     )
     .action(
       async (
         gitUrl: string,
-        opts: { name?: string; server?: string; json?: boolean },
+        opts: { name?: string; path?: string; server?: string; json?: boolean },
       ) => {
         const json = opts.json ?? false;
 
@@ -60,6 +65,19 @@ export function buildSourceAddCommand(deps: {
           process.exit(EXIT_INVALID_INPUT);
         }
 
+        let path: string | undefined;
+        if (opts.path !== undefined) {
+          const pathCheck = skillCreateSourceInputSchema.shape.path.safeParse(
+            opts.path,
+          );
+          if (!pathCheck.success) {
+            const msg = pathCheck.error.issues[0]?.message ?? "invalid path";
+            process.stderr.write(`error: ${msg}\n`);
+            process.exit(EXIT_INVALID_INPUT);
+          }
+          path = pathCheck.data || undefined;
+        }
+
         const host = await resolveActiveHost(deps, {
           flag: opts.server ? { server: opts.server } : undefined,
           exitCodes: {
@@ -70,7 +88,7 @@ export function buildSourceAddCommand(deps: {
 
         const result = await deps
           .createSkillsService(host)
-          .addSource({ name, gitUrl });
+          .addSource({ name, gitUrl, path });
         if (!result.ok) {
           if (result.error.kind === "source-exists") {
             process.stderr.write(

--- a/packages/cli/src/modules/skill/commands/source-list.ts
+++ b/packages/cli/src/modules/skill/commands/source-list.ts
@@ -19,13 +19,13 @@ import { writeStdoutAndExit } from "../../shared/stdout.js";
 import { sourceKind } from "../domain/source-ref.js";
 import type { SkillsService } from "../services/skills-service.js";
 
-const HEADER = ["ID", "NAME", "GIT URL", "KIND"];
+const HEADER = ["ID", "NAME", "GIT URL", "PATH", "KIND"];
 
 function tableFor(sources: readonly SkillSource[]): string {
   const sorted = [...sources].sort((a, b) => a.name.localeCompare(b.name));
   return renderTable([
     HEADER,
-    ...sorted.map((s) => [s.id, s.name, s.gitUrl, sourceKind(s)]),
+    ...sorted.map((s) => [s.id, s.name, s.gitUrl, s.path ?? "", sourceKind(s)]),
   ]);
 }
 

--- a/packages/cli/src/modules/skill/services/skills-service.ts
+++ b/packages/cli/src/modules/skill/services/skills-service.ts
@@ -33,6 +33,7 @@ export interface SkillsService {
   addSource(input: {
     name: string;
     gitUrl: string;
+    path?: string;
   }): Promise<
     Result<
       SkillSource,

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -194,4 +194,5 @@ type EnvVar struct {
 type SkillSource struct {
 	Name   string `json:"name"`
 	GitURL string `json:"gitUrl"`
+	Path   string `json:"path,omitempty"`
 }

--- a/packages/db/drizzle/0004_open_mariko_yashida.sql
+++ b/packages/db/drizzle/0004_open_mariko_yashida.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "agent_skills" ADD COLUMN "path" text;--> statement-breakpoint
+ALTER TABLE "skill_sources" ADD COLUMN "path" text;

--- a/packages/db/drizzle/meta/0004_snapshot.json
+++ b/packages/db/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,1706 @@
+{
+  "id": "8655cd72-fb44-450c-9453-e25e4910db00",
+  "prevId": "4a0335d4-0842-49ed-b3f4-abeb606310b3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_events": {
+      "name": "activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "activity_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_events_type_occurred_idx": {
+          "name": "activity_events_type_occurred_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_actor_occurred_idx": {
+          "name": "activity_events_actor_occurred_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_events\".\"actor_sub\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_surface_occurred_idx": {
+          "name": "activity_events_surface_occurred_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_auth_dedup_idx": {
+          "name": "activity_events_auth_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_trunc('day', \"occurred_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"activity_events\".\"type\" = 'auth'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor_roles": {
+      "name": "actor_roles",
+      "schema": "",
+      "columns": {
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_core": {
+          "name": "is_core",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_env": {
+      "name": "agent_env",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_env_agent_idx": {
+          "name": "agent_env_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_env_agent_id_name_pk": {
+          "name": "agent_env_agent_id_name_pk",
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_publishes": {
+      "name": "agent_skill_publishes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_publishes_agent_idx": {
+          "name": "agent_skill_publishes_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skills": {
+      "name": "agent_skills",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skills_agent_idx": {
+          "name": "agent_skills_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_source_name_pk": {
+          "name": "agent_skills_agent_id_source_name_pk",
+          "columns": [
+            "agent_id",
+            "source",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_protocol_version": {
+          "name": "runtime_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_capabilities": {
+          "name": "runtime_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_last_hello_at": {
+          "name": "runtime_last_hello_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_agent_version": {
+          "name": "runtime_agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_idx": {
+          "name": "agents_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allowed_users": {
+      "name": "allowed_users",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "allowed_users_agent_id_keycloak_sub_pk": {
+          "name": "allowed_users_agent_id_keycloak_sub_pk",
+          "columns": [
+            "agent_id",
+            "keycloak_sub"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_hash_idx": {
+          "name": "api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_owner_idx": {
+          "name": "api_keys_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_keys\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channels_agent_type_idx": {
+          "name": "channels_agent_type_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channels_slack_channel_unique_idx": {
+          "name": "channels_slack_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "(\"config\"->>'slackChannelId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"channels\".\"type\" = 'slack'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_grants": {
+      "name": "connection_grants",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_grants_agent_idx": {
+          "name": "connection_grants_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_connection_id_agent_id_pk": {
+          "name": "connection_grants_connection_id_agent_id_pk",
+          "columns": [
+            "connection_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributions": {
+          "name": "contributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connections_owner_idx": {
+          "name": "connections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_owner_name_unique_idx": {
+          "name": "connections_owner_name_unique_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.egress_rules": {
+      "name": "egress_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "egress_rules_lookup_idx": {
+          "name": "egress_rules_lookup_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"egress_rules\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "egress_rules_source_idx": {
+          "name": "egress_rules_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"egress_rules\".\"status\" = 'active' AND \"egress_rules\".\"source\" != 'manual'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_links": {
+      "name": "identity_links",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "identity_links_provider_external_user_id_pk": {
+          "name": "identity_links_provider_external_user_id_pk",
+          "columns": [
+            "provider",
+            "external_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_approvals": {
+      "name": "pending_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pending_approvals_owner_status_idx": {
+          "name": "pending_approvals_owner_status_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_agent_status_idx": {
+          "name": "pending_approvals_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_undelivered_idx": {
+          "name": "pending_approvals_undelivered_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'resolved' AND delivered_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_events": {
+      "name": "runtime_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runtime_events_agent_pending_idx": {
+          "name": "runtime_events_agent_pending_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_events_expiry_idx": {
+          "name": "runtime_events_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_state_outbox": {
+      "name": "runtime_state_outbox",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_settled_version": {
+          "name": "last_settled_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_hash": {
+          "name": "last_applied_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_at": {
+          "name": "last_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apply_failures": {
+          "name": "apply_failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "apply_attempts": {
+          "name": "apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "runtime_state_outbox_retry_idx": {
+          "name": "runtime_state_outbox_retry_idx",
+          "columns": [
+            {
+              "expression": "apply_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_state_outbox\".\"apply_failures\" <> '[]'::jsonb OR \"runtime_state_outbox\".\"last_settled_version\" < \"runtime_state_outbox\".\"version\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_result": {
+          "name": "last_fired_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_agent_owner_idx": {
+          "name": "schedules_agent_owner_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_enabled_idx": {
+          "name": "schedules_enabled_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"schedules\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_sources": {
+      "name": "skill_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_sources_owner_git_url_idx": {
+          "name": "skill_sources_owner_git_url_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_sources_owner_idx": {
+          "name": "skill_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_threads": {
+      "name": "telegram_threads",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telegram_threads_agent_id_thread_id_pk": {
+          "name": "telegram_threads_agent_id_thread_id_pk",
+          "columns": [
+            "agent_id",
+            "thread_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms_acceptances": {
+      "name": "terms_acceptances",
+      "schema": "",
+      "columns": {
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "terms_acceptances_sub_version_pk": {
+          "name": "terms_acceptances_sub_version_pk",
+          "columns": [
+            "sub",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_outcome": {
+      "name": "activity_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1782212869850,
       "tag": "0003_smart_squadron_sinister",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1782382620734,
+      "tag": "0004_open_mariko_yashida",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -157,6 +157,8 @@ export const skillSources = pgTable(
     owner: text("owner").notNull(),
     name: text("name").notNull(),
     gitUrl: text("git_url").notNull(),
+    // Repo-relative subdir to scan; null ⇒ default (`skills/` then root).
+    path: text("path"),
     createdAt: timestamp("created_at", { withTimezone: true })
       .defaultNow()
       .notNull(),
@@ -178,6 +180,9 @@ export const agentSkills = pgTable(
     name: text("name").notNull(),
     version: text("version").notNull(),
     contentHash: text("content_hash"),
+    // Source's `path` denormalized at install time; the source may be a
+    // non-persisted system/template entry, or since deleted.
+    path: text("path"),
     installedAt: timestamp("installed_at", { withTimezone: true })
       .defaultNow()
       .notNull(),

--- a/packages/ui/src/modules/sessions/components/skills-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/skills-panel.tsx
@@ -1,3 +1,4 @@
+import { SKILL_SOURCE_ROOTS } from "agent-runtime-api";
 import type {
   LocalSkill,
   Skill,
@@ -10,6 +11,7 @@ import {
   ChevronRight,
   ExternalLink,
   Eye,
+  Info,
   Plus,
   RefreshCw,
   Share2,
@@ -20,6 +22,8 @@ import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Tooltip } from "@/components/ui/tooltip";
 
 import { api } from "../../../api.js";
 import { ACTION_FAILED, runAction } from "../../../lib/query-helpers.js";
@@ -100,6 +104,7 @@ function skillSourceUrl(
   source: string,
   version: string,
   name: string,
+  path?: string,
   compareFrom?: string,
 ): string {
   const base = source.replace(/\.git$/, "").replace(/\/$/, "");
@@ -111,7 +116,8 @@ function skillSourceUrl(
   if (compareFrom) {
     return `${base}/compare/${compareFrom}...${version}`;
   }
-  return `${base}/blob/${version}/skills/${name}/SKILL.md`;
+  const dir = path ?? "skills";
+  return `${base}/blob/${version}/${dir}/${name}/SKILL.md`;
 }
 
 export function SkillsPanel({
@@ -139,7 +145,7 @@ export function SkillsPanel({
   const [publishes, setPublishes] = useState<SkillPublishRecord[]>([]);
   const [busyRow, setBusyRow] = useState<string | null>(null);
   const [showAdd, setShowAdd] = useState(false);
-  const [addForm, setAddForm] = useState({ name: "", gitUrl: "" });
+  const [addForm, setAddForm] = useState({ name: "", gitUrl: "", path: "" });
   const [addBusy, setAddBusy] = useState(false);
   const [publishFor, setPublishFor] = useState<LocalSkill | null>(null);
   const [publishForm, setPublishForm] = useState({
@@ -341,13 +347,14 @@ export function SkillsPanel({
         api.skills.sources.create.mutate({
           name: addForm.name.trim(),
           gitUrl: addForm.gitUrl.trim(),
+          path: addForm.path.trim() || undefined,
         }),
       "Failed to add source",
     );
     setAddBusy(false);
     if (result !== ACTION_FAILED) {
       setSources((s) => [...s, result]);
-      setAddForm({ name: "", gitUrl: "" });
+      setAddForm({ name: "", gitUrl: "", path: "" });
       setShowAdd(false);
     }
   };
@@ -600,7 +607,7 @@ export function SkillsPanel({
           size="xs"
           className="w-full"
           onClick={() => {
-            setAddForm({ name: "", gitUrl: "" });
+            setAddForm({ name: "", gitUrl: "", path: "" });
             setShowAdd(true);
           }}
         >
@@ -610,23 +617,61 @@ export function SkillsPanel({
 
       {showAdd && (
         <div className="flex flex-col gap-3 border-b border-border-light p-4 anim-in">
-          <Input
-            size="sm"
-            placeholder='Name (e.g. "My Skills")'
-            value={addForm.name}
-            onChange={(e) =>
-              setAddForm((f) => ({ ...f, name: e.target.value }))
-            }
-          />
-          <Input
-            size="sm"
-            variant="monospace"
-            placeholder="https://github.com/your-org/skills"
-            value={addForm.gitUrl}
-            onChange={(e) =>
-              setAddForm((f) => ({ ...f, gitUrl: e.target.value }))
-            }
-          />
+          <div className="flex flex-col gap-1">
+            <Label className="text-[11px] text-text-muted">Name</Label>
+            <Input
+              size="sm"
+              placeholder='e.g. "My Skills"'
+              value={addForm.name}
+              onChange={(e) =>
+                setAddForm((f) => ({ ...f, name: e.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <Label className="text-[11px] text-text-muted">Git URL</Label>
+            <Input
+              size="sm"
+              variant="monospace"
+              placeholder="https://github.com/your-org/skills"
+              value={addForm.gitUrl}
+              onChange={(e) =>
+                setAddForm((f) => ({ ...f, gitUrl: e.target.value }))
+              }
+            />
+          </div>
+          <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-1">
+              <Label className="text-[11px] text-text-muted">
+                Path (optional)
+              </Label>
+              <Tooltip
+                side="right"
+                content={
+                  <span>
+                    Subdirectory to scan for skills. Leave empty to
+                    auto-discover skills in{" "}
+                    {SKILL_SOURCE_ROOTS.map((r) => `${r}/`).join(", ")} or the
+                    repo root.
+                  </span>
+                }
+              >
+                <Info
+                  size={12}
+                  className="text-text-muted cursor-help shrink-0"
+                />
+              </Tooltip>
+            </div>
+            <Input
+              size="sm"
+              variant="monospace"
+              placeholder="e.g. packages/skills"
+              value={addForm.path}
+              onChange={(e) =>
+                setAddForm((f) => ({ ...f, path: e.target.value }))
+              }
+            />
+          </div>
           <div className="flex justify-end gap-2">
             <Button
               variant="outline"
@@ -699,9 +744,10 @@ export function SkillsPanel({
               )}
               <span
                 className="text-[11px] text-text-muted truncate max-w-[200px]"
-                title={src.gitUrl}
+                title={src.path ? `${src.gitUrl} · ${src.path}` : src.gitUrl}
               >
                 {src.gitUrl.replace(/^https:\/\/github\.com\//, "")}
+                {src.path ? ` · ${src.path}` : ""}
               </span>
               <span
                 role="button"
@@ -822,6 +868,8 @@ export function SkillsPanel({
                             skill.source,
                             skill.version,
                             skill.name,
+                            sources.find((s) => s.gitUrl === skill.source)
+                              ?.path,
                             hasDrift ? installed?.version : undefined,
                           )}
                           target="_blank"


### PR DESCRIPTION
## What

Skill sources can now optionally point at a **subdirectory** inside the repo. When a path is set, that directory is scanned for skills the same way `skills/` is scanned today — any direct subfolder with a `SKILL.md` is picked up. When no path is set, behaviour is unchanged.

This lets teams keep skills next to the project that owns them (e.g. in a monorepo subfolder) and share them through a single source, instead of carving out a dedicated repo with skills at the root or under `skills/`.

## How to use

- **UI:** the Add Source form has an optional, labeled **Path** field (with a tooltip explaining the auto-discovered roots); configured paths show on the source row, and the "View SKILL.md" link points at the right folder.
- **CLI:** `dam skill source add <url> --path <subdir>`; `dam skill source list` shows a PATH column.
- **Platform/template sources:** Helm `skills.skillSources` and template `spec.skillSources` entries accept an optional `path`.

A path is only needed for **non-standard** locations — when empty, skills are auto-discovered in the standard source roots (`skills/`, `.claude/skills/`, `.agents/skills/`). One subdirectory per repo connection; to change it, remove and re-add the source. Sources without a path keep working exactly as before.

## Side findings (out of scope for this PR)

Surfaced while building this; tracked here for follow-up, not addressed in this PR:

- **Add-source form should move to a modal.** This PR adds field labels because the bare inputs were ambiguous, but the form is still an inline expanding panel. A modal would be cleaner UX — likely folded into the coming Skills panel redesign.
- **No edit action for sources.** Sources support create + delete only; there's no edit, so changing a path (or name) means remove + re-add. Worth adding a proper edit action.
- **Skills in a locally cloned repo can't be used from that local copy.** Install *copies* the skill from the pushed git source into the skill path (`.agents/skills`), so local edits must be pushed and re-installed before they take effect. A follow-up could let a skill be *referenced* from an on-pod clone — e.g. a symlink into the skill path pointing at the local repo — instead of copying (today the install path also rejects symlinked skill content, so this is genuinely new work).

Closes #276