### PR TITLE
feat: show unread sessions in the sessions list

### DIFF
--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -1,6 +1,6 @@
 # Platform topology
 
-Last verified: 2026-07-08
+Last verified: 2026-07-09
 
 ## Overview
 
@@ -47,7 +47,7 @@ The api-server proxies all ACP traffic to agent pods; clients never dial pods di
 
 The public port also accepts streamed bundled file imports per agent and proxies them to the target agent-runtime without buffering — ownership-checked and size-capped at the proxy boundary.
 
-A session's mode is agent-owned metadata: the client switching modes persists it over ACP (`session/resume` carrying `_meta.platform.mode`), and other clients observe it on their next `session/list`. There is no server-side mode-change side effect and no cross-client broadcast — mode is a hint about which surface to render, and the running harness is unaffected. The same `session/list` read also reflects each session's live turn status — whether a turn is in flight — so a client can show per-session working/idle state across all of an agent's sessions without holding a connection open to each. That read is passive: it neither wakes a hibernated agent nor defers hibernation of a running one.
+A session's mode is agent-owned metadata: the client switching modes persists it over ACP (`session/resume` carrying `_meta.platform.mode`), and other clients observe it on their next `session/list`. There is no server-side mode-change side effect and no cross-client broadcast — mode is a hint about which surface to render, and the running harness is unaffected. The same `session/list` read also reflects each session's live turn status — whether a turn is in flight — so a client can show per-session working/idle state across all of an agent's sessions without holding a connection open to each. That read is passive: it neither wakes a hibernated agent nor defers hibernation of a running one. Session read state rides the same metadata: agent-runtime stamps when a session was last seen by a viewer (machine-driven channels like the trigger driver don't count), so clients can render unread — activity newer than the stamp — consistently across devices. Read state is per-session, not per-user: agents currently have a single driving user, and shared-agent work must revisit this.
 
 ### agent-runtime
 

--- a/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
@@ -2071,6 +2071,11 @@ function makeFakeStore(now: () => string = () => "2026-03-03T00:00:00Z"): {
         if (!existing) return;
         sessions.set(id, { ...existing, lastActivityAt: now() });
       },
+      recordSeen: (id) => {
+        const existing = sessions.get(id);
+        if (!existing) return;
+        sessions.set(id, { ...existing, seenAt: now() });
+      },
       all: () => Object.fromEntries(sessions),
       tombstone: (id) => {
         sessions.delete(id);

--- a/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/acp-runtime.test.ts
@@ -2064,6 +2064,7 @@ function makeFakeStore(now: () => string = () => "2026-03-03T00:00:00Z"): {
           meta,
           createdAt: existing?.createdAt ?? "2026-01-01T00:00:00Z",
           ...(lastActivityAt !== undefined ? { lastActivityAt } : {}),
+          seenAt: existing?.seenAt ?? now(),
         });
       },
       recordActivity: (id) => {
@@ -2135,6 +2136,7 @@ describe("createAcpRuntime — platform _meta round-trip", () => {
     expect(sessions.get(SID)).toEqual({
       meta: { type: "schedule", scheduleId: "sch-1" },
       createdAt: "2026-01-01T00:00:00Z",
+      seenAt: "2026-03-03T00:00:00Z",
     });
   });
 
@@ -2155,6 +2157,7 @@ describe("createAcpRuntime — platform _meta round-trip", () => {
     expect(sessions.get(SID)).toEqual({
       meta: {},
       createdAt: "2026-01-01T00:00:00Z",
+      seenAt: "2026-03-03T00:00:00Z",
     });
   });
 

--- a/packages/agent-runtime/src/__tests__/unit/session-metadata-store.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/session-metadata-store.test.ts
@@ -43,6 +43,7 @@ describe("createSessionMetadataStore", () => {
     expect(store.get("s1")).toEqual({
       meta: { type: "schedule", scheduleId: "sch-1" },
       createdAt: "2026-01-01T00:00:00Z",
+      seenAt: "2026-01-01T00:00:00Z",
     });
   });
 
@@ -56,6 +57,7 @@ describe("createSessionMetadataStore", () => {
     expect(store.get("s1")).toEqual({
       meta: { mode: "terminal" },
       createdAt: "2026-01-01T00:00:00Z",
+      seenAt: "2026-01-01T00:00:00Z",
     });
   });
 
@@ -67,6 +69,7 @@ describe("createSessionMetadataStore", () => {
     expect(b.get("s1")).toEqual({
       meta: { mode: "chat", threadTs: "1700000000.1" },
       createdAt: "2026-01-01T00:00:00Z",
+      seenAt: "2026-01-01T00:00:00Z",
     });
   });
 
@@ -79,6 +82,7 @@ describe("createSessionMetadataStore", () => {
     expect(store.get("s1")).toEqual({
       meta: {},
       createdAt: "2026-01-01T00:00:00Z",
+      seenAt: "2026-01-01T00:00:00Z",
     });
     expect(store.get("s2")).toBeUndefined();
   });

--- a/packages/agent-runtime/src/modules/acp/compose.ts
+++ b/packages/agent-runtime/src/modules/acp/compose.ts
@@ -4,7 +4,10 @@ import {
   type RuntimeEnvReader,
 } from "../../core/runtime-env.js";
 import { createChildAgentProcess } from "./infrastructure/create-child-agent-process.js";
-import { createSessionMetadataStore } from "./infrastructure/session-metadata-store.js";
+import {
+  createSessionMetadataStore,
+  type SessionMetadataStore,
+} from "./infrastructure/session-metadata-store.js";
 import { createAcpRuntime, type AcpRuntime } from "./services/acp-runtime.js";
 import {
   createTriggerSessionDriver,
@@ -22,6 +25,7 @@ export interface ComposeAcpOptions {
 export function composeAcp(opts: ComposeAcpOptions): {
   runtime: AcpRuntime;
   triggerDriver: TriggerSessionDriver;
+  sessionMetadata: SessionMetadataStore;
 } {
   const sessionMetadata = createSessionMetadataStore(opts.stateBackend);
   const runtime = createAcpRuntime({
@@ -42,5 +46,5 @@ export function composeAcp(opts: ComposeAcpOptions): {
     idleReapDelayMs: 3_000,
   });
   const triggerDriver = createTriggerSessionDriver({ acpRuntime: runtime });
-  return { runtime, triggerDriver };
+  return { runtime, triggerDriver, sessionMetadata };
 }

--- a/packages/agent-runtime/src/modules/acp/infrastructure/session-metadata-store.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/session-metadata-store.ts
@@ -13,6 +13,8 @@ const sessionMetaEntrySchema = z.object({
   meta: platformSessionMetaSchema.catch({}),
   createdAt: z.string(),
   lastActivityAt: z.string().optional(),
+  /** When a viewer last saw the session; unread = lastActivityAt > seenAt. */
+  seenAt: z.string().optional(),
 });
 
 // A malformed entry is dropped rather than discarding the whole store.
@@ -38,6 +40,7 @@ export interface SessionMetadataStore {
   get(sessionId: string): SessionMetaEntry | undefined;
   set(sessionId: string, meta: PlatformSessionMeta): void;
   recordActivity(sessionId: string): void;
+  recordSeen(sessionId: string): void;
   all(): Record<string, SessionMetaEntry>;
   /** Soft delete: drop the entry and remember the id so list
    *  enrichment filters it out even while the harness still lists the JSONL. */
@@ -54,6 +57,22 @@ export function createSessionMetadataStore(
     initial: () => ({ sessions: {}, tombstones: [] }),
   });
 
+  // One-time backfill: pre-feature entries have no seenAt and would all read
+  // as unread. Grandfather them as seen at their last known activity.
+  {
+    const { sessions, tombstones } = store.read();
+    if (Object.values(sessions).some((e) => e.seenAt === undefined)) {
+      const backfilled: Record<string, SessionMetaEntry> = {};
+      for (const [id, e] of Object.entries(sessions)) {
+        backfilled[id] = {
+          ...e,
+          seenAt: e.seenAt ?? e.lastActivityAt ?? e.createdAt,
+        };
+      }
+      store.write({ sessions: backfilled, tombstones });
+    }
+  }
+
   return {
     get(sessionId) {
       return store.read().sessions[sessionId];
@@ -62,6 +81,7 @@ export function createSessionMetadataStore(
       const { sessions, tombstones } = store.read();
       const existing = sessions[sessionId];
       const lastActivityAt = existing?.lastActivityAt;
+      const seenAt = existing?.seenAt ?? now();
       store.write({
         tombstones,
         sessions: {
@@ -70,6 +90,7 @@ export function createSessionMetadataStore(
             meta,
             createdAt: existing?.createdAt ?? now(),
             ...(lastActivityAt !== undefined ? { lastActivityAt } : {}),
+            seenAt,
           },
         },
       });
@@ -83,6 +104,18 @@ export function createSessionMetadataStore(
         sessions: {
           ...sessions,
           [sessionId]: { ...existing, lastActivityAt: now() },
+        },
+      });
+    },
+    recordSeen(sessionId) {
+      const { sessions, tombstones } = store.read();
+      const existing = sessions[sessionId];
+      if (!existing) return;
+      store.write({
+        tombstones,
+        sessions: {
+          ...sessions,
+          [sessionId]: { ...existing, seenAt: now() },
         },
       });
     },

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime.ts
@@ -63,8 +63,11 @@ export interface AcpRuntime {
    * A cross-session call like `listSessions` carries no sessionId and never
    * engages — such channels can do their RPC round-trip without ever seeing
    * another session's permission prompts or updates.
+   *
+   * `viewer: false` marks a machine-driven channel (the in-process trigger
+   * driver): its activity never counts as the user having seen the session.
    */
-  attach(channel: ClientChannel): void;
+  attach(channel: ClientChannel, opts?: { viewer?: boolean }): void;
   status(): AcpRuntimeStatus;
   resetSession(sessionId: string): void;
   /** Env on disk changed: recycle a running harness so it respawns with the new env. */
@@ -242,6 +245,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
    * which channels receive fan-out broadcasts.
    */
   const engagedSessions = new Map<ClientChannel, Set<string>>();
+  /** Machine-driven channels (trigger driver); their activity is never "seen". */
+  const nonViewerChannels = new Set<ClientChannel>();
   const pendingFromAgent = new Map<JsonRpcId, PendingAgentRequest>();
   const outboundIdToClient = new Map<number, OutboundMapping>();
   const activePromptBySession = new Map<string, ActivePrompt>();
@@ -367,6 +372,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
     if (!sessions) return; // channel detached
     if (sessions.has(sessionId)) return; // idempotent
     sessions.add(sessionId);
+    if (!nonViewerChannels.has(channel))
+      deps.sessionMetadata?.recordSeen(sessionId);
 
     // Replay any pending agent→client requests for this session to the
     // newly-engaged channel. A fresh viewer joining an in-progress prompt
@@ -383,6 +390,18 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   function hasEngagedChannel(sessionId: string): boolean {
     for (const [channel, sessions] of engagedSessions) {
       if (sessions.has(sessionId) && channel.isOpen()) return true;
+    }
+    return false;
+  }
+
+  function hasEngagedViewer(sessionId: string): boolean {
+    for (const [channel, sessions] of engagedSessions) {
+      if (
+        sessions.has(sessionId) &&
+        channel.isOpen() &&
+        !nonViewerChannels.has(channel)
+      )
+        return true;
     }
     return false;
   }
@@ -635,6 +654,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   function detach(channel: ClientChannel): void {
     const sessions = engagedSessions.get(channel);
     engagedSessions.delete(channel);
+    nonViewerChannels.delete(channel);
     channelCursors.delete(channel);
 
     // Drop any prompts this channel had queued but not yet sent to the agent.
@@ -1015,6 +1035,10 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
             // Turn boundary — apply a deferred env change if nothing's in flight.
             maybeRecycleForEnv();
           }
+          // A completed turn is activity too — a response landing with no
+          // viewer attached is what makes the session unread.
+          deps.sessionMetadata?.recordActivity(sid);
+          if (hasEngagedViewer(sid)) deps.sessionMetadata?.recordSeen(sid);
           appendAndFanOut(
             sid,
             JSON.stringify(
@@ -1231,6 +1255,8 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
         // A real prompt is genuine activity — stamp it so the session list
         // sorts/displays by last message, not the harness mtime.
         deps.sessionMetadata?.recordActivity(promptSessionId);
+        if (hasEngagedViewer(promptSessionId))
+          deps.sessionMetadata?.recordSeen(promptSessionId);
         // Synthesize user_message_chunk(s) from the prompt payload and
         // append them to the log. The SDK drops plain-text user_message_chunk
         // emissions in live, so without this, viewers other than the sender
@@ -1287,11 +1313,12 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
   }
 
   return {
-    attach(channel) {
+    attach(channel, opts) {
       // One path for both: buffer frames until the agent is bound, then replay.
       // Warm (env present) releases synchronously below — buffered stays empty.
       // Cold-boot parks the release until env lands (or the safety timer fires).
       engagedSessions.set(channel, new Set());
+      if (opts?.viewer === false) nonViewerChannels.add(channel);
       const buffered: string[] = [];
       let live: AgentProcess | null = null;
       const release = (): void => {
@@ -1410,7 +1437,12 @@ function withPlatformMeta(
     ...(entry.lastActivityAt ? { updatedAt: entry.lastActivityAt } : {}),
     _meta: {
       ...existingMeta,
-      platform: { ...entry.meta, createdAt: entry.createdAt, running },
+      platform: {
+        ...entry.meta,
+        createdAt: entry.createdAt,
+        running,
+        ...(entry.seenAt ? { seenAt: entry.seenAt } : {}),
+      },
     },
   };
 }

--- a/packages/agent-runtime/src/modules/acp/services/trigger-session-driver.ts
+++ b/packages/agent-runtime/src/modules/acp/services/trigger-session-driver.ts
@@ -76,7 +76,7 @@ export function createTriggerSessionDriver(deps: {
         );
       }
 
-      deps.acpRuntime.attach(channel);
+      deps.acpRuntime.attach(channel, { viewer: false });
 
       try {
         await request("initialize", {

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -112,7 +112,11 @@ const podService = existsSync(podServicePath)
 
 if (envStore.ready()) podService?.refreshEnv();
 
-const { runtime: acpRuntime, triggerDriver } = composeAcp({
+const {
+  runtime: acpRuntime,
+  triggerDriver,
+  sessionMetadata,
+} = composeAcp({
   command: config.PLATFORM_DEV
     ? ["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
     : ["/usr/local/bin/harness-chat"],
@@ -193,11 +197,22 @@ interface PtySlot {
   client: WsWebSocket | null;
   graceTimer: ReturnType<typeof setTimeout> | null;
   lastOutputAt: number;
+  lastSeenStampAt: number;
 }
 
 const ptySlots = new Map<string, PtySlot>();
 const ptyLog = (sid: string, msg: string) =>
   process.stderr.write(`[pty] [${sid}] ${msg}\n`);
+
+const PTY_SEEN_STAMP_DEBOUNCE_MS = 30_000;
+
+// An attached viewer sees everything the terminal does. Terminal sessions are
+// usually store-less; the first stamp creates their entry (with the explicit
+// mode, which `set` needs and which keeps the terminal decode).
+function markTerminalSeen(sessionId: string): void {
+  if (sessionMetadata.get(sessionId)) sessionMetadata.recordSeen(sessionId);
+  else sessionMetadata.set(sessionId, { mode: "terminal" });
+}
 
 function killPtySlot(sessionId: string): void {
   const slot = ptySlots.get(sessionId);
@@ -239,6 +254,7 @@ function attachPty(
     const slot = ptySlots.get(sessionId);
     if (!slot || slot.client !== ws) return;
     slot.client = null;
+    markTerminalSeen(sessionId);
     if (!slot.pty) return;
     if (slot.graceTimer) clearTimeout(slot.graceTimer);
     slot.graceTimer = setTimeout(
@@ -276,6 +292,7 @@ function attachPty(
           existing.client.close(1000, "replaced by new connection");
         }
         existing.client = ws;
+        markTerminalSeen(sessionId);
         existing.headless.resize(cols, rows);
         existing.pty?.resize(cols, rows);
         const serialized = existing.serialize.serialize();
@@ -320,12 +337,23 @@ function attachPty(
         client: ws,
         graceTimer: null,
         lastOutputAt: Date.now(),
+        lastSeenStampAt: Date.now(),
       };
       ptySlots.set(sessionId, slot);
       ptyLog(sessionId, `spawned PTY (${cols}x${rows})`);
+      markTerminalSeen(sessionId);
 
       pty.onData((data) => {
-        slot.lastOutputAt = Date.now();
+        const now = Date.now();
+        slot.lastOutputAt = now;
+        // Keep other clients' unread honest during long attached work.
+        if (
+          slot.client &&
+          now - slot.lastSeenStampAt > PTY_SEEN_STAMP_DEBOUNCE_MS
+        ) {
+          slot.lastSeenStampAt = now;
+          markTerminalSeen(sessionId);
+        }
         slot.headless.write(data);
         if (slot.client?.readyState === 1)
           slot.client.send(encodeDataFrame(OP_OUTPUT, data));

--- a/packages/api-server-api/src/modules/sessions/types.ts
+++ b/packages/api-server-api/src/modules/sessions/types.ts
@@ -35,4 +35,6 @@ export interface SessionView {
   updatedAt?: string | null;
   /** Live turn state from `session/list` enrichment — true while a turn is in flight. */
   running?: boolean;
+  /** When a viewer last saw the session; unread = updatedAt newer than this. */
+  seenAt?: string | null;
 }

--- a/packages/ui/src/modules/sessions/api/acp-session-ops.ts
+++ b/packages/ui/src/modules/sessions/api/acp-session-ops.ts
@@ -12,6 +12,7 @@ interface PlatformMeta {
   threadTs?: string;
   createdAt?: string;
   running?: boolean;
+  seenAt?: string;
 }
 
 interface ListedSession {
@@ -42,6 +43,7 @@ function toSessionView(agentId: string, s: ListedSession): SessionView {
     title: s.title ?? null,
     updatedAt: s.updatedAt ?? null,
     running: p?.running ?? false,
+    seenAt: p?.seenAt ?? null,
   };
 }
 

--- a/packages/ui/src/modules/sessions/api/queries.ts
+++ b/packages/ui/src/modules/sessions/api/queries.ts
@@ -56,6 +56,17 @@ export function removeSessionFromCache(
   );
 }
 
+// Opening a session marks it seen agent-side; mirror that into the list cache
+// so switching away can't resurrect a stale unread before the next poll.
+export function setSessionSeen(agentId: string, sessionId: string): void {
+  const seenAt = new Date().toISOString();
+  queryClient.setQueriesData<SessionView[]>(
+    { queryKey: acpSessionsKeys.agentLists(agentId) },
+    (prev) =>
+      prev?.map((s) => (s.sessionId === sessionId ? { ...s, seenAt } : s)),
+  );
+}
+
 // Seed the open session's live busy state into the list cache so its status dot
 // stays correct the instant it stops being the open row — before the next poll.
 export function setSessionRunning(

--- a/packages/ui/src/modules/sessions/api/queries.ts
+++ b/packages/ui/src/modules/sessions/api/queries.ts
@@ -56,14 +56,17 @@ export function removeSessionFromCache(
   );
 }
 
-// Opening a session marks it seen agent-side; mirror that into the list cache
-// so switching away can't resurrect a stale unread before the next poll.
+// Mirror the agent-side seen stamp into the list cache ahead of the next poll.
+// Stamps the row's own activity time, not the browser clock, to rule out skew.
 export function setSessionSeen(agentId: string, sessionId: string): void {
-  const seenAt = new Date().toISOString();
   queryClient.setQueriesData<SessionView[]>(
     { queryKey: acpSessionsKeys.agentLists(agentId) },
     (prev) =>
-      prev?.map((s) => (s.sessionId === sessionId ? { ...s, seenAt } : s)),
+      prev?.map((s) =>
+        s.sessionId === sessionId
+          ? { ...s, seenAt: s.updatedAt ?? s.createdAt }
+          : s,
+      ),
   );
 }
 

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -15,7 +15,6 @@ interface Props {
   active: boolean;
   working: boolean;
   needsApproval: boolean;
-  /** Bold title for a session with activity the user hasn't seen. Not yet wired — see #2427. */
   unread?: boolean;
   onResume: () => void;
   onDelete: () => void;

--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -8,7 +8,7 @@ import { useStore } from "../../../store.js";
 import { useAgentRunState } from "../../agents/api/queries.js";
 import { useApprovalsForAgent } from "../../approvals/api/queries.js";
 import { AgentApprovalsTray } from "../../approvals/components/agent-approvals-tray.js";
-import { useAcpSessions } from "../api/queries.js";
+import { setSessionSeen, useAcpSessions } from "../api/queries.js";
 import { SessionRow } from "./session-row.js";
 
 const EMPTY: never[] = [];
@@ -114,6 +114,14 @@ export function SessionsSidebar({
           const needsApproval =
             approvalSessions.has(s.sessionId) ||
             pendingPermissions.some((p) => p.sessionId === s.sessionId);
+          // No stamp means the runtime never tracked the session (legacy,
+          // harness-minted) — read, not unread.
+          const unread = Boolean(
+            !isOpen &&
+            s.seenAt &&
+            s.updatedAt &&
+            Date.parse(s.updatedAt) > Date.parse(s.seenAt),
+          );
           return (
             <SessionRow
               key={s.sessionId}
@@ -121,7 +129,11 @@ export function SessionsSidebar({
               active={isOpen}
               working={working}
               needsApproval={needsApproval}
-              onResume={() => onResumeSession(s.sessionId, s.mode)}
+              unread={unread}
+              onResume={() => {
+                if (selectedAgent) setSessionSeen(selectedAgent, s.sessionId);
+                onResumeSession(s.sessionId, s.mode);
+              }}
               onDelete={() => confirmDelete(s.sessionId, s.title)}
             />
           );


### PR DESCRIPTION
Sessions with activity the user hasn't seen now render with a bold title in the sessions list, clearing when opened — on every device (#2427).

**Where read state lives:** in agent-owned session metadata, not the platform DB — per the review discussion on the withdrawn ADR (#2745): a duplicate server-side session table was deliberately refactored away once, and read state gets no new home that could drift. A `seenAt` stamp rides the same `session/list` enrichment that already carries mode and live turn status.

**Who stamps it:** the agent runtime, from viewer engagement it already observes — clients never write read state:
- engaging, prompting, or completing a turn while a viewer is attached marks seen
- machine-driven channels (the trigger driver) attach as non-viewers, so **scheduled runs bump activity without marking seen** — the headline unread case
- turn completion now counts as activity, so a response landing after you switch away flags the session
- terminal attach/detach stamp seen (with a debounced stamp during long attached work)

**UI:** unread = activity newer than the stamp, never for the open row; opening a session stamps the list cache optimistically so switching away can't flash a stale unread. Pre-feature sessions are grandfathered as read on first boot after upgrade.

Known limits (recorded in the architecture page): read state is **per-session, not per-user** — agents have a single driving user today, and shared-agent work must revisit this. Channel sessions are approximate: the worker's attachment counts as viewing.

Closes #2427
Refs #1081 