### PR TITLE
feat: per-user CPU & memory budgeting

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -277,6 +277,15 @@ spec:
             - name: MAX_IMPORT_BUNDLE_BYTES
               value: {{ .Values.apiServer.maxImportBundleBytes | quote }}
             {{- end }}
+            # Per-user compute ceiling (#1900); AGENT_DEFAULT_* mirrors the controller templateDefaults.
+            - name: DEFAULT_USER_CPU_BUDGET
+              value: {{ .Values.apiServer.defaultUserCpuBudget | quote }}
+            - name: DEFAULT_USER_MEMORY_BUDGET
+              value: {{ .Values.apiServer.defaultUserMemoryBudget | quote }}
+            - name: AGENT_DEFAULT_CPU_REQUEST
+              value: {{ .Values.controller.agent.templateDefaults.resources.requests.cpu | quote }}
+            - name: AGENT_DEFAULT_MEMORY_REQUEST
+              value: {{ .Values.controller.agent.templateDefaults.resources.requests.memory | quote }}
             - name: TRUSTED_HOSTS_PATH
               value: /etc/platform/trusted-hosts
             # agent templates are mounted from a ConfigMap and loaded

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -520,6 +520,15 @@ apiServer:
   # 5 GiB import could fill the disk.
   maxImportBundleBytes: 5368709120
 
+  # -- Per-user ceiling on concurrent CPU and memory across a user's running
+  # agents (#1900), applied when the user has no `user_budgets` override row.
+  # CPU in cores (Kubernetes quantity), memory as a Kubernetes quantity. A user
+  # at their ceiling must stop a running sandbox before starting another;
+  # hibernation also frees room automatically. Raise per-user via a
+  # `user_budgets` row.
+  defaultUserCpuBudget: "4"
+  defaultUserMemoryBudget: "8Gi"
+
   # -- Minimum dam CLI version this server accepts (semver, e.g. "1.2.0").
   # Empty/unset means no floor — every CLI is accepted (a soft-warn fires
   # if the CLI is behind the current server version). Set this to retire a

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,7 @@ Each page is the authoritative, self-contained description of its subsystem — 
 
 - [platform-topology](architecture/platform-topology.md) — the four long-lived components (controller, api-server, agent-runtime, ui), the protocols between them, and the K8s resource model.
 - [agent-lifecycle](architecture/agent-lifecycle.md) — create → wake → trigger → hibernate → delete; per-schedule sessions and forks.
+- [budgets](architecture/budgets.md) — per-user concurrent CPU/memory ceiling, api-server admission at the wake seams, reserved-request accounting, hard stop.
 - [persistence](architecture/persistence.md) — the three substrates (Postgres, ConfigMap spec/status, per-Agent PVC) and what survives each lifecycle event.
 - [security-and-credentials](architecture/security-and-credentials.md) — Keycloak identity, Envoy sidecar credential gateway, K8s-Secret credential storage, ext_authz HITL, network boundary.
 - [channels](architecture/channels.md) — Slack and Telegram adapters inside the api-server, inbound relay, outbound MCP tool, identity linking.

--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-06-25
+Last verified: 2026-06-29
 
 ## Overview
 
@@ -147,6 +147,10 @@ The **target** lifetime model is single-use Kubernetes Jobs per turn, with a Red
 The controller's idle checker periodically scans running Agents. For each, it probes agent-runtime's `/api/status` over the cluster network. The runtime is authoritative about its own idleness: it reports a single `idle` flag (false while a prompt turn is running, prompts are queued, an agent-initiated request awaits a client, or a terminal is open — connected viewers don't count), that flag is the endpoint's entire payload, and the controller derives nothing on its own. If the runtime reports idle for long enough (and the probe doesn't error), the checker hibernates the Agent by scaling its StatefulSets to zero.
 
 The pod terminates; the PVC, Secret, Service, and NetworkPolicy persist. Workspace state survives — the git checkout, `node_modules`, `.venv`, mise cache, and `$HOME` are all on the PVC and rejoin on the next wake. Anything written to the container's ephemeral filesystem (OS-level changes, tools installed outside `$HOME`) is lost; this is a deliberate constraint of the lifetime model.
+
+Idle hibernation is **not** the enforcement mechanism for a fixed compute pool — it is a convenience that helps a user drift back under their own ceiling. The ceiling itself is the [per-user resource budget](budgets.md): the api-server rejects a create or wake that would push a user's running agents past their CPU/memory share, so a user who pins agents awake simply consumes their budget rather than escaping it.
+
+To free room without waiting for the idle checker — or for an agent pinned awake by an open session — the user issues a **hard stop**: the api-server stamps `agent-platform.ai/stop-requested` (and clears `active-session`), which the reconciler honors by scaling the pair to zero immediately, bypassing the idle probe. Any later activity poke clears the annotation so the agent can wake again. This is the only scale-down path other than the idle checker, and the only way to reclaim a keep-awake-pinned agent without deleting it.
 
 ### Delete
 

--- a/docs/architecture/budgets.md
+++ b/docs/architecture/budgets.md
@@ -1,0 +1,39 @@
+# Per-user resource budgets
+
+Last verified: 2026-06-29
+
+## Overview
+
+A **budget** is a ceiling on the CPU and memory a single user's *running* agents may reserve at once. The cluster has a fixed compute pool and all agents share one namespace, so without a ceiling the first users to spin up agents can starve everyone else. The budget makes each user's concurrent share explicit: within it a user is free to deploy whatever they want for as long as they want; they just cannot exceed their share concurrently.
+
+Enforcement lives entirely in the **api-server**, which is the sole writer of the Agent spec and the only actor that initiates a wake. The controller and Kubernetes are unaware of budgets — there is no `ResourceQuota` (it is namespace-scoped, and all agents share one namespace) and no metrics-server, so a Kubernetes-native per-user ceiling is not available. The api-server is also the only place that already knows which agents an owner has.
+
+## What is counted
+
+The budget sums pod resource **requests**, not limits and not live usage:
+
+- Limits are burst ceilings and are not even set on every pod (the paired gateway has requests but no limits), and there is no metrics API to read live consumption from. Requests are the scheduler's actual reservation and the only value knowable before a pod is scheduled — which an admission check requires.
+- A running agent's footprint is its agent-container requests plus a fixed constant for its paired gateway pod. When an agent's spec omits `resources`, the api-server falls back to the chart's default agent requests, surfaced to it as `AGENT_DEFAULT_CPU_REQUEST` / `AGENT_DEFAULT_MEMORY_REQUEST` and templated from the same Helm value the controller uses, so the two cannot drift.
+- Only non-hibernated agents count. Consumption is computed on demand from the live agent list, never persisted — so a hibernate or delete credits the budget back automatically with nothing to reconcile.
+
+Because the cap bounds reservation rather than live use, a user can sit under budget while individual agents burst toward their limits. The visibility surface therefore labels the figure **reserved**, not used. Per-turn fork Jobs are excluded from v1 and are a known undercount.
+
+## The ceiling
+
+Each install has a chart-wide default ceiling (`DEFAULT_USER_CPU_BUDGET` / `DEFAULT_USER_MEMORY_BUDGET`). A `user_budgets` row, keyed on the same plaintext owner identity the `agent-platform.ai/owner` label carries, overrides the default for one user; it is operator-managed (there is no self-service path). Role-based budgets and "request more" approval flows are out of scope.
+
+## Enforcement
+
+The api-server gates every path that brings an agent online against the owner's remaining budget, rejecting before any spec write:
+
+- **Create** — checked against the new agent's requested footprint.
+- **Wake / connect** — when waking a hibernated agent (UI wake, or a UI/channel session attaching), checked against that agent's footprint. Waking an already-running agent is a no-op for the budget.
+- **Scheduled fire** — the scheduler pokes the agent awake through the same gate. A fire that would exceed budget is **blocked and deferred**: the trigger event is already durably committed to the outbox, so nothing is lost — it redelivers once the user frees room, or expires at its TTL. The fire is recorded as failed.
+
+A rejection surfaces a clear over-budget error naming the reserved and limit figures and pointing the user to stop a running agent.
+
+The check is read-decide-write without a cross-replica lock, so two concurrent waking actions by the same user can transiently overshoot; hibernation reclaims the excess. A per-owner advisory lock is the upgrade path if strict correctness across api-server replicas becomes necessary.
+
+## Visibility and freeing room
+
+Any authenticated user can read their own reserved-vs-limit figure (a `budgets.usage` query, rendered as a meter on the sandbox list). To free capacity a user issues a hard stop on a running agent; see [agent-lifecycle](agent-lifecycle.md#hibernate) for the stop mechanics and how hibernation is reframed as a convenience for staying under the ceiling rather than the enforcement mechanism itself.

--- a/packages/api-server-api/src/context.ts
+++ b/packages/api-server-api/src/context.ts
@@ -1,5 +1,6 @@
 import type { AgentsService } from "./modules/agents/types.js";
 import type { ApiKeysService, Scope } from "./modules/api-keys/types.js";
+import type { BudgetsService } from "./modules/budgets/types.js";
 import type { ApprovalsService } from "./modules/approvals/types.js";
 import type { ChannelsService } from "./modules/channels/types.js";
 import type { ConnectionsService } from "./modules/connections/types.js";
@@ -43,6 +44,7 @@ export interface ApiContext {
   terms: TermsService;
   e2e: E2eService;
   apiKeys: ApiKeysService;
+  budgets: BudgetsService;
   user: UserIdentity;
   e2eEnabled: boolean;
 }

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -53,6 +53,7 @@ export {
   PROTECTED_AGENT_ENV_NAMES,
   isProtectedAgentEnvName,
 } from "./modules/agents/types.js";
+export type { BudgetUsage, BudgetsService } from "./modules/budgets/types.js";
 export type { AgentSpecCR, ForkSpecCR } from "./crd-types.gen.js";
 
 export {

--- a/packages/api-server-api/src/modules/agents/router.ts
+++ b/packages/api-server-api/src/modules/agents/router.ts
@@ -14,6 +14,7 @@ import {
   agentDisconnectTelegramInputSchema,
   agentGetInputSchema,
   agentRestartInputSchema,
+  agentStopInputSchema,
   agentUpdateInputSchema,
   agentWakeInputSchema,
 } from "./schemas.js";
@@ -89,6 +90,14 @@ export const agentsRouter = t.router({
     .input(agentWakeInputSchema)
     .mutation(async ({ ctx, input }) => {
       const agent = await ctx.agents.wake(input.id);
+      if (!agent) throw new TRPCError({ code: "NOT_FOUND" });
+      return toView(agent);
+    }),
+
+  stop: manageAgentsProcedure
+    .input(agentStopInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const agent = await ctx.agents.stop(input.id);
       if (!agent) throw new TRPCError({ code: "NOT_FOUND" });
       return toView(agent);
     }),

--- a/packages/api-server-api/src/modules/agents/schemas.ts
+++ b/packages/api-server-api/src/modules/agents/schemas.ts
@@ -8,6 +8,7 @@ export const agentGetInputSchema = idSchema;
 export const agentDeleteInputSchema = idSchema;
 export const agentRestartInputSchema = idSchema;
 export const agentWakeInputSchema = idSchema;
+export const agentStopInputSchema = idSchema;
 export const agentDisconnectSlackInputSchema = idSchema;
 export const agentDisconnectTelegramInputSchema = idSchema;
 

--- a/packages/api-server-api/src/modules/agents/types.ts
+++ b/packages/api-server-api/src/modules/agents/types.ts
@@ -89,6 +89,7 @@ export interface AgentsService {
   delete: (id: string) => Promise<void>;
   restart: (id: string) => Promise<boolean>;
   wake: (id: string) => Promise<Agent | null>;
+  stop: (id: string) => Promise<Agent | null>;
   /**
    * Ensure the agent's pod is reachable. Waits for pod Ready, waking
    * from hibernation if needed. Idempotent; single-flight per id; bumps

--- a/packages/api-server-api/src/modules/budgets/router.ts
+++ b/packages/api-server-api/src/modules/budgets/router.ts
@@ -1,0 +1,6 @@
+import { t } from "../../trpc.js";
+import { readAgentProcedure } from "../../auth-procedures.js";
+
+export const budgetsRouter = t.router({
+  usage: readAgentProcedure.query(({ ctx }) => ctx.budgets.usage()),
+});

--- a/packages/api-server-api/src/modules/budgets/types.ts
+++ b/packages/api-server-api/src/modules/budgets/types.ts
@@ -1,0 +1,9 @@
+/** Reserved (summed running-agent requests, not live use) vs ceiling (#1900). */
+export interface BudgetUsage {
+  cpu: { reservedMilli: number; limitMilli: number };
+  memory: { reservedBytes: number; limitBytes: number };
+}
+
+export interface BudgetsService {
+  usage(): Promise<BudgetUsage>;
+}

--- a/packages/api-server-api/src/router.ts
+++ b/packages/api-server-api/src/router.ts
@@ -1,6 +1,7 @@
 import { t } from "./trpc.js";
 import { agentsRouter } from "./modules/agents/router.js";
 import { apiKeysRouter } from "./modules/api-keys/router.js";
+import { budgetsRouter } from "./modules/budgets/router.js";
 import { approvalsRouter } from "./modules/approvals/router.js";
 import { channelsRouter } from "./modules/channels/router.js";
 import { connectionsRouter } from "./modules/connections/router.js";
@@ -29,6 +30,7 @@ export const appRouter = t.router({
   terms: termsRouter,
   e2e: e2eRouter,
   apiKeys: apiKeysRouter,
+  budgets: budgetsRouter,
 });
 
 export type AppRouter = typeof appRouter;

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -26,6 +26,7 @@ import {
   createKeycloakUserDirectory,
   type ContributionsSettledPort,
 } from "../../modules/agents/index.js";
+import type { BudgetGuard } from "../../modules/budgets/index.js";
 import { composeTemplatesModule } from "../../modules/templates/index.js";
 import { createTemplatesRepository } from "../../modules/templates/infrastructure/templates-repository.js";
 import { createReposRepository } from "../../modules/repos/infrastructure/repos-repository.js";
@@ -111,6 +112,7 @@ export interface ApiServerAppDeps {
   secretStores: SecretStoreRegistry;
   runtimeMutator: RuntimeMutator;
   contributionsSettled: ContributionsSettledPort;
+  budget: BudgetGuard;
   schedulesBoot: SchedulesBoot;
   mountUsageRoutes: (
     app: Hono<{ Variables: { user: UserIdentity; roles: string[] } }>,
@@ -140,6 +142,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     secretStores,
     runtimeMutator,
     contributionsSettled,
+    budget,
     schedulesBoot,
     terms,
     isTermsAccepted,
@@ -147,7 +150,8 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   } = deps;
 
   const k8sClient = createK8sClient(api, config.namespace);
-  const agentsRepo = createAgentsRepository(k8sClient);
+  // Budget-gated so the relays and proxies that wake via the raw repo honor the ceiling (#1900).
+  const agentsRepo = createAgentsRepository(k8sClient, budget);
   // Templates are file-mounted config loaded once at boot; shared
   // across requests rather than re-read from K8s on each tRPC call.
   const templatesRepo = createTemplatesRepository(config.agentTemplatesPath);
@@ -715,6 +719,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       cleanupHooks: agentCleanupHooks,
       runtimeMutator,
       contributionsSettled,
+      budgetGate: budget,
       grantProvisioner: {
         async resolveSpecGrants(sel) {
           return {
@@ -746,6 +751,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       config.brand.name,
       runtimeMutator,
       templatesRepo,
+      budget,
     );
     const isAgentOwnedBy = async (agentId: string, ownerSub: string) =>
       (await agents.get(agentId)) !== null && ownerSub === user.sub;
@@ -789,6 +795,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
         terms,
         e2e,
         apiKeys,
+        budgets: { usage: () => budget.usage(user.sub) },
         user,
         e2eEnabled: config.e2eEnabled,
       }),

--- a/packages/api-server/src/apps/harness-api-server/app.ts
+++ b/packages/api-server/src/apps/harness-api-server/app.ts
@@ -3,6 +3,7 @@ import type { CoreV1Api } from "@kubernetes/client-node";
 import type { RuntimeDeliveryService } from "api-server-api";
 import type { Db } from "db";
 import { createK8sClient } from "../../modules/agents/infrastructure/k8s.js";
+import type { BudgetGuard } from "../../modules/budgets/index.js";
 import {
   composeSchedulesForOwner,
   type SchedulesBoot,
@@ -24,6 +25,7 @@ export interface HarnessApiServerAppDeps {
   runtimeHello: RuntimeDeliveryService;
   schedulesBoot: SchedulesBoot;
   runtimeMutator: RuntimeMutator;
+  budget: BudgetGuard;
 }
 
 export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
@@ -36,6 +38,7 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
     runtimeHello,
     schedulesBoot,
     runtimeMutator,
+    budget,
   } = deps;
 
   const k8sClient = createK8sClient(api, config.namespace);
@@ -57,6 +60,7 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
         config.brand.name,
         runtimeMutator,
         templatesRepo,
+        budget,
       ),
     schedulesServiceFor: (owner) =>
       composeSchedulesForOwner({ boot: schedulesBoot, owner }).schedules,

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -137,6 +137,12 @@ const configSchema = z.object({
     .int()
     .positive()
     .default(5 * 1024 * 1024 * 1024),
+  /** Per-user CPU/memory ceiling when a user has no `user_budgets` row (#1900). */
+  defaultUserCpuBudget: z.string().default("4"),
+  defaultUserMemoryBudget: z.string().default("8Gi"),
+  /** Assumed agent requests when a CR omits `spec.resources`; must mirror the controller's templateDefaults. */
+  agentDefaultCpuRequest: z.string().default("250m"),
+  agentDefaultMemoryRequest: z.string().default("512Mi"),
   /** Brand presented to end users — display name, slash-command identifier,
    *  and theme accent colors. Surfaced to the UI via `GET /api/brand` and
    *  used internally for OAuth client_name, Slack slash command, skill
@@ -210,6 +216,10 @@ export function loadConfig(): Config {
     agentTemplatesPath: process.env.AGENT_TEMPLATES_PATH,
     gitReposPath: process.env.GIT_REPOS_PATH,
     maxImportBundleBytes: process.env.MAX_IMPORT_BUNDLE_BYTES,
+    defaultUserCpuBudget: process.env.DEFAULT_USER_CPU_BUDGET,
+    defaultUserMemoryBudget: process.env.DEFAULT_USER_MEMORY_BUDGET,
+    agentDefaultCpuRequest: process.env.AGENT_DEFAULT_CPU_REQUEST,
+    agentDefaultMemoryRequest: process.env.AGENT_DEFAULT_MEMORY_REQUEST,
     brand: {
       name: process.env.BRAND_NAME ?? "Platform",
       short: process.env.BRAND_SHORT ?? "platform",

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -59,6 +59,10 @@ import {
   createBullConnection,
 } from "./modules/runtime-delivery/index.js";
 import { composeSchedulesAtBoot } from "./modules/schedules/index.js";
+import {
+  composeBudgetsModule,
+  type BudgetGuard,
+} from "./modules/budgets/index.js";
 import { createSecretEnvSource } from "./modules/secrets/services/secret-env-source.js";
 import {
   createKubernetesSecretStore,
@@ -129,7 +133,44 @@ const redisBus = createRedisBus(config.redisUrl, {
 });
 
 const k8sClient = createK8sClient(api, config.namespace);
-const agentsRepo = createAgentsRepository(k8sClient);
+// Late-bound to break the repo↔budget cycle; assigned synchronously below.
+let budgetGuard: BudgetGuard | undefined;
+const agentsRepo = createAgentsRepository(k8sClient, {
+  assertWakeAllowed: (id) => {
+    if (!budgetGuard) throw new Error("budget guard used before wiring");
+    return budgetGuard.assertWakeAllowed(id);
+  },
+});
+const { budget } = composeBudgetsModule({
+  db,
+  running: {
+    listRunning: async (owner) =>
+      (await agentsRepo.list(owner))
+        .filter((a) => !a.hibernated)
+        .map((a) => ({ requests: a.spec.resources?.requests })),
+    describe: async (agentId) => {
+      const [infra, owner] = await Promise.all([
+        agentsRepo.get(agentId),
+        agentsRepo.getOwner(agentId),
+      ]);
+      if (!infra || !owner) return null;
+      return {
+        owner,
+        requests: infra.spec.resources?.requests,
+        hibernated: infra.hibernated,
+      };
+    },
+  },
+  agentDefaultRequests: {
+    cpu: config.agentDefaultCpuRequest,
+    memory: config.agentDefaultMemoryRequest,
+  },
+  defaultCeiling: {
+    cpu: config.defaultUserCpuBudget,
+    memory: config.defaultUserMemoryBudget,
+  },
+});
+budgetGuard = budget;
 const agentEnvRepo = createAgentEnvRepository(db);
 
 // Migrate pre-existing spec.env onto agent_env. First pass runs before serving;
@@ -246,6 +287,7 @@ const { agents: systemAgents } = composeAgentsModule({
   readTemplateSpec: async () => null,
   runtimeMutator: runtimeDelivery.runtimeMutator,
   contributionsSettled: contributionsSettledPort,
+  budgetGate: budget,
 });
 
 const identityLinkService = createIdentityLinkService({
@@ -452,6 +494,7 @@ const schedulesBoot = composeSchedulesAtBoot({
   db,
   bullConnection,
   runtimeMutator: runtimeDelivery.runtimeMutator,
+  // Budget-gated (#1900): a rejected poke is a failed fire; the committed event redelivers later.
   wakeAgent: async (agentId) => {
     await agentsRepo.wakeIfHibernated(agentId);
   },
@@ -506,6 +549,7 @@ const { server: apiServer } = startApiServerApp({
   secretStores,
   runtimeMutator: runtimeDelivery.runtimeMutator,
   contributionsSettled: contributionsSettledPort,
+  budget,
   schedulesBoot,
   mountUsageRoutes: usage.mount,
   terms: termsService,
@@ -522,6 +566,7 @@ const { server: harnessApiServer } = startHarnessApiServerApp({
   runtimeHello: runtimeDelivery.hello,
   schedulesBoot,
   runtimeMutator: runtimeDelivery.runtimeMutator,
+  budget,
 });
 
 // Instance identity for ext-authz now flows from the per-instance

--- a/packages/api-server/src/modules/agents/compose.ts
+++ b/packages/api-server/src/modules/agents/compose.ts
@@ -8,6 +8,7 @@ import type { ChannelSecretStore } from "../channels/infrastructure/channel-secr
 import {
   createAgentsRepository,
   type AgentsRepository,
+  type WakeBudgetGate,
 } from "./infrastructure/agents-repository.js";
 import { createAgentEnvRepository } from "./infrastructure/agent-env-repository.js";
 import {
@@ -15,6 +16,7 @@ import {
   type AgentCleanupHook,
   type PresetSeeder,
   type ContributionsSettledPort,
+  type BudgetGate,
 } from "./services/agents-service.js";
 import {
   listChannelsByOwner,
@@ -41,6 +43,12 @@ export type {
   PresetSeeder,
 } from "./services/agents-service.js";
 
+/** Allow-all gate for repos that never bring an agent online (e.g. the files proxy, which only checks ownership). */
+export const allowAllBudgetGate: BudgetGate & WakeBudgetGate = {
+  assertCreateAllowed: () => Promise.resolve(),
+  assertWakeAllowed: () => Promise.resolve(),
+};
+
 export function composeAgentsModule(deps: {
   api: k8s.CoreV1Api;
   namespace: string;
@@ -55,6 +63,8 @@ export function composeAgentsModule(deps: {
   cleanupHooks?: readonly AgentCleanupHook[];
   runtimeMutator: RuntimeMutator;
   contributionsSettled: ContributionsSettledPort;
+  /** Per-user CPU/memory ceiling — gates create (service) and wake (repo). */
+  budgetGate: BudgetGate & WakeBudgetGate;
   /** Single-shot create; wired from secrets + connections. Omitted system-side. */
   grantProvisioner?: {
     resolveSpecGrants(sel: {
@@ -72,7 +82,7 @@ export function composeAgentsModule(deps: {
   isOwnedAgent: (agentId: string) => Promise<boolean>;
 } {
   const k8s = createK8sClient(deps.api, deps.namespace);
-  const repo = createAgentsRepository(k8s);
+  const repo = createAgentsRepository(k8s, deps.budgetGate);
   const agentEnvRepo = createAgentEnvRepository(deps.db);
   const registrySecretPort = createAgentRegistrySecretPort(k8s);
   // For DB-scoped lookups, an undefined owner means "system-wide". The
@@ -90,6 +100,7 @@ export function composeAgentsModule(deps: {
       registrySecretPort,
       runtimeMutator: deps.runtimeMutator,
       contributionsSettled: deps.contributionsSettled,
+      budgetGate: deps.budgetGate,
       grantProvisioner: deps.grantProvisioner,
       listChannelsByOwner: listChannelsByOwner(deps.db, owner),
       listChannelsByAgent: listChannelsByAgent(deps.db, owner),

--- a/packages/api-server/src/modules/agents/index.ts
+++ b/packages/api-server/src/modules/agents/index.ts
@@ -1,4 +1,4 @@
-export { composeAgentsModule } from "./compose.js";
+export { composeAgentsModule, allowAllBudgetGate } from "./compose.js";
 export type {
   AgentCleanupHook,
   PresetSeeder,

--- a/packages/api-server/src/modules/agents/infrastructure/agents-repository.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agents-repository.ts
@@ -5,6 +5,7 @@ import {
   ANN_ROLL_REV,
   LABEL_OWNER,
   LAST_ACTIVITY_KEY,
+  STOP_REQUESTED_KEY,
 } from "./labels.js";
 import {
   agentIsOwnedBy,
@@ -20,6 +21,11 @@ import {
   WAKE_POLL_MAX_MS,
   WAKE_TIMEOUT_MS,
 } from "./poll-until-ready.js";
+
+/** Gate every wake funnels through (#1900); covers the relays that bypass the service. */
+export interface WakeBudgetGate {
+  assertWakeAllowed(agentId: string): Promise<void>;
+}
 
 export interface AgentsRepository {
   list(owner?: string): Promise<InfraAgent[]>;
@@ -41,6 +47,8 @@ export interface AgentsRepository {
   delete(id: string, owner?: string): Promise<boolean>;
   restart(id: string, owner?: string): Promise<boolean>;
   wake(id: string): Promise<InfraAgent | null>;
+  /** Hard stop: stamp `stop-requested` and clear `active-session`; any later bump clears it. */
+  requestStop(id: string): Promise<InfraAgent | null>;
   isOwnedBy(id: string, owner: string): Promise<boolean>;
   getOwner(id: string): Promise<string | null>;
   /** Resolve an agent CR to its identity. Used by the ext_authz hot path
@@ -61,20 +69,21 @@ export interface AgentsRepository {
   ensureReady(id: string): Promise<void>;
 }
 
-export function createAgentsRepository(k8s: K8sClient): AgentsRepository {
-  // Single-flight per agent id. Concurrent callers for the same id share
-  // one in-flight wake+wait+bump; callers for different ids don't block each
-  // other. Correctness does not depend on this (K8s optimistic concurrency
-  // already serializes concurrent writes) — it keeps API load sane under
-  // bursty call patterns.
+export function createAgentsRepository(
+  k8s: K8sClient,
+  budgetGate: WakeBudgetGate,
+): AgentsRepository {
+  // Single-flight per id: same-id callers share one wake+wait+bump (load, not correctness).
   const inflight = new Map<string, Promise<void>>();
 
-  // RFC 7386 merge-patch — no read-modify-write, no resourceVersion, no 409
-  // conflict possible. One round trip.
   async function bumpLastActivity(id: string): Promise<void> {
     await k8s.patchCustomObject(AGENTS_PLURAL, id, {
       metadata: {
-        annotations: { [LAST_ACTIVITY_KEY]: new Date().toISOString() },
+        annotations: {
+          [LAST_ACTIVITY_KEY]: new Date().toISOString(),
+          // Any activity cancels a pending hard stop so the agent can wake.
+          [STOP_REQUESTED_KEY]: "",
+        },
       },
     });
   }
@@ -141,9 +150,25 @@ export function createAgentsRepository(k8s: K8sClient): AgentsRepository {
     async wake(id) {
       const obj = await k8s.getCustomObject(AGENTS_PLURAL, id);
       if (!obj) return null;
-      // Waking is an activity poke — bump last-activity so the
-      // reconciler scales the pair up. There is no desiredState to flip.
+      // Only a real hibernated→running transition spends budget.
+      if (parseInfraAgent(obj).hibernated)
+        await budgetGate.assertWakeAllowed(id);
       await bumpLastActivity(id);
+      const reread = await k8s.getCustomObject(AGENTS_PLURAL, id);
+      return reread ? parseInfraAgent(reread) : null;
+    },
+
+    async requestStop(id) {
+      const obj = await k8s.getCustomObject(AGENTS_PLURAL, id);
+      if (!obj) return null;
+      await k8s.patchCustomObject(AGENTS_PLURAL, id, {
+        metadata: {
+          annotations: {
+            [STOP_REQUESTED_KEY]: new Date().toISOString(),
+            [ACTIVE_SESSION_KEY]: "",
+          },
+        },
+      });
       const reread = await k8s.getCustomObject(AGENTS_PLURAL, id);
       return reread ? parseInfraAgent(reread) : null;
     },
@@ -188,8 +213,8 @@ export function createAgentsRepository(k8s: K8sClient): AgentsRepository {
     async wakeIfHibernated(id) {
       const obj = await k8s.getCustomObject(AGENTS_PLURAL, id);
       if (!obj) return false;
-      // Unconditional activity poke; waking an already-running
-      // agent simply keeps it warm.
+      if (parseInfraAgent(obj).hibernated)
+        await budgetGate.assertWakeAllowed(id);
       await bumpLastActivity(id);
       return true;
     },

--- a/packages/api-server/src/modules/agents/infrastructure/labels.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/labels.ts
@@ -43,6 +43,9 @@ export const KIND_AGENT = "Agent";
 export const LAST_ACTIVITY_KEY = "agent-platform.ai/last-activity";
 export const ACTIVE_SESSION_KEY = "agent-platform.ai/active-session";
 
+// User-initiated hard stop (#1900): non-empty ⇒ controller scales to zero now; any bump clears it.
+export const STOP_REQUESTED_KEY = "agent-platform.ai/stop-requested";
+
 // Roll trigger. The api-server bumps this annotation on the Agent
 // to request a rolling restart of the pair: the controller stamps its value
 // into both pod templates, so a change rolls the pods without any spec/status

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -26,6 +26,14 @@ export interface ContributionsSettledPort {
   status(agentId: string): Promise<ContributionsStatus>;
   statusMany(agentIds: string[]): Promise<Map<string, ContributionsStatus>>;
 }
+
+/** Rejects a create over the owner's budget (#1900); wakes are gated in the repository. */
+export interface BudgetGate {
+  assertCreateAllowed(
+    owner: string,
+    requests: { cpu?: string; memory?: string } | undefined,
+  ): Promise<void>;
+}
 import {
   assembleAgent,
   type InfraAgent,
@@ -100,6 +108,8 @@ export function createAgentsService(deps: {
   registrySecretPort: AgentRegistrySecretPort;
   runtimeMutator: RuntimeMutator;
   contributionsSettled: ContributionsSettledPort;
+  /** Per-user CPU/memory ceiling; pass the allow-all gate to disable. */
+  budgetGate: BudgetGate;
   /** Single-shot create: seeds spec grant fields before first render, then
    *  applies egress/DB/delivery side-effects. Omitted by system compositions. */
   grantProvisioner?: {
@@ -308,6 +318,14 @@ export function createAgentsService(deps: {
         });
       }
       const owner = deps.owner;
+      await deps.budgetGate.assertCreateAllowed(
+        owner,
+        (
+          spec.resources as
+            | { requests?: { cpu?: string; memory?: string } }
+            | undefined
+        )?.requests,
+      );
       const agentId = generateK8sName("agent");
 
       if (input.registryCredential) {
@@ -561,6 +579,31 @@ export function createAgentsService(deps: {
         result: "success",
       });
       emit({ type: EventType.AgentWoken, agentId: id });
+      return project(infra);
+    },
+
+    async stop(id) {
+      if (deps.owner && !(await deps.repo.isOwnedBy(id, deps.owner))) {
+        securityLog("warn", "authz.owner_mismatch", {
+          category: "authz",
+          actor: deps.owner,
+          actorKind: "user",
+          agentId: id,
+          decision: "deny",
+          reason: "not-owner",
+          detail: { surface: "agent.stop" },
+        });
+        return null;
+      }
+      const infra = await deps.repo.requestStop(id);
+      if (!infra) return null;
+      securityLog("info", "agent.stop", {
+        category: "privileged",
+        actor: deps.owner ?? null,
+        actorKind: "user",
+        agentId: id,
+        result: "success",
+      });
       return project(infra);
     },
 

--- a/packages/api-server/src/modules/budgets/compose.ts
+++ b/packages/api-server/src/modules/budgets/compose.ts
@@ -1,0 +1,30 @@
+import type { Db } from "db";
+import { parseAmount } from "./domain/resources.js";
+import { createUserBudgetsRepository } from "./infrastructure/user-budgets-repository.js";
+import {
+  createBudgetGuard,
+  type BudgetGuard,
+  type RunningAgentsPort,
+} from "./services/budget-guard.js";
+
+export function composeBudgetsModule(deps: {
+  db: Db;
+  running: RunningAgentsPort;
+  agentDefaultRequests: { cpu: string; memory: string };
+  defaultCeiling: { cpu: string; memory: string };
+}): { budget: BudgetGuard } {
+  return {
+    budget: createBudgetGuard({
+      running: deps.running,
+      budgets: createUserBudgetsRepository(deps.db),
+      agentDefault: parseAmount(
+        deps.agentDefaultRequests.cpu,
+        deps.agentDefaultRequests.memory,
+      ),
+      defaultCeiling: parseAmount(
+        deps.defaultCeiling.cpu,
+        deps.defaultCeiling.memory,
+      ),
+    }),
+  };
+}

--- a/packages/api-server/src/modules/budgets/domain/resources.ts
+++ b/packages/api-server/src/modules/budgets/domain/resources.ts
@@ -1,0 +1,86 @@
+/** CPU (millicores) and memory (bytes) — the two budgeted dimensions. */
+export interface ResourceAmount {
+  cpuMilli: number;
+  memoryBytes: number;
+}
+
+/** Raw K8s request strings off an agent's `spec.resources.requests`. */
+export interface ResourceRequests {
+  cpu?: string;
+  memory?: string;
+}
+
+export const ZERO: ResourceAmount = { cpuMilli: 0, memoryBytes: 0 };
+
+/** Fixed per-agent gateway (Envoy) requests; added as a constant since the api-server never renders it. */
+export const GATEWAY: ResourceAmount = {
+  cpuMilli: 50,
+  memoryBytes: 64 * 1024 * 1024,
+};
+
+const MEM_UNITS: Record<string, number> = {
+  Ki: 1024,
+  Mi: 1024 ** 2,
+  Gi: 1024 ** 3,
+  Ti: 1024 ** 4,
+  k: 1e3,
+  M: 1e6,
+  G: 1e9,
+  T: 1e12,
+};
+
+/** "250m" → 250, "1" → 1000; unparseable → 0. */
+export function parseCpuMilli(q: string): number {
+  const s = q.trim();
+  const n = s.endsWith("m") ? Number(s.slice(0, -1)) : Number(s) * 1000;
+  return Number.isFinite(n) ? Math.round(n) : 0;
+}
+
+/** "512Mi" → 536870912, "8Gi" → …, plain bytes when no unit. */
+export function parseMemoryBytes(q: string): number {
+  const m = q.trim().match(/^(\d+(?:\.\d+)?)([A-Za-z]+)?$/);
+  if (!m) return 0;
+  const factor = m[2] ? (MEM_UNITS[m[2]] ?? 1) : 1;
+  return Math.round(Number(m[1]) * factor);
+}
+
+export function parseAmount(cpu: string, memory: string): ResourceAmount {
+  return {
+    cpuMilli: parseCpuMilli(cpu),
+    memoryBytes: parseMemoryBytes(memory),
+  };
+}
+
+export function add(a: ResourceAmount, b: ResourceAmount): ResourceAmount {
+  return {
+    cpuMilli: a.cpuMilli + b.cpuMilli,
+    memoryBytes: a.memoryBytes + b.memoryBytes,
+  };
+}
+
+/** An agent's reserved footprint: its requests (or chart default) plus the gateway. */
+export function footprint(
+  requests: ResourceRequests | undefined,
+  agentDefault: ResourceAmount,
+): ResourceAmount {
+  return add(GATEWAY, {
+    cpuMilli: requests?.cpu
+      ? parseCpuMilli(requests.cpu)
+      : agentDefault.cpuMilli,
+    memoryBytes: requests?.memory
+      ? parseMemoryBytes(requests.memory)
+      : agentDefault.memoryBytes,
+  });
+}
+
+/** True when adding `candidate` to `reserved` would breach `limit` on either dimension. */
+export function wouldExceed(
+  reserved: ResourceAmount,
+  candidate: ResourceAmount,
+  limit: ResourceAmount,
+): boolean {
+  return (
+    reserved.cpuMilli + candidate.cpuMilli > limit.cpuMilli ||
+    reserved.memoryBytes + candidate.memoryBytes > limit.memoryBytes
+  );
+}

--- a/packages/api-server/src/modules/budgets/index.ts
+++ b/packages/api-server/src/modules/budgets/index.ts
@@ -1,0 +1,5 @@
+export { composeBudgetsModule } from "./compose.js";
+export type {
+  BudgetGuard,
+  RunningAgentsPort,
+} from "./services/budget-guard.js";

--- a/packages/api-server/src/modules/budgets/infrastructure/user-budgets-repository.ts
+++ b/packages/api-server/src/modules/budgets/infrastructure/user-budgets-repository.ts
@@ -1,0 +1,23 @@
+import { eq, userBudgets, type Db } from "db";
+import type { ResourceAmount } from "../domain/resources.js";
+
+export interface UserBudgetsRepository {
+  /** The owner's explicit ceiling override, or null to fall back to the chart default. */
+  ceiling(owner: string): Promise<ResourceAmount | null>;
+}
+
+export function createUserBudgetsRepository(db: Db): UserBudgetsRepository {
+  return {
+    async ceiling(owner) {
+      const [row] = await db
+        .select({
+          cpuMilli: userBudgets.cpuMilli,
+          memoryBytes: userBudgets.memoryBytes,
+        })
+        .from(userBudgets)
+        .where(eq(userBudgets.owner, owner))
+        .limit(1);
+      return row ?? null;
+    },
+  };
+}

--- a/packages/api-server/src/modules/budgets/services/budget-guard.ts
+++ b/packages/api-server/src/modules/budgets/services/budget-guard.ts
@@ -1,0 +1,104 @@
+import { TRPCError } from "@trpc/server";
+import type { BudgetUsage } from "api-server-api";
+import type { UserBudgetsRepository } from "../infrastructure/user-budgets-repository.js";
+import {
+  ZERO,
+  add,
+  footprint,
+  wouldExceed,
+  type ResourceAmount,
+  type ResourceRequests,
+} from "../domain/resources.js";
+
+/** Port over the agents' K8s state — the authoritative running set. */
+export interface RunningAgentsPort {
+  /** Non-hibernated agents owned by `owner`, each with its raw requests. */
+  listRunning(
+    owner: string,
+  ): Promise<{ requests: ResourceRequests | undefined }[]>;
+  /** An agent's owner, requests, and whether it is currently hibernated. */
+  describe(agentId: string): Promise<{
+    owner: string;
+    requests: ResourceRequests | undefined;
+    hibernated: boolean;
+  } | null>;
+}
+
+export interface BudgetGuard {
+  usage(owner: string): Promise<BudgetUsage>;
+  /** Throws when creating an agent with `requests` would breach the owner's ceiling. */
+  assertCreateAllowed(
+    owner: string,
+    requests: ResourceRequests | undefined,
+  ): Promise<void>;
+  /** Throws when waking a hibernated agent would breach its owner's ceiling; no-op otherwise. */
+  assertWakeAllowed(agentId: string): Promise<void>;
+}
+
+export function createBudgetGuard(deps: {
+  running: RunningAgentsPort;
+  budgets: UserBudgetsRepository;
+  agentDefault: ResourceAmount;
+  defaultCeiling: ResourceAmount;
+}): BudgetGuard {
+  async function reservedAndLimit(
+    owner: string,
+  ): Promise<{ reserved: ResourceAmount; limit: ResourceAmount }> {
+    const [running, override] = await Promise.all([
+      deps.running.listRunning(owner),
+      deps.budgets.ceiling(owner),
+    ]);
+    const reserved = running.reduce(
+      (acc, a) => add(acc, footprint(a.requests, deps.agentDefault)),
+      ZERO,
+    );
+    return { reserved, limit: override ?? deps.defaultCeiling };
+  }
+
+  async function assertWithin(
+    owner: string,
+    candidate: ResourceAmount,
+  ): Promise<void> {
+    const { reserved, limit } = await reservedAndLimit(owner);
+    if (wouldExceed(reserved, candidate, limit))
+      throw overBudget(reserved, candidate, limit);
+  }
+
+  return {
+    async usage(owner) {
+      const { reserved, limit } = await reservedAndLimit(owner);
+      return {
+        cpu: { reservedMilli: reserved.cpuMilli, limitMilli: limit.cpuMilli },
+        memory: {
+          reservedBytes: reserved.memoryBytes,
+          limitBytes: limit.memoryBytes,
+        },
+      };
+    },
+
+    assertCreateAllowed(owner, requests) {
+      return assertWithin(owner, footprint(requests, deps.agentDefault));
+    },
+
+    async assertWakeAllowed(agentId) {
+      const a = await deps.running.describe(agentId);
+      if (!a || !a.hibernated) return;
+      await assertWithin(a.owner, footprint(a.requests, deps.agentDefault));
+    },
+  };
+}
+
+function overBudget(
+  reserved: ResourceAmount,
+  candidate: ResourceAmount,
+  limit: ResourceAmount,
+): TRPCError {
+  const cpu = (n: number) => `${(n / 1000).toFixed(2)} CPU`;
+  const mem = (n: number) => `${(n / 1024 ** 3).toFixed(2)} Gi`;
+  return new TRPCError({
+    code: "FORBIDDEN",
+    message:
+      `Over your compute budget: this would reserve ${cpu(reserved.cpuMilli + candidate.cpuMilli)} / ${cpu(limit.cpuMilli)} ` +
+      `and ${mem(reserved.memoryBytes + candidate.memoryBytes)} / ${mem(limit.memoryBytes)}. Stop a running agent to free room.`,
+  });
+}

--- a/packages/api-server/src/modules/files/files-service.ts
+++ b/packages/api-server/src/modules/files/files-service.ts
@@ -4,7 +4,7 @@ import { TRPCError } from "@trpc/server";
 import type { AppRouter as AgentRuntimeRouter } from "agent-runtime-api";
 import type { FilesService } from "api-server-api";
 import { emit, EventType, type TurnOutcome } from "../../events.js";
-import { createAgentsRepository } from "../agents/index.js";
+import { allowAllBudgetGate, createAgentsRepository } from "../agents/index.js";
 import { createK8sClient, podBaseUrl } from "../agents/infrastructure/k8s.js";
 
 export function composeFilesModule(
@@ -12,7 +12,10 @@ export function composeFilesModule(
   namespace: string,
   ownerSub: string,
 ): FilesService {
-  const agentsRepo = createAgentsRepository(createK8sClient(api, namespace));
+  const agentsRepo = createAgentsRepository(
+    createK8sClient(api, namespace),
+    allowAllBudgetGate,
+  );
   return {
     async upload(input) {
       if (!(await agentsRepo.isOwnedBy(input.agentId, ownerSub))) {

--- a/packages/api-server/src/modules/skills/compose.ts
+++ b/packages/api-server/src/modules/skills/compose.ts
@@ -1,7 +1,10 @@
 import type * as k8s from "@kubernetes/client-node";
 import type { Db } from "db";
 import type { Skill, SkillsService } from "api-server-api";
-import { createAgentsRepository } from "../agents/infrastructure/agents-repository.js";
+import {
+  createAgentsRepository,
+  type WakeBudgetGate,
+} from "../agents/infrastructure/agents-repository.js";
 import type { TemplatesRepository } from "../templates/infrastructure/templates-repository.js";
 import { createK8sClient } from "../agents/infrastructure/k8s.js";
 import { createAgentRuntimeSkillsClient } from "./infrastructure/agent-runtime-client.js";
@@ -68,12 +71,13 @@ export function composeSkillsModule(
   brandName: string,
   runtimeMutator: RuntimeMutator,
   templatesRepo: TemplatesRepository,
+  budgetGate: WakeBudgetGate,
 ): SkillsService {
   const k8s = createK8sClient(api, namespace);
   return createSkillsService({
     repo: createSkillsRepository(db, seedSources),
     agentSkillsRepo: createAgentSkillsRepository(db),
-    agentsRepo: createAgentsRepository(k8s),
+    agentsRepo: createAgentsRepository(k8s, budgetGate),
     templatesRepo,
     seedSources,
     runtimeClient: createAgentRuntimeSkillsClient(namespace),

--- a/packages/controller/pkg/reconciler/agent_reconciler.go
+++ b/packages/controller/pkg/reconciler/agent_reconciler.go
@@ -219,6 +219,14 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, agent *apiv1.Agent) err
 	}
 	timer.mark("agentStatefulSet")
 
+	// Hard stop (#1900): scale to zero now, bypassing the idle probe.
+	if agent.Annotations[annStopRequested] != "" {
+		if err := hibernateAgentPair(ctx, r.client, r.dynamic, r.config.Namespace, name); err != nil {
+			return r.setError(ctx, name, fmt.Sprintf("stopping agent: %v", err))
+		}
+		return r.publishReconciled(ctx, agent)
+	}
+
 	// The reconciler only scales up; scale-down and the Hibernated
 	// readiness reason are the idle checker's job. So readiness is published
 	// only for a running agent — but rendering succeeded either way, so an idle

--- a/packages/controller/pkg/reconciler/hibernation.go
+++ b/packages/controller/pkg/reconciler/hibernation.go
@@ -2,24 +2,20 @@ package reconciler
 
 import "time"
 
-// Activity annotations the api-server stamps on an Agent. They are the only
-// inputs to the run/hibernate decision now that desiredState is gone.
+// Activity annotations the api-server stamps on an Agent — the only inputs to the run/hibernate decision.
 const (
 	annActiveSession = "agent-platform.ai/active-session"
 	annLastActivity  = "agent-platform.ai/last-activity"
+	// User-initiated hard stop (#1900): forces hibernation, overriding activity and disabled auto-hibernation.
+	annStopRequested = "agent-platform.ai/stop-requested"
 )
 
-// shouldRun reports whether an agent should be scaled up, derived purely from
-// activity annotations. It is the single decision function shared by the
-// reconciler (which scales *up* when it returns true) and the idle checker
-// (which treats a false result as a scale-*down* candidate), so the two can
-// never disagree.
-//
-// It fails open: an agent runs when auto-hibernation is disabled
-// (idleTimeout <= 0) or when the last-activity stamp is missing or unparseable.
-// Hibernation is therefore only ever the result of a *positive* idle signal,
-// never of absent data.
+// shouldRun is the single run/hibernate decision shared by the reconciler (scales up on true)
+// and the idle checker (treats false as a scale-down candidate). Fails open on missing data.
 func shouldRun(annotations map[string]string, idleTimeout time.Duration, now time.Time) bool {
+	if annotations[annStopRequested] != "" {
+		return false
+	}
 	if idleTimeout <= 0 {
 		return true
 	}

--- a/packages/controller/pkg/reconciler/idlechecker.go
+++ b/packages/controller/pkg/reconciler/idlechecker.go
@@ -22,9 +22,7 @@ type IdleChecker struct {
 	client  kubernetes.Interface
 	dynamic dynamic.Interface
 	config  *config.Config
-	// busyProbe reports whether an agent's pod is mid-work and must not be
-	// hibernated. Defaults to the live HTTP probe (podIsBusy); overridable in
-	// tests so the busy-guard branch can be exercised without a real pod.
+	// Whether a pod is mid-work; defaults to podIsBusy, overridable in tests.
 	busyProbe func(agentName string) bool
 }
 
@@ -34,8 +32,7 @@ func NewIdleChecker(client kubernetes.Interface, dyn dynamic.Interface, cfg *con
 	return c
 }
 
-// RunLoop periodically scans running agents and hibernates idle ones.
-// It blocks until ctx is cancelled.
+// RunLoop scans running agents and hibernates idle ones until ctx is cancelled.
 func (c *IdleChecker) RunLoop(ctx context.Context) {
 	timeout := c.config.AgentBase.IdleTimeout.AsDuration()
 	if timeout <= 0 {
@@ -84,17 +81,12 @@ func (c *IdleChecker) check(ctx context.Context) {
 	for i := range agents.Items {
 		agent := &agents.Items[i]
 		name := agent.GetName()
-		// Active by activity annotations → not an idle candidate. This is the
-		// exact decision the reconciler uses to scale up, so the two
-		// can never disagree about whether an agent is idle.
+		// Same decision the reconciler scales up on, so the two never disagree.
 		if shouldRun(agent.GetAnnotations(), timeout, now) {
 			continue
 		}
 
-		// Probe the pod — a long-running session, trigger, or terminal that
-		// hasn't bumped last-activity must not be hibernated out from under
-		// itself. This guard is why scale-down lives here, not in the
-		// reconciler.
+		// Probe so a session/trigger that hasn't bumped activity isn't hibernated under itself.
 		if c.busyProbe(name) {
 			slog.Info("idle checker: skipping busy agent", "agent", name)
 			continue
@@ -107,17 +99,11 @@ func (c *IdleChecker) check(ctx context.Context) {
 		}
 		hibernated++
 	}
-	// Each idle candidate triggers a 3s-timeout busy-probe, so the duration
-	// shows when a sweep over unreachable pods runs long.
 	slog.Debug("idle checker sweep complete",
 		"scanned", len(agents.Items), "hibernated", hibernated, "duration", time.Since(start))
 }
 
-// podIsBusy probes the agent runtime's /api/status endpoint. The runtime is
-// authoritative about its own idleness — it reports a single idle flag and the
-// controller does not re-derive busy-ness from raw counters. A runtime too old
-// to report the flag parses as idle=false, i.e. busy, which fails safe.
-// Returns false (not busy) on any error — allows hibernation if the pod is unreachable.
+// podIsBusy reads the runtime's authoritative /api/status idle flag; any error → not busy.
 func (c *IdleChecker) podIsBusy(agentName string) bool {
 	url := fmt.Sprintf("http://%s-0.%s.%s.svc:8080/api/status", agentName, agentName, c.config.Namespace)
 	client := &http.Client{Timeout: 3 * time.Second}
@@ -139,14 +125,14 @@ func (c *IdleChecker) podIsBusy(agentName string) bool {
 	return !status.Idle
 }
 
-// hibernate scales an agent's paired StatefulSets (agent + gateway, both
-// labelled LabelAgent=name) to zero and records the Hibernated phase on the
-// Agent status subresource. The idle checker is the sole scale-down
-// authority and never writes spec — run state is derived from activity, not a
-// stored desiredState. Idempotent: a StatefulSet already at zero is left
-// untouched.
 func (c *IdleChecker) hibernate(ctx context.Context, name string) error {
-	sss, err := c.client.AppsV1().StatefulSets(c.config.Namespace).List(ctx, metav1.ListOptions{
+	return hibernateAgentPair(ctx, c.client, c.dynamic, c.config.Namespace, name)
+}
+
+// hibernateAgentPair scales an agent's paired StatefulSets to zero and records
+// the Hibernated phase. Idempotent. Shared by the idle checker and the stop path.
+func hibernateAgentPair(ctx context.Context, kube kubernetes.Interface, dyn dynamic.Interface, namespace, name string) error {
+	sss, err := kube.AppsV1().StatefulSets(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: LabelAgent + "=" + name,
 	})
 	if err != nil {
@@ -159,22 +145,20 @@ func (c *IdleChecker) hibernate(ctx context.Context, name string) error {
 		}
 		ssName := ss.Name
 		if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			fresh, err := c.client.AppsV1().StatefulSets(c.config.Namespace).Get(ctx, ssName, metav1.GetOptions{})
+			fresh, err := kube.AppsV1().StatefulSets(namespace).Get(ctx, ssName, metav1.GetOptions{})
 			if err != nil {
 				return err
 			}
 			zero := int32(0)
 			fresh.Spec.Replicas = &zero
-			_, err = c.client.AppsV1().StatefulSets(c.config.Namespace).Update(ctx, fresh, metav1.UpdateOptions{})
+			_, err = kube.AppsV1().StatefulSets(namespace).Update(ctx, fresh, metav1.UpdateOptions{})
 			return err
 		}); err != nil {
 			return fmt.Errorf("scaling down statefulset %s: %w", ssName, err)
 		}
 	}
-	return updateAgentStatus(ctx, c.dynamic, c.config.Namespace, name, func(s *apiv1.AgentStatus) {
-		// Pods are gone, so the agent is not routable until woken — reflect that
-		// on Ready (the api-server's routing signal). The Hibernated reason lets
-		// consumers tell this from a still-starting agent.
+	return updateAgentStatus(ctx, dyn, namespace, name, func(s *apiv1.AgentStatus) {
+		// Not routable until woken; the Hibernated reason distinguishes this from starting.
 		setStatusCondition(s, apiv1.ConditionAgentPodReady, false, "PodReady", apiv1.ReasonHibernated, "", 0)
 		setStatusCondition(s, apiv1.ConditionGatewayPodReady, false, "PodReady", apiv1.ReasonHibernated, "", 0)
 		setStatusCondition(s, apiv1.ConditionReady, false, "AllPodsReady", apiv1.ReasonHibernated, "", 0)

--- a/packages/db/drizzle/0005_shiny_jamie_braddock.sql
+++ b/packages/db/drizzle/0005_shiny_jamie_braddock.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "user_budgets" (
+	"owner" text PRIMARY KEY NOT NULL,
+	"cpu_milli" bigint NOT NULL,
+	"memory_bytes" bigint NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/packages/db/drizzle/meta/0005_snapshot.json
+++ b/packages/db/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,1744 @@
+{
+  "id": "5b63e6aa-3d34-4aea-a693-9bf9504b307d",
+  "prevId": "8655cd72-fb44-450c-9453-e25e4910db00",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.activity_events": {
+      "name": "activity_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "surface": {
+          "name": "surface",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "activity_outcome",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "activity_events_type_occurred_idx": {
+          "name": "activity_events_type_occurred_idx",
+          "columns": [
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_actor_occurred_idx": {
+          "name": "activity_events_actor_occurred_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"activity_events\".\"actor_sub\" IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_surface_occurred_idx": {
+          "name": "activity_events_surface_occurred_idx",
+          "columns": [
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "occurred_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_events_auth_dedup_idx": {
+          "name": "activity_events_auth_dedup_idx",
+          "columns": [
+            {
+              "expression": "actor_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "surface",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "date_trunc('day', \"occurred_at\" AT TIME ZONE 'UTC')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"activity_events\".\"type\" = 'auth'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.actor_roles": {
+      "name": "actor_roles",
+      "schema": "",
+      "columns": {
+        "actor_sub": {
+          "name": "actor_sub",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "is_core": {
+          "name": "is_core",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_env": {
+      "name": "agent_env",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_env_agent_idx": {
+          "name": "agent_env_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_env_agent_id_name_pk": {
+          "name": "agent_env_agent_id_name_pk",
+          "columns": [
+            "agent_id",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skill_publishes": {
+      "name": "agent_skill_publishes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skill_name": {
+          "name": "skill_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_name": {
+          "name": "source_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_git_url": {
+          "name": "source_git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pr_url": {
+          "name": "pr_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skill_publishes_agent_idx": {
+          "name": "agent_skill_publishes_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_skills": {
+      "name": "agent_skills",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "agent_skills_agent_idx": {
+          "name": "agent_skills_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "agent_skills_agent_id_source_name_pk": {
+          "name": "agent_skills_agent_id_source_name_pk",
+          "columns": [
+            "agent_id",
+            "source",
+            "name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_protocol_version": {
+          "name": "runtime_protocol_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_capabilities": {
+          "name": "runtime_capabilities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_last_hello_at": {
+          "name": "runtime_last_hello_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "runtime_agent_version": {
+          "name": "runtime_agent_version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_idx": {
+          "name": "agents_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.allowed_users": {
+      "name": "allowed_users",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "allowed_users_agent_id_keycloak_sub_pk": {
+          "name": "allowed_users_agent_id_keycloak_sub_pk",
+          "columns": [
+            "agent_id",
+            "keycloak_sub"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.api_keys": {
+      "name": "api_keys",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_ids": {
+          "name": "agent_ids",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_used_at": {
+          "name": "last_used_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "revoked_at": {
+          "name": "revoked_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "api_keys_hash_idx": {
+          "name": "api_keys_hash_idx",
+          "columns": [
+            {
+              "expression": "hash",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "api_keys_owner_idx": {
+          "name": "api_keys_owner_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"api_keys\".\"revoked_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channels": {
+      "name": "channels",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "channels_agent_type_idx": {
+          "name": "channels_agent_type_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channels_slack_channel_unique_idx": {
+          "name": "channels_slack_channel_unique_idx",
+          "columns": [
+            {
+              "expression": "(\"config\"->>'slackChannelId')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"channels\".\"type\" = 'slack'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connection_grants": {
+      "name": "connection_grants",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "granted_at": {
+          "name": "granted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connection_grants_agent_idx": {
+          "name": "connection_grants_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "connection_grants_connection_id_agent_id_pk": {
+          "name": "connection_grants_connection_id_agent_id_pk",
+          "columns": [
+            "connection_id",
+            "agent_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.connections": {
+      "name": "connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "inputs": {
+          "name": "inputs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "auth": {
+          "name": "auth",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "contributions": {
+          "name": "contributions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "connections_owner_idx": {
+          "name": "connections_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "connections_owner_name_unique_idx": {
+          "name": "connections_owner_name_unique_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.egress_rules": {
+      "name": "egress_rules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path_pattern": {
+          "name": "path_pattern",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "decided_at": {
+          "name": "decided_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'manual'"
+        }
+      },
+      "indexes": {
+        "egress_rules_lookup_idx": {
+          "name": "egress_rules_lookup_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "host",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "method",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "path_pattern",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"egress_rules\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "egress_rules_source_idx": {
+          "name": "egress_rules_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"egress_rules\".\"status\" = 'active' AND \"egress_rules\".\"source\" != 'manual'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.identity_links": {
+      "name": "identity_links",
+      "schema": "",
+      "columns": {
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_user_id": {
+          "name": "external_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "keycloak_sub": {
+          "name": "keycloak_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "identity_links_provider_external_user_id_pk": {
+          "name": "identity_links_provider_external_user_id_pk",
+          "columns": [
+            "provider",
+            "external_user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_approvals": {
+      "name": "pending_approvals",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_sub": {
+          "name": "owner_sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resolved_at": {
+          "name": "resolved_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "decided_by": {
+          "name": "decided_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "pending_approvals_owner_status_idx": {
+          "name": "pending_approvals_owner_status_idx",
+          "columns": [
+            {
+              "expression": "owner_sub",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_agent_status_idx": {
+          "name": "pending_approvals_agent_status_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_approvals_undelivered_idx": {
+          "name": "pending_approvals_undelivered_idx",
+          "columns": [
+            {
+              "expression": "resolved_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "status = 'resolved' AND delivered_at IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_events": {
+      "name": "runtime_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dispatched_at": {
+          "name": "dispatched_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "runtime_events_agent_pending_idx": {
+          "name": "runtime_events_agent_pending_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "version",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "runtime_events_expiry_idx": {
+          "name": "runtime_events_expiry_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_events\".\"dispatched_at\" IS NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.runtime_state_outbox": {
+      "name": "runtime_state_outbox",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_enqueued_at": {
+          "name": "last_enqueued_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "last_settled_version": {
+          "name": "last_settled_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_version": {
+          "name": "last_applied_version",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_applied_hash": {
+          "name": "last_applied_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_applied_at": {
+          "name": "last_applied_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "apply_failures": {
+          "name": "apply_failures",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "apply_attempts": {
+          "name": "apply_attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "runtime_state_outbox_retry_idx": {
+          "name": "runtime_state_outbox_retry_idx",
+          "columns": [
+            {
+              "expression": "apply_attempts",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"runtime_state_outbox\".\"apply_failures\" <> '[]'::jsonb OR \"runtime_state_outbox\".\"last_settled_version\" < \"runtime_state_outbox\".\"version\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.schedules": {
+      "name": "schedules",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "spec": {
+          "name": "spec",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "next_run": {
+          "name": "next_run",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_at": {
+          "name": "last_fired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_fired_result": {
+          "name": "last_fired_result",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "schedules_agent_owner_idx": {
+          "name": "schedules_agent_owner_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "schedules_enabled_idx": {
+          "name": "schedules_enabled_idx",
+          "columns": [
+            {
+              "expression": "id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"schedules\".\"enabled\" = true",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.skill_sources": {
+      "name": "skill_sources",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "git_url": {
+          "name": "git_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "skill_sources_owner_git_url_idx": {
+          "name": "skill_sources_owner_git_url_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "git_url",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "skill_sources_owner_idx": {
+          "name": "skill_sources_owner_idx",
+          "columns": [
+            {
+              "expression": "owner",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.telegram_threads": {
+      "name": "telegram_threads",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_id": {
+          "name": "thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorized_by": {
+          "name": "authorized_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "telegram_threads_agent_id_thread_id_pk": {
+          "name": "telegram_threads_agent_id_thread_id_pk",
+          "columns": [
+            "agent_id",
+            "thread_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.terms_acceptances": {
+      "name": "terms_acceptances",
+      "schema": "",
+      "columns": {
+        "sub": {
+          "name": "sub",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "version": {
+          "name": "version",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hash": {
+          "name": "hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "terms_acceptances_sub_version_pk": {
+          "name": "terms_acceptances_sub_version_pk",
+          "columns": [
+            "sub",
+            "version"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_budgets": {
+      "name": "user_budgets",
+      "schema": "",
+      "columns": {
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cpu_milli": {
+          "name": "cpu_milli",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "memory_bytes": {
+          "name": "memory_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.activity_outcome": {
+      "name": "activity_outcome",
+      "schema": "public",
+      "values": [
+        "success",
+        "failure"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/db/drizzle/meta/_journal.json
+++ b/packages/db/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1782382620734,
       "tag": "0004_open_mariko_yashida",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1782725494576,
+      "tag": "0005_shiny_jamie_braddock",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -21,6 +21,7 @@ export {
   actorRoles,
   termsAcceptances,
   apiKeys,
+  userBudgets,
 } from "./schema.js";
 export {
   eq,

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -265,6 +265,16 @@ export const agents = pgTable(
   (table) => [index("agents_owner_idx").on(table.ownerSub)],
 );
 
+// Per-user concurrent CPU/memory ceiling; `owner` is the plaintext `agent-platform.ai/owner`.
+export const userBudgets = pgTable("user_budgets", {
+  owner: text("owner").primaryKey(),
+  cpuMilli: bigint("cpu_milli", { mode: "number" }).notNull(),
+  memoryBytes: bigint("memory_bytes", { mode: "number" }).notNull(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .defaultNow()
+    .notNull(),
+});
+
 /** Per-agent user-typed env (the UI Environment editor). */
 export const agentEnv = pgTable(
   "agent_env",

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -148,6 +148,20 @@ export function useWakeAgentMutation() {
   });
 }
 
+/** Hard stop: scales the agent to zero to free its budget without deleting it. */
+export function useStopAgentMutation() {
+  return useMutation({
+    ...trpc.agents.stop.mutationOptions(),
+    meta: {
+      invalidates: [
+        ...invalidatesAgentsList.invalidates,
+        trpc.budgets.usage.queryKey(),
+      ],
+      errorToast: "Failed to stop agent",
+    },
+  });
+}
+
 /**
  * Raw restart mutation. The UI-side "Restarting" pill lifecycle is managed
  * by useRestartAgent in hooks/use-restart-agent.ts — consumers should

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -23,6 +23,7 @@ interface Props {
   onSelect: () => void;
   onWake: () => void;
   onRestart: () => void;
+  onStop: () => void;
   onConfigure: () => void;
   onDelete: () => void;
 }
@@ -35,6 +36,7 @@ export function AgentRow({
   onSelect,
   onWake,
   onRestart,
+  onStop,
   onConfigure,
   onDelete,
 }: Props) {
@@ -73,6 +75,11 @@ export function AgentRow({
                   onSelect={onRestart}
                 >
                   Restart
+                </DropdownMenuItem>
+              )}
+              {display.powerAction === "restart" && (
+                <DropdownMenuItem onSelect={onStop}>
+                  Stop to free capacity
                 </DropdownMenuItem>
               )}
               <DropdownMenuItem onSelect={onConfigure}>

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -6,10 +6,11 @@ import { Card } from "@/components/ui/card";
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useStore } from "../../../store.js";
 import type { AgentView, TemplateView } from "../../../types.js";
+import { BudgetMeter } from "../../budgets/components/budget-meter.js";
 import { useAppConnections } from "../../connections/api/queries.js";
 import { useSecrets } from "../../secrets/api/queries.js";
 import { useTemplates } from "../../templates/api/queries.js";
-import { useDeleteAgent } from "../api/mutations.js";
+import { useDeleteAgent, useStopAgentMutation } from "../api/mutations.js";
 import { useAgents } from "../api/queries.js";
 import { AgentRow } from "../components/agent-row.js";
 import {
@@ -38,6 +39,7 @@ export function ListView() {
   useSyncRestartingAgents();
 
   const deleteAgent = useDeleteAgent();
+  const stopAgent = useStopAgentMutation();
   const { restart: restartAgent } = useRestartAgent();
   const wakeAgent = useWakeAgent();
 
@@ -92,6 +94,8 @@ export function ListView() {
         )}
       </div>
 
+      {agents.length > 0 && <BudgetMeter />}
+
       {!initialLoaded && <ListSkeleton rows={2} rowHeight={70} />}
 
       {initialLoaded && agents.length === 0 && (
@@ -122,6 +126,7 @@ export function ListView() {
               onSelect={() => selectAgent(agent.id)}
               onWake={() => wakeAgent.wake(agent.id)}
               onRestart={() => restartAgent(agent.id)}
+              onStop={() => stopAgent.mutate({ id: agent.id })}
               onConfigure={() => navigateToSandboxSettings(agent.id)}
               onDelete={() => void deleteSandbox(agent)}
             />

--- a/packages/ui/src/modules/budgets/api/queries.ts
+++ b/packages/ui/src/modules/budgets/api/queries.ts
@@ -1,0 +1,12 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { trpc } from "../../../trpc.js";
+
+/** The caller's reserved CPU/memory against their concurrent ceiling. */
+export function useBudgetUsage() {
+  return useQuery({
+    ...trpc.budgets.usage.queryOptions(),
+    refetchInterval: 5000,
+    staleTime: 5000,
+  });
+}

--- a/packages/ui/src/modules/budgets/components/budget-meter.tsx
+++ b/packages/ui/src/modules/budgets/components/budget-meter.tsx
@@ -1,0 +1,71 @@
+import type { CSSProperties } from "react";
+
+import { useBudgetUsage } from "../api/queries.js";
+
+function formatCores(milli: number): string {
+  const cores = milli / 1000;
+  return Number.isInteger(cores) ? String(cores) : cores.toFixed(2);
+}
+
+function formatGi(bytes: number): string {
+  return (bytes / 1024 ** 3).toFixed(1);
+}
+
+function fillPercent(used: number, limit: number): number {
+  return limit > 0 ? Math.min(100, Math.round((used / limit) * 100)) : 0;
+}
+
+interface DimensionProps {
+  label: string;
+  used: string;
+  limit: string;
+  unit: string;
+  fill: number;
+}
+
+function Dimension({ label, used, limit, unit, fill }: DimensionProps) {
+  return (
+    <div className="flex-1">
+      <div className="flex items-center justify-between text-xs text-muted-foreground">
+        <span>{label}</span>
+        <span>
+          {used} / {limit} {unit}
+        </span>
+      </div>
+      <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-muted">
+        <div
+          className="h-full w-[var(--fill)] rounded-full bg-primary"
+          style={{ "--fill": `${fill}%` } as CSSProperties}
+        />
+      </div>
+    </div>
+  );
+}
+
+/** Reserved compute across the user's running sandboxes, against their ceiling. */
+export function BudgetMeter() {
+  const { data } = useBudgetUsage();
+  if (!data) return null;
+  const { cpu, memory } = data;
+  return (
+    <div
+      className="mb-6 flex items-center gap-6 rounded-lg border border-border px-4 py-3"
+      title="Reserved compute across your running sandboxes, against your limit."
+    >
+      <Dimension
+        label="CPU"
+        used={formatCores(cpu.reservedMilli)}
+        limit={formatCores(cpu.limitMilli)}
+        unit="cores"
+        fill={fillPercent(cpu.reservedMilli, cpu.limitMilli)}
+      />
+      <Dimension
+        label="Memory"
+        used={formatGi(memory.reservedBytes)}
+        limit={formatGi(memory.limitBytes)}
+        unit="Gi"
+        fill={fillPercent(memory.reservedBytes, memory.limitBytes)}
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -32,6 +32,7 @@ import { CardList } from "../card-list.js";
 import { StepHeader } from "../step-header.js";
 
 const NO_TEMPLATES: ConnectionTemplateView[] = [];
+const NO_CONNECTIONS: ConnectionView[] = [];
 
 const CATEGORY_ORDER = ["app", "mcp", "other"] as const;
 const CATEGORY_LABEL: Record<(typeof CATEGORY_ORDER)[number], string> = {
@@ -59,7 +60,11 @@ export function ConnectionsStep({
   const [creating, setCreating] = useState<ConnectionTemplateView | null>(null);
 
   const allTemplates = templatesQ.data ?? NO_TEMPLATES;
-  const connections = (connectionsQ.data ?? []) as unknown as ConnectionView[];
+  // Provider connections are managed in the Provider step; keep them out of the
+  // generic grant list so they aren't offered twice.
+  const connections = (connectionsQ.data ?? NO_CONNECTIONS).filter(
+    (c) => !PROVIDER_TEMPLATE_IDS.has(c.templateId),
+  );
 
   const templateById = useMemo(
     () => new Map(allTemplates.map((t) => [t.id, t])),


### PR DESCRIPTION
Closes #1900.

## What
A per-user ceiling on concurrent CPU/memory across a user's running agents, visibility into their consumption, and a self-service way to free capacity.

## How
- **Budget model** — a user's footprint is the summed pod *requests* (CPU + memory) of their non-hibernated agents plus a fixed gateway constant. Requests are the scheduler's real reservation and the only value knowable before a pod is scheduled (there's no live-metrics API). Ceiling = chart default, overridable per-user via a new `user_budgets` table.
- **Enforcement** — the api-server rejects before any spec write on every path that brings an agent online: **create** (service layer) and **all wakes** (the `AgentsRepository` chokepoint, so ACP/terminal/SSH relays, file proxies, and skills inherit it). Over-budget surfaces a `FORBIDDEN` naming reserved-vs-limit.
- **Scheduled fire over budget** — blocked and deferred: the trigger is already committed to the outbox, so it redelivers once the user frees room or expires at its TTL.
- **Free capacity** — a user-initiated hard stop on a running agent. A new controller `stop-requested` annotation scales the pair to zero immediately; any later activity clears it.
- **Visibility** — a `budgets.usage` query rendered as a meter on the sandbox list.

## Out of scope (per the issue)
Role-based limits / approval flows, and token/cost usage.

See `docs/architecture/budgets.md` for the full design.