### PR TITLE
ci: never cancel main/tag/schedule runs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -14,7 +14,10 @@ permissions:
 
 concurrency:
   group: ci-${{ github.event_name }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Only supersede PR runs. main/tag/schedule runs must finish: they publish the
+  # per-commit images (and Helm chart) that releases and the build-vs-reuse
+  # resolver depend on — a cancelled main run leaves that commit without images.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
   IMAGE_PREFIX: quay.io/dam-agents


### PR DESCRIPTION
## Problem

`concurrency.cancel-in-progress: true` applied to **every** event. On `main` the concurrency group is `ci-push-refs/heads/main`, so a new merge cancels the previous commit's in-flight run. With fast-merging main this cancels runs before they publish, e.g. today:

```
completed/cancelled  c49883bf   (superseded)
completed/cancelled  3ab5de53   (superseded)
completed/cancelled  60b15bac   (superseded)
```

A cancelled main run leaves that commit with **no per-commit images and no Helm chart**. Two consequences:

1. **Release integrity** — the commit's images/chart are never published.
2. **Build-vs-reuse resolver** — PRs reuse `<image>:<merge-base-sha>`; if the merge-base commit's run was cancelled, those images don't exist, so every PR falls back to a full rebuild (safe, but defeats the optimization).

## Fix

Scope cancellation to PR runs only:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

- **PRs**: pushing a new commit still cancels the stale run (saves CI). Unchanged.
- **main / tags / schedule**: runs always finish and publish. Concurrent main runs are safe — each publishes its own unique per-commit / `-dev-<sha>` tags (no shared mutable tag except the pre-existing floating `0.0.0-main` chart, last-writer-wins as before).