### PR TITLE
ci: build container images only when their source is stale (shared resolver)

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -94,52 +94,22 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
       - id: d
         env:
+          # PR: reuse from the registry what the merge-base already built.
+          # Everything else (main/tag/schedule/dispatch) rebuilds & republishes all.
           EVENT: ${{ github.event_name }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          if [ "$EVENT" != "pull_request" ]; then
-            echo "platform_base=true" >> "$GITHUB_OUTPUT"
-            echo "platform_base_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-            echo 'agents=["claude-code","codex","pi-agent","bob","k-search"]' >> "$GITHUB_OUTPUT"
-            echo 'archs=["amd64","arm64"]' >> "$GITHUB_OUTPUT"
-            echo "nous=true" >> "$GITHUB_OUTPUT"
-            echo "openevolve=true" >> "$GITHUB_OUTPUT"
-            echo "claude_code_base_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          mb="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
-          echo "::notice::PR merge-base $mb"
-          changed() { ! git diff --quiet "$mb" "$HEAD_SHA" -- "$@"; }
-
-          pb=false
-          changed packages/platform-base packages/agent-runtime \
-                  packages/agent-runtime-api packages/api-server-api \
-                  packages/dev-config scripts/install-pnpm.js \
-                  package.json pnpm-workspace.yaml pnpm-lock.yaml && pb=true
-
-          agents="$(for a in claude-code codex pi-agent bob k-search; do
-            { [ "$pb" = true ] || changed "packages/agents/$a"; } && echo "$a" || true
-          done | jq -R . | jq -cs .)"
-          cc=false; echo "$agents" | jq -e 'index("claude-code")' >/dev/null && cc=true
-
-          nous=false;       { [ "$cc" = true ] || changed packages/agents/nous; }       && nous=true
-          openevolve=false; { [ "$cc" = true ] || changed packages/agents/openevolve; } && openevolve=true
-
-          pb_tag="$mb"; [ "$pb" = true ] && pb_tag="$GITHUB_SHA"
-          cc_tag="$mb"; [ "$cc" = true ] && cc_tag="$GITHUB_SHA"
-
-          echo "platform_base=$pb" >> "$GITHUB_OUTPUT"
-          echo "platform_base_tag=$pb_tag" >> "$GITHUB_OUTPUT"
-          echo "agents=$agents" >> "$GITHUB_OUTPUT"
-          echo 'archs=["amd64"]' >> "$GITHUB_OUTPUT"
-          echo "nous=$nous" >> "$GITHUB_OUTPUT"
-          echo "openevolve=$openevolve" >> "$GITHUB_OUTPUT"
-          echo "claude_code_base_tag=$cc_tag" >> "$GITHUB_OUTPUT"
-          echo "::notice::platform_base=$pb agents=$agents nous=$nous openevolve=$openevolve pb_tag=$pb_tag cc_tag=$cc_tag"
+          [ "$EVENT" = pull_request ] || export RESOLVE_NO_REUSE=1
+          out="$(scripts/resolve-image.sh gha-outputs)"
+          printf '%s\n' "$out" | tee -a "$GITHUB_OUTPUT"
+          printf '::notice::%s\n' "$(printf '%s' "$out" | tr '\n' ' ')"
 
   build-images:
     needs: [check]

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -77,13 +77,77 @@ jobs:
           echo "composite=$composite" >> "$GITHUB_OUTPUT"
           echo "::notice::composite app version: $composite"
 
+  changes:
+    name: detect stale images
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      platform_base: ${{ steps.d.outputs.platform_base }}
+      platform_base_tag: ${{ steps.d.outputs.platform_base_tag }}
+      agents: ${{ steps.d.outputs.agents }}
+      archs: ${{ steps.d.outputs.archs }}
+      nous: ${{ steps.d.outputs.nous }}
+      openevolve: ${{ steps.d.outputs.openevolve }}
+      claude_code_base_tag: ${{ steps.d.outputs.claude_code_base_tag }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - id: d
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" != "pull_request" ]; then
+            echo "platform_base=true" >> "$GITHUB_OUTPUT"
+            echo "platform_base_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            echo 'agents=["claude-code","codex","pi-agent","bob","k-search"]' >> "$GITHUB_OUTPUT"
+            echo 'archs=["amd64","arm64"]' >> "$GITHUB_OUTPUT"
+            echo "nous=true" >> "$GITHUB_OUTPUT"
+            echo "openevolve=true" >> "$GITHUB_OUTPUT"
+            echo "claude_code_base_tag=${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          mb="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"
+          echo "::notice::PR merge-base $mb"
+          changed() { ! git diff --quiet "$mb" "$HEAD_SHA" -- "$@"; }
+
+          pb=false
+          changed packages/platform-base packages/agent-runtime \
+                  packages/agent-runtime-api packages/api-server-api \
+                  packages/dev-config scripts/install-pnpm.js \
+                  package.json pnpm-workspace.yaml pnpm-lock.yaml && pb=true
+
+          agents="$(for a in claude-code codex pi-agent bob k-search; do
+            { [ "$pb" = true ] || changed "packages/agents/$a"; } && echo "$a" || true
+          done | jq -R . | jq -cs .)"
+          cc=false; echo "$agents" | jq -e 'index("claude-code")' >/dev/null && cc=true
+
+          nous=false;       { [ "$cc" = true ] || changed packages/agents/nous; }       && nous=true
+          openevolve=false; { [ "$cc" = true ] || changed packages/agents/openevolve; } && openevolve=true
+
+          pb_tag="$mb"; [ "$pb" = true ] && pb_tag="$GITHUB_SHA"
+          cc_tag="$mb"; [ "$cc" = true ] && cc_tag="$GITHUB_SHA"
+
+          echo "platform_base=$pb" >> "$GITHUB_OUTPUT"
+          echo "platform_base_tag=$pb_tag" >> "$GITHUB_OUTPUT"
+          echo "agents=$agents" >> "$GITHUB_OUTPUT"
+          echo 'archs=["amd64"]' >> "$GITHUB_OUTPUT"
+          echo "nous=$nous" >> "$GITHUB_OUTPUT"
+          echo "openevolve=$openevolve" >> "$GITHUB_OUTPUT"
+          echo "claude_code_base_tag=$cc_tag" >> "$GITHUB_OUTPUT"
+          echo "::notice::platform_base=$pb agents=$agents nous=$nous openevolve=$openevolve pb_tag=$pb_tag cc_tag=$cc_tag"
+
   build-images:
     needs: [check]
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     strategy:
       matrix:
-        component: [controller, api-server, ui, platform-base, keycloak]
+        component: [controller, api-server, ui, keycloak]
         arch: [amd64, arm64]
         include:
           - arch: amd64
@@ -98,9 +162,6 @@ jobs:
             context: .
           - component: ui
             dockerfile: packages/ui/Dockerfile
-            context: .
-          - component: platform-base
-            dockerfile: packages/platform-base/Dockerfile
             context: .
           - component: keycloak
             dockerfile: packages/keycloak-theme/Dockerfile
@@ -148,7 +209,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        component: [controller, api-server, ui, platform-base, keycloak]
+        component: [controller, api-server, ui, keycloak]
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -181,34 +242,14 @@ jobs:
             $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
             $(printf "$IMAGE@sha256:%s " *)
 
-  build-agents:
-    needs: [merge-images]
-    runs-on: ${{ matrix.runner }}
+  build-platform-base:
+    needs: [check, changes]
+    if: ${{ needs.changes.outputs.platform_base == 'true' }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       matrix:
-        component: [claude-code, codex, pi-agent, bob, k-search]
-        arch: [amd64, arm64]
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
-          - component: claude-code
-            dockerfile: packages/agents/claude-code/Dockerfile
-            context: packages/agents/claude-code
-          - component: codex
-            dockerfile: packages/agents/codex/Dockerfile
-            context: packages/agents/codex
-          - component: pi-agent
-            dockerfile: packages/agents/pi-agent/Dockerfile
-            context: packages/agents/pi-agent
-          - component: bob
-            dockerfile: packages/agents/bob/Dockerfile
-            context: packages/agents/bob
-          - component: k-search
-            dockerfile: packages/agents/k-search/Dockerfile
-            context: packages/agents/k-search
+        arch: ${{ fromJSON(needs.changes.outputs.archs) }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -222,12 +263,91 @@ jobs:
       - id: build
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
+          context: .
+          file: packages/platform-base/Dockerfile
+          platforms: linux/${{ matrix.arch }}
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/platform-base,push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=platform-base-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=platform-base-${{ matrix.arch }}
+      - name: Export digest
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${DIGEST#sha256:}"
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: digests-platform-base-${{ matrix.arch }}
+          path: /tmp/digests/*
+          retention-days: 1
+          if-no-files-found: error
+
+  merge-platform-base:
+    name: merge multi-arch platform-base manifest
+    needs: [build-platform-base, appversion, changes]
+    if: ${{ needs.changes.outputs.platform_base == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: digests-platform-base-*
+          path: /tmp/digests
+          merge-multiple: true
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ${{ env.IMAGE_PREFIX }}/platform-base
+          tags: |
+            type=sha,prefix=,format=long
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=${{ needs.appversion.outputs.composite }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+      - name: Create manifest list and push
+        env:
+          IMAGE: ${{ env.IMAGE_PREFIX }}/platform-base
+        run: |
+          set -euo pipefail
+          cd /tmp/digests
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf "$IMAGE@sha256:%s " *)
+
+  build-agents:
+    needs: [merge-platform-base, changes]
+    if: ${{ needs.changes.outputs.agents != '[]' && !cancelled() && !failure() }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        component: ${{ fromJSON(needs.changes.outputs.agents) }}
+        arch: ${{ fromJSON(needs.changes.outputs.archs) }}
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+      - id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: packages/agents/${{ matrix.component }}
+          file: packages/agents/${{ matrix.component }}/Dockerfile
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ github.sha }}
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
           cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.arch }}
       - name: Export digest
@@ -245,12 +365,13 @@ jobs:
 
   merge-agents:
     name: merge multi-arch agent manifests
-    needs: [build-agents, appversion]
+    needs: [build-agents, appversion, changes]
+    if: ${{ needs.changes.outputs.agents != '[]' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
       matrix:
-        component: [claude-code, codex, pi-agent, bob, k-search]
+        component: ${{ fromJSON(needs.changes.outputs.agents) }}
     steps:
       - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
@@ -284,19 +405,13 @@ jobs:
             $(printf "$IMAGE@sha256:%s " *)
 
   build-nous:
-    # nous builds FROM claude-code (not platform-base), so it runs after the
-    # agent manifests are merged and pulls its base by the same per-commit tag.
-    needs: [merge-agents]
-    runs-on: ${{ matrix.runner }}
+    needs: [merge-agents, changes]
+    if: ${{ needs.changes.outputs.nous == 'true' && !cancelled() && !failure() }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       matrix:
-        arch: [amd64, arm64]
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
+        arch: ${{ fromJSON(needs.changes.outputs.archs) }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -315,7 +430,7 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/nous,push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ github.sha }}
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ needs.changes.outputs.claude_code_base_tag }}
           cache-from: type=gha,scope=nous-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=nous-${{ matrix.arch }}
       - name: Export digest
@@ -333,7 +448,8 @@ jobs:
 
   merge-nous:
     name: merge multi-arch nous manifest
-    needs: [build-nous, appversion]
+    needs: [build-nous, appversion, changes]
+    if: ${{ needs.changes.outputs.nous == 'true' && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -369,19 +485,13 @@ jobs:
             $(printf "$IMAGE@sha256:%s " *)
 
   build-openevolve:
-    # openevolve builds FROM claude-code (not platform-base), so it runs after
-    # the agent manifests are merged and pulls its base by the same per-commit tag.
-    needs: [merge-agents]
-    runs-on: ${{ matrix.runner }}
+    needs: [merge-agents, changes]
+    if: ${{ needs.changes.outputs.openevolve == 'true' && !cancelled() && !failure() }}
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       matrix:
-        arch: [amd64, arm64]
-        include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
+        arch: ${{ fromJSON(needs.changes.outputs.archs) }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -400,7 +510,7 @@ jobs:
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/openevolve,push-by-digest=true,name-canonical=true,push=true
           build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ github.sha }}
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ needs.changes.outputs.claude_code_base_tag }}
           cache-from: type=gha,scope=openevolve-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=openevolve-${{ matrix.arch }}
       - name: Export digest
@@ -418,7 +528,8 @@ jobs:
 
   merge-openevolve:
     name: merge multi-arch openevolve manifest
-    needs: [build-openevolve, appversion]
+    needs: [build-openevolve, appversion, changes]
+    if: ${{ needs.changes.outputs.openevolve == 'true' && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -455,8 +566,8 @@ jobs:
 
   build-mock:
     name: build mock (e2e fixture)
-    needs: [merge-images]
-    if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/v')
+    needs: [merge-platform-base, changes]
+    if: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/v') && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -477,13 +588,13 @@ jobs:
           push: true
           tags: ${{ env.IMAGE_PREFIX }}/mock:${{ github.sha }}
           build-args: |
-            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ github.sha }}
+            BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
           cache-from: type=gha,scope=mock
           cache-to: type=gha,mode=max,scope=mock
 
   e2e:
     name: mise e2e
-    needs: [merge-images, merge-agents, build-mock]
+    needs: [merge-images, build-mock]
     if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -507,7 +618,7 @@ jobs:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          for c in controller api-server ui keycloak claude-code codex pi-agent bob mock; do
+          for c in controller api-server ui keycloak mock; do
             docker pull "$IMAGE_PREFIX/$c:$SHA"
             docker tag "$IMAGE_PREFIX/$c:$SHA" "platform-$c:latest"
           done
@@ -785,7 +896,15 @@ jobs:
 
   container-scan:
     name: mise run ${{ matrix.task }}
-    needs: [trivy-tasks, merge-images, merge-agents, merge-nous, merge-openevolve]
+    needs:
+      [
+        trivy-tasks,
+        merge-images,
+        merge-platform-base,
+        merge-agents,
+        merge-nous,
+        merge-openevolve,
+      ]
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:

--- a/packages/agents/bob/tasks.toml
+++ b/packages/agents/bob/tasks.toml
@@ -1,12 +1,8 @@
 ["agents:bob:image"]
-description = "Build the bob agent image"
+description = "Build the bob agent image, or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["platform-base:image"]
-run = '''
-#!/usr/bin/env bash
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
-docker build -t platform-bob:latest packages/agents/bob
-'''
+run = "scripts/resolve-image.sh build-or-reuse bob -- packages/agents/bob"
 
 ["agents:bob:scan"]
 depends = ["agents:bob:scan:*"]

--- a/packages/agents/claude-code/tasks.toml
+++ b/packages/agents/claude-code/tasks.toml
@@ -1,12 +1,8 @@
 ["agents:claude-code:image"]
-description = "Build the claude-code agent image"
+description = "Build the claude-code agent image, or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["platform-base:image"]
-run = '''
-#!/usr/bin/env bash
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
-docker build -t platform-claude-code:latest packages/agents/claude-code
-'''
+run = "scripts/resolve-image.sh build-or-reuse claude-code -- packages/agents/claude-code"
 
 ["agents:claude-code:scan"]
 depends = ["agents:claude-code:scan:*"]

--- a/packages/agents/codex/tasks.toml
+++ b/packages/agents/codex/tasks.toml
@@ -1,12 +1,8 @@
 ["agents:codex:image"]
-description = "Build the codex agent image"
+description = "Build the codex agent image, or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["platform-base:image"]
-run = '''
-#!/usr/bin/env bash
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
-docker build -t platform-codex:latest packages/agents/codex
-'''
+run = "scripts/resolve-image.sh build-or-reuse codex -- packages/agents/codex"
 
 ["agents:codex:scan"]
 depends = ["agents:codex:scan:*"]

--- a/packages/agents/k-search/tasks.toml
+++ b/packages/agents/k-search/tasks.toml
@@ -1,12 +1,8 @@
 ["agents:k-search:image"]
-description = "Build the k-search workload image"
+description = "Build the k-search workload image, or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["platform-base:image"]
-run = '''
-#!/usr/bin/env bash
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
-docker build -t platform-k-search:latest packages/agents/k-search
-'''
+run = "scripts/resolve-image.sh build-or-reuse k-search -- packages/agents/k-search"
 
 ["agents:k-search:scan"]
 depends = ["agents:k-search:scan:*"]

--- a/packages/agents/nous/tasks.toml
+++ b/packages/agents/nous/tasks.toml
@@ -1,11 +1,10 @@
 ["agents:nous:image"]
-description = "Build the nous agent image (Nous orchestrator on the claude-code base)"
+description = "Build the nous agent image (Nous orchestrator on the claude-code base), or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["agents:claude-code:image"]
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
 
 # Nous installs from its public GitHub repo at build time (no vendoring). The
 # Dockerfile pins a default release; override it here with NOUS_REF=<tag|branch|sha>.
@@ -13,7 +12,7 @@ build_args=()
 [ -n "${NOUS_REF:-}" ] && build_args+=(--build-arg "NOUS_REF=${NOUS_REF}")
 
 # ${build_args[@]+...} guards the empty-array expansion under `set -u` (bash 3.2 on macOS).
-docker build ${build_args[@]+"${build_args[@]}"} -t platform-nous:latest packages/agents/nous
+exec scripts/resolve-image.sh build-or-reuse nous -- ${build_args[@]+"${build_args[@]}"} packages/agents/nous
 '''
 
 ["agents:nous:sync-commands"]

--- a/packages/agents/openevolve/tasks.toml
+++ b/packages/agents/openevolve/tasks.toml
@@ -1,11 +1,10 @@
 ["agents:openevolve:image"]
-description = "Build the openevolve agent image (OpenEvolve on the claude-code base)"
+description = "Build the openevolve agent image (OpenEvolve on the claude-code base), or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["agents:claude-code:image"]
 run = '''
 #!/usr/bin/env bash
 set -euo pipefail
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
 
 # OpenEvolve installs from PyPI at build time. The Dockerfile pins a default
 # version; override it here with OPENEVOLVE_VERSION=<version>.
@@ -13,7 +12,7 @@ build_args=()
 [ -n "${OPENEVOLVE_VERSION:-}" ] && build_args+=(--build-arg "OPENEVOLVE_VERSION=${OPENEVOLVE_VERSION}")
 
 # ${build_args[@]+...} guards the empty-array expansion under `set -u` (bash 3.2 on macOS).
-docker build ${build_args[@]+"${build_args[@]}"} -t platform-openevolve:latest packages/agents/openevolve
+exec scripts/resolve-image.sh build-or-reuse openevolve -- ${build_args[@]+"${build_args[@]}"} packages/agents/openevolve
 '''
 
 ["agents:openevolve:scan"]

--- a/packages/agents/pi-agent/tasks.toml
+++ b/packages/agents/pi-agent/tasks.toml
@@ -1,12 +1,8 @@
 ["agents:pi-agent:image"]
-description = "Build the pi-agent agent image"
+description = "Build the pi-agent agent image, or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
 depends = ["platform-base:image"]
-run = '''
-#!/usr/bin/env bash
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
-docker build -t platform-pi-agent:latest packages/agents/pi-agent
-'''
+run = "scripts/resolve-image.sh build-or-reuse pi-agent -- packages/agents/pi-agent"
 
 ["agents:pi-agent:scan"]
 depends = ["agents:pi-agent:scan:*"]

--- a/packages/platform-base/tasks.toml
+++ b/packages/platform-base/tasks.toml
@@ -1,11 +1,7 @@
 ["platform-base:image"]
-description = "Build the platform-base image (shared base layer for every agent image)"
+description = "Build the platform-base image (shared base layer for every agent image), or reuse it from the registry when its source is unchanged"
 dir = "{{config_root}}"
-run = '''
-#!/usr/bin/env bash
-[ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
-docker build -f packages/platform-base/Dockerfile -t platform-base .
-'''
+run = "scripts/resolve-image.sh build-or-reuse platform-base -- -f packages/platform-base/Dockerfile ."
 
 ["platform-base:scan"]
 depends = ["platform-base:scan:*"]

--- a/scripts/resolve-image.sh
+++ b/scripts/resolve-image.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# Decide whether a container image must be built or can be reused from the
+# registry. Single source of truth shared by the local `*:image` mise tasks and
+# CI (the `changes` job) so the dependency graph and skip logic never drift.
+#
+# An image is REUSABLE when its effective source (its own paths PLUS its base's,
+# transitively) has no uncommitted changes AND the registry already has it at the
+# commit that last touched that source. The transitive path union is what makes a
+# base change propagate to its children automatically (a stale base ⇒ the child's
+# last-touching commit moves ⇒ its reuse tag moves too), and the registry check is
+# self-correcting: a missing image (never built, build failed, off-main branch)
+# just falls back to BUILD.
+#
+# Usage:
+#   resolve-image.sh resolve <component>        -> "BUILD" | "REUSE <full-ref>"
+#   resolve-image.sh build-or-reuse <c> -- ...  -> pull+tag locally, or `docker build ... -t <local-tag>`
+#   resolve-image.sh gha-outputs                -> key=value lines for $GITHUB_OUTPUT (all components)
+#   resolve-image.sh paths <component>          -> effective source paths (debug)
+#   resolve-image.sh --self-check               -> run assertions (no docker/git/network)
+#
+# Env: IMAGE_PREFIX (default quay.io/dam-agents), GITHUB_SHA, EVENT (gha-outputs
+# archs), RESOLVE_NO_REUSE=1 forces BUILD everywhere (CI main/tag: publish all).
+# Written for bash 3.2 (macOS) — no associative arrays.
+set -euo pipefail
+
+IMAGE_PREFIX="${IMAGE_PREFIX:-quay.io/dam-agents}"
+
+# platform-base's build context is the repo root but it only COPYs these paths;
+# keep in sync with packages/platform-base/Dockerfile.
+PLATFORM_BASE_PATHS="packages/platform-base packages/agent-runtime packages/agent-runtime-api packages/api-server-api packages/dev-config scripts/install-pnpm.js package.json pnpm-workspace.yaml pnpm-lock.yaml"
+
+own_paths() {
+  case "$1" in
+    platform-base) echo "$PLATFORM_BASE_PATHS" ;;
+    claude-code|codex|pi-agent|bob|k-search|nous|openevolve) echo "packages/agents/$1" ;;
+    mock) echo "packages/e2e/agents/mock" ;;
+    *) echo "unknown component: $1" >&2; return 1 ;;
+  esac
+}
+
+base_of() {
+  case "$1" in
+    platform-base) echo "" ;;
+    claude-code|codex|pi-agent|bob|k-search|mock) echo "platform-base" ;;
+    nous|openevolve) echo "claude-code" ;;
+    *) echo "unknown component: $1" >&2; return 1 ;;
+  esac
+}
+
+# Local docker tag the *:image tasks build/pull to (mirrors values-local.yaml).
+local_tag() { case "$1" in platform-base) echo "platform-base" ;; *) echo "platform-$1:latest" ;; esac; }
+
+effective_paths() {
+  local base; base="$(base_of "$1")"
+  if [ -n "$base" ]; then echo "$(own_paths "$1") $(effective_paths "$base")"; else own_paths "$1"; fi
+}
+
+registry_has() { docker manifest inspect "$1" >/dev/null 2>&1 || docker buildx imagetools inspect "$1" >/dev/null 2>&1; }
+
+resolve() {
+  local comp="$1" paths sha ref
+  [ -n "${RESOLVE_NO_REUSE:-}" ] && { echo BUILD; return; }
+  paths="$(effective_paths "$comp")"
+  # Uncommitted change (or untracked file) in the effective source ⇒ must build.
+  [ -n "$(git status --porcelain -- $paths 2>/dev/null)" ] && { echo BUILD; return; }
+  sha="$(git log -1 --format=%H -- $paths 2>/dev/null || true)"
+  [ -z "$sha" ] && { echo BUILD; return; }
+  ref="${IMAGE_PREFIX}/${comp}:${sha}"
+  if registry_has "$ref"; then echo "REUSE $ref"; else echo BUILD; fi
+}
+
+build_or_reuse() {
+  local comp="$1"; shift
+  [ "${1:-}" = "--" ] && shift
+  [ -n "${SKIP_IMAGE_BUILD:-}" ] && exit 0
+  local decision ref lt; lt="$(local_tag "$comp")"
+  decision="$(resolve "$comp")"
+  if [ "${decision%% *}" = REUSE ]; then
+    ref="${decision#REUSE }"
+    echo "↺ reuse $ref -> $lt"
+    if docker pull "$ref" && docker tag "$ref" "$lt"; then return 0; fi
+    echo "  pull failed, building instead" >&2
+  fi
+  echo "⚒ build $lt"
+  docker build -t "$lt" "$@"
+}
+
+# tag portion to hand children as BASE_IMAGE / to publish under this run's sha
+tag_for() {
+  local d; d="$(resolve "$1")"
+  if [ "${d%% *}" = REUSE ]; then local r="${d#REUSE }"; echo "${r##*:}"; else echo "${GITHUB_SHA:?GITHUB_SHA required}"; fi
+}
+
+gha_outputs() {
+  local archs pb pb_tag built a agents_json cc_tag nous oe
+  archs='["amd64","arm64"]'; [ "${EVENT:-}" = pull_request ] && archs='["amd64"]'
+  if [ "$(resolve platform-base | cut -d' ' -f1)" = REUSE ]; then pb=false; else pb=true; fi
+  pb_tag="$(tag_for platform-base)"
+  built=()
+  for a in claude-code codex pi-agent bob k-search; do
+    [ "$(resolve "$a" | cut -d' ' -f1)" = BUILD ] && built+=("$a")
+  done
+  agents_json="$(printf '%s\n' "${built[@]:-}" | jq -R . | jq -cs 'map(select(length>0))')"
+  cc_tag="$(tag_for claude-code)"
+  nous=false; [ "$(resolve nous | cut -d' ' -f1)" = BUILD ] && nous=true
+  oe=false;   [ "$(resolve openevolve | cut -d' ' -f1)" = BUILD ] && oe=true
+  printf 'platform_base=%s\nplatform_base_tag=%s\nagents=%s\narchs=%s\nnous=%s\nopenevolve=%s\nclaude_code_base_tag=%s\n' \
+    "$pb" "$pb_tag" "$agents_json" "$archs" "$nous" "$oe" "$cc_tag"
+}
+
+self_check() {
+  local f=0
+  chk() { if [ "$1" != "$2" ]; then echo "FAIL: expected [$2] got [$1]" >&2; f=1; fi; }
+  has() { case "$1" in *"$2"*) ;; *) echo "FAIL: [$1] missing [$2]" >&2; f=1 ;; esac; }
+  chk "$(base_of nous)" claude-code
+  chk "$(base_of claude-code)" platform-base
+  chk "$(base_of platform-base)" ""
+  chk "$(local_tag platform-base)" platform-base
+  chk "$(local_tag bob)" "platform-bob:latest"
+  has "$(effective_paths nous)" packages/platform-base
+  has "$(effective_paths nous)" packages/agents/claude-code
+  has "$(effective_paths nous)" packages/agents/nous
+  # NO_REUSE reproduces the full-build (main/tag) output without git/docker.
+  local out; out="$(EVENT=push GITHUB_SHA=deadbeef RESOLVE_NO_REUSE=1; export EVENT GITHUB_SHA RESOLVE_NO_REUSE; gha_outputs)"
+  has "$out" 'platform_base=true'
+  has "$out" 'agents=["claude-code","codex","pi-agent","bob","k-search"]'
+  has "$out" 'archs=["amd64","arm64"]'
+  has "$out" 'claude_code_base_tag=deadbeef'
+  [ "$f" = 0 ] && echo "self-check OK" || exit 1
+}
+
+case "${1:-}" in
+  resolve)        resolve "$2" ;;
+  build-or-reuse) shift; build_or_reuse "$@" ;;
+  gha-outputs)    gha_outputs ;;
+  paths)          effective_paths "$2" ;;
+  --self-check)   self_check ;;
+  *) echo "usage: resolve-image.sh {resolve|build-or-reuse|gha-outputs|paths|--self-check}" >&2; exit 2 ;;
+esac

--- a/tasks.toml
+++ b/tasks.toml
@@ -382,6 +382,12 @@ description = "Static security analysis for GitHub Actions workflows"
 dir = "{{config_root}}"
 run = "zizmor --min-confidence medium .github/workflows/"
 
+["common:check:resolve-image"]
+description = "Assert the image dependency graph in scripts/resolve-image.sh (build-vs-reuse logic)"
+dir = "{{config_root}}"
+sources = ["scripts/resolve-image.sh"]
+run = "scripts/resolve-image.sh --self-check"
+
 ["common:check:lockfile-age"]
 description = "Verify no lockfile dependency is newer than 7 days"
 dir = "{{config_root}}"


### PR DESCRIPTION
## Goal

Faster CI on PRs (and faster local `cluster:install`/`e2e:loop`) by building a container image only when its source actually changed — reusing the registry copy otherwise.

## Approach: one shared resolver

`scripts/resolve-image.sh` is the single source of truth for the image dependency graph and the build-vs-reuse decision, used identically by CI and the local `*:image` mise tasks (so they can't drift).

An image is **REUSABLE** when:
1. its **effective** source is clean — its own paths **plus its base's, transitively** (`platform-base` → agents/mock; `claude-code` → nous/openevolve), and
2. the registry already has it at the commit that **last touched** that effective source.

Two properties fall out of this for free:
- **Base propagation:** because a child's effective paths include its base's, a `platform-base` change moves every child's last-touching commit → every child rebuilds. No explicit "base changed ⇒ rebuild children" logic.
- **Self-correcting:** a missing image (never built, failed build, off-main branch) just falls back to BUILD. No merge-base arithmetic.

## What changed

- **`scripts/resolve-image.sh`** — `resolve` / `build-or-reuse` / `gha-outputs`, plus a dependency-free `--self-check` wired into `common:check`.
- **Local `:image` tasks** (`platform-base` + all 7 agents) now pull-and-tag when their source is unchanged instead of rebuilding — a real inner-loop speedup — and each collapses to a one-line call.
- **CI `changes` job** delegates to `resolve-image.sh gha-outputs`; the ~40 lines of inline merge-base logic are gone. PRs reuse from the registry; **main/tag/schedule rebuild & republish everything** (`RESOLVE_NO_REUSE`) so every release keeps a full set of image tags.
- **JIT-pull for bases:** children pass the resolved base ref as `BASE_IMAGE`, so a reused base is only fetched when a child actually builds.
- E2E stays decoupled from the agent pipeline (mock-only), as before.

## Verification

- `resolve-image.sh --self-check` (asserts the DAG + the full-build output) passes as a mise task.
- Live check against `main`: every image resolves to `REUSE quay.io/dam-agents/<c>:<mainsha>` — a CI-config-only PR builds **zero** images. Editing a source dir flips that image (and its descendants) to BUILD.

## Ceilings

- Source paths are per-image directories — an over-approximation (e.g. editing a `tasks.toml` under `packages/agents/<c>` triggers a rebuild of that image). Safe by design: it never reuses a stale image, only occasionally rebuilds an unchanged one.
- `platform-base`'s path list must track its Dockerfile `COPY`s (repo-root context); flagged in the script.
- `controller`/`api-server`/`ui`/`keycloak` remain always-built (deployed in E2E; repo-root contexts make enumeration painful) — a future extension could bring them under the resolver too.