### PR TITLE
fix(schedules): persist session mode change to Fresh on edit

### DIFF
--- a/packages/api-server/src/__tests__/unit/schedules-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/schedules-service.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import type { Schedule, ScheduleSpec } from "api-server-api";
+import { createSchedulesService } from "../../modules/schedules/services/schedules-service.js";
+import type { SchedulesRepository } from "../../modules/schedules/infrastructure/schedules-repository.js";
+import type { SchedulerRunner } from "../../modules/schedules/services/scheduler-runner.js";
+
+const OWNER = "owner-1";
+const SCHEDULE_ID = "sched-1";
+const RRULE = "FREQ=DAILY;BYHOUR=9;BYMINUTE=0;BYSECOND=0";
+const TIMEZONE = "Europe/Prague";
+
+function makeCurrent(sessionMode?: "continuous" | "fresh"): Schedule {
+  const spec: ScheduleSpec = {
+    version: "1",
+    type: "rrule",
+    rrule: RRULE,
+    timezone: TIMEZONE,
+    task: "do the thing",
+    enabled: true,
+    createdBy: "user",
+    ...(sessionMode ? { sessionMode } : {}),
+  };
+  return { id: SCHEDULE_ID, agentId: "agent-1", name: "daily", spec };
+}
+
+/** Fake repo that returns `current` from get() and captures the spec passed to
+ *  updateSpec(), plus a no-op runner. */
+function makeDeps(current: Schedule) {
+  let savedSpec: ScheduleSpec | undefined;
+  const repo = {
+    async get(id: string) {
+      return id === current.id ? current : null;
+    },
+    async updateName() {
+      return current;
+    },
+    async updateSpec(_id: string, _owner: string, spec: ScheduleSpec) {
+      savedSpec = spec;
+      return { ...current, spec };
+    },
+  } as unknown as SchedulesRepository;
+  const runner = { async sync() {} } as unknown as SchedulerRunner;
+  const service = createSchedulesService({ repo, runner, owner: OWNER });
+  return { service, getSavedSpec: () => savedSpec };
+}
+
+const baseUpdate = {
+  id: SCHEDULE_ID,
+  name: "daily",
+  rrule: RRULE,
+  timezone: TIMEZONE,
+  quietHours: [],
+  task: "do the thing",
+};
+
+describe("updateRRule sessionMode", () => {
+  it("clears sessionMode when switching from continuous to fresh", async () => {
+    const { service, getSavedSpec } = makeDeps(makeCurrent("continuous"));
+
+    await service.updateRRule({ ...baseUpdate, sessionMode: undefined });
+
+    expect(getSavedSpec()?.sessionMode).toBeUndefined();
+  });
+
+  it("sets sessionMode when switching from fresh to continuous", async () => {
+    const { service, getSavedSpec } = makeDeps(makeCurrent(undefined));
+
+    await service.updateRRule({ ...baseUpdate, sessionMode: "continuous" });
+
+    expect(getSavedSpec()?.sessionMode).toBe("continuous");
+  });
+});

--- a/packages/api-server/src/modules/schedules/services/schedules-service.ts
+++ b/packages/api-server/src/modules/schedules/services/schedules-service.ts
@@ -146,8 +146,11 @@ export function createSchedulesService(deps: {
         timezone: input.timezone,
         quietHours: input.quietHours,
         task: input.task,
-        ...(input.sessionMode ? { sessionMode: input.sessionMode } : {}),
       };
+      // "fresh" is the absence of sessionMode — clear any value inherited from
+      // the spread so an edit to fresh isn't masked by the prior setting.
+      if (input.sessionMode) spec.sessionMode = input.sessionMode;
+      else delete spec.sessionMode;
       await deps.repo.updateName(input.id, deps.owner, input.name);
       const updated = await deps.repo.updateSpec(input.id, deps.owner, spec);
       if (updated) await deps.runner.sync(updated.id);


### PR DESCRIPTION
## Problem

Editing a schedule's Session Mode from **Continuous** to **Fresh** didn't stick — the save appeared to succeed but the value reverted to Continuous, with no error shown.

## Cause

"Fresh" is represented as the *absence* of a session-mode value. On edit, the updated schedule was built from the existing one and then only re-applied a session mode when one was present — so switching to Fresh (no value) left the old Continuous setting in place.

## Fix

On edit, the session mode is now set when provided and cleared when not, so changing to Fresh persists. Switching the other way (Fresh → Continuous) is unaffected. Adds a regression test covering both directions.

Closes #1747