### PR TITLE
fix(ui): exclude provider connections from sandbox wizard step 3

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/connections-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/connections-section.tsx
@@ -23,6 +23,7 @@ import {
   filterOfferedTemplates,
   isShowInternalConnectionsEnabled,
 } from "../../connections/internal-only.js";
+import { excludeProviderConnections } from "../lib/provider-connections.js";
 import { CardList } from "./card-list.js";
 
 const NO_TEMPLATES: ConnectionTemplateView[] = [];
@@ -53,10 +54,8 @@ export function ConnectionsSection({
   const [showCatalog, setShowCatalog] = useState(false);
 
   const allTemplates = templatesQ.data ?? NO_TEMPLATES;
-  // Provider connections are managed in the Provider section above; keep them
-  // out of the generic list so they aren't offered twice.
-  const connections = (connectionsQ.data ?? NO_CONNECTIONS).filter(
-    (c) => !PROVIDER_TEMPLATE_IDS.has(c.templateId),
+  const connections = excludeProviderConnections(
+    connectionsQ.data ?? NO_CONNECTIONS,
   );
 
   const templateById = useMemo(

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -1,6 +1,5 @@
 import {
   type ConnectionTemplateView,
-  type ConnectionView,
   PROVIDER_TEMPLATE_IDS,
 } from "api-server-api";
 import { useMemo, useState } from "react";
@@ -24,6 +23,7 @@ import {
   filterOfferedTemplates,
   isShowInternalConnectionsEnabled,
 } from "../../../connections/internal-only.js";
+import { excludeProviderConnections } from "../../lib/provider-connections.js";
 import {
   saveSnapshot,
   type WizardSnapshot,
@@ -59,7 +59,7 @@ export function ConnectionsStep({
   const [creating, setCreating] = useState<ConnectionTemplateView | null>(null);
 
   const allTemplates = templatesQ.data ?? NO_TEMPLATES;
-  const connections = (connectionsQ.data ?? []) as unknown as ConnectionView[];
+  const connections = excludeProviderConnections(connectionsQ.data ?? []);
 
   const templateById = useMemo(
     () => new Map(allTemplates.map((t) => [t.id, t])),

--- a/packages/ui/src/modules/sandboxes/lib/provider-connections.ts
+++ b/packages/ui/src/modules/sandboxes/lib/provider-connections.ts
@@ -1,0 +1,8 @@
+import { type ConnectionView, PROVIDER_TEMPLATE_IDS } from "api-server-api";
+
+export const isProviderConnection = (c: ConnectionView): boolean =>
+  PROVIDER_TEMPLATE_IDS.has(c.templateId);
+
+export const excludeProviderConnections = (
+  connections: readonly ConnectionView[],
+): ConnectionView[] => connections.filter((c) => !isProviderConnection(c));


### PR DESCRIPTION
When creating a sandbox, the wizard's step 3 ("Grant connections") listed the provider you'd already chosen in step 2 under "My connections" — shown as an unchecked checkbox. That was misleading: the provider is attached regardless of step 2, so the box implied it wasn't connected, and unchecking it had no effect.

Step 3's "My connections" list now excludes provider-type connections entirely. Providers are chosen in step 2, and that's the only place they appear. The list shows only the non-provider connections (apps, MCP servers, and the like) you can optionally grant.

No change to how providers are selected in step 2 or attached to the sandbox.

Closes #2037