### PR TITLE
feat(telemetry): deploy ClickStack agent-telemetry backend with the platform

### DIFF
--- a/deploy/helm/platform/Chart.lock
+++ b/deploy/helm/platform/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: clickstack
+  repository: https://clickhouse.github.io/ClickStack-helm-charts
+  version: 3.0.0
+digest: sha256:8022f03da08e8124b067d4d4187ea1cce79bc5e8fbf336a6ee9aec742d713c3e
+generated: "2026-06-26T07:02:36.606817+02:00"

--- a/deploy/helm/platform/Chart.yaml
+++ b/deploy/helm/platform/Chart.yaml
@@ -4,3 +4,16 @@ description: ADK — Secure Agent Execution Platform
 type: application
 version: 0.2.6
 appVersion: "0.2.6"
+
+dependencies:
+  # Agent-telemetry backend. Ships the ClickHouse/Keeper/MongoDB custom resources and the
+  # HyperDX UI; gated by `clickstack.enabled` (default off). Its ClickHouse + MongoDB
+  # operators and CRDs are installed out-of-band (see deploy/tasks.toml), like Istio and
+  # cert-manager, because Helm never upgrades a chart's crds/ on an existing release. We
+  # disable the subchart's own OpenTelemetry collector (clickstack.otel-collector.enabled)
+  # and run our own (templates/clickstack/) so collector access is gated by Istio, not by
+  # HyperDX ingestion tokens.
+  - name: clickstack
+    version: "3.0.0"
+    repository: "https://clickhouse.github.io/ClickStack-helm-charts"
+    condition: clickstack.enabled

--- a/deploy/helm/platform/Chart.yaml
+++ b/deploy/helm/platform/Chart.yaml
@@ -6,13 +6,8 @@ version: 0.2.6
 appVersion: "0.2.6"
 
 dependencies:
-  # Agent-telemetry backend. Ships the ClickHouse/Keeper/MongoDB custom resources and the
-  # HyperDX UI; gated by `clickstack.enabled` (default off). Its ClickHouse + MongoDB
-  # operators and CRDs are installed out-of-band (see deploy/tasks.toml), like Istio and
-  # cert-manager, because Helm never upgrades a chart's crds/ on an existing release. We
-  # disable the subchart's own OpenTelemetry collector (clickstack.otel-collector.enabled)
-  # and run our own (templates/clickstack/) so collector access is gated by Istio, not by
-  # HyperDX ingestion tokens.
+  # Agent-telemetry backend; gated by clickstack.enabled (default off). Operators + CRDs
+  # install out-of-band (deploy/tasks.toml). See docs/architecture/observability.md.
   - name: clickstack
     version: "3.0.0"
     repository: "https://clickhouse.github.io/ClickStack-helm-charts"

--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -323,3 +323,14 @@ API Server ServiceAccount name
 {{- define "platform.apiserver.serviceAccountName" -}}
 {{- printf "%s-apiserver" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/* ---- ClickStack telemetry backend ---- */}}
+
+{{/*
+Platform-owned OpenTelemetry collector for the ClickStack backend (Deployment + Service).
+Replaces the subchart's HyperDX/OpAMP-managed collector so collector access is gated by
+Istio AuthorizationPolicy rather than HyperDX ingestion tokens.
+*/}}
+{{- define "platform.clickstack.collector.fullname" -}}
+{{- printf "%s-clickstack-collector" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}

--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -324,13 +324,7 @@ API Server ServiceAccount name
 {{- printf "%s-apiserver" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
-{{/* ---- ClickStack telemetry backend ---- */}}
-
-{{/*
-Platform-owned OpenTelemetry collector for the ClickStack backend (Deployment + Service).
-Replaces the subchart's HyperDX/OpAMP-managed collector so collector access is gated by
-Istio AuthorizationPolicy rather than HyperDX ingestion tokens.
-*/}}
+{{/* Platform-owned OTel collector for the ClickStack telemetry backend. */}}
 {{- define "platform.clickstack.collector.fullname" -}}
 {{- printf "%s-clickstack-collector" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}

--- a/deploy/helm/platform/templates/clickstack/authorizationpolicy.yaml
+++ b/deploy/helm/platform/templates/clickstack/authorizationpolicy.yaml
@@ -1,19 +1,8 @@
 {{- if .Values.clickstack.enabled }}
 {{- /*
-Mesh-level access control for the telemetry collector.
-
-Out of the box, ClickStack gates the collector with a HyperDX-issued ingestion API key
-(pushed via OpAMP). The platform instead gates the collector at the mesh, consistent with
-its SPIFFE-principal access model (see apiserver/auth-policy-pod-deny.yaml). The collector
-itself runs with no auth extension (collector.yaml), so this policy is the gate.
-
-ALLOW from the release namespace and the agent namespace only; Istio ALLOW semantics deny
-any source matching no rule. Enforced at L4 by ztunnel — no waypoint required.
-
-Namespace `from` matching keys off the source's mesh identity. Release-namespace peers are
-in the ambient mesh and match directly. How agent telemetry ultimately reaches the
-collector (direct vs. via the in-mesh gateway, and the identity it carries) is settled by
-the export-wiring sub-issue; this expresses the intended allow-set now.
+Mesh gate for the collector: ALLOW only the release + agent namespaces (Istio ALLOW denies
+all else, L4 via ztunnel), replacing ClickStack's HyperDX-token gate.
+See docs/architecture/observability.md.
 */ -}}
 apiVersion: security.istio.io/v1
 kind: AuthorizationPolicy

--- a/deploy/helm/platform/templates/clickstack/authorizationpolicy.yaml
+++ b/deploy/helm/platform/templates/clickstack/authorizationpolicy.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.clickstack.enabled }}
+{{- /*
+Mesh-level access control for the telemetry collector.
+
+Out of the box, ClickStack gates the collector with a HyperDX-issued ingestion API key
+(pushed via OpAMP). The platform instead gates the collector at the mesh, consistent with
+its SPIFFE-principal access model (see apiserver/auth-policy-pod-deny.yaml). The collector
+itself runs with no auth extension (collector.yaml), so this policy is the gate.
+
+ALLOW from the release namespace and the agent namespace only; Istio ALLOW semantics deny
+any source matching no rule. Enforced at L4 by ztunnel — no waypoint required.
+
+Namespace `from` matching keys off the source's mesh identity. Release-namespace peers are
+in the ambient mesh and match directly. How agent telemetry ultimately reaches the
+collector (direct vs. via the in-mesh gateway, and the identity it carries) is settled by
+the export-wiring sub-issue; this expresses the intended allow-set now.
+*/ -}}
+apiVersion: security.istio.io/v1
+kind: AuthorizationPolicy
+metadata:
+  name: {{ include "platform.fullname" . }}-clickstack-collector-allow
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickstack-collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: clickstack-collector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  action: ALLOW
+  rules:
+    - from:
+        - source:
+            namespaces:
+              - {{ .Release.Namespace | quote }}
+              - {{ .Values.agentNamespace | quote }}
+{{- end }}

--- a/deploy/helm/platform/templates/clickstack/collector.yaml
+++ b/deploy/helm/platform/templates/clickstack/collector.yaml
@@ -107,7 +107,9 @@ spec:
         - name: collector
           image: {{ .Values.clickstack.collector.image }}
           args: ["--config=/etc/otelcol/config.yaml"]
-          # ClickHouse conn from the shared config/secret; OPAMP_SERVER_URL there is ignored (no opamp in our config).
+          # ClickHouse conn from HyperDX's clickstack-config/secret (rendered with the subchart, not the
+          # disabled bundled collector), so co-gated with this collector under clickstack.enabled.
+          # OPAMP_SERVER_URL there is ignored (no opamp in our config).
           envFrom:
             - configMapRef:
                 name: clickstack-config

--- a/deploy/helm/platform/templates/clickstack/collector.yaml
+++ b/deploy/helm/platform/templates/clickstack/collector.yaml
@@ -1,0 +1,156 @@
+{{- if .Values.clickstack.enabled }}
+{{- /*
+Platform-owned OpenTelemetry collector for the ClickStack telemetry backend.
+
+Replaces the subchart's bundled collector (clickstack.otel-collector.enabled=false). That
+one is driven by HyperDX over OpAMP, which injects an ingestion-API-key check on the OTLP
+receivers — token-based access control we deliberately avoid. This collector runs a static
+config with NO auth extension and NO OpAMP; reachability is gated entirely by the Istio
+AuthorizationPolicy alongside (authorizationpolicy.yaml).
+
+It reuses the subchart's shared `clickstack-config` ConfigMap + `clickstack-secret` Secret
+for the ClickHouse connection, writing as the `otelcollector` user (granted CREATE on
+default.*) into db `default` with the standard otel_* tables that HyperDX's sources read.
+*/ -}}
+{{- $name := include "platform.clickstack.collector.fullname" . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickstack-collector
+data:
+  config.yaml: |
+    receivers:
+      otlp:
+        protocols:
+          grpc:
+            endpoint: 0.0.0.0:4317
+          http:
+            endpoint: 0.0.0.0:4318
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 25
+      batch: {}
+    exporters:
+      clickhouse:
+        endpoint: ${env:CLICKHOUSE_ENDPOINT}
+        username: ${env:CLICKHOUSE_USER}
+        password: ${env:CLICKHOUSE_PASSWORD}
+        database: default
+        create_schema: true
+    extensions:
+      health_check:
+        endpoint: 0.0.0.0:13133
+    service:
+      extensions: [health_check]
+      pipelines:
+        logs:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [clickhouse]
+        traces:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [clickhouse]
+        metrics:
+          receivers: [otlp]
+          processors: [memory_limiter, batch]
+          exporters: [clickhouse]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickstack-collector
+spec:
+  type: ClusterIP
+  ports:
+    - port: 4317
+      targetPort: otlp-grpc
+      protocol: TCP
+      name: otlp-grpc
+      appProtocol: grpc
+    - port: 4318
+      targetPort: otlp-http
+      protocol: TCP
+      name: otlp-http
+  selector:
+    app.kubernetes.io/component: clickstack-collector
+    app.kubernetes.io/instance: {{ .Release.Name }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "platform.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickstack-collector
+  {{- include "platform.annotations" (dict "root" $ "component" .Values.clickstack.collector) | nindent 2 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: clickstack-collector
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: clickstack-collector
+        app.kubernetes.io/instance: {{ .Release.Name }}
+      {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.clickstack.collector) | nindent 6 }}
+    spec:
+      {{- include "platform.imagePullSecrets" . | nindent 6 }}
+      containers:
+        - name: collector
+          image: {{ .Values.clickstack.collector.image }}
+          args: ["--config=/etc/otelcol/config.yaml"]
+          # CLICKHOUSE_ENDPOINT/USER/PASSWORD come from the subchart's shared config/secret.
+          # OPAMP_SERVER_URL is also present there but ignored — our config has no opamp.
+          envFrom:
+            - configMapRef:
+                name: clickstack-config
+            - secretRef:
+                name: clickstack-secret
+          ports:
+            - containerPort: 4317
+              name: otlp-grpc
+            - containerPort: 4318
+              name: otlp-http
+            - containerPort: 13133
+              name: health
+          {{- if .Values.probes.enabled }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 3
+          livenessProbe:
+            httpGet:
+              path: /
+              port: health
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+          {{- end }}
+          resources:
+            {{- toYaml .Values.clickstack.collector.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/otelcol
+      volumes:
+        - name: config
+          configMap:
+            name: {{ $name }}
+{{- end }}

--- a/deploy/helm/platform/templates/clickstack/collector.yaml
+++ b/deploy/helm/platform/templates/clickstack/collector.yaml
@@ -1,16 +1,9 @@
 {{- if .Values.clickstack.enabled }}
 {{- /*
-Platform-owned OpenTelemetry collector for the ClickStack telemetry backend.
-
-Replaces the subchart's bundled collector (clickstack.otel-collector.enabled=false). That
-one is driven by HyperDX over OpAMP, which injects an ingestion-API-key check on the OTLP
-receivers — token-based access control we deliberately avoid. This collector runs a static
-config with NO auth extension and NO OpAMP; reachability is gated entirely by the Istio
-AuthorizationPolicy alongside (authorizationpolicy.yaml).
-
-It reuses the subchart's shared `clickstack-config` ConfigMap + `clickstack-secret` Secret
-for the ClickHouse connection, writing as the `otelcollector` user (granted CREATE on
-default.*) into db `default` with the standard otel_* tables that HyperDX's sources read.
+Platform-owned OTel collector; replaces the subchart's OpAMP/token-gated one so collector
+access is gated by the Istio AuthorizationPolicy alongside. Reuses the subchart's
+clickstack-config/clickstack-secret for the ClickHouse connection.
+See docs/architecture/observability.md.
 */ -}}
 {{- $name := include "platform.clickstack.collector.fullname" . }}
 ---
@@ -114,8 +107,7 @@ spec:
         - name: collector
           image: {{ .Values.clickstack.collector.image }}
           args: ["--config=/etc/otelcol/config.yaml"]
-          # CLICKHOUSE_ENDPOINT/USER/PASSWORD come from the subchart's shared config/secret.
-          # OPAMP_SERVER_URL is also present there but ignored — our config has no opamp.
+          # ClickHouse conn from the shared config/secret; OPAMP_SERVER_URL there is ignored (no opamp in our config).
           envFrom:
             - configMapRef:
                 name: clickstack-config

--- a/deploy/helm/platform/templates/clickstack/collector.yaml
+++ b/deploy/helm/platform/templates/clickstack/collector.yaml
@@ -22,13 +22,35 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            # Retain request headers as client metadata so the
+            # resource/agent-identity processor can read the gateway-stamped
+            # x-platform-agent-id header.
+            include_metadata: true
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: true
     processors:
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      # Trusted agent attribution. The paired gateway Envoy stamps the
+      # x-platform-agent-id header (overwriting anything the agent set) on the
+      # telemetry it forwards here; promote it to the platform.agent.id resource
+      # attribute. delete-then-set so a forged value can never survive a missing
+      # header: unconditionally drop any client-supplied platform.agent.id, then
+      # set it ONLY from the trusted header. MUST run before `batch`, which emits
+      # a new context and drops per-request client metadata. Telemetry with no
+      # header (platform components) ends up with no platform.agent.id, which is
+      # how the read path tells agent telemetry apart. See
+      # docs/architecture/observability.md.
+      resource/agent-identity:
+        attributes:
+          - key: platform.agent.id
+            action: delete
+          - key: platform.agent.id
+            from_context: "metadata.x-platform-agent-id"
+            action: upsert
       batch: {}
     exporters:
       clickhouse:
@@ -45,15 +67,15 @@ data:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource/agent-identity, batch]
           exporters: [clickhouse]
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource/agent-identity, batch]
           exporters: [clickhouse]
         metrics:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource/agent-identity, batch]
           exporters: [clickhouse]
 ---
 apiVersion: v1

--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -79,6 +79,16 @@ spec:
               value: {{ .Values.istio.trustDomain | quote }}
             - name: PLATFORM_ISTIO_WAYPOINT_NAME
               value: {{ .Values.istio.waypointName | quote }}
+            {{- if .Values.clickstack.enabled }}
+            # Telemetry attribution: when the bundled telemetry backend is on,
+            # each gateway gains a collector egress chain that MITM-terminates
+            # this host and stamps the trusted x-platform-agent-id header. Empty
+            # otherwise, so the chain (and the leaf SAN entry) are not rendered.
+            - name: PLATFORM_TELEMETRY_COLLECTOR_HOST
+              value: "{{ include "platform.clickstack.collector.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: PLATFORM_TELEMETRY_COLLECTOR_PORT
+              value: "4318"
+            {{- end }}
             - name: PLATFORM_RELEASE_DOMAIN
               value: "svc.cluster.local"
             - name: ENVOY_IMAGE

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -289,17 +289,6 @@ clickstack:
             requests:
               storage: 20Gi
 
-  # Keep MongoDB out of the ambient mesh: ztunnel tears down the MongoDB driver's
-  # long-lived monitor connections, which breaks HyperDX (agent pods opt out the same way).
-  mongodb:
-    spec:
-      statefulSet:
-        spec:
-          template:
-            metadata:
-              labels:
-                istio.io/dataplane-mode: none
-
 # -- Keycloak (OIDC identity provider)
 keycloak:
   enabled: true

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -239,6 +239,63 @@ redis:
       cpu: 200m
       memory: 256Mi
 
+# -- Agent-telemetry backend (ClickStack: ClickHouse + Keeper + MongoDB + HyperDX, plus
+# the platform's own OpenTelemetry collector). Receives and stores agent telemetry.
+# FOUNDATION component — it only stands the backend up (a running OTLP endpoint + a
+# persistent store). Agents do not yet export to it and the user-facing read path is
+# separate; both are out of scope for now.
+#
+# DISABLED by default: a heavy multi-pod stack with no producer yet. Enable per-cluster
+# once telemetry export is wired. REQUIRES the clickstack-operators chart (ClickHouse +
+# MongoDB operators + CRDs) to be installed out-of-band FIRST — see deploy/tasks.toml
+# (cluster:install) and the install runbook; the operators are treated like Istio and
+# cert-manager.
+#
+# Everything under `clickstack:` EXCEPT `enabled` and `collector` is forwarded to the
+# upstream `clickstack` subchart (see Chart.yaml); those keys mirror that chart's values
+# and deep-merge over its defaults. `collector` configures the platform's OWN collector
+# (templates/clickstack/), which replaces the subchart's HyperDX/OpAMP-managed collector so
+# that collector access is gated by an Istio AuthorizationPolicy, not HyperDX tokens.
+clickstack:
+  enabled: false
+
+  # -- Platform-owned OpenTelemetry collector (NOT forwarded to the subchart). Static
+  # config, no OpAMP, no ingestion key; reachability is gated by the AuthorizationPolicy
+  # in templates/clickstack/. Writes to the operator ClickHouse as the `otelcollector`
+  # user (db `default`, standard otel_* tables) which HyperDX's sources already read.
+  collector:
+    annotations: {}
+    podAnnotations: {}
+    image: otel/opentelemetry-collector-contrib:0.146.1
+    resources:
+      requests:
+        cpu: 100m
+        memory: 256Mi
+      limits:
+        cpu: "1"
+        memory: 512Mi
+
+  # ---------- forwarded to the `clickstack` subchart ----------
+
+  # Disable the subchart's HyperDX/OpAMP-managed collector; we run our own (above). Its
+  # static config only ships a debug exporter — the ClickHouse pipeline AND the ingestion-
+  # key auth are delivered by HyperDX over OpAMP, which is exactly the token-based access
+  # control we are replacing with Istio. HyperDX still reads ClickHouse directly.
+  otel-collector:
+    enabled: false
+
+  clickhouse:
+    cluster:
+      spec:
+        dataVolumeClaimSpec:
+          resources:
+            requests:
+              storage: 20Gi
+
+  # NOTE for production: override the subchart's default app-state secrets
+  # (`clickstack.hyperdx.secrets.*`: HYPERDX_API_KEY, CLICKHOUSE_PASSWORD,
+  # CLICKHOUSE_APP_PASSWORD, MONGODB_PASSWORD) — they default to well-known placeholders.
+
 # -- Keycloak (OIDC identity provider)
 keycloak:
   enabled: true

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -289,6 +289,17 @@ clickstack:
             requests:
               storage: 20Gi
 
+  # Keep MongoDB out of the ambient mesh: ztunnel tears down the MongoDB driver's
+  # long-lived monitor connections, which breaks HyperDX (agent pods opt out the same way).
+  mongodb:
+    spec:
+      statefulSet:
+        spec:
+          template:
+            metadata:
+              labels:
+                istio.io/dataplane-mode: none
+
 # -- Keycloak (OIDC identity provider)
 keycloak:
   enabled: true

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -239,30 +239,14 @@ redis:
       cpu: 200m
       memory: 256Mi
 
-# -- Agent-telemetry backend (ClickStack: ClickHouse + Keeper + MongoDB + HyperDX, plus
-# the platform's own OpenTelemetry collector). Receives and stores agent telemetry.
-# FOUNDATION component — it only stands the backend up (a running OTLP endpoint + a
-# persistent store). Agents do not yet export to it and the user-facing read path is
-# separate; both are out of scope for now.
-#
-# DISABLED by default: a heavy multi-pod stack with no producer yet. Enable per-cluster
-# once telemetry export is wired. REQUIRES the clickstack-operators chart (ClickHouse +
-# MongoDB operators + CRDs) to be installed out-of-band FIRST — see deploy/tasks.toml
-# (cluster:install) and the install runbook; the operators are treated like Istio and
-# cert-manager.
-#
-# Everything under `clickstack:` EXCEPT `enabled` and `collector` is forwarded to the
-# upstream `clickstack` subchart (see Chart.yaml); those keys mirror that chart's values
-# and deep-merge over its defaults. `collector` configures the platform's OWN collector
-# (templates/clickstack/), which replaces the subchart's HyperDX/OpAMP-managed collector so
-# that collector access is gated by an Istio AuthorizationPolicy, not HyperDX tokens.
+# -- Agent-telemetry backend (ClickStack). Off by default. Requires the clickstack-operators
+# chart installed out-of-band first (deploy/tasks.toml). See docs/architecture/observability.md.
+# Keys other than `enabled`/`collector` are forwarded to the clickstack subchart.
 clickstack:
   enabled: false
 
-  # -- Platform-owned OpenTelemetry collector (NOT forwarded to the subchart). Static
-  # config, no OpAMP, no ingestion key; reachability is gated by the AuthorizationPolicy
-  # in templates/clickstack/. Writes to the operator ClickHouse as the `otelcollector`
-  # user (db `default`, standard otel_* tables) which HyperDX's sources already read.
+  # Our own OTLP collector (replaces the subchart's OpAMP/token-gated one): static config,
+  # no auth, gated by the AuthorizationPolicy in templates/clickstack/.
   collector:
     annotations: {}
     podAnnotations: {}
@@ -275,24 +259,15 @@ clickstack:
         cpu: "1"
         memory: 512Mi
 
-  # ---------- forwarded to the `clickstack` subchart ----------
+  # --- forwarded to the clickstack subchart ---
+  # Third-party images pinned to the quay.io/dam-agents mirror (mirror these by hand):
+  #   hyperdx:2.27.0                <- docker.hyperdx.io/hyperdx/hyperdx:2.27.0
+  #   clickhouse-server:25.7-alpine <- clickhouse/clickhouse-server:25.7-alpine
+  #   busybox:1.37.0               <- busybox
+  # Production must override clickstack.hyperdx.secrets.* (placeholders by default).
 
-  # All third-party images are pinned and pulled from the quay.io/dam-agents mirror, like
-  # the other bundled images. Mirror these exact tags by hand:
-  #   quay.io/dam-agents/hyperdx:2.27.0                          <- docker.hyperdx.io/hyperdx/hyperdx:2.27.0
-  #   quay.io/dam-agents/clickhouse-server:25.7-alpine           <- clickhouse/clickhouse-server:25.7-alpine
-  #   quay.io/dam-agents/busybox:1.37.0                          <- busybox (HyperDX mongo-wait init)
-  #   quay.io/dam-agents/opentelemetry-collector-contrib:0.146.1 <- otel/opentelemetry-collector-contrib:0.146.1 (our collector, above)
-  # The two operators are mirrored + pinned in deploy/tasks.toml (cluster:install):
-  #   quay.io/dam-agents/clickhouse-operator:v0.0.1              <- ghcr.io/clickhouse/clickhouse-operator:v0.0.1
-  #   quay.io/dam-agents/mongodb-kubernetes:1.7.0                <- quay.io/mongodb/mongodb-kubernetes:1.7.0
-
-  # Disable the subchart's HyperDX/OpAMP-managed collector; we run our own (above). Its
-  # static config only ships a debug exporter — the ClickHouse pipeline AND the ingestion-
-  # key auth are delivered by HyperDX over OpAMP, which is exactly the token-based access
-  # control we are replacing with Istio. HyperDX still reads ClickHouse directly.
   otel-collector:
-    enabled: false
+    enabled: false        # we run our own collector (above)
 
   hyperdx:
     deployment:
@@ -313,10 +288,6 @@ clickstack:
           resources:
             requests:
               storage: 20Gi
-
-  # NOTE for production: override the subchart's default app-state secrets
-  # (`clickstack.hyperdx.secrets.*`: HYPERDX_API_KEY, CLICKHOUSE_PASSWORD,
-  # CLICKHOUSE_APP_PASSWORD, MONGODB_PASSWORD) — they default to well-known placeholders.
 
 # -- Keycloak (OIDC identity provider)
 keycloak:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -266,7 +266,7 @@ clickstack:
   collector:
     annotations: {}
     podAnnotations: {}
-    image: otel/opentelemetry-collector-contrib:0.146.1
+    image: quay.io/dam-agents/opentelemetry-collector-contrib:0.146.1
     resources:
       requests:
         cpu: 100m
@@ -277,6 +277,16 @@ clickstack:
 
   # ---------- forwarded to the `clickstack` subchart ----------
 
+  # All third-party images are pinned and pulled from the quay.io/dam-agents mirror, like
+  # the other bundled images. Mirror these exact tags by hand:
+  #   quay.io/dam-agents/hyperdx:2.27.0                          <- docker.hyperdx.io/hyperdx/hyperdx:2.27.0
+  #   quay.io/dam-agents/clickhouse-server:25.7-alpine           <- clickhouse/clickhouse-server:25.7-alpine
+  #   quay.io/dam-agents/busybox:1.37.0                          <- busybox (HyperDX mongo-wait init)
+  #   quay.io/dam-agents/opentelemetry-collector-contrib:0.146.1 <- otel/opentelemetry-collector-contrib:0.146.1 (our collector, above)
+  # The two operators are mirrored + pinned in deploy/tasks.toml (cluster:install):
+  #   quay.io/dam-agents/clickhouse-operator:v0.0.1              <- ghcr.io/clickhouse/clickhouse-operator:v0.0.1
+  #   quay.io/dam-agents/mongodb-kubernetes:1.7.0                <- quay.io/mongodb/mongodb-kubernetes:1.7.0
+
   # Disable the subchart's HyperDX/OpAMP-managed collector; we run our own (above). Its
   # static config only ships a debug exporter — the ClickHouse pipeline AND the ingestion-
   # key auth are delivered by HyperDX over OpAMP, which is exactly the token-based access
@@ -284,9 +294,21 @@ clickstack:
   otel-collector:
     enabled: false
 
+  hyperdx:
+    deployment:
+      image:
+        repository: quay.io/dam-agents/hyperdx
+        tag: "2.27.0"
+      waitForMongodb:
+        image: "quay.io/dam-agents/busybox:1.37.0"
+
   clickhouse:
     cluster:
       spec:
+        containerTemplate:
+          image:
+            repository: quay.io/dam-agents/clickhouse-server
+            tag: "25.7-alpine"
         dataVolumeClaimSpec:
           resources:
             requests:

--- a/deploy/helm/tasks.toml
+++ b/deploy/helm/tasks.toml
@@ -1,14 +1,32 @@
 ["helm:check"]
 depends = ["helm:check:*"]
 
+# Build chart dependencies (the clickstack telemetry subchart + its nested
+# opentelemetry-collector) into charts/ from Chart.lock. lint and render both need the
+# dependency present, so they depend on this. `helm repo add` is idempotent.
+["helm:deps"]
+dir = "{{config_root}}/deploy/helm/platform"
+run = """
+helm repo add clickstack https://clickhouse.github.io/ClickStack-helm-charts >/dev/null 2>&1 || true
+helm dependency build .
+"""
+sources = ["Chart.yaml", "Chart.lock"]
+outputs = ["charts/*.tgz"]
+
 ["helm:check:lint"]
+depends = ["helm:deps"]
 dir = "{{config_root}}/deploy/helm/platform"
 run = "helm lint ."
 sources = ["**/*.yaml", "**/*.yml", "**/*.tpl"]
 
+# Render with the telemetry backend enabled so its manifests are schema-checked too. The
+# clickstack subchart emits operator custom resources (ClickHouseCluster/KeeperCluster/
+# MongoDBCommunity) that kubeconform has no schema for — skip them alongside the existing
+# CRD/Istio kinds.
 ["helm:check:render"]
+depends = ["helm:deps"]
 dir = "{{config_root}}/deploy/helm/platform"
-run = "helm template platform . --include-crds --set terms.version=test --set terms.text='Test Terms' | kubeconform -strict -summary -skip Certificate,Issuer,ClusterIssuer,AuthorizationPolicy,Gateway,SecurityContextConstraints,CustomResourceDefinition"
+run = "helm template platform . --include-crds --set terms.version=test --set terms.text='Test Terms' --set clickstack.enabled=true | kubeconform -strict -summary -skip Certificate,Issuer,ClusterIssuer,AuthorizationPolicy,Gateway,SecurityContextConstraints,CustomResourceDefinition,ClickHouseCluster,KeeperCluster,MongoDBCommunity"
 sources = ["**/*.yaml", "**/*.yml", "**/*.tpl"]
 
 ["helm:setup"]

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -347,9 +347,8 @@ YAML
 # chart's validate-istio.yaml asserts this label is present).
 kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mode=ambient --overwrite
 
-# Resolve chart dependencies (the clickstack telemetry subchart) into charts/ before any
-# helm template/upgrade below. charts/ is gitignored (build artifact), and Helm requires
-# declared dependencies to be present even when clickstack.enabled=false.
+# Resolve chart deps into charts/ (gitignored) — Helm needs them present even when
+# clickstack.enabled=false.
 helm repo add clickstack https://clickhouse.github.io/ClickStack-helm-charts >/dev/null 2>&1 || true
 helm dependency build deploy/helm/platform
 
@@ -437,15 +436,11 @@ echo "Installing/upgrading Platform chart..."
 kubectl --kubeconfig="$KUBECONFIG" apply --server-side --force-conflicts -f deploy/helm/platform/crds/
 kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=60s -f deploy/helm/platform/crds/
 
-# ClickStack telemetry operators (ClickHouse + MongoDB) + their CRDs — installed
-# out-of-band like Istio/cert-manager, because Helm never upgrades a chart's crds/ on an
-# existing release. Gated on CLICKSTACK=1 (the telemetry workload is off by default); when
-# set, also enable the bundled clickstack workload in the chart upgrade below.
+# ClickStack operators + CRDs — installed out-of-band (Helm won't upgrade crds/), gated on
+# CLICKSTACK=1; when set, also enable the clickstack workload below. Operator images from
+# the quay.io/dam-agents mirror (their db/agent images stay upstream).
 if [ -n "${CLICKSTACK:-}" ]; then
   echo "Installing ClickStack operators (ClickHouse + MongoDB)..."
-  # Pinned chart version + operator images pulled from the quay.io/dam-agents mirror
-  # (mirror these tags by hand). Only the operator images are redirected — the MongoDB
-  # operator's own database/agent images stay upstream for now.
   helm --kubeconfig="$KUBECONFIG" upgrade --install clickstack-operators clickstack/clickstack-operators \
     --version 1.0.0 --namespace clickstack-operators --create-namespace --wait --timeout 5m \
     --set clickhouse-operator.manager.image.repository=quay.io/dam-agents/clickhouse-operator \

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -480,6 +480,18 @@ fi
 echo "Waiting for deployments to be ready..."
 kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Available deployment --all --timeout=10m
 
+# HyperDX's MongoDB driver can wedge if it starts before Mongo/ztunnel are ready (its
+# long-lived monitor connection is closed, topology stuck Unknown, and it does not
+# self-heal). Once the stack is up and Mongo is ready, a warm restart connects cleanly and
+# stays healthy in-mesh — so restart it here. (Prod installs should likewise ensure HyperDX
+# (re)starts after Mongo is ready.)
+if [ -n "${CLICKSTACK:-}" ] && [ "$NO_RESTART" != true ]; then
+  echo "Restarting HyperDX onto a ready MongoDB..."
+  kubectl --kubeconfig="$KUBECONFIG" rollout status statefulset/platform-clickstack-mongodb --timeout=5m || true
+  kubectl --kubeconfig="$KUBECONFIG" rollout restart deployment platform-clickstack-app
+  kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-clickstack-app --timeout=5m
+fi
+
 # 7. Prune dangling image layers (issue #244). After repeated reinstalls,
 # old `:latest` SHAs lose their tag to the freshly imported one and become
 # `<none>:<none>`. Drop only those — `crictl rmi --prune` would also wipe

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -443,8 +443,14 @@ kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=60
 # set, also enable the bundled clickstack workload in the chart upgrade below.
 if [ -n "${CLICKSTACK:-}" ]; then
   echo "Installing ClickStack operators (ClickHouse + MongoDB)..."
+  # Pinned chart version + operator images pulled from the quay.io/dam-agents mirror
+  # (mirror these tags by hand). Only the operator images are redirected — the MongoDB
+  # operator's own database/agent images stay upstream for now.
   helm --kubeconfig="$KUBECONFIG" upgrade --install clickstack-operators clickstack/clickstack-operators \
-    --namespace clickstack-operators --create-namespace --wait --timeout 5m
+    --version 1.0.0 --namespace clickstack-operators --create-namespace --wait --timeout 5m \
+    --set clickhouse-operator.manager.image.repository=quay.io/dam-agents/clickhouse-operator \
+    --set clickhouse-operator.manager.image.tag=v0.0.1 \
+    --set mongodb-operator.registry.operator=quay.io/dam-agents
   kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=120s \
     crd/clickhouseclusters.clickhouse.com \
     crd/keeperclusters.clickhouse.com \

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -347,6 +347,12 @@ YAML
 # chart's validate-istio.yaml asserts this label is present).
 kubectl --kubeconfig="$KUBECONFIG" label namespace default istio.io/dataplane-mode=ambient --overwrite
 
+# Resolve chart dependencies (the clickstack telemetry subchart) into charts/ before any
+# helm template/upgrade below. charts/ is gitignored (build artifact), and Helm requires
+# declared dependencies to be present even when clickstack.enabled=false.
+helm repo add clickstack https://clickhouse.github.io/ClickStack-helm-charts >/dev/null 2>&1 || true
+helm dependency build deploy/helm/platform
+
 # 3. Load images into k3s (built by depends: image:*, or out-of-band in CI).
 # SKIP_IMAGE_LOAD skips the containerd import — cluster:helm reuses the SHAs
 # already loaded, so pods keep their pinned images. SKIP_IMAGE_BUILD alone (CI)
@@ -430,6 +436,21 @@ echo "Installing/upgrading Platform chart..."
 # the chart ever grows a CR instance (today it deliberately ships none).
 kubectl --kubeconfig="$KUBECONFIG" apply --server-side --force-conflicts -f deploy/helm/platform/crds/
 kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=60s -f deploy/helm/platform/crds/
+
+# ClickStack telemetry operators (ClickHouse + MongoDB) + their CRDs — installed
+# out-of-band like Istio/cert-manager, because Helm never upgrades a chart's crds/ on an
+# existing release. Gated on CLICKSTACK=1 (the telemetry workload is off by default); when
+# set, also enable the bundled clickstack workload in the chart upgrade below.
+if [ -n "${CLICKSTACK:-}" ]; then
+  echo "Installing ClickStack operators (ClickHouse + MongoDB)..."
+  helm --kubeconfig="$KUBECONFIG" upgrade --install clickstack-operators clickstack/clickstack-operators \
+    --namespace clickstack-operators --create-namespace --wait --timeout 5m
+  kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=120s \
+    crd/clickhouseclusters.clickhouse.com \
+    crd/keeperclusters.clickhouse.com \
+    crd/mongodbcommunity.mongodbcommunity.mongodb.com
+  HELM_EXTRA_ARGS+=(--set clickstack.enabled=true)
+fi
 
 # No --wait: the keycloak-provision post-install hook imports the platform realm
 # after deployments come up. With --wait, helm would block on readiness

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -438,14 +438,17 @@ kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=60
 
 # ClickStack operators + CRDs — installed out-of-band (Helm won't upgrade crds/), gated on
 # CLICKSTACK=1; when set, also enable the clickstack workload below. Operator images from
-# the quay.io/dam-agents mirror (their db/agent images stay upstream).
+# the quay.io/dam-agents mirror (their db/agent images stay upstream). The MongoDB operator
+# defaults to watching only its own namespace, so it must be pointed at the release ns
+# (default) where the MongoDBCommunity CR lives, or HyperDX hangs waiting on mongodb.
 if [ -n "${CLICKSTACK:-}" ]; then
   echo "Installing ClickStack operators (ClickHouse + MongoDB)..."
   helm --kubeconfig="$KUBECONFIG" upgrade --install clickstack-operators clickstack/clickstack-operators \
     --version 1.0.0 --namespace clickstack-operators --create-namespace --wait --timeout 5m \
     --set clickhouse-operator.manager.image.repository=quay.io/dam-agents/clickhouse-operator \
     --set clickhouse-operator.manager.image.tag=v0.0.1 \
-    --set mongodb-operator.registry.operator=quay.io/dam-agents
+    --set mongodb-operator.registry.operator=quay.io/dam-agents \
+    --set mongodb-operator.operator.watchNamespace=default
   kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Established --timeout=120s \
     crd/clickhouseclusters.clickhouse.com \
     crd/keeperclusters.clickhouse.com \

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last verified: 2026-06-12
+Last verified: 2026-06-26
 
 ## System context
 
@@ -66,6 +66,7 @@ Each page is the authoritative, self-contained description of its subsystem — 
 - [connections](architecture/connections.md) — unified Connection / Contribution model, runtime channel between api-server and agent-runtime, transactional outbox + worker delivery, agent-side driver model.
 - [usage-tracking](architecture/usage-tracking.md) — append-only activity log in Postgres, SQL views as the read interface, HMAC-pseudonymized identifiers, inspector-role gating.
 - [logging](architecture/logging.md) — Pino structured logging to stdout, and the real-identity security audit trail built on it (the forensic counterpart to pseudonymized usage-tracking).
+- [observability](architecture/observability.md) — the optional, bundled agent-telemetry backend: an OTLP collector writing OpenTelemetry signals into a columnar store with an exploration UI, gated by the mesh rather than ingestion tokens.
 - [supply-chain](security/supply-chain.md) — how each external dependency type is scanned for CVEs and defended against supply-chain attacks.
 - [code](security/code.md) — CodeQL SAST and pre-commit hardening.
 - [secrets](security/secrets.md) — GitHub secret storage, scanning, and push protection.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,0 +1,59 @@
+# Observability (agent telemetry)
+
+Last verified: 2026-06-26
+
+## Overview
+
+The telemetry backend is an **optional, bundled subsystem** that receives and stores the OpenTelemetry signals (logs, traces, metrics) agents emit — the substrate for answering *how agents run*: token consumption, cost, per-sub-agent breakdown. It is the *receiving and storage* half only; configuring agents to export to it, and the user-facing read path, are separate concerns.
+
+It is implemented with **ClickStack**: a columnar telemetry store (ClickHouse) fronted by an exploration UI (HyperDX), plus a separate document store backing that UI's own application state. Installing or upgrading the platform brings the stack up when it is enabled, but it is **disabled by default** — it is a heavy, multi-pod stack, and until agents are wired to export it would receive nothing, so operators opt in per install.
+
+## Topology and roles
+
+```mermaid
+flowchart LR
+  exporters[agent exporters]
+  subgraph cluster[Platform install]
+    collector[OTel collector]
+    store[(telemetry store)]
+    ui[exploration UI]
+    appstate[(UI app state)]
+  end
+  exporters -->|OTLP| collector
+  collector -->|write| store
+  ui -->|read| store
+  ui --> appstate
+```
+
+- **Collector** — an OpenTelemetry collector that receives OTLP and writes the signals into the telemetry store. It is platform-owned (deliberately not the collector ClickStack bundles — see *Access control*) and holds no upstream credentials; it only ingests telemetry.
+- **Telemetry store** — a columnar analytical database built for high-volume, high-cardinality, time-series telemetry. It is the only place telemetry lives.
+- **Exploration UI** — reads the telemetry store directly so an operator can explore signals. Its own application state (dashboards, sources, saved views) lives in a separate document store that holds no telemetry.
+
+The whole stack sits inside the cluster trust boundary.
+
+## Operators are install-time infrastructure
+
+The telemetry store and the UI's app-state store are managed by Kubernetes **operators** driven by custom resources. Like the service mesh and the certificate manager, those operators and their CRDs are installed out-of-band at cluster-install time rather than by the platform chart: Helm never upgrades a chart's CRDs on an existing release, so CRD-owning infrastructure stays outside the chart. The chart ships only the custom resources and the platform-owned collector, which roll with an ordinary platform upgrade.
+
+## Access control: the mesh, not ingestion tokens
+
+ClickStack's default posture secures the collector with an ingestion key the UI issues and manages — application-layer, token-based access control. The platform deliberately does **not** rely on that. The collector is gated the same way as the rest of the platform: by the **service mesh**, through an authorization policy that admits only the platform's own namespaces — the release namespace and the agent namespace — and denies everything else. This keeps telemetry access on the same SPIFFE-principal model as the rest of the system (see [security-and-credentials](security-and-credentials.md)) rather than introducing a parallel token scheme.
+
+Making the mesh the sole gate is why the collector is platform-owned. ClickStack's bundled collector takes its configuration — including the ingestion-key check — dynamically from the exploration UI, so that configuration cannot be the access boundary here. The platform instead runs its own collector with a fixed configuration and no key enforcement. The UI is unaffected: it reads the telemetry store directly, not the collector.
+
+How agent telemetry actually reaches the collector, and the mesh identity that traffic carries, belong to the export path and are described where that lands.
+
+## Persistence
+
+The telemetry store is a **fourth durable substrate** beyond the three in [persistence](persistence.md) (Postgres, the Agent/Fork custom resources, the per-Agent PVC), and it sits outside that platform/agent split — neither the agent nor the controller touches it. Both the telemetry data and the UI's app-state persist on operator-managed volumes that survive pod restarts and a chart uninstall; losing those volumes loses telemetry history and nothing else depends on them for correctness. When the subsystem is disabled, none of it exists.
+
+## Relationship to logging and usage-tracking
+
+This subsystem is distinct from two neighbours and does not overlap them:
+
+- [logging](logging.md) owns structured operational logs and the real-identity security audit trail, emitted to stdout.
+- [usage-tracking](usage-tracking.md) owns pseudonymized usage analytics in Postgres — an append-only activity log read through SQL views.
+
+Telemetry here is the OpenTelemetry-native, explorable signal pipeline: a different store (columnar, not Postgres), a different shape (OTLP logs/traces/metrics), and a different read surface (the exploration UI). Postgres remains the right home for coarse usage analytics; it cannot serve high-volume telemetry, which is the reason this subsystem exists at all.
+
+See [`deploy/helm/platform/`](../../deploy/helm/platform/) for the chart shape — the `clickstack` values block, and the collector and authorization policy under `templates/clickstack/`.

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,6 +1,6 @@
 # Observability (agent telemetry)
 
-Last verified: 2026-06-26
+Last verified: 2026-06-29
 
 ## Overview
 
@@ -41,7 +41,13 @@ ClickStack's default posture secures the collector with an ingestion key the UI 
 
 Making the mesh the sole gate is why the collector is platform-owned. ClickStack's bundled collector takes its configuration — including the ingestion-key check — dynamically from the exploration UI, so that configuration cannot be the access boundary here. The platform instead runs its own collector with a fixed configuration and no key enforcement. The UI is unaffected: it reads the telemetry store directly, not the collector.
 
-How agent telemetry actually reaches the collector, and the mesh identity that traffic carries, belong to the export path and are described where that lands.
+## Trusted attribution
+
+Telemetry only answers *whose agents ran, and how* if each record is reliably tied to the agent that produced it — and agents run untrusted code, so the attribution cannot be taken from what the agent put in its own telemetry. It comes instead from the platform-controlled path the telemetry already travels.
+
+Every agent's egress, telemetry included, leaves through its **paired gateway pod**: the agent has no other admitted route (see [security-and-credentials](security-and-credentials.md)), and the gateway proxy's configuration is controller-rendered, not agent-writable. When the telemetry backend is enabled, that gateway proxy intercepts any agent OTLP bound for the collector and stamps a trusted `platform.agent.id` identifying the producing agent — **overwriting** anything the agent set, since the value is fixed in this gateway's own per-agent configuration. The collector then promotes that value to a `platform.agent.id` resource attribute on every signal in the request, and **drops any agent-supplied `platform.agent.id` that did not arrive from the gateway**, so a forged value can never survive.
+
+The guarantee is **attribution, not content integrity**: an agent can still misreport its own numbers (inflate a token count), but it can only ever pollute *its own* telemetry — never make its telemetry appear under another agent or user. The owner-scoped read path resolves `platform.agent.id` to the owning user; telemetry that carries no `platform.agent.id` (the platform's own components) is not agent telemetry and is never attributed to a user. The attribute is namespaced under the permanent `platform` codename so it never collides with OpenTelemetry semantic-convention or agent-self-reported `agent.*` attributes.
 
 ## Persistence
 

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -19,6 +19,8 @@ Platform persists state on three durable substrates, split cleanly between the p
 
 The controller and api-server never write the same surface — the status subresource makes the split structural, not conventional. The agent's only durable surface is the PVC; everything the platform knows *about* the agent is mirrored onto Postgres or the Agent CR by the api-server or controller, not by the agent itself.
 
+The optional agent-telemetry backend adds a fourth durable substrate, outside this split — see [observability](observability.md). It is operator-managed and self-contained: neither the agent nor the controller touches it, and it exists only when that subsystem is enabled.
+
 ## Diagram
 
 ```mermaid

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -73,6 +73,15 @@ type Config struct {
 	// AuthorizationPolicy's targetRefs. Must match the Helm chart's
 	// `istio.waypointName`.
 	IstioWaypointName string
+	// TelemetryCollectorHost is the in-cluster DNS of the platform OTLP
+	// collector the gateway forwards agent telemetry to. Empty when the
+	// telemetry backend is disabled; the chart sets it from
+	// `clickstack.enabled`. When set, each gateway gains a collector egress
+	// chain that stamps the trusted `x-platform-agent-id` header so the
+	// collector can attribute telemetry to the producing instance.
+	TelemetryCollectorHost string
+	// TelemetryCollectorPort is the collector's OTLP/HTTP port (default 4318).
+	TelemetryCollectorPort int
 }
 
 func LoadFromEnv() (*Config, error) {
@@ -144,6 +153,8 @@ func LoadFromEnv() (*Config, error) {
 	cfg.ExtAuthzHoldSeconds = envOrDefaultInt("EXT_AUTHZ_HOLD_SECONDS", 1800)
 	cfg.IstioTrustDomain = envOrDefault("PLATFORM_ISTIO_TRUST_DOMAIN", "cluster.local")
 	cfg.IstioWaypointName = envOrDefault("PLATFORM_ISTIO_WAYPOINT_NAME", "apiserver-waypoint")
+	cfg.TelemetryCollectorHost = os.Getenv("PLATFORM_TELEMETRY_COLLECTOR_HOST")
+	cfg.TelemetryCollectorPort = envOrDefaultInt("PLATFORM_TELEMETRY_COLLECTOR_PORT", 4318)
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
@@ -250,6 +261,13 @@ func (c *Config) ExtAuthzHostFor(instanceID string) string {
 func (c *Config) HarnessHost() string {
 	return fmt.Sprintf("%s-apiserver-harness.%s.svc.cluster.local", c.ReleaseName, c.ReleaseNamespace)
 }
+
+// TelemetryEnabled reports whether the agent-telemetry backend is configured
+// (collector host set by the chart from `clickstack.enabled`). When true, each
+// gateway renders a collector egress chain that stamps the trusted agent id,
+// and the leaf cert is issued (and mounted) even for an instance with no
+// credential Secrets.
+func (c *Config) TelemetryEnabled() bool { return c.TelemetryCollectorHost != "" }
 
 // PrincipalFor returns the SPIFFE principal string for `instanceID`,
 // matching how istiod stamps workload certs (`<td>/ns/<ns>/sa/<sa>`).

--- a/packages/controller/pkg/config/config_test.go
+++ b/packages/controller/pkg/config/config_test.go
@@ -42,6 +42,32 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	assert.Equal(t, "platform-extauthz-inst-1.default.svc.cluster.local", cfg.ExtAuthzHostFor("inst-1"))
 }
 
+func TestLoadFromEnv_Telemetry(t *testing.T) {
+	// Off by default: no collector host, port defaults to 4318.
+	setEnv(t, map[string]string{
+		"PLATFORM_RELEASE_NAME": "platform",
+		"POD_NAME":              "controller-0",
+	})
+	cfg, err := LoadFromEnv()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.TelemetryCollectorHost)
+	assert.False(t, cfg.TelemetryEnabled())
+	assert.Equal(t, 4318, cfg.TelemetryCollectorPort)
+
+	// Configured by the chart when clickstack is enabled.
+	setEnv(t, map[string]string{
+		"PLATFORM_RELEASE_NAME":             "platform",
+		"POD_NAME":                          "controller-0",
+		"PLATFORM_TELEMETRY_COLLECTOR_HOST": "platform-clickstack-collector.platform.svc.cluster.local",
+		"PLATFORM_TELEMETRY_COLLECTOR_PORT": "4318",
+	})
+	cfg, err = LoadFromEnv()
+	require.NoError(t, err)
+	assert.True(t, cfg.TelemetryEnabled())
+	assert.Equal(t, "platform-clickstack-collector.platform.svc.cluster.local", cfg.TelemetryCollectorHost)
+	assert.Equal(t, 4318, cfg.TelemetryCollectorPort)
+}
+
 // LoadFromEnv fails-loud when the chart-required fields are missing.
 func TestLoadFromEnv_RejectsMissingRequiredAgentBase(t *testing.T) {
 	setEnv(t, map[string]string{
@@ -220,6 +246,7 @@ func setEnv(t *testing.T, vars map[string]string) {
 		"AGENT_BASE", "AGENT_TEMPLATE_DEFAULTS",
 		"EXT_AUTHZ_PORT", "EXT_AUTHZ_HOLD_SECONDS",
 		"PLATFORM_ISTIO_TRUST_DOMAIN", "PLATFORM_ISTIO_WAYPOINT_NAME",
+		"PLATFORM_TELEMETRY_COLLECTOR_HOST", "PLATFORM_TELEMETRY_COLLECTOR_PORT",
 	} {
 		os.Unsetenv(key)
 		t.Cleanup(func() { os.Unsetenv(key) })

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -473,6 +473,22 @@ func hostShort(host string) string {
 	return hex.EncodeToString(h[:])[:8]
 }
 
+// hostInChains reports whether any per-host chain already terminates `host`.
+// Used to suppress the telemetry collector chain when the collector host
+// would collide with a credentialed/allow-only chain (duplicate
+// `server_names` is a fatal Envoy config error).
+func hostInChains(chains []envoyHostChain, host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, c := range chains {
+		if c.Host == host {
+			return true
+		}
+	}
+	return false
+}
+
 // Bootstrap template — TLS-intercepting CONNECT proxy.
 //
 // Topology:
@@ -832,6 +848,61 @@ static_resources:
 {{- end }}
                             timeout: 0s
 {{- end }}
+{{- if .Telemetry }}
+        # Telemetry egress. The agent exports OTLP/HTTP to the collector
+        # through this gateway (its only admitted egress route); we MITM-
+        # terminate here on the collector SNI and stamp the trusted
+        # x-platform-agent-id header, OVERWRITING anything the agent set, so the
+        # collector attributes the telemetry to this instance and no agent can
+        # forge another's identity. No ext_authz (platform-internal traffic,
+        # not user egress) and no credential injection. Forwards plaintext to
+        # the in-cluster collector; ztunnel wraps the gateway→collector hop in
+        # mTLS. The collector host is in the leaf SAN (see leaf.go), so the
+        # agent's TLS client validates this intercept cert.
+        - name: terminate_otel_collector
+          filter_chain_match:
+            server_names: [ "{{ .TelemetryCollectorHost }}" ]
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                tls_certificates:
+                  - certificate_chain: { filename: {{ .LeafTLSDir }}/tls.crt }
+                    private_key:      { filename: {{ .LeafTLSDir }}/tls.key }
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: terminate_otel_collector
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                route_config:
+                  name: forward_otel_collector
+                  virtual_hosts:
+                    - name: default
+                      domains: [ "*" ]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            # Pinned to the static plaintext collector cluster
+                            # (clusters list below); the agent's Host header
+                            # cannot steer the destination.
+                            cluster: otel_collector
+                            host_rewrite_literal: "{{ .TelemetryCollectorHost }}"
+                            timeout: 0s
+                          request_headers_to_add:
+                            # Trusted, unforgeable identity: OVERWRITE replaces
+                            # any x-platform-agent-id the agent supplied. The
+                            # value is fixed in this gateway's controller-
+                            # rendered config; the agent cannot change it.
+                            - header:
+                                key: x-platform-agent-id
+                                value: "{{ .InstanceID }}"
+                              append_action: OVERWRITE_IF_EXISTS_OR_ADD
+{{- end }}
         # SNI miss: every other host hits the L4 ext_authz catch-all, which
         # gates by SNI alone via the API server's gRPC ext_authz endpoint.
         # No TLS termination, no credential injection -- bytes pass through
@@ -999,6 +1070,30 @@ static_resources:
                     exact: {{ $chain.Host }}
 {{- end }}
 {{- end }}
+{{- if .Telemetry }}
+
+    # Pinned plaintext upstream for the telemetry collector chain. STRICT_DNS
+    # resolves {{ .TelemetryCollectorHost }}:{{ .TelemetryCollectorPort }}
+    # directly; the agent's Host header plays no role in destination selection.
+    # No upstream TLS — the collector is in-cluster and ztunnel wraps the
+    # gateway→collector hop in mTLS transparently. dns_lookup_family is set
+    # explicitly (STRICT_DNS defaults to IPv6-first AUTO) to match every other
+    # DNS cluster in this bootstrap.
+    - name: otel_collector
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_lookup_family: V4_PREFERRED
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: otel_collector
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: {{ .TelemetryCollectorHost }}
+                      port_value: {{ .TelemetryCollectorPort }}
+{{- end }}
 
     # Single gRPC ext_authz cluster: both Envoy filters (HTTP on
     # TLS-terminated chains, network on the catch-all) call the same
@@ -1032,14 +1127,17 @@ const envoyListenAddress = "0.0.0.0"
 // renderEnvoyBootstrap returns the Envoy bootstrap YAML for an instance's
 // paired gateway pod.
 //
+// `instanceID` is this gateway's *own* instance (agent or fork name); it is
+// the value stamped into the trusted `x-platform-agent-id` telemetry header.
 // `extAuthzInstanceID` is the instance whose per-instance ext-authz Service
-// the gateway dials. For long-lived pairs this equals the
-// instance name; for forks it is the parent instance's ID — fork pods
-// run as their *own* per-fork SA, but the parent owner's HITL
-// rules should gate fork egress, so the fork's gateway dials the parent's
-// per-instance ext-authz Service. The fork SA is admitted there via a
-// separate per-fork AuthorizationPolicy (`BuildForkExtAuthzAuthorizationPolicy`).
-func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains []envoyHostChain) (string, error) {
+// the gateway dials. For long-lived pairs the two are equal; for forks
+// `extAuthzInstanceID` is the *parent* instance's ID — fork pods run as their
+// *own* per-fork SA, but the parent owner's HITL rules should gate fork
+// egress, so the fork's gateway dials the parent's per-instance ext-authz
+// Service (admitted via `BuildForkExtAuthzAuthorizationPolicy`). The telemetry
+// header, by contrast, must carry the fork's own `instanceID` so its telemetry
+// attributes to the fork, not the parent.
+func renderEnvoyBootstrap(instanceID, extAuthzInstanceID string, cfg *config.Config, chains []envoyHostChain) (string, error) {
 	tmpl, err := template.New("envoy").Parse(envoyBootstrapTmpl)
 	if err != nil {
 		return "", err
@@ -1053,6 +1151,14 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 	// this exact string so the harness route is scoped to api-server
 	// traffic only — fall-through goes through the regular egress paths.
 	harnessAuthority := fmt.Sprintf("%s:%d", cfg.HarnessHost(), cfg.HarnessServerPort)
+	// Render the telemetry collector chain only when the backend is configured
+	// AND the collector host doesn't collide with a credentialed chain host —
+	// two filter chains sharing `server_names` is a fatal Envoy config error.
+	// A collision isn't expected in practice (the collector host is an internal
+	// Service DNS no agent would be granted a credential for), but guard
+	// structurally rather than crash-loop the gateway. The credentialed chain
+	// for that host still wins, and the host is in the leaf SAN regardless.
+	telemetry := cfg.TelemetryEnabled() && !hostInChains(chains, cfg.TelemetryCollectorHost)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, struct {
 		ListenAddress          string
@@ -1069,6 +1175,10 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		ExtAuthzPort           int
 		ExtAuthzHoldSeconds    int
 		ExtAuthzTimeoutSeconds int
+		Telemetry              bool
+		TelemetryCollectorHost string
+		TelemetryCollectorPort int
+		InstanceID             string
 	}{
 		ListenAddress:          envoyListenAddress,
 		Port:                   cfg.EnvoyPort,
@@ -1084,6 +1194,10 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		ExtAuthzPort:           cfg.ExtAuthzPort,
 		ExtAuthzHoldSeconds:    cfg.ExtAuthzHoldSeconds,
 		ExtAuthzTimeoutSeconds: extAuthzTimeoutSeconds,
+		Telemetry:              telemetry,
+		TelemetryCollectorHost: cfg.TelemetryCollectorHost,
+		TelemetryCollectorPort: cfg.TelemetryCollectorPort,
+		InstanceID:             instanceID,
 	}); err != nil {
 		return "", err
 	}
@@ -1098,7 +1212,7 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 // both args; forks pass the parent instance ID for the second.
 func BuildEnvoyBootstrapConfigMap(instanceName, extAuthzInstanceID string, cfg *config.Config, ownerRef metav1.OwnerReference, secrets []corev1.Secret) (*corev1.ConfigMap, error) {
 	chains := chainsFromSecrets(secrets)
-	yaml, err := renderEnvoyBootstrap(extAuthzInstanceID, cfg, chains)
+	yaml, err := renderEnvoyBootstrap(instanceName, extAuthzInstanceID, cfg, chains)
 	if err != nil {
 		return nil, err
 	}
@@ -1118,7 +1232,7 @@ func BuildEnvoyBootstrapConfigMap(instanceName, extAuthzInstanceID string, cfg *
 // TLS leaf used to terminate the agent's intercepted TLS. None of these are
 // referenced from the agent pod — the credential boundary lives at the pod
 // boundary.
-func envoyVolumes(instanceName string, secrets []corev1.Secret) []corev1.Volume {
+func envoyVolumes(instanceName string, cfg *config.Config, secrets []corev1.Secret) []corev1.Volume {
 	volumes := []corev1.Volume{{
 		Name: envoyBootstrapVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -1141,9 +1255,11 @@ func envoyVolumes(instanceName string, secrets []corev1.Secret) []corev1.Volume 
 			},
 		})
 	}
-	// Leaf cert is required whenever ANY route exists (allow-only or
-	// credentialed) — both flavors terminate TLS to gate the request.
-	if len(secrets) > 0 {
+	// Leaf cert is required whenever ANY TLS-terminating chain exists:
+	// allow-only or credentialed chains (both gate the request), or the
+	// telemetry collector chain (it MITM-terminates the collector SNI even
+	// when the instance has no credential Secrets).
+	if len(secrets) > 0 || cfg.TelemetryEnabled() {
 		volumes = append(volumes, corev1.Volume{
 			Name: envoyLeafTLSVolume,
 			VolumeSource: corev1.VolumeSource{
@@ -1168,7 +1284,7 @@ func ptrBool(b bool) *bool { return &b }
 // kubelet keeps the old bootstrap mounted.
 //
 // Bump on any template change that affects pod-visible behavior.
-const envoyBootstrapTemplateRev = "v11-gateway-health-probe"
+const envoyBootstrapTemplateRev = "v12-telemetry-agent-id"
 
 // envoySecretsRev digests the Secret set that drives Envoy's chain
 // rendering. Includes `injection-hosts` JSON so a descriptor change
@@ -1212,7 +1328,7 @@ func envoyContainer(cfg *config.Config, secrets []corev1.Secret) corev1.Containe
 			ReadOnly:  true,
 		})
 	}
-	if len(secrets) > 0 {
+	if len(secrets) > 0 || cfg.TelemetryEnabled() {
 		mounts = append(mounts, corev1.VolumeMount{
 			Name:      envoyLeafTLSVolume,
 			MountPath: envoyLeafTLSMount,

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -178,7 +179,7 @@ func twoCredentialChain(firstName, secondName, host string) envoyHostChain {
 }
 
 func TestRenderEnvoyBootstrap_CredentialedRoutePinnedToStaticCluster(t *testing.T) {
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		credentialedChain("platform-conn-github", "api.github.com"),
 	})
 	require.NoError(t, err)
@@ -223,7 +224,7 @@ func TestRenderEnvoyBootstrap_EmptyRoutesNoLeafTLSReferences(t *testing.T) {
 	// otherwise a no-grants render would crash with "Failed to load
 	// incomplete private key" the moment the CM is updated to include
 	// routes (the volume backing that path doesn't exist yet).
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, nil)
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, nil)
 	require.NoError(t, err)
 	assert.NotContains(t, got, "tls.key",
 		"empty-routes bootstrap must not reference the leaf TLS private key — pod has no envoy-tls volume to back it")
@@ -239,7 +240,7 @@ func TestRenderEnvoyBootstrap_NoCredentialedRouteForwardsViaDynamicForwardProxy(
 	// With no credentialed routes there should be no per-credential cluster
 	// and no host_rewrite_literal — the catch-all/L4 paths still use
 	// dynamic_forward_proxy clusters but those are non-credentialed.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		allowOnlyChain("platform-allow-only-npm", "registry.npmjs.org"),
 	})
 	require.NoError(t, err)
@@ -255,7 +256,7 @@ func TestRenderEnvoyBootstrap_MixedRoutesOnlyPinCredentialed(t *testing.T) {
 	// Credentialed and allow-only side-by-side: only the credentialed one
 	// gets a pinned cluster. The two chains are visually adjacent in the
 	// output, so we anchor each assertion on its specific cluster name.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		credentialedChain("platform-conn-github", "api.github.com"),
 		allowOnlyChain("platform-allow-only-npm", "registry.npmjs.org"),
 	})
@@ -268,6 +269,140 @@ func TestRenderEnvoyBootstrap_MixedRoutesOnlyPinCredentialed(t *testing.T) {
 	assert.Equal(t, 1, pinnedCount, "exactly one pinned upstream cluster should be rendered (credentialed routes only)")
 	assert.Contains(t, got, "name: upstream_platform-conn-github")
 	assert.NotContains(t, got, "name: upstream_platform-allow-only-npm")
+}
+
+// telemetryTestCfg copies bootstrapTestCfg with the telemetry collector
+// configured, so the gateway renders the collector egress chain.
+func telemetryTestCfg() *config.Config {
+	c := *bootstrapTestCfg
+	c.TelemetryCollectorHost = "platform-clickstack-collector.platform.svc.cluster.local"
+	c.TelemetryCollectorPort = 4318
+	return &c
+}
+
+func TestRenderEnvoyBootstrap_TelemetryStampsTrustedAgentID(t *testing.T) {
+	// Telemetry on, no credential Secrets — the collector chain stands alone.
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", telemetryTestCfg(), nil)
+	require.NoError(t, err)
+
+	// Dedicated collector chain, matched on the collector SNI.
+	assert.Contains(t, got, "terminate_otel_collector")
+	assert.Contains(t, got, `server_names: [ "platform-clickstack-collector.platform.svc.cluster.local" ]`)
+
+	// Trusted identity header stamped with OVERWRITE so an agent-supplied
+	// value can't survive; value is this instance's id.
+	assert.Contains(t, got, "key: x-platform-agent-id")
+	assert.Contains(t, got, `value: "inst-1"`)
+	assert.Contains(t, got, "OVERWRITE_IF_EXISTS_OR_ADD")
+
+	// Pinned STRICT_DNS collector cluster on the OTLP/HTTP port.
+	assert.Contains(t, got, "address: platform-clickstack-collector.platform.svc.cluster.local")
+	assert.Contains(t, got, "port_value: 4318")
+
+	// The collector chain is platform-internal: no HITL ext_authz and no
+	// credential injection on it. Isolate the chain (it precedes the L4
+	// catch-all) so the assertion doesn't trip on ext_authz elsewhere.
+	cs := strings.Index(got, "- name: terminate_otel_collector")
+	ce := strings.Index(got, "# SNI miss")
+	require.True(t, cs >= 0 && ce > cs, "collector chain must precede the L4 catch-all")
+	collectorChain := got[cs:ce]
+	assert.NotContains(t, collectorChain, "ext_authz")
+	assert.NotContains(t, collectorChain, "credential_injector")
+
+	// The collector upstream is plaintext (ztunnel adds mTLS on the in-cluster
+	// hop) — no upstream TLS transport_socket on the cluster definition.
+	clusterDef := got[strings.Index(got, "- name: otel_collector"):]
+	clusterDef = clusterDef[:strings.Index(clusterDef[len("- name: otel_collector"):], "- name: ")+len("- name: otel_collector")]
+	assert.Contains(t, clusterDef, "type: STRICT_DNS")
+	assert.NotContains(t, clusterDef, "transport_socket")
+}
+
+func TestRenderEnvoyBootstrap_TelemetryRendersValidYAML(t *testing.T) {
+	// The bootstrap is a templated YAML string embedded in a ConfigMap, so a
+	// stray indent in the collector chain/cluster only surfaces when Envoy
+	// boots. Render with telemetry on AND a credentialed chain (both new
+	// template blocks plus the existing ones active) and confirm the whole
+	// document parses as YAML.
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", telemetryTestCfg(), []envoyHostChain{
+		credentialedChain("platform-conn-github", "api.github.com"),
+	})
+	require.NoError(t, err)
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(got), &doc), "rendered bootstrap must be valid YAML")
+	// The collector chain/cluster coexist with the credentialed chain (distinct
+	// hosts → no collision).
+	assert.Contains(t, got, "terminate_otel_collector")
+	assert.Contains(t, got, "- name: otel_collector")
+	assert.Contains(t, got, "name: upstream_platform-conn-github")
+}
+
+func TestRenderEnvoyBootstrap_TelemetryDisabledNoCollectorChain(t *testing.T) {
+	// bootstrapTestCfg has no collector host → telemetry off.
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, nil)
+	require.NoError(t, err)
+	assert.NotContains(t, got, "terminate_otel_collector")
+	assert.NotContains(t, got, "otel_collector")
+	assert.NotContains(t, got, "x-platform-agent-id")
+}
+
+func TestRenderEnvoyBootstrap_TelemetryHeaderUsesInstanceNotExtAuthzID(t *testing.T) {
+	// Forks dial the PARENT's ext-authz Service (extAuthzInstanceID=parent)
+	// but their telemetry must attribute to the fork itself — the header value
+	// tracks the instance id, not the ext-authz id.
+	got, err := renderEnvoyBootstrap("fork-xyz", "parent-agent", telemetryTestCfg(), nil)
+	require.NoError(t, err)
+	assert.Contains(t, got, `value: "fork-xyz"`)
+	assert.NotContains(t, got, `value: "parent-agent"`)
+	// ext-authz authority still points at the parent's per-instance Service.
+	assert.Contains(t, got, "extauthz-parent-agent")
+}
+
+func hasVolumeNamed(vols []corev1.Volume, name string) bool {
+	for _, v := range vols {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMountNamed(mounts []corev1.VolumeMount, name string) bool {
+	for _, m := range mounts {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEnvoyVolumes_TelemetryMountsLeafWithoutSecrets(t *testing.T) {
+	// No credential Secrets, telemetry on: the leaf TLS volume + mount must
+	// still be present because the collector chain MITM-terminates with it.
+	// Without this the gateway would crash loading a non-existent tls.key.
+	cfg := telemetryTestCfg()
+	assert.True(t, hasVolumeNamed(envoyVolumes("inst-1", cfg, nil), envoyLeafTLSVolume),
+		"leaf TLS volume must be present when telemetry is on even with no Secrets")
+	assert.True(t, hasMountNamed(envoyContainer(cfg, nil).VolumeMounts, envoyLeafTLSVolume),
+		"leaf TLS mount must be present when telemetry is on even with no Secrets")
+}
+
+func TestEnvoyVolumes_NoLeafWhenNoSecretsNoTelemetry(t *testing.T) {
+	assert.False(t, hasVolumeNamed(envoyVolumes("inst-1", bootstrapTestCfg, nil), envoyLeafTLSVolume))
+	assert.False(t, hasMountNamed(envoyContainer(bootstrapTestCfg, nil).VolumeMounts, envoyLeafTLSVolume))
+}
+
+func TestRenderEnvoyBootstrap_TelemetryHostCollisionSuppressesCollectorChain(t *testing.T) {
+	// If the collector host collided with a credentialed chain host, two
+	// filter chains would share server_names — fatal to Envoy. The collector
+	// chain is suppressed; the credentialed chain wins (and the host stays in
+	// the leaf SAN via that chain).
+	cfg := telemetryTestCfg()
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", cfg, []envoyHostChain{
+		credentialedChain("platform-conn-collector", cfg.TelemetryCollectorHost),
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, got, "terminate_otel_collector")
+	assert.NotContains(t, got, "- name: otel_collector")
 }
 
 // secretWithEnvMappings returns an owner-labelled Secret carrying an
@@ -461,7 +596,7 @@ func TestRenderEnvoyBootstrap_QueryParamCredentialRendersLuaFilter(t *testing.T)
 	// SDS value into the credential's header; Lua moves it into the URL
 	// query parameter and strips the header before the request leaves
 	// the sidecar.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		queryParamChain("platform-cred-bob", "prod.ibm-bob-staging.cloud.ibm.com", "X-Bobshell-Cred", "key"),
 	})
 	require.NoError(t, err)
@@ -484,7 +619,7 @@ func TestRenderEnvoyBootstrap_HeaderOnlyChainSkipsLua(t *testing.T) {
 	// Without QueryParamName the chain has only credential_injector — no
 	// Lua. credential_injector writes the pre-formatted SDS value (baked
 	// by api-server) directly into the user header.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		credentialedChain("platform-conn-github", "api.github.com"),
 	})
 	require.NoError(t, err)
@@ -497,7 +632,7 @@ func TestRenderEnvoyBootstrap_TwoCredentialsOnSameHostStackInOneChain(t *testing
 	// stack as two credential_injector entries inside a single TLS chain.
 	// Exactly one chain definition, one route-config, one upstream cluster —
 	// the second credential MUST NOT spawn a duplicate filter chain.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		twoCredentialChain("platform-cred-header", "platform-cred-query", "prod.ibm-bob-staging.cloud.ibm.com"),
 	})
 	require.NoError(t, err)

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -49,7 +49,7 @@ func BuildGatewayStatefulSet(agentName string, hibernated bool, cfg *config.Conf
 		LabelRole:  RoleGateway,
 	}
 
-	volumes := envoyVolumes(agentName, credentialSecrets)
+	volumes := envoyVolumes(agentName, cfg, credentialSecrets)
 	containers := []corev1.Container{envoyContainer(cfg, credentialSecrets)}
 
 	falseVal := false
@@ -164,7 +164,7 @@ func BuildForkGatewayPod(forkName, parentAgentID string, cfg *config.Config, own
 		ForkLabelType: ForkJobLabelType,
 	}
 
-	volumes := envoyVolumes(forkName, credentialSecrets)
+	volumes := envoyVolumes(forkName, cfg, credentialSecrets)
 	containers := []corev1.Container{envoyContainer(cfg, credentialSecrets)}
 
 	falseVal := false

--- a/packages/controller/pkg/reconciler/leaf.go
+++ b/packages/controller/pkg/reconciler/leaf.go
@@ -41,6 +41,16 @@ func dnsNamesFromChains(chains []envoyHostChain) []string {
 	return out
 }
 
+// containsHost reports whether `host` is already in the sorted SAN list.
+func containsHost(hosts []string, host string) bool {
+	for _, h := range hosts {
+		if h == host {
+			return true
+		}
+	}
+	return false
+}
+
 // Placeholder SAN for a leaf issued with no credential hosts; never presented.
 func leafPlaceholderDNS(instanceName string) string {
 	return instanceName + ".mitm-placeholder.invalid"
@@ -52,6 +62,15 @@ func leafPlaceholderDNS(instanceName string) string {
 // false (forks) returns nil when there's nothing to MITM.
 func BuildEnvoyLeafCertificate(instanceName string, cfg *config.Config, ownerRef metav1.OwnerReference, secrets []corev1.Secret, alwaysIssue bool) *cmv1.Certificate {
 	hosts := dnsNamesFromChains(chainsFromSecrets(secrets))
+	// When telemetry is on, the gateway MITM-terminates the collector host to
+	// stamp the trusted agent id, so the leaf must cover it — even for an
+	// instance (or fork) with no credential Secrets. Dedupe in case the host
+	// also appears as a credentialed chain (the collision-guarded chain in
+	// envoy.go is suppressed in that case, but the SAN is still needed).
+	if cfg.TelemetryEnabled() && !containsHost(hosts, cfg.TelemetryCollectorHost) {
+		hosts = append(hosts, cfg.TelemetryCollectorHost)
+		sort.Strings(hosts)
+	}
 	if len(hosts) == 0 {
 		if !alwaysIssue {
 			return nil

--- a/packages/controller/pkg/reconciler/leaf_test.go
+++ b/packages/controller/pkg/reconciler/leaf_test.go
@@ -39,6 +39,30 @@ func TestBuildEnvoyLeafCertificate_DedupesAndSortsHosts(t *testing.T) {
 	assert.Equal(t, []string{"a.example.com", "b.example.com"}, cert.Spec.DNSNames)
 }
 
+func TestBuildEnvoyLeafCertificate_TelemetryHostInSAN_ZeroSecretsFork(t *testing.T) {
+	cfg := *testConfig
+	cfg.TelemetryCollectorHost = "platform-clickstack-collector.default.svc.cluster.local"
+	// Fork (alwaysIssue=false) with no credential Secrets: telemetry alone
+	// makes the leaf non-nil and puts the collector host in the SAN, so the
+	// gateway can MITM-terminate the agent's OTLP to it.
+	cert := BuildEnvoyLeafCertificate("my-instance", &cfg, configMapOwnerRef(testOwnerCM), nil, false)
+	require.NotNil(t, cert, "telemetry-on fork with no Secrets must still issue a leaf for the collector SNI")
+	assert.Equal(t, []string{"platform-clickstack-collector.default.svc.cluster.local"}, cert.Spec.DNSNames)
+}
+
+func TestBuildEnvoyLeafCertificate_TelemetryHostDedupedWithChainHost(t *testing.T) {
+	cfg := *testConfig
+	cfg.TelemetryCollectorHost = "a.example.com" // pathological: collides with a credentialed host
+	secrets := []corev1.Secret{
+		credSecret("platform-cred-aaa", "a.example.com"),
+		credSecret("platform-cred-bbb", "b.example.com"),
+	}
+	cert := BuildEnvoyLeafCertificate("my-instance", &cfg, configMapOwnerRef(testOwnerCM), secrets, false)
+	require.NotNil(t, cert)
+	// Collector host already present via the credentialed chain — not duplicated.
+	assert.Equal(t, []string{"a.example.com", "b.example.com"}, cert.Spec.DNSNames)
+}
+
 func TestBuildEnvoyLeafCertificate_IssuerRef(t *testing.T) {
 	cfg := *testConfig
 	cfg.EnvoyMitmCAIssuer = "platform-mitm-ca-issuer"


### PR DESCRIPTION
## What

Bundles the agent-telemetry backend (**ClickStack**: ClickHouse + Keeper + MongoDB + HyperDX) as an optional, toggleable component of the platform Helm chart, gated by `clickstack.enabled` (**default off**). This is the foundation: it stands up a running OTLP collector endpoint and a persistent telemetry datastore — the substrate later work builds on.

## How

- **Subchart, deployed/upgraded with the chart.** The `clickstack` workload chart (ClickHouse/Keeper/MongoDB custom resources + HyperDX) is a chart dependency gated by `clickstack.enabled`, so it rolls with `helm upgrade platform`.
- **Operators install out-of-band.** The ClickHouse + MongoDB operators and their CRDs install in `cluster:install` (gated on `CLICKSTACK=1`), exactly like Istio and cert-manager — because Helm never upgrades a chart's `crds/` on an existing release.
- **Collector access is the mesh, not HyperDX tokens.** ClickStack normally secures the collector with a HyperDX-issued ingestion key delivered over OpAMP. Instead, the platform runs its **own** OpenTelemetry collector with a static config and no OpAMP, and gates it with an Istio `AuthorizationPolicy` that allows the **release and agent namespaces** only. The collector writes to the operator ClickHouse as the `otelcollector` user (db `default`, standard `otel_*` tables); HyperDX reads ClickHouse directly, so disabling the bundled collector doesn't affect it.
- **Off by default**: a heavy multi-pod stack with no producer yet (agent export is a separate sub-issue). Opt in per install with `CLICKSTACK=1 mise run cluster:install`.

## Out of scope (separate sub-issues under #1908)

- Configuring agents to export telemetry, and the agent-egress NetworkPolicy to reach the collector.
- The user-facing read path / access control for the HyperDX UI.
- Production hardening (HA, retention/TTL, external/managed ClickHouse) and air-gap image pre-loading.

## Validation

- `mise run helm:check` — lint clean; kubeconform 52 valid / 0 invalid / 11 skipped (operator CR + Istio kinds).
- Default render (toggle off) emits **zero** ClickStack resources; enabled render wires the collector→ClickHouse env, the ALLOW policy, and drops the subchart's own collector.
- Confirmed the `clickhouse` storage override deep-merges without dropping the `otelcollector` user's `CREATE` grant.
- **Not yet run:** live end-to-end on a cluster (operators reconcile → OTLP ingest with no auth header from an allowed namespace → rows surface in HyperDX → mesh denies other namespaces → persistence across restart). Draft until verified live.

## Docs

New `docs/architecture/observability.md`; indexed in `docs/architecture.md`; cross-linked from `persistence.md` as a fourth (optional) durable substrate.

Part of #1908. Closes #2027.
