### PR TITLE
fix(skills): degrade skills.state when the agent pod is unreachable

### DIFF
--- a/packages/api-server/src/__tests__/unit/skills-service-state-unreachable.test.ts
+++ b/packages/api-server/src/__tests__/unit/skills-service-state-unreachable.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi } from "vitest";
+import type { LocalSkill, SkillRef } from "api-server-api";
+import { createSkillsService } from "../../modules/skills/services/skills-service.js";
+import type { SkillsServiceDeps } from "../../modules/skills/services/skills-service.js";
+import {
+  AgentRuntimeUnreachableError,
+  AgentRuntimeUpstreamError,
+} from "../../modules/skills/infrastructure/agent-runtime-client.js";
+
+const AGENT = "agent-1";
+const OWNER = "owner-1";
+
+const TRACKED: SkillRef[] = [
+  { source: "https://github.com/acme/skills", name: "deploy", version: "abc" },
+];
+
+/** Minimal running InfraAgent — computeAgentState reads only error/ready/
+ *  hibernated, so the rest is irrelevant here. */
+function runningInfra() {
+  return { id: AGENT, name: AGENT, spec: {}, ready: true, hibernated: false };
+}
+
+function makeDeps(listLocal: () => Promise<LocalSkill[]>) {
+  const reconcile = vi.fn(async () => {});
+  const agentsRepo = {
+    async get(id: string) {
+      return id === AGENT ? runningInfra() : null;
+    },
+  };
+  const agentSkillsRepo = {
+    async listSkills() {
+      return TRACKED;
+    },
+    async listPublishes() {
+      return [];
+    },
+    reconcile,
+  };
+  const runtimeClient = { listLocal };
+  const deps = {
+    agentsRepo,
+    agentSkillsRepo,
+    runtimeClient,
+    owner: OWNER,
+  } as unknown as SkillsServiceDeps;
+  return { service: createSkillsService(deps), reconcile };
+}
+
+describe("skills getState — unreachable running pod", () => {
+  it("falls back to tracked refs (no reconcile) when the pod is unreachable", async () => {
+    const { service, reconcile } = makeDeps(() => {
+      throw new AgentRuntimeUnreachableError("listLocal: connect ECONNREFUSED");
+    });
+
+    const state = await service.getState(AGENT);
+
+    expect(state).toEqual({
+      installed: TRACKED,
+      standalone: [],
+      instancePublishes: [],
+    });
+    // Must not evict rows when we can't see the disk.
+    expect(reconcile).not.toHaveBeenCalled();
+  });
+
+  it("still throws on a non-unreachable error (no over-catching)", async () => {
+    const { service } = makeDeps(() => {
+      throw new AgentRuntimeUpstreamError("listLocal: boom", { status: 500 });
+    });
+
+    await expect(service.getState(AGENT)).rejects.toBeInstanceOf(
+      AgentRuntimeUpstreamError,
+    );
+  });
+});
+
+describe("skills listLocal — unreachable running pod", () => {
+  it("returns an empty list when the pod is unreachable", async () => {
+    const { service } = makeDeps(() => {
+      throw new AgentRuntimeUnreachableError("listLocal: timeout");
+    });
+
+    await expect(service.listLocal(AGENT)).resolves.toEqual([]);
+  });
+});

--- a/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
@@ -51,6 +51,20 @@ export class AgentRuntimeUpstreamError extends Error {
   }
 }
 
+/**
+ * The request never reached a responding agent-runtime tRPC server —
+ * connection refused, timeout, DNS, or a bare proxy 5xx while the pod is
+ * rolling/starting. The controller's cached Ready condition can still read
+ * True during that window, so read-side callers (state/listLocal) catch this
+ * to degrade gracefully instead of 500ing on a transient.
+ */
+export class AgentRuntimeUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentRuntimeUnreachableError";
+  }
+}
+
 // Auth on the api-server → agent-runtime hop is enforced at the kernel by
 // the agent pod's NetworkPolicy (ingress admitted only from the api-server
 // pod). No Bearer header is sent.
@@ -91,6 +105,11 @@ async function runWithUpstreamMapping<T>(
       const upstream = data?.upstream;
       if (isUpstreamGatewayError(upstream)) {
         throw new AgentRuntimeUpstreamError(`${label}: ${e.message}`, upstream);
+      }
+      // No error envelope means no agent-runtime tRPC server responded — a
+      // transport failure, not an application error from the pod.
+      if (data === null) {
+        throw new AgentRuntimeUnreachableError(`${label}: ${e.message}`);
       }
       throw new Error(`${label}: ${e.message}`);
     }

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -26,6 +26,7 @@ import { seedToSkillSource } from "../infrastructure/seed-sources.js";
 import { securityLog } from "../../../core/security-log.js";
 import { isUniqueViolation } from "../../../core/db-errors.js";
 import {
+  AgentRuntimeUnreachableError,
   AgentRuntimeUpstreamError,
   type AgentRuntimeSkillsClient,
 } from "../infrastructure/agent-runtime-client.js";
@@ -450,7 +451,16 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
       if (!infra) return [];
       // No filesystem to read when the pod isn't running.
       if (computeAgentState(infra) !== "running") return [];
-      const all = await deps.runtimeClient.listLocal(agentId);
+      let all: LocalSkill[];
+      try {
+        all = await deps.runtimeClient.listLocal(agentId);
+      } catch (err) {
+        // "running" is the controller's cached Ready condition, not a live
+        // probe; the pod's tRPC listener can be briefly unreachable while it
+        // rolls/starts. Treat that like "not running" rather than 500ing.
+        if (err instanceof AgentRuntimeUnreachableError) return [];
+        throw err;
+      }
       // Subtract anything already tracked as installed-from-remote (by directory
       // name). Matches behavior that the remote-installed entry is the canonical
       // one when names collide.
@@ -470,23 +480,37 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
      * because the filesystem is the source of truth for "what is installed";
      * the DB row is the declarative record that just needs to catch up.
      *
-     * When the pod isn't running we can't see the filesystem, so we return
-     * the tracked refs as-is (no reconciliation) and an empty standalone
-     * list. This avoids wrongly dropping rows during a restart.
+     * When we can't see the filesystem — the pod isn't running, or it reports
+     * "running" off the controller's cached Ready condition but its tRPC
+     * listener is momentarily unreachable (rolling/starting) — we return the
+     * tracked refs as-is (no reconciliation) and an empty standalone list.
+     * This avoids wrongly dropping rows during a restart, and avoids a 500 on
+     * a transient unreachable window.
      */
     async getState(agentId: string): Promise<SkillsState> {
       const infra = await deps.agentsRepo.get(agentId, deps.owner);
       if (!infra)
         return { installed: [], standalone: [], instancePublishes: [] };
-      if (computeAgentState(infra) !== "running") {
+
+      // The declarative record without a filesystem read — the safe view
+      // whenever the pod's disk isn't observable.
+      const trackedOnly = async (): Promise<SkillsState> => {
         const [installed, instancePublishes] = await Promise.all([
           deps.agentSkillsRepo.listSkills(agentId),
           deps.agentSkillsRepo.listPublishes(agentId),
         ]);
         return { installed, standalone: [], instancePublishes };
-      }
+      };
 
-      const local = await deps.runtimeClient.listLocal(agentId);
+      if (computeAgentState(infra) !== "running") return trackedOnly();
+
+      let local: LocalSkill[];
+      try {
+        local = await deps.runtimeClient.listLocal(agentId);
+      } catch (err) {
+        if (err instanceof AgentRuntimeUnreachableError) return trackedOnly();
+        throw err;
+      }
 
       const onDisk = new Set(local.map((s) => s.name));
 


### PR DESCRIPTION
## Problem

`skills.state` returns **HTTP 500** when an agent's configuration is changed while it's running (and on other pod-disrupting actions). The Skills panel breaks until the pod settles.

Repro: agent running fine → change env/secret configuration (or restart / wake) → `GET /api/trpc/skills.state?...` returns 500.

## Root cause

`skills.state` → `SkillsService.getState()` reads `"running"` from `computeAgentState()`, which is derived from the controller's **cached `Ready` condition** (`Ready = AgentPodReady ∧ GatewayPodReady`) — not a live probe. In the `"running"` branch it then calls `runtimeClient.listLocal(agentId)` — a tRPC call into the agent pod — **with no error handling**.

When the pod rolls or starts (a `secretRef` change patches the CR → pod roll; also `agent.restart`, wake-from-hibernate, and the normal startup window), the in-pod tRPC listener is briefly unreachable *while `Ready` is still cached `True`*. The connection error is rethrown by the skills runtime client as a plain `Error` (only `AgentRuntimeUpstreamError` was special-cased), `getState` doesn't catch it, and there is no tRPC `errorFormatter` — so the default `INTERNAL_SERVER_ERROR` (HTTP 500) is returned.

`getState`'s **not-running** branch already degrades gracefully (returns tracked refs, no reconcile); the **running** branch just never anticipated a "running-but-unreachable" pod.

## Fix

- Add `AgentRuntimeUnreachableError`, thrown by the skills runtime client when a tRPC call fails with **no error envelope** (transport failure: connection refused / timeout / bare proxy 5xx) — distinct from an upstream-gateway error or a genuine application error from the pod.
- `getState` and `listLocal` catch **only** that error and fall back to the tracked-only view (no reconcile, empty `standalone`), the same behavior as the not-running branch. This avoids dropping `agent_skills` rows when the disk isn't observable.
- Genuine failures — including `reconcile`/`listSkills` DB errors — still propagate as 500 (no over-catching).

## Notes / scope

- `skills.list()` (private-source scan) shares the underlying client but is an explicit user action that already `ensureAgentReachable`-wakes the pod first; left as-is here to keep the change focused on the render-path queries. Its behavior is unchanged (a transport failure still surfaces as an error rather than silently degrading).
- A broader sweep for the same class of bug in other render-time queries that call into the pod (files panel, connections, relays) was **not** completed and is worth a follow-up.

## Testing

- New unit tests (`skills-service-state-unreachable.test.ts`): `getState` falls back to tracked refs without calling `reconcile` on unreachable; a non-unreachable error still throws; `listLocal` returns `[]` on unreachable.
- `mise run api-server:check` (tsc + lint + format) and full `mise run api-server:test` (218 tests) pass.