### PR TITLE
feat(telemetry): tag agent telemetry with a trusted, unforgeable identity

### DIFF
--- a/deploy/helm/platform/templates/clickstack/collector.yaml
+++ b/deploy/helm/platform/templates/clickstack/collector.yaml
@@ -22,13 +22,35 @@ data:
         protocols:
           grpc:
             endpoint: 0.0.0.0:4317
+            # Retain request headers as client metadata so the
+            # resource/agent-identity processor can read the gateway-stamped
+            # x-platform-agent-id header.
+            include_metadata: true
           http:
             endpoint: 0.0.0.0:4318
+            include_metadata: true
     processors:
       memory_limiter:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 25
+      # Trusted agent attribution. The paired gateway Envoy stamps the
+      # x-platform-agent-id header (overwriting anything the agent set) on the
+      # telemetry it forwards here; promote it to the platform.agent.id resource
+      # attribute. delete-then-set so a forged value can never survive a missing
+      # header: unconditionally drop any client-supplied platform.agent.id, then
+      # set it ONLY from the trusted header. MUST run before `batch`, which emits
+      # a new context and drops per-request client metadata. Telemetry with no
+      # header (platform components) ends up with no platform.agent.id, which is
+      # how the read path tells agent telemetry apart. See
+      # docs/architecture/observability.md.
+      resource/agent-identity:
+        attributes:
+          - key: platform.agent.id
+            action: delete
+          - key: platform.agent.id
+            from_context: "metadata.x-platform-agent-id"
+            action: upsert
       batch: {}
     exporters:
       clickhouse:
@@ -45,15 +67,15 @@ data:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource/agent-identity, batch]
           exporters: [clickhouse]
         traces:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource/agent-identity, batch]
           exporters: [clickhouse]
         metrics:
           receivers: [otlp]
-          processors: [memory_limiter, batch]
+          processors: [memory_limiter, resource/agent-identity, batch]
           exporters: [clickhouse]
 ---
 apiVersion: v1

--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -79,6 +79,16 @@ spec:
               value: {{ .Values.istio.trustDomain | quote }}
             - name: PLATFORM_ISTIO_WAYPOINT_NAME
               value: {{ .Values.istio.waypointName | quote }}
+            {{- if .Values.clickstack.enabled }}
+            # Telemetry attribution: when the bundled telemetry backend is on,
+            # each gateway gains a collector egress chain that MITM-terminates
+            # this host and stamps the trusted x-platform-agent-id header. Empty
+            # otherwise, so the chain (and the leaf SAN entry) are not rendered.
+            - name: PLATFORM_TELEMETRY_COLLECTOR_HOST
+              value: "{{ include "platform.clickstack.collector.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local"
+            - name: PLATFORM_TELEMETRY_COLLECTOR_PORT
+              value: "4318"
+            {{- end }}
             - name: PLATFORM_RELEASE_DOMAIN
               value: "svc.cluster.local"
             - name: ENVOY_IMAGE

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,6 +1,6 @@
 # Observability (agent telemetry)
 
-Last verified: 2026-06-26
+Last verified: 2026-06-29
 
 ## Overview
 
@@ -41,7 +41,13 @@ ClickStack's default posture secures the collector with an ingestion key the UI 
 
 Making the mesh the sole gate is why the collector is platform-owned. ClickStack's bundled collector takes its configuration — including the ingestion-key check — dynamically from the exploration UI, so that configuration cannot be the access boundary here. The platform instead runs its own collector with a fixed configuration and no key enforcement. The UI is unaffected: it reads the telemetry store directly, not the collector.
 
-How agent telemetry actually reaches the collector, and the mesh identity that traffic carries, belong to the export path and are described where that lands.
+## Trusted attribution
+
+Telemetry only answers *whose agents ran, and how* if each record is reliably tied to the agent that produced it — and agents run untrusted code, so the attribution cannot be taken from what the agent put in its own telemetry. It comes instead from the platform-controlled path the telemetry already travels.
+
+Every agent's egress, telemetry included, leaves through its **paired gateway pod**: the agent has no other admitted route (see [security-and-credentials](security-and-credentials.md)), and the gateway proxy's configuration is controller-rendered, not agent-writable. When the telemetry backend is enabled, that gateway proxy intercepts any agent OTLP bound for the collector and stamps a trusted `platform.agent.id` identifying the producing agent — **overwriting** anything the agent set, since the value is fixed in this gateway's own per-agent configuration. The collector then promotes that value to a `platform.agent.id` resource attribute on every signal in the request, and **drops any agent-supplied `platform.agent.id` that did not arrive from the gateway**, so a forged value can never survive.
+
+The guarantee is **attribution, not content integrity**: an agent can still misreport its own numbers (inflate a token count), but it can only ever pollute *its own* telemetry — never make its telemetry appear under another agent or user. The owner-scoped read path resolves `platform.agent.id` to the owning user; telemetry that carries no `platform.agent.id` (the platform's own components) is not agent telemetry and is never attributed to a user. The attribute is namespaced under the permanent `platform` codename so it never collides with OpenTelemetry semantic-convention or agent-self-reported `agent.*` attributes.
 
 ## Persistence
 

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -73,6 +73,15 @@ type Config struct {
 	// AuthorizationPolicy's targetRefs. Must match the Helm chart's
 	// `istio.waypointName`.
 	IstioWaypointName string
+	// TelemetryCollectorHost is the in-cluster DNS of the platform OTLP
+	// collector the gateway forwards agent telemetry to. Empty when the
+	// telemetry backend is disabled; the chart sets it from
+	// `clickstack.enabled`. When set, each gateway gains a collector egress
+	// chain that stamps the trusted `x-platform-agent-id` header so the
+	// collector can attribute telemetry to the producing instance.
+	TelemetryCollectorHost string
+	// TelemetryCollectorPort is the collector's OTLP/HTTP port (default 4318).
+	TelemetryCollectorPort int
 }
 
 func LoadFromEnv() (*Config, error) {
@@ -144,6 +153,8 @@ func LoadFromEnv() (*Config, error) {
 	cfg.ExtAuthzHoldSeconds = envOrDefaultInt("EXT_AUTHZ_HOLD_SECONDS", 1800)
 	cfg.IstioTrustDomain = envOrDefault("PLATFORM_ISTIO_TRUST_DOMAIN", "cluster.local")
 	cfg.IstioWaypointName = envOrDefault("PLATFORM_ISTIO_WAYPOINT_NAME", "apiserver-waypoint")
+	cfg.TelemetryCollectorHost = os.Getenv("PLATFORM_TELEMETRY_COLLECTOR_HOST")
+	cfg.TelemetryCollectorPort = envOrDefaultInt("PLATFORM_TELEMETRY_COLLECTOR_PORT", 4318)
 	if err := cfg.validate(); err != nil {
 		return nil, err
 	}
@@ -250,6 +261,13 @@ func (c *Config) ExtAuthzHostFor(instanceID string) string {
 func (c *Config) HarnessHost() string {
 	return fmt.Sprintf("%s-apiserver-harness.%s.svc.cluster.local", c.ReleaseName, c.ReleaseNamespace)
 }
+
+// TelemetryEnabled reports whether the agent-telemetry backend is configured
+// (collector host set by the chart from `clickstack.enabled`). When true, each
+// gateway renders a collector egress chain that stamps the trusted agent id,
+// and the leaf cert is issued (and mounted) even for an instance with no
+// credential Secrets.
+func (c *Config) TelemetryEnabled() bool { return c.TelemetryCollectorHost != "" }
 
 // PrincipalFor returns the SPIFFE principal string for `instanceID`,
 // matching how istiod stamps workload certs (`<td>/ns/<ns>/sa/<sa>`).

--- a/packages/controller/pkg/config/config_test.go
+++ b/packages/controller/pkg/config/config_test.go
@@ -42,6 +42,32 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	assert.Equal(t, "platform-extauthz-inst-1.default.svc.cluster.local", cfg.ExtAuthzHostFor("inst-1"))
 }
 
+func TestLoadFromEnv_Telemetry(t *testing.T) {
+	// Off by default: no collector host, port defaults to 4318.
+	setEnv(t, map[string]string{
+		"PLATFORM_RELEASE_NAME": "platform",
+		"POD_NAME":              "controller-0",
+	})
+	cfg, err := LoadFromEnv()
+	require.NoError(t, err)
+	assert.Empty(t, cfg.TelemetryCollectorHost)
+	assert.False(t, cfg.TelemetryEnabled())
+	assert.Equal(t, 4318, cfg.TelemetryCollectorPort)
+
+	// Configured by the chart when clickstack is enabled.
+	setEnv(t, map[string]string{
+		"PLATFORM_RELEASE_NAME":             "platform",
+		"POD_NAME":                          "controller-0",
+		"PLATFORM_TELEMETRY_COLLECTOR_HOST": "platform-clickstack-collector.platform.svc.cluster.local",
+		"PLATFORM_TELEMETRY_COLLECTOR_PORT": "4318",
+	})
+	cfg, err = LoadFromEnv()
+	require.NoError(t, err)
+	assert.True(t, cfg.TelemetryEnabled())
+	assert.Equal(t, "platform-clickstack-collector.platform.svc.cluster.local", cfg.TelemetryCollectorHost)
+	assert.Equal(t, 4318, cfg.TelemetryCollectorPort)
+}
+
 // LoadFromEnv fails-loud when the chart-required fields are missing.
 func TestLoadFromEnv_RejectsMissingRequiredAgentBase(t *testing.T) {
 	setEnv(t, map[string]string{
@@ -220,6 +246,7 @@ func setEnv(t *testing.T, vars map[string]string) {
 		"AGENT_BASE", "AGENT_TEMPLATE_DEFAULTS",
 		"EXT_AUTHZ_PORT", "EXT_AUTHZ_HOLD_SECONDS",
 		"PLATFORM_ISTIO_TRUST_DOMAIN", "PLATFORM_ISTIO_WAYPOINT_NAME",
+		"PLATFORM_TELEMETRY_COLLECTOR_HOST", "PLATFORM_TELEMETRY_COLLECTOR_PORT",
 	} {
 		os.Unsetenv(key)
 		t.Cleanup(func() { os.Unsetenv(key) })

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -473,6 +473,22 @@ func hostShort(host string) string {
 	return hex.EncodeToString(h[:])[:8]
 }
 
+// hostInChains reports whether any per-host chain already terminates `host`.
+// Used to suppress the telemetry collector chain when the collector host
+// would collide with a credentialed/allow-only chain (duplicate
+// `server_names` is a fatal Envoy config error).
+func hostInChains(chains []envoyHostChain, host string) bool {
+	if host == "" {
+		return false
+	}
+	for _, c := range chains {
+		if c.Host == host {
+			return true
+		}
+	}
+	return false
+}
+
 // Bootstrap template — TLS-intercepting CONNECT proxy.
 //
 // Topology:
@@ -832,6 +848,61 @@ static_resources:
 {{- end }}
                             timeout: 0s
 {{- end }}
+{{- if .Telemetry }}
+        # Telemetry egress. The agent exports OTLP/HTTP to the collector
+        # through this gateway (its only admitted egress route); we MITM-
+        # terminate here on the collector SNI and stamp the trusted
+        # x-platform-agent-id header, OVERWRITING anything the agent set, so the
+        # collector attributes the telemetry to this instance and no agent can
+        # forge another's identity. No ext_authz (platform-internal traffic,
+        # not user egress) and no credential injection. Forwards plaintext to
+        # the in-cluster collector; ztunnel wraps the gateway→collector hop in
+        # mTLS. The collector host is in the leaf SAN (see leaf.go), so the
+        # agent's TLS client validates this intercept cert.
+        - name: terminate_otel_collector
+          filter_chain_match:
+            server_names: [ "{{ .TelemetryCollectorHost }}" ]
+          transport_socket:
+            name: envoy.transport_sockets.tls
+            typed_config:
+              "@type": type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext
+              common_tls_context:
+                tls_certificates:
+                  - certificate_chain: { filename: {{ .LeafTLSDir }}/tls.crt }
+                    private_key:      { filename: {{ .LeafTLSDir }}/tls.key }
+          filters:
+            - name: envoy.filters.network.http_connection_manager
+              typed_config:
+                "@type": type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager
+                stat_prefix: terminate_otel_collector
+                http_filters:
+                  - name: envoy.filters.http.router
+                    typed_config:
+                      "@type": type.googleapis.com/envoy.extensions.filters.http.router.v3.Router
+                route_config:
+                  name: forward_otel_collector
+                  virtual_hosts:
+                    - name: default
+                      domains: [ "*" ]
+                      routes:
+                        - match: { prefix: "/" }
+                          route:
+                            # Pinned to the static plaintext collector cluster
+                            # (clusters list below); the agent's Host header
+                            # cannot steer the destination.
+                            cluster: otel_collector
+                            host_rewrite_literal: "{{ .TelemetryCollectorHost }}"
+                            timeout: 0s
+                          request_headers_to_add:
+                            # Trusted, unforgeable identity: OVERWRITE replaces
+                            # any x-platform-agent-id the agent supplied. The
+                            # value is fixed in this gateway's controller-
+                            # rendered config; the agent cannot change it.
+                            - header:
+                                key: x-platform-agent-id
+                                value: "{{ .InstanceID }}"
+                              append_action: OVERWRITE_IF_EXISTS_OR_ADD
+{{- end }}
         # SNI miss: every other host hits the L4 ext_authz catch-all, which
         # gates by SNI alone via the API server's gRPC ext_authz endpoint.
         # No TLS termination, no credential injection -- bytes pass through
@@ -999,6 +1070,30 @@ static_resources:
                     exact: {{ $chain.Host }}
 {{- end }}
 {{- end }}
+{{- if .Telemetry }}
+
+    # Pinned plaintext upstream for the telemetry collector chain. STRICT_DNS
+    # resolves {{ .TelemetryCollectorHost }}:{{ .TelemetryCollectorPort }}
+    # directly; the agent's Host header plays no role in destination selection.
+    # No upstream TLS — the collector is in-cluster and ztunnel wraps the
+    # gateway→collector hop in mTLS transparently. dns_lookup_family is set
+    # explicitly (STRICT_DNS defaults to IPv6-first AUTO) to match every other
+    # DNS cluster in this bootstrap.
+    - name: otel_collector
+      connect_timeout: 5s
+      type: STRICT_DNS
+      dns_lookup_family: V4_PREFERRED
+      lb_policy: ROUND_ROBIN
+      load_assignment:
+        cluster_name: otel_collector
+        endpoints:
+          - lb_endpoints:
+              - endpoint:
+                  address:
+                    socket_address:
+                      address: {{ .TelemetryCollectorHost }}
+                      port_value: {{ .TelemetryCollectorPort }}
+{{- end }}
 
     # Single gRPC ext_authz cluster: both Envoy filters (HTTP on
     # TLS-terminated chains, network on the catch-all) call the same
@@ -1032,14 +1127,17 @@ const envoyListenAddress = "0.0.0.0"
 // renderEnvoyBootstrap returns the Envoy bootstrap YAML for an instance's
 // paired gateway pod.
 //
+// `instanceID` is this gateway's *own* instance (agent or fork name); it is
+// the value stamped into the trusted `x-platform-agent-id` telemetry header.
 // `extAuthzInstanceID` is the instance whose per-instance ext-authz Service
-// the gateway dials. For long-lived pairs this equals the
-// instance name; for forks it is the parent instance's ID — fork pods
-// run as their *own* per-fork SA, but the parent owner's HITL
-// rules should gate fork egress, so the fork's gateway dials the parent's
-// per-instance ext-authz Service. The fork SA is admitted there via a
-// separate per-fork AuthorizationPolicy (`BuildForkExtAuthzAuthorizationPolicy`).
-func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains []envoyHostChain) (string, error) {
+// the gateway dials. For long-lived pairs the two are equal; for forks
+// `extAuthzInstanceID` is the *parent* instance's ID — fork pods run as their
+// *own* per-fork SA, but the parent owner's HITL rules should gate fork
+// egress, so the fork's gateway dials the parent's per-instance ext-authz
+// Service (admitted via `BuildForkExtAuthzAuthorizationPolicy`). The telemetry
+// header, by contrast, must carry the fork's own `instanceID` so its telemetry
+// attributes to the fork, not the parent.
+func renderEnvoyBootstrap(instanceID, extAuthzInstanceID string, cfg *config.Config, chains []envoyHostChain) (string, error) {
 	tmpl, err := template.New("envoy").Parse(envoyBootstrapTmpl)
 	if err != nil {
 		return "", err
@@ -1053,6 +1151,14 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 	// this exact string so the harness route is scoped to api-server
 	// traffic only — fall-through goes through the regular egress paths.
 	harnessAuthority := fmt.Sprintf("%s:%d", cfg.HarnessHost(), cfg.HarnessServerPort)
+	// Render the telemetry collector chain only when the backend is configured
+	// AND the collector host doesn't collide with a credentialed chain host —
+	// two filter chains sharing `server_names` is a fatal Envoy config error.
+	// A collision isn't expected in practice (the collector host is an internal
+	// Service DNS no agent would be granted a credential for), but guard
+	// structurally rather than crash-loop the gateway. The credentialed chain
+	// for that host still wins, and the host is in the leaf SAN regardless.
+	telemetry := cfg.TelemetryEnabled() && !hostInChains(chains, cfg.TelemetryCollectorHost)
 	var buf bytes.Buffer
 	if err := tmpl.Execute(&buf, struct {
 		ListenAddress          string
@@ -1069,6 +1175,10 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		ExtAuthzPort           int
 		ExtAuthzHoldSeconds    int
 		ExtAuthzTimeoutSeconds int
+		Telemetry              bool
+		TelemetryCollectorHost string
+		TelemetryCollectorPort int
+		InstanceID             string
 	}{
 		ListenAddress:          envoyListenAddress,
 		Port:                   cfg.EnvoyPort,
@@ -1084,6 +1194,10 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 		ExtAuthzPort:           cfg.ExtAuthzPort,
 		ExtAuthzHoldSeconds:    cfg.ExtAuthzHoldSeconds,
 		ExtAuthzTimeoutSeconds: extAuthzTimeoutSeconds,
+		Telemetry:              telemetry,
+		TelemetryCollectorHost: cfg.TelemetryCollectorHost,
+		TelemetryCollectorPort: cfg.TelemetryCollectorPort,
+		InstanceID:             instanceID,
 	}); err != nil {
 		return "", err
 	}
@@ -1098,7 +1212,7 @@ func renderEnvoyBootstrap(extAuthzInstanceID string, cfg *config.Config, chains 
 // both args; forks pass the parent instance ID for the second.
 func BuildEnvoyBootstrapConfigMap(instanceName, extAuthzInstanceID string, cfg *config.Config, ownerRef metav1.OwnerReference, secrets []corev1.Secret) (*corev1.ConfigMap, error) {
 	chains := chainsFromSecrets(secrets)
-	yaml, err := renderEnvoyBootstrap(extAuthzInstanceID, cfg, chains)
+	yaml, err := renderEnvoyBootstrap(instanceName, extAuthzInstanceID, cfg, chains)
 	if err != nil {
 		return nil, err
 	}
@@ -1118,7 +1232,7 @@ func BuildEnvoyBootstrapConfigMap(instanceName, extAuthzInstanceID string, cfg *
 // TLS leaf used to terminate the agent's intercepted TLS. None of these are
 // referenced from the agent pod — the credential boundary lives at the pod
 // boundary.
-func envoyVolumes(instanceName string, secrets []corev1.Secret) []corev1.Volume {
+func envoyVolumes(instanceName string, cfg *config.Config, secrets []corev1.Secret) []corev1.Volume {
 	volumes := []corev1.Volume{{
 		Name: envoyBootstrapVolume,
 		VolumeSource: corev1.VolumeSource{
@@ -1141,9 +1255,11 @@ func envoyVolumes(instanceName string, secrets []corev1.Secret) []corev1.Volume 
 			},
 		})
 	}
-	// Leaf cert is required whenever ANY route exists (allow-only or
-	// credentialed) — both flavors terminate TLS to gate the request.
-	if len(secrets) > 0 {
+	// Leaf cert is required whenever ANY TLS-terminating chain exists:
+	// allow-only or credentialed chains (both gate the request), or the
+	// telemetry collector chain (it MITM-terminates the collector SNI even
+	// when the instance has no credential Secrets).
+	if len(secrets) > 0 || cfg.TelemetryEnabled() {
 		volumes = append(volumes, corev1.Volume{
 			Name: envoyLeafTLSVolume,
 			VolumeSource: corev1.VolumeSource{
@@ -1168,7 +1284,7 @@ func ptrBool(b bool) *bool { return &b }
 // kubelet keeps the old bootstrap mounted.
 //
 // Bump on any template change that affects pod-visible behavior.
-const envoyBootstrapTemplateRev = "v11-gateway-health-probe"
+const envoyBootstrapTemplateRev = "v12-telemetry-agent-id"
 
 // envoySecretsRev digests the Secret set that drives Envoy's chain
 // rendering. Includes `injection-hosts` JSON so a descriptor change
@@ -1212,7 +1328,7 @@ func envoyContainer(cfg *config.Config, secrets []corev1.Secret) corev1.Containe
 			ReadOnly:  true,
 		})
 	}
-	if len(secrets) > 0 {
+	if len(secrets) > 0 || cfg.TelemetryEnabled() {
 		mounts = append(mounts, corev1.VolumeMount{
 			Name:      envoyLeafTLSVolume,
 			MountPath: envoyLeafTLSMount,

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -178,7 +178,7 @@ func twoCredentialChain(firstName, secondName, host string) envoyHostChain {
 }
 
 func TestRenderEnvoyBootstrap_CredentialedRoutePinnedToStaticCluster(t *testing.T) {
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		credentialedChain("platform-conn-github", "api.github.com"),
 	})
 	require.NoError(t, err)
@@ -223,7 +223,7 @@ func TestRenderEnvoyBootstrap_EmptyRoutesNoLeafTLSReferences(t *testing.T) {
 	// otherwise a no-grants render would crash with "Failed to load
 	// incomplete private key" the moment the CM is updated to include
 	// routes (the volume backing that path doesn't exist yet).
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, nil)
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, nil)
 	require.NoError(t, err)
 	assert.NotContains(t, got, "tls.key",
 		"empty-routes bootstrap must not reference the leaf TLS private key — pod has no envoy-tls volume to back it")
@@ -239,7 +239,7 @@ func TestRenderEnvoyBootstrap_NoCredentialedRouteForwardsViaDynamicForwardProxy(
 	// With no credentialed routes there should be no per-credential cluster
 	// and no host_rewrite_literal — the catch-all/L4 paths still use
 	// dynamic_forward_proxy clusters but those are non-credentialed.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		allowOnlyChain("platform-allow-only-npm", "registry.npmjs.org"),
 	})
 	require.NoError(t, err)
@@ -255,7 +255,7 @@ func TestRenderEnvoyBootstrap_MixedRoutesOnlyPinCredentialed(t *testing.T) {
 	// Credentialed and allow-only side-by-side: only the credentialed one
 	// gets a pinned cluster. The two chains are visually adjacent in the
 	// output, so we anchor each assertion on its specific cluster name.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		credentialedChain("platform-conn-github", "api.github.com"),
 		allowOnlyChain("platform-allow-only-npm", "registry.npmjs.org"),
 	})
@@ -268,6 +268,121 @@ func TestRenderEnvoyBootstrap_MixedRoutesOnlyPinCredentialed(t *testing.T) {
 	assert.Equal(t, 1, pinnedCount, "exactly one pinned upstream cluster should be rendered (credentialed routes only)")
 	assert.Contains(t, got, "name: upstream_platform-conn-github")
 	assert.NotContains(t, got, "name: upstream_platform-allow-only-npm")
+}
+
+// telemetryTestCfg copies bootstrapTestCfg with the telemetry collector
+// configured, so the gateway renders the collector egress chain.
+func telemetryTestCfg() *config.Config {
+	c := *bootstrapTestCfg
+	c.TelemetryCollectorHost = "platform-clickstack-collector.platform.svc.cluster.local"
+	c.TelemetryCollectorPort = 4318
+	return &c
+}
+
+func TestRenderEnvoyBootstrap_TelemetryStampsTrustedAgentID(t *testing.T) {
+	// Telemetry on, no credential Secrets — the collector chain stands alone.
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", telemetryTestCfg(), nil)
+	require.NoError(t, err)
+
+	// Dedicated collector chain, matched on the collector SNI.
+	assert.Contains(t, got, "terminate_otel_collector")
+	assert.Contains(t, got, `server_names: [ "platform-clickstack-collector.platform.svc.cluster.local" ]`)
+
+	// Trusted identity header stamped with OVERWRITE so an agent-supplied
+	// value can't survive; value is this instance's id.
+	assert.Contains(t, got, "key: x-platform-agent-id")
+	assert.Contains(t, got, `value: "inst-1"`)
+	assert.Contains(t, got, "OVERWRITE_IF_EXISTS_OR_ADD")
+
+	// Pinned STRICT_DNS collector cluster on the OTLP/HTTP port.
+	assert.Contains(t, got, "address: platform-clickstack-collector.platform.svc.cluster.local")
+	assert.Contains(t, got, "port_value: 4318")
+
+	// The collector chain is platform-internal: no HITL ext_authz and no
+	// credential injection on it. Isolate the chain (it precedes the L4
+	// catch-all) so the assertion doesn't trip on ext_authz elsewhere.
+	cs := strings.Index(got, "- name: terminate_otel_collector")
+	ce := strings.Index(got, "# SNI miss")
+	require.True(t, cs >= 0 && ce > cs, "collector chain must precede the L4 catch-all")
+	collectorChain := got[cs:ce]
+	assert.NotContains(t, collectorChain, "ext_authz")
+	assert.NotContains(t, collectorChain, "credential_injector")
+
+	// The collector upstream is plaintext (ztunnel adds mTLS on the in-cluster
+	// hop) — no upstream TLS transport_socket on the cluster definition.
+	clusterDef := got[strings.Index(got, "- name: otel_collector"):]
+	clusterDef = clusterDef[:strings.Index(clusterDef[len("- name: otel_collector"):], "- name: ")+len("- name: otel_collector")]
+	assert.Contains(t, clusterDef, "type: STRICT_DNS")
+	assert.NotContains(t, clusterDef, "transport_socket")
+}
+
+func TestRenderEnvoyBootstrap_TelemetryDisabledNoCollectorChain(t *testing.T) {
+	// bootstrapTestCfg has no collector host → telemetry off.
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, nil)
+	require.NoError(t, err)
+	assert.NotContains(t, got, "terminate_otel_collector")
+	assert.NotContains(t, got, "otel_collector")
+	assert.NotContains(t, got, "x-platform-agent-id")
+}
+
+func TestRenderEnvoyBootstrap_TelemetryHeaderUsesInstanceNotExtAuthzID(t *testing.T) {
+	// Forks dial the PARENT's ext-authz Service (extAuthzInstanceID=parent)
+	// but their telemetry must attribute to the fork itself — the header value
+	// tracks the instance id, not the ext-authz id.
+	got, err := renderEnvoyBootstrap("fork-xyz", "parent-agent", telemetryTestCfg(), nil)
+	require.NoError(t, err)
+	assert.Contains(t, got, `value: "fork-xyz"`)
+	assert.NotContains(t, got, `value: "parent-agent"`)
+	// ext-authz authority still points at the parent's per-instance Service.
+	assert.Contains(t, got, "extauthz-parent-agent")
+}
+
+func hasVolumeNamed(vols []corev1.Volume, name string) bool {
+	for _, v := range vols {
+		if v.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func hasMountNamed(mounts []corev1.VolumeMount, name string) bool {
+	for _, m := range mounts {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestEnvoyVolumes_TelemetryMountsLeafWithoutSecrets(t *testing.T) {
+	// No credential Secrets, telemetry on: the leaf TLS volume + mount must
+	// still be present because the collector chain MITM-terminates with it.
+	// Without this the gateway would crash loading a non-existent tls.key.
+	cfg := telemetryTestCfg()
+	assert.True(t, hasVolumeNamed(envoyVolumes("inst-1", cfg, nil), envoyLeafTLSVolume),
+		"leaf TLS volume must be present when telemetry is on even with no Secrets")
+	assert.True(t, hasMountNamed(envoyContainer(cfg, nil).VolumeMounts, envoyLeafTLSVolume),
+		"leaf TLS mount must be present when telemetry is on even with no Secrets")
+}
+
+func TestEnvoyVolumes_NoLeafWhenNoSecretsNoTelemetry(t *testing.T) {
+	assert.False(t, hasVolumeNamed(envoyVolumes("inst-1", bootstrapTestCfg, nil), envoyLeafTLSVolume))
+	assert.False(t, hasMountNamed(envoyContainer(bootstrapTestCfg, nil).VolumeMounts, envoyLeafTLSVolume))
+}
+
+func TestRenderEnvoyBootstrap_TelemetryHostCollisionSuppressesCollectorChain(t *testing.T) {
+	// If the collector host collided with a credentialed chain host, two
+	// filter chains would share server_names — fatal to Envoy. The collector
+	// chain is suppressed; the credentialed chain wins (and the host stays in
+	// the leaf SAN via that chain).
+	cfg := telemetryTestCfg()
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", cfg, []envoyHostChain{
+		credentialedChain("platform-conn-collector", cfg.TelemetryCollectorHost),
+	})
+	require.NoError(t, err)
+	assert.NotContains(t, got, "terminate_otel_collector")
+	assert.NotContains(t, got, "- name: otel_collector")
 }
 
 // secretWithEnvMappings returns an owner-labelled Secret carrying an
@@ -461,7 +576,7 @@ func TestRenderEnvoyBootstrap_QueryParamCredentialRendersLuaFilter(t *testing.T)
 	// SDS value into the credential's header; Lua moves it into the URL
 	// query parameter and strips the header before the request leaves
 	// the sidecar.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		queryParamChain("platform-cred-bob", "prod.ibm-bob-staging.cloud.ibm.com", "X-Bobshell-Cred", "key"),
 	})
 	require.NoError(t, err)
@@ -484,7 +599,7 @@ func TestRenderEnvoyBootstrap_HeaderOnlyChainSkipsLua(t *testing.T) {
 	// Without QueryParamName the chain has only credential_injector — no
 	// Lua. credential_injector writes the pre-formatted SDS value (baked
 	// by api-server) directly into the user header.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		credentialedChain("platform-conn-github", "api.github.com"),
 	})
 	require.NoError(t, err)
@@ -497,7 +612,7 @@ func TestRenderEnvoyBootstrap_TwoCredentialsOnSameHostStackInOneChain(t *testing
 	// stack as two credential_injector entries inside a single TLS chain.
 	// Exactly one chain definition, one route-config, one upstream cluster —
 	// the second credential MUST NOT spawn a duplicate filter chain.
-	got, err := renderEnvoyBootstrap("inst-1", bootstrapTestCfg, []envoyHostChain{
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", bootstrapTestCfg, []envoyHostChain{
 		twoCredentialChain("platform-cred-header", "platform-cred-query", "prod.ibm-bob-staging.cloud.ibm.com"),
 	})
 	require.NoError(t, err)

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -314,6 +315,25 @@ func TestRenderEnvoyBootstrap_TelemetryStampsTrustedAgentID(t *testing.T) {
 	clusterDef = clusterDef[:strings.Index(clusterDef[len("- name: otel_collector"):], "- name: ")+len("- name: otel_collector")]
 	assert.Contains(t, clusterDef, "type: STRICT_DNS")
 	assert.NotContains(t, clusterDef, "transport_socket")
+}
+
+func TestRenderEnvoyBootstrap_TelemetryRendersValidYAML(t *testing.T) {
+	// The bootstrap is a templated YAML string embedded in a ConfigMap, so a
+	// stray indent in the collector chain/cluster only surfaces when Envoy
+	// boots. Render with telemetry on AND a credentialed chain (both new
+	// template blocks plus the existing ones active) and confirm the whole
+	// document parses as YAML.
+	got, err := renderEnvoyBootstrap("inst-1", "inst-1", telemetryTestCfg(), []envoyHostChain{
+		credentialedChain("platform-conn-github", "api.github.com"),
+	})
+	require.NoError(t, err)
+	var doc map[string]any
+	require.NoError(t, yaml.Unmarshal([]byte(got), &doc), "rendered bootstrap must be valid YAML")
+	// The collector chain/cluster coexist with the credentialed chain (distinct
+	// hosts → no collision).
+	assert.Contains(t, got, "terminate_otel_collector")
+	assert.Contains(t, got, "- name: otel_collector")
+	assert.Contains(t, got, "name: upstream_platform-conn-github")
 }
 
 func TestRenderEnvoyBootstrap_TelemetryDisabledNoCollectorChain(t *testing.T) {

--- a/packages/controller/pkg/reconciler/gateway.go
+++ b/packages/controller/pkg/reconciler/gateway.go
@@ -49,7 +49,7 @@ func BuildGatewayStatefulSet(agentName string, hibernated bool, cfg *config.Conf
 		LabelRole:  RoleGateway,
 	}
 
-	volumes := envoyVolumes(agentName, credentialSecrets)
+	volumes := envoyVolumes(agentName, cfg, credentialSecrets)
 	containers := []corev1.Container{envoyContainer(cfg, credentialSecrets)}
 
 	falseVal := false
@@ -164,7 +164,7 @@ func BuildForkGatewayPod(forkName, parentAgentID string, cfg *config.Config, own
 		ForkLabelType: ForkJobLabelType,
 	}
 
-	volumes := envoyVolumes(forkName, credentialSecrets)
+	volumes := envoyVolumes(forkName, cfg, credentialSecrets)
 	containers := []corev1.Container{envoyContainer(cfg, credentialSecrets)}
 
 	falseVal := false

--- a/packages/controller/pkg/reconciler/leaf.go
+++ b/packages/controller/pkg/reconciler/leaf.go
@@ -41,6 +41,16 @@ func dnsNamesFromChains(chains []envoyHostChain) []string {
 	return out
 }
 
+// containsHost reports whether `host` is already in the sorted SAN list.
+func containsHost(hosts []string, host string) bool {
+	for _, h := range hosts {
+		if h == host {
+			return true
+		}
+	}
+	return false
+}
+
 // Placeholder SAN for a leaf issued with no credential hosts; never presented.
 func leafPlaceholderDNS(instanceName string) string {
 	return instanceName + ".mitm-placeholder.invalid"
@@ -52,6 +62,15 @@ func leafPlaceholderDNS(instanceName string) string {
 // false (forks) returns nil when there's nothing to MITM.
 func BuildEnvoyLeafCertificate(instanceName string, cfg *config.Config, ownerRef metav1.OwnerReference, secrets []corev1.Secret, alwaysIssue bool) *cmv1.Certificate {
 	hosts := dnsNamesFromChains(chainsFromSecrets(secrets))
+	// When telemetry is on, the gateway MITM-terminates the collector host to
+	// stamp the trusted agent id, so the leaf must cover it — even for an
+	// instance (or fork) with no credential Secrets. Dedupe in case the host
+	// also appears as a credentialed chain (the collision-guarded chain in
+	// envoy.go is suppressed in that case, but the SAN is still needed).
+	if cfg.TelemetryEnabled() && !containsHost(hosts, cfg.TelemetryCollectorHost) {
+		hosts = append(hosts, cfg.TelemetryCollectorHost)
+		sort.Strings(hosts)
+	}
 	if len(hosts) == 0 {
 		if !alwaysIssue {
 			return nil

--- a/packages/controller/pkg/reconciler/leaf_test.go
+++ b/packages/controller/pkg/reconciler/leaf_test.go
@@ -39,6 +39,30 @@ func TestBuildEnvoyLeafCertificate_DedupesAndSortsHosts(t *testing.T) {
 	assert.Equal(t, []string{"a.example.com", "b.example.com"}, cert.Spec.DNSNames)
 }
 
+func TestBuildEnvoyLeafCertificate_TelemetryHostInSAN_ZeroSecretsFork(t *testing.T) {
+	cfg := *testConfig
+	cfg.TelemetryCollectorHost = "platform-clickstack-collector.default.svc.cluster.local"
+	// Fork (alwaysIssue=false) with no credential Secrets: telemetry alone
+	// makes the leaf non-nil and puts the collector host in the SAN, so the
+	// gateway can MITM-terminate the agent's OTLP to it.
+	cert := BuildEnvoyLeafCertificate("my-instance", &cfg, configMapOwnerRef(testOwnerCM), nil, false)
+	require.NotNil(t, cert, "telemetry-on fork with no Secrets must still issue a leaf for the collector SNI")
+	assert.Equal(t, []string{"platform-clickstack-collector.default.svc.cluster.local"}, cert.Spec.DNSNames)
+}
+
+func TestBuildEnvoyLeafCertificate_TelemetryHostDedupedWithChainHost(t *testing.T) {
+	cfg := *testConfig
+	cfg.TelemetryCollectorHost = "a.example.com" // pathological: collides with a credentialed host
+	secrets := []corev1.Secret{
+		credSecret("platform-cred-aaa", "a.example.com"),
+		credSecret("platform-cred-bbb", "b.example.com"),
+	}
+	cert := BuildEnvoyLeafCertificate("my-instance", &cfg, configMapOwnerRef(testOwnerCM), secrets, false)
+	require.NotNil(t, cert)
+	// Collector host already present via the credentialed chain — not duplicated.
+	assert.Equal(t, []string{"a.example.com", "b.example.com"}, cert.Spec.DNSNames)
+}
+
 func TestBuildEnvoyLeafCertificate_IssuerRef(t *testing.T) {
 	cfg := *testConfig
 	cfg.EnvoyMitmCAIssuer = "platform-mitm-ca-issuer"


### PR DESCRIPTION
## Problem

Telemetry in the ClickStack collector carried only what the agent put in it, and agents run untrusted code. Nothing stopped an agent from labelling its telemetry as belonging to another user's agent — so the owner-scoped read path (#2029), which decides ownership from the identity on each record, was subvertible.

Implements #2046.

## Solution

Derive each record's identity from the **platform-controlled egress path**, not from agent-supplied data.

- **Gateway Envoy** (controller-rendered, the agent's only egress route): when the telemetry backend is enabled, a dedicated collector chain MITM-terminates the collector SNI and stamps a trusted `x-platform-agent-id` header with `OVERWRITE_IF_EXISTS_OR_ADD`, carrying the gateway's own per-agent identity. No `ext_authz`/HITL, no credential injection; forwards plaintext to a pinned in-cluster collector cluster (ztunnel adds mTLS on that hop). Forks stamp the **fork's own** id, not the parent's ext-authz id.
- **Collector**: promotes the header to a `platform.agent.id` resource attribute with **delete-then-set** (`include_metadata: true` + a `resource` processor before `batch`), so a forged value can never survive a missing header. Telemetry with no header (platform components) carries no `platform.agent.id`.
- **Leaf cert**: gains the collector host in its SAN, and is issued + mounted even for an instance with no credential Secrets, when telemetry is on.
- **No Istio L7 waypoint**: the gateway is the unbypassable, controller-rendered chokepoint, so the collector keeps its existing namespace-scoped `AuthorizationPolicy`.

The attribute is namespaced under the permanent `platform` codename to avoid clashing with OTel `gen_ai.agent.*` / generic `agent.*`.

## Scope

- **Guarantees attribution, not content integrity** — an agent can still misreport its own numbers, but never make its telemetry appear under another agent or user.
- **Out of scope**: enabling agent export (#2028). This builds the trust so that *when* export is on, identity is stamped and honored. Targets `feat/clickstack-telemetry-backend`.

## Testing

- `mise run controller:test` — new unit tests: collector chain/cluster/header present when on & absent when off; plaintext upstream (no `transport_socket`); no `ext_authz`/`credential_injector` on the collector chain; fork header uses the instance id while ext-authz authority uses the parent; host-collision suppression; leaf SAN includes the collector host (incl. zero-Secrets + fork); leaf volume/mount gating; config env loading.
- `mise run controller:check:build`, `:vet`, `:fmt` — clean. (`staticcheck` fails on a pre-existing Go 1.26 stdlib/toolchain mismatch, unrelated to this change.)
- `mise run helm:check:lint` + `helm:check:render` — pass; rendered output (clickstack enabled) confirms `include_metadata`, the delete-then-set processor before `batch` on all three pipelines, and the controller telemetry env vars.
- End-to-end with a live agent requires #2028; until then verify by sending an OTLP/HTTP request through a gateway with a forged attribute + header and confirming the stored `platform.agent.id` is the gateway's real id (and stripped when no header is sent).

See `docs/architecture/observability.md` → *Trusted attribution*.