### PR TITLE
feat(helm): enable agent telemetry for the nous template

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1077,6 +1077,10 @@ agentTemplates:
     experimental: true
     displayName: "NOUS"
     description: "Nous hypothesis-driven experimentation agent"
+    # The image is claude-code-based and Nous drives campaigns through the
+    # Claude Agent SDK, whose subprocesses inherit the pod env — so the
+    # standard telemetry env rail covers campaign turns, not just chat.
+    telemetry: true
     tags: ["Any provider"]
     docsUrl: "https://github.com/dam-agents/dam/blob/main/packages/agents/nous/README.md"
     image:

--- a/packages/agents/nous/README.md
+++ b/packages/agents/nous/README.md
@@ -16,6 +16,16 @@ the `claude-code` harness uses. `git`/`gh` for cloning and publishing target
 repos go through the same gateway. The per-agent PVC persists campaign state
 across hibernation, so `nous resume` recovers a long run.
 
+The same inheritance makes agent telemetry work without any image change: the
+template sets `telemetry: true`, and when the telemetry backend is installed
+(`clickstack.enabled`) the pod receives the standard Claude Code OTLP env.
+Both of Nous's dispatch paths — the Claude Agent SDK (which builds its
+subprocess env from `os.environ`) and the legacy `claude -p` fallback — pass
+that env through to the harness, so every planner/executor turn of a campaign
+exports token/cost/duration telemetry with trusted per-agent attribution.
+Gate summaries go through the OpenAI-format endpoint instead of the Claude
+CLI and are the one dispatch path that does not export.
+
 ## Image
 
 Built **FROM the `claude-code` image** (`ARG BASE_IMAGE=platform-claude-code`)
@@ -66,6 +76,13 @@ harness scripts. The chat harness drives `nous` per `AGENTS.md`:
   **auto-approve** by default, or — when a Slack/Telegram channel is bound —
   **on-demand approval** (`NOUS_ALLOW_AUTO_APPROVE=0`), where each gate pauses and
   is relayed to the channel for the user to approve.
+
+- **Experiment trial** → when launched as an arm of a platform Experiment
+  (the Trial prompt carries the autonomous-trial directive), the interactive
+  doctrine is suspended: the agent self-authors the campaign, runs
+  `--auto-approve`, keeps its turn alive until `DONE`, and reports one
+  `record_run` per iteration (composite score from `best_found.json`) before
+  `finish_arm` — see `AGENTS.md` → "Experiment trial sessions".
 
 ### Hibernation & resume
 


### PR DESCRIPTION
## Summary

Adds `telemetry: true` to the `nous` agent template so Nous campaigns export token/cost/duration telemetry to the ClickStack backend, exactly like the `claude-code` template — no image changes required.

## Why this works (investigated upstream nous v0.4.0)

The nous image is built `FROM platform-claude-code`, and the telemetry rail is entirely env-driven: with `clickstack.enabled` + the template flag, the pod receives `CLAUDE_CODE_ENABLE_TELEMETRY=1` and the `OTEL_*` exporter env. Both of Nous's dispatch paths pass that env through to the harness:

- **SDK path (default):** `claude-agent-sdk`'s subprocess transport constructs the child env as `{**os.environ, ...}` (filtering only `CLAUDECODE`), and Nous's `SDKDispatcher` passes no `env` override in `ClaudeAgentOptions` (`orchestrator/sdk_dispatch.py`). The SDK additionally propagates active OTel trace context into the child.
- **`claude -p` fallback:** `subprocess.run` without `env=` — inherits the pod env (`orchestrator/cli_dispatch.py`).
- **No interference:** the orchestrator never scrubs `os.environ`, and the campaign `.claude/settings.json` Nous writes is a permissions allowlist only — no `env` block, no telemetry keys (`orchestrator/settings_template.py`). The image's `nous-model-gateway.sh` doesn't touch `OTEL_*` either.

Attribution needs nothing from Nous: the collector's Istio waypoint stamps the trusted `platform.agent.id` (#2046), so campaign spend lands under the right agent/owner and becomes readable through the owner-scoped read path (#2029).

## Verification

- `mise run helm:check:lint` and `mise run helm:check:render` pass (the render task already exercises `clickstack.enabled=true`).
- Targeted render confirms the `nous.yaml` template entry now carries the same OTLP env block as `claude-code`.

## Caveats

- **Runtime smoke test still advisable** on a `clickstack.enabled` cluster: run a one-iteration campaign and confirm records with the nous agent's `platform.agent.id` land in ClickHouse. Static analysis covers the env plumbing; this confirms the collector round trip.
- **Gate summaries stay dark**: they go through the OpenAI-format endpoint, not the Claude CLI, so they don't export. Noted in the README.
- **No campaign dimension yet**: all phases of all campaigns share the agent's stream. Per-campaign/iteration correlation (e.g. `OTEL_RESOURCE_ATTRIBUTES=platform.nous.campaign=<run_id>`) is deliberately out of scope here; relates to the Experiments Phase 2 direction (#2328, #2335).

The `observability.md` statement ("wired for the Claude Code harness only; a per-template `telemetry` flag opts a harness in") remains accurate — nous *is* the Claude Code harness underneath, so no architecture-doc change is needed.