### PR TITLE
fix: fork gateway Envoy crash on stale connection Secrets + leaked gateway pods

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-07-01
+Last verified: 2026-07-06
 
 ## Overview
 
@@ -179,6 +179,8 @@ Schedules are independent Postgres rows and survive Agent deletion as orphans un
 ## Forks
 
 Forks are the third durable concept in the bounded context (alongside Template and Agent). An `agent-fork` ConfigMap runs a derivative of an existing Agent with credential and env overrides. Unlike Agents, forks reconcile to a **Kubernetes Job** rather than a StatefulSet — they run to completion and are not woken, hibernated, or kept warm. This already matches the run-to-completion shape the target lifetime model intends for Agents. The interesting machinery is which secrets the fork can see and how its identity propagates upstream; see [security-and-credentials](security-and-credentials.md). A fork's Job inherits the parent Agent's image-pull Secret, so the kubelet pulls a private parent image without the fork ever seeing the credential.
+
+Fork teardown mirrors the Run executor's two-layer model: the api-server deletes the Fork CR when the fork's turn completes **or fails**, and K8s GC cascades to everything owner-refed to it — including the paired gateway pod, which as a bare always-restarting Pod has no terminal state of its own and lives exactly as long as the CR. A controller hard-lifetime reaper backstops any fork the api-server never cleaned up (crash mid-fork, lost in-memory state), reaping over-age CRs regardless of phase.
 
 ## Run executors (`dam-run`)
 

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-06-30
+Last verified: 2026-07-06
 
 ## Overview
 
@@ -331,6 +331,14 @@ On the wire:
 Hosts the api-server has issued a credential for surface as L7 chains (SNI
 match, header injection); hosts with no credential surface as L4
 passthrough chains.
+
+A referenced SDS file missing from the mounted Secret is a fatal Envoy
+boot error, so the controller verifies each credential's SDS key against
+the Secret's data at render time and degrades that host to an allow-only
+chain (logged as a warning) rather than emit an unbootable bootstrap.
+Requests to the host then go out uncredentialed — failing upstream auth
+for that host only — instead of crash-looping the whole gateway. Stale
+Secrets written by since-replaced code paths are the known trigger.
 
 A host's L7 chain can opt into HTTP/2 so credential injection also covers
 gRPC request streams (e.g. Modal); hosts default to HTTP/1.1 unchanged.

--- a/packages/api-server/src/__tests__/unit/forks-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/forks-service.test.ts
@@ -172,6 +172,75 @@ describe("ForksService.openFork", () => {
     ]);
   });
 
+  it("deletes the K8s fork state when the orchestrator reports Failed", async () => {
+    const h = makeHarness({});
+    await h.service.openFork({
+      agentId: "inst-1",
+      foreignSub: "kc|user-42",
+      replyId: "reply-1",
+    });
+    h.statusStream("fork-1", [
+      {
+        phase: "Failed",
+        error: { reason: "PodNotReady", detail: "CrashLoopBackOff" },
+      },
+    ]);
+    await h.streamDone();
+
+    // The gateway pod is owner-refed to the Fork CR; without this delete a
+    // failed fork's crash-looping gateway would outlive the turn forever.
+    expect(h.calls.deletedForks).toEqual(["fork-1"]);
+    // A later ChannelTurnRelayed-driven closeFork must not re-emit anything.
+    await h.service.closeFork("fork-1");
+    expect(h.events.filter((e) => e.type === EventType.ForkCompleted)).toEqual(
+      [],
+    );
+  });
+
+  it("deletes the K8s fork state when createFork errors", async () => {
+    const h = makeHarness({
+      orchestrator: {
+        createFork: async () =>
+          err({ kind: "WriteFailed", detail: "apiserver 503" }),
+      },
+    });
+    await h.service.openFork({
+      agentId: "inst-1",
+      foreignSub: "kc|user-42",
+      replyId: "reply-1",
+    });
+
+    expect(h.calls.deletedForks).toEqual(["fork-1"]);
+  });
+
+  it("still emits ForkFailed when the failure-path delete throws", async () => {
+    const h = makeHarness({
+      orchestrator: {
+        deleteFork: async () => {
+          throw new Error("apiserver 503");
+        },
+      },
+    });
+    await h.service.openFork({
+      agentId: "inst-1",
+      foreignSub: "kc|user-42",
+      replyId: "reply-1",
+    });
+    h.statusStream("fork-1", [
+      { phase: "Failed", error: { reason: "Timeout" } },
+    ]);
+    await h.streamDone();
+
+    expect(h.events).toEqual([
+      {
+        type: EventType.ForkFailed,
+        forkId: "fork-1",
+        replyId: "reply-1",
+        reason: "Timeout",
+      },
+    ]);
+  });
+
   it("rejects empty foreignSub", async () => {
     const h = makeHarness({});
     await expect(

--- a/packages/api-server/src/modules/forks/services/forks-service.ts
+++ b/packages/api-server/src/modules/forks/services/forks-service.ts
@@ -40,14 +40,25 @@ export function createForksService(deps: {
   const generateForkId = deps.generateForkId ?? (() => `fork-${randomUUID()}`);
   const open = new Map<string, Fork>();
 
-  function emitFailed(
+  async function emitFailed(
     fork: Fork,
     reason: ForkFailureReason,
     detail?: string,
-  ): void {
+  ): Promise<void> {
     const next = markFailed(fork, reason, detail);
     if (!next.ok) return;
     open.delete(fork.forkId);
+    // A failed fork never reaches closeFork (the saga's map lookup misses
+    // the entry deleted above, and markCompleted rejects Failed), so tear
+    // down the Fork CR here — K8s GC cascades to the paired gateway pod,
+    // which otherwise crash-loops forever.
+    try {
+      await deps.orchestrator.deleteFork(fork.forkId);
+    } catch (err) {
+      process.stderr.write(
+        `[forks] deleting failed fork ${fork.forkId}: ${err}\n`,
+      );
+    }
     emit({
       type: EventType.ForkFailed,
       forkId: fork.forkId,
@@ -74,7 +85,7 @@ export function createForksService(deps: {
         continue;
       }
       if (status.phase === "Failed") {
-        emitFailed(
+        await emitFailed(
           current,
           status.error?.reason ?? "OrchestrationFailed",
           status.error?.detail,
@@ -112,7 +123,7 @@ export function createForksService(deps: {
           created.error.kind === "WriteFailed"
             ? created.error.detail
             : created.error.kind;
-        emitFailed(fork, "OrchestrationFailed", detail);
+        await emitFailed(fork, "OrchestrationFailed", detail);
         return;
       }
 

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -86,8 +86,9 @@ type envoyCredential struct {
 	QueryParamName string
 	VolumeName     string // pod-level volume name for this Secret
 	// SDS file key inside the Secret's volume. Single-host
-	// Secrets use `sds.yaml`; connection Secrets use `host-<sha8>.sds.yaml`
-	// so one Secret carries N chains' credentials (issue #219).
+	// Secrets use `sds.yaml`; connection Secrets use the api-server's
+	// `sdsKey` (host-<base64url>.sds.yaml) so one Secret carries N
+	// chains' credentials (issue #219).
 	SDSFileKey string
 }
 
@@ -433,6 +434,18 @@ func chainsFromSecrets(secrets []corev1.Secret) []envoyHostChain {
 		case "connection":
 			for _, hc := range expandConnectionSecret(s) {
 				cred := hc.cred
+				// A bootstrap referencing an SDS file absent from the mounted
+				// Secret is a fatal Envoy boot error (crash-loops the whole
+				// gateway). Stale Secrets with mismatched data keys exist
+				// (pre-cutover writers used a different key naming), so
+				// degrade the host to allow-only instead of rendering an
+				// unbootable config.
+				if len(s.Data[cred.SDSFileKey]) == 0 {
+					slog.Warn("connection Secret missing SDS data key; rendering host allow-only (no credential injection)",
+						"namespace", s.Namespace, "secret", s.Name, "host", hc.host, "sdsKey", cred.SDSFileKey)
+					add(hc.host, s.Name, nil, hc.http2)
+					continue
+				}
 				add(hc.host, s.Name, &cred, hc.http2)
 			}
 			continue
@@ -447,6 +460,12 @@ func chainsFromSecrets(secrets []corev1.Secret) []envoyHostChain {
 		}
 		http2 := s.Annotations[envoyInjectionHTTP2Ann] == "true"
 		if s.Labels[envoySecretTypeLabel] == envoySecretTypeAllowOnly {
+			add(host, s.Name, nil, http2)
+			continue
+		}
+		if len(s.Data[envoyCredentialKeySDS]) == 0 {
+			slog.Warn("credential Secret missing sds.yaml data key; rendering host allow-only (no credential injection)",
+				"namespace", s.Namespace, "secret", s.Name, "host", host)
 			add(host, s.Name, nil, http2)
 			continue
 		}
@@ -1858,22 +1877,39 @@ const envoyBootstrapTemplateRev = "v13-gateway-otel"
 // rendering. Includes `injection-hosts` JSON so a descriptor change
 // (host added / removed / retargeted on a connection) rolls the gateway —
 // Envoy reads the bootstrap once at boot, so without a roll the chain
-// shape goes stale.
+// shape goes stale. The SDS data-key set is included too: chain rendering
+// degrades a host to allow-only when its SDS key is missing, so a Secret
+// gaining (or losing) an SDS key changes the chain shape and must roll.
 func envoySecretsRev(secrets []corev1.Secret) string {
 	parts := []string{"tmpl=" + envoyBootstrapTemplateRev}
 	for _, s := range secrets {
-		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s|%s|%s",
+		parts = append(parts, fmt.Sprintf("%s|%s|%s|%s|%s|%s|%s",
 			s.Name,
 			s.Annotations[envoyHostPatternAnn],
 			s.Labels[envoySecretTypeLabel],
 			s.Annotations[envoyHeaderNameAnn],
 			s.Annotations[envoyQueryParamAnn],
 			s.Annotations[envoyInjectionHostsAnn],
+			strings.Join(sdsDataKeys(s), ","),
 		))
 	}
 	sort.Strings(parts[1:])
 	sum := sha256.Sum256([]byte(strings.Join(parts, "\n")))
 	return hex.EncodeToString(sum[:8])
+}
+
+// sdsDataKeys returns the sorted SDS file keys present in a Secret's data —
+// the only data keys that shape chain rendering (token fields hot-reload
+// via SDS and never require a roll).
+func sdsDataKeys(s corev1.Secret) []string {
+	var keys []string
+	for k := range s.Data {
+		if k == envoyCredentialKeySDS || strings.HasSuffix(k, ".sds.yaml") {
+			keys = append(keys, k)
+		}
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // envoyContainer returns the gateway pod's Envoy container spec. Drops all caps,

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -28,7 +28,23 @@ func ownerSecret(name, secretType, connection string) corev1.Secret {
 			Annotations: map[string]string{envoyHostPatternAnn: "api.example.com"},
 			Labels:      labels,
 		},
+		// Healthy Secrets carry the SDS file the bootstrap references;
+		// chain rendering degrades to allow-only without it. Connection
+		// fixtures add their per-host keys via withHostSDS.
+		Data: map[string][]byte{envoyCredentialKeySDS: []byte("resources: []")},
 	}
+}
+
+// withHostSDS stamps the per-host SDS data keys a connection Secret's
+// injection-hosts entries reference (api-server naming, no sdsKey override).
+func withHostSDS(s corev1.Secret, hosts ...string) corev1.Secret {
+	if s.Data == nil {
+		s.Data = map[string][]byte{}
+	}
+	for _, h := range hosts {
+		s.Data[sdsFileKeyForHost(h)] = []byte("resources: []")
+	}
+	return s
 }
 
 func names(in []corev1.Secret) []string {
@@ -517,6 +533,7 @@ func TestChainsFromSecrets_ConnectionSecretFansIntoNChains(t *testing.T) {
 		{"host":"github.com","valueFormat":"Basic {value}","encoding":"basic-x-access-token"},
 		{"host":"raw.githubusercontent.com"}
 	]`
+	s = withHostSDS(s, "api.github.com", "github.com", "raw.githubusercontent.com")
 
 	chains := chainsFromSecrets([]corev1.Secret{s})
 	require.Len(t, chains, 3)
@@ -550,6 +567,7 @@ func TestChainsFromSecrets_MultiHostSecretYieldsDistinctClusterNames(t *testing.
 		{"host":"github.com","valueFormat":"Basic {value}","encoding":"basic-x-access-token"},
 		{"host":"raw.githubusercontent.com"}
 	]`
+	s = withHostSDS(s, "api.github.com", "github.com", "raw.githubusercontent.com")
 
 	chains := chainsFromSecrets([]corev1.Secret{s})
 	require.Len(t, chains, 3)
@@ -564,6 +582,63 @@ func TestChainsFromSecrets_MultiHostSecretYieldsDistinctClusterNames(t *testing.
 		clusters[c.UpstreamCluster] = true
 		chainIDs[c.ChainID] = true
 	}
+}
+
+func TestChainsFromSecrets_ConnectionMissingSDSKeyDegradesToAllowOnly(t *testing.T) {
+	// Regression for the fork-gateway boot crash: a stale pre-cutover
+	// connection Secret carries an injection-hosts annotation without
+	// sdsKey entries, and data keys under a naming scheme older than the
+	// fallback computes (here the sha8-era `host-<hex8>.sds.yaml`). A
+	// bootstrap referencing the missing base64url file is a fatal Envoy
+	// config error that crash-loops the gateway — render the host
+	// allow-only instead.
+	s := ownerSecret("platform-conn-347e511ae0055405-64b2b6d12bfe4baa", "connection", "github")
+	delete(s.Annotations, envoyHostPatternAnn)
+	s.Annotations[envoyInjectionHostsAnn] = `[{"host":"api.github.com"}]`
+	s.Data = map[string][]byte{
+		"access_token":           []byte("gho_abc"),
+		"host-1a2b3c4d.sds.yaml": []byte("resources: []"),
+	}
+
+	chains := chainsFromSecrets([]corev1.Secret{s})
+	require.Len(t, chains, 1)
+	assert.Equal(t, "api.github.com", chains[0].Host)
+	assert.False(t, chains[0].Credentialed(),
+		"missing SDS data key must degrade to allow-only, not render an unbootable bootstrap")
+}
+
+func TestChainsFromSecrets_ConnectionPartialSDSKeysDegradePerHost(t *testing.T) {
+	// Only the host whose SDS file is missing degrades; the healthy host
+	// keeps its credential.
+	s := ownerSecret("platform-conn-github", "connection", "github")
+	delete(s.Annotations, envoyHostPatternAnn)
+	s.Annotations[envoyInjectionHostsAnn] = `[
+		{"host":"api.github.com"},
+		{"host":"github.com","valueFormat":"Basic {value}","encoding":"basic-x-access-token"}
+	]`
+	s = withHostSDS(s, "api.github.com")
+
+	chains := chainsFromSecrets([]corev1.Secret{s})
+	require.Len(t, chains, 2)
+	byHost := map[string]envoyHostChain{}
+	for _, c := range chains {
+		byHost[c.Host] = c
+	}
+	assert.True(t, byHost["api.github.com"].Credentialed())
+	assert.False(t, byHost["github.com"].Credentialed())
+}
+
+func TestChainsFromSecrets_SingleHostSecretMissingSDSYamlDegradesToAllowOnly(t *testing.T) {
+	// Same guard for the legacy single-host shape: no sds.yaml in data →
+	// allow-only chain, never a bootstrap path Envoy can't open.
+	s := ownerSecret("platform-cred-aaa", "generic", "")
+	s.Annotations[envoyHeaderNameAnn] = "Authorization"
+	s.Data = map[string][]byte{"value": []byte("Bearer abc")}
+
+	chains := chainsFromSecrets([]corev1.Secret{s})
+	require.Len(t, chains, 1)
+	assert.Equal(t, "api.example.com", chains[0].Host)
+	assert.False(t, chains[0].Credentialed())
 }
 
 func TestSDSFileKeyForHost_StableAndShort(t *testing.T) {
@@ -779,6 +854,26 @@ func TestEnvoySecretsRev_InjectionHostsAnnotationRollsExistingPods(t *testing.T)
 	)
 }
 
+func TestEnvoySecretsRev_SDSDataKeysRollExistingPods(t *testing.T) {
+	// Chain rendering degrades a host to allow-only when its SDS data key
+	// is missing, so a Secret gaining the key back (re-bake, reconnect)
+	// changes the chain shape and must roll the gateway.
+	missing := ownerSecret("platform-conn-github", "connection", "github")
+	missing.Annotations[envoyInjectionHostsAnn] = `[{"host":"api.github.com"}]`
+	missing.Data = map[string][]byte{"access_token": []byte("gho_abc")}
+
+	healed := ownerSecret("platform-conn-github", "connection", "github")
+	healed.Annotations[envoyInjectionHostsAnn] = `[{"host":"api.github.com"}]`
+	healed.Data = map[string][]byte{"access_token": []byte("gho_abc")}
+	healed = withHostSDS(healed, "api.github.com")
+
+	assert.NotEqual(t,
+		envoySecretsRev([]corev1.Secret{missing}),
+		envoySecretsRev([]corev1.Secret{healed}),
+		"SDS data-key changes must change the rev so the StatefulSet rolls",
+	)
+}
+
 func TestEnvoySecretsRev_TemplateRevBumpRollsExistingPods(t *testing.T) {
 	// The rev hash must include a template-revision marker so any structural
 	// template change rolls existing pods on chart upgrade. Without it, the
@@ -899,6 +994,7 @@ func TestChainsFromSecrets_ConnectionEntryHTTP2MarksChain(t *testing.T) {
 	s.Annotations[envoyInjectionHostsAnn] = `[
 		{"host":"api.modal.com","headerName":"x-modal-token-id","http2":true}
 	]`
+	s = withHostSDS(s, "api.modal.com")
 
 	chains := chainsFromSecrets([]corev1.Secret{s})
 	require.Len(t, chains, 1)

--- a/packages/controller/pkg/reconciler/fork.go
+++ b/packages/controller/pkg/reconciler/fork.go
@@ -24,6 +24,13 @@ import (
 
 const ForkPodReadyTimeout = 120 * time.Second
 
+// ForkMaxLifetime is a hard GC backstop, mirroring RunMaxLifetime: the
+// api-server deletes a Fork CR when its turn ends or fails, but if it
+// crashes (or its in-memory fork state is lost) the CR — and the gateway
+// Pod, Job, Service, SA, netpol, bootstrap CM and leaf Cert owner-refed to
+// it — would otherwise leak until the parent Agent is deleted.
+const ForkMaxLifetime = 60 * time.Minute
+
 type ForkReconciler struct {
 	client   kubernetes.Interface
 	dynamic  dynamic.Interface // required to apply per-fork cert-manager Certificates
@@ -46,6 +53,19 @@ func (r *ForkReconciler) WithDynamicClient(d dynamic.Interface) *ForkReconciler 
 func (r *ForkReconciler) Reconcile(ctx context.Context, fork *apiv1.Fork) error {
 	forkName := fork.Name
 	ownerRef := forkOwnerRef(fork)
+
+	// Over-age reaper runs before the terminal-phase short-circuit so a
+	// Failed/Completed CR the api-server never deleted is reaped too —
+	// its gateway Pod crash-loops (RestartPolicy=Always) for as long as
+	// the CR exists.
+	if age := r.now().Sub(fork.CreationTimestamp.Time); age > ForkMaxLifetime {
+		slog.Warn("reaping over-age fork", "fork", forkName, "age", age.String())
+		if err := r.dynamic.Resource(ForksGVR).Namespace(r.config.Namespace).
+			Delete(ctx, forkName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return fmt.Errorf("reaping fork %s: %w", forkName, err)
+		}
+		return nil
+	}
 
 	currentPhase := fork.Status.Phase
 	if currentPhase == apiv1.ForkPhaseFailed || currentPhase == apiv1.ForkPhaseCompleted {

--- a/packages/controller/pkg/reconciler/fork_test.go
+++ b/packages/controller/pkg/reconciler/fork_test.go
@@ -203,6 +203,35 @@ func TestForkReconcile_MissingAgentEmitsOrchestrationFailed(t *testing.T) {
 	assert.Equal(t, types.ForkReasonOrchestrationFailed, status.Error.Reason)
 }
 
+func TestForkReconcile_OverAgeForkIsReaped(t *testing.T) {
+	// Hard GC backstop: an api-server crash mid-fork loses its in-memory
+	// fork state, so nothing would ever delete the CR — and the gateway
+	// Pod owner-refed to it would crash-loop forever.
+	fork := forkCR("fork-old", minimalForkSpec("my-agent"), time.Unix(1_000_000, 0).Add(-ForkMaxLifetime-time.Minute))
+	r, client := setupForkReconciler(t, map[string]*apiv1.Agent{"my-agent": agentCR()}, fork)
+
+	require.NoError(t, r.Reconcile(context.Background(), fork))
+
+	_, err := r.dynamic.Resource(ForksGVR).Namespace("test-agents").Get(context.Background(), "fork-old", metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "over-age fork CR must be deleted")
+	_, err = client.BatchV1().Jobs("test-agents").Get(context.Background(), "fork-old", metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "no job should be created for a reaped fork")
+}
+
+func TestForkReconcile_OverAgeTerminalForkIsReaped(t *testing.T) {
+	// The reaper must run ahead of the terminal-phase short-circuit: a
+	// Failed CR the api-server never deleted still owns a crash-looping
+	// gateway Pod.
+	fork := forkCR("fork-old-failed", minimalForkSpec("my-agent"), time.Unix(1_000_000, 0).Add(-ForkMaxLifetime-time.Minute))
+	fork.Status.Phase = apiv1.ForkPhaseFailed
+	r, _ := setupForkReconciler(t, map[string]*apiv1.Agent{"my-agent": agentCR()}, fork)
+
+	require.NoError(t, r.Reconcile(context.Background(), fork))
+
+	_, err := r.dynamic.Resource(ForksGVR).Namespace("test-agents").Get(context.Background(), "fork-old-failed", metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "over-age Failed fork CR must be deleted")
+}
+
 func TestForkReconcile_TerminalPhasesAreNoOp(t *testing.T) {
 	fork := forkCR("fork-7", minimalForkSpec("my-agent"), time.Unix(1_000_000-1, 0))
 	fork.Status.Phase = apiv1.ForkPhaseCompleted

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -87,7 +87,13 @@ func credSecret(name, host string) corev1.Secret {
 			Annotations: ann,
 			Labels:      map[string]string{"agent-platform.ai/owner": "owner-1", "agent-platform.ai/managed-by": "api-server"},
 		},
-		Data: map[string][]byte{"value": []byte("Bearer abc")},
+		// Real api-server-written Secrets always carry the SDS file the
+		// bootstrap references; chain rendering degrades to allow-only
+		// without it.
+		Data: map[string][]byte{
+			"value":               []byte("Bearer abc"),
+			envoyCredentialKeySDS: []byte("resources: []"),
+		},
 	}
 }
 


### PR DESCRIPTION
## Problem

Tagging the Slack bot as a non-owner (foreign replier) reliably failed: the fork gateway's Envoy exited at boot with

```
paths must refer to an existing path in the system: '/etc/envoy/credentials/cred-platform-conn-<...>/host-YXBpLmdpdGh1Yi5jb20.sds.yaml' does not exist
```

np-gate in the fork agent pod then failed convergence (the gateway never serves `/__platform_healthz` with Envoy down), the Job failed, and its 60s TTL deleted the agent pod — while the gateway pod crash-looped **forever**.

## Root causes

**Crash** — the replier owned a connection Secret written by the since-deleted pre-cutover writer (`platform-conn-<hash>-<hash>` naming): its `injection-hosts` annotation has no `sdsKey` fields and its data keys use the old per-host naming. The controller's fallback computes the current base64url filename, which never existed in that Secret's data, and a bootstrap referencing a missing SDS file is a **fatal Envoy boot error**. No migration ever re-baked or removed these Secrets. Owner agents never mount them (grant filtering screens them out by connection id), but fork gateways mount **every** Secret the replier owns — which is why only foreign-replier forks crashed.

**Leak** — a failed fork never reached `orchestrator.deleteFork`: `emitFailed` removed the fork from the in-memory `open` map *before* emitting `ForkFailed`, so the `ChannelTurnRelayed` saga's `closeFork` lookup missed (and `markCompleted` rejects `Failed` anyway). The Fork CR persisted, and the gateway pod — a bare `RestartPolicy: Always` Pod owner-refed to it — lived until the parent Agent was deleted. Forks also had no controller backstop reaper (Runs got one for exactly the api-server-crash case).

## Fixes

- **controller**: verify each credential's SDS key against the Secret's data at render time; a host whose file is missing renders as an **allow-only chain** with a warning instead of an unbootable bootstrap. The SDS data-key set is folded into `envoy-secrets-rev` so a healed Secret rolls the agent gateway.
- **controller**: `ForkMaxLifetime` (60 min) over-age reaper, mirroring `RunMaxLifetime`, running ahead of the terminal-phase short-circuit so leaked `Failed`/`Completed` CRs are reaped too.
- **api-server**: the fork failure path now deletes the Fork CR itself (`deleteFork` is 404-tolerant), so K8s GC cascades to the gateway pod immediately on failure.

## Verification

- New controller tests reproduce the stale-Secret shape (annotation without `sdsKey`, old-naming data keys) and pin the allow-only degradation, per-host partial degradation, the rev roll, and both reaper paths.
- New api-server tests pin `deleteFork` on status-Failed and create-failure paths, and that a failed delete still emits `ForkFailed`.
- `mise run check` and `mise run test` pass.

Existing leaked gateway pods self-heal on deploy: their Fork CRs are past `ForkMaxLifetime`, so the reaper deletes them on the first resync.

## Note / follow-up

Orphaned pre-cutover `platform-conn-*` Secrets still exist on installs (invisible in the UI, not referenced by any DB row, excluded from the legacy-secret migration and from #2198's drain gate). After this PR they merely degrade those hosts to allow-only with a warning; a sweep to remove them outright is worth a separate issue.