### PR TITLE
fix(connections): key kubeconfig context by connection name, not host

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-07-07
+Last verified: 2026-07-09
 
 ## Overview
 
@@ -178,7 +178,9 @@ token, and — only when the API cert isn't publicly trusted — the cluster's C
 The build synthesizes three contributions: an `egress-inject` carrying the port,
 the streaming-upgrade opt-in, and (when a CA was given) the upstream-CA marker;
 a `file` contribution writing a ready-to-use kubeconfig at a **per-connection
-path**; and a `KUBECONFIG` `env` pointing at that file. The kubeconfig's trust
+path** (the file, and the kubeconfig's cluster/user/context, are all named after
+the connection — unique per user); and a `KUBECONFIG` `env` pointing at that
+file. The kubeconfig's trust
 anchor is the platform MITM CA already mounted in every agent pod, and its user
 carries only an **inert placeholder token** — the gateway overwrites it with
 the real service-account token on the wire, so `kubectl`/`oc` work out of the
@@ -191,7 +193,10 @@ kubeconfig file, and the `env` driver joins their `KUBECONFIG` entries into the
 `:`-separated list `kubectl`/`oc` merge at load time (kubeconfig has no
 include-another-file mechanism, so this is the idiomatic route). The driver
 resolves `$HOME` and dedups; the first-granted connection's context is the
-default.
+default. Because the cluster/user/context are keyed by the connection name — not
+the API host — two clusters that share a host on different ports stay distinct in
+the merged config (the host alone dropped the port and collided), and each is
+addressable as `--context <connection-name>`.
 
 The CA is optional and never reaches the agent — it configures the gateway's
 upstream validation only. Publicly-trusted endpoints (most managed clusters)
@@ -211,10 +216,10 @@ blindly.
     { "kind": "egress-inject", "host": "api.prod.example", "port": 6443,
       "headerName": "Authorization", "valueFormat": "Bearer {value}",
       "upgrades": true, "upstreamCa": true },
-    { "kind": "env", "name": "KUBECONFIG", "placeholder": "$HOME/.kube/connections/api.prod.example-6443.config" },
-    { "kind": "file", "path": "$HOME/.kube/connections/api.prod.example-6443.config", "format": "yaml",
+    { "kind": "env", "name": "KUBECONFIG", "placeholder": "$HOME/.kube/connections/prod-cluster.config" },
+    { "kind": "file", "path": "$HOME/.kube/connections/prod-cluster.config", "format": "yaml",
       "mergeMode": "overwrite",
-      "content": { "clusters": [ { "cluster": { "server": "https://api.prod.example:6443", "certificate-authority": "/etc/platform/ca/ca.crt" } } ], "users": [ { "user": { "token": "injected-by-gateway" } } ], "…": "…" } }
+      "content": { "clusters": [ { "name": "prod-cluster", "cluster": { "server": "https://api.prod.example:6443", "certificate-authority": "/etc/platform/ca/ca.crt" } } ], "users": [ { "name": "prod-cluster", "user": { "token": "injected-by-gateway" } } ], "contexts": [ { "name": "prod-cluster", "context": { "cluster": "prod-cluster", "user": "prod-cluster" } } ], "current-context": "prod-cluster" } }
   ]
 }
 ```

--- a/packages/api-server/src/__tests__/unit/connections-kubernetes-template.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-kubernetes-template.test.ts
@@ -43,6 +43,7 @@ function kubernetesTemplate() {
 
 async function buildKubernetes(input: {
   host: string;
+  name?: string;
   value?: string;
   caData?: string;
 }) {
@@ -50,7 +51,7 @@ async function buildKubernetes(input: {
     kubernetesTemplate(),
     {
       templateId: "kubernetes",
-      name: "my-cluster",
+      name: input.name ?? "my-cluster",
       authKind: "header",
       host: input.host,
       value: input.value ?? "sa-token",
@@ -94,11 +95,14 @@ describe("kubernetes connection template", () => {
   });
 
   it("writes a per-connection kubeconfig and points KUBECONFIG at it", async () => {
-    const built = await buildKubernetes({ host: "api.cluster.example:6443" });
+    const built = await buildKubernetes({
+      host: "api.cluster.example:6443",
+      name: "prod-cluster",
+    });
     const file = fileOf(built.contributions);
-    expect(file.path).toBe(
-      "$HOME/.kube/connections/api.cluster.example-6443.config",
-    );
+    // File + context/cluster/user are keyed by the connection name, not the
+    // host (see the same-host-different-port test for why).
+    expect(file.path).toBe("$HOME/.kube/connections/prod-cluster.config");
     // The env driver joins KUBECONFIG across connections, so it must point at
     // this connection's own file.
     expect(envOf(built.contributions, "KUBECONFIG").placeholder).toBe(
@@ -108,9 +112,12 @@ describe("kubernetes connection template", () => {
     expect(file.mergeMode).toBe("overwrite");
     const content = file.content as {
       clusters: {
+        name: string;
         cluster: { server: string; "certificate-authority": string };
       }[];
-      users: { user: { token?: string } }[];
+      users: { name: string; user: { token?: string } }[];
+      contexts: { name: string; context: { cluster: string; user: string } }[];
+      "current-context": string;
     };
     expect(content.clusters[0].cluster.server).toBe(
       "https://api.cluster.example:6443",
@@ -118,19 +125,59 @@ describe("kubernetes connection template", () => {
     expect(content.clusters[0].cluster["certificate-authority"]).toBe(
       "/etc/platform/ca/ca.crt",
     );
+    // Cluster/user/context all carry the connection name; it's the current one.
+    expect(content.clusters[0].name).toBe("prod-cluster");
+    expect(content.users[0].name).toBe("prod-cluster");
+    expect(content.contexts[0]).toMatchObject({
+      name: "prod-cluster",
+      context: { cluster: "prod-cluster", user: "prod-cluster" },
+    });
+    expect(content["current-context"]).toBe("prod-cluster");
     // Real token stays gateway-side; user holds only the placeholder.
     expect(JSON.stringify(content)).not.toContain("sa-token");
     expect(content.users[0].user.token).toBe("injected-by-gateway");
   });
 
-  it("gives distinct clusters distinct kubeconfig files (so they compose)", async () => {
+  it("gives distinct connections distinct kubeconfig files (so they compose)", async () => {
     const a = fileOf(
-      (await buildKubernetes({ host: "api.a.example:6443" })).contributions,
+      (await buildKubernetes({ host: "api.a.example:6443", name: "cluster-a" }))
+        .contributions,
     );
     const b = fileOf(
-      (await buildKubernetes({ host: "api.b.example" })).contributions,
+      (await buildKubernetes({ host: "api.b.example", name: "cluster-b" }))
+        .contributions,
     );
     expect(a.path).not.toBe(b.path);
+  });
+
+  it("keeps same-host clusters on different ports distinct (name, not host, is the key)", async () => {
+    const ctxOf = (path: string, content: unknown) => ({
+      path,
+      ctx: (content as { "current-context": string })["current-context"],
+    });
+    const a = fileOf(
+      (
+        await buildKubernetes({
+          host: "api.shared.example:6443",
+          name: "shared-a",
+        })
+      ).contributions,
+    );
+    const b = fileOf(
+      (
+        await buildKubernetes({
+          host: "api.shared.example:8443",
+          name: "shared-b",
+        })
+      ).contributions,
+    );
+    const A = ctxOf(a.path, a.content);
+    const B = ctxOf(b.path, b.content);
+    // Same host, different ports — before the fix these collided (context name
+    // dropped the port). Now file paths AND context names are distinct.
+    expect(A.path).not.toBe(B.path);
+    expect(A.ctx).toBe("shared-a");
+    expect(B.ctx).toBe("shared-b");
   });
 
   it("normalizes :443 away and omits the port field", async () => {

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -284,7 +284,12 @@ function buildHeader(
 
   if (template.id === KUBERNETES_TEMPLATE_ID) {
     contributions.push(
-      ...buildKubernetesContributions({ host, port, hasUpstreamCa: !!caPem }),
+      ...buildKubernetesContributions({
+        name: input.name,
+        host,
+        port,
+        hasUpstreamCa: !!caPem,
+      }),
     );
   }
 

--- a/packages/api-server/src/modules/connections/domain/kubernetes-contributions.ts
+++ b/packages/api-server/src/modules/connections/domain/kubernetes-contributions.ts
@@ -15,6 +15,12 @@ const PLATFORM_CA_PATH = "/etc/platform/ca/ca.crt";
 const KUBECONFIG_PLACEHOLDER_TOKEN = "injected-by-gateway";
 
 export interface KubernetesTarget {
+  /** The connection's user-given name (unique per user; a DNS-label slug —
+   *  see connectionNameSchema). Used as the kubeconfig cluster/user/context
+   *  name and file path. The host is NOT a safe key: two clusters can share a
+   *  host on different ports, and the context name dropped the port — so
+   *  same-host clusters collided in the merged KUBECONFIG. The name can't. */
+  name: string;
   host: string;
   port?: number;
   hasUpstreamCa: boolean;
@@ -57,7 +63,11 @@ export function buildKubernetesContributions(
     );
   }
   const server = `https://${target.host}${target.port ? `:${target.port}` : ""}`;
-  const kubeconfigPath = `${KUBECONFIG_DIR}/${fileSlug(target.host, target.port)}.config`;
+  // Cluster/user/context all named after the connection (unique per user), so
+  // distinct connections never collide in the merged KUBECONFIG. Routing (the
+  // egress-inject) still keys on host/port — the gateway routes by SNI.
+  const label = target.name;
+  const kubeconfigPath = `${KUBECONFIG_DIR}/${label}.config`;
   return [
     {
       kind: "egress-inject",
@@ -79,23 +89,21 @@ export function buildKubernetesContributions(
         kind: "Config",
         clusters: [
           {
-            name: target.host,
+            name: label,
             cluster: {
               server,
               "certificate-authority": PLATFORM_CA_PATH,
             },
           },
         ],
-        users: [
-          { name: target.host, user: { token: KUBECONFIG_PLACEHOLDER_TOKEN } },
-        ],
+        users: [{ name: label, user: { token: KUBECONFIG_PLACEHOLDER_TOKEN } }],
         contexts: [
           {
-            name: target.host,
-            context: { cluster: target.host, user: target.host },
+            name: label,
+            context: { cluster: label, user: label },
           },
         ],
-        "current-context": target.host,
+        "current-context": label,
       },
     },
   ];
@@ -126,9 +134,4 @@ export function decodeCaData(caData: string): string {
 // Host is already bracket-stripped, so a remaining ':' means bare IPv6.
 function isIpLiteral(host: string): boolean {
   return /^\d{1,3}(\.\d{1,3}){3}$/.test(host) || host.includes(":");
-}
-
-// Per-endpoint kubeconfig filename; distinct endpoints get distinct files.
-function fileSlug(host: string, port?: number): string {
-  return `${host}${port ? `-${port}` : ""}`.replace(/[^a-zA-Z0-9.-]/g, "_");
 }


### PR DESCRIPTION
## Problem

The Kubernetes/OpenShift connection writes a per-connection kubeconfig whose `cluster`, `user`, and `context` were all named after the **API host** — with the port dropped from the name (`name: target.host`). Two clusters that share a host on different ports (e.g. `https://shared-cloud-cluster-host:6335` and `…:6336`) therefore produced the **same** context/cluster/user name and collided in the merged `KUBECONFIG`: one clobbered the other, and the second cluster was unaddressable.

(The file *path* already included the port, so files didn't collide — but the in-file names did, which is what `kubectl`/`oc` merge on.)

## Fix

Key the kubeconfig file path and its `cluster`/`user`/`context`/`current-context` by the **connection's name** instead of the host:

- The name is **unique per user** (`connections-service` rejects duplicates) and already a DNS-label slug (`connectionNameSchema`: `^[a-z0-9]+(-[a-z0-9]+)*$`), so distinct connections never collide and each is selectable as `--context <connection-name>` — a stable, readable handle instead of a raw hostname.
- **Egress routing is unchanged**: the `egress-inject` still keys on host/port (the gateway routes upstream by TLS SNI). Only the kubeconfig *labels* changed.

## Changes

- `buildKubernetesContributions` takes the connection `name`; drops the host-based `fileSlug`.
- `build-connection` passes `input.name` through.
- Regression test: same host, different ports, distinct names → distinct files **and** distinct contexts.
- `docs/architecture/connections.md` updated (context naming + example).

## Test

`mise run api-server:test` → 236 passing; `mise run api-server:check` clean.

## Motivation

Surfaced while making the `mockingbird` agent (agentic-user-journey) able to dynamically pick a target install-env cluster among multiple connected providers — it needs a stable `--context` handle, which the host-based naming couldn't provide.