### PR TITLE
feat(ui): curated workload images in the create wizard

### DIFF
--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -31,8 +31,23 @@ data:
     image: "{{ $tmpl.image.repository }}:{{ $tmpl.image.tag | default $.Chart.AppVersion }}"
     description: {{ $tmpl.description | quote }}
     agentHome: {{ $home | quote }}
+    {{- with $tmpl.displayName }}
+    name: {{ . | quote }}
+    {{- end }}
     {{- with $tmpl.category }}
     category: {{ . | quote }}
+    {{- end }}
+    {{- with $tmpl.tags }}
+    tags:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
+    {{- with $tmpl.docsUrl }}
+    docsUrl: {{ . | quote }}
+    {{- end }}
+    {{- with $tmpl.setupNote }}
+    setupNote:
+      title: {{ .title | quote }}
+      body: {{ .body | quote }}
     {{- end }}
     {{- if $tmpl.experimental }}
     experimental: true

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -62,9 +62,6 @@ agentTemplates:
 
   openevolve:
     enabled: false
-    setupNote:
-      title: "GPT-5 model recommended"
-      body: "gpt-5 is available by connecting to IBM LiteLLM ETE Proxy, or OpenAI as a provider"
     image:
       repository: platform-openevolve
       tag: latest

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -62,6 +62,9 @@ agentTemplates:
 
   openevolve:
     enabled: false
+    setupNote:
+      title: "GPT-5 model recommended"
+      body: "gpt-5 is available by connecting to IBM LiteLLM ETE Proxy, or OpenAI as a provider"
     image:
       repository: platform-openevolve
       tag: latest

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -958,8 +958,10 @@ controller:
 agentTemplates:
   claude-code:
     enabled: true
+    displayName: "Claude Code"
     description: "Default Claude Code agent"
     telemetry: true
+    tags: ["Anthropic"]
     image:
       repository: quay.io/dam-agents/claude-code
       tag: ""
@@ -967,7 +969,9 @@ agentTemplates:
 
   codex:
     enabled: true
+    displayName: "Codex"
     description: "OpenAI Codex coding agent"
+    tags: ["OpenAI"]
     image:
       repository: quay.io/dam-agents/codex
       tag: ""
@@ -975,7 +979,9 @@ agentTemplates:
 
   pi-agent:
     enabled: true
+    displayName: "PI Agent"
     description: "Pi coding agent with multi-LLM support"
+    tags: ["Any provider"]
     image:
       repository: quay.io/dam-agents/pi-agent
       tag: ""
@@ -983,7 +989,9 @@ agentTemplates:
 
   bob:
     enabled: true
+    displayName: "IBM Bob"
     description: "Bob shell agent"
+    tags: ["Anthropic", "Mistral", "Granite"]
     image:
       repository: quay.io/dam-agents/bob
       tag: ""
@@ -1056,7 +1064,10 @@ agentTemplates:
     enabled: true
     category: preconfigured
     experimental: true
+    displayName: "NOUS"
     description: "Nous hypothesis-driven experimentation agent"
+    tags: ["Any provider"]
+    docsUrl: "https://github.com/dam-agents/dam/blob/main/packages/agents/nous/README.md"
     image:
       repository: quay.io/dam-agents/nous
       tag: ""
@@ -1075,7 +1086,10 @@ agentTemplates:
     enabled: true
     category: preconfigured
     experimental: true
+    displayName: "OpenEvolve"
     description: "OpenEvolve — evolutionary code-optimization agent"
+    tags: ["OpenAI-compatible"]
+    docsUrl: "https://github.com/dam-agents/dam/blob/main/packages/agents/openevolve/README.md"
     image:
       repository: quay.io/dam-agents/openevolve
       tag: ""

--- a/packages/api-server-api/src/modules/templates/router.ts
+++ b/packages/api-server-api/src/modules/templates/router.ts
@@ -11,6 +11,9 @@ function toView(tmpl: Template) {
     image: tmpl.spec.image,
     description: tmpl.spec.description,
     category: tmpl.spec.category ?? "harness",
+    tags: tmpl.spec.tags,
+    docsUrl: tmpl.spec.docsUrl,
+    setupNote: tmpl.spec.setupNote,
     experimental: tmpl.spec.experimental ?? false,
   };
 }

--- a/packages/api-server-api/src/modules/templates/schemas.ts
+++ b/packages/api-server-api/src/modules/templates/schemas.ts
@@ -39,8 +39,12 @@ export const templateSpecSchema = z
   .object({
     version: z.string(),
     image: z.string(),
+    name: z.string().optional(),
     description: z.string().optional(),
     category: templateCategorySchema,
+    tags: z.array(z.string()).optional(),
+    docsUrl: z.string().optional(),
+    setupNote: z.object({ title: z.string(), body: z.string() }).optional(),
     experimental: z.boolean().optional(),
     mounts: z.array(mountSchema).optional(),
     init: z.string().optional(),

--- a/packages/api-server-api/src/modules/templates/types.ts
+++ b/packages/api-server-api/src/modules/templates/types.ts
@@ -33,8 +33,12 @@ export interface SkillSourceSeed {
 export interface TemplateSpec {
   version: string;
   image: string;
+  name?: string;
   description?: string;
   category?: TemplateCategory;
+  tags?: string[];
+  docsUrl?: string;
+  setupNote?: { title: string; body: string };
   experimental?: boolean;
   mounts?: Mount[];
   init?: string;

--- a/packages/api-server/src/modules/templates/infrastructure/templates-repository.ts
+++ b/packages/api-server/src/modules/templates/infrastructure/templates-repository.ts
@@ -57,7 +57,7 @@ function loadTemplates(dir: string): Map<string, Template> {
       const spec = templateSpecSchema.parse(
         yaml.load(readFileSync(join(dir, entry), "utf8")),
       );
-      byId.set(id, { id, name: id, spec });
+      byId.set(id, { id, name: spec.name ?? id, spec });
     } catch (err) {
       process.stderr.write(
         `agent-templates: skipping ${entry}: ${err instanceof Error ? err.message : err}\n`,

--- a/packages/e2e/playwright/src/tests/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/03-agent.spec.ts
@@ -46,7 +46,7 @@ test("create a mock agent with the connection attached", async ({ page }) => {
 
   await test.step("pick the mock image", async () => {
     await page.getByRole("button", { name: /create sandbox/i }).click();
-    await page.getByText(harnessName, { exact: true }).click();
+    await page.getByTestId(`template-card-${harnessName}`).click();
     // The image step now only selects on click; advance with its Continue button.
     await page.getByRole("button", { name: /continue/i }).click();
   });

--- a/packages/ui/public/icons/claude-code.svg
+++ b/packages/ui/public/icons/claude-code.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 38 38">
+  <!-- Generator: Adobe Illustrator 30.6.0, SVG Export Plug-In . SVG Version: 2.1.4 Build 109)  -->
+  <defs>
+    <style>
+      .st0 {
+        fill: #fff;
+        fill-rule: evenodd;
+      }
+
+      .st1 {
+        fill: #d97757;
+      }
+    </style>
+  </defs>
+  <path class="st1" d="M0,7.5C0,3.36,3.36,0,7.5,0h23c4.14,0,7.5,3.36,7.5,7.5v23c0,4.14-3.36,7.5-7.5,7.5H7.5c-4.14,0-7.5-3.36-7.5-7.5V7.5Z"/>
+  <path class="st0" d="M25.75,18.21h2.25v2.33h-2.25v2.27h-1.12v2.19h-1.13v-2.19h-1.12v2.19h-1.13v-2.19h-4.5v2.19h-1.13v-2.19h-1.12v2.19h-1.13v-2.19h-1.12v-2.27h-2.25v-2.33h2.25v-4.46h13.5v4.46ZM14.5,18.21h1.12v-2.14h-1.12v2.14ZM22.38,18.21h1.12v-2.14h-1.12v2.14Z"/>
+</svg>

--- a/packages/ui/public/icons/pi-agent.svg
+++ b/packages/ui/public/icons/pi-agent.svg
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 38 38" fill="none">
+  <path d="M0 7.5C0 3.35787 3.35786 0 7.5 0H30.5C34.6421 0 38 3.35786 38 7.5V30.5C38 34.6421 34.6421 38 30.5 38H7.5C3.35787 38 0 34.6421 0 30.5V7.5Z" fill="#F2F4F8"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M13.719 13.719H21.6406V19H19V21.6406H16.3596V24.2812H13.719V13.719ZM16.3596 16.3596V19H19V16.3596H16.3596Z" fill="#09090B"/>
+  <path d="M21.6406 19H24.2812V24.2812H21.6406V19Z" fill="#09090B"/>
+</svg>

--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -27,6 +27,8 @@
   --color-danger-light: var(--c-danger-light);
   --color-info: var(--c-info);
   --color-info-light: var(--c-info-light);
+  --color-callout: var(--c-callout-bg);
+  --color-callout-border: var(--c-callout-border);
   --color-template: var(--c-template);
   --color-template-light: var(--c-template-light);
   --font-sans: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
@@ -80,6 +82,8 @@
   --c-danger-light: #fef2f2;
   --c-info: #000000;
   --c-info-light: #f2f4f8;
+  --c-callout-bg: #edf5ff4d;
+  --c-callout-border: #a6c8ff;
   --c-template: #7c3aed;
   --c-template-light: #f5f3ff;
 
@@ -128,6 +132,8 @@
   --c-danger-light: #3a1515;
   --c-info: #60a5fa;
   --c-info-light: #0f1f3a;
+  --c-callout-bg: #0f1f3a;
+  --c-callout-border: #3c92fd;
   --c-template: #a78bfa;
   --c-template-light: #1f1438;
   color-scheme: dark;

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -147,14 +147,14 @@ function MainApp() {
             <SandboxWizardView />
           ) : view === "experiment-new" ? (
             <ExperimentWizardView />
+          ) : view === "sandbox-settings" ? (
+            <SandboxSettingsView />
           ) : (
             <div className="mx-auto w-full max-w-[960px] px-4 md:px-[5%] py-6 md:py-10 pb-20 md:pb-10">
               {view === "settings" ? (
                 <SettingsView />
               ) : view === "inbox" ? (
                 <InboxView />
-              ) : view === "sandbox-settings" ? (
-                <SandboxSettingsView />
               ) : view === "experiments" ? (
                 <ExperimentsListView />
               ) : view === "experiment-detail" ? (

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -70,7 +70,7 @@ export function IconRail() {
   return (
     <>
       <nav
-        className="hidden md:flex flex-col items-center h-full w-[56px] bg-card shrink-0"
+        className="hidden md:flex flex-col items-center h-full w-[56px] bg-card border-r border-border shrink-0"
         data-testid="app-sidebar"
       >
         <div className="flex items-center justify-center pt-2">

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -1,0 +1,5 @@
+export const CUSTOM_IMAGE_DOCS_URL =
+  "https://pages.github.ibm.com/dam-agents/docs/guides/custom-image/";
+
+export const KEY_GUIDE_URL =
+  "https://pages.github.ibm.com/dam-agents/docs/guides/litellm-key/";

--- a/packages/ui/src/modules/connections/forms/template-create-form.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form.tsx
@@ -436,7 +436,7 @@ function OverridableSection({
   // sense overridden together (your own app means all of its credentials, not
   // a mix of presets and custom values), so we don't expose them per-field.
   return (
-    <Inset className="rounded-lg border border-dashed border-border p-4">
+    <Inset className="rounded-lg border border-dashed border-border p-6">
       <div className="flex items-start justify-between gap-3">
         <div>
           <SectionLabel>Customize defaults</SectionLabel>
@@ -501,6 +501,7 @@ function LabeledInput({
   value,
   onChange,
   help,
+  disableInset,
 }: {
   label: string;
   testId?: string;
@@ -509,9 +510,10 @@ function LabeledInput({
   value: string;
   onChange: (v: string) => void;
   help?: string;
+  disableInset?: boolean;
 }) {
   return (
-    <FormField label={label} hint={help}>
+    <FormField label={label} hint={help} disableInset={disableInset}>
       <Input
         type={type ?? "text"}
         data-testid={testId}

--- a/packages/ui/src/modules/providers/components/card-icon.tsx
+++ b/packages/ui/src/modules/providers/components/card-icon.tsx
@@ -27,8 +27,8 @@ const STYLES: Record<
 > = {
   anthropic: {
     Icon: AnthropicIcon,
-    bg: "bg-[#D97757]",
-    iconClass: "w-5 h-5 text-white",
+    bg: "bg-foreground",
+    iconClass: "w-5 h-5 text-background",
   },
   openai: {
     Icon: OpenAIIcon,
@@ -49,7 +49,7 @@ const STYLES: Record<
 
 const TILE_SIZE_CLASS: Record<"lg" | "md" | "sm", string> = {
   lg: "w-[68px] h-[68px]",
-  md: "w-10 h-10",
+  md: "w-[38px] h-[38px]",
   sm: "w-7 h-7",
 };
 

--- a/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
@@ -5,12 +5,10 @@ import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { KEY_GUIDE_URL } from "@/constants.js";
 
 import { ProviderFormShell } from "../provider-form-shell.js";
 import { MODES, stripWhitespace } from "./modes.js";
-
-const KEY_GUIDE_URL =
-  "https://pages.github.ibm.com/dam-agents/docs/guides/litellm-key/";
 
 const ibmLitellmCredentialSchema = z
   .object({ value: z.string() })

--- a/packages/ui/src/modules/sandboxes/components/sandbox-wizard-shell.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-wizard-shell.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 
 import type { WizardStep } from "../lib/wizard-snapshot.js";
+import { StickyFooterLayout } from "./sticky-footer-layout.js";
 import { WizardStepIndicator } from "./wizard-step-indicator.js";
 
 interface Props {
@@ -8,6 +9,7 @@ interface Props {
   maxStep: WizardStep;
   imageLabel: string | null;
   onNavigate: (step: WizardStep) => void;
+  footer?: ReactNode;
   children: ReactNode;
 }
 
@@ -16,19 +18,22 @@ export function SandboxWizardShell({
   maxStep,
   imageLabel,
   onNavigate,
+  footer,
   children,
 }: Props) {
   return (
-    <div className="mx-auto w-full max-w-[920px] px-4 pt-6 pb-24 md:px-8 md:py-12">
-      <div className="flex flex-col gap-6 md:flex-row md:gap-10">
-        <WizardStepIndicator
-          step={step}
-          maxStep={maxStep}
-          imageLabel={imageLabel}
-          onNavigate={onNavigate}
-        />
-        <div className="min-w-0 flex-1 md:max-w-[666px]">{children}</div>
+    <StickyFooterLayout footer={footer} footerClassName="max-w-[920px]">
+      <div className="mx-auto w-full max-w-[920px] px-4 pt-6 pb-8 md:px-8 md:pt-12">
+        <div className="flex flex-col gap-6 md:flex-row md:gap-10">
+          <WizardStepIndicator
+            step={step}
+            maxStep={maxStep}
+            imageLabel={imageLabel}
+            onNavigate={onNavigate}
+          />
+          <div className="min-w-0 flex-1 md:max-w-[666px]">{children}</div>
+        </div>
       </div>
-    </div>
+    </StickyFooterLayout>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/steps/card-content.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/card-content.tsx
@@ -1,0 +1,29 @@
+import { Badge } from "@/components/ui/badge";
+
+import type { TemplateView } from "../../../../types.js";
+import { CardTags } from "./card-tags.js";
+
+export function CardContent({ template }: { template: TemplateView }) {
+  return (
+    <>
+      <div className="flex items-baseline justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <p className="text-[16px] font-semibold text-foreground">
+            {template.name}
+          </p>
+          {template.experimental && (
+            <Badge className="shrink-0 border-transparent bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300">
+              Alpha
+            </Badge>
+          )}
+        </div>
+        <CardTags tags={template.tags} />
+      </div>
+      {template.description && (
+        <p className="text-[14px] text-muted-foreground">
+          {template.description}
+        </p>
+      )}
+    </>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/card-tags.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/card-tags.tsx
@@ -1,0 +1,8 @@
+export function CardTags({ tags }: { tags?: string[] }) {
+  if (!tags || tags.length === 0) return null;
+  return (
+    <span className="shrink-0 text-[14px] text-muted-foreground">
+      {tags.join(" · ")}
+    </span>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -4,7 +4,6 @@ import {
 } from "api-server-api";
 import { useMemo, useState } from "react";
 
-import { Button } from "@/components/ui/button";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import {
@@ -43,16 +42,9 @@ const CATEGORY_LABEL: Record<(typeof CATEGORY_ORDER)[number], string> = {
 interface Props {
   snapshot: WizardSnapshot;
   update: (patch: Partial<WizardSnapshot>) => void;
-  onFinish: () => void;
-  finishing: boolean;
 }
 
-export function ConnectionsStep({
-  snapshot,
-  update,
-  onFinish,
-  finishing,
-}: Props) {
+export function ConnectionsStep({ snapshot, update }: Props) {
   const templatesQ = useConnectionTemplates();
   const connectionsQ = useAppConnections();
   const { confirmAndDelete, deletingId } = useDisconnectConnection();
@@ -164,12 +156,6 @@ export function ConnectionsStep({
           </section>
         );
       })}
-
-      <div className="flex justify-end gap-3">
-        <Button onClick={onFinish} disabled={finishing}>
-          Create sandbox
-        </Button>
-      </div>
 
       {creating && (
         <TemplateCreateForm

--- a/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
@@ -1,0 +1,57 @@
+import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { CUSTOM_IMAGE_DOCS_URL } from "@/constants";
+import { cn } from "@/lib/utils";
+
+export function CustomImageCard({
+  value,
+  selected,
+  onChange,
+  onSubmit,
+}: {
+  value: string;
+  selected: boolean;
+  onChange: (value: string) => void;
+  onSubmit: () => void;
+}) {
+  return (
+    <div
+      className={cn(
+        "rounded-lg border px-4 py-4",
+        selected ? "border-foreground" : "border-border",
+      )}
+    >
+      <div className="flex items-center gap-2">
+        <p className="text-[16px] font-semibold text-foreground">Custom</p>
+        <Badge
+          variant="outline"
+          className="border-transparent bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300"
+        >
+          Advanced
+        </Badge>
+      </div>
+      <p className="mt-1 text-[14px] text-muted-foreground">
+        Bring your own ACP-compatible image{" "}
+        <a
+          href={CUSTOM_IMAGE_DOCS_URL}
+          target="_blank"
+          rel="noreferrer"
+          className="text-[14px] text-muted-foreground underline underline-offset-2 hover:text-primary"
+        >
+          Learn more
+        </a>
+      </p>
+      <div className="mt-3">
+        <Input
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter") onSubmit();
+          }}
+          placeholder="ghcr.io/org/agent:latest"
+          variant="monospace"
+        />
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/harness-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/harness-card.tsx
@@ -1,0 +1,66 @@
+import { Box } from "lucide-react";
+
+import type { ProviderPresetType, TemplateView } from "../../../../types.js";
+import { CardIcon } from "../../../providers/components/card-icon.js";
+import { CardContent } from "./card-content.js";
+import { SelectableCard } from "./selectable-card.js";
+
+const HARNESS_PRESET: Record<string, ProviderPresetType> = {
+  codex: "openai",
+  bob: "bob",
+};
+
+const HARNESS_ICON_SRC: Record<string, string> = {
+  "claude-code": "/icons/claude-code.svg",
+  "pi-agent": "/icons/pi-agent.svg",
+};
+
+function HarnessIcon({ templateId }: { templateId: string }) {
+  const iconSrc = HARNESS_ICON_SRC[templateId];
+  if (iconSrc) {
+    return (
+      <img
+        src={iconSrc}
+        alt=""
+        width={38}
+        height={38}
+        className="shrink-0 rounded-lg"
+      />
+    );
+  }
+  const preset = HARNESS_PRESET[templateId];
+  if (preset) {
+    return <CardIcon provider={preset} size="md" />;
+  }
+  return (
+    <div className="flex size-[38px] shrink-0 items-center justify-center rounded-lg bg-muted">
+      <Box className="size-5 text-muted-foreground" />
+    </div>
+  );
+}
+
+export function HarnessCard({
+  template,
+  selected,
+  onSelect,
+}: {
+  template: TemplateView;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <SelectableCard
+      selected={selected}
+      onSelect={onSelect}
+      ariaLabel={template.name}
+      testId={`template-card-${template.id}`}
+    >
+      <div className="flex items-start gap-3">
+        <HarnessIcon templateId={template.id} />
+        <div className="min-w-0 flex-1">
+          <CardContent template={template} />
+        </div>
+      </div>
+    </SelectableCard>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/image-step.tsx
@@ -1,15 +1,12 @@
-import { ArrowRight } from "lucide-react";
-
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
 import { SectionLabel } from "@/components/ui/section-label";
-import { cn } from "@/lib/utils";
 
 import { ListSkeleton } from "../../../../components/list-skeleton.js";
 import type { TemplateView } from "../../../../types.js";
 import { CardList } from "../card-list.js";
 import { StepHeader } from "../step-header.js";
+import { CustomImageCard } from "./custom-image-card.js";
+import { HarnessCard } from "./harness-card.js";
+import { WorkloadCard } from "./workload-card.js";
 
 interface Props {
   templates: TemplateView[];
@@ -30,8 +27,6 @@ export function ImageStep({
   onCustomImageChange,
   onContinue,
 }: Props) {
-  const canContinue =
-    selectedTemplateId !== null || customImage.trim().length > 0;
   const harnessImages = templates.filter((t) => t.category === "harness");
   const preconfiguredImages = templates.filter(
     (t) => t.category === "preconfigured",
@@ -40,22 +35,20 @@ export function ImageStep({
     <div>
       <StepHeader
         step={1}
-        title="Create a sandbox"
-        subtitle="Select an image to get started"
+        title="Choose your starting point"
+        subtitle="Every sandbox boots from an image. Start with a coding agent, a pre-configured framework, or bring your own."
       />
 
       <section className="mb-8">
-        <SectionLabel spaced>Harness Images</SectionLabel>
+        <SectionLabel spaced>Coding agents</SectionLabel>
         <CardList>
           {loading ? (
             <ListSkeleton rows={4} rowHeight={64} />
           ) : (
             harnessImages.map((template) => (
-              <ImageCard
+              <HarnessCard
                 key={template.id}
-                name={template.name}
-                description={template.description}
-                experimental={template.experimental}
+                template={template}
                 selected={template.id === selectedTemplateId}
                 onSelect={() => onPickTemplate(template.id)}
               />
@@ -64,16 +57,26 @@ export function ImageStep({
         </CardList>
       </section>
 
+      <section className="mb-8">
+        <SectionLabel spaced>Custom images</SectionLabel>
+        <CardList>
+          <CustomImageCard
+            value={customImage}
+            selected={customImage.trim().length > 0}
+            onChange={onCustomImageChange}
+            onSubmit={onContinue}
+          />
+        </CardList>
+      </section>
+
       {!loading && preconfiguredImages.length > 0 && (
         <section className="mb-8">
-          <SectionLabel spaced>Pre-configured Images</SectionLabel>
+          <SectionLabel spaced>Pre-configured images</SectionLabel>
           <CardList>
             {preconfiguredImages.map((template) => (
-              <ImageCard
+              <WorkloadCard
                 key={template.id}
-                name={template.name}
-                description={template.description}
-                experimental={template.experimental}
+                template={template}
                 selected={template.id === selectedTemplateId}
                 onSelect={() => onPickTemplate(template.id)}
               />
@@ -81,114 +84,6 @@ export function ImageStep({
           </CardList>
         </section>
       )}
-
-      <section className="mb-8">
-        <SectionLabel spaced>Custom Image</SectionLabel>
-        <CardList>
-          <CustomImageCard
-            value={customImage}
-            selected={customImage.trim().length > 0}
-            onChange={onCustomImageChange}
-            onSubmit={() => {
-              if (canContinue) onContinue();
-            }}
-          />
-        </CardList>
-      </section>
-
-      <div className="flex justify-end">
-        <Button onClick={onContinue} disabled={!canContinue}>
-          Continue <ArrowRight size={16} />
-        </Button>
-      </div>
-    </div>
-  );
-}
-
-function ImageCard({
-  name,
-  description,
-  experimental,
-  selected,
-  onSelect,
-}: {
-  name: string;
-  description?: string;
-  experimental?: boolean;
-  selected: boolean;
-  onSelect: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-pressed={selected}
-      className={cn(
-        "w-full rounded-lg border p-4 text-left transition-colors",
-        selected
-          ? "border-foreground bg-muted/60"
-          : "border-border bg-card hover:bg-muted/40",
-      )}
-    >
-      <div className="flex items-center gap-2">
-        <p className="text-[16px] font-semibold text-foreground">{name}</p>
-        {experimental && (
-          <Badge
-            variant="outline"
-            className="border-transparent bg-amber-100 text-amber-700 dark:bg-amber-950 dark:text-amber-300"
-          >
-            Alpha
-          </Badge>
-        )}
-      </div>
-      {description && (
-        <p className="mt-1 text-[14px] text-muted-foreground">{description}</p>
-      )}
-    </button>
-  );
-}
-
-function CustomImageCard({
-  value,
-  selected,
-  onChange,
-  onSubmit,
-}: {
-  value: string;
-  selected: boolean;
-  onChange: (value: string) => void;
-  onSubmit: () => void;
-}) {
-  return (
-    <div
-      className={cn(
-        "rounded-lg border px-4 py-4",
-        selected ? "border-foreground" : "border-border",
-      )}
-    >
-      <div className="flex items-center gap-2">
-        <p className="text-[16px] font-semibold text-foreground">Custom</p>
-        <Badge
-          variant="outline"
-          className="border-transparent bg-violet-100 text-violet-700 dark:bg-violet-950 dark:text-violet-300"
-        >
-          Advanced
-        </Badge>
-      </div>
-      <p className="mt-1 text-[14px] text-muted-foreground">
-        Bring your own ACP-compatible image
-      </p>
-      <div className="mt-3">
-        <Input
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onKeyDown={(event) => {
-            if (event.key === "Enter") onSubmit();
-          }}
-          placeholder="ghcr.io/org/agent:latest"
-          variant="monospace"
-        />
-      </div>
     </div>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/steps/selectable-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/selectable-card.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function SelectableCard({
+  selected,
+  onSelect,
+  ariaLabel,
+  testId,
+  children,
+}: {
+  selected: boolean;
+  onSelect: () => void;
+  ariaLabel: string;
+  testId?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "relative rounded-lg border p-4 transition-colors",
+        selected
+          ? "border-foreground bg-muted/60"
+          : "border-border bg-card hover:bg-muted/40",
+      )}
+    >
+      {/* Stretched overlay so a nested link can sit above it, which a real <button> can't wrap. */}
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-pressed={selected}
+        aria-label={ariaLabel}
+        data-testid={testId}
+        className="absolute inset-0 rounded-lg focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+      />
+      <div className="pointer-events-none relative">{children}</div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -1,7 +1,4 @@
-import { ArrowRight } from "lucide-react";
-
 import { FormField } from "@/components/form-field";
-import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { FIELD_INSET } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
@@ -51,7 +48,7 @@ interface Props {
   registryCredential: RegistryCredential;
   onRegistryChange: (value: RegistryCredential) => void;
   update: (patch: Partial<WizardSnapshot>) => void;
-  onContinue: () => void;
+  setupNote?: { title: string; body: string };
 }
 
 export function SetupStep({
@@ -62,14 +59,12 @@ export function SetupStep({
   registryCredential,
   onRegistryChange,
   update,
-  onContinue,
+  setupNote,
 }: Props) {
   const registryPartial =
     showRegistry &&
     registryFilledCount(registryCredential) > 0 &&
     registryFilledCount(registryCredential) < 3;
-  const canContinue =
-    name.trim().length > 0 && providerRef !== null && !registryPartial;
 
   return (
     <div>
@@ -89,6 +84,19 @@ export function SetupStep({
           />
         </FormField>
       </section>
+
+      {setupNote && (
+        <section className="mb-8">
+          <div className="rounded-lg border border-callout-border bg-callout p-4 md:-ml-4">
+            <p className="text-[14px] font-semibold text-foreground">
+              {setupNote.title}
+            </p>
+            <p className="mt-1 text-[14px] text-muted-foreground">
+              {setupNote.body}
+            </p>
+          </div>
+        </section>
+      )}
 
       <section className="mb-8">
         <SectionLabel spaced>Provider</SectionLabel>
@@ -126,12 +134,6 @@ export function SetupStep({
           partial={registryPartial}
         />
       )}
-
-      <div className="flex justify-end">
-        <Button onClick={onContinue} disabled={!canContinue}>
-          Continue <ArrowRight size={16} />
-        </Button>
-      </div>
     </div>
   );
 }
@@ -153,24 +155,16 @@ function NetworkPresetRow({
       onClick={onSelect}
       aria-pressed={selected}
       className={cn(
-        "flex w-full items-start gap-3 rounded-lg border px-4 py-3 text-left transition-colors",
+        "w-full rounded-lg border px-4 py-3 text-left transition-colors",
         selected
           ? "border-foreground bg-card"
           : "border-border bg-card hover:bg-muted/30",
       )}
     >
-      <span
-        className={cn(
-          "mt-0.5 h-4 w-4 shrink-0 rounded-full transition-all",
-          selected ? "border-[5px] border-foreground" : "border border-border",
-        )}
-      />
-      <div>
-        <p className="text-[16px] font-medium text-foreground leading-[1.2]">
-          {label}
-        </p>
-        <p className="text-[14px] text-muted-foreground">{help}</p>
-      </div>
+      <p className="text-[16px] font-medium text-foreground leading-[1.2]">
+        {label}
+      </p>
+      <p className="text-[14px] text-muted-foreground">{help}</p>
     </button>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/steps/workload-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/workload-card.tsx
@@ -1,0 +1,36 @@
+import type { TemplateView } from "../../../../types.js";
+import { CardContent } from "./card-content.js";
+import { SelectableCard } from "./selectable-card.js";
+
+export function WorkloadCard({
+  template,
+  selected,
+  onSelect,
+}: {
+  template: TemplateView;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <SelectableCard
+      selected={selected}
+      onSelect={onSelect}
+      ariaLabel={template.name}
+      testId={`template-card-${template.id}`}
+    >
+      <div className="flex min-w-0 flex-col gap-1">
+        <CardContent template={template} />
+        {template.docsUrl && (
+          <a
+            href={template.docsUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="pointer-events-auto inline-block w-fit text-[14px] text-muted-foreground underline underline-offset-2 hover:text-primary"
+          >
+            Learn more
+          </a>
+        )}
+      </div>
+    </SelectableCard>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/sticky-footer-layout.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sticky-footer-layout.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface Props {
+  footer?: ReactNode;
+  footerClassName?: string;
+  children: ReactNode;
+}
+
+export function StickyFooterLayout({
+  footer,
+  footerClassName,
+  children,
+}: Props) {
+  return (
+    <div className="flex h-full flex-col pb-[calc(52px_+_env(safe-area-inset-bottom))] md:pb-0">
+      <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+      {footer && (
+        <div className="border-t border-border bg-background">
+          <div
+            className={cn(
+              "mx-auto flex h-[52px] w-full items-center justify-end gap-3 px-4 md:h-[70px] md:px-8",
+              footerClassName,
+            )}
+          >
+            {footer}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/wizard-step-indicator.tsx
+++ b/packages/ui/src/modules/sandboxes/components/wizard-step-indicator.tsx
@@ -24,7 +24,7 @@ export function WizardStepIndicator({
   return (
     <nav
       aria-label="Wizard steps"
-      className="flex shrink-0 flex-row gap-1 md:w-[200px] md:flex-col"
+      className="flex shrink-0 flex-row gap-1 md:sticky md:top-12 md:w-[200px] md:flex-col md:self-start"
     >
       {STEPS.map((item) => (
         <StepItem

--- a/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-settings-view.tsx
@@ -12,7 +12,10 @@ import { AgentEgressEditor } from "../../egress-rules/components/agent-egress-ed
 import { ProviderSection } from "../../providers/components/provider-section.js";
 import { ConnectionsSection } from "../components/connections-section.js";
 import { HibernationTimeoutField } from "../components/hibernation-timeout-field.js";
+import { StickyFooterLayout } from "../components/sticky-footer-layout.js";
 import { useSandboxSettingsForm } from "../hooks/use-sandbox-settings-form.js";
+
+const CONTENT = "mx-auto w-full max-w-[666px] px-4 pt-6 pb-8 md:px-8 md:pt-10";
 
 const READ_ONLY_FIELD =
   "flex h-10 w-full items-center rounded-md border border-input bg-muted/40 px-4 text-sm text-muted-foreground";
@@ -22,138 +25,146 @@ export function SandboxSettingsView() {
 
   if (f.status !== "ready" || !f.agent) {
     return (
-      <div className="mx-auto w-full max-w-[666px]">
-        <BackLink onClick={f.goBack} />
-        {f.status === "no-agent" && (
-          <p className="mt-4 text-[13px] text-muted-foreground">
-            No sandbox selected.
-          </p>
-        )}
-        {f.status === "not-found" && (
-          <p className="mt-4 text-[13px] text-muted-foreground">
-            Sandbox not found.
-          </p>
-        )}
-      </div>
+      <StickyFooterLayout>
+        <div className={CONTENT}>
+          <BackLink onClick={f.goBack} />
+          {f.status === "no-agent" && (
+            <p className="mt-4 text-[13px] text-muted-foreground">
+              No sandbox selected.
+            </p>
+          )}
+          {f.status === "not-found" && (
+            <p className="mt-4 text-[13px] text-muted-foreground">
+              Sandbox not found.
+            </p>
+          )}
+        </div>
+      </StickyFooterLayout>
     );
   }
 
   const { agent } = f;
 
-  return (
-    <div className="mx-auto w-full max-w-[666px]">
-      <BackLink onClick={f.goBack} />
-      <h1 className="mb-8 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-        {agent.name}
-      </h1>
-
-      <section className="mb-8">
-        <FormField label="Name" error={f.errors.name?.message}>
-          <Input disabled={f.saving} {...f.register("name")} />
-        </FormField>
-      </section>
-
-      <section className="mb-8">
-        {/* Read-only: image/template are create-only — changing them would mean
-            delete+recreate, destroying the workspace PVC. */}
-        <FormField
-          label="Image"
-          hint={
-            agent.templateId ? (
-              <span className="truncate font-mono">{agent.image}</span>
-            ) : undefined
-          }
+  const footer = (
+    <>
+      {f.wildcardHostInScope && (
+        <span
+          role="alert"
+          className="mr-auto inline-flex items-center gap-1.5 text-[12px] text-warning"
+          title="A wildcard host '*' rule is in scope. Any unmatched egress is allowed."
         >
-          <div className={READ_ONLY_FIELD}>
-            <span className={`truncate ${agent.templateId ? "" : "font-mono"}`}>
-              {f.templateName ?? agent.image}
-            </span>
-          </div>
-        </FormField>
-      </section>
+          <span aria-hidden="true">⚠</span>
+          Allow everything is on — narrow with deny rules or remove the
+          wildcard.
+        </span>
+      )}
+      <Button onClick={f.onSave} disabled={f.isSubmitDisabled}>
+        {f.saving ? "Saving…" : "Save"}
+      </Button>
+    </>
+  );
 
-      <section className="mb-8">
-        <SectionLabel spaced>Provider</SectionLabel>
-        <ProviderSection
-          variant="collapsible"
-          listClassName={FIELD_INSET}
-          selected={f.selectedProvider}
-          onSelect={f.selectProvider}
-          onProviderRemoved={f.dropProviderGrant}
-        />
-        <p className="mt-3 text-[12px] text-muted-foreground">
-          Changing the provider swaps this sandbox's model credential. A
-          cross-family switch (e.g. Anthropic → OpenAI on a Claude image) can
-          break the agent and may need a restart.
-        </p>
-      </section>
+  return (
+    <StickyFooterLayout footer={footer} footerClassName="max-w-[666px]">
+      <div className={CONTENT}>
+        <BackLink onClick={f.goBack} />
+        <h1 className="mb-8 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
+          {agent.name}
+        </h1>
 
-      <ConnectionsSection
-        grantedIds={f.grantedAppIds}
-        onToggleGrant={f.toggleAppGrant}
-        oauthReturnView={`/sandboxes/${agent.id}`}
-      />
+        <section className="mb-8">
+          <FormField label="Name" error={f.errors.name?.message}>
+            <Input disabled={f.saving} {...f.register("name")} />
+          </FormField>
+        </section>
 
-      <section className="mb-8">
-        <SectionLabel spaced>Network access</SectionLabel>
-        <Inset className="rounded-lg border border-border p-4">
-          <AgentEgressEditor
-            agentId={agent.id}
-            currentPreset={f.currentPreset}
-            staged={f.egressStaged}
-          />
-        </Inset>
-      </section>
-
-      <section className="mb-8">
-        <SectionLabel spaced>Lifecycle</SectionLabel>
-        <Inset className="rounded-lg border border-border p-4">
-          <HibernationTimeoutField
-            register={f.register("hibernationTimeoutMin", {
-              valueAsNumber: true,
-            })}
-            value={f.hibernationTimeoutMin}
-            error={f.errors.hibernationTimeoutMin?.message}
-            disabled={f.saving}
-          />
-        </Inset>
-      </section>
-
-      <section className="mb-8">
-        <SectionLabel spaced>Environment</SectionLabel>
-        <Inset className="rounded-lg border border-border p-4">
-          <Controller
-            control={f.control}
-            name="envVars"
-            render={({ field }) => (
-              <EnvTab
-                inherited={f.inheritedEnvs}
-                envVars={field.value}
-                setEnvVars={field.onChange}
-                saving={f.saving}
-              />
-            )}
-          />
-        </Inset>
-      </section>
-
-      <div className="flex items-center justify-end gap-3 pb-4">
-        {f.wildcardHostInScope && (
-          <span
-            role="alert"
-            className="mr-auto inline-flex items-center gap-1.5 text-[12px] text-warning"
-            title="A wildcard host '*' rule is in scope. Any unmatched egress is allowed."
+        <section className="mb-8">
+          {/* Read-only: image/template are create-only — changing them would mean
+            delete+recreate, destroying the workspace PVC. */}
+          <FormField
+            label="Image"
+            hint={
+              agent.templateId ? (
+                <span className="truncate font-mono">{agent.image}</span>
+              ) : undefined
+            }
           >
-            <span aria-hidden="true">⚠</span>
-            Allow everything is on — narrow with deny rules or remove the
-            wildcard.
-          </span>
-        )}
-        <Button onClick={f.onSave} disabled={f.isSubmitDisabled}>
-          {f.saving ? "Saving…" : "Save"}
-        </Button>
+            <div className={READ_ONLY_FIELD}>
+              <span
+                className={`truncate ${agent.templateId ? "" : "font-mono"}`}
+              >
+                {f.templateName ?? agent.image}
+              </span>
+            </div>
+          </FormField>
+        </section>
+
+        <section className="mb-8">
+          <SectionLabel spaced>Provider</SectionLabel>
+          <ProviderSection
+            variant="collapsible"
+            listClassName={FIELD_INSET}
+            selected={f.selectedProvider}
+            onSelect={f.selectProvider}
+            onProviderRemoved={f.dropProviderGrant}
+          />
+          <p className="mt-3 text-[12px] text-muted-foreground">
+            Changing the provider swaps this sandbox's model credential. A
+            cross-family switch (e.g. Anthropic → OpenAI on a Claude image) can
+            break the agent and may need a restart.
+          </p>
+        </section>
+
+        <ConnectionsSection
+          grantedIds={f.grantedAppIds}
+          onToggleGrant={f.toggleAppGrant}
+          oauthReturnView={`/sandboxes/${agent.id}`}
+        />
+
+        <section className="mb-8">
+          <SectionLabel spaced>Network access</SectionLabel>
+          <Inset className="rounded-lg border border-border p-4">
+            <AgentEgressEditor
+              agentId={agent.id}
+              currentPreset={f.currentPreset}
+              staged={f.egressStaged}
+            />
+          </Inset>
+        </section>
+
+        <section className="mb-8">
+          <SectionLabel spaced>Lifecycle</SectionLabel>
+          <Inset className="rounded-lg border border-border p-4">
+            <HibernationTimeoutField
+              register={f.register("hibernationTimeoutMin", {
+                valueAsNumber: true,
+              })}
+              value={f.hibernationTimeoutMin}
+              error={f.errors.hibernationTimeoutMin?.message}
+              disabled={f.saving}
+            />
+          </Inset>
+        </section>
+
+        <section className="mb-8">
+          <SectionLabel spaced>Environment</SectionLabel>
+          <Inset className="rounded-lg border border-border p-4">
+            <Controller
+              control={f.control}
+              name="envVars"
+              render={({ field }) => (
+                <EnvTab
+                  inherited={f.inheritedEnvs}
+                  envVars={field.value}
+                  setEnvVars={field.onChange}
+                  saving={f.saving}
+                />
+              )}
+            />
+          </Inset>
+        </section>
       </div>
-    </div>
+    </StickyFooterLayout>
   );
 }
 

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -1,4 +1,7 @@
+import { ArrowRight } from "lucide-react";
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
 
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
@@ -83,6 +86,16 @@ export function SandboxWizardView() {
 
   const goToStep = (step: WizardStep) => update({ step });
 
+  const step1CanAdvance =
+    snapshot.templateId !== null || snapshot.customImage.trim().length > 0;
+  const registryFilled = registryFilledCount(registryCredential);
+  const registryPartial =
+    isCustomImage && registryFilled > 0 && registryFilled < 3;
+  const step2CanAdvance =
+    snapshot.name.trim().length > 0 &&
+    snapshot.providerRef !== null &&
+    !registryPartial;
+
   const finish = async () => {
     const image = snapshot.customImage.trim();
     const useRegistry =
@@ -121,12 +134,28 @@ export function SandboxWizardView() {
     }
   };
 
+  const footer =
+    snapshot.step === 1 ? (
+      <Button onClick={() => update({ step: 2 })} disabled={!step1CanAdvance}>
+        Continue <ArrowRight size={16} />
+      </Button>
+    ) : snapshot.step === 2 ? (
+      <Button onClick={() => update({ step: 3 })} disabled={!step2CanAdvance}>
+        Continue <ArrowRight size={16} />
+      </Button>
+    ) : (
+      <Button onClick={finish} disabled={createAgent.isPending}>
+        Create sandbox
+      </Button>
+    );
+
   return (
     <SandboxWizardShell
       step={snapshot.step}
       maxStep={snapshot.maxStep || snapshot.step}
       imageLabel={imageLabel}
       onNavigate={goToStep}
+      footer={footer}
     >
       {snapshot.step === 1 && (
         <ImageStep
@@ -140,7 +169,9 @@ export function SandboxWizardView() {
           onCustomImageChange={(customImage) =>
             update({ customImage, templateId: null })
           }
-          onContinue={() => update({ step: 2 })}
+          onContinue={() => {
+            if (step1CanAdvance) update({ step: 2 });
+          }}
         />
       )}
 
@@ -153,17 +184,14 @@ export function SandboxWizardView() {
           registryCredential={registryCredential}
           onRegistryChange={setRegistryCredential}
           update={update}
-          onContinue={() => update({ step: 3 })}
+          setupNote={
+            templateList.find((t) => t.id === snapshot.templateId)?.setupNote
+          }
         />
       )}
 
       {snapshot.step === 3 && (
-        <ConnectionsStep
-          snapshot={snapshot}
-          update={update}
-          onFinish={finish}
-          finishing={createAgent.isPending}
-        />
+        <ConnectionsStep snapshot={snapshot} update={update} />
       )}
     </SandboxWizardShell>
   );

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -93,6 +93,9 @@ export interface TemplateView {
   image: string;
   description?: string;
   category: "harness" | "preconfigured";
+  tags?: string[];
+  docsUrl?: string;
+  setupNote?: { title: string; body: string };
   experimental: boolean;
 }
 


### PR DESCRIPTION
Reworks sandbox-creation step 1 to distinguish base coding-agent harnesses from purpose-built workload images, and lets a workload tailor step 2 via a recommended-setup note — per #921.

Closes #921
Closes #1094 