### PR TITLE
fix(nous): address the bound chat explicitly in the channel bridge

### DIFF
--- a/packages/agents/nous/nous-channel-bridge.py
+++ b/packages/agents/nous/nous-channel-bridge.py
@@ -19,7 +19,7 @@ webhook — so no external egress and no webhook secret on disk.
 Why this works in the pod (all verified against a live agent):
   * Auth is mesh-based — a process inside the agent pod inherits the pod's
     mesh identity, which the api-server waypoint accepts for
-    ``/api/agents/<id>/mcp`` (ADR-041). No token needed.
+    ``/api/agents/<id>/mcp``. No token needed.
   * The MCP endpoint URL is injected as ``PLATFORM_MCP_URL``.
   * The MCP call must traverse the egress gateway (the pod's NetworkPolicy
     routes all egress through it); urllib's default opener honors ``HTTP_PROXY``
@@ -86,6 +86,41 @@ def _mcp_post(payload: dict, session_id: str | None):
         return resp.headers, _first_jsonrpc(body, resp.headers.get("Content-Type", ""))
 
 
+def _resolve_chat_id(channel: str, session_id: str | None) -> str | None:
+    """Resolve the bound chat for ``channel`` via ``describe_channel``.
+
+    Nous's webhook wiring is just ``?channel=<slack|telegram>`` with no chatId, so
+    without this the tool falls back to the *last-active* thread — and Telegram
+    rejects the send outright when no thread is currently active ("no active
+    Telegram thread"), silently dropping every gate summary on a fresh campaign.
+    ``describe_channel`` returns the authorized chats; we address the first one
+    explicitly so delivery never depends on a live thread. An explicit
+    ``?chatId=`` in the webhook URL still wins — this runs only when none is given.
+    """
+    _, parsed = _mcp_post(
+        {
+            "jsonrpc": "2.0",
+            "id": 2,
+            "method": "tools/call",
+            "params": {"name": "describe_channel", "arguments": {"channel": channel}},
+        },
+        session_id,
+    )
+    result = (parsed or {}).get("result", {})
+    if result.get("isError"):  # channel not bound / not available
+        return None
+    for item in result.get("content", []):
+        if item.get("type") != "text":
+            continue
+        try:
+            chats = json.loads(item.get("text", "") or "{}").get("chats")
+        except json.JSONDecodeError:
+            continue
+        if isinstance(chats, list) and chats:
+            return chats[0].get("id")
+    return None
+
+
 def send_channel_message(channel: str, text: str, chat_id: str | None) -> None:
     """Run the MCP handshake and call send_channel_message."""
     if not MCP_URL:
@@ -107,14 +142,19 @@ def send_channel_message(channel: str, text: str, chat_id: str | None) -> None:
     sid = headers.get("mcp-session-id")
     # 2. initialized notification (the transport expects it before tool calls).
     _mcp_post({"jsonrpc": "2.0", "method": "notifications/initialized"}, sid)
-    # 3. the actual tool call.
+    # 3. Address the bound chat explicitly. Without a chatId the tool targets the
+    #    last-active thread, which Telegram rejects when none is active — so
+    #    resolve it from describe_channel unless the webhook URL pinned one.
+    if not chat_id:
+        chat_id = _resolve_chat_id(channel, sid)
+    # 4. the actual tool call.
     args: dict = {"channel": channel, "text": text}
     if chat_id:
         args["chatId"] = chat_id
     _, parsed = _mcp_post(
         {
             "jsonrpc": "2.0",
-            "id": 2,
+            "id": 3,
             "method": "tools/call",
             "params": {"name": "send_channel_message", "arguments": args},
         },


### PR DESCRIPTION
Closes #2217.

## Problem

Nous campaigns never delivered their DESIGN/FINDINGS gate summaries into a bound Slack/Telegram thread. The summary is generated fine; only the final relay hop failed — silently, every time (delivery is best-effort).

## Root cause (confirmed against a live agent)

The bridge called `send_channel_message` **without a `chatId`**, because Nous's webhook wiring is just `?channel=<slack|telegram>` (no chat id). With no `chatId`, the tool targets the *last-active* thread — and Telegram rejects that outright when no thread is currently active (`isError: "no active Telegram thread"`), which is the normal state on a fresh campaign. So every summary was dropped.

Reproduced in-cluster against a live agent with a bound Telegram channel:

| Call | Result |
|---|---|
| `send_channel_message` (no chatId) | ❌ `isError: "no active Telegram thread; pass conversationId…"` |
| `describe_channel` (telegram) | ✅ `chats: [{ id: "telegram:1203195890", … }]` |
| `send_channel_message` (chatId = that id) | ✅ `"Message sent"` |

### Note on the first commit (reverted)

My initial hypothesis was a transport mismatch — that `urllib`'s absolute-URI proxying hit a different, broken gateway route than the harness's Node CONNECT tunnel. An in-cluster A/B probe **disproved** it: both `curl -x $HTTP_PROXY` (absolute-URI) and `curl -x $HTTP_PROXY --proxytunnel` (CONNECT) return `200` from the harness MCP. The transport change was reverted; this PR is only the `chatId` fix.

## Fix

When the webhook supplies no `chatId`, resolve the bound chat from `describe_channel` and pass it explicitly. An explicit `?chatId=` in the webhook URL still wins. Pure stdlib, in-image; no gateway or campaign-config change.

## Testing

- `python -m py_compile` clean; a mock-MCP unit check confirms no-chatId sends resolve to the bound chat and explicit `?chatId=` is preserved.
- **End-to-end, live cluster:** copied the fixed bridge into a running agent pod with a bound Telegram channel and no active thread; `send_channel_message("telegram", …, None)` resolved `telegram:1203195890` via `describe_channel` and delivered without error. Verified the resolver returns the explicit id (not a coincidental active-thread success).