### PR TITLE
feat(sessions): SessionType.ExperimentTrial + experimentId tagging (dam-u1n.5)

### DIFF
--- a/packages/agent-runtime/src/modules/acp/infrastructure/session-metadata-store.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/session-metadata-store.ts
@@ -5,6 +5,7 @@ export const platformSessionMetaSchema = z.object({
   mode: z.string().optional(),
   type: z.string().optional(),
   scheduleId: z.string().optional(),
+  experimentId: z.string().optional(),
   threadTs: z.string().optional(),
 });
 

--- a/packages/api-server-api/src/modules/sessions/types.ts
+++ b/packages/api-server-api/src/modules/sessions/types.ts
@@ -5,6 +5,7 @@ export const SessionType = {
   ChannelSlack: "channel_slack",
   ChannelTelegram: "channel_telegram",
   ScheduleCron: "schedule_cron",
+  ExperimentTrial: "experiment_trial",
 } as const;
 
 export type SessionType = (typeof SessionType)[keyof typeof SessionType];
@@ -29,6 +30,7 @@ export interface SessionView {
   mode: SessionMode;
   createdAt: string;
   scheduleId?: string | null;
+  experimentId?: string | null;
   title?: string | null;
   updatedAt?: string | null;
 }

--- a/packages/api-server/src/core/acp-client.ts
+++ b/packages/api-server/src/core/acp-client.ts
@@ -50,6 +50,7 @@ export interface PlatformSessionMeta {
   mode?: string;
   type?: string;
   scheduleId?: string;
+  experimentId?: string;
   threadTs?: string;
   createdAt?: string;
 }
@@ -67,6 +68,7 @@ const platformSessionMetaSchema = z.object({
   mode: z.string().optional(),
   type: z.string().optional(),
   scheduleId: z.string().optional(),
+  experimentId: z.string().optional(),
   threadTs: z.string().optional(),
   createdAt: z.string().optional(),
 });

--- a/packages/cli/src/modules/chat/infrastructure/acp-session-client.ts
+++ b/packages/cli/src/modules/chat/infrastructure/acp-session-client.ts
@@ -17,6 +17,7 @@ interface PlatformMeta {
   mode?: string;
   type?: string;
   scheduleId?: string;
+  experimentId?: string;
   threadTs?: string;
   createdAt?: string;
 }
@@ -84,6 +85,7 @@ function toSessionView(agentId: string, s: ListedSession): SessionView {
       : SessionMode.Terminal,
     createdAt: p?.createdAt ?? s.updatedAt ?? new Date(0).toISOString(),
     scheduleId: p?.scheduleId ?? null,
+    experimentId: p?.experimentId ?? null,
     title: s.title ?? null,
     updatedAt: s.updatedAt ?? null,
   };

--- a/packages/ui/src/modules/sessions/api/acp-session-ops.ts
+++ b/packages/ui/src/modules/sessions/api/acp-session-ops.ts
@@ -8,6 +8,7 @@ interface PlatformMeta {
   mode?: string;
   type?: string;
   scheduleId?: string;
+  experimentId?: string;
   threadTs?: string;
   createdAt?: string;
 }
@@ -36,6 +37,7 @@ function toSessionView(agentId: string, s: ListedSession): SessionView {
       : SessionMode.Terminal,
     createdAt: p?.createdAt ?? s.updatedAt ?? new Date(0).toISOString(),
     scheduleId: p?.scheduleId ?? null,
+    experimentId: p?.experimentId ?? null,
     title: s.title ?? null,
     updatedAt: s.updatedAt ?? null,
   };

--- a/packages/ui/src/modules/sessions/api/queries.ts
+++ b/packages/ui/src/modules/sessions/api/queries.ts
@@ -32,6 +32,7 @@ export function optimisticInsertSession(
     mode,
     createdAt: new Date().toISOString(),
     scheduleId: null,
+    experimentId: null,
     title: null,
     updatedAt: null,
   };
@@ -57,8 +58,8 @@ export function removeSessionFromCache(
 
 /**
  * Sessions list, read straight off the agent over ACP `session/list`
- * and decoded from `_meta.platform`. Schedule sessions are excluded from the
- * main list; channel sessions are included only when asked. Pass
+ * and decoded from `_meta.platform`. Schedule and experiment-trial sessions are
+ * excluded from the main list; channel sessions are included only when asked. Pass
  * `enabled: false` (e.g. while the agent is waking) to keep the query in cache
  * without firing requests.
  *


### PR DESCRIPTION
Stacked on #2033 (`feat/experiments`). Implements dam-u1n.5.

Plumbing only, parallel to the existing `scheduleId` / `schedule_cron` pattern. The start path that mints and tags trial sessions is dam-u1n.6.

## What

- New `SessionType.ExperimentTrial = "experiment_trial"`.
- Carry `experimentId` through every `_meta.platform` decode site: agent-runtime session-metadata store, api-server acp-client, ui, cli, and `SessionView`.
- No `armId`: an Arm is keyed `(experiment_id, agent_id)`, and a Trial session already carries `agentId`, so the Arm is derivable from `experimentId` + `agentId`.

## Sidebar hide

Structural, no new branch. `useAcpSessions` filters by an allowlist (`Regular` + optionally channels), so `experiment_trial` is excluded by construction. The other `listAgentSessions` consumers are the schedules tab (filters by `scheduleId`) and a by-`sessionId` mode lookup, neither of which list trials.

## Verification

All touched packages pass `check` + tests (agent-runtime 107, api-server 210, ui 52, cli 144).