### PR TITLE
fix(connections): scrub real cluster hostname from kubernetes connection examples

### DIFF
--- a/packages/api-server/src/__tests__/unit/connections-kubernetes-template.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-kubernetes-template.test.ts
@@ -147,16 +147,16 @@ describe("kubernetes connection template", () => {
 
   it("accepts an oc login-style https:// URL and strips the scheme", async () => {
     const built = await buildKubernetes({
-      host: "https://c111-e.us-east.containers.cloud.ibm.com:30767",
+      host: "https://api.my-cluster.example:6443",
     });
     const inject = injectOf(built.contributions);
-    expect(inject.host).toBe("c111-e.us-east.containers.cloud.ibm.com");
-    expect(inject.port).toBe(30767);
+    expect(inject.host).toBe("api.my-cluster.example");
+    expect(inject.port).toBe(6443);
     const file = fileOf(built.contributions);
     expect(
       (file.content as { clusters: { cluster: { server: string } }[] })
         .clusters[0].cluster.server,
-    ).toBe("https://c111-e.us-east.containers.cloud.ibm.com:30767");
+    ).toBe("https://api.my-cluster.example:6443");
   });
 
   it("ignores a trailing path on the URL", async () => {
@@ -187,7 +187,7 @@ describe("kubernetes connection template", () => {
 
   it("rejects an https:// IP URL too", async () => {
     await expect(
-      buildKubernetes({ host: "https://169.51.0.1:30767" }),
+      buildKubernetes({ host: "https://203.0.113.10:6443" }),
     ).rejects.toThrow(/IP address/);
   });
 

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -211,7 +211,7 @@ function inputsFor(
             name: "host",
             state: "required",
             label: "API server URL",
-            hint: "The cluster API endpoint, exactly as you'd pass to `oc login` / `kubectl` — e.g. https://c111-e.us-east.containers.cloud.ibm.com:30767. A bare host[:port] works too.",
+            hint: "The cluster API endpoint, exactly as you'd pass to `oc login` / `kubectl` — e.g. https://api.my-cluster.example:6443. A bare host[:port] works too.",
           });
         } else {
           out.push(t.host ? overridable("host", t.host) : required("host"));

--- a/packages/api-server/src/modules/connections/domain/kubernetes-contributions.ts
+++ b/packages/api-server/src/modules/connections/domain/kubernetes-contributions.ts
@@ -53,7 +53,7 @@ export function buildKubernetesContributions(
         "must be given as a DNS hostname — the gateway routes upstream by TLS " +
         "SNI, which clients don't send for IPs. Managed clusters (IBM Cloud, " +
         "EKS, GKE, AKS, OpenShift) all expose a DNS endpoint; use that " +
-        "(e.g. https://c111-e.us-east.containers.cloud.ibm.com:30767).",
+        "(e.g. https://api.my-cluster.example:6443).",
     );
   }
   const server = `https://${target.host}${target.port ? `:${target.port}` : ""}`;


### PR DESCRIPTION
The Kubernetes/OpenShift connection (merged in #2423) used a real IBM Cloud cluster endpoint (`c111-e.us-east.containers.cloud.ibm.com:30767`) as the example string in three places:

- the **API-server-URL field hint** shown in the UI (`connection-template.ts`),
- the **IP-rejection error message** shown to users on invalid input (`kubernetes-contributions.ts`),
- a unit test (`connections-kubernetes-template.test.ts`).

That leaks a specific cluster's identity into user-facing copy and the repo. This replaces it with reserved placeholders — `api.my-cluster.example` (RFC 2606 `.example` TLD) for hostnames and `203.0.113.10` (RFC 5737 TEST-NET-3) for the IP-rejection test — and drops the real NodePort (`30767`). No behavior change; the kubernetes template unit tests pass unchanged.