### PR TITLE
fix(nous): route gate-summary OpenAI calls through the model gateway

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -74,7 +74,7 @@ agentTemplates:
 
   - name: nous
     enabled: true
-    category: harness
+    category: preconfigured
     experimental: true
     description: "Nous hypothesis-driven experimentation agent"
     image:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -926,7 +926,7 @@ agentTemplates:
   # harness drives long-running Nous campaigns — see packages/agents/nous/README.md.
   - name: nous
     enabled: true
-    category: harness
+    category: preconfigured
     experimental: true
     description: "Nous hypothesis-driven experimentation agent"
     image:

--- a/packages/agents/nous/Dockerfile
+++ b/packages/agents/nous/Dockerfile
@@ -44,6 +44,12 @@ RUN "$NOUS_VENV/bin/python" /usr/local/bin/nous-patch-campaign-schema
 # Put the venv (and thus `nous`, `python`, `pip`) ahead of the base tools.
 ENV PATH="/opt/nous-venv/bin:${PATH}"
 
+# Route Nous's OpenAI-format gate-summary calls through the in-pod model gateway
+# by extending the base model-gateway shim (see nous-model-gateway.sh), so the
+# shell env — chat/terminal harness and SSH login — also carries OPENAI_BASE_URL.
+RUN mv /usr/local/lib/model-gateway.sh /usr/local/lib/model-gateway-base.sh
+COPY nous-model-gateway.sh /usr/local/lib/model-gateway.sh
+
 # Every campaign in this pod runs `--auto-approve`; some Nous versions gate that
 # behind this env. Setting it here makes unattended/background runs unconditional
 # (the design/findings human gates auto-pass). `locked_parameters` is still

--- a/packages/agents/nous/README.md
+++ b/packages/agents/nous/README.md
@@ -88,6 +88,15 @@ the per-agent MCP endpoint authorizes by the pod's **mesh identity** (no token �
 ADR-041). Stdlib-only; the agent launches it on demand (see `AGENTS.md`). Needs a
 channel bound to the agent; delivery is best-effort.
 
+Each summary is itself an OpenAI-format LLM call (`OPENAI_BASE_URL`). Under
+LiteLLM that hits the proxy's intercept CA and a model-id `403`, so the image
+extends the base model-gateway shim ([`nous-model-gateway.sh`](./nous-model-gateway.sh)):
+after the base repoints `ANTHROPIC_BASE_URL` at the in-pod gateway, it does the
+same for `OPENAI_BASE_URL` when that is unset or a LiteLLM endpoint. It's sourced
+by the chat/terminal harness and the SSH login profile, so the whole shell env —
+and everything `nous` spawns — carries the gateway URL (a deliberately-distinct
+OpenAI endpoint is left alone).
+
 ## Harness modes
 
 | Mode | Entrypoint | Behavior |
@@ -119,8 +128,8 @@ The nous image is published by CI (`.github/workflows/cd.yml`): `build-nous`
 (per-arch) runs after `merge-agents` — nous builds `FROM` claude-code, so it
 pulls its base by the same per-commit tag — and `merge-nous` publishes the
 multi-arch manifest to `quay.io/dam-agents/nous`. The `publish` (Helm) job waits
-on `merge-nous`. The template is enabled by default in `values.yaml`
-(`experimental: true`).
+on `merge-nous`. The template is enabled by default in `values.yaml` under
+"Pre-configured Images" (`category: preconfigured`, `experimental: true`).
 
 ## Known follow-ups (not yet wired)
 

--- a/packages/agents/nous/nous-model-gateway.sh
+++ b/packages/agents/nous/nous-model-gateway.sh
@@ -1,0 +1,16 @@
+# Nous override of the claude-code model-gateway shim (the base is renamed to
+# model-gateway-base.sh at build time). The base repoints ANTHROPIC_BASE_URL at
+# the in-pod gateway when a custom upstream is fronted; we route OpenAI-format
+# traffic (Nous's gate summaries) through it too, so OPENAI_BASE_URL matches and
+# the summaries don't fail against the raw LiteLLM URL (intercept-CA TLS + a
+# model-id 403). Sourced by harness-chat, harness-terminal, and the SSH login
+# profile, so the whole shell env — and everything it spawns — is fixed.
+. /usr/local/lib/model-gateway-base.sh
+
+case "${ANTHROPIC_BASE_URL:-}" in
+http://127.0.0.1:* | http://localhost:*)
+	case "${OPENAI_BASE_URL:-}" in
+	"" | *litellm*) export OPENAI_BASE_URL="$ANTHROPIC_BASE_URL" ;;
+	esac
+	;;
+esac


### PR DESCRIPTION
## Problem

A bound Telegram/Slack channel never receives Nous gate summaries. The bridge is healthy and receives nothing — the failure is one step upstream, in the LLM call that *generates* each summary.

Nous produces each DESIGN/FINDINGS gate summary with an OpenAI-compatible client pointed at `OPENAI_BASE_URL` (`orchestrator/llm_dispatch.py`). Under the platform's **LiteLLM** provider, the connection injects `OPENAI_BASE_URL` as the raw LiteLLM URL, so that call leaves the pod through the egress proxy and fails two ways:

1. **TLS** — a bundled-certifi Python client won't trust the proxy's intercept CA → `CERTIFICATE_VERIFY_FAILED`.
2. **Model id** — LiteLLM's OpenAI allow-list rejects the `claude/`-prefixed model id → `403`.

Either one kills the summary, and with it the channel delivery. The Anthropic/SDK path already works because the base `model-gateway.sh` repoints `ANTHROPIC_BASE_URL` at the in-pod model gateway (plain-HTTP localhost; rewrites the model id) — `OPENAI_BASE_URL` just never got the same treatment.

## Fix

Extend that exact mechanism for OpenAI, **nous-side**. The base shim `/usr/local/lib/model-gateway.sh` is renamed to `model-gateway-base.sh` at build time, and the image ships [`nous-model-gateway.sh`](../blob/fix/nous-gate-summary-litellm/packages/agents/nous/nous-model-gateway.sh) in its place: it sources the base (which repoints `ANTHROPIC_BASE_URL`) and then does the same for `OPENAI_BASE_URL` when it is unset or a LiteLLM endpoint. That file is sourced by the chat harness, the terminal harness, and the SSH login profile, so the whole **shell env** — and everything `nous` spawns — carries the gateway URL. A deliberately-distinct OpenAI endpoint is left alone.

This is reliable for the same reason the `ANTHROPIC` rewrite is: it modifies the inherited process env (not a `PATH` shim or an in-process hack). `env | grep OPENAI` now shows the gateway.

Also: move the `nous` template to **`category: preconfigured`** (alongside `openevolve`), so it groups under "Pre-configured Images" in the creation wizard rather than "Harness Images".

## Verified live in-cluster

Built the image, loaded it into the dev cluster, restarted the agent pods, and in a fresh pod:

- `model-gateway.sh` (override) + `model-gateway-base.sh` (renamed base) both present.
- Replicating the harness env (`ANTHROPIC`/`OPENAI` = LiteLLM) and sourcing the shim rewrites **both** to `http://127.0.0.1:24180`.
- Nous's exact gate-summary call (`openai` client, `claude/aws/claude-sonnet-4-6`) returns `'ok'` through the gateway.

## Related

Builds on #2026 (campaign-schema patch so `channels:` validates). That PR makes the channel config accepted; this one makes the summary that flows through it actually generate.
