### PR TITLE
docs(adr): reframe doc-cap steering as a re-think signal

### DIFF
--- a/docs/guidelines/documentation-guidelines.md
+++ b/docs/guidelines/documentation-guidelines.md
@@ -24,7 +24,7 @@ Architecture pages are the **authoritative, self-contained description of the cu
 
 - One page per subsystem under [`docs/architecture/`](../architecture/), indexed from [`docs/architecture.md`](../architecture.md).
 - Adding a new subsystem means adding a new page and linking it from the landing page.
-- No shared template. Free-form per page, under a per-page character cap (enforced by `mise run check` and a write-time hook). The cap is a forcing function, not a style rule: going over means the page drifted below architecture altitude, or grew to cover more than one subsystem. Reconcile by raising altitude and cutting volatile detail, or by splitting the subsystem and reconsidering its boundaries — not by rewording to fit. Do not offload description into an ADR to relieve size: the log holds decisions authored when they were made, not documentation spillover.
+- No shared template. Free-form per page, under a per-page character cap (enforced by `mise run check` and a write-time hook). The cap is a forcing function, not a style rule: going over means the page dropped to the level of the code, or grew to cover more than one subsystem. Reconcile by raising the level and cutting volatile detail, or by splitting the subsystem and reconsidering its boundaries — not by rewording to fit. Do not offload description into an ADR to relieve size: the log holds decisions authored when they were made, not documentation spillover.
 - Cross-page concept ownership: one page owns each concept in depth; others one-liner + cross-link.
 
 ### Mandatory headers
@@ -35,7 +35,7 @@ Each subsystem page starts with one header directly under the title:
 
 ### Content policy
 
-**Durable content only.** Architecture pages outlive refactors; volatile facts rot. Write at the altitude of architecture — roles, decisions, couplings, and contracts — in the project's [ubiquitous language](#vocabulary), not at the altitude of the code. If a sentence would break when someone renames a field, reorders a function's arguments, or adds an optional property, it is pitched too low — raise it until it describes the *meaning*, not the *shape*.
+**Durable content only.** Architecture pages outlive refactors; volatile facts rot. Write at the level of architecture — roles, decisions, couplings, and contracts — in the project's [ubiquitous language](#vocabulary), not at the level of the code. If a sentence would break when someone renames a field, reorders a function's arguments, or adds an optional property, it is pitched too low — raise it until it describes the *meaning*, not the *shape*.
 
 - **Include**: component roles, who-talks-to-whom, protocols *and what their messages mean*, persistence substrates, resource-model invariants, framework-level tech, security layers, trust boundaries.
 - **Omit**: exact package names, file paths, Helm template tree, implementation phase markers, library-level choices below framework level, and **code-level shape** — type signatures, field names, function arguments, enum members. Name the concept in domain vocabulary, not the symbol in the code.

--- a/docs/guidelines/documentation-guidelines.md
+++ b/docs/guidelines/documentation-guidelines.md
@@ -24,7 +24,7 @@ Architecture pages are the **authoritative, self-contained description of the cu
 
 - One page per subsystem under [`docs/architecture/`](../architecture/), indexed from [`docs/architecture.md`](../architecture.md).
 - Adding a new subsystem means adding a new page and linking it from the landing page.
-- No shared template. Free-form per page. No length cap.
+- No shared template. Free-form per page, under a per-page character cap (enforced by `mise run check` and a write-time hook). The cap is a forcing function, not a style rule: going over means the page carries too much detail or too many concerns. Reconcile by moving detail and rationale down into an ADR, or by splitting the subsystem and reconsidering its boundaries — not by rewording to fit.
 - Cross-page concept ownership: one page owns each concept in depth; others one-liner + cross-link.
 
 ### Mandatory headers

--- a/docs/guidelines/documentation-guidelines.md
+++ b/docs/guidelines/documentation-guidelines.md
@@ -18,13 +18,13 @@ Use the ubiquitous language defined in [`tseng/vocabulary.md`](../../tseng/vocab
 
 ## Architecture Documentation Guidelines
 
-Architecture pages are the **authoritative, self-contained description of the current system** — both what it looks like and enough of the *why* to work in it. They must stand alone: a reader never needs an ADR to understand a page, and pages never link to ADRs. Make drift the harder path, not the default.
+Architecture pages are the **authoritative, self-contained description of the current system** — both what it looks like and enough of the *why* to work in it. That "why" is **operational** — the couplings and invariants you need to work in the system — not **decision history** (why an alternative was weighed and rejected), which lives in the ADR log. They must stand alone: a reader never needs an ADR to understand a page, and pages never link to ADRs. Make drift the harder path, not the default.
 
 ### Structure
 
 - One page per subsystem under [`docs/architecture/`](../architecture/), indexed from [`docs/architecture.md`](../architecture.md).
 - Adding a new subsystem means adding a new page and linking it from the landing page.
-- No shared template. Free-form per page, under a per-page character cap (enforced by `mise run check` and a write-time hook). The cap is a forcing function, not a style rule: going over means the page carries too much detail or too many concerns. Reconcile by moving detail and rationale down into an ADR, or by splitting the subsystem and reconsidering its boundaries — not by rewording to fit.
+- No shared template. Free-form per page, under a per-page character cap (enforced by `mise run check` and a write-time hook). The cap is a forcing function, not a style rule: going over means the page drifted below architecture altitude, or grew to cover more than one subsystem. Reconcile by raising altitude and cutting volatile detail, or by splitting the subsystem and reconsidering its boundaries — not by rewording to fit. Do not offload description into an ADR to relieve size: the log holds decisions authored when they were made, not documentation spillover.
 - Cross-page concept ownership: one page owns each concept in depth; others one-liner + cross-link.
 
 ### Mandatory headers

--- a/scripts/doc-size.mjs
+++ b/scripts/doc-size.mjs
@@ -3,8 +3,8 @@
 //
 // Architecture docs are a hand-maintained, reduced view of the current system;
 // the cap keeps them reduced. It is a forcing function, not a byte budget: going
-// over means the page drifted below architecture altitude, or grew to cover more
-// than one subsystem. The remedy is to raise altitude, cut volatile detail, or
+// over means the page dropped to the level of the code, or grew to cover more
+// than one subsystem. The remedy is to raise the level, cut volatile detail, or
 // split — not to reword to fit, and not to offload description into the ADR log
 // (the log holds decisions, not documentation spillover). Precision of the
 // number is not the point; a hard limit that forces the re-think is.
@@ -52,8 +52,8 @@ export function capFor(filePath) {
 }
 
 // The steering message, shared so the hook rejection and the gate failure read
-// identically. Over-cap is an altitude/scope signal, not a conciseness ask, so
-// the ladder leads with raising altitude and splitting. It never tells the agent
+// identically. Over-cap is a wrong-level or too-broad signal, not a conciseness
+// ask, so the ladder leads with raising the level and splitting. It never tells the agent
 // to reword to fit, and never to mint an ADR as a spillover bucket: relocating
 // is the narrow last case, only for genuine decision rationale, which the log
 // already owns from when the decision was made.
@@ -63,7 +63,7 @@ export function overageReport({ path, size, cap, kind }) {
   return (
     `${path} is ${size} chars — ${over} over the ${cap}-char ${label} cap.\n` +
     `Over the cap means the page carries too much, not that it is worded verbosely. It is a signal to re-think what belongs here — do not reword or trim meaning to fit. Diagnose the overflow, then reconcile:\n` +
-    `  - most often the page has drifted below architecture altitude (field names, mechanics, how-it-works detail). Raise the altitude or cut it — that content is volatile and belongs nowhere durable;\n` +
+    `  - most often the page has dropped to the level of the code (field names, mechanics, how-it-works detail). Raise the level or cut it — that content is volatile and belongs nowhere durable;\n` +
     `  - if the page has grown to cover more than one subsystem, split it and reconsider the boundaries;\n` +
     `  - only if genuine decision rationale (why X was chosen over Y) has leaked onto the page, cut it. That "why" lives in the ADR log, authored when the decision was made — do not mint a new ADR now to relieve size. The page keeps the why-you-need-to-work-here; the log keeps the why-it-was-decided.`
   );

--- a/scripts/doc-size.mjs
+++ b/scripts/doc-size.mjs
@@ -50,17 +50,19 @@ export function capFor(filePath) {
 }
 
 // The steering message, shared so the hook rejection and the gate failure read
-// identically. It states the overage and prescribes the reconcile, so the agent
-// does not simply trim meaning to fit.
+// identically. It names the cap as a signal to re-think what the page carries,
+// and orders the remedies so relocating and splitting come first and prose
+// tightening is the last resort — otherwise the cheapest move (reword to fit)
+// is also the first one read, and the agent stops there.
 export function overageReport({ path, size, cap, kind }) {
   const over = size - cap;
   const label = kind === "index" ? "index (always loaded, hardest cap)" : "page";
   return (
     `${path} is ${size} chars — ${over} over the ${cap}-char ${label} cap.\n` +
-    `Architecture docs are a capped projection of the ADR log. Do not trim meaning to fit. Reconcile:\n` +
-    `  - tighten prose and merge related statements;\n` +
-    `  - push detail and rationale down into an ADR (the log holds the "why");\n` +
-    `  - if the subsystem genuinely no longer fits one page, reconsider its boundaries — do not shrink meaning.`
+    `Over the cap means this page carries too much — too much detail, or too many concerns — not that it is worded verbosely. Treat it as a signal to re-think what belongs here, not a request to be more concise. Do not trim meaning to fit. Reconcile in this order:\n` +
+    `  - move detail and rationale down into an ADR — the log holds the "why", the page keeps the "what";\n` +
+    `  - if the page has grown to cover more than one subsystem, split it and reconsider the boundaries;\n` +
+    `  - only once the content is right, tighten prose and merge related statements — last, never the first move.`
   );
 }
 

--- a/scripts/doc-size.mjs
+++ b/scripts/doc-size.mjs
@@ -1,11 +1,13 @@
 #!/usr/bin/env node
 // check:doc-size — enforce the architecture-doc character budget.
 //
-// Architecture docs are a projection of the ADR log, capped by construction. The
-// cap is a forcing function: when a recompile does not fit, the agent must
-// consolidate prose and push detail and rationale down into an ADR rather than
-// let the page grow unbounded. The point is not to precisely budget context; it
-// is to set a hard limit so the projection stays reduced.
+// Architecture docs are a hand-maintained, reduced view of the current system;
+// the cap keeps them reduced. It is a forcing function, not a byte budget: going
+// over means the page drifted below architecture altitude, or grew to cover more
+// than one subsystem. The remedy is to raise altitude, cut volatile detail, or
+// split — not to reword to fit, and not to offload description into the ADR log
+// (the log holds decisions, not documentation spillover). Precision of the
+// number is not the point; a hard limit that forces the re-think is.
 //
 // This module is the single measurement shared by two surfaces:
 //   - the authoritative gate (this file's `main`, wired as docs:check:doc-size
@@ -50,19 +52,20 @@ export function capFor(filePath) {
 }
 
 // The steering message, shared so the hook rejection and the gate failure read
-// identically. It names the cap as a signal to re-think what the page carries,
-// and orders the remedies so relocating and splitting come first and prose
-// tightening is the last resort — otherwise the cheapest move (reword to fit)
-// is also the first one read, and the agent stops there.
+// identically. Over-cap is an altitude/scope signal, not a conciseness ask, so
+// the ladder leads with raising altitude and splitting. It never tells the agent
+// to reword to fit, and never to mint an ADR as a spillover bucket: relocating
+// is the narrow last case, only for genuine decision rationale, which the log
+// already owns from when the decision was made.
 export function overageReport({ path, size, cap, kind }) {
   const over = size - cap;
   const label = kind === "index" ? "index (always loaded, hardest cap)" : "page";
   return (
     `${path} is ${size} chars — ${over} over the ${cap}-char ${label} cap.\n` +
-    `Over the cap means this page carries too much — too much detail, or too many concerns — not that it is worded verbosely. Treat it as a signal to re-think what belongs here, not a request to be more concise. Do not trim meaning to fit. Reconcile in this order:\n` +
-    `  - move detail and rationale down into an ADR — the log holds the "why", the page keeps the "what";\n` +
+    `Over the cap means the page carries too much, not that it is worded verbosely. It is a signal to re-think what belongs here — do not reword or trim meaning to fit. Diagnose the overflow, then reconcile:\n` +
+    `  - most often the page has drifted below architecture altitude (field names, mechanics, how-it-works detail). Raise the altitude or cut it — that content is volatile and belongs nowhere durable;\n` +
     `  - if the page has grown to cover more than one subsystem, split it and reconsider the boundaries;\n` +
-    `  - only once the content is right, tighten prose and merge related statements — last, never the first move.`
+    `  - only if genuine decision rationale (why X was chosen over Y) has leaked onto the page, cut it. That "why" lives in the ADR log, authored when the decision was made — do not mint a new ADR now to relieve size. The page keeps the why-you-need-to-work-here; the log keeps the why-it-was-decided.`
   );
 }
 


### PR DESCRIPTION
Merges into #2735.

The doc-size cap is meant to make the agent re-think whether a page carries too much detail or needs splitting. Two problems in #2735 defeated that.

## Problem 1 — the steering invited rewording

`overageReport` led with "tighten prose and merge related statements." Under a hard gate the agent does the cheapest thing that clears it and stops — and the cheapest thing was rewording, listed first. The re-think options came after.

## Problem 2 — "relocate to an ADR" was conceptually broken

The original remedy told the agent to "move detail and rationale down into an ADR." That treats the log as a spillover tank. It isn't:

- ADRs are filed *before* work, capture a *decision*, and are *accepted* then *immutable*. Descriptive reality has no acceptance semantics and rots once frozen. Minting an ADR after the fact to relieve doc size is a category error.
- Over-cap is almost always an **altitude/scope** problem: the page drifted below architecture level, or covers two subsystems. The remedy is raise altitude, cut volatile detail, or split — no ADR involved.
- Relocating to the log is valid only for genuine **decision rationale** (why X over Y), and that already has an ADR from when the decision was made. So the move is "cut it from the page," not "author a new ADR."

The "docs are a projection of the ADR log / the cap and the log are one mechanism" framing seeded the error. Architecture docs are a hand-maintained reduced view, not a generated projection (only `adrs/index.md` is generated). Dropped that vocabulary.

## Changes

- **`scripts/doc-size.mjs`** — steering is now diagnose-then-reconcile: raise altitude first, split second, relocate decision-rationale last (and never mint a new ADR to relieve size). Top comment drops the projection/recompile/one-mechanism framing.
- **`documentation-guidelines.md`** — grade the "why" explicitly (pages keep *operational* why and stand alone; the log keeps *decision history*), and replace the stale "No length cap" line with the corrected remedy ladder.

Shared message, so hook rejection and CI gate read identically. Verified rendering and the gate still runs.

## Note (out of scope)

`docs/architecture/connections.md` is already ~1KB over the cap on the #2735 branch, so that PR is currently tripping its own gate. Worth resolving there.