### PR TITLE
docs(experiments): add architecture page, fix subsystem drift

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Last verified: 2026-06-12
+Last verified: 2026-07-01
 
 ## System context
 
@@ -64,6 +64,7 @@ Each page is the authoritative, self-contained description of its subsystem — 
 - [cli](architecture/cli.md) — `dam` command-line client, an npm-distributed Node package that points at a configured Platform deployment.
 - [skills](architecture/skills.md) — connectable git-based skill sources, install onto the per-Agent PVC, REST-only publish back as a PR, Envoy sidecar credential injection for GitHub.
 - [connections](architecture/connections.md) — unified Connection / Contribution model, runtime channel between api-server and agent-runtime, transactional outbox + worker delivery, agent-side driver model.
+- [experiments](architecture/experiments.md) — group competing agent sessions under one goal as arms, and collect the scores and downloadable artifacts each reports for comparison.
 - [usage-tracking](architecture/usage-tracking.md) — append-only activity log in Postgres, SQL views as the read interface, HMAC-pseudonymized identifiers, inspector-role gating.
 - [logging](architecture/logging.md) — Pino structured logging to stdout, and the real-identity security audit trail built on it (the forensic counterpart to pseudonymized usage-tracking).
 - [supply-chain](security/supply-chain.md) — how each external dependency type is scanned for CVEs and defended against supply-chain attacks.

--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-06-25
+Last verified: 2026-07-01
 
 ## Overview
 
@@ -74,10 +74,11 @@ Connector state that doesn't fit the env model (per-host CLI configs, allowlists
 Every caller that sends work to a pod — the api-server's ACP relay, channel adapters, skills management — routes through a single reachability primitive in the api-server. The primitive's contract: **the controller-published `Ready` condition is the authoritative answer to "can I call this pod?"** The primitive pokes activity by bumping the `agent-platform.ai/last-activity` annotation (the reconciler scales up any Agent with recent activity), single-flights concurrent waits per Agent, and bumps the same annotation on every successful call, so any caller implicitly keeps the pod warm.
 Contributions are applied out-of-band by a single background worker (a pod's `hello` is presence-only — it just signals the worker to dispatch). The worker dispatches **only to a Ready agent** — the same readiness gate the relay's `ensureReady` uses (the controller's `Ready` condition) — so an apply never targets a pod that is down or rolling; when the agent isn't Ready the outbox row stays unsettled and the periodic sweep re-dispatches once it is. Each apply runs every contribution to termination and records which drivers failed; a degraded agent (failed installs retrying in the background, capped) surfaces via its `contributionFailures` badge and never wedges. Readiness itself does **not** wait on contributions — configuration applies in the background.
 
-Three paths trigger a wake:
+Four paths trigger a wake:
 
 - **Connect-driven** — the api-server is about to forward an ACP frame to a hibernated Agent and ensures readiness before the relay completes. The frame can originate from a UI tab attaching to a session or from a channel worker (Slack / Telegram) routing an inbound message to its bound session.
 - **Schedule-driven** — a schedule fire commits a `trigger` event to the runtime outbox, then pokes the Agent awake without waiting for readiness; the boot-time `hello` catch-up delivers the event once the pod is `Ready`, and the event's TTL bounds how stale a fire can land (see [Trigger fire](#trigger-fire)).
+- **Experiment-driven** — starting an Experiment pokes each Arm's Agent awake the same way, committing an `experiment-trigger` event that opens the Arm's Trial session on delivery. See [experiments](experiments.md).
 - **Skills-management-driven** — install / uninstall / private-source scan / publish all route through the same primitive before reaching the agent (scan and publish reach agent-runtime directly over the harness port; install/uninstall keep the pod warm so the apply worker dispatches the bumped outbox). See [skills](skills.md).
 
 Wake is bounded — the primitive polls pod readiness with backoff and gives up after two minutes, surfacing a loud error to its caller (WS close code, channel log, or skills call error). The schedule-driven poke is the exception: it doesn't wait, so there is no bounded wait to fail.

--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-06-25
+Last verified: 2026-07-01
 
 ## Overview
 
@@ -52,7 +52,7 @@ The wire payload carries:
 
 - **`version`** (top-level) — per-agent monotonic counter, the single ack cursor for the payload. Bumped on any contribution edit or event insert.
 - **`state`** — the agent's full desired configuration (Contributions). Reconciled by diff. `hash` short-circuits no-op pushes.
-- **`events`** — ordered one-shot directives the agent must execute (schedule triggers, schedule resets, workspace seeding). Processed in order through per-kind handlers inside the agent-runtime.
+- **`events`** — ordered one-shot directives the agent must execute (schedule triggers, schedule resets, workspace seeding, experiment-trial launches). Processed in order through per-kind handlers inside the agent-runtime.
 
 State changes write to the outbox, the worker reads and dispatches a fresh payload, the agent receives state + events and reconciles contributions + invokes event handlers, and the agent calls back on boot/wake to catch up.
 
@@ -114,7 +114,7 @@ Kinds are added by extending the union and gating on agent capabilities (see [Ve
 
 ### Event
 
-A one-shot directive the agent executes through a per-kind handler inside the agent-runtime. Each event carries an `id` (stable across redeliveries — the dedupe key), a `kind`, a kind-specific `payload`, the agent-monotonic `version` slot it occupies, and an `expiresAt` ttl. The kinds today are **trigger** (fire a scheduled task, optionally continuing or starting fresh), **schedule-reset** (clear a schedule's state), and **workspace-seed** (clone a repo into the workspace). Exact payload shapes live in the [runtime contract types](../../packages/agent-runtime-api/src/modules/runtime/).
+A one-shot directive the agent executes through a per-kind handler inside the agent-runtime. Each event carries an `id` (stable across redeliveries — the dedupe key), a `kind`, a kind-specific `payload`, the agent-monotonic `version` slot it occupies, and an `expiresAt` ttl. The kinds today are **trigger** (fire a scheduled task, optionally continuing or starting fresh), **schedule-reset** (clear a schedule's state), **workspace-seed** (clone a repo into the workspace), and **experiment-trigger** (open a Trial session for an Experiment Arm — see [experiments](experiments.md)). Exact payload shapes live in the [runtime contract types](../../packages/agent-runtime-api/src/modules/runtime/).
 
 The `id` is the dedupe key. Redelivery is caught agent-side: the event loop settles without re-firing when the event's `version` is already covered by the applied cursor or its dedupe key already ran at the same or a later fire timestamp (tracked in the agent's local state store), and locally expires anything past its ttl.
 

--- a/docs/architecture/experiments.md
+++ b/docs/architecture/experiments.md
@@ -1,0 +1,89 @@
+# Experiments
+
+Last verified: 2026-07-01
+
+## Overview
+
+An **Experiment** races several AI-driven R&D harnesses against one goal and compares what each produced. Each **Arm** is one competitor — an existing Agent (its harness is fixed as the Agent's image) plus an optional **Arm Variation**. Starting an Experiment opens one **Trial** session per Arm; inside that Trial the harness runs its own iterate-and-score loop and appends scored **Runs** to a shared **Run Ledger**.
+
+The platform's role is deliberately narrow: it **starts Arms, captures Runs, and presents the comparison**. It never runs the optimization loop and never interprets a Score. A Score is opaque — captured, never normalized or ranked across Arms.
+
+### The bet
+
+There is no bespoke experiment harness. A generic Agent runs its own iterate-and-score loop and populates the ledger, driven by two things the platform already had:
+
+- **The interface is exposed as MCP tools.** Every agent pod already runs a platform-outbound MCP server — the same one the harness uses to reach channels, skills, and schedules. Experiments adds two tools to it: one to append a scored Run, one to declare the Arm finished. MCP is the one tool-calling surface every modern harness already speaks, so putting the reporting interface there means any harness image can report back with no per-harness client and no new transport. The harness passes no Experiment or Arm id — the platform attributes the call to the caller's active Arm from its network-verified Agent identity (mechanics under [Trial flow](#trial-flow)).
+- **The contract rides in the Trial prompt.** The tools exist, but nothing makes a generic harness call them unprompted. So the composed prompt carries the full reporting contract inline — an autonomous-trial directive telling the harness to run unattended to completion and to report every scored candidate, through those tools, the moment its score lands.
+
+The contract lives in the session-scoped prompt rather than a skill for two reasons: a skill reaches only Claude-family harnesses (those that mount skill files), whereas the prompt is harness-agnostic; and a skill would leak reporting nags into every non-experiment session, whereas the prompt is scoped to the Trial. The MCP tools (how to report) plus the prompt (what to do) are what make Experiments work across any harness image without per-harness code.
+
+## Bounded contexts
+
+The subsystem splits across two contexts, mirroring the Connections owner/grant split ([`docs/ubiquitous-language.md`](../ubiquitous-language.md)):
+
+- **api-server — Experiments context** owns Experiments, Arms, the Run Ledger, and Candidate storage. It composes the Trial prompt, launches Trials, attributes and records inbound Runs, serves Candidate downloads, and enforces the completion and liveness rules. Owner-scoped end to end — like a Connection, an Experiment belongs to a user and references many Agents through its Arms.
+- **agent-runtime side** runs the Trial. A new runtime-channel event handler opens the Trial session against the harness and submits the composed prompt; from then on the harness drives itself and reports back over MCP.
+
+Experiments is assembled from existing rails rather than new plumbing:
+
+- **Ownership** copies the Connections owner + grant-to-many-Agents model.
+- **Launch** reuses the runtime channel's trigger/wake primitive — the same durable outbox delivery and agent-poke the scheduler uses ([connections](connections.md#event), [agent-lifecycle](agent-lifecycle.md)).
+- **Reporting** rides the in-pod outbound MCP surface the agent already uses for channels and skills.
+- **The reporting contract** travels in the Trial prompt, not in code shipped to the harness.
+
+## Resources
+
+Described in [ubiquitous language](../ubiquitous-language.md#experiments-bounded-context--proposed-mvp-design); field-level shapes live in the [Experiments contract types](../../packages/api-server-api/src/modules/experiments/).
+
+- **Experiment** — owner-scoped, holds the shared prompt (the common instruction every Arm receives), a lifecycle status, and the Run Ledger. Peer to the Agent.
+- **Arm** — one competitor: a reference to one owned Agent plus its Arm Variation. Keyed per `(Experiment, Agent)`, so the same Agent cannot be two Arms of one Experiment, but the same harness image can back many Agents raced against each other.
+- **Arm Variation** — optional free text appended verbatim to the shared prompt at Trial launch, under its own header. The single declared variable that distinguishes one Arm from another. Opaque to the platform, which stores and forwards it but never parses it; the shared prompt is the un-overridable control and the variation only adds.
+- **Trial** — the single Session an Arm's Agent opens when the Experiment starts. The harness runs its loop here. It owns the transcript and session-level telemetry, which are therefore Arm-level, not Run-level.
+- **Run** — one entry the harness appends to the Run Ledger per loop iteration: a Score plus a Candidate. Numbered monotonically within its Arm.
+- **Candidate** — the artifact a Run produced, retrievable as a download. Opaque to the platform.
+- **Score** — the number a harness reports for a Run. Higher-is-better by convention; captured, never normalized across Arms.
+- **Run Ledger** — the append-only record of every Run across an Experiment's Arms. The one genuinely new persistence primitive.
+
+## Trial flow
+
+```mermaid
+sequenceDiagram
+  participant U as user (UI)
+  participant API as api-server<br/>(Experiments)
+  participant RT as agent-runtime
+  participant H as harness
+
+  U->>API: start Experiment
+  API->>API: mark Arms running, compose Trial prompt per Arm
+  loop per Arm
+    API->>RT: experiment-trigger event (runtime channel) + wake
+    RT->>H: open Trial session, submit prompt
+  end
+  loop each scored candidate
+    H->>API: record_run (MCP): score + candidate file
+    API->>API: store Candidate blob, append Run to ledger
+  end
+  H->>API: finish_arm (MCP)
+  API->>API: Arm completed; Experiment completed once all Arms terminal
+```
+
+**Launch.** Start marks each Arm running and composes its Trial prompt — the shared prompt, then the Arm Variation, then the autonomous-trial directive. The prompt is delivered as an `experiment-trigger` event on the runtime channel, which wakes a hibernated Agent and opens the Trial session ([connections](connections.md#event)). A Trial that fails to launch fails its Arm immediately rather than waiting for the liveness sweep — an Arm that never started can never report or finish.
+
+**Ingestion and attribution.** The harness reports through two outbound MCP tools — one to append a scored Run, one to declare the Arm finished. Neither takes an Experiment or Arm id: the platform resolves the caller's active Arm from the Agent's network-verified identity (the mesh waypoint guarantees the MCP principal matches the pod), so a harness cannot report against an Experiment it isn't running. Both are rejected once the calling Arm is no longer running — the ledger is closed after Stop or completion. The completion tool is success-only: a harness that gives up simply stops and is caught by the liveness sweep.
+
+## Candidate storage
+
+A Candidate is stored inline as a capped blob in Postgres, written and read by the api-server — not on a per-Agent PVC and not in object storage (agents are egress-locked to their gateway, so S3 is unreachable). Living in Postgres is what makes a Candidate **downloadable while the producing Agent is hibernated**: Postgres is independent of agent pods and the api-server, its sole reader and writer, is always running. On a Run, the reporting path reads the candidate file from the Agent's workspace over the harness file API and hands the bytes to the api-server, which stores the blob and points the Run at it. Downloads are owner-scoped — the Run is resolved through the owner's Experiment first, so a non-owned Experiment reads back as not-found and the opaque storage key is never trusted from the client. Substrate details are owned by [persistence](persistence.md).
+
+## Completion and liveness
+
+Per-Arm status is the source of truth for completion. An Arm moves `pending → running` at launch, then to one terminal state: **completed** (the harness declared it finished), **failed** (the Inactivity Deadline tripped, or the Trial failed to launch), or **stopped** (the user Stopped the Experiment while the Arm was still running). An **Experiment becomes completed once every Arm is terminal**, regardless of the mix — the platform reports the comparison, it never judges the whole Experiment failed, so there is no Experiment-level `failed`. Stop is the distinct user-driven terminal path: it moves any still-running Arm to `stopped`.
+
+The **Inactivity Deadline** is the liveness guarantee that lets a started Experiment always reach a terminal state. A background sweep marks a running Arm failed if it records no Run and never declares itself finished within a configured window; the clock resets on each Run. Without it, a harness that crashes, forgets to finish, or hibernates mid-loop would strand its Arm running forever — the one-shot Trial prompt is never re-issued, so a hibernated mid-loop Arm goes quiet permanently. The sweep is safe to run on every api-server replica: each reap is an atomic conditional transition, so a contention race just no-ops on the already-terminal row, and a randomized start offset keeps replicas from scanning in lockstep.
+
+## Where the code lives
+
+- Contract (resources, service interface, MCP tool inputs): [`packages/api-server-api/src/modules/experiments/`](../../packages/api-server-api/src/modules/experiments/)
+- Implementation (service, repository, Trial prompt, launcher, liveness sweep, Candidate serving): [`packages/api-server/src/modules/experiments/`](../../packages/api-server/src/modules/experiments/)
+- Trial-side event handler: [`packages/agent-runtime/src/modules/runtime-channel/`](../../packages/agent-runtime/src/modules/runtime-channel/)
+- UI destination: [`packages/ui/src/modules/experiments/`](../../packages/ui/src/modules/experiments/)

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -1,6 +1,6 @@
 # Persistence
 
-Last verified: 2026-06-26
+Last verified: 2026-07-01
 
 ## Overview
 
@@ -59,7 +59,7 @@ Postgres carries application state the api-server owns end-to-end — anything t
 - **skills catalog** — connected sources, per-Agent install records, and publish history. Owned by [skills](skills.md).
 - **activity log + agent mirror** — append-only event log (`activity_events`), per-sub role flags (`actor_roles`), and the K8s↔Postgres agent ownership mirror (`agents`). Pseudonymized `actor_sub` and `owner_sub` columns at the write boundary. Owned by [usage-tracking](usage-tracking.md).
 - **schedules** — RRULE, quiet hours, task payload, session mode, and firing bookkeeping (`schedules`). The api-server's schedule loop fires them; the controller plays no part. Owned by [agent-lifecycle](agent-lifecycle.md).
-- **experiment candidates** — the downloadable Candidate artifact a Run produced, stored inline as a capped blob (`run_artifacts`). Living here rather than on a per-Agent PVC is what makes a Candidate downloadable while the producing agent is hibernated — Postgres is independent of agent pods, and the api-server (the sole reader/writer) is always running. Owned by Experiments.
+- **experiment candidates** — the downloadable Candidate artifact a Run produced, stored inline as a capped blob (`run_artifacts`). Living here rather than on a per-Agent PVC is what makes a Candidate downloadable while the producing agent is hibernated — Postgres is independent of agent pods, and the api-server (the sole reader/writer) is always running. Owned by [experiments](experiments.md).
 
 The api-server is the sole writer for all of it. The controller does not touch Postgres — its bookkeeping lives on the `status` subresource of the custom resources it owns. The authoritative schema and migrations live in [`packages/db/`](../../packages/db/): migrations run automatically on api-server startup — table/index/enum changes generated from the schema, the reporting views hand-written — with the original history squashed to a baseline that fresh installs run and existing deployments skip, and a no-database guard asserting every schema change was generated (workflow in [`packages/db/README.md`](../../packages/db/README.md)).
 


### PR DESCRIPTION
The experiments subsystem shipped on `feat/experiments` with no architecture page, and left a few existing pages stale. Fixes the drift.

## Changes
- **New page** `docs/architecture/experiments.md` — roles (platform starts arms, captures runs, presents comparison; never runs the loop or interprets a score), the bet (MCP tools expose the interface + Trial prompt carries the contract), resources, Trial-flow diagram, identity-based ingestion, capped-Postgres Candidate storage, per-arm completion + inactivity liveness sweep.
- **Landing page** — added the `experiments` subsystem entry.
- **persistence.md** — linked the "experiment candidates" bullet to the new page.
- **connections.md** — added the `experiment-trigger` event kind to both enumerations.
- **agent-lifecycle.md** — added the experiment-driven wake path (fourth path).
- Bumped `Last verified` on edited pages.

Docs only. Markdown isn't prettier-linted here (prettier is scoped to `src/**/*.ts`).