### PR TITLE
fix(cd): build helm chart dependencies before packaging

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -556,6 +556,9 @@ jobs:
             echo "npmTag=latest" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Build Helm chart dependencies
+        run: mise run helm:deps
+
       - name: Push Helm chart (release)
         if: startsWith(github.ref, 'refs/tags/v')
         env:


### PR DESCRIPTION
## Problem

The CD `publish` job fails when packaging the chart:

```
Run helm package deploy/helm/platform --version "0.0.0-main.${RUN_NUMBER}" ...
Error: found in Chart.yaml, but missing in charts/ directory: clickstack
```

The `clickstack` telemetry subchart was added to `Chart.yaml` / `Chart.lock` in #2030, but `deploy/helm/platform/charts/` is gitignored — the vendored `.tgz` is never committed and must be fetched from `Chart.lock` at build time. The `check` job already does this (`mise run check` → `helm:check` → `helm:deps`), which is why lint/render stayed green. The `publish` job ran `helm package` with **no** dependency build, so `charts/` was empty in a clean CI checkout.

## Fix

Add one step to the `publish` job that reuses the existing `helm:deps` task (`helm repo add` + `helm dependency build` from `Chart.lock`) before the `helm package` calls — the same source of truth the lint/render checks use.

## Verification

Reproduced locally by simulating a clean checkout (moving `charts/` aside):

1. `helm package` without deps → exact error: `missing in charts/ directory: clickstack` (exit 1)
2. `mise run helm:deps` → regenerated byte-identical `clickstack-3.0.0.tgz` (exit 0)
3. `helm package` after deps → `Successfully packaged chart` (exit 0)

Confirmed `publish` is the only CI job invoking `helm package`/`template`/`lint` outside a mise task, so this was the sole gap.