### PR TITLE
fix(cluster): add cluster:fix-certs and roll waypoints on expired mesh certs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ mise run cluster:build-ui        # rebuild UI image only, restart UI pod
 mise run cluster:build-controller# rebuild controller image only, restart controller pod
 mise run cluster:build-agent     # rebuild agent image only, restart agent pods
 mise run cluster:build-keycloak  # rebuild keycloak image only, restart keycloak pod
+mise run cluster:fix-certs       # roll ztunnel + waypoint pods after an expired-SVID wedge (issue #283)
 mise run cluster:status          # show pods and cluster state
 mise run cluster:logs            # show api-server pod logs
 mise run cluster:stop            # stop k3s VM (preserves data)
@@ -43,7 +44,7 @@ mise run cluster:uninstall       # helm uninstall + cleanup PVCs
 mise run cluster:delete          # destroy k3s VM entirely
 ```
 
-The `cluster:build-*` tasks honor a `LIMA_INSTANCE` env var (default `platform-k3s`); set it to target a different VM (e.g. the e2e cluster).
+The `cluster:build-*`, `cluster:fix-certs`, and `cluster:status` tasks honor a `LIMA_INSTANCE` env var (default `platform-k3s`); set it to target a different VM (e.g. the e2e cluster).
 
 Services are available at `*.localhost:4444` automatically (Traefik on port 4444, auto-forwarded by lima). `*.localtest.me:4444` also works as an alias.
 
@@ -63,7 +64,7 @@ Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` i
 
 Activate cluster environment for interactive use: `export KUBECONFIG="$(mise run cluster:kubeconfig)"`.
 
-If the UI suddenly can't log in or `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, suspect expired Istio ambient workload SVIDs (issue #283). The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` within ~10 min when it sees the expired-cert signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait.
+If in-mesh traffic misbehaves — the UI suddenly can't log in, `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, or a new agent never seeds its workspace (agent pod logs repeat `[runtime] hello failed`) — suspect expired Istio ambient workload SVIDs (issue #283). `mise run cluster:status` reports whether the expired-cert signature is present. The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` and the waypoint deployments within ~10 min when it sees the signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait.
 
 ## System Architecture (what this system is)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ mise run cluster:build-ui        # rebuild UI image only, restart UI pod
 mise run cluster:build-controller# rebuild controller image only, restart controller pod
 mise run cluster:build-agent     # rebuild agent image only, restart agent pods
 mise run cluster:build-keycloak  # rebuild keycloak image only, restart keycloak pod
-mise run cluster:fix-certs       # roll ztunnel + waypoint pods after an expired-SVID wedge (issue #283)
+mise run cluster:fix-certs       # recover from expired dev-cluster certs: roll ztunnel, waypoints, cert-manager webhook (issue #283)
 mise run cluster:status          # show pods and cluster state
 mise run cluster:logs            # show api-server pod logs
 mise run cluster:stop            # stop k3s VM (preserves data)
@@ -64,7 +64,7 @@ Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` i
 
 Activate cluster environment for interactive use: `export KUBECONFIG="$(mise run cluster:kubeconfig)"`.
 
-If in-mesh traffic misbehaves — the UI suddenly can't log in, `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, or a new agent never seeds its workspace (agent pod logs repeat `[runtime] hello failed`) — suspect expired Istio ambient workload SVIDs (issue #283). `mise run cluster:status` reports whether the expired-cert signature is present. The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` and the waypoint deployments within ~10 min when it sees the signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait.
+If in-mesh traffic misbehaves — the UI suddenly can't log in, `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, or a new agent never seeds its workspace (agent pod logs repeat `[runtime] hello failed`) — suspect expired Istio ambient workload SVIDs (issue #283). `mise run cluster:status` reports whether the expired-cert signature is present. The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` and the waypoint deployments within ~10 min when it sees the signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait. The same suspend/resume clock skip can expire cert-manager's webhook serving cert (`cluster:install` fails at admission with `failed calling webhook ... certificate has expired`) — `cluster:status` probes for it and `cluster:fix-certs` heals it too.
 
 ## System Architecture (what this system is)
 

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -254,11 +254,13 @@ kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout status ds/ztunnel --t
 kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout status ds/istio-cni-node --timeout=120s
 
 # Watchdog: every 10 min, scan ztunnel pod logs for the expired-SVID
-# markers (issue #283) and roll ds/ztunnel if any are present. Belt-and-
-# suspenders against any rotation failure that slips past the 30d
-# DEFAULT_WORKLOAD_CERT_TTL pinned on istiod above (e.g. a cluster left
-# running past TTL, an upstream istio bug). Apply is idempotent on
-# re-runs of cluster:install.
+# markers (issue #283) and, if any are present, roll ds/ztunnel plus all
+# istiod-synthesised waypoint deployments — waypoints hold their own
+# SVIDs, and ztunnel logs the failed HBONE dial when a waypoint's cert
+# is the expired one (issue #705). Belt-and-suspenders against any
+# rotation failure that slips past the 30d DEFAULT_WORKLOAD_CERT_TTL
+# pinned on istiod above (e.g. a cluster left running past TTL, an
+# upstream istio bug). Apply is idempotent on re-runs of cluster:install.
 kubectl --kubeconfig="$KUBECONFIG" apply -f - <<'YAML'
 apiVersion: v1
 kind: ServiceAccount
@@ -298,6 +300,30 @@ subjects:
     name: ztunnel-cert-watchdog
     namespace: istio-system
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: ztunnel-cert-watchdog-waypoints
+rules:
+  # Cluster-scoped: waypoint deployments are synthesised wherever an
+  # istio-waypoint Gateway lives; discovery is label-based across namespaces.
+  - apiGroups: ["apps"]
+    resources: ["deployments"]
+    verbs: ["get", "list", "watch", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: ztunnel-cert-watchdog-waypoints
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: ztunnel-cert-watchdog-waypoints
+subjects:
+  - kind: ServiceAccount
+    name: ztunnel-cert-watchdog
+    namespace: istio-system
+---
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -328,16 +354,27 @@ spec:
                   for pod in $(kubectl -n istio-system get pods -l app=ztunnel -o name); do
                     if kubectl -n istio-system logs --since=15m "$pod" 2>/dev/null \
                         | grep -qiE 'certificate expired|AlertReceived\(CertificateExpired\)'; then
-                      echo "watchdog: $pod reported expired SVID — rolling ds/ztunnel"
+                      echo "watchdog: $pod reported expired SVID — rolling ztunnel + waypoints"
                       TRIGGERED=1
                       break
                     fi
                   done
                   if [ "$TRIGGERED" = 1 ]; then
+                    # The expired cert may be a waypoint's own SVID (ztunnel logs the
+                    # failed HBONE dial); istiod labels the deployments it synthesises.
+                    WAYPOINTS=$(kubectl get deploy -A -l gateway.istio.io/managed=istio.io-mesh-controller \
+                      -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
                     kubectl -n istio-system rollout restart ds/ztunnel
+                    for wp in $WAYPOINTS; do
+                      echo "watchdog: rolling waypoint deploy/${wp##*/} (ns ${wp%%/*})"
+                      kubectl -n "${wp%%/*}" rollout restart "deploy/${wp##*/}"
+                    done
                     kubectl -n istio-system rollout status ds/ztunnel --timeout=120s
+                    for wp in $WAYPOINTS; do
+                      kubectl -n "${wp%%/*}" rollout status "deploy/${wp##*/}" --timeout=120s
+                    done
                   else
-                    echo "watchdog: ztunnel SVIDs healthy"
+                    echo "watchdog: mesh SVIDs healthy"
                   fi
 YAML
 
@@ -908,8 +945,67 @@ echo "[4/4] Disk usage on the cluster VM:"
 $RUN_IN_VM df -h /
 '''
 
+["cluster:fix-certs"]
+description = "Recover from expired Istio ambient SVIDs (issue #283): roll ztunnel + all waypoint deployments. Honors LIMA_INSTANCE."
+run = '''
+#!/usr/bin/env bash
+set -eo pipefail
+if [ -n "${IS_SANDBOX:-}" ]; then
+  KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
+else
+  LIMA_INSTANCE="${LIMA_INSTANCE:-platform-k3s}"
+  KUBECONFIG="${LIMA_HOME:-$HOME/.lima}/$LIMA_INSTANCE/copied-from-guest/kubeconfig.yaml"
+fi
+
+# Diagnose first: the expired-SVID signature always surfaces in ztunnel
+# logs — for ztunnel-held workload certs and for an expired waypoint cert
+# alike (the dialing ztunnel logs the failed HBONE handshake). Keep the
+# regex in sync with the ztunnel-cert-watchdog CronJob (cluster:install).
+echo "Scanning ztunnel logs (last 30m) for expired-cert markers..."
+FOUND=0
+for pod in $(kubectl --kubeconfig="$KUBECONFIG" -n istio-system get pods -l app=ztunnel -o name); do
+  if kubectl --kubeconfig="$KUBECONFIG" -n istio-system logs --since=30m "$pod" 2>/dev/null \
+      | grep -qiE 'certificate expired|AlertReceived\(CertificateExpired\)'; then
+    echo "  $pod: expired-cert signature PRESENT"
+    FOUND=1
+  else
+    echo "  $pod: clean"
+  fi
+done
+if [ "$FOUND" = 0 ]; then
+  echo "No expired-cert signature found — rolling anyway is harmless if you suspect a wedge."
+fi
+
+# Waypoint pods carry their own SVIDs; istiod stamps the deployments it
+# synthesises from istio-waypoint Gateways with this label.
+WAYPOINTS=$(kubectl --kubeconfig="$KUBECONFIG" get deploy -A \
+  -l gateway.istio.io/managed=istio.io-mesh-controller \
+  -o jsonpath='{range .items[*]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}')
+if [ -z "$WAYPOINTS" ]; then
+  if kubectl --kubeconfig="$KUBECONFIG" get gateways.gateway.networking.k8s.io -A \
+      -o jsonpath='{.items[*].spec.gatewayClassName}' 2>/dev/null | grep -qw istio-waypoint; then
+    echo "WARN: istio-waypoint Gateways exist but no waypoint deployments carry the" >&2
+    echo "      mesh-controller label — istiod still reconciling, or label drift after an istio bump." >&2
+  else
+    echo "No waypoints found (platform chart not installed?) — rolling ztunnel only."
+  fi
+fi
+
+echo "Rolling ds/ztunnel..."
+kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout restart ds/ztunnel
+for wp in $WAYPOINTS; do
+  echo "Rolling waypoint deploy/${wp##*/} (ns ${wp%%/*})..."
+  kubectl --kubeconfig="$KUBECONFIG" -n "${wp%%/*}" rollout restart "deploy/${wp##*/}"
+done
+kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout status ds/ztunnel --timeout=120s
+for wp in $WAYPOINTS; do
+  kubectl --kubeconfig="$KUBECONFIG" -n "${wp%%/*}" rollout status "deploy/${wp##*/}" --timeout=120s
+done
+echo "Done. If symptoms persist, re-check with: mise run cluster:status"
+'''
+
 ["cluster:status"]
-description = "Show cluster and pod status. Options: --watch (continuous refresh every 2s)"
+description = "Show cluster and pod status. Options: --watch (continuous refresh every 2s). Honors LIMA_INSTANCE."
 raw = true
 run = '''
 #!/usr/bin/env bash
@@ -917,7 +1013,7 @@ set -eo pipefail
 if [ -n "${IS_SANDBOX:-}" ]; then
   KUBECONFIG="/etc/rancher/k3s/k3s.yaml"
 else
-  KUBECONFIG="${LIMA_HOME:-$HOME/.lima}/platform-k3s/copied-from-guest/kubeconfig.yaml"
+  KUBECONFIG="${LIMA_HOME:-$HOME/.lima}/${LIMA_INSTANCE:-platform-k3s}/copied-from-guest/kubeconfig.yaml"
 fi
 
 STATUS_CMD="
@@ -950,7 +1046,27 @@ case "${1:-}" in
       sleep 0.5
     done
     ;;
-  *) eval "$STATUS_CMD" ;;
+  *)
+    eval "$STATUS_CMD"
+    # One-shot only — log fetches are too slow for the --watch loop. Same
+    # expiry signature the ztunnel-cert-watchdog CronJob keys on (see
+    # cluster:install); keep the regex in sync. ztunnel logs cover both its
+    # own expired SVID and an expired waypoint cert (it dials the mTLS hop).
+    echo ''
+    echo '=== Mesh cert health (istio-system) ==='
+    CERT_HITS=$(kubectl --kubeconfig="$KUBECONFIG" -n istio-system logs \
+        -l app=ztunnel --since=30m --tail=2000 --prefix 2>/dev/null \
+      | grep -iE 'certificate expired|AlertReceived\(CertificateExpired\)' | tail -5 || true)
+    if [ -n "$CERT_HITS" ]; then
+      echo 'WARNING: expired ambient-mesh certs detected (issue #283).'
+      echo 'Known symptoms: UI login failure, keycloak "Connection reset" during install,'
+      echo 'agent pods looping "[runtime] hello failed" (workspace seeding never starts).'
+      echo 'Fix now: mise run cluster:fix-certs   (the watchdog auto-heals within ~10 min)'
+      printf '%s\n' "$CERT_HITS"
+    else
+      echo 'ok — no expired-cert signature in recent ztunnel logs'
+    fi
+    ;;
 esac
 '''
 

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -946,7 +946,7 @@ $RUN_IN_VM df -h /
 '''
 
 ["cluster:fix-certs"]
-description = "Recover from expired Istio ambient SVIDs (issue #283): roll ztunnel + all waypoint deployments. Honors LIMA_INSTANCE."
+description = "Recover from expired dev-cluster certs (issue #283): roll ztunnel + waypoint deployments + cert-manager webhook. Honors LIMA_INSTANCE."
 run = '''
 #!/usr/bin/env bash
 set -eo pipefail
@@ -991,16 +991,32 @@ if [ -z "$WAYPOINTS" ]; then
   fi
 fi
 
+# cert-manager's webhook holds a short-lived in-memory serving cert that a
+# suspended VM can age past expiry, failing chart installs at admission with
+# "failed calling webhook ... certificate has expired". A restart re-issues
+# it from the long-lived CA Secret.
+CM_WEBHOOK=0
+if kubectl --kubeconfig="$KUBECONFIG" -n cert-manager get deploy cert-manager-webhook >/dev/null 2>&1; then
+  CM_WEBHOOK=1
+fi
+
 echo "Rolling ds/ztunnel..."
 kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout restart ds/ztunnel
 for wp in $WAYPOINTS; do
   echo "Rolling waypoint deploy/${wp##*/} (ns ${wp%%/*})..."
   kubectl --kubeconfig="$KUBECONFIG" -n "${wp%%/*}" rollout restart "deploy/${wp##*/}"
 done
+if [ "$CM_WEBHOOK" = 1 ]; then
+  echo "Rolling cert-manager webhook..."
+  kubectl --kubeconfig="$KUBECONFIG" -n cert-manager rollout restart deploy/cert-manager-webhook
+fi
 kubectl --kubeconfig="$KUBECONFIG" -n istio-system rollout status ds/ztunnel --timeout=120s
 for wp in $WAYPOINTS; do
   kubectl --kubeconfig="$KUBECONFIG" -n "${wp%%/*}" rollout status "deploy/${wp##*/}" --timeout=120s
 done
+if [ "$CM_WEBHOOK" = 1 ]; then
+  kubectl --kubeconfig="$KUBECONFIG" -n cert-manager rollout status deploy/cert-manager-webhook --timeout=120s
+fi
 echo "Done. If symptoms persist, re-check with: mise run cluster:status"
 '''
 
@@ -1065,6 +1081,26 @@ case "${1:-}" in
       printf '%s\n' "$CERT_HITS"
     else
       echo 'ok — no expired-cert signature in recent ztunnel logs'
+    fi
+    echo ''
+    echo '=== cert-manager webhook health ==='
+    # The webhook's in-memory serving cert can expire while the VM sleeps,
+    # failing chart installs at admission. Probe with a server dry-run — the
+    # same call the platform chart's cert-manager objects go through.
+    if ! kubectl --kubeconfig="$KUBECONFIG" -n cert-manager get deploy cert-manager-webhook >/dev/null 2>&1; then
+      echo 'skipped — cert-manager not installed'
+    else
+      PROBE_ERR=$(printf 'apiVersion: cert-manager.io/v1\nkind: ClusterIssuer\nmetadata:\n  name: webhook-health-probe\nspec:\n  selfSigned: {}\n' \
+        | kubectl --kubeconfig="$KUBECONFIG" apply --dry-run=server -f - 2>&1 >/dev/null || true)
+      if [ -z "$PROBE_ERR" ]; then
+        echo 'ok — webhook admission responding'
+      elif printf '%s' "$PROBE_ERR" | grep -q 'certificate has expired'; then
+        echo 'WARNING: cert-manager webhook serving cert has expired — helm installs will'
+        echo 'fail at admission. Fix now: mise run cluster:fix-certs'
+      else
+        echo 'WARN: webhook probe failed for another reason:'
+        printf '%s\n' "$PROBE_ERR" | head -3
+      fi
     fi
     ;;
 esac

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-07-07
+Last verified: 2026-07-08
 
 ## Overview
 
@@ -505,10 +505,18 @@ k3s/lima `cluster:install` ([`deploy/tasks.toml`](../../deploy/tasks.toml))
 pins `DEFAULT_WORKLOAD_CERT_TTL=720h` on istiod so workload SVIDs
 outlive a typical dev cluster's lifetime, and installs a
 `ztunnel-cert-watchdog` CronJob in `istio-system` that scans recent
-ztunnel logs every 10 min and rolls `ds/ztunnel` if it sees
-`certificate expired` / `AlertReceived(CertificateExpired)`. Together
-these absorb the race where lima VM suspend/resume on a sleeping host
-laptop slips past the default 24h rotation window and stalls every
-mesh hop — see [issue #283](https://github.com/dam-agents/dam/issues/283).
+ztunnel logs every 10 min for `certificate expired` /
+`AlertReceived(CertificateExpired)` and rolls the affected mesh
+workloads — `ds/ztunnel` and the istio-synthesised waypoint
+deployments, whose SVIDs expire independently. An expired waypoint
+cert stalls only the flows through that waypoint (e.g. the harness
+path), which is why it can masquerade as an app-level bug — see
+[issue #705](https://github.com/dam-agents/dam/issues/705).
+`mise run cluster:fix-certs` performs the same roll on demand, and
+`mise run cluster:status` reports whether the expired-cert signature
+is present. Together these absorb the race where lima VM
+suspend/resume on a sleeping host laptop slips past the default 24h
+rotation window and stalls every mesh hop — see
+[issue #283](https://github.com/dam-agents/dam/issues/283).
 Production deployments configure mesh PKI separately and don't get
-either knob.
+any of these knobs.

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-07-08
+Last verified: 2026-07-09
 
 ## Overview
 
@@ -518,5 +518,8 @@ is present. Together these absorb the race where lima VM
 suspend/resume on a sleeping host laptop slips past the default 24h
 rotation window and stalls every mesh hop — see
 [issue #283](https://github.com/dam-agents/dam/issues/283).
+The same clock skip can age out cert-manager's short-lived webhook
+serving cert, failing chart installs at admission; `cluster:status`
+probes for that and `cluster:fix-certs` restarts the webhook too.
 Production deployments configure mesh PKI separately and don't get
 any of these knobs.

--- a/tasks.toml
+++ b/tasks.toml
@@ -71,6 +71,19 @@ cleanup() {
         echo ""
       done
     done
+    echo ""
+    echo "--- Mesh cert-expiry check (ztunnel) ---"
+    # Same signature the ztunnel-cert-watchdog keys on (deploy/tasks.toml);
+    # keep the regex in sync. Rules mesh certs in or out as the failure cause.
+    CERT_HITS=$(kubectl --kubeconfig="$KUBECONFIG" -n istio-system logs \
+        -l app=ztunnel --since=6h --tail=5000 --prefix 2>/dev/null \
+      | grep -iE 'certificate expired|AlertReceived\(CertificateExpired\)' | tail -5 || true)
+    if [ -n "$CERT_HITS" ]; then
+      echo "expired-cert signature PRESENT — mesh certs are a likely failure cause:"
+      printf '%s\n' "$CERT_HITS"
+    else
+      echo "no expired-cert signature (mesh certs are not the failure cause)"
+    fi
     echo "=== End diagnostics ==="
   fi
 
@@ -285,7 +298,13 @@ done
 if [ "$READY" != true ]; then
   echo "ERROR: warm e2e cluster is up but not routing on http://localhost:5555." >&2
   echo "Traefik/ingress likely failed to install. e2e:loop does not auto-heal —" >&2
-  echo "reprovision with 'mise run e2e', or check 'mise run cluster:fix-certs'." >&2
+  echo "reprovision with 'mise run e2e', or check 'LIMA_INSTANCE=$VM_NAME mise run cluster:fix-certs'." >&2
+  # Same signature the ztunnel-cert-watchdog keys on (deploy/tasks.toml);
+  # keep the regex in sync. Turns the generic advice above into a verdict.
+  if kubectl --kubeconfig="$KUBECONFIG" -n istio-system logs -l app=ztunnel --since=6h --tail=5000 2>/dev/null \
+      | grep -qiE 'certificate expired|AlertReceived\(CertificateExpired\)'; then
+    echo "Detected expired mesh certs — run 'LIMA_INSTANCE=$VM_NAME mise run cluster:fix-certs', then rerun e2e:loop." >&2
+  fi
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Fixes #705.

- **`mise run cluster:fix-certs` now exists** (it was promised in CLAUDE.md and the `e2e:loop` error message but never implemented). It scans ztunnel logs for the expired-SVID signature, reports a per-pod verdict, then rolls `ds/ztunnel` **and every istiod-synthesised waypoint deployment**, waiting for all rollouts. Honors `LIMA_INSTANCE` so it can heal the warm e2e cluster.
- **Waypoint discovery is generic**, not hardcoded: deployments labeled `gateway.istio.io/managed=istio.io-mesh-controller` (the label istiod stamps on deployments it synthesises from `istio-waypoint` Gateways — verified against istio release-1.29 source and empirically on a dev cluster). If a waypoint Gateway exists but no deployment carries the label, the task warns loudly instead of silently no-oping.
- **The `ztunnel-cert-watchdog` CronJob remediation now covers waypoints.** Detection is unchanged (ztunnel logs are the single observation point — the dialing ztunnel logs the failed HBONE handshake even when the *waypoint's* cert is the expired one), but on trigger it now rolls waypoint deployments in addition to `ds/ztunnel`. A new ClusterRole/ClusterRoleBinding grants the watchdog SA deployment patch across namespaces. The CronJob keeps its name so `kubectl apply` converges existing clusters without leaving a stale duplicate.
- **The failure is now recognizable**: `cluster:status` gains a mesh cert health section (one-shot mode only, never in `--watch`); the `e2e` failure dump and the `e2e:loop` readiness gate print an expired-cert verdict (positive *or* negative, so readers stop chasing certs when they're not the cause); CLAUDE.md and the security architecture page document the agent-workspace-seeding symptom (`[runtime] hello failed` loop).

## Verification (on the live dev cluster)

- Created a throwaway `istio-waypoint` Gateway; istiod synthesised the deployment with exactly the expected label — discovery matched it.
- `mise run cluster:fix-certs` end-to-end with a waypoint present: diagnosed, rolled ztunnel + waypoint, both rollouts completed. Also exercised the no-waypoint branch.
- Applied the updated watchdog heredoc over the pre-existing objects: idempotent (`unchanged`/`created`/`configured`); `kubectl auth can-i` confirms the SA can list deployments cluster-wide and patch in `default`.
- Ran the watchdog Job manually: healthy path prints `mesh SVIDs healthy`; with the grep temporarily forced to match, the in-pod script rolled ztunnel + the waypoint and waited for both (then restored the real manifest).
- `mise run cluster:status` prints the `ok` verdict on a healthy cluster; `--watch` code path untouched.
- `mise run check` passes; `bash -n` passes for every task script in both tasks.toml files.

## Follow-up: cert-manager webhook coverage

While this PR was open, the same suspend/resume clock skip expired a *different* dev-cluster cert in the wild: cert-manager's short-lived in-memory webhook serving cert, which fails every chart install at admission (`failed calling webhook "webhook.cert-manager.io" ... certificate has expired`). Since this task is the documented recovery entry point, it now covers that too:

- **`cluster:fix-certs`** also rolls `deploy/cert-manager-webhook` (a restart re-issues the leaf from the long-lived CA Secret); skipped when cert-manager isn't installed.
- **`cluster:status`** gains a cert-manager webhook health section that probes admission with a server dry-run ClusterIssuer apply — the same call chart installs go through — and distinguishes "expired cert" from other probe failures.
- CLAUDE.md and the architecture page document the symptom → fix mapping.

Verified on the live dev cluster (now fully installed): the real recovery was performed by hand first (webhook restart un-blocked the failing `cluster:install`), then `cluster:fix-certs` exercised end-to-end — it discovered and rolled the *real* chart-installed `apiserver-waypoint` plus the cert-manager webhook, all rollouts completed, UI serves 200 afterwards, and both `cluster:status` probes report ok.
