### PR TITLE
fix(api-server): make ws liveness the source of truth for ACP turns

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -275,6 +275,8 @@ spec:
             {{- end }}
             - name: APPROVAL_HOLD_SECONDS
               value: {{ .Values.apiServer.approvalHoldSeconds | quote }}
+            - name: ACP_TURN_CEILING_SECONDS
+              value: {{ .Values.apiServer.acpTurnCeilingSeconds | quote }}
             {{- if .Values.apiServer.maxImportBundleBytes }}
             - name: MAX_IMPORT_BUNDLE_BYTES
               value: {{ .Values.apiServer.maxImportBundleBytes | quote }}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -570,6 +570,13 @@ apiServer:
   # timeouts are an external ceiling.
   approvalHoldSeconds: 1800
 
+  # -- Absolute per-turn ceiling (seconds) for the ACP sendPrompt path
+  # (Slack/Telegram/forks). Turn liveness is a ws ping/pong signal, so a
+  # silent-but-alive turn stays connected; this only caps a wedged agent.
+  # Must be >= approvalHoldSeconds so a turn blocked on an egress approval
+  # outlives the hold. Default 1 hour.
+  acpTurnCeilingSeconds: 3600
+
   # -- Hard ceiling for file-import bundle uploads, in bytes. Enforced at
   # the api-server proxy boundary (rejects oversized Content-Length AND
   # destroys the upstream pipe when streamed bytes pass the cap). The

--- a/packages/api-server/src/__tests__/unit/config.test.ts
+++ b/packages/api-server/src/__tests__/unit/config.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { loadConfig } from "../../config.js";
+
+/** Every config field with no default, set to a valid dummy so loadConfig()
+ *  reaches the acpTurnCeilingSeconds >= approvalHoldSeconds refine. Individual
+ *  cases layer the two timer knobs on top. */
+const REQUIRED_ENV: Record<string, string> = {
+  PLATFORM_RELEASE_NAME: "platform",
+  PLATFORM_HARNESS_SERVER_URL: "http://harness.local:8080",
+  DATABASE_URL: "postgres://localhost:5432/test",
+  ACTIVITY_HMAC_KEY: "test-activity-hmac-key",
+  API_KEY_HMAC_KEY: "test-api-hmac-key",
+  TERMS_VERSION: "1",
+  TERMS_TEXT: "terms",
+};
+
+// Only the keys these tests touch are saved/restored, so host env can't
+// satisfy or violate the invariant under test and the suite leaves env pristine.
+const MANAGED_KEYS = [
+  ...Object.keys(REQUIRED_ENV),
+  "APPROVAL_HOLD_SECONDS",
+  "ACP_TURN_CEILING_SECONDS",
+];
+
+describe("loadConfig — acpTurnCeilingSeconds vs approvalHoldSeconds invariant", () => {
+  const saved: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of MANAGED_KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+    Object.assign(process.env, REQUIRED_ENV);
+  });
+
+  afterEach(() => {
+    for (const k of MANAGED_KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  it("rejects a ceiling below the approval hold", () => {
+    process.env.APPROVAL_HOLD_SECONDS = "1800";
+    process.env.ACP_TURN_CEILING_SECONDS = "60";
+    expect(() => loadConfig()).toThrow(
+      /acpTurnCeilingSeconds must be >= approvalHoldSeconds/,
+    );
+  });
+
+  it("accepts a ceiling equal to the approval hold", () => {
+    process.env.APPROVAL_HOLD_SECONDS = "1800";
+    process.env.ACP_TURN_CEILING_SECONDS = "1800";
+    expect(loadConfig().acpTurnCeilingSeconds).toBe(1800);
+  });
+
+  it("accepts the built-in defaults (1h ceiling, 30m hold)", () => {
+    const config = loadConfig();
+    expect(config.approvalHoldSeconds).toBe(1800);
+    expect(config.acpTurnCeilingSeconds).toBe(3600);
+  });
+});

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -114,6 +114,12 @@ const configSchema = z.object({
   /** Default hold window for ext_authz HITL (seconds). Helm-configurable;
    *  matches `pending_approvals.expires_at` and the synchronous-hold deadline. */
   approvalHoldSeconds: z.coerce.number().int().positive().default(1800),
+  /** Absolute per-turn ceiling for the ACP sendPrompt path (Slack/Telegram/
+   *  forks), in seconds. Turn liveness is a ws ping/pong signal; this only caps
+   *  a wedged-but-still-ponging agent. Enforced >= approvalHoldSeconds (see
+   *  configSchema refine) so a turn blocked on an egress approval outlives the
+   *  hold rather than dying mid-approval. Helm-configurable; default 1h. */
+  acpTurnCeilingSeconds: z.coerce.number().int().positive().default(3600),
   /** Minimum CLI version this server accepts. Optional — when unset, no
    *  floor is advertised and every CLI is accepted (a soft-warn fires on
    *  the CLI side when the local CLI is behind the current server). */
@@ -162,8 +168,19 @@ const configSchema = z.object({
 
 export type Config = z.infer<typeof configSchema>;
 
+// A turn blocked on an egress approval must outlive the hold, else the ceiling
+// kills the connection before the human can respond.
+const validatedConfigSchema = configSchema.refine(
+  (c) => c.acpTurnCeilingSeconds >= c.approvalHoldSeconds,
+  {
+    message:
+      "acpTurnCeilingSeconds must be >= approvalHoldSeconds so a turn blocked on an egress approval does not die before the hold resolves",
+    path: ["acpTurnCeilingSeconds"],
+  },
+);
+
 export function loadConfig(): Config {
-  return configSchema.parse({
+  return validatedConfigSchema.parse({
     serverVersion: pkg.version,
     appVersion: process.env.PLATFORM_APP_VERSION ?? "0.0.0",
     namespace: process.env.NAMESPACE,
@@ -214,6 +231,7 @@ export function loadConfig(): Config {
     redisUrl: process.env.REDIS_URL,
     redisPassword: process.env.REDIS_PASSWORD,
     approvalHoldSeconds: process.env.APPROVAL_HOLD_SECONDS,
+    acpTurnCeilingSeconds: process.env.ACP_TURN_CEILING_SECONDS,
     minClientCliVersion: process.env.MIN_CLIENT_CLI_VERSION,
     trustedHostsPath: process.env.TRUSTED_HOSTS_PATH,
     agentTemplatesPath: process.env.AGENT_TEMPLATES_PATH,

--- a/packages/api-server/src/core/acp-client.ts
+++ b/packages/api-server/src/core/acp-client.ts
@@ -9,7 +9,12 @@ import type {
 } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { podBaseUrl } from "../modules/agents/infrastructure/k8s.js";
 
-const TIMEOUT_MS = 120_000;
+/** How often we ping the agent-runtime ws to prove the socket is alive.
+ *  Mirrors the ssh-relay heartbeat. */
+const PING_INTERVAL_MS = 30_000;
+/** Fallback per-turn ceiling when a caller doesn't supply one (tests, direct
+ *  use). Production wires config.acpTurnCeilingSeconds through the factories. */
+const DEFAULT_TURN_CEILING_MS = 60 * 60 * 1000;
 
 function wsStream(url: string): Promise<{ stream: Stream; ws: WebSocket }> {
   return new Promise((resolve, reject) => {
@@ -110,6 +115,7 @@ async function withAcpConnection<T>(
   url: string,
   clientName: string,
   handlers: { sessionUpdate?: (params: any) => Promise<void> },
+  turnCeilingMs: number,
   fn: (
     connection: ClientSideConnection,
     init: InitializeResponse,
@@ -118,11 +124,35 @@ async function withAcpConnection<T>(
   const { stream, ws } = await wsStream(url);
 
   const ac = new AbortController();
-  let timer = setTimeout(() => ac.abort(), TIMEOUT_MS);
-  const resetTimeout = () => {
-    clearTimeout(timer);
-    timer = setTimeout(() => ac.abort(), TIMEOUT_MS);
-  };
+  let abortReason = "ACP connection aborted";
+
+  // Liveness is a transport signal, not an application one. The agent-runtime's
+  // ws server auto-pongs, so a live-but-silent turn — an egress approval hold, a
+  // long tool, a slow first token — stays connected; only a dead/half-open
+  // socket aborts. Mirrors the ssh-relay heartbeat.
+  let alive = true;
+  ws.on("pong", () => {
+    alive = true;
+  });
+  const heartbeat = setInterval(() => {
+    if (!alive) {
+      abortReason = "ACP connection lost (agent unreachable)";
+      ac.abort();
+      return;
+    }
+    alive = false;
+    try {
+      ws.ping();
+    } catch {}
+  }, PING_INTERVAL_MS);
+
+  // Absolute backstop against a wedged-but-still-ponging agent. Sized at/above
+  // the egress approval hold (config enforces acpTurnCeilingSeconds >=
+  // approvalHoldSeconds) so a human taking the full approval window never trips it.
+  const ceiling = setTimeout(() => {
+    abortReason = `ACP turn exceeded the ${Math.round(turnCeilingMs / 1000)}s ceiling`;
+    ac.abort();
+  }, turnCeilingMs);
 
   const connection = new ClientSideConnection(
     () => ({
@@ -135,7 +165,6 @@ async function withAcpConnection<T>(
         };
       },
       async sessionUpdate(params: any) {
-        resetTimeout();
         await handlers.sessionUpdate?.(params);
       },
       async writeTextFile() {
@@ -150,7 +179,8 @@ async function withAcpConnection<T>(
   );
 
   const cleanup = () => {
-    clearTimeout(timer);
+    clearInterval(heartbeat);
+    clearTimeout(ceiling);
     if (
       ws.readyState === WebSocket.OPEN ||
       ws.readyState === WebSocket.CONNECTING
@@ -159,7 +189,6 @@ async function withAcpConnection<T>(
   };
 
   try {
-    ac.signal.addEventListener("abort", cleanup, { once: true });
     const init = await connection.initialize({
       protocolVersion: 1,
       clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } },
@@ -167,47 +196,53 @@ async function withAcpConnection<T>(
     });
     return await Promise.race([
       fn(connection, init),
+      // On abort the race settles here regardless of whether fn is hung, so the
+      // finally block runs promptly; no separate abort→cleanup listener needed.
       new Promise<never>((_, reject) => {
         if (ac.signal.aborted) {
-          reject(
-            new Error(
-              `ACP connection timed out after ${TIMEOUT_MS / 1000}s of inactivity`,
-            ),
-          );
+          reject(new Error(abortReason));
           return;
         }
         ac.signal.addEventListener(
           "abort",
-          () =>
-            reject(
-              new Error(
-                `ACP connection timed out after ${TIMEOUT_MS / 1000}s of inactivity`,
-              ),
-            ),
+          () => reject(new Error(abortReason)),
           { once: true },
         );
       }),
     ]);
   } finally {
-    ac.signal.removeEventListener("abort", cleanup);
     cleanup();
   }
 }
 
+/** Builds an AcpClient for a resolved agent instance. Bound at the composition
+ *  root with the turn ceiling baked in, then injected into the channel workers. */
+export type AcpClientFactory = (instanceName: string) => AcpClient;
+/** Builds an AcpClient for a fork pod addressed by IP. */
+export type ForkAcpClientFactory = (podIP: string) => AcpClient;
+
 export function createAcpClient(opts: {
   namespace: string;
   instanceName: string;
+  turnCeilingMs?: number;
 }): AcpClient {
   return createAcpClientForUrl(
     `ws://${podBaseUrl(opts.instanceName, opts.namespace)}/api/acp`,
+    opts.turnCeilingMs ?? DEFAULT_TURN_CEILING_MS,
   );
 }
 
-export function createForkAcpClient(opts: { podIP: string }): AcpClient {
-  return createAcpClientForUrl(`ws://${opts.podIP}:8080/api/acp`);
+export function createForkAcpClient(opts: {
+  podIP: string;
+  turnCeilingMs?: number;
+}): AcpClient {
+  return createAcpClientForUrl(
+    `ws://${opts.podIP}:8080/api/acp`,
+    opts.turnCeilingMs ?? DEFAULT_TURN_CEILING_MS,
+  );
 }
 
-function createAcpClientForUrl(url: string): AcpClient {
+function createAcpClientForUrl(url: string, turnCeilingMs: number): AcpClient {
   return {
     // Throws on connection/RPC failure; callers (the repository and the
     // channel workers) catch and treat an unreachable agent as "no sessions".
@@ -278,6 +313,7 @@ function createAcpClientForUrl(url: string): AcpClient {
             }
           },
         },
+        turnCeilingMs,
         async (connection, init) => {
           let sessionId: string;
           if ("resumeSessionId" in sendOpts) {
@@ -333,6 +369,7 @@ function createAcpClientForUrl(url: string): AcpClient {
         url,
         "platform-trigger",
         {},
+        turnCeilingMs,
         async (connection, _init) => {
           let sessionId: string;
           const mcpServers = (triggerOpts.mcpServers ?? []) as any[];

--- a/packages/api-server/src/core/acp-client.ts
+++ b/packages/api-server/src/core/acp-client.ts
@@ -8,10 +8,17 @@ import type {
   InitializeResponse,
 } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { podBaseUrl } from "../modules/agents/infrastructure/k8s.js";
+import { getLogger } from "./logger.js";
 
 /** How often we ping the agent-runtime ws to prove the socket is alive.
  *  Mirrors the ssh-relay heartbeat. */
 const PING_INTERVAL_MS = 30_000;
+/** Consecutive unanswered pings before the socket is declared dead. A single
+ *  GC pause or event-loop stall on a healthy agent-runtime can delay one pong
+ *  past a 30s tick; requiring two misses (~90s of silence) rides that out
+ *  without killing a live turn, while still catching a real half-open socket
+ *  far inside the turn ceiling. */
+const MAX_MISSED_PONGS = 2;
 /** Fallback per-turn ceiling when a caller doesn't supply one (tests, direct
  *  use). Production wires config.acpTurnCeilingSeconds through the factories. */
 const DEFAULT_TURN_CEILING_MS = 60 * 60 * 1000;
@@ -129,21 +136,27 @@ async function withAcpConnection<T>(
   // Liveness is a transport signal, not an application one. The agent-runtime's
   // ws server auto-pongs, so a live-but-silent turn — an egress approval hold, a
   // long tool, a slow first token — stays connected; only a dead/half-open
-  // socket aborts. Mirrors the ssh-relay heartbeat.
-  let alive = true;
+  // socket aborts. Mirrors the ssh-relay heartbeat. A pong resets the miss
+  // counter; MAX_MISSED_PONGS consecutive unanswered pings aborts.
+  let missedPongs = 0;
   ws.on("pong", () => {
-    alive = true;
+    missedPongs = 0;
   });
   const heartbeat = setInterval(() => {
-    if (!alive) {
+    if (missedPongs >= MAX_MISSED_PONGS) {
       abortReason = "ACP connection lost (agent unreachable)";
       ac.abort();
       return;
     }
-    alive = false;
+    missedPongs += 1;
     try {
       ws.ping();
-    } catch {}
+    } catch (err) {
+      // A throw here means the socket is already broken; the next tick will
+      // trip the miss ceiling and abort. Log so a real transport failure
+      // isn't invisible.
+      getLogger().debug({ err, clientName }, "acp heartbeat ping failed");
+    }
   }, PING_INTERVAL_MS);
 
   // Absolute backstop against a wedged-but-still-ponging agent. Sized at/above

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -25,6 +25,12 @@ import {
   startSkillsCleanupSaga,
 } from "./modules/skills/index.js";
 import { createK8sClient } from "./modules/agents/infrastructure/k8s.js";
+import {
+  createAcpClient,
+  createForkAcpClient,
+  type AcpClientFactory,
+  type ForkAcpClientFactory,
+} from "./core/acp-client.js";
 import { createPostgresState } from "@chat-adapter/state-pg";
 import {
   createSlackWorker,
@@ -358,9 +364,21 @@ const slackGatewayFactory = slackTokens
     ? () => fakeSlackGateway
     : undefined;
 
+// Bind the ACP turn ceiling (and namespace) into the client factories at the
+// composition root; workers get pre-wired factories and stay ignorant of both.
+const acpTurnCeilingMs = config.acpTurnCeilingSeconds * 1000;
+const makeAcpClient: AcpClientFactory = (instanceName) =>
+  createAcpClient({
+    namespace: config.namespace,
+    instanceName,
+    turnCeilingMs: acpTurnCeilingMs,
+  });
+const makeForkAcpClient: ForkAcpClientFactory = (podIP) =>
+  createForkAcpClient({ podIP, turnCeilingMs: acpTurnCeilingMs });
+
 const slackWorker = slackGatewayFactory
   ? createSlackWorker(
-      config.namespace,
+      makeAcpClient,
       slackGatewayFactory,
       () => systemAgents,
       identityLinkService,
@@ -377,13 +395,14 @@ const slackWorker = slackGatewayFactory
       config.brand.short,
       isTermsAccepted,
       config.uiBaseUrl,
+      makeForkAcpClient,
     )
   : undefined;
 
 const telegramWorker =
   config.telegramEnabled && chatSdkState
     ? createTelegramWorker(
-        config.namespace,
+        makeAcpClient,
         chatSdkState,
         () => systemAgents,
         {

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -5,9 +5,9 @@ import type { StoredChannelConfig } from "../stored-channel.js";
 import type { PostMessageOptions } from "../services/channel-manager.js";
 import type { ContentBlock } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import {
-  createAcpClient,
-  createForkAcpClient,
   type AcpClient,
+  type AcpClientFactory,
+  type ForkAcpClientFactory,
 } from "../../../core/acp-client.js";
 import {
   EventType,
@@ -166,7 +166,7 @@ export interface SlackOAuthPending {
 }
 
 export function createSlackWorker(
-  namespace: string,
+  makeAcpClient: AcpClientFactory,
   createGateway: () => SlackGateway,
   agents: () => AgentsService,
   identityLinks: IdentityLinkService,
@@ -179,6 +179,7 @@ export function createSlackWorker(
   brandShort: string,
   isTermsAccepted: (sub: string) => Promise<boolean>,
   uiBaseUrl: string,
+  makeForkAcpClient: ForkAcpClientFactory,
   emit: (event: DomainEvent) => void = defaultEmit,
 ): SlackWorker {
   let gateway: SlackGateway | null = null;
@@ -244,7 +245,7 @@ export function createSlackWorker(
       );
     try {
       await agents().ensureReady(instanceName);
-      const acp = createAcpClient({ namespace, instanceName });
+      const acp = makeAcpClient(instanceName);
       const platformMeta = {
         type: SessionType.ChannelSlack,
         threadTs: ctx.threadTs,
@@ -444,7 +445,7 @@ export function createSlackWorker(
             "This agent can't process images yet — answering text only.",
           );
         try {
-          const acp = createForkAcpClient({ podIP: event.podIP });
+          const acp = makeForkAcpClient(event.podIP);
           const existing = await findThreadSession(acp, ctx.threadTs);
           const response = existing
             ? await acp.sendPrompt(ctx.prompt, {

--- a/packages/api-server/src/modules/channels/infrastructure/telegram.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/telegram.ts
@@ -9,7 +9,7 @@ import type {
   StoredTelegramChannel,
 } from "../stored-channel.js";
 import type { PostMessageOptions } from "../services/channel-manager.js";
-import { createAcpClient } from "../../../core/acp-client.js";
+import { type AcpClientFactory } from "../../../core/acp-client.js";
 import { securityLog } from "../../../core/security-log.js";
 import {
   buildAuthorizeUrl,
@@ -118,7 +118,7 @@ async function fetchTelegramChatTitle(
 }
 
 export function createTelegramWorker(
-  namespace: string,
+  makeAcpClient: AcpClientFactory,
   state: StateAdapter,
   agents: () => AgentsService,
   threads: TelegramThreadsRepo,
@@ -134,7 +134,7 @@ export function createTelegramWorker(
   // The thread's session carries this threadId in `_meta.platform.threadTs`
   // — resolved off the agent, no server store.
   async function findThreadSession(instanceName: string, threadId: string) {
-    const acp = createAcpClient({ namespace, instanceName });
+    const acp = makeAcpClient(instanceName);
     const sessions = await acp.listSessions().catch((err) => {
       process.stderr.write(
         `[telegram:${instanceName}] listSessions failed: ${err}\n`,
@@ -167,7 +167,7 @@ export function createTelegramWorker(
     let outcome: TurnOutcome = "failure";
     try {
       await agents().ensureReady(instanceName);
-      const acp = createAcpClient({ namespace, instanceName });
+      const acp = makeAcpClient(instanceName);
 
       const existing = await findThreadSession(instanceName, thread.id);
       if (existing) {


### PR DESCRIPTION
## Problem

Messaging an agent over a channel (Slack/Telegram/forks) fails with a raw `Error: ACP connection timed out after 120s of inactivity` on longer tasks, while the agent keeps running and the reply lands in the web UI. Root cause verified in #2122.

`withAcpConnection` (`acp-client.ts`) armed a 120s timer that **only `sessionUpdate` reset**. `requestPermission` / file ops / `extNotification` didn't. So the timer inferred "agent alive" from "agent is streaming" and aborted a *live* turn during any silent stretch >120s:

- **Egress approval holds** — `approvalHoldSeconds` defaults to **1800s** (30 min). The agent's outbound call is blocked server-side while the 120s ACP timer kills the connection at 2 min — the two timers disagreed by **15×**.
- **Long tools** with no intermediate streaming (build/test/install, slow API/MCP).
- **Slow first token / long thinking**.

Scope note: the **web UI is unaffected** — its `acp-relay` is a raw passthrough with no app-level timeout (that's why completed replies always show up there). The cutoff lived only in the shared `sendPrompt` path.

## Fix

- **WS ping/pong is now the liveness source of truth.** `withAcpConnection` runs a 30s ping/pong heartbeat (mirrors `ssh-relay.ts`); the agent-runtime `ws` server auto-pongs, so this is api-server-only. A live-but-silent turn stays connected; only a dead/half-open socket aborts (detected within ~60s).
- **Configurable absolute per-turn ceiling** (`acpTurnCeilingSeconds`, default **1h**) as a backstop for a wedged-but-still-ponging agent. **Validated `>= approvalHoldSeconds`** at config load, so the two timers can never disagree again.
- **Composition-root wiring** — the ceiling is bound into the acp-client factory in `index.ts` and injected into the channel workers, which drop their direct `createAcpClient` import (a pre-existing DI leak).
- **Helm** — `apiServer.acpTurnCeilingSeconds: 3600` + `ACP_TURN_CEILING_SECONDS` env on the api-server.

## Testing

- `mise run check` (all packages), `mise run api-server:test` (144 passing), `helm lint` + `helm template | kubeconform` — all green.
- **Reproduced and verified in-cluster over Slack**: `sleep 130 && echo done` errored at ~120s on the old build; on the fixed build it waits quietly and returns `done`.

## Notes / follow-up

- Left the issue's optional "still running" Slack UX out — with a 1h ceiling the connection no longer dies on legitimate work, so the remaining error surface is genuine failures worth reporting honestly. Easy follow-up if wanted.
- Drive-by observation (not changed here): `triggerSession` in `acp-client.ts` has no callers anywhere in the repo — appears to be dead code.

Fixes #2122