### PR TITLE
feat(experiments): record_run MCP tool (dam-u1n.7)

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -84,6 +84,7 @@ export type {
   ActiveArm,
   ExperimentCreateInput,
   ExperimentAddArmInput,
+  ExperimentRecordRunInput,
   ExperimentsService,
 } from "./modules/experiments/types.js";
 export {

--- a/packages/api-server-api/src/modules/experiments/types.ts
+++ b/packages/api-server-api/src/modules/experiments/types.ts
@@ -83,6 +83,14 @@ export interface ExperimentAddArmInput {
   armSpec: ExperimentConfig;
 }
 
+export interface ExperimentRecordRunInput {
+  experimentId: string;
+  agentId: string;
+  sessionId: string;
+  candidateRef: string;
+  score: number;
+}
+
 /** Owner-scoped application service. Composed per-owner for both the user tRPC
  *  router and the in-pod MCP session (the owner is bound at composition time,
  *  never taken from request input). */
@@ -97,4 +105,8 @@ export interface ExperimentsService {
    *  agent belongs to, or null. Used by the ingestion path to attribute a run
    *  without trusting agent-supplied experiment ids. */
   resolveActiveArm(agentId: string): Promise<ActiveArm | null>;
+  /** Append a Run to the ledger for an already attribution-resolved arm,
+   *  allocating the next per-arm run number. The caller stores the Candidate
+   *  artifact first; `candidateRef` is its key. */
+  recordRun(input: ExperimentRecordRunInput): Promise<ExperimentRun>;
 }

--- a/packages/api-server/src/apps/harness-api-server/app.ts
+++ b/packages/api-server/src/apps/harness-api-server/app.ts
@@ -7,6 +7,8 @@ import {
   composeSchedulesForOwner,
   type SchedulesBoot,
 } from "../../modules/schedules/index.js";
+import { composeExperimentsForOwner } from "../../modules/experiments/index.js";
+import { composeArtifactsModule } from "../../modules/artifacts/compose.js";
 import { composeSkillsModule } from "../../modules/skills/compose.js";
 import { createTemplatesRepository } from "../../modules/templates/infrastructure/templates-repository.js";
 import type { SkillSourceSeed } from "../../modules/skills/index.js";
@@ -41,6 +43,10 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
   const k8sClient = createK8sClient(api, config.namespace);
   // Boot-loaded, file-mounted templates, shared across requests.
   const templatesRepo = createTemplatesRepository(config.agentTemplatesPath);
+  const { service: artifacts } = composeArtifactsModule({
+    db,
+    maxBytes: config.maxArtifactBytes,
+  });
 
   const app = createHarnessRouter({
     channelManager,
@@ -60,6 +66,9 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
       ),
     schedulesServiceFor: (owner) =>
       composeSchedulesForOwner({ boot: schedulesBoot, owner }).schedules,
+    experimentsServiceFor: (owner) =>
+      composeExperimentsForOwner({ db, owner }).experiments,
+    artifacts,
   });
 
   const server = serve(

--- a/packages/api-server/src/apps/harness-api-server/harness-router.ts
+++ b/packages/api-server/src/apps/harness-api-server/harness-router.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type {
+  ExperimentsService,
   SchedulesService,
   SkillsService,
   RuntimeDeliveryService,
@@ -8,6 +9,7 @@ import { mountMcpRoutes } from "./mcp-endpoint.js";
 import { mountRuntimeTrpc } from "./runtime-trpc.js";
 import type { ChannelManager } from "./../../modules/channels/services/channel-manager.js";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
+import type { ArtifactService } from "../../modules/artifacts/services/artifact-service.js";
 
 export function createHarnessRouter(deps: {
   channelManager: ChannelManager;
@@ -15,6 +17,8 @@ export function createHarnessRouter(deps: {
   composeSkills: (owner: string) => SkillsService;
   agentHome: string;
   schedulesServiceFor: (owner: string) => SchedulesService;
+  experimentsServiceFor: (owner: string) => ExperimentsService;
+  artifacts: ArtifactService;
   runtimeHello: RuntimeDeliveryService;
 }) {
   const app = new Hono();
@@ -25,6 +29,8 @@ export function createHarnessRouter(deps: {
     composeSkills: deps.composeSkills,
     agentHome: deps.agentHome,
     schedulesServiceFor: deps.schedulesServiceFor,
+    experimentsServiceFor: deps.experimentsServiceFor,
+    artifacts: deps.artifacts,
   });
   mountRuntimeTrpc(app, {
     k8s: deps.k8s,

--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -8,6 +8,8 @@ import { z } from "zod";
 import { TRPCError } from "@trpc/server";
 import {
   ChannelType,
+  SessionType,
+  type ExperimentsService,
   type SchedulesService,
   type SkillsService,
 } from "api-server-api";
@@ -17,6 +19,8 @@ import type {
 } from "./../../modules/channels/services/channel-manager.js";
 import type { K8sClient } from "../../modules/agents/infrastructure/k8s.js";
 import { podBaseUrl } from "../../modules/agents/infrastructure/k8s.js";
+import { createAcpClient } from "../../core/acp-client.js";
+import type { ArtifactService } from "../../modules/artifacts/services/artifact-service.js";
 import { resolveAgent } from "./agent-auth.js";
 import { securityLog } from "../../core/security-log.js";
 
@@ -101,6 +105,8 @@ export interface McpSessionDeps {
   k8s: K8sClient;
   skills: SkillsService;
   schedules: SchedulesService;
+  experiments: ExperimentsService;
+  artifacts: ArtifactService;
   agentHome: string;
 }
 
@@ -121,6 +127,29 @@ export function createMcpSession(
       }),
     ],
   });
+
+  async function resolveTrialSessionId(
+    experimentId: string,
+  ): Promise<string | null> {
+    const acp = createAcpClient({
+      namespace: deps.k8s.namespace,
+      instanceName: agentId,
+    });
+    let sessions: Awaited<ReturnType<typeof acp.listSessions>>;
+    try {
+      sessions = await acp.listSessions();
+    } catch {
+      return null;
+    }
+    const trial = sessions
+      .filter(
+        (s) =>
+          s.platform?.type === SessionType.ExperimentTrial &&
+          s.platform?.experimentId === experimentId,
+      )
+      .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""))[0];
+    return trial?.sessionId ?? null;
+  }
 
   server.tool(
     "describe_channel",
@@ -468,6 +497,92 @@ export function createMcpSession(
     },
   );
 
+  // ---- Experiments tools ----------------------------------------------------
+  server.tool(
+    "record_run",
+    `Append a Run to your Experiment's ledger — call this once per optimization-loop iteration that produced a result. Pass the iteration's \`score\` (a single number, higher is better) and \`candidate\`, the path to the artifact file the iteration produced (absolute under ${agentHome} or workspace-relative, e.g. candidate.json). The platform reads and stores that file (10 MiB cap) and attributes the Run to your active experiment arm automatically. Only works while this agent is an arm of a running experiment.`,
+    {
+      score: z
+        .number()
+        .describe("The iteration's score; a single number, higher is better."),
+      candidate: z
+        .string()
+        .min(1)
+        .describe(
+          `Path to the candidate artifact file: absolute under ${agentHome} or workspace-relative (e.g. candidate.json).`,
+        ),
+    },
+    async ({ score, candidate }) => {
+      const active = await deps.experiments.resolveActiveArm(agentId);
+      if (!active) {
+        return errorResult(
+          "record_run is only available while this agent is an arm of a running experiment; none is active.",
+        );
+      }
+
+      const resolvedPath = resolveWorkspacePath(candidate, agentHome);
+      let file: { content: string; binary: boolean; mimeType?: string };
+      try {
+        file = await runtimeClient.files.read.query({ path: resolvedPath });
+      } catch (err) {
+        if (err instanceof TRPCClientError) {
+          if (err.data?.code === "NOT_FOUND") {
+            return errorResult(
+              `candidate not found: ${candidate} (resolved to ${resolvedPath})`,
+            );
+          }
+          if (err.data?.code === "PAYLOAD_TOO_LARGE") {
+            return errorResult(
+              `candidate ${candidate} exceeds the 10 MB per-file cap`,
+            );
+          }
+        }
+        return errorResult(
+          `failed to read candidate ${candidate}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      const content = file.binary
+        ? Buffer.from(file.content, "base64")
+        : Buffer.from(file.content, "utf8");
+      const contentType = file.mimeType ?? "application/octet-stream";
+
+      const sessionId = await resolveTrialSessionId(active.experimentId);
+      if (!sessionId) {
+        return errorResult(
+          "no active trial session found for this experiment; start the experiment before recording runs.",
+        );
+      }
+
+      const key = `${active.experimentId}/${agentId}/${crypto.randomUUID()}/${basename(candidate)}`;
+      try {
+        await deps.artifacts.put({ key, content, contentType });
+      } catch (err) {
+        return errorResult(
+          `failed to store candidate: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+
+      const run = await deps.experiments.recordRun({
+        experimentId: active.experimentId,
+        agentId,
+        sessionId,
+        candidateRef: key,
+        score,
+      });
+
+      return textResult(
+        JSON.stringify({
+          runId: run.id,
+          runNumber: run.runNumber,
+          experimentId: run.experimentId,
+          score: run.score,
+          candidateRef: run.candidateRef,
+        }),
+      );
+    },
+  );
+
   // ---- Transport ------------------------------------------------------------
 
   const transport = new WebStandardStreamableHTTPServerTransport({
@@ -494,6 +609,8 @@ export interface MountMcpDeps {
   k8s: K8sClient;
   composeSkills: (owner: string) => SkillsService;
   schedulesServiceFor: (owner: string) => SchedulesService;
+  experimentsServiceFor: (owner: string) => ExperimentsService;
+  artifacts: ArtifactService;
   agentHome: string;
 }
 
@@ -547,11 +664,14 @@ export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
 
     const skills = deps.composeSkills(verified.owner);
     const schedules = deps.schedulesServiceFor(verified.owner);
+    const experiments = deps.experimentsServiceFor(verified.owner);
     const session = createMcpSession(agentId, {
       channelManager: deps.channelManager,
       k8s: deps.k8s,
       skills,
       schedules,
+      experiments,
+      artifacts: deps.artifacts,
       agentHome: deps.agentHome,
     });
     await session.server.connect(session.transport);

--- a/packages/api-server/src/modules/experiments/infrastructure/experiments-repository.ts
+++ b/packages/api-server/src/modules/experiments/infrastructure/experiments-repository.ts
@@ -39,6 +39,15 @@ export interface ExperimentsRepository {
   listArms(experimentId: string): Promise<ExperimentArm[]>;
   listRuns(experimentId: string): Promise<ExperimentRun[]>;
 
+  addRun(input: {
+    experimentId: string;
+    agentId: string;
+    sessionId: string;
+    candidateRef: string;
+    score: number;
+    status: string;
+  }): Promise<ExperimentRun>;
+
   /** The arm of the owner's single running experiment that contains `agentId`,
    *  or null. Owner-scoped so a leaked agentId can't reach another tenant. */
   findActiveArm(
@@ -178,6 +187,40 @@ export function createExperimentsRepository(db: Db): ExperimentsRepository {
         .where(eq(experimentRunsTable.experimentId, experimentId))
         .orderBy(asc(experimentRunsTable.runNumber));
       return rows.map(rowToRun);
+    },
+
+    async addRun(input): Promise<ExperimentRun> {
+      const id = `run-${randomBytes(6).toString("hex")}`;
+      const [last] = await db
+        .select({ runNumber: experimentRunsTable.runNumber })
+        .from(experimentRunsTable)
+        .where(
+          and(
+            eq(experimentRunsTable.experimentId, input.experimentId),
+            eq(experimentRunsTable.agentId, input.agentId),
+          ),
+        )
+        .orderBy(desc(experimentRunsTable.runNumber))
+        .limit(1);
+      const runNumber = (last?.runNumber ?? 0) + 1;
+      await db.insert(experimentRunsTable).values({
+        id,
+        experimentId: input.experimentId,
+        agentId: input.agentId,
+        runNumber,
+        sessionId: input.sessionId,
+        candidateRef: input.candidateRef,
+        score: input.score,
+        status: input.status,
+      });
+      const [row] = await db
+        .select()
+        .from(experimentRunsTable)
+        .where(eq(experimentRunsTable.id, id));
+      if (!row) {
+        throw new Error(`addRun: run ${id} not found after insert`);
+      }
+      return rowToRun(row);
     },
 
     async findActiveArm(

--- a/packages/api-server/src/modules/experiments/services/experiments-service.ts
+++ b/packages/api-server/src/modules/experiments/services/experiments-service.ts
@@ -5,6 +5,8 @@ import type {
   ExperimentAddArmInput,
   ExperimentArm,
   ExperimentCreateInput,
+  ExperimentRecordRunInput,
+  ExperimentRun,
   ExperimentsService,
   ExperimentWithRuns,
 } from "api-server-api";
@@ -131,6 +133,28 @@ export function createExperimentsService(deps: {
         agentId: arm.agentId,
         armSpec: arm.armSpec,
       };
+    },
+
+    async recordRun(input: ExperimentRecordRunInput): Promise<ExperimentRun> {
+      const run = await deps.repo.addRun({
+        experimentId: input.experimentId,
+        agentId: input.agentId,
+        sessionId: input.sessionId,
+        candidateRef: input.candidateRef,
+        score: input.score,
+        status: "completed",
+      });
+      securityLog("info", "experiment.record_run", {
+        category: "resource",
+        actor: input.agentId,
+        actorKind: "agent",
+        surface: "mcp",
+        agentId: input.agentId,
+        target: input.experimentId,
+        result: "success",
+        detail: { runNumber: run.runNumber },
+      });
+      return run;
     },
   };
 }


### PR DESCRIPTION
Stacks on #2033 (the experiments epic branch). Implements dam-u1n.7.

## What

Adds the \`record_run\` outbound MCP tool, the ingestion path for Experiments. An arm's harness calls it once per optimization-loop iteration with a score and a candidate file path; the platform captures a ledger row + the stored candidate.

Handler (orchestrated in the MCP endpoint, same shape as \`send_channel_message\`):
1. Resolve the active arm from the network-verified \`agentId\` (never from tool input).
2. Read the candidate file via the runtime \`files.read\` client.
3. Resolve the producing Trial session over ACP \`listSessions\`, matching \`_meta.platform.type=experiment_trial\` + \`experimentId\`.
4. Store the blob via the artifact store (10 MiB cap, Postgres bytea); \`candidate_ref\` = the artifact key.
5. Write the \`experiment_runs\` row (per-arm \`run_number\` allocated).

## Changes
- Contract: \`ExperimentRecordRunInput\` + \`ExperimentsService.recordRun\`.
- Repo: \`addRun\` (allocates next per-arm run number, inserts).
- Service: \`recordRun\` (ledger write + security audit line).
- Wiring: artifacts module composed once at the harness app root; experiments composed per-owner; threaded into the MCP session deps.

## Notes
- \`experiment_runs.session_id\` is resolved over ACP because sessions are agent-owned (no server-side session store). Full end-to-end needs dam-u1n.6 (start path) to stamp a real \`experiment_trial\` session.
- Download endpoint deferred to dam-u1n.10.

## Verification
- \`api-server-api\` + \`api-server\` checks (tsc, lint, prettier) pass.
- 210 \`api-server\` unit tests pass.