### PR TITLE
chore: migrate env from agent spec to contributions

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-06-15
+Last verified: 2026-06-25
 
 ## Overview
 
@@ -60,13 +60,12 @@ When the create request carries a private-registry credential, the api-server wr
 
 The pod image is built from `platform-base` plus a harness-specific layer. The platform contract is two executables at fixed paths: `/usr/local/bin/harness-chat` (spawned as the ACP subprocess for chat-mode sessions) and `/usr/local/bin/harness-terminal` (spawned attached to a PTY for terminal-mode sessions, with `HARNESS_SESSION_ID` exported so the harness can pick up the right resumable session). agent-runtime otherwise treats the harness as opaque. The workspace PVC is provisioned on first wake and survives subsequent hibernations — unless the warm pool is enabled and a pre-provisioned spare matches the mount's size, in which case the controller claims that already-bound spare at create time so first start skips the provisioning wait. The choice is invisible after the fact: a claimed spare becomes an ordinary per-Agent PVC. See [persistence](persistence.md#warm-pvc-pool).
 
-Pod env at start is the composition of **three** layers — last occurrence wins, with `PORT` server-enforced:
+Pod env at start is composed by the controller from platform wiring only — last occurrence wins, with `PORT` server-enforced:
 
 1. **platform envs** — proxy + auth wiring rendered by the controller (`HTTPS_PROXY`, harness URL, ext-authz routing, etc.).
-2. **`credentialEnvVars`** — env contributions derived from the Agent's mounted credential Secrets (e.g. `GH_TOKEN` from a GitHub PAT half).
-3. **`agent.env`** — the single env list on the Agent's spec. The api-server is its sole writer.
+2. **chart-level platform defaults** — any `env` the install declares as defaults.
 
-Template env contributes at *create time only*: when an Agent is created from a Template, the api-server's `assembleSpecFromTemplate` step copies template env into `agent.env`. The controller never reads the Template again at pod start, so editing a Template never re-flows into a running Agent — there is no "template envs" runtime layer. Editing `agent.env` takes effect on the next pod restart.
+Everything tied to an Agent's *configuration* rides the runtime channel as `env`-kind contributions instead, never the pod spec: connection-derived env (credential placeholders the gateway swaps on the wire), user-typed env (the Environment editor), and template env. The api-server stores user-typed and template env in Postgres `agent_env` and delivers all of it at the next idle turn with no pod roll, ordering user env ahead of connection/secret env so it wins on a name collision. Template env is seeded into `agent_env` at create time only, so editing a Template never re-flows into a running Agent. The Agent CR's `spec.env` field is retained but no longer read. See [connections](connections.md).
 
 Connector state that doesn't fit the env model (per-host CLI configs, allowlists, and similar) is materialized as files directly under HOME by `agent-runtime` itself, which holds an SSE connection to the api-server and merges declarative file fragments without restarting the pod. Image-baked content under the same paths participates in the merge — `agent-runtime` writes to the real PVC path, not a shadowing `emptyDir`.
 

--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-06-23
+Last verified: 2026-06-25
 
 ## Overview
 

--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-06-18
+Last verified: 2026-06-23
 
 ## Overview
 
@@ -103,7 +103,7 @@ A header connection's stored credential can be **updated in place** — the valu
 
 A typed unit a Connection emits when granted to an Agent — a discriminated union over `kind`. The kinds today:
 
-- **`env`** — an environment variable the harness merges in at spawn, carrying a credential placeholder rather than the secret itself.
+- **`env`** — an environment variable the harness merges in at spawn. For credential-derived env the value is a placeholder (the real secret is injected gateway-side); for user-typed and non-credential config env it is the literal value.
 - **`egress-allow`** — permission to reach a host (optionally path-scoped).
 - **`egress-inject`** — an allowed host plus a credential the gateway injects on the wire, as a header or a query parameter.
 - **`file`** — a config file to author, with a format and a merge mode (see [Built-in contribution impls](#built-in-contribution-impls)).
@@ -195,7 +195,7 @@ The api-server's contribution-fanout layer routes each Contribution kind to the 
 
 | Kind | Rail | Delivery semantics | Note |
 |---|---|---|---|
-| `env` | Runtime channel `applyState` (state slice) | Sub-second push; applied at next harness spawn | Written to a JSON file on the PV; the harness spawn path merges it into the process env (user env wins). A change recycles the harness at an idle turn boundary — no pod roll. |
+| `env` | Runtime channel `applyState` (state slice) | Sub-second push; applied at next harness spawn | Written to a JSON file on the PV; the harness spawn path merges it into the process env. Three sources feed this kind — user-typed env (the UI Environment editor, stored in Postgres `agent_env`, #1079), connection-derived env, and secret-derived env — and the state-builder orders user env first so it wins on name collision (the driver is first-occurrence-wins). A change recycles the harness at an idle turn boundary — no pod roll. |
 | `egress-allow` | Postgres `egress_rules` → Envoy `ext_authz` | Live read; no pod involvement | Joined per-grant; revoke sweeps rows. Agent never sees these. |
 | `egress-inject` | Postgres `egress_rules` → Envoy `ext_authz`, plus a wire-injected credential at the gateway | Live read; no pod involvement | Same `egress_rules` row as `egress-allow`; the gateway also injects `headerName`/`valueFormat` on the wire (mechanics in [security and credentials](security-and-credentials.md)). Agent never sees these. |
 | `file` | Runtime channel `applyState` (state slice) | Sub-second push; idempotent reconciliation | Per-format + per-mergeMode driver materializes. |
@@ -523,6 +523,7 @@ The UI surfaces the gap at grant time: connecting GitHub to a Claude-Code agent 
 | Substrate | What lives there | Notes |
 |---|---|---|
 | Postgres `connections` | Connection records (template id, auth, contributions[], inputs, owner) | New table for the unified model. |
+| Postgres `agent_env` | User-typed env per agent (`agent_id`, `name`, `value`) | The Environment editor's store since #1079 — read by the state-builder as `env` contributions (ordered first), replacing the Agent CR's `spec.env`. The CR field is retained but no longer read. |
 | Postgres `runtime_state_outbox` | One row per agent | `agent_id`, `version`, `last_enqueued_at`, `last_applied_version`, `last_applied_hash`, `last_applied_at`. |
 | Postgres `runtime_events` | One row per pending event | `id`, `agent_id`, `kind`, `payload`, `version`, `created_at`, `expires_at`, `dispatched_at`. Read by the state-builder; stamped by the worker in the apply-ack transaction. |
 | Runtime-state file on the agent PVC | Applied cursor (`lastAppliedVersion`, `lastAppliedHash`) and per-key event last-run timestamps | The agent-side dedupe state for event redelivery. |

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -8,8 +8,10 @@ import {
 import {
   composeAgentsModule,
   createAgentsRepository,
+  createAgentEnvRepository,
   createAgentRegistrySecretPort,
   createKeycloakUserDirectory,
+  backfillUserEnv,
   startChannelSecretCleanupSaga,
   startChannelCleanupSaga,
   deleteChannelsByAgent,
@@ -128,6 +130,21 @@ const redisBus = createRedisBus(config.redisUrl, {
 
 const k8sClient = createK8sClient(api, config.namespace);
 const agentsRepo = createAgentsRepository(k8sClient);
+const agentEnvRepo = createAgentEnvRepository(db);
+
+// Migrate pre-existing spec.env onto agent_env. First pass runs before serving;
+// per-agent failures are isolated and retried on a timer until a clean pass.
+let backfillRetry: ReturnType<typeof setTimeout> | undefined;
+async function runUserEnvBackfill(): Promise<void> {
+  const { failed } = await backfillUserEnv({
+    repo: agentsRepo,
+    agentEnvRepo,
+    log: (m) => getLogger().info(`[user-env] ${m}`),
+  });
+  if (failed > 0)
+    backfillRetry = setTimeout(() => void runUserEnvBackfill(), 60_000);
+}
+await runUserEnvBackfill();
 
 const runtimeDelivery = composeRuntimeDelivery({
   db,
@@ -382,11 +399,15 @@ const agentsCleanupK8s = createAgentsK8sClient(api, config.namespace);
 const registrySecretPort = createAgentRegistrySecretPort(agentsCleanupK8s);
 const connectionGrantsCleanupHook = createConnectionGrantsCleanupHook(db);
 
+const agentEnvCleanupHook = (agentId: string) =>
+  agentEnvRepo.deleteForAgent(agentId);
+
 const agentCleanupHooks = [
   createEgressRulesCleanupHook(db),
   createApprovalsCleanupHook(db),
   (agentId: string) => registrySecretPort.delete(agentId),
   connectionGrantsCleanupHook,
+  agentEnvCleanupHook,
 ];
 
 // Cross-store orphan reaper. Lists live agent ConfigMaps, finds DB rows
@@ -415,6 +436,11 @@ const agentArtifactsSweeper = createAgentArtifactsSweeper({
       name: "connection-grants",
       listAgentIds: () => listConnectionGrantAgentIds(db),
       cleanup: connectionGrantsCleanupHook,
+    },
+    {
+      name: "agent-env",
+      listAgentIds: () => agentEnvRepo.listAgentIds(),
+      cleanup: agentEnvCleanupHook,
     },
   ],
   intervalMs: 30 * 60_000,
@@ -522,6 +548,7 @@ listChannelsByOwner(db, "")()
 
 async function shutdown() {
   process.stderr.write("shutting down...\n");
+  if (backfillRetry) clearTimeout(backfillRetry);
   channelSecretCleanupSub.unsubscribe();
   channelCleanupSub.unsubscribe();
   skillsCleanupSub.unsubscribe();

--- a/packages/api-server/src/modules/agents/compose.ts
+++ b/packages/api-server/src/modules/agents/compose.ts
@@ -9,6 +9,7 @@ import {
   createAgentsRepository,
   type AgentsRepository,
 } from "./infrastructure/agents-repository.js";
+import { createAgentEnvRepository } from "./infrastructure/agent-env-repository.js";
 import {
   createAgentsService,
   type AgentCleanupHook,
@@ -72,6 +73,7 @@ export function composeAgentsModule(deps: {
 } {
   const k8s = createK8sClient(deps.api, deps.namespace);
   const repo = createAgentsRepository(k8s);
+  const agentEnvRepo = createAgentEnvRepository(deps.db);
   const registrySecretPort = createAgentRegistrySecretPort(k8s);
   // For DB-scoped lookups, an undefined owner means "system-wide". The
   // Postgres queries that already accept an empty-string owner-filter
@@ -80,6 +82,7 @@ export function composeAgentsModule(deps: {
   return {
     agents: createAgentsService({
       repo,
+      agentEnvRepo,
       owner: deps.owner,
       readTemplateSpec: deps.readTemplateSpec,
       presetSeeder: deps.presetSeeder,

--- a/packages/api-server/src/modules/agents/index.ts
+++ b/packages/api-server/src/modules/agents/index.ts
@@ -9,6 +9,11 @@ export {
   type AgentsRepository,
 } from "./infrastructure/agents-repository.js";
 export {
+  createAgentEnvRepository,
+  type AgentEnvRepository,
+} from "./infrastructure/agent-env-repository.js";
+export { backfillUserEnv } from "./services/backfill-user-env.js";
+export {
   createAgentRegistrySecretPort,
   type AgentRegistrySecretPort,
 } from "./infrastructure/agent-registry-secret-port.js";

--- a/packages/api-server/src/modules/agents/infrastructure/agent-env-repository.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-env-repository.ts
@@ -1,5 +1,5 @@
 import type { Db } from "db";
-import { agentEnv, eq, inArray, sql } from "db";
+import { agentEnv, eq, inArray } from "db";
 import type { EnvVar } from "api-server-api";
 
 /** Postgres store for user-typed agent env, keyed by `agent_id` (ownership enforced by the agents service). */
@@ -62,12 +62,10 @@ export function createAgentEnvRepository(db: Db): AgentEnvRepository {
     },
 
     async listAgentIds() {
-      const rows = await db.execute<{ agent_id: string }>(sql`
-        SELECT DISTINCT agent_id FROM ${agentEnv}
-      `);
-      return (rows as unknown as Array<{ agent_id: string }>).map(
-        (r) => r.agent_id,
-      );
+      const rows = await db
+        .selectDistinct({ agentId: agentEnv.agentId })
+        .from(agentEnv);
+      return rows.map((r) => r.agentId);
     },
   };
 }

--- a/packages/api-server/src/modules/agents/infrastructure/agent-env-repository.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-env-repository.ts
@@ -1,0 +1,73 @@
+import type { Db } from "db";
+import { agentEnv, eq, inArray, sql } from "db";
+import type { EnvVar } from "api-server-api";
+
+/** Postgres store for user-typed agent env, keyed by `agent_id` (ownership enforced by the agents service). */
+export interface AgentEnvRepository {
+  list(agentId: string): Promise<EnvVar[]>;
+  /** Batched form; every input id is present in the map. */
+  listMany(agentIds: string[]): Promise<Map<string, EnvVar[]>>;
+  /** Replace an agent's full env set (the editor sends the complete list). */
+  replace(agentId: string, env: EnvVar[]): Promise<void>;
+  deleteForAgent(agentId: string): Promise<void>;
+  /** Distinct agent ids with env rows, for the orphan sweeper. */
+  listAgentIds(): Promise<string[]>;
+}
+
+export function createAgentEnvRepository(db: Db): AgentEnvRepository {
+  return {
+    async list(agentId) {
+      const rows = await db
+        .select({ name: agentEnv.name, value: agentEnv.value })
+        .from(agentEnv)
+        .where(eq(agentEnv.agentId, agentId));
+      return rows.map((r) => ({ name: r.name, value: r.value }));
+    },
+
+    async listMany(agentIds) {
+      const map = new Map<string, EnvVar[]>();
+      for (const id of agentIds) map.set(id, []);
+      if (agentIds.length === 0) return map;
+      const rows = await db
+        .select({
+          agentId: agentEnv.agentId,
+          name: agentEnv.name,
+          value: agentEnv.value,
+        })
+        .from(agentEnv)
+        .where(inArray(agentEnv.agentId, agentIds));
+      for (const r of rows) {
+        map.get(r.agentId)?.push({ name: r.name, value: r.value });
+      }
+      return map;
+    },
+
+    async replace(agentId, env) {
+      // Dedupe by name (last wins) so a doubly-typed key can't violate the PK.
+      const byName = new Map<string, string>();
+      for (const e of env) byName.set(e.name, e.value);
+      const rows = [...byName].map(([name, value]) => ({
+        agentId,
+        name,
+        value,
+      }));
+      await db.transaction(async (tx) => {
+        await tx.delete(agentEnv).where(eq(agentEnv.agentId, agentId));
+        if (rows.length > 0) await tx.insert(agentEnv).values(rows);
+      });
+    },
+
+    async deleteForAgent(agentId) {
+      await db.delete(agentEnv).where(eq(agentEnv.agentId, agentId));
+    },
+
+    async listAgentIds() {
+      const rows = await db.execute<{ agent_id: string }>(sql`
+        SELECT DISTINCT agent_id FROM ${agentEnv}
+      `);
+      return (rows as unknown as Array<{ agent_id: string }>).map(
+        (r) => r.agent_id,
+      );
+    },
+  };
+}

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -278,6 +278,10 @@ export function createAgentsService(deps: {
           description: input.description,
         });
       }
+      // Template-declared env rides the rail like user env (seeded below), not
+      // the CR — the controller no longer reads spec.env.
+      const templateEnv = (spec.env as EnvVar[] | undefined) ?? [];
+      delete spec.env;
       if (input.secretRef !== undefined) spec.secretRef = input.secretRef;
 
       // Single-shot create: seed grants into the spec before first render so
@@ -338,10 +342,11 @@ export function createAgentsService(deps: {
         throw e;
       }
 
-      // The agent's boot `hello` pulls agent_env on first apply, so no enqueue here.
-      const userEnv = input.env?.length
-        ? preserveProtectedEnvs([], input.env)
-        : [];
+      // Input is ordered last so user env wins over a same-named template default (replace dedupes last-wins).
+      const userEnv = preserveProtectedEnvs(
+        [],
+        [...templateEnv, ...(input.env ?? [])],
+      );
       if (userEnv.length > 0)
         await deps.agentEnvRepo.replace(infra.id, userEnv);
 

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -12,6 +12,7 @@ import {
 } from "api-server-api";
 import { TRPCError } from "@trpc/server";
 import type { AgentsRepository } from "../infrastructure/agents-repository.js";
+import type { AgentEnvRepository } from "../infrastructure/agent-env-repository.js";
 
 /** Outbox-derived contribution status, supplied by runtime-delivery. */
 export interface ContributionsStatus {
@@ -77,8 +78,15 @@ function preserveProtectedEnvs(
   return [...preserved, ...user];
 }
 
+/** Feed the view's `spec.env` from the store (the CR no longer carries user env). */
+function withUserEnv(infra: InfraAgent, env: EnvVar[]): InfraAgent {
+  return { ...infra, spec: { ...infra.spec, env } };
+}
+
 export function createAgentsService(deps: {
   repo: AgentsRepository;
+  /** Postgres store for user-typed env. */
+  agentEnvRepo: AgentEnvRepository;
   owner: string | undefined;
   readTemplateSpec: (
     id: string,
@@ -168,14 +176,15 @@ export function createAgentsService(deps: {
   async function project(
     infra: InfraAgent,
   ): Promise<ReturnType<typeof assembleAgent>> {
-    const [channels, allowedSubs, status] = await Promise.all([
+    const [channels, allowedSubs, status, userEnv] = await Promise.all([
       deps.listChannelsByAgent(infra.id),
       deps.listAllowedUsersByAgent(infra.id),
       safeStatus(infra.id),
+      deps.agentEnvRepo.list(infra.id),
     ]);
     const emails = await subsToEmails(allowedSubs);
     return assembleAgent(
-      infra,
+      withUserEnv(infra, userEnv),
       channels,
       emails,
       status.failures,
@@ -221,16 +230,19 @@ export function createAgentsService(deps: {
           ? await deps.userDirectory.resolveManyBySub(allSubs)
           : new Map<string, string>();
 
-      const failuresMap = await deps.contributionsSettled
-        .statusMany([...infraIds])
-        .catch(() => new Map<string, ContributionsStatus>());
+      const [failuresMap, envMap] = await Promise.all([
+        deps.contributionsSettled
+          .statusMany([...infraIds])
+          .catch(() => new Map<string, ContributionsStatus>()),
+        deps.agentEnvRepo.listMany([...infraIds]),
+      ]);
 
       return infraAgents.map((infra) => {
         const subs = allowedUsersMap.get(infra.id) ?? [];
         const emails = subs.map((s) => subEmailMap.get(s) ?? s);
         const status = failuresMap.get(infra.id);
         return assembleAgent(
-          infra,
+          withUserEnv(infra, envMap.get(infra.id) ?? []),
           channelMap.get(infra.id) ?? [],
           emails,
           status?.failures ?? [],
@@ -265,13 +277,6 @@ export function createAgentsService(deps: {
           image: input.image,
           description: input.description,
         });
-      }
-      // Append caller-supplied extras (e.g. envMappings from granted app
-      // connections). `preserveProtectedEnvs` ensures PORT is always sourced
-      // from the template/defaults, no matter what the caller sends.
-      if (input.env?.length) {
-        const base = (spec.env as EnvVar[] | undefined) ?? [];
-        spec.env = preserveProtectedEnvs(base, [...base, ...input.env]);
       }
       if (input.secretRef !== undefined) spec.secretRef = input.secretRef;
 
@@ -333,6 +338,12 @@ export function createAgentsService(deps: {
         throw e;
       }
 
+      // The agent's boot `hello` pulls agent_env on first apply, so no enqueue here.
+      const userEnv = input.env?.length
+        ? preserveProtectedEnvs([], input.env)
+        : [];
+      if (userEnv.length > 0) await deps.agentEnvRepo.replace(infra.id, userEnv);
+
       const emails = input.allowedUserEmails ?? [];
       if (emails.length > 0) {
         const subs = await emailsToSubs(emails);
@@ -381,7 +392,7 @@ export function createAgentsService(deps: {
         await deps.grantProvisioner.applyAfterCreate(infra.id, grantSel);
       }
 
-      const agent = assembleAgent(infra, [], emails, []);
+      const agent = assembleAgent(withUserEnv(infra, userEnv), [], emails, []);
       // Records the agent's initial security posture (preset, secret ref,
       // allow-list size, env key names — never env values).
       securityLog("info", "agent.create", {
@@ -408,19 +419,26 @@ export function createAgentsService(deps: {
     },
 
     async update(input: AgentUpdateInput) {
-      let env = input.env;
-      if (env !== undefined) {
-        const current = await deps.repo.get(input.id, deps.owner);
-        env = preserveProtectedEnvs(current?.spec.env ?? [], env);
-      }
       const patch: Record<string, unknown> = {};
       if (input.name !== undefined) patch.name = input.name;
       if (input.description !== undefined)
         patch.description = input.description;
-      if (env !== undefined) patch.env = env;
       if (input.secretRef !== undefined) patch.secretRef = input.secretRef;
-      const infra = await deps.repo.updateSpec(input.id, deps.owner, patch);
+      // Both branches do the owner check; an env-only update skips the no-op CR patch.
+      const infra =
+        Object.keys(patch).length > 0
+          ? await deps.repo.updateSpec(input.id, deps.owner, patch)
+          : await deps.repo.get(input.id, deps.owner);
       if (!infra) return null;
+
+      let env = input.env;
+      if (env !== undefined) {
+        // Strip protected names, then bump + enqueue so a running agent applies it next turn.
+        env = preserveProtectedEnvs([], env);
+        await deps.agentEnvRepo.replace(input.id, env);
+        await deps.runtimeMutator.bump(input.id, []);
+        await deps.runtimeMutator.enqueueAfterCommit(input.id);
+      }
 
       if (input.env !== undefined || input.secretRef !== undefined) {
         // Env and secretRef control what credentials the pod receives — log

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -342,7 +342,8 @@ export function createAgentsService(deps: {
       const userEnv = input.env?.length
         ? preserveProtectedEnvs([], input.env)
         : [];
-      if (userEnv.length > 0) await deps.agentEnvRepo.replace(infra.id, userEnv);
+      if (userEnv.length > 0)
+        await deps.agentEnvRepo.replace(infra.id, userEnv);
 
       const emails = input.allowedUserEmails ?? [];
       if (emails.length > 0) {

--- a/packages/api-server/src/modules/agents/services/backfill-user-env.ts
+++ b/packages/api-server/src/modules/agents/services/backfill-user-env.ts
@@ -35,7 +35,9 @@ export async function backfillUserEnv(deps: {
       await deps.repo.patchSpec(infra.id, { env: [] });
     } catch (e) {
       failed++;
-      deps.log(`user-env backfill: agent ${infra.id} failed, will retry: ${errMsg(e)}`);
+      deps.log(
+        `user-env backfill: agent ${infra.id} failed, will retry: ${errMsg(e)}`,
+      );
     }
   }
   deps.log(`user-env backfill: migrated ${migrated}, failed ${failed}`);

--- a/packages/api-server/src/modules/agents/services/backfill-user-env.ts
+++ b/packages/api-server/src/modules/agents/services/backfill-user-env.ts
@@ -1,0 +1,47 @@
+import { isProtectedAgentEnvName } from "api-server-api";
+import type { AgentsRepository } from "../infrastructure/agents-repository.js";
+import type { AgentEnvRepository } from "../infrastructure/agent-env-repository.js";
+
+/** Copy non-protected `spec.env` into `agent_env` (only when empty), then clear
+ *  `spec.env`; idempotent and self-disarming. Never throws — per-agent failures
+ *  are isolated and counted so the caller can retry. `failed > 0` means a later
+ *  pass should run. */
+export async function backfillUserEnv(deps: {
+  repo: Pick<AgentsRepository, "list" | "patchSpec">;
+  agentEnvRepo: Pick<AgentEnvRepository, "list" | "replace">;
+  log: (msg: string) => void;
+}): Promise<{ migrated: number; failed: number }> {
+  let agents;
+  try {
+    agents = await deps.repo.list();
+  } catch (e) {
+    deps.log(`user-env backfill: agent list failed, will retry: ${errMsg(e)}`);
+    return { migrated: 0, failed: 1 };
+  }
+  let migrated = 0;
+  let failed = 0;
+  for (const infra of agents) {
+    const userEnv = (infra.spec.env ?? []).filter(
+      (e) => !isProtectedAgentEnvName(e.name),
+    );
+    if (userEnv.length === 0) continue; // nothing to migrate (or already cleared)
+    try {
+      // Skip the write if rows already exist so a post-migration edit is never clobbered.
+      if ((await deps.agentEnvRepo.list(infra.id)).length === 0) {
+        await deps.agentEnvRepo.replace(infra.id, userEnv);
+        migrated++;
+      }
+      // Clear the CR values: disarms re-runs and avoids double-delivery with the rail.
+      await deps.repo.patchSpec(infra.id, { env: [] });
+    } catch (e) {
+      failed++;
+      deps.log(`user-env backfill: agent ${infra.id} failed, will retry: ${errMsg(e)}`);
+    }
+  }
+  deps.log(`user-env backfill: migrated ${migrated}, failed ${failed}`);
+  return { migrated, failed };
+}
+
+function errMsg(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}

--- a/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
+++ b/packages/api-server/src/modules/runtime-delivery/services/state-builder.ts
@@ -1,6 +1,7 @@
 import {
   eq,
   type Db,
+  agentEnv,
   agentSkills,
   connectionGrants,
   connections as connectionsTable,
@@ -53,13 +54,21 @@ export function createStateBuilder(deps: {
 }): StateBuilder {
   return {
     async build(agentId, capabilities): Promise<StatePayload> {
-      const [granted, skills, secretEnv] = await Promise.all([
+      const [userEnv, granted, skills, secretEnv] = await Promise.all([
+        readUserEnvContributions(deps.db, agentId),
         readGrantedContributions(deps.db, agentId),
         readSkillRefContributions(deps.db, agentId),
         deps.secretEnv.forAgent(agentId),
       ]);
       const builtin = deps.builtin.for(agentId);
-      const rawContribs = [...builtin, ...granted, ...skills, ...secretEnv];
+      // User env first: the env driver is first-occurrence-wins, so it shadows connection/secret env.
+      const rawContribs = [
+        ...userEnv,
+        ...builtin,
+        ...granted,
+        ...skills,
+        ...secretEnv,
+      ];
       const pending = await deps.outboxRepo.pendingEvents(agentId);
       const events = pending.map(toEvent).filter((e): e is Event => e !== null);
       const filtered = filterByCapabilities(capabilities, rawContribs, events);
@@ -72,6 +81,24 @@ export function createStateBuilder(deps: {
       };
     },
   };
+}
+
+/** `env` contributions for an agent's user-typed env; the literal value rides in `placeholder`. */
+async function readUserEnvContributions(
+  db: Db,
+  agentId: string,
+): Promise<Contribution[]> {
+  const rows = await db
+    .select({ name: agentEnv.name, value: agentEnv.value })
+    .from(agentEnv)
+    .where(eq(agentEnv.agentId, agentId));
+  return rows.map(
+    (r): Contribution => ({
+      kind: "env",
+      name: r.name,
+      placeholder: r.value,
+    }),
+  );
 }
 
 async function readGrantedContributions(

--- a/packages/controller/pkg/reconciler/fork_resources.go
+++ b/packages/controller/pkg/reconciler/fork_resources.go
@@ -75,10 +75,8 @@ func BuildForkAgentJob(
 		agentHome = defaults.AgentHome
 	}
 	specMounts := resolveSpecMounts(agentSpec, defaults)
-	specEnv := agentSpec.Env
-	if len(specEnv) == 0 {
-		specEnv = configEnvToTypes(defaults.Env)
-	}
+	// Project only chart-level platform defaults; user env rides the runtime channel, not spec.env.
+	specEnv := configEnvToTypes(defaults.Env)
 
 	labels := map[string]string{
 		ForkLabelType:   ForkJobLabelType,
@@ -132,8 +130,8 @@ func BuildForkAgentJob(
 	// Placeholder credential envs from the replier's K8s Secrets — same
 	// purpose as the long-lived shape: satisfy the harness's is-env-set
 	// check; the gateway's Envoy overwrites the header on the wire.
-	// The merged AgentSpec carries the only user-owned env layer.
 	env = append(env, credentialEnvVars(credentialSecrets)...)
+	// Chart-level platform default env; user env arrives via the runtime channel.
 	for _, e := range specEnv {
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
 	}

--- a/packages/controller/pkg/reconciler/fork_resources_test.go
+++ b/packages/controller/pkg/reconciler/fork_resources_test.go
@@ -103,11 +103,8 @@ func TestBuildForkAgentJob_MountsAgentPVC_NotVolumeClaimTemplate(t *testing.T) {
 	assert.Nil(t, persistentVol.EmptyDir)
 }
 
-// The merged Agent CM carries env + secretRef directly; the fork
-// inherits them transitively through the AgentSpec.
-func TestBuildForkAgentJob_InheritsAgentEnvAndSecretRef(t *testing.T) {
-	// testAgent already carries Env=[ACP_PORT=8080] from the test fixture;
-	// add SecretRef + an extra env to exercise both paths.
+// The fork inherits secretRef via the AgentSpec; user env (spec.env) is not — it rides the runtime channel.
+func TestBuildForkAgentJob_InheritsAgentSecretRefNotEnv(t *testing.T) {
 	agent := *testAgent
 	agent.Env = append([]types.EnvVar{{Name: "FOO", Value: "bar"}}, testAgent.Env...)
 	agent.SecretRef = "my-extra-secret"
@@ -115,7 +112,8 @@ func TestBuildForkAgentJob_InheritsAgentEnvAndSecretRef(t *testing.T) {
 	job := BuildForkAgentJob("fork-abc", testForkSpec, &agent, testConfig, configMapOwnerRef(testForkOwnerCM), nil, "")
 	c := job.Spec.Template.Spec.Containers[0]
 
-	assert.Equal(t, "bar", envMap(c.Env)["FOO"])
+	_, hasFOO := envMap(c.Env)["FOO"]
+	assert.False(t, hasFOO, "spec.env must not be projected into the fork — user env rides the rail")
 	require.Len(t, c.EnvFrom, 1)
 	require.NotNil(t, c.EnvFrom[0].SecretRef)
 	assert.Equal(t, "my-extra-secret", c.EnvFrom[0].SecretRef.Name)

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -110,10 +110,8 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		agentHome = defaults.AgentHome
 	}
 	specMounts := resolveSpecMounts(agentSpec, defaults)
-	specEnv := agentSpec.Env
-	if len(specEnv) == 0 {
-		specEnv = configEnvToTypes(defaults.Env)
-	}
+	// Project only chart-level platform defaults; user env rides the runtime channel, not spec.env.
+	specEnv := configEnvToTypes(defaults.Env)
 
 	replicas := int32(1)
 
@@ -179,7 +177,7 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		{Name: "PLATFORM_POD_FILES_EVENTS_URL", Value: fmt.Sprintf("%s/api/agents/%s/pod-files/events", cfg.HarnessServerURL, name)},
 	}
 
-	// User-supplied agent env; credential placeholders arrive via the runtime channel.
+	// Chart-level platform default env; user env arrives via the runtime channel.
 	for _, e := range specEnv {
 		env = append(env, corev1.EnvVar{Name: e.Name, Value: e.Value})
 	}

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -153,8 +153,11 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	_, hasGitCAInfo := envMap["GIT_SSL_CAINFO"]
 	assert.False(t, hasGitCAInfo, "GIT_SSL_CAINFO must be left to the entrypoint")
 	assert.Equal(t, "my-instance", envMap["PLATFORM_AGENT_ID"])
-	assert.Equal(t, "8080", envMap["ACP_PORT"])
-	assert.Equal(t, "alpha", envMap["GITHUB_ORG"])
+	// User env (spec.env) is no longer projected — it rides the runtime channel.
+	_, hasACPPort := envMap["ACP_PORT"]
+	assert.False(t, hasACPPort, "spec.env must not be projected into the container")
+	_, hasGithubOrg := envMap["GITHUB_ORG"]
+	assert.False(t, hasGithubOrg, "spec.env must not be projected into the container")
 
 	require.Len(t, c.EnvFrom, 1)
 	assert.Equal(t, "my-secrets", c.EnvFrom[0].SecretRef.LocalObjectReference.Name)

--- a/packages/db/drizzle/0003_smart_squadron_sinister.sql
+++ b/packages/db/drizzle/0003_smart_squadron_sinister.sql
@@ -1,0 +1,8 @@
+CREATE TABLE "agent_env" (
+	"agent_id" text NOT NULL,
+	"name" text NOT NULL,
+	"value" text NOT NULL,
+	CONSTRAINT "agent_env_agent_id_name_pk" PRIMARY KEY("agent_id","name")
+);
+--> statement-breakpoint
+CREATE INDEX "agent_env_agent_idx" ON "agent_env" USING btree ("agent_id");

--- a/packages/db/drizzle/meta/0003_snapshot.json
+++ b/packages/db/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,1694 @@
+{
+  "id": "4a0335d4-0842-49ed-b3f4-abeb606310b3",
+  "prevId": "2055223c-ee0b-444f-91ba-96fde811284d",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_events": {
+      "name": "activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "activity_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_events_type_occurred_idx": {
+          "name": "activity_events_type_occurred_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_actor_occurred_idx": {
+          "name": "activity_events_actor_occurred_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_events\".\"actor_sub\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_surface_occurred_idx": {
+          "name": "activity_events_surface_occurred_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_auth_dedup_idx": {
+          "name": "activity_events_auth_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_trunc('day', \"occurred_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"activity_events\".\"type\" = 'auth'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor_roles": {
+      "name": "actor_roles",
+      "schema": "",
+      "columns": {
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_core": {
+          "name": "is_core",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_env": {
+      "name": "agent_env",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_env_agent_idx": {
+          "name": "agent_env_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_env_agent_id_name_pk": {
+          "name": "agent_env_agent_id_name_pk",
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_publishes": {
+      "name": "agent_skill_publishes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_publishes_agent_idx": {
+          "name": "agent_skill_publishes_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skills": {
+      "name": "agent_skills",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skills_agent_idx": {
+          "name": "agent_skills_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_source_name_pk": {
+          "name": "agent_skills_agent_id_source_name_pk",
+          "columns": [
+            "agent_id",
+            "source",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_protocol_version": {
+          "name": "runtime_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_capabilities": {
+          "name": "runtime_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_last_hello_at": {
+          "name": "runtime_last_hello_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_agent_version": {
+          "name": "runtime_agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_idx": {
+          "name": "agents_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allowed_users": {
+      "name": "allowed_users",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "allowed_users_agent_id_keycloak_sub_pk": {
+          "name": "allowed_users_agent_id_keycloak_sub_pk",
+          "columns": [
+            "agent_id",
+            "keycloak_sub"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_hash_idx": {
+          "name": "api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_owner_idx": {
+          "name": "api_keys_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_keys\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channels_agent_type_idx": {
+          "name": "channels_agent_type_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channels_slack_channel_unique_idx": {
+          "name": "channels_slack_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "(\"config\"->>'slackChannelId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"channels\".\"type\" = 'slack'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_grants": {
+      "name": "connection_grants",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_grants_agent_idx": {
+          "name": "connection_grants_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_connection_id_agent_id_pk": {
+          "name": "connection_grants_connection_id_agent_id_pk",
+          "columns": [
+            "connection_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributions": {
+          "name": "contributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connections_owner_idx": {
+          "name": "connections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_owner_name_unique_idx": {
+          "name": "connections_owner_name_unique_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.egress_rules": {
+      "name": "egress_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "egress_rules_lookup_idx": {
+          "name": "egress_rules_lookup_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"egress_rules\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "egress_rules_source_idx": {
+          "name": "egress_rules_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"egress_rules\".\"status\" = 'active' AND \"egress_rules\".\"source\" != 'manual'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_links": {
+      "name": "identity_links",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "identity_links_provider_external_user_id_pk": {
+          "name": "identity_links_provider_external_user_id_pk",
+          "columns": [
+            "provider",
+            "external_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_approvals": {
+      "name": "pending_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pending_approvals_owner_status_idx": {
+          "name": "pending_approvals_owner_status_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_agent_status_idx": {
+          "name": "pending_approvals_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_undelivered_idx": {
+          "name": "pending_approvals_undelivered_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'resolved' AND delivered_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_events": {
+      "name": "runtime_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runtime_events_agent_pending_idx": {
+          "name": "runtime_events_agent_pending_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_events_expiry_idx": {
+          "name": "runtime_events_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_state_outbox": {
+      "name": "runtime_state_outbox",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_settled_version": {
+          "name": "last_settled_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_hash": {
+          "name": "last_applied_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_at": {
+          "name": "last_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apply_failures": {
+          "name": "apply_failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "apply_attempts": {
+          "name": "apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "runtime_state_outbox_retry_idx": {
+          "name": "runtime_state_outbox_retry_idx",
+          "columns": [
+            {
+              "expression": "apply_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_state_outbox\".\"apply_failures\" <> '[]'::jsonb OR \"runtime_state_outbox\".\"last_settled_version\" < \"runtime_state_outbox\".\"version\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_result": {
+          "name": "last_fired_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_agent_owner_idx": {
+          "name": "schedules_agent_owner_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_enabled_idx": {
+          "name": "schedules_enabled_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"schedules\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_sources": {
+      "name": "skill_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_sources_owner_git_url_idx": {
+          "name": "skill_sources_owner_git_url_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_sources_owner_idx": {
+          "name": "skill_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_threads": {
+      "name": "telegram_threads",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telegram_threads_agent_id_thread_id_pk": {
+          "name": "telegram_threads_agent_id_thread_id_pk",
+          "columns": [
+            "agent_id",
+            "thread_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms_acceptances": {
+      "name": "terms_acceptances",
+      "schema": "",
+      "columns": {
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "terms_acceptances_sub_version_pk": {
+          "name": "terms_acceptances_sub_version_pk",
+          "columns": [
+            "sub",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_outcome": {
+      "name": "activity_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1781512361632,
       "tag": "0002_marvelous_dragon_man",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1782212869850,
+      "tag": "0003_smart_squadron_sinister",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -8,6 +8,7 @@ export {
   skillSources,
   agentSkills,
   agentSkillPublishes,
+  agentEnv,
   egressRules,
   pendingApprovals,
   connections,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -260,6 +260,20 @@ export const agents = pgTable(
   (table) => [index("agents_owner_idx").on(table.ownerSub)],
 );
 
+/** Per-agent user-typed env (the UI Environment editor). */
+export const agentEnv = pgTable(
+  "agent_env",
+  {
+    agentId: text("agent_id").notNull(),
+    name: text("name").notNull(),
+    value: text("value").notNull(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.agentId, table.name] }),
+    index("agent_env_agent_idx").on(table.agentId),
+  ],
+);
+
 export const termsAcceptances = pgTable(
   "terms_acceptances",
   {

--- a/packages/e2e/playwright/src/tests/09-user-env.spec.ts
+++ b/packages/e2e/playwright/src/tests/09-user-env.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAgentRunning } from "../lib/agents.js";
+import { createApiClient, type ApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+import { agentName, envName, placeholder } from "../lib/fixtures.js";
+
+const userEnvName = "E2E_USER_ENV";
+const userEnvValue = "user-value-9d2f";
+const userEnvEdited = "user-value-edited-4a7b";
+// A user entry colliding with the granted connection's env (envName).
+const shadowValue = "user-overrides-connection-1c8e";
+
+/** Poll the agent's live process env until the named var converges to `expected`. */
+async function expectAgentEnv(
+  api: ApiClient,
+  agentId: string,
+  name: string,
+  expected: string,
+  message: string,
+): Promise<void> {
+  await expect
+    .poll(
+      async () => {
+        try {
+          return (await api.e2e.getEnv.query({ agentId, name })).value;
+        } catch {
+          return undefined;
+        }
+      },
+      { timeout: 120_000, intervals: [2_000], message },
+    )
+    .toBe(expected);
+}
+
+// User env is delivered over the runtime channel, not the controller, so edits apply next turn.
+test("user env rides the contribution rail", async () => {
+  test.setTimeout(420_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+
+  // getEnv talks to the pod directly, so wake it in case earlier specs let it idle.
+  const listed = (await api.agents.list.query()).find(
+    (a) => a.name === agentName,
+  );
+  expect(listed, `agent ${agentName} must exist from earlier specs`).toBeTruthy();
+  await api.agents.wake.mutate({ id: listed!.id });
+  const agentId = await waitForAgentRunning(api, agentName);
+
+  await test.step("setting user env reaches the agent — no pod roll", async () => {
+    await api.agents.update.mutate({
+      id: agentId,
+      env: [{ name: userEnvName, value: userEnvValue }],
+    });
+    await expectAgentEnv(
+      api,
+      agentId,
+      userEnvName,
+      userEnvValue,
+      `user env ${userEnvName} did not reach the agent`,
+    );
+  });
+
+  await test.step("editor view is fed from the store, not the CR", async () => {
+    const agent = await api.agents.get.query({ id: agentId });
+    expect(agent.env).toContainEqual({ name: userEnvName, value: userEnvValue });
+  });
+
+  await test.step("editing the value applies at the next turn", async () => {
+    await api.agents.update.mutate({
+      id: agentId,
+      env: [{ name: userEnvName, value: userEnvEdited }],
+    });
+    await expectAgentEnv(
+      api,
+      agentId,
+      userEnvName,
+      userEnvEdited,
+      `edited user env did not converge`,
+    );
+  });
+
+  await test.step("user env wins over connection env on name collision", async () => {
+    await api.agents.update.mutate({
+      id: agentId,
+      env: [
+        { name: userEnvName, value: userEnvEdited },
+        { name: envName, value: shadowValue },
+      ],
+    });
+    await expectAgentEnv(
+      api,
+      agentId,
+      envName,
+      shadowValue,
+      `user env did not shadow the connection-derived env`,
+    );
+  });
+
+  await test.step("clearing user env reverts to the connection env", async () => {
+    await api.agents.update.mutate({ id: agentId, env: [] });
+    await expectAgentEnv(
+      api,
+      agentId,
+      envName,
+      placeholder,
+      `connection env did not revert to its placeholder after clearing user env`,
+    );
+  });
+});

--- a/packages/e2e/playwright/src/tests/09-user-env.spec.ts
+++ b/packages/e2e/playwright/src/tests/09-user-env.spec.ts
@@ -44,7 +44,10 @@ test("user env rides the contribution rail", async () => {
   const listed = (await api.agents.list.query()).find(
     (a) => a.name === agentName,
   );
-  expect(listed, `agent ${agentName} must exist from earlier specs`).toBeTruthy();
+  expect(
+    listed,
+    `agent ${agentName} must exist from earlier specs`,
+  ).toBeTruthy();
   await api.agents.wake.mutate({ id: listed!.id });
   const agentId = await waitForAgentRunning(api, agentName);
 
@@ -64,7 +67,10 @@ test("user env rides the contribution rail", async () => {
 
   await test.step("editor view is fed from the store, not the CR", async () => {
     const agent = await api.agents.get.query({ id: agentId });
-    expect(agent.env).toContainEqual({ name: userEnvName, value: userEnvValue });
+    expect(agent.env).toContainEqual({
+      name: userEnvName,
+      value: userEnvValue,
+    });
   });
 
   await test.step("editing the value applies at the next turn", async () => {


### PR DESCRIPTION
## What & why

User-typed environment variables (the UI **Environment** editor) were the last piece of agent config still delivered through the Agent CR's `spec.env` and projected into the container by the controller at pod start — so an edit only took effect on the **next pod restart**, unlike connections/secrets/skills/MCP which all ride the runtime contribution rail and apply on the next turn.

This moves user env onto the **same contribution rail**: it's stored in a new `agent_env` table, emitted as an `env` contribution, and reconciled into the harness at the next idle turn boundary — **no pod roll**, and **one** env mechanism for everything.

Closes #1079.

## How it works

- **Storage** — new `agent_env` table (`agent_id`, `name`, `value`), the `agent_skills` pattern.
- **Read path** — a new source in the state-builder reads `agent_env` and emits `env` contributions, placed **first** so user env wins over connection/secret env on name collision (the in-pod driver is first-occurrence-wins — preserving today's precedence now that user env no longer rides `process.env`).
- **Write/read-back** — the agents service writes/reads `agent_env` (and bumps + enqueues a state push on edit) instead of `spec.env`. The tRPC contract, UI editor, validation, and inherited/shadowing rules are unchanged.
- **Controller** — stops projecting `spec.env` into the agent and fork containers; projects only chart-level platform defaults. The CRD `spec.env` field is **retained but unread** (no CRD schema change → no backwards-compat exposure).
- **Migration** — an idempotent, self-disarming startup backfill moves any existing `spec.env` onto `agent_env`, then clears the CR field. Per-agent fault-isolated, never crashes startup, logged, and retried on a timer until a clean pass.

### Notes
- `PORT` was never actually carried on `spec.env` (it's the hardcoded container port + agent-runtime's own default), so dropping the projection can't affect it; it stays a protected name.
- Platform-infra env (proxy, CA, `HOME`, `PLATFORM_*`) stays controller-injected — it's bootstrap-critical and can't ride the rail it bootstraps.

## Testing

- **e2e** (`09-user-env.spec.ts`): asserts the agent's **live process env** — set reaches the agent with no pod roll, edit applies, user env shadows a connection env, and clearing reverts to the connection value.
- **Manual, on a dev cluster** — verified the backfill end-to-end on an actual **hibernated** agent: `migrated 1`, `agent_env` row written, CR `spec.env` cleared, existing rows untouched; a re-run logs `migrated 0` with no resurrection/duplication (self-disarming).
- Controller Go tests updated to assert `spec.env` is no longer projected.

No unit tests by request; team leans e2e.