### PR TITLE
test: demo — resolver rebuild scope for a claude-code change

### DIFF
--- a/packages/agents/claude-code/model-gateway.sh
+++ b/packages/agents/claude-code/model-gateway.sh
@@ -1,3 +1,4 @@
+# resolver rebuild demo — harmless no-op change (remove before merge)
 _GATEWAY_BASE="http://127.0.0.1:24180"
 
 _gateway_custom_upstream() {


### PR DESCRIPTION
**Throwaway demo — do not merge.** A one-line no-op comment in `claude-code`'s `model-gateway.sh` to observe what the resolver rebuilds.

Local resolution against healthy main (`b62d21c2`):

| image | decision |
|---|---|
| claude-code | **BUILD** (changed) |
| nous | **BUILD** (FROM claude-code) |
| openevolve | **BUILD** (FROM claude-code) |
| platform-base | REUSE `…:61dab10` |
| codex | REUSE `…:61dab10` |
| pi-agent | REUSE `…:61dab10` |
| bob | REUSE `…:61dab10` |
| k-search | REUSE `…:61dab10` |

Expected CI: `build-agents` runs only for `claude-code` (amd64), plus `build-nous`/`build-openevolve`; `build-platform-base` skipped; the other agents skipped. `build-images` (controller/api-server/ui/keycloak) + mock build as always.