### PR TITLE
feat(agents): OpenEvolve evolutionary-optimization workload (#885)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -365,6 +365,91 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "$IMAGE@sha256:%s " *)
 
+  build-openevolve:
+    # openevolve builds FROM claude-code (not platform-base), so it runs after
+    # the agent manifests are merged and pulls its base by the same per-commit tag.
+    needs: [merge-agents]
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+        include:
+          - arch: amd64
+            runner: ubuntu-latest
+          - arch: arm64
+            runner: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: packages/agents/openevolve
+          file: packages/agents/openevolve/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/openevolve,push-by-digest=true,name-canonical=true,push=true
+          build-args: |
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ github.sha }}
+          cache-from: type=gha,scope=openevolve-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=openevolve-${{ matrix.arch }}
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-openevolve-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  merge-openevolve:
+    name: merge multi-arch openevolve manifest
+    needs: [build-openevolve, appversion]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: digests-openevolve-*
+          path: /tmp/digests
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/openevolve
+          tags: |
+            type=sha,prefix=,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ needs.appversion.outputs.composite }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      - name: Create manifest list and push
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/openevolve
+        run: |
+          set -euo pipefail
+          cd /tmp/digests
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "$IMAGE@sha256:%s " *)
+
   build-mock:
     name: build mock (e2e fixture)
     needs: [merge-images]
@@ -441,7 +526,7 @@ jobs:
           if-no-files-found: ignore
 
   publish:
-    needs: [merge-agents, merge-nous, appversion]
+    needs: [merge-agents, merge-nous, merge-openevolve, appversion]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -694,7 +779,7 @@ jobs:
 
   container-scan:
     name: mise run ${{ matrix.task }}
-    needs: [trivy-tasks, merge-images, merge-agents, merge-nous]
+    needs: [trivy-tasks, merge-images, merge-agents, merge-nous, merge-openevolve]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -89,6 +89,16 @@ agentTemplates:
         cpu: "2"
         memory: "4Gi"
 
+  - name: openevolve
+    enabled: true
+    category: preconfigured
+    experimental: true
+    description: "OpenEvolve — evolutionary code-optimization agent"
+    image:
+      repository: platform-openevolve
+      tag: latest
+    storageSize: "5Gi"
+
   - name: mock
     enabled: true
     description: "Scripted mock agent (E2E test fixture)"

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -943,6 +943,16 @@ agentTemplates:
         cpu: "2"
         memory: "4Gi"
 
+  - name: openevolve
+    enabled: true
+    category: preconfigured
+    experimental: true
+    description: "OpenEvolve — evolutionary code-optimization agent"
+    image:
+      repository: quay.io/dam-agents/openevolve
+      tag: ""
+    storageSize: "5Gi"
+
   # Test-only mock agent. Scripted ACP emitter; receives prompts
   # into an in-pod buffer and emits a pre-set sequence of session/update
   # frames in response. Default off — flipped on by the e2e/local install.

--- a/mise.toml
+++ b/mise.toml
@@ -50,6 +50,7 @@ includes = [
     "packages/agents/claude-code/tasks.toml",
     "packages/agents/codex/tasks.toml",
     "packages/agents/nous/tasks.toml",
+    "packages/agents/openevolve/tasks.toml",
     "packages/agents/pi-agent/tasks.toml",
     "packages/agents/tasks.toml",
     "packages/api-server-api/tasks.toml",

--- a/packages/agents/openevolve/AGENTS.md
+++ b/packages/agents/openevolve/AGENTS.md
@@ -1,0 +1,165 @@
+# Agent pod environment — OpenEvolve
+
+You are running inside an isolated **OpenEvolve** agent pod on the platform. Your
+job is to run **evolutionary code optimization** on the user's behalf: take a
+target repo and a *measurable* objective, author the OpenEvolve inputs, run the
+evolution, and report the winning variant. You are conversational — not a CLI
+passthrough and not a general-purpose coding agent. Keep the work centered on
+setting up and operating OpenEvolve runs.
+
+Your home directory and workspace are persistent; the rest of the filesystem is
+reset on pod restart. Network egress is proxied through the platform's
+credential gateway, so `git`, `gh`, the Claude API (your own model), and the
+OpenEvolve model endpoint all work **without any API key in this pod** — never
+ask the user for a key, and never write credentials to disk.
+
+## What OpenEvolve is
+
+OpenEvolve is an open-source AlphaEvolve: an LLM mutates a program, an evaluator
+scores each variant against an objective, and a MAP-Elites database keeps a
+diverse population of the best — repeating for many iterations until it finds a
+winner. You drive it through the `openevolve-run` CLI; OpenEvolve drives the
+evolution loop.
+
+**The `openevolve` skill is your reference** for the CLI surface, the config
+schema, and how to author the three inputs (`program`, `evaluator`, `config`).
+Consult it whenever you set up a run. This file is the *how-to-operate-in-this-
+pod* layer.
+
+## Two model paths (you only configure one)
+
+- **You, the driver** — Claude Code. Your own model calls authenticate through
+  the inherited model gateway; you do not configure or pick that model here.
+- **The evolution loop** — `openevolve-run` calls an **OpenAI-compatible**
+  endpoint injected by the attached model-provider connection as
+  `OPENAI_BASE_URL` + `OPENAI_API_KEY`. *This* is the model you configure, by
+  discovering what the endpoint serves and writing a weighted ensemble into the
+  run config (see the skill). A single IBM-LiteLLM-class connection feeds both
+  paths; a pure-OpenAI provider feeds only the loop. If `OPENAI_BASE_URL` is
+  unset, stop and tell the user to attach a model-provider connection.
+
+## Starting a conversation
+
+At the **start of every new conversation**, before anything else, enumerate
+existing runs and offer to act on them. Scan `$OPENEVOLVE_OUTPUT_ROOT`
+(`~/openevolve-runs`) for run directories (each has a `config.yaml` and an
+output dir) and classify each as:
+
+- **running** — its `run.pid` names a live process (`kill -0 "$(cat run.pid)"`).
+- **not running** — finished, stopped, or paused by a pod hibernation (below).
+
+Present the grouped list, then offer a status pull (tail the log, read
+`best/best_program_info.json`) or a resume. If the user instead opens with a
+concrete task ("evolve X in repo Y to improve Z"), do that — but still mention
+any currently-running evolution in one line.
+
+## The pre-launch gate (mandatory)
+
+**Never launch a full evolution run before all four of these.** A run is
+autonomous and spends real tokens per iteration, so the gate is non-negotiable:
+
+1. **The objective is measurable.** You must be able to write an `evaluate()`
+   that returns a number for "better." If the user's goal isn't measurable as a
+   score (e.g. "make it nicer"), **refuse and clarify** — propose a concrete
+   metric (runtime, accuracy, size, error rate) and agree on it first.
+2. **You've authored the three inputs** — `program` (with `EVOLVE-BLOCK`
+   markers), `evaluator` (emitting `combined_score`), and `config.yaml` — per
+   the skill.
+3. **You've run a 1–2 iteration smoke-eval** and shown the evaluator scores a
+   known input sensibly (a baseline number the user recognizes as correct). This
+   catches the silent failure mode where the evaluator runs but scores the wrong
+   thing.
+4. **You've presented an iteration/cost estimate and the user has confirmed.**
+   State the rough call count (≈ iterations × models-per-iteration), that it runs
+   autonomously, and the keep-awake tradeoff (below). Get an explicit go-ahead.
+
+## Run discipline
+
+- **Launch backgrounded** so you stay conversational and can poll while it runs.
+  Keep the PID and log in the run directory:
+
+  ```sh
+  dir="$OPENEVOLVE_OUTPUT_ROOT/<run-id>"
+  cd "$dir"
+  nohup openevolve-run program.py evaluator.py -c config.yaml \
+    -o "$dir/output" -i <N> -l INFO \
+    > run.log 2>&1 &
+  echo $! > run.pid
+  ```
+
+- **Always pass an explicit `--output`** on the **persisted** workspace
+  (`$OPENEVOLVE_OUTPUT_ROOT`, on `$HOME`) and **outside the cloned target repo** —
+  so checkpoints survive hibernation and never pollute the target.
+- **Always bound the run** with `--iterations` and/or `--target-score`. The
+  config default is 10000 iterations — never run unbounded.
+- **Clone the target into its own run directory**, never the pod home root or an
+  unrelated path. Give each run a unique web-safe `<run-id>` (repo + objective
+  slug; append `-2`, `-3` on collision).
+
+## Surviving hibernation (resume-on-wake)
+
+The pod **scales to zero when the session goes idle** — no active turn, no
+queued prompt, no open terminal/SSH session. That kills any background
+`openevolve-run`. The output dir lives on persistent `$HOME`, so the run is
+recoverable but **does not progress while you're not engaged**.
+
+Therefore, **at the start of every turn**, for each run the user cares about (or
+any you launched this session): if `run.pid` is dead but the run hasn't reached
+its target/iteration budget, resume from the latest checkpoint —
+
+```sh
+cd "$OPENEVOLVE_OUTPUT_ROOT/<run-id>"
+latest=$(ls -d output/checkpoints/checkpoint_* 2>/dev/null | sort -t_ -k2 -n | tail -1)
+nohup openevolve-run program.py evaluator.py -c config.yaml \
+  -o "$PWD/output" -i <N> --checkpoint "$latest" -l INFO >> run.log 2>&1 &
+echo $! > run.pid
+```
+
+`--checkpoint` restores the full MAP-Elites state and continues the iteration
+numbering. For short or babysat runs to leave a resumable checkpoint, lower
+`checkpoint_interval` in the config (the default is every 100 iterations — see
+the skill).
+
+**Keep-awake escape hatch:** for a long evolution that must progress
+continuously (e.g. overnight), tell the user to keep a **terminal or SSH session
+open** to this agent — that pins the pod awake, so a backgrounded run completes
+without hibernation gaps. Genuinely unattended overnight progress is a future
+capability; today a run advances only while you're engaged or a session is open.
+
+## Hard guardrails
+
+- **Never enable `manual_mode`.** It makes OpenEvolve wait for human-typed model
+  answers via a queue directory instead of calling the API — it will hang an
+  autonomous run. Keep it off (the default).
+- **Every evaluator must emit `combined_score`** in its metrics dict. That is the
+  single key OpenEvolve optimizes; if it's absent, OpenEvolve silently averages
+  *all* numeric metrics and optimizes the wrong thing.
+- **Discover and validate the model before writing the config.** OpenEvolve does
+  **not** validate model names — a name the endpoint doesn't serve burns the full
+  retry budget every iteration. See the skill's model-setup step.
+- **Refuse if the objective isn't measurable** (see the pre-launch gate).
+- **Always bound the run** (`--iterations` / `--target-score`).
+
+## GitHub access goes through the connection — never a held token
+
+`git clone`, `gh`, and `gh pr create` work **because of the granted GitHub
+connection**, not a token in the pod: the pod holds only a placeholder, and
+Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
+
+- **Never** introduce a side path that puts a raw token in the agent or the run
+  subprocess — no PAT in env, no `gh auth login` with a literal token, no writing
+  credentials to disk.
+- Credential injection is **host-keyed**: any in-pod process reaching an allowed
+  GitHub host — *including LLM-generated evaluator code* — gets the credential.
+  The control surface is therefore the **connection's scope**: keep the GitHub
+  connection least-privilege (the target repo, minimal permission). A report-only
+  run against a public repo needs no GitHub write at all.
+
+## Where things live
+
+- **Per-run directory** = `$OPENEVOLVE_OUTPUT_ROOT/<run-id>/` (`~/openevolve-runs`,
+  on persistent `$HOME`). Holds `program.py`, `evaluator.py`, `config.yaml`, the
+  `repo/` clone, `run.pid`, `run.log`, and OpenEvolve's `output/`.
+- **OpenEvolve output** under `output/`: `best/best_program.*` +
+  `best/best_program_info.json` (the winner + its metrics), `checkpoints/checkpoint_<N>/`
+  (resumable state), `logs/`.

--- a/packages/agents/openevolve/AGENTS.md
+++ b/packages/agents/openevolve/AGENTS.md
@@ -55,8 +55,13 @@ any currently-running evolution in one line.
 
 ## The pre-launch gate (mandatory)
 
-**Never launch a full evolution run before all four of these.** A run is
-autonomous and spends real tokens per iteration, so the gate is non-negotiable:
+**Work through all four before launching a full evolution run.** A run is
+autonomous and spends real tokens per iteration. Steps 1–3 are *correctness*
+checks that protect the user's own tokens, so they always run — "go fast" lets
+you run them inline without narrating each one, but it does **not** let you drop
+them (the smoke-eval especially: skipping it can silently burn the whole run on a
+miswired evaluator). Step 4 is a *consent* check: always show the estimate, but
+an informed user may pre-authorize it (see below).
 
 1. **The objective is measurable.** You must be able to write an `evaluate()`
    that returns a number for "better." If the user's goal isn't measurable as a
@@ -69,9 +74,13 @@ autonomous and spends real tokens per iteration, so the gate is non-negotiable:
    known input sensibly (a baseline number the user recognizes as correct). This
    catches the silent failure mode where the evaluator runs but scores the wrong
    thing.
-4. **You've presented an iteration/cost estimate and the user has confirmed.**
-   State the rough call count (≈ iterations × models-per-iteration), that it runs
-   autonomously, and the keep-awake tradeoff (below). Get an explicit go-ahead.
+4. **You've presented an iteration/cost estimate.** State the rough call count
+   (≈ iterations × models-per-iteration), that it runs autonomously, and the
+   keep-awake tradeoff (below). Then **wait for an explicit go-ahead — unless the
+   user already pre-authorized this run** ("just launch it," "don't ask"):
+   pre-authorization waives the *wait*, never the estimate — show the numbers,
+   then launch. (Resuming an already-approved run after hibernation needs no new
+   confirmation — see resume-on-wake.)
 
 ## Run discipline
 
@@ -90,11 +99,23 @@ autonomous and spends real tokens per iteration, so the gate is non-negotiable:
 - **Always pass an explicit `--output`** on the **persisted** workspace
   (`$OPENEVOLVE_OUTPUT_ROOT`, on `$HOME`) and **outside the cloned target repo** —
   so checkpoints survive hibernation and never pollute the target.
-- **Always bound the run** with `--iterations` and/or `--target-score`. The
-  config default is 10000 iterations — never run unbounded.
+- **Always bound the run** (`--iterations` / `--target-score`); never unbounded.
+  Set `config.yaml`'s `max_iterations` to the agreed budget (what the user
+  approved, not a stock 100/10000) and pass a matching `-i`.
 - **Clone the target into its own run directory**, never the pod home root or an
   unrelated path. Give each run a unique web-safe `<run-id>` (repo + objective
   slug; append `-2`, `-3` on collision).
+
+## Run dependencies
+
+Candidate code runs in the OpenEvolve venv (`$OPENEVOLVE_VENV`), which has only
+`openevolve` + numpy. PyPI egress is open, so install whatever the run needs into
+that venv (`uv pip install --python "$OPENEVOLVE_VENV/bin/python" …`) — and
+anticipate what the **evolved** code will reach for, not just the initial
+program's imports (e.g. `scipy` for a numerical-optimization task). The venv is
+ephemeral but the uv cache is on persistent `$HOME`, so reinstall after a restart
+— it's fast. A missing import scores that mutation zero and the run continues, so
+install up front rather than chasing failures.
 
 ## Surviving hibernation (resume-on-wake)
 
@@ -103,22 +124,15 @@ queued prompt, no open terminal/SSH session. That kills any background
 `openevolve-run`. The output dir lives on persistent `$HOME`, so the run is
 recoverable but **does not progress while you're not engaged**.
 
-Therefore, **at the start of every turn**, for each run the user cares about (or
-any you launched this session): if `run.pid` is dead but the run hasn't reached
-its target/iteration budget, resume from the latest checkpoint —
-
-```sh
-cd "$OPENEVOLVE_OUTPUT_ROOT/<run-id>"
-latest=$(ls -d output/checkpoints/checkpoint_* 2>/dev/null | sort -t_ -k2 -n | tail -1)
-nohup openevolve-run program.py evaluator.py -c config.yaml \
-  -o "$PWD/output" -i <N> --checkpoint "$latest" -l INFO >> run.log 2>&1 &
-echo $! > run.pid
-```
-
-`--checkpoint` restores the full MAP-Elites state and continues the iteration
-numbering. For short or babysat runs to leave a resumable checkpoint, lower
-`checkpoint_interval` in the config (the default is every 100 iterations — see
-the skill).
+So at the **start of each turn**, check any run you care about: if its `run.pid`
+is dead and it hasn't reached its budget, reinstall the run's deps (the venv
+reset) and resume from the latest checkpoint with `--checkpoint`. One non-obvious
+catch — `-i` counts the iterations *this invocation* runs, not an absolute cap, so
+on a resume it runs that many **more**: pass the **remaining** budget
+(`max_iterations` − the latest checkpoint's number, since a resume restarts from
+that checkpoint), not the original `-i`, or it overshoots. A run that's reached
+its budget is done; going further is a new, re-gated decision, not a resume.
+(Lower `checkpoint_interval` if a short run needs to leave a resumable checkpoint.)
 
 **Keep-awake escape hatch:** for a long evolution that must progress
 continuously (e.g. overnight), tell the user to keep a **terminal or SSH session
@@ -148,7 +162,12 @@ Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
 
 - **Never** introduce a side path that puts a raw token in the agent or the run
   subprocess — no PAT in env, no `gh auth login` with a literal token, no writing
-  credentials to disk.
+  credentials to disk. If the user offers a token, decline and point them at the
+  connection.
+- **Confirm a connection is attached before promising a PR** — check
+  `PLATFORM_GH_TOKEN_AVAILABLE` (`true` when granted) or `gh auth status`; if it's
+  missing, tell the user to grant one (and still never take a token). A public
+  repo clones read-only without one.
 - Credential injection is **host-keyed**: any in-pod process reaching an allowed
   GitHub host — *including LLM-generated evaluator code* — gets the credential.
   The control surface is therefore the **connection's scope**: keep the GitHub

--- a/packages/agents/openevolve/Dockerfile
+++ b/packages/agents/openevolve/Dockerfile
@@ -28,6 +28,17 @@ RUN uv python install 3.11 &&\
 # Put the venv (and thus `openevolve-run`, `python`) ahead of the base tools.
 ENV PATH="/opt/openevolve-venv/bin:${PATH}"
 
+# claude-code symlinks /etc/claude-code/CLAUDE.md -> /etc/AGENTS.md; the
+# behavioral policy (pre-launch gate, resume-on-wake, guardrails) lives here.
+COPY AGENTS.md /etc/AGENTS.md
+
+# Run outputs (target clones + checkpoints) persist on $HOME. /app/working-dir is
+# ephemeral image content the agent init seeds into $HOME on first boot, so create
+# the dir under the seed and point the env at the persisted path.
+ENV OPENEVOLVE_OUTPUT_ROOT=/home/agent/openevolve-runs
+RUN mkdir -p /app/working-dir/openevolve-runs &&\
+    chown -R 65532:0 /app/working-dir/openevolve-runs
+
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
 USER 65532

--- a/packages/agents/openevolve/Dockerfile
+++ b/packages/agents/openevolve/Dockerfile
@@ -1,0 +1,33 @@
+# OpenEvolve agent — an evolutionary code-optimization workload. Built FROM the
+# claude-code image (not platform-base) on purpose: the agent is Claude Code,
+# which shells out to OpenEvolve's `openevolve-run` for the evolution loop.
+# Inheriting the claude-code harness gives it the model gateway and CA trust, so
+# the pod holds no model key, exactly like the Claude Code harness.
+#
+# OpenEvolve installs from PyPI (no vendoring); the build is a plain `docker build`.
+# Override the pinned version with `--build-arg OPENEVOLVE_VERSION=<v>`.
+ARG BASE_IMAGE=platform-claude-code
+FROM ${BASE_IMAGE}
+
+USER root
+
+# Pinned OpenEvolve release. Bump here (or pass --build-arg OPENEVOLVE_VERSION=...).
+ARG OPENEVOLVE_VERSION=0.2.27
+
+# uv-managed Python in a shared location so the agent user (uid 65532) can use
+# it at runtime. UV_PYTHON_INSTALL_DIR keeps interpreters out of root's $HOME.
+# uv itself is provided by the mise-managed base image.
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    OPENEVOLVE_VENV=/opt/openevolve-venv
+
+RUN uv python install 3.11 &&\
+    uv venv --python 3.11 "$OPENEVOLVE_VENV" &&\
+    uv pip install --python "$OPENEVOLVE_VENV/bin/python" "openevolve==${OPENEVOLVE_VERSION}" &&\
+    chown -R 65532:0 /opt/openevolve-venv /opt/uv
+
+# Put the venv (and thus `openevolve-run`, `python`) ahead of the base tools.
+ENV PATH="/opt/openevolve-venv/bin:${PATH}"
+
+COPY --chown=65532:0 workspace/ /app/working-dir/
+
+USER 65532

--- a/packages/agents/openevolve/Dockerfile
+++ b/packages/agents/openevolve/Dockerfile
@@ -28,6 +28,15 @@ RUN uv python install 3.11 &&\
 # Put the venv (and thus `openevolve-run`, `python`) ahead of the base tools.
 ENV PATH="/opt/openevolve-venv/bin:${PATH}"
 
+# OpenEvolve's loop calls the model endpoint via the OpenAI SDK (httpx), which
+# defaults to certifi's bundle and so misses the egress-gateway CA the platform
+# injects into the system store at runtime (curl and the node driver trust it; a
+# bare Python httpx call wouldn't, failing TLS verification). Point Python's TLS
+# clients at the system bundle — httpx honors SSL_CERT_FILE, requests honors
+# REQUESTS_CA_BUNDLE.
+ENV SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
 # claude-code symlinks /etc/claude-code/CLAUDE.md -> /etc/AGENTS.md; the
 # behavioral policy (pre-launch gate, resume-on-wake, guardrails) lives here.
 COPY AGENTS.md /etc/AGENTS.md

--- a/packages/agents/openevolve/README.md
+++ b/packages/agents/openevolve/README.md
@@ -1,0 +1,55 @@
+# OpenEvolve agent
+
+Runs [**OpenEvolve**](https://github.com/algorithmicsuperintelligence/openevolve)
+— an open-source AlphaEvolve: an evolutionary coding agent that improves code by
+generating many variations, scoring each against a measurable objective, and
+keeping the best, iterating until it finds a winner — as a platform agent type.
+
+This is a **conversational, claude-code-driven workload**, not a bare CLI. You
+point it at a target repo and a measurable objective in chat ("evolve this
+function to run faster on this input set"); it clones the repo, sets up the
+evolution, runs it, and reports the winning variant (and can open a PR with it).
+
+## Required connections
+
+- **Model provider** (required) — an OpenAI- and Anthropic-compatible endpoint
+  (an IBM-LiteLLM-class connection). A single such connection powers both the
+  conversation and OpenEvolve's optimization loop; a pure-OpenAI provider only
+  covers the loop and leaves the agent itself without a model.
+- **GitHub** — needed to clone a private target repo or to open a PR with the
+  evolved code. A report-only run against a public repo needs no GitHub access.
+
+## Image
+
+Built **FROM the `claude-code` image** (`ARG BASE_IMAGE=platform-claude-code`) so it
+inherits the Claude harness, the model gateway, and CA trust — the pod holds no
+credentials. On top it adds Python 3.11 + the `openevolve` package in a venv at
+`/opt/openevolve-venv` (installed with `uv` from PyPI, pinned via
+`ARG OPENEVOLVE_VERSION`). Both harnesses (chat and terminal) are inherited
+unchanged from the base; OpenEvolve customizes behavior via `AGENTS.md` + the
+`openevolve` skill, not the harness scripts.
+
+## Build
+
+```sh
+mise run agents:openevolve:image            # plain docker build (pip-installs openevolve)
+mise run cluster:build-agent                 # rebuild + restart agent pods in the dev cluster
+```
+
+Override the pinned release with `OPENEVOLVE_VERSION`:
+
+```sh
+OPENEVOLVE_VERSION=0.2.27 mise run agents:openevolve:image
+```
+
+`values-local.yaml` enables the openevolve template against the locally-built
+`platform-openevolve:latest`.
+
+## CI / publishing
+
+The openevolve image is published by CI (`.github/workflows/cd.yml`):
+`build-openevolve` runs after `merge-agents` — it builds `FROM` claude-code, so
+it pulls its base by the same per-commit tag — and `merge-openevolve` publishes
+the multi-arch manifest to the public `quay.io/dam-agents/openevolve` (no
+`imagePullSecret`). The template is enabled in `values.yaml` under "Pre-configured
+Images" (`category: preconfigured`, `experimental: true`).

--- a/packages/agents/openevolve/tasks.toml
+++ b/packages/agents/openevolve/tasks.toml
@@ -1,0 +1,41 @@
+["agents:openevolve:image"]
+description = "Build the openevolve agent image (OpenEvolve on the claude-code base)"
+dir = "{{config_root}}"
+depends = ["agents:claude-code:image"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
+
+# OpenEvolve installs from PyPI at build time. The Dockerfile pins a default
+# version; override it here with OPENEVOLVE_VERSION=<version>.
+build_args=()
+[ -n "${OPENEVOLVE_VERSION:-}" ] && build_args+=(--build-arg "OPENEVOLVE_VERSION=${OPENEVOLVE_VERSION}")
+
+# ${build_args[@]+...} guards the empty-array expansion under `set -u` (bash 3.2 on macOS).
+docker build ${build_args[@]+"${build_args[@]}"} -t platform-openevolve:latest packages/agents/openevolve
+'''
+
+["agents:openevolve:scan"]
+depends = ["agents:openevolve:scan:*"]
+
+["agents:openevolve:scan:trivy"]
+dir = "{{config_root}}"
+usage = '''
+flag "--json" help="Emit Trivy JSON (exit 0) instead of failing on findings"
+flag "--tag <tag>" help="Scan quay.io/dam-agents/openevolve:<tag> instead of building locally"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${usage_tag:-}" ]; then
+  image="quay.io/dam-agents/openevolve:${usage_tag}"
+else
+  {{ mise_bin }} run agents:openevolve:image
+  image="platform-openevolve:latest"
+fi
+if [[ "${usage_json:-false}" == "true" ]]; then
+  exec trivy image --quiet --format json "$image"
+fi
+exec trivy image --quiet --exit-code 1 "$image"
+'''

--- a/packages/agents/openevolve/workspace/.agents/skills/openevolve/SKILL.md
+++ b/packages/agents/openevolve/workspace/.agents/skills/openevolve/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: openevolve
+description: >-
+  Run OpenEvolve, the evolutionary coding agent, to optimize code against a
+  measurable objective via the `openevolve-run` CLI. Use when the user wants to
+  evolve / optimize a function or program in a target repo to improve a metric
+  (speed, accuracy, size, error rate), author the OpenEvolve inputs
+  (program + EVOLVE-BLOCK, evaluator, config.yaml), pick the evolution model, or
+  launch / monitor / resume / report on an evolution run.
+---
+
+# OpenEvolve — evolutionary code optimization
+
+OpenEvolve is an open-source AlphaEvolve: an LLM mutates a program, an
+**evaluator** scores each variant against an objective, and a MAP-Elites
+database keeps a diverse population of the best — iterating until it converges or
+hits a budget. It fits objectives that are **measurable as a number**: make a
+function faster, more accurate, smaller, lower-error.
+
+> Upstream: https://github.com/algorithmicsuperintelligence/openevolve
+
+## This is an OpenEvolve agent pod
+
+`openevolve-run` is **pre-installed** (on `PATH`); the model endpoint and your
+own Claude model are reached through the platform's credential gateway — **no API
+key lives in this pod**. Never ask the user for a key, never write one to disk,
+never `pip install openevolve` yourself.
+
+The pod-level workflow — the mandatory pre-launch gate, per-run directories,
+backgrounding runs, resume-on-wake, and the hard guardrails — is defined in this
+pod's system context (`AGENTS.md`). **This skill is the setup-and-CLI
+reference**; follow `AGENTS.md` for *how* to operate a run in this environment.
+
+## Step 1 — set up the evolution model
+
+The evolution loop calls an **OpenAI-compatible** endpoint that the attached
+model-provider connection injects as `OPENAI_BASE_URL` + `OPENAI_API_KEY`.
+OpenEvolve does **not** validate model names — a name the endpoint doesn't serve
+burns the full retry budget every iteration — so always discover the catalog
+first:
+
+```sh
+# Through the egress gateway (do NOT bypass the proxy — the gateway injects the
+# real credential and authorizes egress to the endpoint host). Strip a trailing
+# /v1 first so the path is right whether or not the base already includes it:
+base="${OPENAI_BASE_URL%/}"; base="${base%/v1}"
+curl -fsS "$base/v1/models" \
+  -H "Authorization: Bearer $OPENAI_API_KEY" | jq -r '.data[].id'
+```
+
+Pick a **fast** model (cheap — most iterations) and a **strong** model
+(occasional higher-quality steps), and write a **weighted ensemble** — this is
+OpenEvolve's native task-based model switching. If the endpoint can't list
+models, fall back to a pinned known-good id (for IBM LiteLLM: `aws/claude-sonnet-4-6`).
+
+`config.yaml` model section — note the two env-var rules (validated against
+`openevolve.config`):
+
+- **`api_base` must be set inside the file** at the `llm` level. Ensemble models
+  inherit it at load time; the `--api-base` CLI flag does **not** reach models in
+  an `llm.models` list. Write the resolved `$OPENAI_BASE_URL` literally (the
+  shell expands it when you generate the file).
+- **`api_key` stays the literal `${OPENAI_API_KEY}`.** OpenEvolve interpolates
+  `${VAR}` for `api_key` only, at load; the gateway swaps the placeholder for the
+  real credential on the wire.
+
+```sh
+cat > config.yaml <<YAML
+max_iterations: 100
+checkpoint_interval: 10          # leave a resumable checkpoint on shorter runs (default 100)
+diff_based_evolution: true       # requires EVOLVE-BLOCK markers in program (default)
+llm:
+  api_base: "${OPENAI_BASE_URL}" # shell-expanded to the literal endpoint URL
+  api_key: "\${OPENAI_API_KEY}"  # literal; OpenEvolve interpolates, gateway swaps on the wire
+  models:
+    - name: "<fast-model-id>"    # high weight — the bulk of iterations
+      weight: 0.8
+    - name: "<strong-model-id>"  # low weight — occasional higher-quality mutations
+      weight: 0.2
+evaluator:
+  cascade_evaluation: false      # single-stage evaluate(); default true needs evaluate_stage1
+  timeout: 120
+YAML
+```
+
+## Step 2 — author the three inputs
+
+**`program`** — the initial code. Bound the mutable region with markers:
+
+```python
+# EVOLVE-BLOCK-START
+def solve(x):
+    return 0.0   # OpenEvolve rewrites only what's between the markers
+# EVOLVE-BLOCK-END
+```
+
+Markers are strongly recommended. If you omit them, set `diff_based_evolution:
+false` (and keep the file small) — marker-less diff mode wastes iterations on
+"No valid diffs found".
+
+**`evaluator`** — `evaluate(program_path) -> dict`. It imports/runs the candidate
+and returns a metrics dict that **must include `combined_score`** (a float, by
+convention in `[0, 1]`, higher = better). `combined_score` is the single key
+OpenEvolve optimizes; **if it's absent, OpenEvolve averages all numeric metrics**
+and silently optimizes the wrong thing. Extra metrics are fine for visibility but
+only `combined_score` drives selection.
+
+```python
+def evaluate(program_path):
+    import importlib.util
+    spec = importlib.util.spec_from_file_location("cand", program_path)
+    cand = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cand)
+    error = measure_error(cand)            # your objective, computed here
+    return {"combined_score": 1.0 / (1.0 + error), "error": error}
+```
+
+For a cheap pre-filter before the full evaluation, add an `evaluate_stage1` and
+set `cascade_evaluation: true`; otherwise keep `cascade_evaluation: false`.
+
+## Step 3 — smoke-eval, then launch (see the pre-launch gate in AGENTS.md)
+
+Before any full run, do a **1–2 iteration smoke-eval** and confirm the evaluator
+scores a known input sensibly, then present a cost estimate and get the user's
+go-ahead. Then launch backgrounded with an explicit `--output` on the persisted
+workspace (see `AGENTS.md`).
+
+## CLI reference
+
+```
+openevolve-run <program> <evaluator> -c config.yaml -o <output> -i <N> \
+  [-t <target-score>] [--checkpoint <dir>] [-l INFO]
+```
+
+| Flag | Meaning |
+|---|---|
+| `<program> <evaluator>` | positional: initial program file, evaluator file |
+| `-c, --config` | config YAML |
+| `-o, --output` | output dir — **always** an explicit path on `$OPENEVOLVE_OUTPUT_ROOT`, outside the target repo |
+| `-i, --iterations` | max iterations — **always bound** (config default is 10000) |
+| `-t, --target-score` | stop once `combined_score` reaches this |
+| `--checkpoint <dir>` | resume full state from `output/checkpoints/checkpoint_<N>` (continues iteration numbering) |
+| `-l, --log-level` | `INFO` for the per-iteration progress lines |
+
+(`--api-base` / `--primary-model` / `--secondary-model` exist but do **not**
+override an `llm.models` ensemble loaded from the config — configure models in
+`config.yaml`, per Step 1.)
+
+**Monitoring:** tail `run.log` for `Iteration {n}: ... Metrics: ...` lines and
+`Saved checkpoint at iteration {n}`. A run doesn't advance faster because you
+look at it — poll infrequently.
+
+## Outputs
+
+Under `<output>/`:
+- `best/best_program.*` — the winning variant; `best/best_program_info.json` — its
+  metrics (report `combined_score` and the objective metric from here).
+- `checkpoints/checkpoint_<N>/` — resumable full state (drives `--checkpoint`).
+- `logs/` — run logs.
+
+## Worked example — approximate sin(x) on [0, π]
+
+A self-contained objective: evolve a polynomial to approximate `math.sin` with
+minimum mean-squared error. (Also the CI/local smoke fixture — not a user-facing
+"demo".)
+
+`program.py`:
+
+```python
+import math
+# EVOLVE-BLOCK-START
+def approx(x):
+    return x            # OpenEvolve improves this toward sin(x) on [0, π]
+# EVOLVE-BLOCK-END
+```
+
+`evaluator.py`:
+
+```python
+import importlib.util, math
+
+def evaluate(program_path):
+    spec = importlib.util.spec_from_file_location("cand", program_path)
+    cand = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(cand)
+    xs = [i * math.pi / 50 for i in range(51)]
+    mse = sum((cand.approx(x) - math.sin(x)) ** 2 for x in xs) / len(xs)
+    return {"combined_score": 1.0 / (1.0 + mse), "mse": mse}
+```
+
+Run it (after Step 1 wrote `config.yaml`):
+
+```sh
+openevolve-run program.py evaluator.py -c config.yaml -o "$PWD/output" -i 30 -l INFO
+```
+
+`combined_score` rises toward 1.0 as `mse` falls; the winner lands in
+`output/best/best_program.py`.
+
+## Reporting (and optional PR)
+
+Report from `output/best/best_program_info.json`: the final `combined_score`, the
+objective metric, and the evolved code. If the user wants the change landed and a
+GitHub connection is granted, open a PR with the evolved file via `gh` — which
+works through the connection, never a held token (see `AGENTS.md`).

--- a/packages/agents/openevolve/workspace/.agents/skills/openevolve/SKILL.md
+++ b/packages/agents/openevolve/workspace/.agents/skills/openevolve/SKILL.md
@@ -26,6 +26,20 @@ own Claude model are reached through the platform's credential gateway — **no 
 key lives in this pod**. Never ask the user for a key, never write one to disk,
 never `pip install openevolve` yourself.
 
+Candidate code runs in the OpenEvolve venv (`$OPENEVOLVE_VENV`) — `openevolve` +
+numpy only. Install whatever else a run needs (PyPI egress is allowed; `scipy` is
+the usual one for numerical work):
+
+```sh
+uv pip install --python "$OPENEVOLVE_VENV/bin/python" scipy
+```
+
+The venv is ephemeral but the uv cache is on persistent `$HOME`, so reinstall on
+resume (fast, from cache). An unavailable import just scores that mutation
+`combined_score = 0` and the run continues — so install what the **evolved** code
+will reach for up front (e.g. scipy for numerical work), not just the initial
+program's imports. See `AGENTS.md` ("Run dependencies").
+
 The pod-level workflow — the mandatory pre-launch gate, per-run directories,
 backgrounding runs, resume-on-wake, and the hard guardrails — is defined in this
 pod's system context (`AGENTS.md`). **This skill is the setup-and-CLI
@@ -66,7 +80,7 @@ models, fall back to a pinned known-good id (for IBM LiteLLM: `aws/claude-sonnet
 
 ```sh
 cat > config.yaml <<YAML
-max_iterations: 100
+max_iterations: 100              # the agreed TOTAL budget — single source of truth; set to what the user approved
 checkpoint_interval: 10          # leave a resumable checkpoint on shorter runs (default 100)
 diff_based_evolution: true       # requires EVOLVE-BLOCK markers in program (default)
 llm:
@@ -137,10 +151,13 @@ openevolve-run <program> <evaluator> -c config.yaml -o <output> -i <N> \
 | `<program> <evaluator>` | positional: initial program file, evaluator file |
 | `-c, --config` | config YAML |
 | `-o, --output` | output dir — **always** an explicit path on `$OPENEVOLVE_OUTPUT_ROOT`, outside the target repo |
-| `-i, --iterations` | max iterations — **always bound** (config default is 10000) |
+| `-i, --iterations` | iterations **this invocation** runs (not an absolute cap) — **always bound**; config default is 10000 |
 | `-t, --target-score` | stop once `combined_score` reaches this |
 | `--checkpoint <dir>` | resume full state from `output/checkpoints/checkpoint_<N>` (continues iteration numbering) |
 | `-l, --log-level` | `INFO` for the per-iteration progress lines |
+
+> On a `--checkpoint` resume `-i` adds that many **more** iterations, so pass the
+> remaining budget (`max_iterations − checkpoint_N`), not the original `-i`.
 
 (`--api-base` / `--primary-model` / `--secondary-model` exist but do **not**
 override an `llm.models` ensemble loaded from the config — configure models in


### PR DESCRIPTION
Adds **OpenEvolve** ([upstream](https://github.com/algorithmicsuperintelligence/openevolve), Apache-2.0 — an open-source AlphaEvolve) as a ready-to-use **curated workload**. A user spins up a sandbox from the OpenEvolve template, points the agent at their repo and a measurable objective in chat, and the agent runs an evolutionary code optimization end-to-end — discovering improvements, scoring each variant, and reporting (optionally PR-ing) the winner.

It's a real conversational agent, not a scripted demo: you chat with it, it clones your repo, authors the OpenEvolve inputs, runs the evolution, and reports back.

Closes #885.

## How you use it
1. Create a sandbox from the **OpenEvolve** template (under "Pre-configured Images").
2. Attach a model-provider connection — one connection can power both the agent and the evolution loop — plus a GitHub connection if you want a PR opened.
3. In chat: *"Evolve `<function>` in `<repo>` to minimize/maximize `<measurable metric>`."*
4. The agent agrees a measurable objective, authors the program / evaluator / config, picks the evolution model, runs a quick smoke-eval, shows a cost estimate, and — on your go-ahead — runs the evolution and reports the best variant. If the sandbox hibernates mid-run, it resumes from the latest checkpoint.

## What's included
- **OpenEvolve agent image** — Claude-Code-driven; the evolution loop runs as a subprocess against an OpenAI-compatible endpoint, so the chat agent and the optimization loop use independent models.
- **Pre-configured template** so it appears in the sandbox wizard.
- **The agent's operating manual** (`AGENTS.md` + skill) — objective elicitation, model discovery, a pre-launch smoke-eval gate, run / monitor / resume-on-wake, reporting, and safety guardrails (never holds a raw credential, always bounds the run, refuses non-measurable objectives).

## Try it
*"Evolve `search_algorithm` in https://github.com/PetrBulanek/openevolve-function-min to minimize the function."* → the agent evolves naive random search into a multi-start gradient-descent optimizer that reliably lands on the global minimum.

## Limitation (v1)
Fully usable for short and interactive runs. A run that keeps progressing while you're away (e.g. overnight) needs the generic stay-awake signal tracked in #1373 — a follow-up; resume-on-wake already preserves progress across hibernation.
