### PR TITLE
feat(helm): reference a pre-existing pull Secret from an agent template

### DIFF
--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -68,8 +68,14 @@ data:
     nodeSelector:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- if and $tmpl.imagePullSecret $tmpl.imagePullSecretRef }}
+    {{- fail (printf "agentTemplates.%s: set either imagePullSecret (chart-managed Secret) or imagePullSecretRef (pre-existing Secret), not both" $name) }}
+    {{- end }}
     {{- if $tmpl.imagePullSecret }}
     imagePullSecretRef: {{ printf "%s-tmpl-%s-pull" (include "platform.fullname" $) $name | quote }}
+    {{- end }}
+    {{- with $tmpl.imagePullSecretRef }}
+    imagePullSecretRef: {{ . | quote }}
     {{- end }}
     {{- with $tmpl.resources }}
     resources:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -967,6 +967,14 @@ controller:
 #       username: iamapikey
 #       password: "<registry-api-key>" # keep out of plaintext values in prod (sealed/SOPS/external secret)
 #
+# Or, to reference a pull Secret you manage yourself (it must already exist in
+# `agentNamespace`), set `imagePullSecretRef` instead — mutually exclusive with
+# `imagePullSecret`:
+#
+#   bugstone:
+#     # ...
+#     imagePullSecretRef: "icr-pull-secret"
+#
 agentTemplates:
   claude-code:
     enabled: true


### PR DESCRIPTION
## What

`agentTemplates.<name>.imagePullSecretRef` names a `kubernetes.io/dockerconfigjson` Secret the operator manages themselves in `agentNamespace`, for templates whose registry credential shouldn't live in Helm values:

```yaml
agentTemplates:
  myagent:
    imagePullSecretRef: "my-agent-pull-secret"   # must already exist in agentNamespace
```

Mutually exclusive with the chart-managed `imagePullSecret` credential block — setting both fails the render with a clear message (same pattern as the existing `_validators.tpl` exclusivity checks).

## Why

The only per-template option today is `imagePullSecret` (server/username/password), which embeds the registry key in values. Everything downstream already accepted a secret ref — the template zod schema (`imagePullSecretRef`), spec assembly, and the controller (`agentSpec.ImagePullSecretRef` → pod `imagePullSecrets`) — only the agent-templates ConfigMap lacked the passthrough.

## Testing

- `mise run helm:check:lint` + `helm:check:render` (kubeconform) pass.
- Render verified for all three cases: ref-only passes through verbatim; credential-block-only keeps generating `<release>-tmpl-<name>-pull`; both set → render fails with the exclusivity message.