### PR TITLE
feat(experiments): user tRPC contract + router (dam-u1n.4)

### DIFF
--- a/packages/api-server-api/src/context.ts
+++ b/packages/api-server-api/src/context.ts
@@ -5,6 +5,7 @@ import type { ChannelsService } from "./modules/channels/types.js";
 import type { ConnectionsService } from "./modules/connections/types.js";
 import type { E2eService } from "./modules/e2e/types.js";
 import type { EgressRulesService } from "./modules/egress-rules/types.js";
+import type { ExperimentsService } from "./modules/experiments/types.js";
 import type { FilesService } from "./modules/files/router.js";
 import type { SchedulesService } from "./modules/schedules/types.js";
 import type { SecretsService } from "./modules/secrets/types.js";
@@ -39,6 +40,7 @@ export interface ApiContext {
   skills: SkillsService;
   approvals: ApprovalsService;
   egressRules: EgressRulesService;
+  experiments: ExperimentsService;
   files: FilesService;
   terms: TermsService;
   e2e: E2eService;

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -87,6 +87,12 @@ export type {
   ExperimentsService,
 } from "./modules/experiments/types.js";
 export {
+  experimentAddArmInputSchema,
+  experimentConfigSchema,
+  experimentCreateInputSchema,
+  experimentIdInputSchema,
+} from "./modules/experiments/schemas.js";
+export {
   quietWindowSchema,
   scheduleCreateCronInputSchema,
   scheduleCreateRRuleInputSchema,

--- a/packages/api-server-api/src/modules/experiments/router.ts
+++ b/packages/api-server-api/src/modules/experiments/router.ts
@@ -1,0 +1,39 @@
+import { TRPCError } from "@trpc/server";
+import { t } from "../../trpc.js";
+import {
+  manageAgentsProcedure,
+  readAgentProcedure,
+} from "../../auth-procedures.js";
+import {
+  experimentAddArmInputSchema,
+  experimentCreateInputSchema,
+  experimentIdInputSchema,
+} from "./schemas.js";
+
+export const experimentsRouter = t.router({
+  list: readAgentProcedure.query(({ ctx }) => ctx.experiments.list()),
+
+  get: readAgentProcedure
+    .input(experimentIdInputSchema)
+    .query(async ({ ctx, input }) => {
+      const experiment = await ctx.experiments.getWithRuns(input.id);
+      if (!experiment) throw new TRPCError({ code: "NOT_FOUND" });
+      return experiment;
+    }),
+
+  create: manageAgentsProcedure
+    .input(experimentCreateInputSchema)
+    .mutation(({ ctx, input }) => ctx.experiments.create(input)),
+
+  addArm: manageAgentsProcedure
+    .input(experimentAddArmInputSchema)
+    .mutation(({ ctx, input }) => ctx.experiments.addArm(input)),
+
+  start: manageAgentsProcedure
+    .input(experimentIdInputSchema)
+    .mutation(({ ctx, input }) => ctx.experiments.start(input.id)),
+
+  stop: manageAgentsProcedure
+    .input(experimentIdInputSchema)
+    .mutation(({ ctx, input }) => ctx.experiments.stop(input.id)),
+});

--- a/packages/api-server-api/src/modules/experiments/schemas.ts
+++ b/packages/api-server-api/src/modules/experiments/schemas.ts
@@ -1,0 +1,19 @@
+import { z } from "zod";
+
+export const experimentConfigSchema = z.record(z.string(), z.unknown());
+
+export const experimentIdInputSchema = z.object({
+  id: z.string().min(1),
+});
+
+export const experimentCreateInputSchema = z.object({
+  name: z.string().trim().min(1, "name is required").max(200),
+  goal: z.string().trim().min(1, "goal is required"),
+  spec: experimentConfigSchema.default({}),
+});
+
+export const experimentAddArmInputSchema = z.object({
+  experimentId: z.string().min(1),
+  agentId: z.string().min(1),
+  armSpec: experimentConfigSchema.default({}),
+});

--- a/packages/api-server-api/src/modules/experiments/types.ts
+++ b/packages/api-server-api/src/modules/experiments/types.ts
@@ -92,6 +92,8 @@ export interface ExperimentsService {
   create(input: ExperimentCreateInput): Promise<Experiment>;
   /** Add an arm referencing an existing owned agent. */
   addArm(input: ExperimentAddArmInput): Promise<ExperimentArm>;
+  start(id: string): Promise<Experiment>;
+  stop(id: string): Promise<Experiment>;
   delete(id: string): Promise<void>;
   /** Resolve the arm of the owner's currently-running experiment that this
    *  agent belongs to, or null. Used by the ingestion path to attribute a run

--- a/packages/api-server-api/src/router.ts
+++ b/packages/api-server-api/src/router.ts
@@ -6,6 +6,7 @@ import { channelsRouter } from "./modules/channels/router.js";
 import { connectionsRouter } from "./modules/connections/router.js";
 import { e2eRouter } from "./modules/e2e/router.js";
 import { egressRulesRouter } from "./modules/egress-rules/router.js";
+import { experimentsRouter } from "./modules/experiments/router.js";
 import { filesRouter } from "./modules/files/router.js";
 import { schedulesRouter } from "./modules/schedules/router.js";
 import { secretsRouter } from "./modules/secrets/router.js";
@@ -25,6 +26,7 @@ export const appRouter = t.router({
   skills: skillsRouter,
   approvals: approvalsRouter,
   egressRules: egressRulesRouter,
+  experiments: experimentsRouter,
   files: filesRouter,
   terms: termsRouter,
   e2e: e2eRouter,

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -33,6 +33,7 @@ import {
   composeSchedulesForOwner,
   type SchedulesBoot,
 } from "../../modules/schedules/index.js";
+import { composeExperimentsForOwner } from "../../modules/experiments/index.js";
 import { composeSkillsModule } from "../../modules/skills/compose.js";
 import { composeFilesModule } from "../../modules/files/files-service.js";
 import { createSlackOAuthRoutes } from "../../modules/channels/infrastructure/slack-oauth.js";
@@ -737,6 +738,11 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       owner: user.sub,
       agentExists: async (agentId) => (await agents.get(agentId)) !== null,
     });
+    const { experiments } = composeExperimentsForOwner({
+      db,
+      owner: user.sub,
+      agentExists: async (agentId) => (await agents.get(agentId)) !== null,
+    });
     const skills = composeSkillsModule(
       api,
       config.namespace,
@@ -785,6 +791,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
         skills,
         approvals,
         egressRules,
+        experiments,
         files,
         terms,
         e2e,

--- a/packages/api-server/src/modules/experiments/infrastructure/experiments-repository.ts
+++ b/packages/api-server/src/modules/experiments/infrastructure/experiments-repository.ts
@@ -29,6 +29,11 @@ export interface ExperimentsRepository {
   }): Promise<Experiment>;
   listByOwner(ownerId: string): Promise<Experiment[]>;
   get(id: string, ownerId: string): Promise<Experiment | null>;
+  updateStatus(
+    id: string,
+    ownerId: string,
+    status: ExperimentStatus,
+  ): Promise<Experiment | null>;
   delete(id: string, ownerId: string): Promise<void>;
 
   addArm(input: {
@@ -123,6 +128,16 @@ export function createExperimentsRepository(db: Db): ExperimentsRepository {
           and(eq(experimentsTable.id, id), eq(experimentsTable.owner, ownerId)),
         );
       return rows[0] ? rowToExperiment(rows[0]) : null;
+    },
+
+    async updateStatus(id, ownerId, status): Promise<Experiment | null> {
+      await db
+        .update(experimentsTable)
+        .set({ status, updatedAt: new Date() })
+        .where(
+          and(eq(experimentsTable.id, id), eq(experimentsTable.owner, ownerId)),
+        );
+      return this.get(id, ownerId);
     },
 
     async delete(id, ownerId): Promise<void> {

--- a/packages/api-server/src/modules/experiments/services/experiments-service.ts
+++ b/packages/api-server/src/modules/experiments/services/experiments-service.ts
@@ -108,6 +108,49 @@ export function createExperimentsService(deps: {
       }
     },
 
+    async start(id): Promise<Experiment> {
+      const experiment = await deps.repo.get(id, deps.owner);
+      if (!experiment) throw new TRPCError({ code: "NOT_FOUND" });
+      if (experiment.status === "completed") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: "A completed experiment cannot be started again.",
+        });
+      }
+      if (experiment.status === "running") return experiment;
+      const updated = await deps.repo.updateStatus(id, deps.owner, "running");
+      if (!updated) throw new TRPCError({ code: "NOT_FOUND" });
+      securityLog("info", "experiment.start", {
+        category: "resource",
+        actor: deps.owner,
+        actorKind: "user",
+        target: id,
+        result: "success",
+      });
+      return updated;
+    },
+
+    async stop(id): Promise<Experiment> {
+      const experiment = await deps.repo.get(id, deps.owner);
+      if (!experiment) throw new TRPCError({ code: "NOT_FOUND" });
+      if (experiment.status !== "running") {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `Only a running experiment can be stopped (status: ${experiment.status}).`,
+        });
+      }
+      const updated = await deps.repo.updateStatus(id, deps.owner, "stopped");
+      if (!updated) throw new TRPCError({ code: "NOT_FOUND" });
+      securityLog("info", "experiment.stop", {
+        category: "resource",
+        actor: deps.owner,
+        actorKind: "user",
+        target: id,
+        result: "success",
+      });
+      return updated;
+    },
+
     async delete(id): Promise<void> {
       await deps.repo.delete(id, deps.owner);
       securityLog("info", "experiment.delete", {


### PR DESCRIPTION
User-facing Experiments tRPC contract + router on top of the dam-u1n.3 service. Both UI and CLI consume this; harness reporting stays on MCP.

## Changes
- **Router** (`api-server-api`): `list`, `get`, `create`, `addArm`, `start`, `stop`. Reads gated by `agents:read`, mutations by `agents:manage` (wildcard-bound, fits an owner-scoped resource).
- **Zod schemas**: `spec`/`armSpec` validated as opaque `record(string, unknown)`.
- **Service** (`api-server`): added `start`/`stop` as owner-scoped status transitions (start →running, rejects completed, idempotent when running; stop running→stopped), security-logged. Trial-session triggering is the seam for dam-u1n.6.
- **Repository**: `updateStatus`.
- **Wiring**: registered in `appRouter` + `ApiContext`; composed `composeExperimentsForOwner` per owner in app.ts.

## Notes
- No `delete` procedure (ticket enumerated 6 procedures; service still has `delete` unexposed).
- `mise run <pkg>:check` passes for `api-server-api`, `api-server`, `ui`.

Closes dam-u1n.4.