### PR TITLE
feat(adr): review-time policy (item 6)

### DIFF
--- a/.agents/skills/adr-policy/SKILL.md
+++ b/.agents/skills/adr-policy/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: adr-policy
+description: >
+  Review-time policy check for pull requests that touch `docs/adrs/`. Surfaces the
+  deterministic ADR immutability gate (`scripts/adr-immutable.mjs`) and adds the
+  judgment checks a script cannot own: re-litigation of settled decisions, `supersedes`
+  pointer correctness, and summary honesty. Scope is ADR log integrity and decision
+  judgment only — the ADR files, their frontmatter, and git history. Docs-match-the-code
+  is doc-drift's job, not this skill's. Triggers on phrases like "adr policy", "check
+  this ADR", "review the ADR change", "is this ADR re-litigating", "is supersedes
+  correct". Also invocable via the `/adr-policy` slash command.
+---
+
+# ADR Policy
+
+Reviews changes to the **ADR log** under [`docs/adrs/`](../../../docs/adrs/) at review
+time. The ADR model is an immutable event log with two projections (architecture docs,
+generated index); see the split in
+[`docs/design/adr-governance.md`](../../../docs/design/adr-governance.md).
+
+Enforcement is split by what needs judgment. This skill owns **log integrity and
+decision judgment**. It does **not** rewrite ADRs — it surfaces findings, the user
+decides.
+
+## Scope: the ADR log only
+
+- **In scope**: files under `docs/adrs/`, their frontmatter, and the git history of the
+  diff (base-to-head).
+- **Out of scope**: whether the architecture docs match the code — that is
+  [`doc-drift`](../doc-drift/SKILL.md). Never flag docs-vs-code drift here.
+- **Out of scope**: whether some code "should have an ADR." ADRs are filed by humans
+  before work begins; coverage is never this skill's call.
+
+## Read discipline
+
+ADRs are human-first; agent reads are gated to authoring and recompiling. A review pass
+is an authoring-adjacent read: read [`docs/adrs/index.md`](../../../docs/adrs/index.md)
+first, then open only the ADR files changed in the diff and any record a changed ADR
+points at (its `supersedes` target). Never read the log wholesale to understand the
+current system.
+
+## What this skill checks
+
+### 1. Immutability (deterministic — surfaced, never re-judged)
+
+The one invariant the read model rests on — an accepted ADR body is never rewritten — is
+owned by a standalone deterministic script, never by an LLM. Run it and surface its
+result verbatim:
+
+```bash
+node scripts/adr-immutable.mjs --merge-base
+```
+
+Report its pass/fail as the first line of the ADR section so everything lands in one
+place. Do **not** second-guess it, soften a failure, or re-derive the verdict by reading
+diffs yourself. One check, multiple surfaces: this skill is a surface, not the owner.
+
+### 2. Re-litigation (judgment)
+
+Does a new or changed ADR re-decide something already settled — or already superseded —
+without acknowledging it? Scan the index one-liners for records covering the same
+decision space. If the new ADR reverses or narrows a live decision, it must point at it
+with `supersedes`; if it merely restates a settled one, that is churn. Flag either.
+
+### 3. `supersedes` correctness (judgment)
+
+When a changed ADR carries `supersedes: NNN`:
+- Does id `NNN` exist, and is it the record actually being replaced (not a sibling or a
+  record already superseded by a third ADR)?
+- Is the superseded decision genuinely the *live* one this ADR overrides? A forward link
+  aimed at the wrong record silently corrupts the derived status the index shows.
+
+### 4. Summary honesty (judgment)
+
+Does the one-line `summary` frontmatter state what the `Decision` body actually decided?
+The summary is projected into the index and read *instead of* the record most of the
+time, so a summary that oversells, hedges, or describes a different decision than the
+body is a defect — it steers readers wrong at the cheapest, most-read layer.
+
+## Report
+
+Produce one ADR section:
+
+- **Immutability** — the script's verdict, verbatim. `✅` or the `❌` lines it printed.
+  A `❌` here is **blocking**; the deterministic gate fails the build regardless of this
+  skill.
+- **Judgment findings** — every re-litigation / `supersedes` / summary issue, with the
+  ADR file and the specific frontmatter field or body claim it concerns, and the
+  question the human must answer. These are **surfaced, not blocking**.
+
+If nothing is wrong, the section is just the immutability `✅` line.
+
+## Guidelines
+
+- **Read-only.** Never edit ADRs; propose, the user decides. Fixing a re-litigation or
+  summary problem means authoring or amending an ADR through the [`/adr`](../adr/SKILL.md)
+  flow, not editing here.
+- **Never own immutability.** The script is authoritative. This skill only relays it.
+- **One pass with doc-drift.** On a PR touching `docs/adrs/` or `docs/architecture/`, the
+  code-review agent runs this skill and [`doc-drift`](../doc-drift/SKILL.md) together and
+  folds both into one report. This skill covers the log; doc-drift covers the docs. They
+  stay separate to keep single responsibility.

--- a/.agents/skills/doc-drift/SKILL.md
+++ b/.agents/skills/doc-drift/SKILL.md
@@ -31,8 +31,10 @@ landing page at [`docs/architecture.md`](../../../docs/architecture.md). Everyth
 **out of scope** — do not flag it, even if it looks drifted:
 
 - Vocabulary in [`tseng/vocabulary.md`](../../../tseng/vocabulary.md).
-- ADRs (`docs/adrs/`) — out of this skill's scope; never flag "this code
-  should have an ADR" or anything else about ADR coverage.
+- ADRs (`docs/adrs/`) — out of this skill's scope with **one** narrow exception (check 7
+  below): never flag "this code should have an ADR", ADR prose quality, or anything else
+  about ADR coverage. ADR log integrity and decision judgment are
+  [`adr-policy`](../adr-policy/SKILL.md)'s job.
 - READMEs, `CLAUDE.md`, code comments, guidelines, strategy docs.
 - Cross-reference rot in non-architecture docs.
 
@@ -41,13 +43,18 @@ If a check would land outside `docs/architecture/`, drop it.
 ## Direction of drift: code → docs
 
 Code leads, docs trail. Drift is measured **code vs docs**, in that direction only. ADRs play
-no part in any check: they are human-first and out of this skill's scope, so no check may
-depend on an ADR's content or existence.
+no part in the code→docs checks (1–6): they are human-first, so no code-drift check may depend
+on an ADR's content or existence.
 
 Drift only exists when **code in the diff** changes subsystem behavior/responsibility and the
-matching architecture page does not reflect that code. Anchor every check on something concrete
-in the diff. If the only evidence is "an ADR exists", ignore it — silently. Do not narrate
-the exclusion.
+matching architecture page does not reflect that code. Anchor every code→docs check on something
+concrete in the diff. If the only evidence for one of those checks is "an ADR exists", ignore it
+— silently. Do not narrate the exclusion.
+
+**One exception (check 7):** an ADR *state change* in the diff — an accepted record flipped to
+deprecated/superseded — flags its own `subsystem` page as *possible* rot. This is the sole
+ADR-anchored signal, it is never blocking, and it flags a page for a human look, not a required
+edit. Everything else about ADRs stays out of scope.
 
 ## What this skill checks
 
@@ -72,6 +79,14 @@ Each check is grounded in code changes observed in the diff and lands inside
    renamed, or deleted in the diff: inbound links from *other architecture pages* and from
    `docs/architecture.md` must be updated. Inbound links from outside `docs/architecture/`
    are out of scope.
+7. **ADR state-change impact** (the one ADR-anchored check) — if the diff flips an accepted
+   ADR to `deprecated` or supersedes it (a new ADR whose `supersedes` points at a live
+   record), the page named by that ADR's `subsystem` frontmatter may still describe the
+   superseded state. The cap only catches rot on *growth*; a superseded decision rots a page
+   at unchanged size, so nothing else catches it. Flag that page as ⚠️ **possible drift** —
+   "an ADR it derives from changed state; needs a re-fold look." Never a ❌, never an edit you
+   prescribe: net-new state, not observed mismatch. Anchor on the ADR status change in the
+   diff; if no ADR status changed, this check produces nothing.
 
 ## Report
 
@@ -81,9 +96,10 @@ Take the subagent's output and present a focused report to the user:
 - **Drift** — every ❌, with file/line evidence and the proposed edit. Group by check number.
 - **Possible drift** — every ⚠️, with the human-judgement question that needs answering.
 
-Items excluded by the rules above (ADR-related, trivial, out-of-scope) must not appear
-anywhere in the report — not in either section, not as a parenthetical, not as a footnote.
-If there is nothing to flag, the report is just the verdict.
+Items excluded by the rules above (trivial, out-of-scope, and every ADR concern except the
+check-7 state-change signal) must not appear anywhere in the report — not in either section,
+not as a parenthetical, not as a footnote. If there is nothing to flag, the report is just the
+verdict.
 
 ## Guidelines
 
@@ -92,5 +108,10 @@ If there is nothing to flag, the report is just the verdict.
   the guidelines don't forbid (e.g., short architecture pages — there is no length cap).
 - **Trivial changes are exempt.** README typos, comment-only edits, dependency bumps with no
   behavior change, lint fixes, and test-only changes do not trigger doc drift. Don't report.
-- **Code is the anchor.** Every flagged drift must point at a concrete code change in the diff.
-  Never flag drift whose only evidence is an ADR file or its absence.
+- **Code is the anchor** for checks 1–6. Every flagged code→docs drift must point at a concrete
+  code change in the diff. Never flag such drift whose only evidence is an ADR file or its
+  absence. Check 7 is the lone exception: it anchors on an ADR *status change* in the diff and
+  only ever emits ⚠️, never ❌.
+- **Log integrity is not this skill's job.** Re-litigation, `supersedes` correctness, and summary
+  honesty belong to [`adr-policy`](../adr-policy/SKILL.md). On a PR touching `docs/adrs/` the
+  code-review agent runs both skills in one pass; keep to docs-vs-code (plus check 7) here.

--- a/.agents/skills/review-work/references/code-reviewer.md
+++ b/.agents/skills/review-work/references/code-reviewer.md
@@ -27,6 +27,21 @@ git diff --stat {BASE_SHA}..{HEAD_SHA}
 git diff {BASE_SHA}..{HEAD_SHA}
 ```
 
+## Review-time ADR / architecture policy
+
+If the diff touches `docs/adrs/` or `docs/architecture/`, run both skills below in this
+same pass and fold their output into one **ADR / docs** section of your report:
+
+- **`adr-policy`** — when `docs/adrs/` changed. Surfaces the deterministic immutability
+  gate (`node scripts/adr-immutable.mjs --merge-base`, blocking) plus judgment findings:
+  re-litigation, `supersedes` correctness, summary honesty.
+- **`doc-drift`** — when `docs/architecture/` changed, or when an ADR status change should
+  flag its `subsystem` page for a re-fold look (doc-drift check 7).
+
+They cover different things — the log vs the docs — so run both; do not merge or skip one.
+A `❌` from the immutability gate is blocking; everything else the two skills surface is
+judgment for the human.
+
 ## Review Checklist
 
 **Code Quality:**

--- a/.claude/skills/adr-policy
+++ b/.claude/skills/adr-policy
@@ -1,0 +1,1 @@
+../../.agents/skills/adr-policy


### PR DESCRIPTION
Implements item 6 of #2735 (review-time policy). Targets the PR branch, not main.

The design splits ADR enforcement into a deterministic blocking gate (already shipped: `check:adr-immutable`) and the parts that need judgment. This adds the judgment layer.

## What's here

- **New `adr-policy` skill** — owns ADR log integrity and decision judgment. Surfaces the immutability gate verbatim (never re-judges it), then checks re-litigation of settled decisions, `supersedes` pointer correctness, and summary honesty. Read-only; findings surface, the user decides.
- **doc-drift** — keeps docs-vs-code as before, plus one new ADR-anchored check: an ADR flipped to deprecated/superseded flags its `subsystem` page for a re-fold look (catches same-size rot the cap misses). Narrow carve-out to the "ADRs play no part" stance, ⚠️ only, never blocking.
- **One pass** — the reviewer template routes any PR touching `docs/adrs/` or `docs/architecture/` to both skills, folded into one report. The two stay separate to keep single responsibility.

## Verification

- `check:adr-immutable` and all docs checks green.
- Skills are markdown; no gate logic changed.