### PR TITLE
feat(helm): key agentTemplates by name instead of a list

### DIFF
--- a/deploy/helm/platform/templates/agent-template-pull-secrets.yaml
+++ b/deploy/helm/platform/templates/agent-template-pull-secrets.yaml
@@ -12,8 +12,8 @@ manual "Private registry" credential entry needed.
 
 Secret name MUST match the reference rendered in agent-templates.yaml.
 */}}
-{{- range $tmpl := .Values.agentTemplates }}
-{{- if and $tmpl.enabled $tmpl.imagePullSecret }}
+{{- range $name, $tmpl := .Values.agentTemplates }}
+{{- if and $tmpl $tmpl.enabled $tmpl.imagePullSecret }}
 {{- $cred := $tmpl.imagePullSecret }}
 {{- $auth := printf "%s:%s" $cred.username $cred.password | b64enc }}
 {{- $dockercfg := dict "auths" (dict $cred.server (dict "auth" $auth)) | toJson }}
@@ -21,7 +21,7 @@ Secret name MUST match the reference rendered in agent-templates.yaml.
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $tmpl.name | quote }}
+  name: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $name | quote }}
   namespace: {{ $.Values.agentNamespace }}
   labels:
     {{- include "platform.labels" $ | nindent 4 }}

--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -23,10 +23,10 @@ metadata:
     {{- include "platform.labels" . | nindent 4 }}
     app.kubernetes.io/component: apiserver
 data:
-  {{- range $tmpl := .Values.agentTemplates }}
-  {{- if $tmpl.enabled }}
+  {{- range $name, $tmpl := .Values.agentTemplates }}
+  {{- if and $tmpl $tmpl.enabled }}
   {{- $home := $tmpl.agentHome | default $.Values.controller.agent.templateDefaults.agentHome }}
-  {{ $tmpl.name }}.yaml: |
+  {{ $name }}.yaml: |
     version: agent-platform.ai/v1
     image: "{{ $tmpl.image.repository }}:{{ $tmpl.image.tag | default $.Chart.AppVersion }}"
     description: {{ $tmpl.description | quote }}
@@ -51,7 +51,7 @@ data:
       {{- toYaml . | nindent 6 }}
     {{- end }}
     {{- if $tmpl.imagePullSecret }}
-    imagePullSecretRef: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $tmpl.name | quote }}
+    imagePullSecretRef: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $name | quote }}
     {{- end }}
     {{- with $tmpl.resources }}
     resources:

--- a/deploy/helm/platform/values-e2e.yaml
+++ b/deploy/helm/platform/values-e2e.yaml
@@ -14,18 +14,8 @@ keycloak:
     username: dev2
     password: dev2
 
-# Helm replaces lists wholesale — narrow values-local.yaml's agentTemplates
-# down to just `mock`. The e2e task builds only platform-base + mock images,
-# so registering claude-code / codex / pi-agent / bob would
-# leave the chart pointing at images that aren't loaded in the test cluster.
+# Only the mock image is built for the e2e cluster — disable claude-code,
+# the one other template values-local.yaml leaves enabled.
 agentTemplates:
-  - name: mock
-    enabled: true
-    description: "Scripted mock agent (E2E test fixture)"
-    image:
-      repository: platform-mock
-      tag: latest
-    storageSize: "1Gi"
-    env:
-      - name: MOCK_DEFAULT_REPLY
-        value: "Hello from the mock agent."
+  claude-code:
+    enabled: false

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -28,79 +28,47 @@ controller:
 nfsProvisioner:
   enabled: true
 
-# Helm replaces lists wholesale — this `agentTemplates` array fully
-# overrides the one in values.yaml. Every field that the chart sets on
-# bundled templates must be repeated here, plus the locally-built image.
-# All four templates are enabled by default for local dev.
+# Merges over the values.yaml catalog. Every template gets a local image
+# override so enabling one later never pulls from quay.
 agentTemplates:
-  - name: claude-code
-    enabled: true
-    description: "Default Claude Code agent"
-    telemetry: true
+  claude-code:
     image:
       repository: platform-claude-code
       tag: latest
-    storageSize: "5Gi"
 
-  - name: codex
+  codex:
     enabled: false
-    description: "OpenAI Codex coding agent"
     image:
       repository: platform-codex
       tag: latest
-    storageSize: "5Gi"
 
-  - name: pi-agent
-    enabled: true
-    description: "Pi coding agent with multi-LLM support"
+  pi-agent:
+    enabled: false
     image:
       repository: platform-pi-agent
       tag: latest
-    storageSize: "2Gi"
 
-  - name: bob
+  bob:
     enabled: false
-    description: "Bob shell agent"
     image:
       repository: platform-bob
       tag: latest
-    storageSize: "2Gi"
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "1Gi"
-      limits:
-        cpu: "2"
-        memory: "4Gi"
 
-  - name: nous
+  nous:
     enabled: false
-    category: preconfigured
-    experimental: true
-    description: "Nous hypothesis-driven experimentation agent"
     image:
       repository: platform-nous
       tag: latest
-    storageSize: "10Gi"
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "1Gi"
-      limits:
-        cpu: "2"
-        memory: "4Gi"
 
-  - name: openevolve
+  openevolve:
     enabled: false
-    category: preconfigured
-    experimental: true
-    description: "OpenEvolve — evolutionary code-optimization agent"
     image:
       repository: platform-openevolve
       tag: latest
-    storageSize: "5Gi"
 
-  - name: mock
+  # Test fixture; not in the values.yaml catalog — the mock image is never
+  # release-tagged (CI pushes per-commit shas for the e2e job only).
+  mock:
     enabled: true
     description: "Scripted mock agent (E2E test fixture)"
     image:
@@ -111,51 +79,16 @@ agentTemplates:
       - name: MOCK_DEFAULT_REPLY
         value: "Hello from the mock agent."
 
-  - name: k-search
+  k-search:
     enabled: false
-    category: preconfigured
-    experimental: true
-    description: "K-Search — LLM-driven GPU kernel optimization (Modal eval)"
     image:
       repository: platform-k-search
       tag: latest
-    storageSize: "5Gi"
-    resources:
-      requests:
-        cpu: "500m"
-        memory: "1Gi"
-      limits:
-        cpu: "2"
-        memory: "4Gi"
 
-  # Local-GPU variant. Disabled — the lima dev cluster has no GPU. See
-  # values.yaml for the GPU Kata runtime-class setup.
-  - name: k-search-local
-    enabled: false
-    category: preconfigured
-    experimental: true
-    description: "K-Search — LLM-driven GPU kernel optimization (local GPU eval)"
+  k-search-local:
     image:
       repository: platform-k-search
       tag: latest
-    storageSize: "10Gi"
-    # runtimeClassName: "kata-nvidia-gpu"
-    # nodeSelector:
-    #   nvidia.com/gpu.present: "true"
-    env:
-      - name: KSEARCH_EVAL_MODE
-        value: "local"
-      - name: KSEARCH_TARGET_GPU
-        value: "A100"
-    resources:
-      requests:
-        cpu: "1"
-        memory: "8Gi"
-        nvidia.com/gpu: "1"
-      limits:
-        cpu: "2"
-        memory: "16Gi"
-        nvidia.com/gpu: "1"
 
 # Local dev convenience: route requests with any Host header (including
 # IP literals like 127.0.0.1) to the app, so the cluster is reachable

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -731,7 +731,7 @@ controller:
   #                           to every agent + fork agent pod.
   #   2. `templateDefaults` — chart-wide fallbacks for fields a template
   #                           can override (template wins when set).
-  #   3. agentTemplates[]   — per-template values (further down).
+  #   3. agentTemplates.*   — per-template values (further down).
   # Use the literal string `$HOME` in mount paths; the chart substitutes
   # it at render time with the template's `agentHome` if set, else
   # `templateDefaults.agentHome`.
@@ -926,9 +926,10 @@ controller:
       cpu: 500m
       memory: 256Mi
 
-# -- Agent templates. Each enabled entry renders an agent-template ConfigMap
-# in `agentNamespace`. Fields named identically to `controller.agent.templateDefaults.*`
-# override the chart-wide default for agents created from this template.
+# -- Agent templates, keyed by template name. Override values files merge
+# per entry; set an entry to `null` to drop it. Fields named identically to
+# `controller.agent.templateDefaults.*` override the chart-wide default for
+# agents created from this template.
 # `$HOME` in mount paths is substituted at chart render time
 # using this entry's `agentHome` if set, else `templateDefaults.agentHome`.
 # `category` groups the entry in the creation wizard's Step 1: "harness"
@@ -940,7 +941,7 @@ controller:
 # just pick from the template list, with no manual "Private registry" entry),
 # add an entry with `imagePullSecret`:
 #
-#   - name: bugstone
+#   bugstone:
 #     enabled: true
 #     category: preconfigured
 #     experimental: true
@@ -955,7 +956,7 @@ controller:
 #       password: "<registry-api-key>" # keep out of plaintext values in prod (sealed/SOPS/external secret)
 #
 agentTemplates:
-  - name: claude-code
+  claude-code:
     enabled: true
     description: "Default Claude Code agent"
     telemetry: true
@@ -964,7 +965,7 @@ agentTemplates:
       tag: ""
     storageSize: "5Gi"
 
-  - name: codex
+  codex:
     enabled: true
     description: "OpenAI Codex coding agent"
     image:
@@ -972,7 +973,7 @@ agentTemplates:
       tag: ""
     storageSize: "5Gi"
 
-  - name: pi-agent
+  pi-agent:
     enabled: true
     description: "Pi coding agent with multi-LLM support"
     image:
@@ -980,7 +981,7 @@ agentTemplates:
       tag: ""
     storageSize: "5Gi"
 
-  - name: bob
+  bob:
     enabled: true
     description: "Bob shell agent"
     image:
@@ -998,8 +999,8 @@ agentTemplates:
         cpu: "2"
         memory: "4Gi"
 
-  - name: k-search
-    enabled: false
+  k-search:
+    enabled: true
     category: preconfigured
     experimental: true
     description: "K-Search — LLM-driven GPU kernel optimization (Modal eval)"
@@ -1019,7 +1020,7 @@ agentTemplates:
   # (KSEARCH_EVAL_MODE=local). Disabled by default — stays Pending without a GPU.
   # GPU passthrough under Kata needs a GPU-capable runtime class set per-template
   # below (the chart-wide class can't carry the GPU VM config for every agent).
-  - name: k-search-local
+  k-search-local:
     enabled: false
     category: preconfigured
     experimental: true
@@ -1051,8 +1052,8 @@ agentTemplates:
 
   # Published by CI (build-nous / merge-nous in cd.yml). Experimental: the
   # harness drives long-running Nous campaigns — see packages/agents/nous/README.md.
-  - name: nous
-    enabled: false
+  nous:
+    enabled: true
     category: preconfigured
     experimental: true
     description: "Nous hypothesis-driven experimentation agent"
@@ -1070,8 +1071,8 @@ agentTemplates:
         cpu: "2"
         memory: "4Gi"
 
-  - name: openevolve
-    enabled: false
+  openevolve:
+    enabled: true
     category: preconfigured
     experimental: true
     description: "OpenEvolve — evolutionary code-optimization agent"
@@ -1079,17 +1080,6 @@ agentTemplates:
       repository: quay.io/dam-agents/openevolve
       tag: ""
     storageSize: "5Gi"
-
-  # Test-only mock agent. Scripted ACP emitter; receives prompts
-  # into an in-pod buffer and emits a pre-set sequence of session/update
-  # frames in response. Default off — flipped on by the e2e/local install.
-  - name: mock
-    enabled: false
-    description: "Scripted mock agent (E2E test fixture)"
-    image:
-      repository: quay.io/dam-agents/mock
-      tag: ""
-    storageSize: "1Gi"
 
 # -- E2E test affordances. Gated test-only surface: the api-server
 # registers a control tRPC namespace that drives the mock Agent harness over

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -19,7 +19,7 @@ Three kinds of source show up in the Skills panel:
 - **Platform** (blue) — seeded by the cluster admin; read-only.
 - **Agent** (purple) — declared by this instance's agent template; read-only.
 
-Seed Platform sources via `skills.skillSources`, or per-template sources via `agentTemplates[i].skillSources` — same shape either way:
+Seed Platform sources via `skills.skillSources`, or per-template sources via `agentTemplates.<name>.skillSources` — same shape either way:
 
 ```yaml
 skills:
@@ -28,7 +28,7 @@ skills:
       gitUrl: "https://github.com/anthropics/skills"
 
 agentTemplates:
-  - name: claude-code
+  claude-code:
     skillSources:
       - name: "Anthropic Skills"
         gitUrl: "https://github.com/anthropics/skills"


### PR DESCRIPTION
Closes #2318

## What

`agentTemplates` in the chart values is now a map keyed by template name instead of a list. Helm deep-merges maps across values files (lists are replaced wholesale), so an override file now states only what it changes:

```yaml
agentTemplates:
  codex:
    enabled: false
```

A key absent from values.yaml merges in as a brand-new template (that's how the mock fixture ships now), and setting an entry to `null` removes it from the catalog entirely.

## Changes

- `values.yaml` — catalog converted to map form (the `name` field is gone; the key is the name). Ships every template enabled except the GPU-bound `k-search-local`. The `mock` test fixture is removed from the default catalog: no release-tagged image exists for it (CI pushes mock only as a per-commit sha for the e2e job), so the entry pointed at an image that never exists.
- `values-local.yaml` — shrinks from a full catalog copy to per-template deltas: local image overrides for every template (so a locally flipped-on template never pulls from quay), `enabled` flips narrowing local dev to `claude-code` + `mock`, and the full overlay-added `mock` definition.
- `values-e2e.yaml` — shrinks to one line of intent: disable `claude-code`, leaving only `mock` (whose definition rides in from values-local).
- Chart templates iterate the map (`range $name, $tmpl`) and tolerate `null` entries; the pull-secret name derives from the key.
- `docs/configuration.md` — skill-sources example migrated.

## Breaking / migration

Existing deployment values that override `agentTemplates` must migrate each `- name: <x>` list item to a `<x>:` map key. Overrides that previously restated bundled entries can shrink to just the fields they change — and note values.yaml now enables previously-off templates (`k-search`, `nous`, `openevolve`), so deployments that relied on list replacement hiding templates should add explicit `enabled: false` entries. There is intentionally no list-form validator (dropped in review): an un-migrated list renders template data keys from list indices (`0.yaml`, …) rather than failing.

## Verification

- `helm lint` + `helm template | kubeconform` pass.
- Rendered the agent-templates ConfigMap for all three stacks (default / local / local+e2e): before the enabled-policy unification the map form produced byte-identical output to the list form; after it, the stacks render exactly the intended sets (all-but-k-search-local-and-mock / claude-code+mock / mock), with the overlay-added mock carrying its full definition.
- Smoke-tested `imagePullSecret` rendering (secret name from map key) and `null`-deletion of an entry.