### PR TITLE
docs(readme): fix mismatched code fence in local setup block

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ git clone https://github.com/dam-agents/dam && cd dam
 
 mise install
 mise run cluster:install
-````
+```
 
 Open [localhost:4444](http://localhost:4444) and log in with:
 


### PR DESCRIPTION
## What

The "Local Setup" snippet in `README.md` opens its fenced code block with three backticks but closes it with four (`` ```` ``). GitHub renders the extra backtick as a stray literal and swallows the following prose into the code block.

This aligns the closing fence to three backticks.

```diff
 mise install
 mise run cluster:install
-````
+```
```

## Why

Cosmetic docs-only fix — no code, config, or behavior change. This is also a **dummy PR requested by the operator** to demo the PR workflow; expected to be closed rather than merged.

## Testing

Rendered-markdown only; nothing to run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)