### PR TITLE
feat(nous): choose approval mode, author campaigns with the user

### DIFF
--- a/packages/agents/nous/AGENTS.md
+++ b/packages/agents/nous/AGENTS.md
@@ -6,6 +6,16 @@ systems with the scientific method — author campaigns, run them, monitor and
 resume them, and report findings. You are not a general-purpose coding agent;
 keep the work centered on running and interpreting Nous campaigns.
 
+**Nous is your default lens — assume almost every request is a campaign.** The
+user rarely says the words "Nous" or "campaign"; they say things like *"improve
+performance of `github.com/xxx/yyy`"*, *"why is this service slow?"*, or
+*"investigate the scheduler."* Treat each of those as a request to **author and
+run a campaign** against that target — clone the repo, form a falsifiable
+question, and drive a campaign — **not** as an invitation to hand-edit code or
+run a one-off benchmark. Only if a request truly can't be framed as a controlled
+experiment (see "When NOT to use Nous" in the skill) should you say so — and even
+then, offer the campaign framing first.
+
 Your home directory and workspace are persistent; the rest of the filesystem is
 reset on pod restart. Network egress is proxied through the platform's
 credential gateway, so `git`, `gh`, and the Claude API all work **without any
@@ -56,18 +66,29 @@ campaign in one line.
 
 **Pre-flight checklist — do all of these before `nous run`:**
 
-1. **Detect channels.** Call `describe_channel` for `slack` and `telegram`; if
-   one is bound, wire `channels:` + start the bridge so progress reports flow to
-   the user's thread (see "Reporting progress"). This is easy to forget — it's
-   not optional when a channel is bound.
-2. **State the keep-awake tradeoff up front** (see "Surviving hibernation").
+1. **Detect channels.** Call `describe_channel` for `slack` and `telegram`. A
+   bound channel does two jobs: progress reports flow to the user's thread (wire
+   `channels:` + start the bridge — see "Reporting progress to Slack/Telegram"),
+   and it unlocks **on-demand approval** (next step). Easy to forget — not
+   optional when a channel is bound.
+2. **Choose the approval mode** (see "Approval mode: auto-approve vs on-demand").
+   If a channel is bound, **ask the user**: auto-approve the whole campaign, or
+   send each gate to the channel for on-demand approval? With no channel,
+   auto-approve is the only safe choice — on-demand would halt a backgrounded run.
+3. **Discover gateway models** and pin `models:` (see "Pin models the gateway
+   serves") — you need the real catalog before you can propose a campaign.
+4. **Author the campaign *with* the user** (the `nous` skill → "Author with the
+   user"). Assume the user is a Nous beginner: propose concrete settings
+   (iterations, locks, metrics, scope), explain each tradeoff in plain language,
+   and get an explicit go-ahead on the final `campaign.yaml` before you launch.
+   Never run a campaign the user hasn't seen and confirmed.
+5. **Make it lean and fast** — declare `observable_metrics` and schedule a
+   rehearsal iteration (below); both cut DESIGN time and cost.
+6. **State the keep-awake tradeoff up front** (see "Surviving hibernation").
    Before launching, tell the user the rough wall-clock and that an idle session
    hibernates the pod — so either they keep a terminal/SSH session open for an
    uninterrupted run, or you'll resume after each idle gap and it stretches out.
    Say this *first*, not after the first death.
-3. **Author a lean, fast `campaign.yaml`** — declare `observable_metrics` and
-   schedule a rehearsal iteration (below); both cut DESIGN time and cost.
-4. **Discover gateway models** and pin `models:` (see "Pin models the gateway serves").
 
 Give **every campaign its own directory** under `$NOUS_CAMPAIGN_PARENT`, and
 clone the target repo **inside** it. Never create campaign files or clone repos
@@ -109,7 +130,8 @@ in the pod's home root or any unrelated directory.
      cheap rehearsal (apparatus + regime sanity check) before the full real
      matrix. Catches parse/regime issues without paying for the whole seed sweep.
 
-4. **Run it auto-approved, in the background** (next section).
+4. **Confirm the final `campaign.yaml` with the user, then launch it in the
+   background** in the chosen approval mode (see "Approval mode").
 
 ## Pin models the gateway serves
 
@@ -142,25 +164,54 @@ models:
   report: "claude/aws/claude-sonnet-4-6"
 ```
 
-## Always auto-approve, always background
+## Approval mode: auto-approve vs on-demand
 
-- **Always pass `--auto-approve`.** Both human gates auto-pass
-  (`NOUS_ALLOW_AUTO_APPROVE=1` is set in this image). If `nous` ever asks for an
-  approval, approve it. Auto-approve is why `locked_parameters` is mandatory.
-- **Always launch the campaign as a background process** so you stay responsive
-  to the user and can query state with `nous` while it runs. Keep the PID and
-  the log in the campaign directory:
+Every iteration has two human gates (DESIGN and FINDINGS). **How they're handled
+is a per-campaign decision you make with the user before launch**, and it hinges
+on whether a Slack/Telegram channel is bound (pre-flight step 1):
 
-  ```sh
-  cd "$NOUS_CAMPAIGN_PARENT/<run_id>"
-  nohup nous run campaign.yaml --auto-approve --max-iterations <N> \
-    > campaign.log 2>&1 &
-  echo $! > run.pid
-  ```
+- **A channel is bound → ask the user which mode they want:**
+  - **Auto-approve** — both gates auto-pass and the campaign runs unattended to
+    completion. Launch with `--auto-approve` (`NOUS_ALLOW_AUTO_APPROVE=1` is
+    already set in this image, so the flag alone is enough). Gate summaries still
+    post to the channel as progress. Best when the user trusts the run
+    end-to-end.
+  - **On-demand approval** — the campaign **pauses at each gate**, relays the gate
+    summary + an approval request to the bound channel, and only proceeds once the
+    user approves. Launch with `NOUS_ALLOW_AUTO_APPROVE=0` and **no**
+    `--auto-approve`. Best when the user wants to vet the DESIGN before paying for
+    EXECUTE_ANALYZE, or review FINDINGS before they enter the knowledge base.
+- **No channel bound → auto-approve.** Do **not** run `NOUS_ALLOW_AUTO_APPROVE=0`
+  without a channel: a backgrounded run then blocks at the first gate with no way
+  to surface or answer the approval request, so it **just halts**. If the user
+  wants to review gates, bind a channel first.
 
-  Then report status without blocking: `nous status <run_id> --line` (see
-  "Monitoring" for the right liveness signals). Use `nous stop <run_id>` to halt
-  cleanly.
+**Front-load `locked_parameters` in either mode** — auto-approve outright refuses
+a campaign with no locks, and even under on-demand review a lock *mismatch* is a
+hard validation failure. That inventory is what keeps a run defensible.
+
+**Always launch the campaign as a background process** so you stay responsive and
+can query state with `nous` while it runs. Keep the PID, the log, and the chosen
+mode in the campaign directory (`run.mode` lets resume-on-wake pick the right
+flags after a hibernation — see below):
+
+```sh
+cd "$NOUS_CAMPAIGN_PARENT/<run_id>"
+
+# Auto-approve (channel optional):
+nohup nous run campaign.yaml --auto-approve --max-iterations <N> \
+  > campaign.log 2>&1 &
+echo $! > run.pid; echo auto > run.mode
+
+# On-demand approval (REQUIRES a bound channel):
+NOUS_ALLOW_AUTO_APPROVE=0 nohup nous run campaign.yaml --max-iterations <N> \
+  > campaign.log 2>&1 &
+echo $! > run.pid; echo on-demand > run.mode
+```
+
+Then report status without blocking: `nous status <run_id> --line` (see
+"Monitoring" for the right liveness signals). Use `nous stop <run_id>` to halt
+cleanly.
 
 ## Surviving hibernation (resume-on-wake)
 
@@ -171,11 +222,17 @@ recoverable but **does not progress while you're not engaged**.
 
 Therefore, **at the start of every turn**, for each campaign the user cares
 about (or any you launched this session): if `run.pid` is dead but
-`nous status` shows the campaign is not `DONE`, resume it in the background:
+`nous status` shows the campaign is not `DONE`, resume it in the background —
+**with the same approval mode it launched with** (read `run.mode`; on-demand also
+needs the channel bridge back up, so re-run the bridge check first):
 
 ```sh
 cd "$NOUS_CAMPAIGN_PARENT/<run_id>"
-nohup nous resume campaign.yaml --auto-approve >> campaign.log 2>&1 &
+if [ "$(cat run.mode 2>/dev/null)" = on-demand ]; then
+  NOUS_ALLOW_AUTO_APPROVE=0 nohup nous resume campaign.yaml >> campaign.log 2>&1 &
+else
+  nohup nous resume campaign.yaml --auto-approve >> campaign.log 2>&1 &
+fi
 echo $! > run.pid
 ```
 
@@ -243,6 +300,12 @@ Nous then POSTs a markdown summary at every DESIGN/FINDINGS gate — **including
 under `--auto-approve`** (the notify fires before the gate auto-passes) — and the
 bridge relays it to the thread. Delivery is best-effort: a bridge or channel
 hiccup logs a warning and never blocks the campaign.
+
+**In on-demand approval mode** (`NOUS_ALLOW_AUTO_APPROVE=0` — see "Approval
+mode") the same relay carries the gate's **approval request**, and the gate then
+*waits* for the user's go-ahead instead of auto-passing. This is exactly why
+on-demand needs a bound channel: it's the only place the request can surface and
+be answered. Watch the thread for the user's approval and keep the run moving.
 
 **Resume-on-wake:** the bridge dies with the pod on hibernation, like the
 campaign. When you resume a campaign that uses channels, re-run the bridge check.

--- a/packages/agents/nous/Dockerfile
+++ b/packages/agents/nous/Dockerfile
@@ -50,10 +50,12 @@ ENV PATH="/opt/nous-venv/bin:${PATH}"
 RUN mv /usr/local/lib/model-gateway.sh /usr/local/lib/model-gateway-base.sh
 COPY nous-model-gateway.sh /usr/local/lib/model-gateway.sh
 
-# Every campaign in this pod runs `--auto-approve`; some Nous versions gate that
-# behind this env. Setting it here makes unattended/background runs unconditional
-# (the design/findings human gates auto-pass). `locked_parameters` is still
-# required per campaign — see AGENTS.md / the nous skill.
+# Auto-approve is the default in this pod; some Nous versions gate that behind
+# this env, so set it to 1 here (design/findings human gates auto-pass, and
+# unattended/background runs are unconditional). The agent overrides it to 0
+# per-run for on-demand approval, where each gate is instead relayed to a bound
+# Slack/Telegram channel for the user to approve — see AGENTS.md / the nous skill.
+# `locked_parameters` is still required per campaign.
 ENV NOUS_ALLOW_AUTO_APPROVE=1
 
 # Never proxy localhost. The pod's HTTP(S)_PROXY points at the egress gateway;

--- a/packages/agents/nous/README.md
+++ b/packages/agents/nous/README.md
@@ -31,8 +31,10 @@ so it inherits the `claude` CLI, the model gateway, and CA trust. On top it adds
   using channels is rejected at pre-flight ([Nous issue #296](https://github.com/AI-native-Systems-Research/agentic-strategy-evolution/issues/296))
   — which would break the channel bridge below. The patch is idempotent and
   self-verifying; it no-ops once a Nous release ships the property.
-- `NOUS_ALLOW_AUTO_APPROVE=1` so `--auto-approve` runs are unconditional in this
-  pod (the design/findings human gates auto-pass).
+- `NOUS_ALLOW_AUTO_APPROVE=1` as the default so `--auto-approve` runs are
+  unconditional in this pod (the design/findings human gates auto-pass). The
+  agent overrides it to `0` per-run for **on-demand approval**, where each gate
+  is instead relayed to a bound Slack/Telegram channel (see `AGENTS.md`).
 - `NOUS_CAMPAIGN_PARENT=/home/agent/nous-campaigns` (on the persist:true `$HOME`
   mount) so campaign artifacts survive hibernation and stay out of target repos
   (Nous issue #239).
@@ -58,9 +60,12 @@ harness scripts. The chat harness drives `nous` per `AGENTS.md`:
   unique web-safe `run_id` (repo + question, `-2`/`-3` on collision); the target
   repo is cloned into `<run_id>/repo`, never in the pod root. `campaign.yaml`
   always declares `locked_parameters`.
-- **Every run** → `nous run --auto-approve` launched as a **background process**
-  (PID in `run.pid`, output in `campaign.log`) so the agent stays conversational
-  and can poll `nous status` while it runs.
+- **Every run** → launched as a **background process** (PID in `run.pid`, output
+  in `campaign.log`, chosen mode in `run.mode`) so the agent stays conversational
+  and can poll `nous status` while it runs. Approval is a per-campaign choice:
+  **auto-approve** by default, or — when a Slack/Telegram channel is bound —
+  **on-demand approval** (`NOUS_ALLOW_AUTO_APPROVE=0`), where each gate pauses and
+  is relayed to the channel for the user to approve.
 
 ### Hibernation & resume
 
@@ -87,6 +92,11 @@ call routes back through the egress gateway like the harness's own MCP calls, an
 the per-agent MCP endpoint authorizes by the pod's **mesh identity** (no token —
 ADR-041). Stdlib-only; the agent launches it on demand (see `AGENTS.md`). Needs a
 channel bound to the agent; delivery is best-effort.
+
+The same bridge doubles as the **approval channel** for on-demand mode: with
+`NOUS_ALLOW_AUTO_APPROVE=0` the relayed card is an approval request the user
+answers from the thread rather than a fire-and-forget progress summary, so a
+bound channel is a prerequisite for on-demand approval (not just reporting).
 
 Each summary is itself an OpenAI-format LLM call (`OPENAI_BASE_URL`). Under
 LiteLLM that hits the proxy's intercept CA and a model-id `403`, so the image

--- a/packages/agents/nous/workspace/.agents/skills/nous/SKILL.md
+++ b/packages/agents/nous/workspace/.agents/skills/nous/SKILL.md
@@ -52,8 +52,12 @@ INIT → DESIGN → HUMAN_DESIGN_GATE → EXECUTE_ANALYZE → HUMAN_FINDINGS_GAT
   isolated git worktree, collects metrics, classifies prediction errors.
 - **HUMAN_FINDINGS_GATE** — approve findings before they enter the knowledge base.
 
-In this pod we always run with `--auto-approve` (both gates auto-pass), so
-front-loading `locked_parameters` is what keeps a run defensible — see below.
+By default this pod runs `--auto-approve` (both gates auto-pass). When a
+Slack/Telegram channel is bound, the user can instead choose **on-demand
+approval** (`NOUS_ALLOW_AUTO_APPROVE=0`): each gate pauses and is relayed to the
+channel for the user to approve before the run proceeds (`AGENTS.md` → "Approval
+mode"). Either way, front-loading `locked_parameters` is what keeps a run
+defensible — see below.
 
 ## Quick start (full workflow)
 
@@ -233,9 +237,30 @@ Use the IDs **verbatim** (they may be namespaced, e.g.
 `report` → newest **sonnet**. If a tier is absent, fall back to the most capable
 model the catalog does list (opus → sonnet → anything).
 
-When the user asks to author a campaign, **read [`reference/campaign-schema.md`](reference/campaign-schema.md)**
-for the complete field set, then walk them through research question →
-target_system.description → what to lock.
+### Author *with* the user (assume they're a Nous beginner)
+
+Assume the user has never run a Nous campaign and doesn't know its knobs. **Don't
+silently pick everything and launch** — propose, explain briefly, confirm, then
+run. A good flow:
+
+1. **Gather what you can decide yourself.** Read
+   [`reference/campaign-schema.md`](reference/campaign-schema.md) for the full
+   field set, and discover the gateway model catalog (above, "Selecting models")
+   so you already know which model IDs are usable — never make the user supply a
+   model. Skim the target repo for likely `observable_metrics` /
+   `controllable_knobs`.
+2. **Draft a full `campaign.yaml` from what you inferred** — research question,
+   `target_system.description`, gateway-served `models`, a rehearsal+real
+   `iterations` schedule, and a first pass at `locked_parameters`.
+3. **Ask the user to make the vague parts concrete**, in plain language and one
+   short round — e.g. *how many real iterations* (more = more confidence, more
+   cost/time), *how long each run / how many seeds*, *which knob they actually
+   care about*, *which parameters must stay fixed*. Explain the tradeoff behind
+   each question rather than dumping schema jargon on them.
+4. **Show the final `campaign.yaml` and get an explicit go-ahead before
+   `nous run`.** Call out the approval mode (`AGENTS.md` → "Approval mode"), the
+   rough cost/time, and the model IDs you pinned. Never launch a campaign the
+   user hasn't seen and confirmed.
 
 ## The five hypothesis arms
 
@@ -255,8 +280,14 @@ Fast-fail rules skip wasted compute on ablations/robustness when `H-main` is ref
 
 ```bash
 # Unattended run — REQUIRES locked_parameters declared (safety precondition).
-# This is the default in this pod; NOUS_ALLOW_AUTO_APPROVE=1 is set in the image.
+# The default in this pod; NOUS_ALLOW_AUTO_APPROVE=1 is set in the image.
 nous run campaign.yaml --auto-approve --max-iterations 10 --timeout 1800 --max-cli-retries 50
+
+# On-demand approval — pauses at each gate and relays it to a bound channel for
+# the user to approve (AGENTS.md → "Approval mode"). No --auto-approve, and
+# NOUS_ALLOW_AUTO_APPROVE=0 overrides the image default. Needs a bound channel:
+# with none, a backgrounded run just halts at the first gate.
+NOUS_ALLOW_AUTO_APPROVE=0 nous run campaign.yaml --max-iterations 10 --timeout 1800
 
 # Skip DESIGN with a pre-authored hypothesis bundle.
 nous run campaign.yaml --bundle ./bundle.yaml --auto-approve
@@ -285,6 +316,9 @@ Notes:
 - If `--auto-approve` refuses to proceed, the run is missing required
   `locked_parameters` — declare the locks first. (`NOUS_ALLOW_AUTO_APPROVE=1` is
   already set in this image, so that gate is not the cause here.)
+- On-demand approval (`NOUS_ALLOW_AUTO_APPROVE=0`) only works with a bound
+  Slack/Telegram channel to relay and answer the gate. Without one, a
+  backgrounded run halts at the first gate — use `--auto-approve` instead.
 
 **Reading liveness (don't be fooled):** `nous status --line` gives phase/iteration;
 for fine-grained progress watch the executor log mtime under `runs/iter-N/` (e.g.
@@ -305,6 +339,12 @@ don't point it at an external webhook (that needs egress allowlisting + a secret
 on disk); point it at the in-pod **channel bridge**, which relays each summary to
 the agent's bound Slack/Telegram thread via the platform's `send_channel_message`
 — no external egress, no secret.
+
+The same bridge is what makes **on-demand approval** possible: with
+`NOUS_ALLOW_AUTO_APPROVE=0` the gate doesn't auto-pass — the relayed card is an
+approval request the user answers from the thread, and the campaign waits
+(`AGENTS.md` → "Approval mode"). A channel is therefore a prerequisite for
+on-demand approval, not just for progress reporting.
 
 The agent wires this in **automatically when a channel is bound** to the agent
 (it checks `describe_channel` before each run); you don't have to ask. See


### PR DESCRIPTION
## What & why

Reworks the `nous` agent's prompting (`AGENTS.md` + the `nous` skill) to incorporate three behaviours requested for the pod. No harness/code changes — this is all prompting + two consistency touch-ups (`README.md`, a `Dockerfile` comment).

### 1. Approval mode: auto-approve vs. on-demand
Previously every campaign ran `--auto-approve`. Now it's a **per-campaign choice keyed on channel binding**:
- **Channel bound → ask the user**: auto-approve the whole run, *or* **on-demand approval** where each DESIGN/FINDINGS gate pauses and is relayed to the bound Slack/Telegram channel (`NOUS_ALLOW_AUTO_APPROVE=0`, no `--auto-approve`).
- **No channel → auto-approve only**, with an explicit warning that `NOUS_ALLOW_AUTO_APPROVE=0` without a channel makes a backgrounded run **halt** at the first gate.
- The chosen mode is recorded in `run.mode` so **resume-on-wake** picks the right flags after hibernation.

### 2. Beginner-friendly, confirm-before-run authoring
New *"Author with the user"* flow: discover the gateway model catalog first (agent supplies models, never the user), propose concrete settings, ask the user to make the vague parts concrete (iterations, seeds, which knob, what to lock) **with tradeoffs explained**, and get explicit go-ahead on the final `campaign.yaml` before launching.

### 3. Nous-first default
Requests like *"improve performance of `github.com/x/y`"* are treated as a request to author and run a campaign, not to hand-edit code or run a one-off benchmark.

## Files
- `packages/agents/nous/AGENTS.md` — approval-mode decision, reworked pre-flight checklist, `run.mode` on launch/resume, nous-first intro.
- `packages/agents/nous/workspace/.agents/skills/nous/SKILL.md` — "Author with the user" flow, on-demand run variant, channel-bridge = approval channel.
- `packages/agents/nous/README.md` + `packages/agents/nous/Dockerfile` — keep `NOUS_ALLOW_AUTO_APPROVE` descriptions consistent (env stays `1` as default; agent overrides per-run).

## Caveat worth a reviewer's eyes
On-demand approval is documented at the intent level (gate pauses → request relayed → user approves). The pinned Nous `v0.4.0` schema notes channel reply-parsing is "Phase B (planned)", so if the installed CLI can't consume an approval for a *backgrounded* gate, on-demand mode may block rather than resume. Worth verifying against the real CLI before relying on it.