### PR TITLE
fix(api-server): stop migration from resurrecting deleted connections

### DIFF
--- a/packages/api-server/src/modules/connections/migration/secrets-to-connections.ts
+++ b/packages/api-server/src/modules/connections/migration/secrets-to-connections.ts
@@ -21,6 +21,11 @@
  * Secret in place lets every gateway roll cleanly; the #1273 follow-up (#2198)
  * sweeps the drained Secrets once the field confirms no gateway still mounts them.
  *
+ * Because the Secret lingers, a connection is (re)created only while an agent
+ * still grants the legacy secret. After the first flip the secret is ungranted,
+ * so a connection the user then deletes stays deleted instead of being rebuilt
+ * on the next boot — the deferred-deletion window can't resurrect user deletes.
+ *
  * Non-blocking and self-disarming: a transient failure leaves the legacy secret
  * intact and re-arms a retry; a permanent skip (malformed / unrecoverable /
  * orphan half) is logged and left alone. A pass with nothing to migrate is a
@@ -206,6 +211,24 @@ async function ensureConnection(
   const connId = deterministicId("conn-", cred.primary.id);
   const existing = await deps.repo.get(connId, cred.owner);
   const granting = await findGrantingAgents(deps, cred);
+
+  // Only (re)create a connection while an agent still grants the legacy secret.
+  // Once the first pass flips an agent, the legacy secret is ungranted — so a
+  // connection the user later deletes must NOT be rebuilt. Because deletion is
+  // deferred to #2198, the legacy Secret lingers, and a bare "no connection
+  // yet" check would resurrect the deleted connection on every boot (or the
+  // 60s retry). An ungranted secret with no connection is either that
+  // user-deleted case or an unused orphan; log and leave it for the #2198 sweep
+  // rather than migrate it into a connection nothing uses.
+  if (!existing && granting.length === 0) {
+    report.push(
+      `SKIP [${cred.owner}] ${cred.primary.id}: no connection and no granting agent (deleted or unused)`,
+    );
+    deps.log(
+      `secrets→connections: skip ${cred.primary.id} — no connection, no granting agent`,
+    );
+    return null;
+  }
 
   if (deps.dryRun) {
     report.push(


### PR DESCRIPTION
## Problem

The #2200 migration defers deleting the legacy `platform-cred-*` Secrets to #2198, so they linger. The migration recreates a connection for any legacy Secret without one — so a connection the user **deletes gets rebuilt on the next api-server boot**. Users can't remove migrated connections.

## Fix

Only (re)create a connection **while an agent still grants the legacy Secret**. Once flipped, the Secret is ungranted, so a deleted connection stays deleted. Still-granted Secrets migrate and re-flip as before; an ungranted Secret with no connection (deleted, or an unused orphan) is logged and left for the #2198 sweep.

## Validated (local, full pre-cutover → migrate → delete → restart)

Fresh migration still drains (`migrated 2, failed 0`); after deleting a connection and restarting, it logged `skip … no granting agent` and **did not reappear**.

Interim fix for the #2200 → #2198 window. #2198 removes the migration and must also sweep the retained Secrets. Refs #1273, #2198