### PR TITLE
fix(ci): don't skip merge-agents when platform-base is reused

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -339,7 +339,11 @@ jobs:
   merge-agents:
     name: merge multi-arch agent manifests
     needs: [build-agents, appversion, changes]
-    if: ${{ needs.changes.outputs.agents != '[]' }}
+    # !cancelled() && !failure() so this still runs when merge-platform-base was
+    # skipped (platform-base reused) — build-agents runs via the same guard, and
+    # without it here GitHub's implicit success() gate skips this merge (leaving
+    # claude-code untagged, which breaks build-nous/build-openevolve).
+    if: ${{ needs.changes.outputs.agents != '[]' && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:


### PR DESCRIPTION
## Bug

On a PR that changes an agent but **reuses `platform-base`** (found via the resolver-reuse demo, PR #2309, changing only `claude-code`):

- `build-agents (claude-code)` ✅ built
- `merge multi-arch agent manifests` (**`merge-agents`**) ⏭️ **skipped**
- `build-nous`, `build-openevolve` ❌ **failed** — `quay.io/dam-agents/claude-code:<sha>: not found`

`build-nous`/`build-openevolve` are FROM `claude-code:<github.sha>`, a tag that `merge-agents` is responsible for creating. With `merge-agents` skipped, the tag never exists → they fail.

## Root cause

`merge-agents` had `if: ${{ needs.changes.outputs.agents != '[]' }}` — **no status-check function**. When `platform-base` is reused, `merge-platform-base` is skipped; `build-agents` still runs (its `if` includes `!cancelled() && !failure()`), but GitHub's implicit `success()` gate then **skips** `merge-agents` because a skipped job (`merge-platform-base`) sits in its dependency chain.

It didn't surface in #2216 because that PR *built* `platform-base`, so nothing upstream was skipped.

## Fix

```yaml
if: ${{ needs.changes.outputs.agents != '[]' && !cancelled() && !failure() }}
```

Matches the guard already on `build-agents`, `build-nous`, `build-openevolve`, `merge-nous`, `merge-openevolve`. `merge-agents` still skips on a genuine `build-agents` failure (`!failure()`), and still doesn't run when no agents changed (`agents != '[]'`).

`push`/tag/schedule builds are unaffected — they build `platform-base` (`RESOLVE_NO_REUSE`), so `merge-platform-base` runs and nothing upstream is skipped.

## Verification

Once merged, re-running the #2309 demo should show `merge-agents` running and `build-nous`/`build-openevolve` succeeding on the reused `claude-code:<sha>`.