### PR TITLE
fix(deps): remediate open vulnerability scanner findings

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,10 @@
     "overrides": {
       "@anthropic-ai/sdk@<0.91.1": "0.91.1",
       "@babel/core@<7.29.6": "7.29.6",
-      "brace-expansion@5.0.5": "5.0.6",
+      "brace-expansion@2": "2.1.2",
+      "brace-expansion@5": "5.0.7",
       "esbuild@<0.25.0": "0.25.12",
+      "fast-uri@<3.1.3": "3.1.3",
       "form-data@<4.0.6": "4.0.6",
       "js-yaml@<4.2.0": "4.2.0",
       "protobufjs@<7.6.3": "7.6.3",

--- a/packages/api-server/Dockerfile
+++ b/packages/api-server/Dockerfile
@@ -30,7 +30,7 @@ RUN pnpm --filter api-server exec tsup \
 FROM registry.access.redhat.com/hi/nodejs:24 AS runner
 
 USER root
-ARG NPM_VERSION=11.16.0
+ARG NPM_VERSION=11.18.0
 RUN npm install -g "npm@${NPM_VERSION}" && rm -rf /usr/lib/node_modules_24/npm
 USER 65532
 

--- a/packages/keycloak-theme/Dockerfile
+++ b/packages/keycloak-theme/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/keycloak/keycloak:26.6.3@sha256:5fdbf2dbb5897cc34e82de49d13e23db011f9925089dbc555fc095f2c8bc1dac
+FROM quay.io/keycloak/keycloak:26.6.4@sha256:0aae0de7fca85525f727d3354df17896092de8bb26ae4c12d89c77e5df8cbce4
 
 COPY packages/keycloak-theme/dist_keycloak/keycloak-theme-for-kc-all-other-versions.jar \
     /opt/keycloak/providers/keycloak-theme.jar

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -27,6 +27,10 @@ RUN --mount=type=cache,target=/root/.cache/mise \
     cd /tmp/lockgen; mise trust -q; mise lock; \
     cp mise.lock /etc/mise/mise.lock; chmod 644 /etc/mise/mise.lock; rm -r /tmp/lockgen
 RUN --mount=type=cache,target=/root/.cache/mise mise install node
+# node 24.18.0's bundled npm 11.16.0 ships vulnerable undici 6.26.0
+# (CVE-2026-12151) and tar 7.5.15 (CVE-2026-53655); self-upgrade until a
+# node release bundles npm >= 11.17.0.
+RUN mise exec node -- npm install -g npm@11.18.0
 
 FROM registry.access.redhat.com/hi/core-runtime:latest-builder AS sysroot
 USER root

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,8 +7,10 @@ settings:
 overrides:
   '@anthropic-ai/sdk@<0.91.1': 0.91.1
   '@babel/core@<7.29.6': 7.29.6
-  brace-expansion@5.0.5: 5.0.6
+  brace-expansion@2: 2.1.2
+  brace-expansion@5: 5.0.7
   esbuild@<0.25.0: 0.25.12
+  fast-uri@<3.1.3: 3.1.3
   form-data@<4.0.6: 4.0.6
   js-yaml@<4.2.0: 4.2.0
   protobufjs@<7.6.3: 7.6.3
@@ -4019,11 +4021,11 @@ packages:
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   browserslist@4.28.2:
@@ -4653,8 +4655,8 @@ packages:
   fast-string-width@3.0.2:
     resolution: {integrity: sha512-gX8LrtNEI5hq8DVUfRQMbr5lpaS4nMIWV+7XEbXk2b8kiQIizgnlr12B4dA3ZEx3308ze0O4Q1R+cHts8kyUJg==}
 
-  fast-uri@3.1.2:
-    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
 
   fast-wrap-ansi@0.2.0:
     resolution: {integrity: sha512-rLV8JHxTyhVmFYhBJuMujcrHqOT2cnO5Zxj37qROj23CP39GXubJRBUFF0z8KFK77Uc0SukZUf7JZhsVEQ6n8w==}
@@ -10490,14 +10492,14 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.2
+      fast-uri: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -10640,11 +10642,11 @@ snapshots:
 
   bowser@2.14.1: {}
 
-  brace-expansion@2.1.1:
+  brace-expansion@2.1.2:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -11297,7 +11299,7 @@ snapshots:
     dependencies:
       fast-string-truncated-width: 3.0.3
 
-  fast-uri@3.1.2: {}
+  fast-uri@3.1.3: {}
 
   fast-wrap-ansi@0.2.0:
     dependencies:
@@ -12436,11 +12438,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@5.1.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 2.1.2
 
   minipass@7.1.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,26 +49,10 @@ trustPolicyExclude:
   - "@mariozechner/clipboard-win32-arm64-msvc@0.3.6"
   - "@mariozechner/clipboard-win32-x64-msvc@0.3.6"
 minimumReleaseAgeExclude:
-  # Pinned in the pi-agent workspace mise config and the pi-dynamic-providers
-  # extension to keep the extension's types aligned with the runtime fork that
-  # actually loads against them (issue #375). The fork ships its core/ai/tui
-  # packages at the same version; bump all four together with the mise
-  # config. Safe to drop from this list once the chosen version ages past 7 days.
-  - "@earendil-works/pi-coding-agent@0.79.10"
-  - "@earendil-works/pi-agent-core@0.79.10"
-  - "@earendil-works/pi-ai@0.79.10"
-  - "@earendil-works/pi-tui@0.79.10"
-  # form-data 4.0.6 fixes CVE-2026-12143 (HIGH), pulled in via the override
-  # above; published <7 days ago. Safe to drop once it ages past 7 days.
-  - "form-data@4.0.6"
-  # undici 8.5.0 fixes the 8.x line of the undici advisory cluster (CVE-2026-12151
-  # HIGH et al.), pulled in by @earendil-works/pi-coding-agent@0.79.10; published
-  # 2026-06-15 (<7 days). Safe to drop once it ages past 7 days.
-  - "undici@8.5.0"
-  # @mistralai/mistralai 2.2.6 is pulled in transitively by @earendil-works/pi-ai
-  # @0.79.10 (the pi-coding-agent bump above); published 2026-06-16 (<7 days).
+  # brace-expansion 2.1.2 fixes CVE-2026-13149 (high) on the 2.x line, pulled
+  # in via the override in package.json; published 2026-07-08 (<7 days).
   # Safe to drop once it ages past 7 days.
-  - "@mistralai/mistralai@2.2.6"
+  - "brace-expansion@2.1.2"
 allowBuilds:
   # grpc-tools downloads the protoc binary in a postinstall step; needed
   # by `mise run api-server:gen:proto` (ts-proto codegen for ext_authz).


### PR DESCRIPTION
Remediates the fixable findings from #2737 and closes the SCA issues.

## Fixes
- **npm 11.16.0 → 11.18.0** in the api-server and platform-base images. Node 24.18.0's bundled npm ships undici 6.26.0 (CVE-2026-12151 HIGH, CVE-2026-11525) and tar 7.5.15 (CVE-2026-53655); npm 11.18.0 bundles undici 6.27.0 and tar 7.5.19 (verified by installing and inspecting). All agent images derive from platform-base, so this clears the undici/tar findings across all 10 Node images.
- **Keycloak 26.6.3 → 26.6.4** (digest-pinned, multi-arch index). Verified the image ships netty 4.1.135.Final (fixes the 13 netty CVEs, 6 HIGH) and RHEL 9.8 errata for glibc 2.34-272, coreutils-single 8.32-41, libtasn1 4.16.0-10.
- **brace-expansion → 2.1.2 / 5.0.7** via pnpm overrides (CVE-2026-13149). 2.1.2 was published 2026-07-08, so it is listed in `minimumReleaseAgeExclude` with a dated drop-when-aged comment. Closes #2222, closes #2223.
- **fast-uri → 3.1.3** via pnpm override (CVE-2026-13676). Closes #2133.
- **Dropped all 7 stale `minimumReleaseAgeExclude` entries** (pi-agent×4, form-data, undici, mistralai) — added Jun 12–23, all aged past the 7-day window.

## Not fixed (blocked upstream)
- esbuild GHSA-g7r4-m6w7-qqqr (#2113, low, Windows-only dev server): overriding to 0.28.1 breaks vite 6 (`Transforming destructuring to the configured target environment is not supported`) and drizzle-kit; both pin older esbuild lines. Labeled `blocked-upstream`.
- opentelemetry-api 1.57.0 (CVE-2026-45416 HIGH) is still bundled in Keycloak 26.6.4; needs a future Keycloak release.

## Verification
- `mise run test` — 141 tests pass
- `mise run check` — passes except `db:check:generated`, which fails identically on an unmodified baseline in this sandbox (pnpm links cache doesn't expose the drizzle-orm peer to drizzle-kit); CI runs it with a normal layout
- `vite build` (ui) and `tsup` (api-server) succeed with the final lockfile