### PR TITLE
feat(experiments): owner-scoped service + repository (dam-u1n.3)

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -73,6 +73,19 @@ export type {
   ScheduleUpdateRRuleInput,
   SchedulesService,
 } from "./modules/schedules/types.js";
+export type {
+  ExperimentConfig,
+  ExperimentStatus,
+  Experiment,
+  ExperimentArm,
+  ExperimentRun,
+  ExperimentArmWithRuns,
+  ExperimentWithRuns,
+  ActiveArm,
+  ExperimentCreateInput,
+  ExperimentAddArmInput,
+  ExperimentsService,
+} from "./modules/experiments/types.js";
 export {
   quietWindowSchema,
   scheduleCreateCronInputSchema,

--- a/packages/api-server-api/src/modules/experiments/types.ts
+++ b/packages/api-server-api/src/modules/experiments/types.ts
@@ -1,0 +1,100 @@
+/** Opaque JSON config the platform stores but does not interpret. The
+ *  experiment `spec` (shared task + budget) and per-arm `armSpec` are both
+ *  user-authored blobs handed to the harness at start; only the harness reads
+ *  them (epic decision D4). */
+export type ExperimentConfig = Record<string, unknown>;
+
+/** Lifecycle of an Experiment. `draft` is the create-time default; the start
+ *  path (later ticket) moves it to `running`; stop/finish move it to `stopped`
+ *  / `completed`. Only a `running` experiment has an active arm. */
+export type ExperimentStatus = "draft" | "running" | "completed" | "stopped";
+
+export interface Experiment {
+  id: string;
+  ownerId: string;
+  name: string;
+  /** Prose statement of what every arm is racing toward. */
+  goal: string;
+  spec: ExperimentConfig;
+  status: ExperimentStatus;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/** One competitor: an existing Agent (the harness image) plus its config.
+ *  Keyed `(experimentId, agentId)` — the same agent cannot be two arms of one
+ *  experiment, but the same harness image can back many agents (same-framework
+ *  racing happens at the agent level). */
+export interface ExperimentArm {
+  experimentId: string;
+  agentId: string;
+  armSpec: ExperimentConfig;
+  createdAt: string;
+}
+
+/** One ledger entry an arm's harness loop emits. `score` is opaque jsonb (the
+ *  platform does not rank or normalize it) and `candidateRef` points at a
+ *  stored Candidate artifact; both are populated by the ingestion path in a
+ *  later ticket. */
+export interface ExperimentRun {
+  id: string;
+  experimentId: string;
+  agentId: string;
+  runNumber: number;
+  sessionId: string;
+  candidateRef: string | null;
+  score: unknown;
+  status: string;
+  startedAt: string;
+  endedAt: string | null;
+}
+
+export interface ExperimentArmWithRuns extends ExperimentArm {
+  runs: ExperimentRun[];
+}
+
+/** The detail rollup: an experiment with its arms, each arm carrying its own
+ *  run ledger. Comparison in the MVP is per-arm only. */
+export interface ExperimentWithRuns extends Experiment {
+  arms: ExperimentArmWithRuns[];
+}
+
+/** What the ingestion / harness side needs to attribute work to the right
+ *  experiment for a given agent, resolved from the agent's verified identity.
+ *  Carries the goal + specs so the harness has its task context in hand. */
+export interface ActiveArm {
+  experimentId: string;
+  experimentName: string;
+  goal: string;
+  spec: ExperimentConfig;
+  agentId: string;
+  armSpec: ExperimentConfig;
+}
+
+export interface ExperimentCreateInput {
+  name: string;
+  goal: string;
+  spec: ExperimentConfig;
+}
+
+export interface ExperimentAddArmInput {
+  experimentId: string;
+  agentId: string;
+  armSpec: ExperimentConfig;
+}
+
+/** Owner-scoped application service. Composed per-owner for both the user tRPC
+ *  router and the in-pod MCP session (the owner is bound at composition time,
+ *  never taken from request input). */
+export interface ExperimentsService {
+  list(): Promise<Experiment[]>;
+  getWithRuns(id: string): Promise<ExperimentWithRuns | null>;
+  create(input: ExperimentCreateInput): Promise<Experiment>;
+  /** Add an arm referencing an existing owned agent. */
+  addArm(input: ExperimentAddArmInput): Promise<ExperimentArm>;
+  delete(id: string): Promise<void>;
+  /** Resolve the arm of the owner's currently-running experiment that this
+   *  agent belongs to, or null. Used by the ingestion path to attribute a run
+   *  without trusting agent-supplied experiment ids. */
+  resolveActiveArm(agentId: string): Promise<ActiveArm | null>;
+}

--- a/packages/api-server/src/modules/experiments/compose.ts
+++ b/packages/api-server/src/modules/experiments/compose.ts
@@ -1,0 +1,30 @@
+import type { Db } from "db";
+import type { ExperimentsService } from "api-server-api";
+import { createExperimentsRepository } from "./infrastructure/experiments-repository.js";
+import { createExperimentsService } from "./services/experiments-service.js";
+
+export interface ComposeExperimentsForOwnerOpts {
+  db: Db;
+  owner: string;
+  /** Resolve whether the agent exists for this owner — gates `addArm` so an arm
+   *  can only reference an owned agent. Omit in contexts without an agents
+   *  service (the check is then skipped). */
+  agentExists?: (agentId: string) => Promise<boolean>;
+}
+
+/** Compose the owner-scoped Experiments service. The owner is bound here, so
+ *  the same factory backs both the user tRPC router and the in-pod MCP session
+ *  without either passing an owner through request input. No boot-time
+ *  singleton: the service is plain db-backed CRUD with no shared worker state. */
+export function composeExperimentsForOwner(
+  opts: ComposeExperimentsForOwnerOpts,
+): { experiments: ExperimentsService } {
+  const repo = createExperimentsRepository(opts.db);
+  return {
+    experiments: createExperimentsService({
+      owner: opts.owner,
+      repo,
+      ...(opts.agentExists ? { agentExists: opts.agentExists } : {}),
+    }),
+  };
+}

--- a/packages/api-server/src/modules/experiments/domain/experiment-rollup.ts
+++ b/packages/api-server/src/modules/experiments/domain/experiment-rollup.ts
@@ -1,0 +1,30 @@
+import type {
+  Experiment,
+  ExperimentArm,
+  ExperimentRun,
+  ExperimentWithRuns,
+} from "api-server-api";
+
+/** Assemble the detail rollup: nest each arm's runs under it, keyed by agentId.
+ *  Pure — the repository fetches arms and runs flat, this groups them. Runs
+ *  whose agentId has no matching arm are dropped (a run can only belong to an
+ *  arm; an orphan means a deleted arm and is not surfaced). */
+export function rollupExperiment(
+  experiment: Experiment,
+  arms: ExperimentArm[],
+  runs: ExperimentRun[],
+): ExperimentWithRuns {
+  const runsByAgent = new Map<string, ExperimentRun[]>();
+  for (const run of runs) {
+    const list = runsByAgent.get(run.agentId);
+    if (list) list.push(run);
+    else runsByAgent.set(run.agentId, [run]);
+  }
+  return {
+    ...experiment,
+    arms: arms.map((arm) => ({
+      ...arm,
+      runs: runsByAgent.get(arm.agentId) ?? [],
+    })),
+  };
+}

--- a/packages/api-server/src/modules/experiments/index.ts
+++ b/packages/api-server/src/modules/experiments/index.ts
@@ -1,0 +1,3 @@
+export { composeExperimentsForOwner } from "./compose.js";
+export type { ComposeExperimentsForOwnerOpts } from "./compose.js";
+export type { ExperimentsRepository } from "./infrastructure/experiments-repository.js";

--- a/packages/api-server/src/modules/experiments/infrastructure/experiments-repository.ts
+++ b/packages/api-server/src/modules/experiments/infrastructure/experiments-repository.ts
@@ -1,0 +1,216 @@
+import { randomBytes } from "node:crypto";
+import {
+  and,
+  asc,
+  desc,
+  eq,
+  inArray,
+  type Db,
+  experiments as experimentsTable,
+  experimentArms as experimentArmsTable,
+  experimentRuns as experimentRunsTable,
+} from "db";
+import type {
+  Experiment,
+  ExperimentArm,
+  ExperimentConfig,
+  ExperimentRun,
+  ExperimentStatus,
+} from "api-server-api";
+
+const RUNNING_STATUS: ExperimentStatus = "running";
+
+export interface ExperimentsRepository {
+  create(input: {
+    ownerId: string;
+    name: string;
+    goal: string;
+    spec: ExperimentConfig;
+  }): Promise<Experiment>;
+  listByOwner(ownerId: string): Promise<Experiment[]>;
+  get(id: string, ownerId: string): Promise<Experiment | null>;
+  delete(id: string, ownerId: string): Promise<void>;
+
+  addArm(input: {
+    experimentId: string;
+    agentId: string;
+    armSpec: ExperimentConfig;
+  }): Promise<ExperimentArm>;
+  listArms(experimentId: string): Promise<ExperimentArm[]>;
+  listRuns(experimentId: string): Promise<ExperimentRun[]>;
+
+  /** The arm of the owner's single running experiment that contains `agentId`,
+   *  or null. Owner-scoped so a leaked agentId can't reach another tenant. */
+  findActiveArm(
+    agentId: string,
+    ownerId: string,
+  ): Promise<{ experiment: Experiment; arm: ExperimentArm } | null>;
+}
+
+type ExperimentRow = typeof experimentsTable.$inferSelect;
+type ArmRow = typeof experimentArmsTable.$inferSelect;
+type RunRow = typeof experimentRunsTable.$inferSelect;
+
+function rowToExperiment(row: ExperimentRow): Experiment {
+  return {
+    id: row.id,
+    ownerId: row.owner,
+    name: row.name,
+    goal: row.goal,
+    spec: (row.spec as ExperimentConfig) ?? {},
+    status: row.status as ExperimentStatus,
+    createdAt: row.createdAt.toISOString(),
+    updatedAt: row.updatedAt.toISOString(),
+  };
+}
+
+function rowToArm(row: ArmRow): ExperimentArm {
+  return {
+    experimentId: row.experimentId,
+    agentId: row.agentId,
+    armSpec: (row.armSpec as ExperimentConfig) ?? {},
+    createdAt: row.createdAt.toISOString(),
+  };
+}
+
+function rowToRun(row: RunRow): ExperimentRun {
+  return {
+    id: row.id,
+    experimentId: row.experimentId,
+    agentId: row.agentId,
+    runNumber: row.runNumber,
+    sessionId: row.sessionId,
+    candidateRef: row.candidateRef,
+    score: row.score,
+    status: row.status,
+    startedAt: row.startedAt.toISOString(),
+    endedAt: row.endedAt ? row.endedAt.toISOString() : null,
+  };
+}
+
+export function createExperimentsRepository(db: Db): ExperimentsRepository {
+  return {
+    async create(input): Promise<Experiment> {
+      const id = `exp-${randomBytes(6).toString("hex")}`;
+      await db.insert(experimentsTable).values({
+        id,
+        owner: input.ownerId,
+        name: input.name,
+        goal: input.goal,
+        spec: input.spec,
+      });
+      const created = await this.get(id, input.ownerId);
+      if (!created) {
+        throw new Error(`create: experiment ${id} not found after insert`);
+      }
+      return created;
+    },
+
+    async listByOwner(ownerId): Promise<Experiment[]> {
+      const rows = await db
+        .select()
+        .from(experimentsTable)
+        .where(eq(experimentsTable.owner, ownerId))
+        .orderBy(desc(experimentsTable.createdAt));
+      return rows.map(rowToExperiment);
+    },
+
+    async get(id, ownerId): Promise<Experiment | null> {
+      const rows = await db
+        .select()
+        .from(experimentsTable)
+        .where(
+          and(eq(experimentsTable.id, id), eq(experimentsTable.owner, ownerId)),
+        );
+      return rows[0] ? rowToExperiment(rows[0]) : null;
+    },
+
+    async delete(id, ownerId): Promise<void> {
+      const existing = await this.get(id, ownerId);
+      if (!existing) return;
+      await db
+        .delete(experimentRunsTable)
+        .where(eq(experimentRunsTable.experimentId, id));
+      await db
+        .delete(experimentArmsTable)
+        .where(eq(experimentArmsTable.experimentId, id));
+      await db
+        .delete(experimentsTable)
+        .where(
+          and(eq(experimentsTable.id, id), eq(experimentsTable.owner, ownerId)),
+        );
+    },
+
+    async addArm(input): Promise<ExperimentArm> {
+      await db.insert(experimentArmsTable).values({
+        experimentId: input.experimentId,
+        agentId: input.agentId,
+        armSpec: input.armSpec,
+      });
+      const rows = await db
+        .select()
+        .from(experimentArmsTable)
+        .where(
+          and(
+            eq(experimentArmsTable.experimentId, input.experimentId),
+            eq(experimentArmsTable.agentId, input.agentId),
+          ),
+        );
+      if (!rows[0]) {
+        throw new Error(`addArm: arm not found after insert`);
+      }
+      return rowToArm(rows[0]);
+    },
+
+    async listArms(experimentId): Promise<ExperimentArm[]> {
+      const rows = await db
+        .select()
+        .from(experimentArmsTable)
+        .where(eq(experimentArmsTable.experimentId, experimentId))
+        .orderBy(asc(experimentArmsTable.createdAt));
+      return rows.map(rowToArm);
+    },
+
+    async listRuns(experimentId): Promise<ExperimentRun[]> {
+      const rows = await db
+        .select()
+        .from(experimentRunsTable)
+        .where(eq(experimentRunsTable.experimentId, experimentId))
+        .orderBy(asc(experimentRunsTable.runNumber));
+      return rows.map(rowToRun);
+    },
+
+    async findActiveArm(
+      agentId,
+      ownerId,
+    ): Promise<{ experiment: Experiment; arm: ExperimentArm } | null> {
+      const armRows = await db
+        .select()
+        .from(experimentArmsTable)
+        .where(eq(experimentArmsTable.agentId, agentId));
+      if (armRows.length === 0) return null;
+
+      const expRows = await db
+        .select()
+        .from(experimentsTable)
+        .where(
+          and(
+            inArray(
+              experimentsTable.id,
+              armRows.map((a) => a.experimentId),
+            ),
+            eq(experimentsTable.owner, ownerId),
+            eq(experimentsTable.status, RUNNING_STATUS),
+          ),
+        )
+        .orderBy(desc(experimentsTable.createdAt))
+        .limit(1);
+      const expRow = expRows[0];
+      if (!expRow) return null;
+
+      const armRow = armRows.find((a) => a.experimentId === expRow.id);
+      if (!armRow) return null;
+      return { experiment: rowToExperiment(expRow), arm: rowToArm(armRow) };
+    },
+  };
+}

--- a/packages/api-server/src/modules/experiments/services/experiments-service.ts
+++ b/packages/api-server/src/modules/experiments/services/experiments-service.ts
@@ -1,0 +1,136 @@
+import { TRPCError } from "@trpc/server";
+import type {
+  ActiveArm,
+  Experiment,
+  ExperimentAddArmInput,
+  ExperimentArm,
+  ExperimentCreateInput,
+  ExperimentsService,
+  ExperimentWithRuns,
+} from "api-server-api";
+import type { ExperimentsRepository } from "../infrastructure/experiments-repository.js";
+import { rollupExperiment } from "../domain/experiment-rollup.js";
+import { securityLog } from "../../../core/security-log.js";
+import { isUniqueViolation } from "../../../core/db-errors.js";
+
+export function createExperimentsService(deps: {
+  owner: string;
+  repo: ExperimentsRepository;
+  agentExists?: (agentId: string) => Promise<boolean>;
+}): ExperimentsService {
+  async function ensureAgent(agentId: string): Promise<void> {
+    if (!deps.agentExists) return;
+    const ok = await deps.agentExists(agentId);
+    if (!ok) {
+      securityLog("warn", "experiment.arm_add", {
+        category: "authz",
+        actor: deps.owner,
+        actorKind: "user",
+        agentId,
+        decision: "deny",
+        reason: "agent-not-owned",
+        result: "failure",
+      });
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: `Agent "${agentId}" not found`,
+      });
+    }
+  }
+
+  return {
+    list: (): Promise<Experiment[]> => deps.repo.listByOwner(deps.owner),
+
+    async getWithRuns(id): Promise<ExperimentWithRuns | null> {
+      const experiment = await deps.repo.get(id, deps.owner);
+      if (!experiment) return null;
+      const [arms, runs] = await Promise.all([
+        deps.repo.listArms(id),
+        deps.repo.listRuns(id),
+      ]);
+      return rollupExperiment(experiment, arms, runs);
+    },
+
+    async create(input: ExperimentCreateInput): Promise<Experiment> {
+      try {
+        const experiment = await deps.repo.create({
+          ownerId: deps.owner,
+          name: input.name,
+          goal: input.goal,
+          spec: input.spec,
+        });
+        securityLog("info", "experiment.create", {
+          category: "resource",
+          actor: deps.owner,
+          actorKind: "user",
+          target: experiment.id,
+          result: "success",
+        });
+        return experiment;
+      } catch (err) {
+        if (isUniqueViolation(err)) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: `An experiment named "${input.name}" already exists. Names must be unique per user.`,
+          });
+        }
+        throw err;
+      }
+    },
+
+    async addArm(input: ExperimentAddArmInput): Promise<ExperimentArm> {
+      const experiment = await deps.repo.get(input.experimentId, deps.owner);
+      if (!experiment) throw new TRPCError({ code: "NOT_FOUND" });
+      await ensureAgent(input.agentId);
+      try {
+        const arm = await deps.repo.addArm({
+          experimentId: input.experimentId,
+          agentId: input.agentId,
+          armSpec: input.armSpec,
+        });
+        securityLog("info", "experiment.arm_add", {
+          category: "resource",
+          actor: deps.owner,
+          actorKind: "user",
+          agentId: input.agentId,
+          target: input.experimentId,
+          result: "success",
+        });
+        return arm;
+      } catch (err) {
+        if (isUniqueViolation(err)) {
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: `Agent "${input.agentId}" is already an arm of this experiment.`,
+          });
+        }
+        throw err;
+      }
+    },
+
+    async delete(id): Promise<void> {
+      await deps.repo.delete(id, deps.owner);
+      securityLog("info", "experiment.delete", {
+        category: "resource",
+        actor: deps.owner,
+        actorKind: "user",
+        target: id,
+        result: "success",
+      });
+    },
+
+    async resolveActiveArm(agentId): Promise<ActiveArm | null> {
+      const found = await deps.repo.findActiveArm(agentId, deps.owner);
+      if (!found) return null;
+      const { experiment, arm } = found;
+      return {
+        experimentId: experiment.id,
+        experimentName: experiment.name,
+        goal: experiment.goal,
+        spec: experiment.spec,
+        agentId: arm.agentId,
+        armSpec: arm.armSpec,
+      };
+    },
+  };
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,9 @@ export {
   actorRoles,
   termsAcceptances,
   apiKeys,
+  experiments,
+  experimentArms,
+  experimentRuns,
   runArtifacts,
 } from "./schema.js";
 export {


### PR DESCRIPTION
Owner-scoped Experiments service + repository, copied from the connections/schedules pattern. Service+repo only; the tRPC router and MCP wiring land in follow-up tickets.

## What's here
- `ExperimentsService` + `experiments-repository`, sliced into application / domain / infrastructure.
- `types.ts` (`Experiment`, `ExperimentArm`, `ExperimentRun`, `ExperimentWithRuns`, `ActiveArm`, inputs, `ExperimentsService`) in `api-server-api`, exported from the index.
- `composeExperimentsForOwner({db, owner, agentExists?})`, so the same factory backs both the user tRPC router and the in-pod MCP session (owner bound at compose time, never from request input).
- Experiment tables exported from `packages/db`.

## Operations
- `list` / `getWithRuns` (rollup nests each arm's runs under it by agentId)
- `create` (status `draft`; unique name per owner -> CONFLICT)
- `addArm` (NOT_FOUND if experiment not owned, BAD_REQUEST if agent not owned via `agentExists`, CONFLICT on duplicate agent)
- `delete` (cascades arms + runs)
- `resolveActiveArm(agentId)` (owner-scoped, only a `running` experiment; returns goal + spec + armSpec for the ingestion side)

## Deferred (kept to ticket boundary)
- tRPC router + Zod input schemas + `ApiContext.experiments` wiring -> dam-u1n.4
- record_run ingestion + MCP session wiring (consumes `resolveActiveArm`) -> dam-u1n.7
- status transition to `running` -> dam-u1n.6
- cleanup of dangling arms on agent delete (no hook)

`spec`/`armSpec`/`score` are treated as opaque JSON pending the score/spec contract.

## Checks
`api-server`, `api-server-api`, `db` lint + type-check + format all green.