### PR TITLE
feat(telemetry): identify agent telemetry by template and agent name

### DIFF
--- a/deploy/helm/platform/templates/_helpers.tpl
+++ b/deploy/helm/platform/templates/_helpers.tpl
@@ -340,8 +340,14 @@ API Server ServiceAccount name
 {{- printf "http://%s-clickhouse-clickhouse-headless.%s.svc.cluster.local:8123" $fullname .Release.Namespace }}
 {{- end }}
 
+{{/* Call with (dict "root" $ "templateName" <name>): the harness's default
+     OTel service name is the CLI's own ("claude-code" for every claude-code-
+     based image), which makes derived templates like nous indistinguishable
+     in the exploration UI — so name the service after the template. */}}
 {{- define "platform.agentTelemetry.env" -}}
-{{- $host := printf "%s.%s.svc.cluster.local" (include "platform.clickstack.collector.fullname" .) .Release.Namespace }}
+{{- $host := printf "%s.%s.svc.cluster.local" (include "platform.clickstack.collector.fullname" .root) .root.Release.Namespace }}
+- name: OTEL_SERVICE_NAME
+  value: {{ .templateName | quote }}
 - name: CLAUDE_CODE_ENABLE_TELEMETRY
   value: "1"
 - name: CLAUDE_CODE_ENHANCED_TELEMETRY_BETA

--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -87,7 +87,7 @@ data:
     {{- end }}
     {{- $env := $tmpl.env | default list }}
     {{- if and $.Values.clickstack.enabled $tmpl.telemetry }}
-    {{- $env = concat $env (include "platform.agentTelemetry.env" $ | fromYamlArray) }}
+    {{- $env = concat $env (include "platform.agentTelemetry.env" (dict "root" $ "templateName" $name) | fromYamlArray) }}
     {{- end }}
     {{- with $env }}
     env:

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,6 +1,6 @@
 # Observability (agent telemetry)
 
-Last verified: 2026-07-07
+Last verified: 2026-07-08
 
 ## Overview
 
@@ -48,6 +48,7 @@ Harnesses produce telemetry by exporting it themselves over OTLP — the platfor
 - **Rides the agent's ordinary egress.** The exporter honours the agent's `HTTPS_PROXY`, so telemetry leaves through the paired gateway pod over HTTPS to the bundled collector — the same dedicated, MITM-terminating chain that performs the trusted attribution below. No new network path, and no credential is injected into the export.
 - **Config travels the harness env rail.** The OTLP environment (enable flag, per-signal exporters, endpoint, protocol, flush intervals) reaches the harness through the same runtime channel that carries connection env — not a pod-level Secret or env.
 - **Signals.** Metrics, logs, and traces (the last via the enhanced-telemetry beta) over OTLP/HTTP. **Content bodies are not exported** — prompt text, tool arguments, and raw API bodies stay off; only structural telemetry (durations, model/tool names, token and cost counters, span shape) leaves the agent.
+- **Self-declared identity for exploration.** The export env names the OTel service after the agent's **template** (so a nous agent reads as `nous`, not as the underlying Claude Code CLI's default), and seeds the user-declared agent name as a `platform.agent.name` resource attribute, kept current on rename. Both are exported by the harness itself and exist for finding an instance in the exploration UI — they are **display-only**; attribution rests solely on the gateway-stamped `platform.agent.id` below.
 - **Trace-context propagation stays on.** The harness keeps W3C trace-context propagation on even when it fronts a custom model upstream — a case where it would otherwise switch it off — so its subprocesses inherit the session's trace context and its requests carry the `traceparent` header. The gateway's TLS-intercepting chains that see the decrypted header join their spans — and the egress-approval check's api-server spans — to that same trace, so a model request reads as one trace across harness, gateway, and api-server. See [logging — gateway telemetry](logging.md#gateway-telemetry) for which chains are traced and what never reaches a span.
 
 ## Platform-service export

--- a/packages/agents/nous/README.md
+++ b/packages/agents/nous/README.md
@@ -22,7 +22,10 @@ template sets `telemetry: true`, and when the telemetry backend is installed
 Both of Nous's dispatch paths — the Claude Agent SDK (which builds its
 subprocess env from `os.environ`) and the legacy `claude -p` fallback — pass
 that env through to the harness, so every planner/executor turn of a campaign
-exports token/cost/duration telemetry with trusted per-agent attribution.
+exports token/cost/duration telemetry with trusted per-agent attribution —
+under the service name `nous` (the chart names the OTel service after the
+template), with the user-declared agent name riding along as a display-only
+resource attribute.
 Gate summaries go through the OpenAI-format endpoint instead of the Claude
 CLI and are the one dispatch path that does not export.
 

--- a/packages/api-server/src/__tests__/unit/telemetry-env.test.ts
+++ b/packages/api-server/src/__tests__/unit/telemetry-env.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import type { EnvVar } from "api-server-api";
+import {
+  seedTelemetryIdentity,
+  renamedTelemetryIdentity,
+} from "../../modules/agents/domain/telemetry-env.js";
+
+const telemetryEnv: EnvVar[] = [
+  { name: "CLAUDE_CODE_ENABLE_TELEMETRY", value: "1" },
+  { name: "OTEL_EXPORTER_OTLP_ENDPOINT", value: "https://collector:4318" },
+];
+
+describe("seedTelemetryIdentity", () => {
+  it("appends the agent name attribute when the template enables telemetry", () => {
+    const env = seedTelemetryIdentity(telemetryEnv, "calm-harbor");
+    expect(env).toContainEqual({
+      name: "OTEL_RESOURCE_ATTRIBUTES",
+      value: "platform.agent.name=calm-harbor",
+    });
+  });
+
+  it("leaves non-telemetry env untouched", () => {
+    const env: EnvVar[] = [{ name: "FOO", value: "bar" }];
+    expect(seedTelemetryIdentity(env, "calm-harbor")).toBe(env);
+  });
+
+  it("merges into an existing OTEL_RESOURCE_ATTRIBUTES, replacing a stale name", () => {
+    const env = seedTelemetryIdentity(
+      [
+        ...telemetryEnv,
+        {
+          name: "OTEL_RESOURCE_ATTRIBUTES",
+          value: "team=blue,platform.agent.name=old",
+        },
+      ],
+      "new-name",
+    );
+    const attrs = env.find((e) => e.name === "OTEL_RESOURCE_ATTRIBUTES");
+    expect(attrs?.value).toBe("team=blue,platform.agent.name=new-name");
+    // No duplicate entry appended.
+    expect(
+      env.filter((e) => e.name === "OTEL_RESOURCE_ATTRIBUTES"),
+    ).toHaveLength(1);
+  });
+
+  it("percent-encodes names that would break the key=value,: format", () => {
+    const env = seedTelemetryIdentity(telemetryEnv, "a,b=c");
+    const attrs = env.find((e) => e.name === "OTEL_RESOURCE_ATTRIBUTES");
+    expect(attrs?.value).toBe("platform.agent.name=a%2Cb%3Dc");
+  });
+});
+
+describe("renamedTelemetryIdentity", () => {
+  const withAttr: EnvVar[] = [
+    ...telemetryEnv,
+    {
+      name: "OTEL_RESOURCE_ATTRIBUTES",
+      value: "platform.agent.name=old-name",
+    },
+  ];
+
+  it("rewrites the name attribute where it exists", () => {
+    const env = renamedTelemetryIdentity(withAttr, "new-name");
+    expect(env).not.toBeNull();
+    expect(env?.find((e) => e.name === "OTEL_RESOURCE_ATTRIBUTES")?.value).toBe(
+      "platform.agent.name=new-name",
+    );
+  });
+
+  it("returns null when the agent carries no name attribute (never adds one)", () => {
+    expect(renamedTelemetryIdentity(telemetryEnv, "any")).toBeNull();
+    expect(renamedTelemetryIdentity([], "any")).toBeNull();
+  });
+
+  it("returns null when the name is already current (no needless env bump)", () => {
+    expect(renamedTelemetryIdentity(withAttr, "old-name")).toBeNull();
+  });
+});

--- a/packages/api-server/src/modules/agents/domain/telemetry-env.ts
+++ b/packages/api-server/src/modules/agents/domain/telemetry-env.ts
@@ -1,0 +1,59 @@
+import type { EnvVar } from "api-server-api";
+
+// Resource attribute carrying the user-declared agent name so telemetry from
+// one instance is spottable in the exploration UI. Display-only: unlike
+// `platform.agent.id` (gateway-stamped, unforgeable), this value is exported
+// by the harness itself and must never be used for attribution or authz.
+const AGENT_NAME_ATTR = "platform.agent.name";
+const RESOURCE_ATTRS_ENV = "OTEL_RESOURCE_ATTRIBUTES";
+const TELEMETRY_MARKER_ENV = "CLAUDE_CODE_ENABLE_TELEMETRY";
+
+/** Set or replace `platform.agent.name` inside an OTEL_RESOURCE_ATTRIBUTES
+ *  value (comma-separated `key=value` pairs; values percent-encoded per the
+ *  W3C Baggage rules the OTel env spec uses). */
+function upsertNameAttr(value: string | undefined, agentName: string): string {
+  const pair = `${AGENT_NAME_ATTR}=${encodeURIComponent(agentName)}`;
+  const others = (value ?? "")
+    .split(",")
+    .map((p) => p.trim())
+    .filter((p) => p !== "" && !p.startsWith(`${AGENT_NAME_ATTR}=`));
+  return [...others, pair].join(",");
+}
+
+/**
+ * Create-time: when the template env enables telemetry, return a copy with
+ * the agent's user-declared name merged into OTEL_RESOURCE_ATTRIBUTES.
+ * Env without the telemetry marker passes through untouched.
+ */
+export function seedTelemetryIdentity(
+  env: EnvVar[],
+  agentName: string,
+): EnvVar[] {
+  if (!env.some((e) => e.name === TELEMETRY_MARKER_ENV)) return env;
+  const existing = env.find((e) => e.name === RESOURCE_ATTRS_ENV);
+  const next = {
+    name: RESOURCE_ATTRS_ENV,
+    value: upsertNameAttr(existing?.value, agentName),
+  };
+  return existing
+    ? env.map((e) => (e === existing ? next : e))
+    : [...env, next];
+}
+
+/**
+ * Rename-time: rewrite the name attribute only where it already exists, so a
+ * rename never adds telemetry env to an agent that doesn't carry it (or that
+ * the user stripped it from). Returns null when nothing needs writing.
+ */
+export function renamedTelemetryIdentity(
+  env: EnvVar[],
+  agentName: string,
+): EnvVar[] | null {
+  const existing = env.find(
+    (e) => e.name === RESOURCE_ATTRS_ENV && e.value.includes(AGENT_NAME_ATTR),
+  );
+  if (!existing) return null;
+  const value = upsertNameAttr(existing.value, agentName);
+  if (value === existing.value) return null;
+  return env.map((e) => (e === existing ? { ...e, value } : e));
+}

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -35,6 +35,10 @@ import {
   assembleSpecFromTemplate,
   assembleSpecFromImage,
 } from "../domain/spec-assembly.js";
+import {
+  seedTelemetryIdentity,
+  renamedTelemetryIdentity,
+} from "../domain/telemetry-env.js";
 import { generateK8sName } from "../infrastructure/configmap-mappers.js";
 import type { AgentRegistrySecretPort } from "../infrastructure/agent-registry-secret-port.js";
 import type { KeycloakUserDirectory } from "../infrastructure/keycloak-user-directory.js";
@@ -284,7 +288,10 @@ export function createAgentsService(deps: {
       }
       // Template-declared env rides the rail like user env (seeded below), not
       // the CR — the controller no longer reads spec.env.
-      const templateEnv = (spec.env as EnvVar[] | undefined) ?? [];
+      const templateEnv = seedTelemetryIdentity(
+        (spec.env as EnvVar[] | undefined) ?? [],
+        input.name,
+      );
       delete spec.env;
       if (input.secretRef !== undefined) spec.secretRef = input.secretRef;
       if (input.hibernationTimeoutMin !== undefined)
@@ -455,9 +462,23 @@ export function createAgentsService(deps: {
       if (env !== undefined) {
         // Strip protected names, then bump + enqueue so a running agent applies it next turn.
         env = preserveProtectedEnvs([], env);
+        if (input.name !== undefined)
+          env = renamedTelemetryIdentity(env, input.name) ?? env;
         await deps.agentEnvRepo.replace(input.id, env);
         await deps.runtimeMutator.bump(input.id, []);
         await deps.runtimeMutator.enqueueAfterCommit(input.id);
+      } else if (input.name !== undefined) {
+        // Rename: keep the telemetry name attribute in step with the new
+        // name; skipped entirely when the agent doesn't carry it.
+        const refreshed = renamedTelemetryIdentity(
+          await deps.agentEnvRepo.list(input.id),
+          input.name,
+        );
+        if (refreshed) {
+          await deps.agentEnvRepo.replace(input.id, refreshed);
+          await deps.runtimeMutator.bump(input.id, []);
+          await deps.runtimeMutator.enqueueAfterCommit(input.id);
+        }
       }
 
       if (input.env !== undefined || input.secretRef !== undefined) {


### PR DESCRIPTION
## Summary

Agent telemetry from claude-code-derived images is currently indistinguishable in the exploration UI: every harness exports under the Claude Code CLI's default OTel service name, so a `nous` agent's traces file under service `claude-code` alongside everyone else's, and nothing anywhere carries the name the user gave their agent. Found while verifying #2419 end-to-end ("I don't see nous in the logs").

Two changes:

- **Service name = template name.** The chart's agent telemetry env helper now emits `OTEL_SERVICE_NAME` set to the template key, for every telemetry-enabled template. A nous agent reads as service `nous`; `claude-code` is unchanged; future templates get this for free.
- **User-declared agent name as a resource attribute.** Creating an agent from a telemetry-enabled template seeds `OTEL_RESOURCE_ATTRIBUTES` with `platform.agent.name=<name>` (percent-encoded per the W3C Baggage rules the OTel env spec uses), merged into an existing value if the template declares one. A rename refreshes the attribute — but only where it already exists, so a rename never adds telemetry env to an agent that doesn't carry it or that the user stripped it from. Searching `platform.agent.name:"calm-harbor"` in HyperDX finds the instance directly.

## Trust boundary

Both values are exported by the harness itself and are **display-only**. Attribution continues to rest solely on the gateway-stamped `platform.agent.id` (#2046) — `observability.md` now states this explicitly.

## Implementation notes

- Pure domain helpers (`seedTelemetryIdentity` / `renamedTelemetryIdentity`) in the agents module, wired into the create and update flows; the rename path reuses the existing env bump + enqueue so a running agent picks the new name up next turn.
- Existing agents keep their creation-time env — they gain the identity on recreation or by pasting the env vars into the agent's env editor.

## Testing

- 7 new unit tests for the domain helpers; all 241 api-server unit tests, `mise run check`, `helm:check:lint`, and `helm:check:render` pass.
- Chart render with `clickstack.enabled=true` confirms per-template `OTEL_SERVICE_NAME` (`claude-code`, `nous`).
- The underlying export path was verified live on a `CLICKSTACK=1` dev cluster as part of #2419.