### PR TITLE
fix(helm): pin clickhouse-keeper image to the quay.io mirror

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -261,9 +261,10 @@ clickstack:
 
   # --- forwarded to the clickstack subchart ---
   # Third-party images pinned to the quay.io/dam-agents mirror (mirror these by hand):
-  #   hyperdx:2.27.0                <- docker.hyperdx.io/hyperdx/hyperdx:2.27.0
-  #   clickhouse-server:25.7-alpine <- clickhouse/clickhouse-server:25.7-alpine
-  #   busybox:1.37.0               <- busybox
+  #   hyperdx:2.27.0                 <- docker.hyperdx.io/hyperdx/hyperdx:2.27.0
+  #   clickhouse-server:25.7-alpine  <- clickhouse/clickhouse-server:25.7-alpine
+  #   clickhouse-keeper:25.7-alpine  <- clickhouse/clickhouse-keeper:25.7-alpine
+  #   busybox:1.37.0                 <- busybox
   # Production must override clickstack.hyperdx.secrets.* (placeholders by default).
 
   otel-collector:
@@ -278,6 +279,15 @@ clickstack:
         image: "quay.io/dam-agents/busybox:1.37.0"
 
   clickhouse:
+    # Without an explicit image the operator injects its built-in default
+    # (docker.io/clickhouse/clickhouse-keeper:latest) — pin to the mirror and
+    # match the server tag. Merges over the subchart's keeper.spec defaults.
+    keeper:
+      spec:
+        containerTemplate:
+          image:
+            repository: quay.io/dam-agents/clickhouse-keeper
+            tag: "25.7-alpine"
     cluster:
       spec:
         containerTemplate:


### PR DESCRIPTION
## Problem

The ClickStack `KeeperCluster` CR is rendered **without an image field** — the subchart templates `clickstack.clickhouse.keeper.spec` verbatim, its default carries only `replicas` + `dataVolumeClaimSpec`, and our `values.yaml` pinned only the `cluster:` branch (the `ClickHouseCluster`). With no image set, the clickhouse-operator fills it from its compiled-in default:

```
DefaultKeeperContainerRepository = "docker.io/clickhouse/clickhouse-keeper"
DefaultKeeperContainerTag        = "latest"
```

So the keeper pods pulled `docker.io/clickhouse/clickhouse-keeper:latest` — the only clickstack image escaping the `quay.io/dam-agents` mirror, and doubly bad since `:latest` floats while everything else is pinned.

## Fix

Pin `clickstack.clickhouse.keeper.spec.containerTemplate.image` to `quay.io/dam-agents/clickhouse-keeper:25.7-alpine` (same tag as the server image), and add it to the by-hand mirror list in the comment. The override deep-merges over the subchart's keeper defaults, so `replicas`/`dataVolumeClaimSpec` are untouched.

Rendered `KeeperCluster` after the change:

```yaml
spec:
  containerTemplate:
    image:
      repository: quay.io/dam-agents/clickhouse-keeper
      tag: 25.7-alpine
  dataVolumeClaimSpec: { ... }   # 5Gi, from subchart default
  replicas: 1
```

## Mirror step (required before deploy)

The mirror tag does not exist yet — populate it with `crane`:

```sh
crane copy docker.io/clickhouse/clickhouse-keeper:25.7-alpine \
           quay.io/dam-agents/clickhouse-keeper:25.7-alpine
```

## Verification

- `mise run helm:check` — lint clean, render valid (52/0 errors)
- Rendered `KeeperCluster` now carries the mirrored image; no `docker.io/...keeper` reference remains

## Out of scope

MongoDB operator-injected images stay on `quay.io/mongodb` / Docker Hub by design — Docker Hub for the ClickHouse keeper was the specific gap.