### PR TITLE
feat(telemetry): export OpenTelemetry from Claude Code agents (#2028)

### DIFF
--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -346,9 +346,9 @@ API Server ServiceAccount name
 - name: OTEL_EXPORTER_OTLP_ENDPOINT
   value: {{ printf "https://%s:4318" $host | quote }}
 - name: OTEL_METRIC_EXPORT_INTERVAL
-  value: "30000"
+  value: "1000"
 - name: OTEL_LOGS_EXPORT_INTERVAL
-  value: "5000"
+  value: "1000"
 - name: OTEL_TRACES_EXPORT_INTERVAL
-  value: "5000"
+  value: "1000"
 {{- end }}

--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -328,3 +328,27 @@ API Server ServiceAccount name
 {{- define "platform.clickstack.collector.fullname" -}}
 {{- printf "%s-clickstack-collector" (include "platform.fullname" .) | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{- define "platform.agentTelemetry.env" -}}
+{{- $host := printf "%s.%s.svc.cluster.local" (include "platform.clickstack.collector.fullname" .) .Release.Namespace }}
+- name: CLAUDE_CODE_ENABLE_TELEMETRY
+  value: "1"
+- name: CLAUDE_CODE_ENHANCED_TELEMETRY_BETA
+  value: "1"
+- name: OTEL_METRICS_EXPORTER
+  value: "otlp"
+- name: OTEL_LOGS_EXPORTER
+  value: "otlp"
+- name: OTEL_TRACES_EXPORTER
+  value: "otlp"
+- name: OTEL_EXPORTER_OTLP_PROTOCOL
+  value: "http/protobuf"
+- name: OTEL_EXPORTER_OTLP_ENDPOINT
+  value: {{ printf "https://%s:4318" $host | quote }}
+- name: OTEL_METRIC_EXPORT_INTERVAL
+  value: "30000"
+- name: OTEL_LOGS_EXPORT_INTERVAL
+  value: "5000"
+- name: OTEL_TRACES_EXPORT_INTERVAL
+  value: "5000"
+{{- end }}

--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -60,7 +60,11 @@ data:
         {{- end }}
       {{- end }}
     {{- end }}
-    {{- with $tmpl.env }}
+    {{- $env := $tmpl.env | default list }}
+    {{- if and $.Values.clickstack.enabled $tmpl.telemetry }}
+    {{- $env = concat $env (include "platform.agentTelemetry.env" $ | fromYamlArray) }}
+    {{- end }}
+    {{- with $env }}
     env:
       {{- toYaml . | nindent 6 }}
     {{- end }}

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -36,6 +36,7 @@ agentTemplates:
   - name: claude-code
     enabled: true
     description: "Default Claude Code agent"
+    telemetry: true
     image:
       repository: platform-claude-code
       tag: latest

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -933,6 +933,7 @@ agentTemplates:
   - name: claude-code
     enabled: true
     description: "Default Claude Code agent"
+    telemetry: true
     image:
       repository: quay.io/dam-agents/claude-code
       tag: ""

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,10 +1,10 @@
 # Observability (agent telemetry)
 
-Last verified: 2026-06-29
+Last verified: 2026-06-30
 
 ## Overview
 
-The telemetry backend is an **optional, bundled subsystem** that receives and stores the OpenTelemetry signals (logs, traces, metrics) agents emit — the substrate for answering *how agents run*: token consumption, cost, per-sub-agent breakdown. It is the *receiving and storage* half only; configuring agents to export to it, and the user-facing read path, are separate concerns.
+The telemetry backend is an **optional, bundled subsystem** that receives and stores the OpenTelemetry signals (logs, traces, metrics) agents emit — the substrate for answering *how agents run*: token consumption, cost, per-sub-agent breakdown. This page covers the backend (receiving and storage) and the agent **export** path that feeds it (see [Agent export](#agent-export)); the user-facing read path is a separate concern.
 
 It is implemented with **ClickStack**: a columnar telemetry store (ClickHouse) fronted by an exploration UI (HyperDX), plus a separate document store backing that UI's own application state. Installing or upgrading the platform brings the stack up when it is enabled, but it is **disabled by default** — it is a heavy, multi-pod stack, and until agents are wired to export it would receive nothing, so operators opt in per install.
 
@@ -40,6 +40,14 @@ The telemetry store and the UI's app-state store are managed by Kubernetes **ope
 ClickStack's default posture secures the collector with an ingestion key the UI issues and manages — application-layer, token-based access control. The platform deliberately does **not** rely on that. The collector is gated the same way as the rest of the platform: by the **service mesh**, through an authorization policy that admits only the platform's own namespaces — the release namespace and the agent namespace — and denies everything else. This keeps telemetry access on the same SPIFFE-principal model as the rest of the system (see [security-and-credentials](security-and-credentials.md)) rather than introducing a parallel token scheme.
 
 Making the mesh the sole gate is why the collector is platform-owned. ClickStack's bundled collector takes its configuration — including the ingestion-key check — dynamically from the exploration UI, so that configuration cannot be the access boundary here. The platform instead runs its own collector with a fixed configuration and no key enforcement. The UI is unaffected: it reads the telemetry store directly, not the collector.
+
+## Agent export
+
+Harnesses produce telemetry by exporting it themselves over OTLP — the platform does not scrape or tap it. Export turns on with the backend: enabling `clickstack.enabled` stands up the collector, the gateway's collector egress chain, and the [trusted attribution](#trusted-attribution) below, and configures the harness to export to the collector. It is wired for the **Claude Code harness only** for now; a per-template `telemetry` flag opts a harness in, so others follow by flipping that flag.
+
+- **Rides the agent's ordinary egress.** The exporter honours the agent's `HTTPS_PROXY`, so telemetry leaves through the paired gateway pod over HTTPS to the bundled collector — the same dedicated, MITM-terminating chain that performs the trusted attribution below. No new network path, and no credential is injected into the export.
+- **Config travels the harness env rail.** The OTLP environment (enable flag, per-signal exporters, endpoint, protocol, flush intervals) reaches the harness through the same runtime channel that carries connection env — not a pod-level Secret or env.
+- **Signals.** Metrics, logs, and traces (the last via the enhanced-telemetry beta) over OTLP/HTTP. **Content bodies are not exported** — prompt text, tool arguments, and raw API bodies stay off; only structural telemetry (durations, model/tool names, token and cost counters, span shape) leaves the agent.
 
 ## Trusted attribution
 


### PR DESCRIPTION
## What

Turns on Claude Code's native OpenTelemetry export (metrics, logs, traces) pointed at the bundled telemetry collector, so the backend from #2030 starts receiving agent telemetry.

This is the only piece that was missing: #2030 already stood up the collector, the gateway's MITM-terminating collector egress chain, and the trusted `x-platform-agent-id` attribution — all gated on `clickstack.enabled`. The harness just wasn't being told to export.

## How

- The `claude-code` agent template opts in via a render-time `telemetry` flag. When `clickstack.enabled`, the template's env gains the OTLP config: `CLAUDE_CODE_ENABLE_TELEMETRY`, the three `OTEL_*_EXPORTER=otlp`, `CLAUDE_CODE_ENHANCED_TELEMETRY_BETA=1` (traces beta), protocol, endpoint, and flush intervals.
- The env rides the harness **runtime-channel env rail**, so it reaches the Claude Code CLI on both chat and terminal spawns — scoped to Claude Code only (other harnesses follow later by flipping the flag).
- Endpoint targets the bundled collector over **HTTPS:4318** — the exact host the gateway's `terminate_otel_collector` chain MITM-terminates and attributes. That chain runs no ext_authz, so **no egress allowlist entry is needed**.
- Gated on `clickstack.enabled`, consistent with how #2030 gates the rest of the telemetry path.
- **Content bodies stay off** (no prompt text, tool args, or raw API bodies) — structural telemetry only.

## Scope

- Claude Code only; other harnesses deferred (flip `telemetry: true` on their template entries later).
- Per-agent attribution is already handled by #2030 (gateway stamping + collector promotion of `platform.agent.id`).

## Validation

- `mise run helm:check` — lint clean; kubeconform 52 valid / 0 invalid (the render exercises `clickstack.enabled=true`).
- Renders verified: enabled → claude-code gets the OTLP env, endpoint matching the controller's `PLATFORM_TELEMETRY_COLLECTOR_HOST` exactly (so the agent's TLS SNI hits the gateway chain); codex/other templates get no telemetry env; disabled → no telemetry env at all.

## Docs

`observability.md` gains an **Agent export** section (the producing side), complementing the existing **Trusted attribution**.

Closes #2028. Part of #1908.
