### PR TITLE
feat(ui): unify selects and textareas via shared components

### DIFF
--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -1,0 +1,54 @@
+import { ChevronDown } from "@carbon/icons-react";
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const selectVariants = cva(
+  "flex w-full cursor-pointer appearance-none rounded-md border bg-background pr-9 text-foreground ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        standard: "border-input",
+        invalid: "border-destructive focus-visible:ring-destructive",
+      },
+      size: {
+        default: "h-10 pl-4 py-2 text-sm",
+        sm: "h-8 pl-3 text-[12px]",
+        xs: "h-7 pl-3 text-[12px]",
+      },
+    },
+    defaultVariants: {
+      variant: "standard",
+      size: "default",
+    },
+  },
+);
+
+const chevronSize: Record<NonNullable<SelectProps["size"]>, number> = {
+  default: 16,
+  sm: 14,
+  xs: 14,
+};
+
+export interface SelectProps
+  extends
+    Omit<React.ComponentProps<"select">, "size">,
+    VariantProps<typeof selectVariants> {}
+
+function Select({ className, variant, size, ...props }: SelectProps) {
+  return (
+    <div className="relative w-full">
+      <select
+        className={cn(selectVariants({ variant, size, className }))}
+        {...props}
+      />
+      <ChevronDown
+        size={chevronSize[size ?? "default"]}
+        className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+      />
+    </div>
+  );
+}
+
+export { Select, selectVariants };

--- a/packages/ui/src/components/ui/textarea.tsx
+++ b/packages/ui/src/components/ui/textarea.tsx
@@ -1,17 +1,36 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+const textareaVariants = cva(
+  "flex min-h-[80px] w-full rounded-md border bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        standard: "border-input",
+        monospace: "border-input font-mono",
+        invalid: "border-destructive focus-visible:ring-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "standard",
+    },
+  },
+);
+
+export interface TextareaProps
+  extends
+    React.ComponentProps<"textarea">,
+    VariantProps<typeof textareaVariants> {}
+
+function Textarea({ className, variant, ...props }: TextareaProps) {
   return (
     <textarea
-      className={cn(
-        "flex min-h-[80px] w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50",
-        className,
-      )}
+      className={cn(textareaVariants({ variant, className }))}
       {...props}
     />
   );
 }
 
-export { Textarea };
+export { Textarea, textareaVariants };

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -14,6 +14,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { SectionLabel } from "@/components/ui/section-label";
+import { Select } from "@/components/ui/select";
 
 import {
   useApplyEgressPreset,
@@ -244,17 +245,17 @@ export function AgentEgressEditor({
       <Card className="px-3 py-3 flex flex-wrap items-end gap-2">
         <div className="flex flex-col gap-1 flex-1 min-w-[260px]">
           <SectionLabel>{stagedMode ? "Preset" : "Apply preset"}</SectionLabel>
-          <select
+          <Select
+            size="xs"
             value={dropdownValue}
             onChange={(e) => onPresetSelect(e.target.value as EgressPreset)}
-            className="h-7 px-2 rounded border border-input bg-background text-[12px] text-foreground"
           >
             <option value="trusted">
               Trusted defaults (npm, PyPI, GitHub, Anthropic, …)
             </option>
             <option value="none">Strict default-deny (no rules added)</option>
             <option value="all">Allow everything (development only)</option>
-          </select>
+          </Select>
         </div>
         {!stagedMode && (
           <Button
@@ -289,7 +290,8 @@ export function AgentEgressEditor({
             />
           </Field>
           <Field label="Method" widthClass="w-[100px]">
-            <select
+            <Select
+              size="xs"
               value={
                 ALL_METHODS.includes(
                   draft.method as (typeof ALL_METHODS)[number],
@@ -298,7 +300,6 @@ export function AgentEgressEditor({
                   : "*"
               }
               onChange={(e) => setDraft({ ...draft, method: e.target.value })}
-              className="w-full h-7 px-2 rounded border border-input bg-background text-[12px] text-foreground"
             >
               <option value="*">* (any)</option>
               {ALL_METHODS.map((m) => (
@@ -306,7 +307,7 @@ export function AgentEgressEditor({
                   {m}
                 </option>
               ))}
-            </select>
+            </Select>
           </Field>
           <Field label="Path" widthClass="min-w-[160px] flex-1">
             <Input
@@ -321,7 +322,8 @@ export function AgentEgressEditor({
             />
           </Field>
           <Field label="Verdict" widthClass="w-[100px]">
-            <select
+            <Select
+              size="xs"
               value={draft.verdict}
               onChange={(e) =>
                 setDraft({
@@ -329,11 +331,10 @@ export function AgentEgressEditor({
                   verdict: e.target.value as "allow" | "deny",
                 })
               }
-              className="w-full h-7 px-2 rounded border border-input bg-background text-[12px] text-foreground"
             >
               <option value="allow">allow</option>
               <option value="deny">deny</option>
-            </select>
+            </Select>
           </Field>
           <Button
             type="button"

--- a/packages/ui/src/modules/sessions/components/skills-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/skills-panel.tsx
@@ -23,6 +23,8 @@ import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
 import { Tooltip } from "@/components/ui/tooltip";
 
 import { api } from "../../../api.js";
@@ -453,9 +455,6 @@ export function SkillsPanel({
     }
   };
 
-  const inp =
-    "w-full h-8 rounded-md border-2 border-border-light bg-surface px-3 text-[12px] text-text outline-none transition-all focus:border-accent focus:shadow-[0_0_0_3px_var(--color-accent-glow)]";
-
   return (
     <div className="flex flex-col">
       {isError && (
@@ -484,8 +483,8 @@ export function SkillsPanel({
                 <span className="font-mono text-text">{publishFor.name}</span>{" "}
                 as a pull request.
               </div>
-              <select
-                className={inp}
+              <Select
+                size="sm"
                 value={publishForm.sourceId}
                 onChange={(e) =>
                   setPublishForm((f) => ({ ...f, sourceId: e.target.value }))
@@ -497,7 +496,7 @@ export function SkillsPanel({
                     {s.gitUrl.replace(/^https:\/\/(github|gitlab)\.com\//, "")})
                   </option>
                 ))}
-              </select>
+              </Select>
               <Input
                 size="sm"
                 placeholder="Pull request title"
@@ -506,8 +505,8 @@ export function SkillsPanel({
                   setPublishForm((f) => ({ ...f, title: e.target.value }))
                 }
               />
-              <textarea
-                className="w-full rounded-md border-2 border-border-light bg-surface px-3 py-2 text-[12px] text-text outline-none transition-all focus:border-accent resize-y min-h-[60px]"
+              <Textarea
+                className="resize-y min-h-[60px] text-[12px]"
                 placeholder="Pull request body (optional)"
                 value={publishForm.body}
                 onChange={(e) =>


### PR DESCRIPTION
Follows the button/input unification (#223) by extracting shared `Select` and `Textarea` primitives and migrating every hand-styled call site onto them. No functional change.

Closes #832