### PR TITLE
fix(claude-code): DDG WebSearch/WebFetch fallback on non-Anthropic backends (#1087)

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -658,6 +658,10 @@ apiServer:
     - cdn.mise.run
     # Bob Shell (IBM)
     - api.us-east.bob.ibm.com
+    # DuckDuckGo — backend for the claude-code harness's `websearch` skill, the
+    # replacement for the built-in WebSearch tool on non-Anthropic backends
+    # (#1087). `lite.duckduckgo.com` is the only host the bundle contacts.
+    - lite.duckduckgo.com
 
   # -- Optional platform-wide defaults for OAuth app credentials. When a field
   # is set the connect form for the matching app collapses the corresponding

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -27,12 +27,12 @@ COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 # deny the built-ins and the seeded skills (.agents/skills/{websearch,webfetch})
 # invoke these self-contained esbuild bundles instead, which need only `node`.
 # Pinned to a commit SHA and checksum-verified.
-ARG CC_WEBSEARCH_REF=02d4993492ed0a957e7908bfff61fef245d36583
+ARG CC_WEBSEARCH_REF=c10add64e36e98259a31fe097e72ff9085e68dee
 RUN mkdir -p /opt/cc-websearch &&\
     base="https://raw.githubusercontent.com/Djarvur/cc-websearch/${CC_WEBSEARCH_REF}/skills" &&\
     curl -fsSL "$base/websearch/scripts/websearch.cjs" -o /opt/cc-websearch/websearch.cjs &&\
     curl -fsSL "$base/webfetch/scripts/webfetch.cjs" -o /opt/cc-websearch/webfetch.cjs &&\
-    node -e 'const c=require("crypto"),f=require("fs"),d="/opt/cc-websearch/";const want={"websearch.cjs":"3f3054ab1ec65f301152e0567b6415b8c92264a2fb94e9e7d95685911cde058e","webfetch.cjs":"56cc2e9c23e594308ae010e185211313f637f38d633cdcbdd7b2c5e565355054"};for(const[n,h]of Object.entries(want)){const g=c.createHash("sha256").update(f.readFileSync(d+n)).digest("hex");if(g!==h){console.error(`cc-websearch: checksum mismatch for ${n}: got ${g} want ${h}`);process.exit(1);}}console.log("cc-websearch bundles verified");'
+    node -e 'const c=require("crypto"),f=require("fs"),d="/opt/cc-websearch/";const want={"websearch.cjs":"7a5e95cb865f905879635ddaa2de564c4e9bc3a8c14d5125595917a670fef90a","webfetch.cjs":"81be0f6666237bbd46de9cfbbe3d3f4b4296f777e28cc552c9f6de003708f297"};for(const[n,h]of Object.entries(want)){const g=c.createHash("sha256").update(f.readFileSync(d+n)).digest("hex");if(g!==h){console.error(`cc-websearch: checksum mismatch for ${n}: got ${g} want ${h}`);process.exit(1);}}console.log("cc-websearch bundles verified");'
 COPY --chmod=0755 deny-web-tool.sh /opt/cc-websearch/deny-web-tool.sh
 
 # managed-settings.json carries the WebSearch/WebFetch deny hooks (above); keep

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -19,11 +19,28 @@ COPY model-gateway-login.sh /etc/profile.d/model-gateway.sh
 COPY --chmod=0755 harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 
-# empty managed-settings stub: legacy allowedMcpServers shape breaks Claude Code 2.x startup
+# cc-websearch (github.com/Djarvur/cc-websearch, MIT) — DuckDuckGo-backed
+# WebSearch/WebFetch replacements. The built-in tools depend on an Anthropic
+# server-side capability that non-Anthropic model backends don't provide, so
+# they fail on this platform's custom backends (#1087). On such backends the
+# managed-settings hooks (deny-web-tool.sh, gated on PLATFORM_CUSTOM_BACKEND)
+# deny the built-ins and the seeded skills (.agents/skills/{websearch,webfetch})
+# invoke these self-contained esbuild bundles instead, which need only `node`.
+# Pinned to a commit SHA and checksum-verified.
+ARG CC_WEBSEARCH_REF=02d4993492ed0a957e7908bfff61fef245d36583
+RUN mkdir -p /opt/cc-websearch &&\
+    base="https://raw.githubusercontent.com/Djarvur/cc-websearch/${CC_WEBSEARCH_REF}/skills" &&\
+    curl -fsSL "$base/websearch/scripts/websearch.cjs" -o /opt/cc-websearch/websearch.cjs &&\
+    curl -fsSL "$base/webfetch/scripts/webfetch.cjs" -o /opt/cc-websearch/webfetch.cjs &&\
+    node -e 'const c=require("crypto"),f=require("fs"),d="/opt/cc-websearch/";const want={"websearch.cjs":"3f3054ab1ec65f301152e0567b6415b8c92264a2fb94e9e7d95685911cde058e","webfetch.cjs":"56cc2e9c23e594308ae010e185211313f637f38d633cdcbdd7b2c5e565355054"};for(const[n,h]of Object.entries(want)){const g=c.createHash("sha256").update(f.readFileSync(d+n)).digest("hex");if(g!==h){console.error(`cc-websearch: checksum mismatch for ${n}: got ${g} want ${h}`);process.exit(1);}}console.log("cc-websearch bundles verified");'
+COPY --chmod=0755 deny-web-tool.sh /opt/cc-websearch/deny-web-tool.sh
+
+# managed-settings.json carries the WebSearch/WebFetch deny hooks (above); keep
+# it otherwise minimal — a legacy allowedMcpServers shape breaks Claude Code 2.x startup.
 RUN ln -s ../.agents/skills /app/working-dir/.claude/skills &&\
     mkdir -p /etc/claude-code &&\
-    echo '{}' > /etc/claude-code/managed-settings.json &&\
     ln -s /etc/AGENTS.md /etc/claude-code/CLAUDE.md
+COPY managed-settings.json /etc/claude-code/managed-settings.json
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
 

--- a/packages/agents/claude-code/deny-web-tool.sh
+++ b/packages/agents/claude-code/deny-web-tool.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+# PreToolUse hook: deny a built-in web tool (WebSearch/WebFetch) and redirect the
+# model to its DDG-backed replacement skill — but ONLY on a custom (non-Anthropic)
+# backend, where the built-in Anthropic server-side tool doesn't work (#1087).
+#
+# model-gateway.sh exports PLATFORM_CUSTOM_BACKEND=1 exactly when the pod fronts a
+# custom upstream. On genuine Anthropic backends the marker is unset: we print
+# nothing and exit 0, so the built-in tool proceeds through the normal permission
+# flow. Args: <ToolName> <skill-name>.
+tool="$1"
+skill="$2"
+
+if [ "${PLATFORM_CUSTOM_BACKEND:-}" = "1" ]; then
+	printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"The built-in %s tool is unavailable on this backend. Use the %s skill instead."}}\n' "$tool" "$skill"
+fi

--- a/packages/agents/claude-code/managed-settings.json
+++ b/packages/agents/claude-code/managed-settings.json
@@ -1,0 +1,24 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "WebSearch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/cc-websearch/deny-web-tool.sh WebSearch websearch"
+          }
+        ]
+      },
+      {
+        "matcher": "WebFetch",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "/opt/cc-websearch/deny-web-tool.sh WebFetch webfetch"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/packages/agents/claude-code/model-gateway.sh
+++ b/packages/agents/claude-code/model-gateway.sh
@@ -19,6 +19,12 @@ _gateway_wait_env() {
 }
 
 if _gateway_custom_upstream; then
+	# A custom (non-Anthropic) upstream means Claude's built-in WebSearch/WebFetch
+	# — Anthropic server-side tools — won't work. The cc-websearch managed hooks
+	# read this marker to deny them and route to the DDG-backed replacement skills
+	# (#1087); on genuine Anthropic backends it stays unset and the built-ins work.
+	# Set before the readiness wait so it holds on the gateway-not-ready path too.
+	export PLATFORM_CUSTOM_BACKEND=1
 	if _gateway_wait_env; then
 		export ANTHROPIC_BASE_URL="$_GATEWAY_BASE"
 		export NO_PROXY="127.0.0.1,localhost,::1${NO_PROXY:+,$NO_PROXY}"

--- a/packages/agents/claude-code/workspace/.agents/skills/webfetch/SKILL.md
+++ b/packages/agents/claude-code/workspace/.agents/skills/webfetch/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: webfetch
+description: Replacement for the built-in WebFetch tool on backends where it is unavailable (this platform's non-Anthropic backends). Fetches a URL and extracts its main content as markdown. Use it when WebFetch is denied and the harness tells you to use this skill, or when you otherwise need to fetch a page.
+allowed-tools: Bash(node *)
+---
+
+# WebFetch
+
+On this platform's non-Anthropic model backends the built-in `WebFetch` tool
+doesn't work (it relies on an Anthropic server-side capability), so the harness
+denies it and directs you here. This skill fetches the page locally and
+extracts the readable content as markdown. (On genuine Anthropic backends the
+built-in works and this skill is unnecessary.)
+
+## Usage
+
+Pipe a JSON request to the fetch script on stdin:
+
+```bash
+echo '{"url":"URL","prompt":"QUESTION"}' | node /opt/cc-websearch/webfetch.cjs
+```
+
+The request accepts:
+
+- `url` (string, required, must be a valid URL) — the page to fetch
+- `prompt` (string, required) — the question to answer about the page
+
+The script writes the extracted page content to stdout; errors and diagnostics
+go to stderr. HTTP URLs are upgraded to HTTPS. Cross-host redirects are
+reported but not followed. Only HTML content types are supported.
+
+Fetching an arbitrary host may require a one-time egress approval for that host
+before it succeeds. Use the returned content to answer the user's question.

--- a/packages/agents/claude-code/workspace/.agents/skills/websearch/SKILL.md
+++ b/packages/agents/claude-code/workspace/.agents/skills/websearch/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: websearch
+description: Replacement for the built-in WebSearch tool on backends where it is unavailable (this platform's non-Anthropic backends). Searches the web via DuckDuckGo. Use it when WebSearch is denied and the harness tells you to use this skill, or when you otherwise need web search results.
+allowed-tools: Bash(node *)
+---
+
+# WebSearch
+
+On this platform's non-Anthropic model backends the built-in `WebSearch` tool
+doesn't work (it relies on an Anthropic server-side capability), so the harness
+denies it and directs you here. This skill queries DuckDuckGo locally and
+returns the same shape of results. (On genuine Anthropic backends the built-in
+works and this skill is unnecessary.)
+
+## Usage
+
+Pipe a JSON request to the search script on stdin:
+
+```bash
+echo '{"query":"SEARCH TERMS"}' | node /opt/cc-websearch/websearch.cjs
+```
+
+The request accepts:
+
+- `query` (string, required, minimum 2 characters) — the search query
+- `allowed_domains` (string[], optional) — only return results from these domains
+- `blocked_domains` (string[], optional) — exclude results from these domains
+
+The script writes `<search_results>` XML (title, URL, and snippet per result)
+to stdout. Errors and diagnostics go to stderr.
+
+Always use the results to inform your response, and cite source URLs when you
+draw on them.


### PR DESCRIPTION
Resolves #1087.

## Problem

Claude Code's built-in `WebSearch`/`WebFetch` are Anthropic **server-side** tools. When a pod fronts a custom (non-Anthropic) model backend — the platform's `model-gateway` case — the upstream doesn't implement them, so asking the agent to search the web fails.

## Fix

Vendor [cc-websearch](https://github.com/Djarvur/cc-websearch) (DuckDuckGo-backed, MIT) as self-contained `node` bundles and — **only on custom backends** — deny the built-ins via a managed-settings `PreToolUse` hook that redirects the model to replacement skills. On genuine Anthropic backends the hook stays silent and the native tools work unchanged.

Lives in the **claude-code harness image**, so `nous` and `openevolve` (both derive `FROM platform-claude-code`) inherit the fix; non-Claude harnesses (codex, pi-agent, bob, k-search) are untouched.

## Changes

- **Dockerfile** — fetch cc-websearch `v1.2.4` bundles (pinned commit `02d4993` + SHA-256 verification) into `/opt/cc-websearch`; ship `deny-web-tool.sh`; install the managed-settings hooks. Bundles need only `node` (no `npm install`), and stay in the image layer (not duplicated onto every PVC).
- **model-gateway.sh** — export `PLATFORM_CUSTOM_BACKEND=1` when fronting a custom upstream (set before the readiness wait, so it holds on the gateway-not-ready path too). DRY: the gateway already computes this; the hook just consumes it.
- **deny-web-tool.sh** — `PreToolUse` hook gated on `PLATFORM_CUSTOM_BACKEND`; emits a `deny` decision → replacement skill on custom backends, nothing (built-in proceeds) otherwise.
- **skills** — seed `websearch`/`webfetch` skills that invoke the bundles via `node` (discovered through the existing `.claude/skills` → `.agents/skills` symlink).
- **helm** — add `lite.duckduckgo.com` (websearch's only backend host) to the `trusted` egress preset. Node's `fetch` already tunnels through Envoy via the controller's `NODE_USE_ENV_PROXY=1`. `webfetch`'s arbitrary hosts use the normal per-host egress-approval flow.

## Verification

- Both bundles run under node 24 and return the expected output (`<search_results>` XML / extracted markdown).
- Hook: custom backend → valid `deny` JSON, exit 0; genuine Anthropic → empty output, exit 0. `sh -n` clean; `managed-settings.json` valid JSON.
- `helm:check:lint` and `helm:check:render` (kubeconform) pass; `lite.duckduckgo.com` renders into the trusted-hosts ConfigMap.

**Not yet verified in-cluster:** the Docker image build and true in-pod e2e (deny → skill → proxied DDG fetch). 

## Note / edge case

During the brief cold-boot window before `model-gateway.sh` finishes (or on a `dam-run` executor pod that doesn't run the chat harness), the marker can be momentarily unset on a custom backend — the built-in would then be attempted and fail as it does today, rather than being redirected. Steady-state chat sessions are unaffected.