### PR TITLE
fix(platform-base): bump node to 24.18.0 to patch bundled-npm CVEs

### DIFF
--- a/packages/platform-base/mise.lock
+++ b/packages/platform-base/mise.lock
@@ -41,16 +41,16 @@ url = "https://github.com/jqlang/jq/releases/download/jq-1.8.1/jq-linux-amd64"
 provenance = "github-attestations"
 
 [[tools.node]]
-version = "24.14.1"
+version = "24.18.0"
 backend = "core:node"
 
 [tools.node."platforms.linux-arm64"]
-checksum = "sha256:734ff04fa7f8ed2e8a78d40cacf5ac3fc4515dac2858757cbab313eb483ba8a2"
-url = "https://nodejs.org/dist/v24.14.1/node-v24.14.1-linux-arm64.tar.gz"
+checksum = "sha256:6b4484c2190274175df9aa8f28e2d758a819cb1c1fe6ab481e2f95b463ab8508"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-arm64.tar.gz"
 
 [tools.node."platforms.linux-x64"]
-checksum = "sha256:ace9fa104992ed0829642629c46ca7bd7fd6e76278cb96c958c4b387d29658ea"
-url = "https://nodejs.org/dist/v24.14.1/node-v24.14.1-linux-x64.tar.gz"
+checksum = "sha256:783130984963db7ba9cbd01089eaf2c2efb055c7c1693c943174b967b3050cb8"
+url = "https://nodejs.org/dist/v24.18.0/node-v24.18.0-linux-x64.tar.gz"
 
 [[tools."npm:@googleworkspace/cli"]]
 version = "0.22.5"

--- a/packages/platform-base/mise.toml
+++ b/packages/platform-base/mise.toml
@@ -3,7 +3,10 @@ lockfile = true
 minimum_release_age = "7d"
 
 [tools]
-node = "24"
+# Exact pin (not "24") so minimum_release_age doesn't gate it: node's bundled npm
+# vendors the patched brace-expansion/tar/picomatch/ip-address/minimatch only from
+# 24.18.0 (npm 11.16.0) onward. Bump in lockstep when patching those CVEs.
+node = "24.18.0"
 gh = "latest"
 ripgrep = "latest"
 fd = "latest"


### PR DESCRIPTION
## What

Bumps the pinned node in `packages/platform-base` from **24.14.1 → 24.18.0** (npm 11.11.0 → 11.16.0).

## Why

The Trivy supply-chain findings for `brace-expansion`, `tar`, `picomatch`, `ip-address` and `minimatch` across all six agent/base images (`bob`, `claude-code`, `codex`, `nous`, `pi-agent`, `platform-base`) do **not** come from the workspace dependencies — those are already patched in `pnpm-lock.yaml`. They come from the **vendored `node_modules` inside node's bundled npm**, which mise installs and the Dockerfile copies wholesale into every image (`/usr/local/share/mise/`).

node 24.18.0 ships npm 11.16.0, whose vendored copies are all fixed:

| package | was (npm 11.11.0) | now (npm 11.16.0) |
|---|---|---|
| brace-expansion | 5.0.3 | 5.0.6 |
| tar | 7.5.9 | 7.5.15 |
| picomatch | 4.0.3 | 4.0.4 |
| ip-address | 10.1.0 | 10.2.0 |
| minimatch | (old) | 10.2.5 |

### Why exact pin instead of an age exclusion

node 24.18.0 is only a few days old, so the `minimum_release_age = "7d"` gate would normally block it. Per mise's documented behavior the gate applies **only to fuzzy requests** — an exact pin (`node = "24.18.0"`) bypasses it, which is cleaner than adding a `minimum_release_age_excludes` entry.

## Covers

CVE-2026-27904, -29786, -31802, -33671, -33672, -33750, -45149, -42338 (npm group, issues #1821–#1869). These auto-close on the next clean Trivy rescan.

## Not in scope

Keycloak Java CVEs #1862 / #1863 / #1870 (netty, opentelemetry): **26.6.3 is already the latest Keycloak release** and bundles the vulnerable libs; no fixed Keycloak release exists yet. Revisit on 26.6.4+.