### PR TITLE
fix(ui): drop staged grant when disconnecting a connection in sandbox settings

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -572,7 +572,17 @@ jobs:
   e2e:
     name: mise e2e
     needs: [merge-images, build-mock]
-    if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/v')
+    # Without a status-check function the implicit success() applies, and it is
+    # false whenever any transitive dependency was skipped — merge-platform-base
+    # skips on PRs that don't touch platform-base, which silently skipped e2e on
+    # most PRs. Require the direct needs explicitly instead: e2e pulls exactly
+    # the images those two jobs push.
+    if: >-
+      ${{ github.event_name != 'schedule' &&
+          !startsWith(github.ref, 'refs/tags/v') &&
+          !cancelled() &&
+          needs.merge-images.result == 'success' &&
+          needs.build-mock.result == 'success' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -73,6 +73,16 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"], storageState },
     },
     {
+      // Pure-API spec (mints its own JWT, no browser session, so no
+      // storageState); needs the agent + granted connection from "agent".
+      // Listed late so its harness recycles on env changes can't interrupt
+      // the message-driven suites.
+      name: "user-env",
+      testMatch: /09-.*\.spec\.ts$/,
+      dependencies: ["agent"],
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       // Churns its own dedicated connection on the shared agent; listed last
       // so the delete/recreate can't disturb the injection/slack suites.
       name: "connection-regrant",

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -72,5 +72,13 @@ export default defineConfig({
       dependencies: ["agent"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
+    {
+      // Churns its own dedicated connection on the shared agent; listed last
+      // so the delete/recreate can't disturb the injection/slack suites.
+      name: "connection-regrant",
+      testMatch: /10-.*\.spec\.ts$/,
+      dependencies: ["agent"],
+      use: { ...devices["Desktop Chrome"], storageState },
+    },
   ],
 });

--- a/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
+++ b/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
@@ -1,0 +1,146 @@
+import { expect, test } from "@playwright/test";
+
+import { baseUrl } from "../config.js";
+import { waitForAgentRunning } from "../lib/agents.js";
+import { createApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+import {
+  ensureCustomHeaderConnection,
+  getConnectionId,
+} from "../lib/connections.js";
+import {
+  agentName,
+  connectionHost,
+  headerName,
+  valueFormat,
+} from "../lib/fixtures.js";
+
+const originalName = "e2e-regrant-original";
+const recreatedName = "e2e-regrant-recreated";
+const regrantEnvName = "E2E_REGRANT_KEY";
+const regrantValue = "e2e-regrant-secret-5e1c";
+
+// Regression for #2426: disconnecting a granted connection on the sandbox
+// settings page and creating a replacement of the same type left the deleted
+// id staged in the form, so Save failed with "connection ... not owned by
+// caller".
+test("recreating a disconnected connection saves cleanly", async ({ page }) => {
+  test.setTimeout(240_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+
+  let agentId = "";
+  let originalId = "";
+
+  await test.step("grant a dedicated connection to the agent", async () => {
+    const listed = (await api.agents.list.query()).find(
+      (a) => a.name === agentName,
+    );
+    expect(
+      listed,
+      `agent ${agentName} must exist from earlier specs`,
+    ).toBeTruthy();
+    // The grant fanout pushes contributions to the pod, so make sure earlier
+    // specs didn't leave the agent hibernating.
+    await api.agents.wake.mutate({ id: listed!.id });
+    agentId = await waitForAgentRunning(api, agentName);
+
+    for (const c of await api.connections.list.query()) {
+      if (c.name === originalName || c.name === recreatedName)
+        await api.connections.delete.mutate({ id: c.id });
+    }
+
+    originalId = await ensureCustomHeaderConnection(api, {
+      name: originalName,
+      host: connectionHost,
+      headerName,
+      valueFormat,
+      value: regrantValue,
+      envName: regrantEnvName,
+    });
+
+    const current = await api.connections.getAgentConnections.query({
+      agentId,
+    });
+    await api.connections.setAgentConnections.mutate({
+      agentId,
+      connectionIds: [
+        ...current.connections.map((c) => c.connectionId),
+        originalId,
+      ],
+    });
+  });
+
+  await test.step("open the sandbox settings page", async () => {
+    await page.goto(`${baseUrl}/sandboxes/${agentId}`);
+    await expect(page.getByRole("heading", { name: agentName })).toBeVisible();
+    await expect(
+      page.getByTestId(`connection-grant-${originalId}`).getByRole("checkbox"),
+    ).toBeChecked();
+  });
+
+  await test.step("disconnect the granted connection", async () => {
+    await page
+      .getByTestId(`connection-grant-${originalId}`)
+      .getByRole("button", { name: "Disconnect" })
+      .click();
+    await page
+      .getByRole("alertdialog")
+      .getByRole("button", { name: "Disconnect" })
+      .click();
+    await expect(page.getByTestId(`connection-grant-${originalId}`)) //
+      .toBeHidden();
+  });
+
+  await test.step("create a replacement of the same type", async () => {
+    await page.getByRole("button", { name: /show all/i }).click();
+    await page.getByTestId("connection-template-custom-header").click();
+
+    await page.getByTestId("connection-field-name").fill(recreatedName);
+    await page.getByTestId("connection-field-host").fill(connectionHost);
+    await page.getByTestId("connection-field-headerName").fill(headerName);
+    await page.getByTestId("connection-field-valueFormat").fill(valueFormat);
+    await page.getByTestId("connection-field-value").fill(regrantValue);
+    await page.getByTestId("connection-field-envName").fill(regrantEnvName);
+    await page.getByTestId("connection-create-submit").click();
+    await expect(page.getByTestId("connection-create-submit")).toBeHidden();
+  });
+
+  await test.step("save succeeds and the new grant lands", async () => {
+    const recreatedId = await getConnectionId(api, recreatedName);
+    await expect(
+      page.getByTestId(`connection-grant-${recreatedId}`).getByRole("checkbox"),
+    ).toBeChecked();
+
+    await page.getByRole("button", { name: "Save", exact: true }).click();
+
+    await expect
+      .poll(
+        async () => {
+          const grants = await api.connections.getAgentConnections.query({
+            agentId,
+          });
+          return grants.connections.map((c) => c.connectionId);
+        },
+        {
+          timeout: 30_000,
+          message: "recreated connection grant did not land",
+        },
+      )
+      .toContain(recreatedId);
+
+    const grants = await api.connections.getAgentConnections.query({
+      agentId,
+    });
+    expect(grants.connections.map((c) => c.connectionId)) //
+      .not.toContain(originalId);
+    await expect(page.getByText(/not owned by caller/)).toBeHidden();
+  });
+
+  await test.step("clean up the replacement connection", async () => {
+    await api.connections.delete.mutate({
+      id: await getConnectionId(api, recreatedName),
+    });
+  });
+});

--- a/packages/ui/src/modules/sandboxes/components/connections-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/connections-section.tsx
@@ -63,6 +63,13 @@ export function ConnectionsSection({
     [allTemplates],
   );
 
+  // Deleting a granted connection must also drop its staged grant — a stale
+  // id in the form would make Save fail with "not owned by caller" (#2426).
+  const disconnect = async (id: string, name: string) => {
+    if ((await confirmAndDelete(id, name)) && grantedIds.has(id))
+      onToggleGrant(id, false);
+  };
+
   const showInternal = isShowInternalConnectionsEnabled();
   const byCategory = useMemo(() => {
     const m = new Map<string, ConnectionTemplateView[]>();
@@ -91,11 +98,12 @@ export function ConnectionsSection({
                 selectable
                 selected={grantedIds.has(c.id)}
                 onSelectedChange={(on) => onToggleGrant(c.id, on)}
+                testId={`connection-grant-${c.id}`}
               >
                 <ConnectionAction
                   label="Disconnect"
                   tone="danger"
-                  onClick={() => void confirmAndDelete(c.id, c.name)}
+                  onClick={() => void disconnect(c.id, c.name)}
                   disabled={deletingId === c.id}
                 />
               </ConnectionRow>


### PR DESCRIPTION
## Problem

On the sandbox settings page, disconnecting a granted connection and then creating a replacement of the same type made **Save** fail with:

> Failed to update app connections: connection conn-… not owned by caller

`useDisconnectConnection` deletes the connection globally, but the settings form kept the deleted id staged in `assignedAppIds`. Creating the replacement marked the field dirty, so Save sent the stale id to `connections.setAgentConnections`, which (correctly) rejects ids the caller no longer owns.

## Fix

After a confirmed disconnect, drop the staged grant (`onToggleGrant(id, false)`) — exactly what the `useDisconnectConnection` doc comment calls for, and what the create wizard (`connections-step.tsx`) and the provider section (`onProviderRemoved`) already do. Also adds the `connection-grant-<id>` test id to the settings rows, matching the wizard.

## Regression test

New Playwright spec `10-connection-regrant.spec.ts` drives the exact repro: grant a dedicated connection → disconnect it in the settings page → create a same-type replacement → Save → assert the new grant lands and the stale id never errors. Wired as a last-running `connection-regrant` project so its connection churn can't disturb the injection/slack suites.

## Bonus 1: re-enable the dead 09-user-env spec

`09-user-env.spec.ts` matches no Playwright project — it landed in #1899 without a config entry, so it has never run anywhere. This PR adds the missing `user-env` project (pure-API spec, so no `storageState`, following the `api-keys` pattern). Its runtime assumptions were re-verified against current code: `e2e.getEnv` → mock agent `scriptedMock.getEnv`, idle-harness recycle on env change in `acp-runtime.ts`, and the `dummy-placeholder` fallback in `envoy.go`.

## Bonus 2: CI silently skipped e2e on most PRs

The `e2e` job's plain `if` got the implicit `success()`, which is false when any **transitive** dependency was skipped. `merge-platform-base` skips on PRs that don't touch platform-base, so `mise e2e` skipped on every such PR (compare: it ran on the platform-base-touching PR run [29085217857](https://github.com/dam-agents/dam/actions/runs/29085217857), skipped on this PR's earlier runs). `build-mock` already carried the `!cancelled() && !failure()` override for exactly this; `e2e` one level down did not. The condition now breaks the implicit `success()` with `!cancelled()` and requires its two direct needs explicitly — which also stops unrelated agent-image failures from skipping e2e.

With that fixed, this PR's own CI now actually executes the e2e suite, including both new specs.

`playwright test --list` resolves 15 tests in 10 files.

Fixes #2426