### PR TITLE
fix(nous): patch campaign schema to accept channels: at build time

### DIFF
--- a/packages/agents/nous/Dockerfile
+++ b/packages/agents/nous/Dockerfile
@@ -30,6 +30,17 @@ RUN uv python install 3.11 &&\
       "git+https://github.com/AI-native-Systems-Research/agentic-strategy-evolution.git@${NOUS_REF}" &&\
     chown -R 65532:0 /opt/nous-venv /opt/uv
 
+# Patch the installed campaign schema so `channels:` validates (Nous issue #296).
+# Nous's runtime reads campaign.channels at every DESIGN/FINDINGS gate, but the
+# v0.4.0 schema never declares the property while forbidding unknown top-level
+# keys — so any campaign using channels is rejected at pre-flight. That breaks
+# the channel bridge below, which *requires* a `channels:` webhook to relay gate
+# summaries into the agent's chat thread. The patch mutates the installed schema
+# in place (no vendoring); it is idempotent and self-verifying, so it becomes a
+# clean no-op once a Nous release ships the property and NOUS_REF is bumped.
+COPY --chmod=0755 patch-campaign-schema.py /usr/local/bin/nous-patch-campaign-schema
+RUN "$NOUS_VENV/bin/python" /usr/local/bin/nous-patch-campaign-schema
+
 # Put the venv (and thus `nous`, `python`, `pip`) ahead of the base tools.
 ENV PATH="/opt/nous-venv/bin:${PATH}"
 

--- a/packages/agents/nous/README.md
+++ b/packages/agents/nous/README.md
@@ -24,6 +24,13 @@ so it inherits the `claude` CLI, the model gateway, and CA trust. On top it adds
 - Python 3.11 + the `nous` package in a venv at `/opt/nous-venv`, installed with
   `uv` **straight from the public GitHub repo** (pinned via `ARG NOUS_REF`,
   default `v0.4.0`), with the venv on `PATH`. No source vendoring.
+- A build-time patch ([`patch-campaign-schema.py`](./patch-campaign-schema.py))
+  that adds the `channels:` property to the installed `campaign.schema.yaml`.
+  Nous's runtime reads `campaign.channels` at every gate, but the v0.4.0 schema
+  omits the property while forbidding unknown top-level keys, so any campaign
+  using channels is rejected at pre-flight ([Nous issue #296](https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/issues/296))
+  — which would break the channel bridge below. The patch is idempotent and
+  self-verifying; it no-ops once a Nous release ships the property.
 - `NOUS_ALLOW_AUTO_APPROVE=1` so `--auto-approve` runs are unconditional in this
   pod (the design/findings human gates auto-pass).
 - `NOUS_CAMPAIGN_PARENT=/home/agent/nous-campaigns` (on the persist:true `$HOME`

--- a/packages/agents/nous/patch-campaign-schema.py
+++ b/packages/agents/nous/patch-campaign-schema.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""Build-time patch: teach Nous's campaign schema about ``channels:``.
+
+Nous's runtime reads and dispatches ``campaign.channels`` at every
+DESIGN/FINDINGS gate (``orchestrator/iteration.py`` → ``orchestrator/channels.py``),
+but ``orchestrator/schemas/campaign.schema.yaml`` never declares the property
+while setting ``additionalProperties: false`` at the top level. So a campaign
+that uses ``channels:`` is rejected at pre-flight before the run starts::
+
+    Campaign validation error: Additional properties are not allowed
+    ('channels' was unexpected)
+
+That makes the documented feature impossible to use — and in this image it
+breaks the channel bridge (``nous-channel-bridge.py``), which relies on a
+``channels:`` webhook to relay gate summaries into the agent's bound chat
+thread. Upstream issue:
+https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/issues/296
+
+This script patches the schema *in place in the installed package* so the fix
+travels with the pinned ``NOUS_REF`` without vendoring the orchestrator. It is:
+
+  * idempotent — re-running (or running against a future Nous that ships the
+    property itself) is a no-op;
+  * version-agnostic — it mutates the parsed schema dict, so it survives an
+    upstream key reorder under a bumped ``NOUS_REF``;
+  * self-verifying — it asserts a ``channels``-bearing campaign now validates
+    AND that an unknown key is still rejected (i.e. ``additionalProperties:
+    false`` is preserved), failing the build if either regresses.
+
+The ``channels`` item shape mirrors exactly what ``orchestrator/channels.py``
+reads: ``kind`` ∈ {webhook, slack} (defaults to ``webhook``); ``url`` for a
+webhook channel; ``webhook_url`` for a slack channel; optional ``headers`` for a
+webhook channel.
+
+stdlib + the orchestrator's own deps (pyyaml, jsonschema) only — runs on the
+nous venv python during ``docker build``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import jsonschema
+import yaml
+
+# Schema fragment for one ``channels`` entry. Kept faithful to the dispatchers
+# in ``orchestrator/channels.py`` — ``additionalProperties: false`` so a typo'd
+# field is caught, matching the strictness of the rest of the campaign schema.
+CHANNELS_PROPERTY = {
+    "type": "array",
+    "description": (
+        "Notification channels POSTed a markdown gate summary at each "
+        "DESIGN/FINDINGS gate (fires even under --auto-approve). Consumed by "
+        "orchestrator/channels.py (issue #130). Best-effort: a timeout/5xx/DNS "
+        "failure logs a warning and never blocks the gate or campaign."
+    ),
+    "items": {
+        "type": "object",
+        "additionalProperties": False,
+        "properties": {
+            "kind": {
+                "type": "string",
+                "enum": ["webhook", "slack"],
+                "description": (
+                    "Dispatcher. 'webhook' POSTs {\"markdown\": ...} to 'url'; "
+                    "'slack' POSTs {\"text\": ...} to 'webhook_url'. "
+                    "Defaults to 'webhook' when omitted."
+                ),
+            },
+            "url": {
+                "type": "string",
+                "description": "Target URL for a 'webhook' channel.",
+            },
+            "webhook_url": {
+                "type": "string",
+                "description": "Incoming-webhook URL for a 'slack' channel.",
+            },
+            "headers": {
+                "type": "object",
+                "additionalProperties": True,
+                "description": "Optional extra HTTP headers for a 'webhook' channel.",
+            },
+        },
+    },
+}
+
+
+def _schema_path() -> Path:
+    """Locate the installed campaign schema without executing the package."""
+    spec = importlib.util.find_spec("orchestrator")
+    if spec is None or not spec.submodule_search_locations:
+        raise SystemExit("[patch-schema] orchestrator package not found in venv")
+    return Path(spec.submodule_search_locations[0]) / "schemas" / "campaign.schema.yaml"
+
+
+def _self_test(schema: dict) -> None:
+    """Prove the fix works and that strictness is preserved."""
+    base = {
+        "research_question": "probe",
+        "target_system": {"name": "X", "description": "x"},
+        "prompts": {"methodology_layer": "prompts/methodology"},
+    }
+    with_channels = {
+        **base,
+        "channels": [
+            {"kind": "webhook", "url": "http://127.0.0.1:8765/gate",
+             "headers": {"Authorization": "Bearer x"}},
+            {"kind": "slack", "webhook_url": "https://hooks.slack.com/services/X/Y/Z"},
+        ],
+    }
+    # Positive: a channels-bearing campaign must now validate.
+    jsonschema.validate(with_channels, schema)
+    # Negative: additionalProperties:false must still reject an unknown key.
+    try:
+        jsonschema.validate({**base, "definitely_not_a_real_key": 1}, schema)
+    except jsonschema.ValidationError:
+        pass
+    else:
+        raise SystemExit("[patch-schema] regression: unknown top-level key was accepted")
+
+
+def main() -> int:
+    path = _schema_path()
+    schema = yaml.safe_load(path.read_text())
+
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        raise SystemExit(f"[patch-schema] unexpected schema shape at {path}")
+
+    if "channels" in properties:
+        # Upstream (or a prior build) already declares it — verify and stop.
+        _self_test(schema)
+        print(f"[patch-schema] 'channels' already present in {path}; no-op.")
+        return 0
+
+    properties["channels"] = CHANNELS_PROPERTY
+    _self_test(schema)  # fail the build before writing if something is off
+
+    path.write_text(
+        yaml.safe_dump(schema, sort_keys=False, allow_unicode=True, width=4096)
+    )
+    print(f"[patch-schema] added 'channels' property to {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Problem

Nous's runtime reads `campaign.channels` and POSTs a markdown gate summary to each configured channel at every DESIGN/FINDINGS gate (`orchestrator/iteration.py` → `orchestrator/channels.py`). But the pinned **v0.4.0** campaign schema never declares a `channels` property while setting `additionalProperties: false` at the top level. So `nous run` aborts at pre-flight:

```
Campaign validation error: Additional properties are not allowed ('channels' was unexpected)
```

This isn't only the documented-but-unusable feature from the upstream issue — it **silently breaks our channel bridge**. [`nous-channel-bridge.py`](https://github.com/dam-agents/dam/blob/main/packages/agents/nous/nous-channel-bridge.py) relies on a campaign declaring a `channels:` webhook (pointed at `http://127.0.0.1:8765/gate`) to relay gate summaries into the agent's bound Slack/Telegram thread. Every such campaign was being rejected before the run started.

Upstream issue (filed, no response, not fixed on `main` either): AI-native-Systems-Research/agentic-strategy-evolution#296

## Fix

We pip-install `nous` from GitHub (no vendoring), so this patches the **installed** schema during `docker build`:

- **New** `patch-campaign-schema.py` — injects a `channels` property whose item shape mirrors exactly what `channels.py` reads (`kind` ∈ {`webhook`, `slack`}, `url`, `webhook_url`, `headers`). It is:
  - **idempotent** — no-ops if the property is already present;
  - **version-agnostic** — mutates the parsed schema dict, so it survives a `NOUS_REF` bump / key reorder;
  - **self-verifying** — fails the build if a `channels`-bearing campaign doesn't validate, or if an unknown top-level key stops being rejected (i.e. `additionalProperties: false` is preserved).
- **Dockerfile** — `COPY` + `RUN` the patch right after `uv pip install`.
- **README** — documents the patch in the image-contents list.

A companion upstream PR fixes the schema at source; once a Nous release ships the property, bumping `NOUS_REF` past it turns this patch into a clean no-op (and it can then be removed).

## Verification

Installed `nous` v0.4.0 into a throwaway venv and ran the **actual** patch script end-to-end:

| Check | Result |
|---|---|
| Exact issue #296 repro, before patch | ❌ `Additional properties are not allowed ('channels' was unexpected)` (reproduced) |
| After patch | ✅ campaign validates; `additionalProperties: false` preserved |
| `nous schema campaign` | ✅ now lists `channels` |
| Bad `kind` / typo'd channel field | ✅ still rejected |
| Re-run patch | ✅ idempotent no-op |

Full image build not run locally (base-image chain not built); the patch runs identically there and is exercised by CI's `build-nous`.