### PR TITLE
chore(bob): bump bobshell 1.0.4 -> 1.0.5

### DIFF
--- a/packages/agents/bob/Dockerfile
+++ b/packages/agents/bob/Dockerfile
@@ -3,8 +3,8 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG BOBSHELL_VERSION=1.0.4
-ARG BOBSHELL_SHA256=128f8da8bc3a4a1eb07add4abcf05306096615f177a32d02058532c945b5489e
+ARG BOBSHELL_VERSION=1.0.5
+ARG BOBSHELL_SHA256=38fe36e42318282d8b440340a776bb16eaefe3eaa2681184c786373b501f2bf7
 RUN --mount=type=cache,target=/root/.npm \
     curl -fsSL "https://s3.us-south.cloud-object-storage.appdomain.cloud/bob-shell/bobshell-${BOBSHELL_VERSION}.tgz" -o /tmp/bobshell.tgz &&\
     echo "${BOBSHELL_SHA256} /tmp/bobshell.tgz" | sha256sum -c - &&\


### PR DESCRIPTION
- update pinned BOBSHELL_VERSION and verified SHA256