### PR TITLE
fix(helm): grant the controller update/delete on fork CRs

### DIFF
--- a/deploy/helm/platform/templates/controller/rbac.yaml
+++ b/deploy/helm/platform/templates/controller/rbac.yaml
@@ -29,10 +29,17 @@ metadata:
 rules:
   # the reconciled resources are agent-platform.ai/v1 Agent + Fork
   # custom resources. The controller watches them and is the sole writer of
-  # their status subresource; the api-server owns spec.
+  # their status subresource; the api-server owns spec, so Agents stay
+  # read-only here.
   - apiGroups: ["agent-platform.ai"]
-    resources: ["agents", "forks"]
+    resources: ["agents"]
     verbs: ["get", "list", "watch"]
+  # Forks additionally need update/patch (the controller stamps the
+  # parent-Agent owner reference onto the Fork CR) and delete (the over-age
+  # fork reaper), mirroring the runs grant below.
+  - apiGroups: ["agent-platform.ai"]
+    resources: ["forks"]
+    verbs: ["get", "list", "watch", "update", "patch", "delete"]
   - apiGroups: ["agent-platform.ai"]
     resources: ["agents/status", "forks/status"]
     verbs: ["get", "update", "patch"]


### PR DESCRIPTION
## Problem

The fork over-age reaper merged in #2344 is failing on RBAC in live deployments — the controller logs show, on every resync:

```
reaping fork fork-…: forks.agent-platform.ai "fork-…" is forbidden: User "system:serviceaccount:…:…-controller" cannot delete resource "forks"
```

so leaked Fork CRs are never actually reaped. The controller Role grants only `get/list/watch` on `forks`; the reaper needs `delete`, and `ensureForkOwnerReference` (which stamps the parent-Agent owner ref onto the Fork CR so agent deletion cascades to in-flight forks) needs `update`.

## Change

Split the combined `agents, forks` read-only rule: `agents` stays `get/list/watch` (the api-server owns spec), `forks` gets `get/list/watch/update/patch/delete` — mirroring the `runs` grant, which was widened for exactly the same reaper pattern.

## Verification

- `mise run helm:check:lint` + `mise run helm:check:render` pass.
- After deploy: `kubectl auth can-i delete forks.agent-platform.ai --as=system:serviceaccount:<release-ns>:<controller-sa>` flips to yes; the reaper deletes the leaked Failed fork CRs (10 on the dev cluster dating back to June 24) on the next resync.