### PR TITLE
fix(platform-base): create ca-trust dirs before chown

### DIFF
--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -115,7 +115,7 @@ COPY packages/platform-base/working-dir/.claude/settings.json /app/working-dir/.
 COPY packages/platform-base/runtime-manifest.yaml /app/runtime-manifest.yaml
 COPY packages/platform-base/AGENTS.md /etc/AGENTS.md
 
-RUN mkdir -p /home/agent &&\
+RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs &&\
     chown -R 65532 /etc/mise /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs /app /home/agent /usr/local/share/mise &&\
     ldconfig &&\
     echo 'sshd:x:74:' >> /etc/group &&\


### PR DESCRIPTION
Agent image builds currently fail at the runner stage:

```
chown: cannot access '/etc/pki/ca-trust/source/anchors': No such file or directory
```

The runner base (`core-runtime:latest`, a floating tag) recently shipped without the empty ca-trust anchors directory — empty dirs are exactly what image minimization tends to drop. `mkdir -p` the dirs before chowning them, making the build independent of which directories the base happens to pre-create. The dirs are needed regardless: the entrypoint installs the gateway CA there.

No change for bases that still ship the dirs.