### PR TITLE
fix(agent-runtime): don't crash the pod on harness stdin EPIPE

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/create-child-agent-process.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/create-child-agent-process.test.ts
@@ -30,4 +30,42 @@ describe("createChildAgentProcess", () => {
 
     expect(lines).toEqual(['{"id":1,"a":"hello"}', '{"id":2}']);
   });
+
+  it("survives EPIPE when the harness closes stdin while alive", async () => {
+    // The no-chat-harness stub case: the child's stdin reader is gone but the
+    // process hasn't exited, so send()'s writable guard still passes and the
+    // dispatched write fails async with EPIPE. Without a stdin error handler
+    // that's an unhandled 'error' event — it would crash this test process.
+    const proc = createChildAgentProcess({
+      command: [
+        process.execPath,
+        "-e",
+        // fs.closeSync, not process.stdin.destroy(): node never really closes
+        // stdio fds through the stream API, so only the raw close makes the
+        // parent's pipe reader-less.
+        `require("fs").closeSync(0); console.log("ready"); setTimeout(() => {}, 2000);`,
+      ],
+      workingDir: process.cwd(),
+    });
+
+    // "ready" on stdout ⇒ the child has already destroyed its stdin.
+    await new Promise<void>((resolve) => proc.onLine(() => resolve()));
+
+    proc.send({ jsonrpc: "2.0", method: "ping" });
+    // Let the dispatched write's async EPIPE surface before passing.
+    await new Promise((r) => setTimeout(r, 200));
+
+    proc.kill();
+    await proc.exited;
+  });
+
+  it("drops sends after the harness exited", async () => {
+    const proc = createChildAgentProcess({
+      command: [process.execPath, "-e", "process.exit(0)"],
+      workingDir: process.cwd(),
+    });
+    await proc.exited;
+    proc.send({ jsonrpc: "2.0", method: "ping" });
+    await new Promise((r) => setTimeout(r, 100));
+  });
 });

--- a/packages/agent-runtime/src/modules/acp/infrastructure/create-child-agent-process.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/create-child-agent-process.ts
@@ -30,6 +30,14 @@ export function createChildAgentProcess(
     process.stderr.write(`[agent-process] spawn error: ${err.message}\n`);
   });
 
+  // send()'s writable guard is racy: after the harness exits (e.g. an image
+  // without a chat harness, whose stub exits immediately), a dispatched write
+  // fails async with EPIPE on this stream — unhandled, it kills the runtime
+  // (PID 1) and the whole pod. Exit cleanup already closes the sessions.
+  child.stdin!.on("error", (err) => {
+    process.stderr.write(`[agent-process] stdin error: ${err.message}\n`);
+  });
+
   const handlers: ((line: string) => void)[] = [];
 
   const rl = readline.createInterface({


### PR DESCRIPTION
## Problem

Opening a **chat** session against an agent image that ships platform-base's no-chat-harness stub (a supported configuration — e.g. terminal-only agents) crashes the whole agent pod:

```
harness-chat: this agent image does not provide a chat harness
Error: write EPIPE
    at Object.send (file:///app/dist/server.js:6375:21)
    at handleClientMessage (file:///app/dist/server.js:7170:9)
Emitted 'error' event on Socket instance ...
```

agent-runtime is PID 1's child, so the unhandled error takes down the container — killing the pod-service, terminal sessions, and any in-flight work.

## Root cause

`createChildAgentProcess`'s `send()` guards `child.stdin.writable`, but the guard is racy: when the harness exits, a write dispatched during pipe teardown fails **asynchronously** with EPIPE, emitted as an `'error'` event on the stdin stream — which had no listener. The existing `child.on("error", …)` only covers spawn failures.

## Fix

Attach a stdin `'error'` handler that logs and drops, mirroring what `modules/ssh.ts` already does for the sshd child. Session teardown is unchanged — the `exited` cleanup already closes engaged channels with `1011 "agent exited"`.

## Tests

- New regression test reproduces the crash deterministically (child closes fd 0 while alive → dispatched write EPIPEs). Fails with an unhandled `write EPIPE` without the fix; passes with it.
- `mise run agent-runtime:test` (161 tests) and `mise run check` green.