### PR TITLE
fix(approvals): resolve expired inbox requests after a verdict

### DIFF
--- a/packages/api-server/src/__tests__/unit/approvals-service-expired.test.ts
+++ b/packages/api-server/src/__tests__/unit/approvals-service-expired.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, test } from "vitest";
+
+import type { PendingApprovalRow } from "../../modules/approvals/domain/types.js";
+import type { ApprovalsRepository } from "../../modules/approvals/infrastructure/approvals-repository.js";
+import { createApprovalsService } from "../../modules/approvals/services/approvals-service.js";
+
+function extAuthzRow(
+  overrides: Partial<PendingApprovalRow> = {},
+): PendingApprovalRow {
+  return {
+    id: "appr-1",
+    type: "ext_authz",
+    agentId: "agent-1",
+    ownerSub: "owner-1",
+    sessionId: null,
+    payload: {
+      kind: "ext_authz",
+      host: "api.example.com",
+      method: "GET",
+      path: "/v1/data",
+    },
+    createdAt: new Date(),
+    expiresAt: new Date(Date.now() - 60_000),
+    resolvedAt: null,
+    verdict: null,
+    decidedBy: null,
+    status: "expired",
+    deliveredAt: null,
+    ...overrides,
+  };
+}
+
+function makeService(seed: PendingApprovalRow) {
+  const rows = [seed];
+  const inserts: { verdict: string }[] = [];
+  const repo: ApprovalsRepository = {
+    insertPending: async () => {},
+    getPending: async (id) => rows.find((r) => r.id === id) ?? null,
+    findActivePendingExtAuthz: async () => null,
+    listPendingForOwner: async () => rows,
+    listPendingForInstance: async () => rows,
+    resolvePending: async (id, verdict, decidedBy) => {
+      const row = rows.find((r) => r.id === id && r.status === "pending");
+      if (!row) return false;
+      row.status = "resolved";
+      if (verdict !== "deny_once") row.verdict = verdict;
+      row.decidedBy = decidedBy;
+      row.resolvedAt = new Date();
+      return true;
+    },
+    resolveExpired: async (id, verdict, decidedBy) => {
+      const row = rows.find((r) => r.id === id && r.status === "expired");
+      if (!row) return;
+      row.status = "resolved";
+      row.verdict = verdict;
+      row.decidedBy = decidedBy;
+      row.resolvedAt = new Date();
+      row.deliveredAt = new Date();
+    },
+    markDelivered: async () => {},
+    listResolvedUndelivered: async () => [],
+    expirePending: async () => {},
+    expireOverdue: async () => [],
+    deleteForAgent: async () => {},
+    listDistinctAgentIds: async () => [],
+  };
+  const service = createApprovalsService({
+    repo,
+    egressRuleWriter: {
+      insert: async (input) => {
+        inserts.push({ verdict: input.verdict });
+      },
+    },
+    notifier: { notifyResolved: async () => {} },
+    wrapperFrameSender: { send: async () => {} },
+    isAgentOwnedBy: async () => true,
+    ownerSub: "owner-1",
+    agentBinding: "*",
+  });
+  return { rows, service, inserts };
+}
+
+describe("approvals verdicts on expired requests (#2125)", () => {
+  test("approvePermanent writes the rule and resolves an expired row", async () => {
+    const { rows, service, inserts } = makeService(extAuthzRow());
+    const outcome = await service.approvePermanent("appr-1");
+    expect(inserts).toHaveLength(1);
+    expect(outcome.outcome).toBe("rule_written_expired");
+    expect(rows[0].status).toBe("resolved");
+    expect(rows[0].deliveredAt).not.toBeNull();
+  });
+
+  test("denyForever resolves an expired row", async () => {
+    const { rows, service } = makeService(extAuthzRow());
+    await service.denyForever("appr-1");
+    expect(rows[0].status).toBe("resolved");
+    expect(rows[0].verdict).toBe("deny");
+  });
+
+  test("a live pending row still resolves via the CAS path (applied)", async () => {
+    const { rows, service } = makeService(
+      extAuthzRow({
+        status: "pending",
+        expiresAt: new Date(Date.now() + 60_000),
+      }),
+    );
+    const outcome = await service.approvePermanent("appr-1");
+    expect(outcome.outcome).toBe("applied");
+    expect(rows[0].status).toBe("resolved");
+  });
+});

--- a/packages/api-server/src/__tests__/unit/ext-authz-gate.test.ts
+++ b/packages/api-server/src/__tests__/unit/ext-authz-gate.test.ts
@@ -54,6 +54,7 @@ function makeFakeRepo(): FakeRepo {
     listPendingForOwner: async () => [],
     listPendingForInstance: async () => [],
     resolvePending: async () => true,
+    resolveExpired: async () => {},
     markDelivered: async () => {},
     listResolvedUndelivered: async () => [],
     expirePending: async (id) => {

--- a/packages/api-server/src/modules/approvals/infrastructure/approvals-repository.ts
+++ b/packages/api-server/src/modules/approvals/infrastructure/approvals-repository.ts
@@ -46,6 +46,11 @@ export interface ApprovalsRepository {
     decidedBy: string,
     opts?: { markDelivered?: boolean },
   ): Promise<boolean>;
+  resolveExpired(
+    id: string,
+    verdict: "allow" | "deny",
+    decidedBy: string,
+  ): Promise<void>;
   /** Idempotent. Stamps `delivered_at` on a row whose response frame has
    *  reached the wrapper. Re-running is harmless: the WHERE keeps it from
    *  overwriting an earlier delivery timestamp. */
@@ -233,6 +238,25 @@ export function createApprovalsRepository(db: Db): ApprovalsRepository {
         )
         .returning({ id: pendingApprovals.id });
       return rows.length > 0;
+    },
+
+    async resolveExpired(id, verdict, decidedBy) {
+      const now = new Date();
+      await db
+        .update(pendingApprovals)
+        .set({
+          status: "resolved",
+          verdict,
+          decidedBy,
+          resolvedAt: now,
+          deliveredAt: now,
+        })
+        .where(
+          and(
+            eq(pendingApprovals.id, id),
+            eq(pendingApprovals.status, "expired"),
+          ),
+        );
     },
 
     async markDelivered(id) {

--- a/packages/api-server/src/modules/approvals/services/approvals-service.ts
+++ b/packages/api-server/src/modules/approvals/services/approvals-service.ts
@@ -197,14 +197,12 @@ export function createApprovalsService(
           decidedBy: deps.ownerSub,
           source: "inbox",
         });
-        // The pending row may already be expired (the held call timed out),
-        // in which case resolvePending no-ops — that's the timed-out
-        // approve-permanent flow: rule is written, future retries match.
         const casWon = await deps.repo.resolvePending(
           id,
           "allow",
           deps.ownerSub,
         );
+        if (!casWon) await deps.repo.resolveExpired(id, "allow", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
         auditVerdict(deps, row, "allow", {
           verdict: "allow",
@@ -249,6 +247,7 @@ export function createApprovalsService(
           "allow",
           deps.ownerSub,
         );
+        if (!casWon) await deps.repo.resolveExpired(id, "allow", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
         // Host-wide allow (method:*/path:*) — a broad widening of the
         // allow-list; flag it.
@@ -286,6 +285,7 @@ export function createApprovalsService(
           "deny",
           deps.ownerSub,
         );
+        if (!casWon) await deps.repo.resolveExpired(id, "deny", deps.ownerSub);
         await deps.notifier.notifyResolved(id);
         auditVerdict(deps, row, "deny", {
           verdict: "deny",


### PR DESCRIPTION
Acting on an expired (timed-out) egress request in the inbox wrote the rule but left the row `expired` — `resolvePending`'s CAS only matches `pending`, so the inbox item kept its buttons and repeat clicks silently no-oped. Adds `resolveExpired` (expired → resolved) called from the rule-writing verdicts when the pending CAS misses, so expired rows clear like active ones.

### Scope
Covers the ext_authz (network/egress) inbox — what #2125 describes. The acp_native (harness permission) verdict paths have an analogous expired-row problem but are rooted in a different cause (a 24h inbox-only expiry vs. the harness's no real timeout); tracked separately in #2213.

Closes #2125