### PR TITLE
fix(helm): derive ClickHouse headless service name from release name

### DIFF
--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -331,9 +331,13 @@ API Server ServiceAccount name
 
 {{/* HTTP endpoint of the ClickStack ClickHouse store — the api-server's
      owner-scoped telemetry read path queries it directly (docs/architecture/
-     observability.md). Mirrors the subchart's ClickHouse headless Service. */}}
+     observability.md). The operator names the headless Service
+     {clickstack.fullname}-clickhouse-clickhouse-headless, and the subchart's
+     fullname derives from .Release.Name (NOT platform.fullname) — mirror that
+     logic. Assumes clickstack.nameOverride/fullnameOverride stay unset. */}}
 {{- define "platform.clickstack.clickhouse.httpUrl" -}}
-{{- printf "http://%s-clickstack-clickhouse-clickhouse-headless.%s.svc.cluster.local:8123" (include "platform.fullname" .) .Release.Namespace }}
+{{- $fullname := ternary .Release.Name (printf "%s-clickstack" .Release.Name) (contains "clickstack" .Release.Name) | trunc 63 | trimSuffix "-" }}
+{{- printf "http://%s-clickhouse-clickhouse-headless.%s.svc.cluster.local:8123" $fullname .Release.Namespace }}
 {{- end }}
 
 {{- define "platform.agentTelemetry.env" -}}


### PR DESCRIPTION
## Problem

On deployments where the Helm release is not named `platform` (e.g. `dam` in `dam-dev`), the clickstack collector's `wait-for-clickhouse` init container loops forever:

```
wget: bad address 'dam-platform-clickstack-clickhouse-clickhouse-headless.dam-dev.svc.cluster.local:8123'
waiting for ClickHouse to be ready
```

The same wrong URL is injected into the api-server's telemetry read path.

## Root cause

`platform.clickstack.clickhouse.httpUrl` built the service name from `platform.fullname` (`<release>-platform-clickstack-...`), but the clickstack subchart names its ClickHouseCluster CR — and the operator the headless Service — from `.Release.Name` (`<release>-clickstack-clickhouse-clickhouse-headless`). With release name `platform` the two coincide, which is why local clusters never hit this.

## Fix

Mirror the subchart's `clickstack.fullname` logic (`.Release.Name`, its `contains "clickstack"` edge case, 63-char truncation) in the helper. Assumes `clickstack.nameOverride`/`fullnameOverride` stay unset, as noted in the helper comment.

## Verification

Rendered the chart with release names `dam` and `platform`: the helper URL now matches the hostname in the subchart's own `clickstack-config` in both cases. `mise run helm:check:lint` and `helm:check:render` pass.