### PR TITLE
fix(cli): route WebSocket connections through the proxy env

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,6 +36,8 @@
     "api-server-api": "workspace:*",
     "commander": "^14.0.3",
     "dev-config": "workspace:*",
+    "http-proxy-agent": "^7.0.2",
+    "https-proxy-agent": "^7.0.6",
     "open": "^11.0.0",
     "smol-toml": "^1.6.1",
     "tar-stream": "^3.1.8",

--- a/packages/cli/src/__tests__/ws-proxy.test.ts
+++ b/packages/cli/src/__tests__/ws-proxy.test.ts
@@ -1,0 +1,73 @@
+import { HttpProxyAgent } from "http-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { describe, expect, it } from "vitest";
+
+import { proxyAgentForUrl } from "../modules/shared/ws-proxy.js";
+
+describe("proxyAgentForUrl", () => {
+  it("returns undefined when no proxy env var is set", () => {
+    expect(proxyAgentForUrl("wss://api.example.com/x", {})).toBeUndefined();
+  });
+
+  it("uses HTTPS_PROXY for a wss target", () => {
+    const agent = proxyAgentForUrl("wss://api.example.com/x", {
+      HTTPS_PROXY: "http://proxy:10000",
+    });
+    expect(agent).toBeInstanceOf(HttpsProxyAgent);
+  });
+
+  it("uses HTTP_PROXY for a ws target", () => {
+    const agent = proxyAgentForUrl("ws://api.example.com/x", {
+      HTTP_PROXY: "http://proxy:10000",
+    });
+    expect(agent).toBeInstanceOf(HttpProxyAgent);
+  });
+
+  it("accepts lowercase env var names", () => {
+    const agent = proxyAgentForUrl("wss://api.example.com/x", {
+      https_proxy: "http://proxy:10000",
+    });
+    expect(agent).toBeInstanceOf(HttpsProxyAgent);
+  });
+
+  it("does not use HTTP_PROXY for a secure target", () => {
+    // A wss target must not fall back to HTTP_PROXY — only HTTPS_PROXY applies.
+    expect(
+      proxyAgentForUrl("wss://api.example.com/x", {
+        HTTP_PROXY: "http://proxy:10000",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("skips proxying when the host matches NO_PROXY", () => {
+    expect(
+      proxyAgentForUrl("wss://api.internal.example.com/x", {
+        HTTPS_PROXY: "http://proxy:10000",
+        NO_PROXY: "localhost,.internal.example.com",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("honors a NO_PROXY wildcard", () => {
+    expect(
+      proxyAgentForUrl("wss://api.example.com/x", {
+        HTTPS_PROXY: "http://proxy:10000",
+        NO_PROXY: "*",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("still proxies a host not covered by NO_PROXY", () => {
+    const agent = proxyAgentForUrl("wss://api.example.com/x", {
+      HTTPS_PROXY: "http://proxy:10000",
+      NO_PROXY: "localhost,.other.example.com",
+    });
+    expect(agent).toBeInstanceOf(HttpsProxyAgent);
+  });
+
+  it("returns undefined for an unparseable url", () => {
+    expect(
+      proxyAgentForUrl("not-a-url", { HTTPS_PROXY: "http://proxy:10000" }),
+    ).toBeUndefined();
+  });
+});

--- a/packages/cli/src/__tests__/ws-proxy.test.ts
+++ b/packages/cli/src/__tests__/ws-proxy.test.ts
@@ -48,6 +48,15 @@ describe("proxyAgentForUrl", () => {
     ).toBeUndefined();
   });
 
+  it("matches NO_PROXY entries case-insensitively", () => {
+    expect(
+      proxyAgentForUrl("wss://api.internal.example.com/x", {
+        HTTPS_PROXY: "http://proxy:10000",
+        NO_PROXY: ".Internal.Example.com",
+      }),
+    ).toBeUndefined();
+  });
+
   it("honors a NO_PROXY wildcard", () => {
     expect(
       proxyAgentForUrl("wss://api.example.com/x", {

--- a/packages/cli/src/modules/chat/infrastructure/acp-session-client.ts
+++ b/packages/cli/src/modules/chat/infrastructure/acp-session-client.ts
@@ -4,6 +4,8 @@ import type { Stream } from "@agentclientprotocol/sdk/dist/stream.js";
 import { SessionMode, SessionType, type SessionView } from "api-server-api";
 import { WebSocket } from "ws";
 
+import { proxyAgentForUrl } from "../../shared/ws-proxy.js";
+
 /**
  * Sessions are agent-owned: there is no server session store. The CLI
  * reads and mutates them directly over the api-server's ACP relay WebSocket,
@@ -31,7 +33,7 @@ interface ListedSession {
 
 function wsStream(url: string): Promise<{ stream: Stream; ws: WebSocket }> {
   return new Promise((resolve, reject) => {
-    const ws = new WebSocket(url);
+    const ws = new WebSocket(url, { agent: proxyAgentForUrl(url) });
     ws.on("open", () => {
       const readable = new ReadableStream<AnyMessage>({
         start(controller) {

--- a/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
+++ b/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
@@ -8,6 +8,8 @@ import {
   OP_OUTPUT,
 } from "api-server-api";
 
+import { proxyAgentForUrl } from "../../shared/ws-proxy.js";
+
 export type BridgeResult =
   | { kind: "exited"; code: number }
   | { kind: "disconnected"; reason: string };
@@ -30,9 +32,8 @@ export function connectTerminalBridge({
     const proto = host.startsWith("https://") ? "wss:" : "ws:";
     const base = host.replace(/^https?:\/\//, "").replace(/\/+$/, "");
     const sep = terminalPath.includes("?") ? "&" : "?";
-    const ws = new WebSocket(
-      `${proto}//${base}${terminalPath}${sep}token=${encodeURIComponent(token)}`,
-    );
+    const url = `${proto}//${base}${terminalPath}${sep}token=${encodeURIComponent(token)}`;
+    const ws = new WebSocket(url, { agent: proxyAgentForUrl(url) });
 
     const onData = (chunk: Buffer) => {
       if (ws.readyState === WebSocket.OPEN)

--- a/packages/cli/src/modules/shared/ws-proxy.ts
+++ b/packages/cli/src/modules/shared/ws-proxy.ts
@@ -1,0 +1,59 @@
+import type { Agent } from "node:http";
+
+import { HttpProxyAgent } from "http-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
+
+/**
+ * The `ws` client opens its own raw http/https socket and, unlike Node's global
+ * fetch/undici (which honors `NODE_USE_ENV_PROXY`), it ignores the standard
+ * proxy env vars. In locked-down environments — e.g. an agent pod whose only
+ * egress path is a forward proxy that also injects auth — a WebSocket opened
+ * without an explicit agent bypasses the proxy, so the connection is refused
+ * and the caller sees the stream close mid-handshake. The tRPC/REST calls work
+ * in the same environment precisely because they go through fetch.
+ *
+ * Build a proxy agent from the environment so `ws` tunnels through it too.
+ * Returns undefined when no proxy applies (no relevant `*_PROXY` var, or the
+ * target host matches `NO_PROXY`), which leaves direct-connection behavior
+ * unchanged — `ws` treats `{ agent: undefined }` as "no agent".
+ */
+export function proxyAgentForUrl(
+  url: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Agent | undefined {
+  let target: URL;
+  try {
+    target = new URL(url);
+  } catch {
+    return undefined;
+  }
+
+  const secure = target.protocol === "wss:" || target.protocol === "https:";
+  const proxy = secure
+    ? (env.HTTPS_PROXY ?? env.https_proxy)
+    : (env.HTTP_PROXY ?? env.http_proxy);
+  if (!proxy) return undefined;
+  if (isNoProxy(target.hostname, env.NO_PROXY ?? env.no_proxy)) return undefined;
+
+  // A `wss:`/`https:` target is tunneled through the proxy with CONNECT
+  // (HttpsProxyAgent); a plain `ws:`/`http:` target is forwarded with an
+  // absolute-form request (HttpProxyAgent). The proxy URL's own scheme is
+  // orthogonal — both agents accept an `http://` proxy.
+  return secure ? new HttpsProxyAgent(proxy) : new HttpProxyAgent(proxy);
+}
+
+/**
+ * Match a hostname against a `NO_PROXY` list: comma-separated hosts or domain
+ * suffixes, an optional leading dot, and `*` as a wildcard for all hosts.
+ */
+function isNoProxy(host: string, noProxy: string | undefined): boolean {
+  if (!noProxy) return false;
+  for (const raw of noProxy.split(",")) {
+    const entry = raw.trim();
+    if (entry === "") continue;
+    if (entry === "*") return true;
+    const bare = entry.startsWith(".") ? entry.slice(1) : entry;
+    if (host === bare || host.endsWith(`.${bare}`)) return true;
+  }
+  return false;
+}

--- a/packages/cli/src/modules/shared/ws-proxy.ts
+++ b/packages/cli/src/modules/shared/ws-proxy.ts
@@ -33,7 +33,8 @@ export function proxyAgentForUrl(
     ? (env.HTTPS_PROXY ?? env.https_proxy)
     : (env.HTTP_PROXY ?? env.http_proxy);
   if (!proxy) return undefined;
-  if (isNoProxy(target.hostname, env.NO_PROXY ?? env.no_proxy)) return undefined;
+  if (isNoProxy(target.hostname, env.NO_PROXY ?? env.no_proxy))
+    return undefined;
 
   // A `wss:`/`https:` target is tunneled through the proxy with CONNECT
   // (HttpsProxyAgent); a plain `ws:`/`http:` target is forwarded with an

--- a/packages/cli/src/modules/shared/ws-proxy.ts
+++ b/packages/cli/src/modules/shared/ws-proxy.ts
@@ -53,7 +53,9 @@ function isNoProxy(host: string, noProxy: string | undefined): boolean {
     const entry = raw.trim();
     if (entry === "") continue;
     if (entry === "*") return true;
-    const bare = entry.startsWith(".") ? entry.slice(1) : entry;
+    // Compare case-insensitively like curl/undici; URL already lowercases
+    // the target hostname, so only the entry needs normalizing.
+    const bare = (entry.startsWith(".") ? entry.slice(1) : entry).toLowerCase();
     if (host === bare || host.endsWith(`.${bare}`)) return true;
   }
   return false;

--- a/packages/cli/src/modules/ssh/infrastructure/raw-bridge.ts
+++ b/packages/cli/src/modules/ssh/infrastructure/raw-bridge.ts
@@ -1,5 +1,7 @@
 import WebSocket from "ws";
 
+import { proxyAgentForUrl } from "../../shared/ws-proxy.js";
+
 export function connectRawBridge({
   host,
   token,
@@ -17,9 +19,8 @@ export function connectRawBridge({
     let settled = false;
     const proto = host.startsWith("https://") ? "wss:" : "ws:";
     const base = host.replace(/^https?:\/\//, "").replace(/\/+$/, "");
-    const ws = new WebSocket(
-      `${proto}//${base}/api/agents/${encodeURIComponent(agentId)}/ssh?token=${encodeURIComponent(token)}`,
-    );
+    const url = `${proto}//${base}/api/agents/${encodeURIComponent(agentId)}/ssh?token=${encodeURIComponent(token)}`;
+    const ws = new WebSocket(url, { agent: proxyAgentForUrl(url) });
     ws.binaryType = "nodebuffer";
 
     const onStdin = (chunk: Buffer) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -377,6 +377,12 @@ importers:
       dev-config:
         specifier: workspace:*
         version: link:../dev-config
+      http-proxy-agent:
+        specifier: ^7.0.2
+        version: 7.0.2
+      https-proxy-agent:
+        specifier: ^7.0.6
+        version: 7.0.6
       open:
         specifier: ^11.0.0
         version: 11.0.0


### PR DESCRIPTION
## Problem

Every `dam` command that opens a **WebSocket** fails from inside an agent pod (and any environment whose only egress is a forward proxy):

- `dam ssh connect <agent>` → ssh reports `kex_exchange_identification: Connection closed by remote host`
- `dam chat` terminal bridge and the ACP session client fail the same way

Meanwhile `dam agent list`, `dam file list`, etc. work fine in the same environment.

### Root cause

The `ws` client opens its own raw `http`/`https` socket. Unlike Node's global `fetch`/undici — which honors `NODE_USE_ENV_PROXY=1` — **`ws` ignores the standard proxy env vars unless you hand it an `agent`**. All three CLI WebSocket call sites constructed `new WebSocket(url)` with no options, so the connection went **direct**, bypassing the mandatory forward proxy. In a locked-down pod, direct egress is blocked (and the proxy is also what injects the real bearer token — in-pod `DAM_TOKEN` is a placeholder), so the socket is refused and the stream closes mid-handshake.

tRPC/REST calls work because they use `fetch`, which respects the proxy.

### Evidence

Reproduced from a `claude-code` agent pod (egress via `HTTPS_PROXY`, `NODE_USE_ENV_PROXY=1`):

| Check | Result |
|---|---|
| `dam ping` / `dam agent get` (tRPC) | ✅ works |
| `dam file list <agent> /home/agent` (REST) | ✅ works |
| direct (`--noproxy`) curl to DAM host | ❌ blocked |
| curl via `HTTPS_PROXY` to DAM host | ✅ `HTTP 200` |
| `ssh <managed-host>` (WebSocket bridge) | ❌ `Connection closed by remote host` at kex |

## Fix

Add a shared `proxyAgentForUrl()` helper (`packages/cli/src/modules/shared/ws-proxy.ts`) that builds an `http(s)-proxy-agent` from the environment:

- `wss:`/`https:` targets → `HttpsProxyAgent` (CONNECT tunnel); `ws:`/`http:` → `HttpProxyAgent`
- picks `HTTPS_PROXY`/`HTTP_PROXY` (and lowercase variants) by target scheme
- respects `NO_PROXY` (suffix match, leading dot, `*`)
- returns `undefined` when no proxy applies → **direct-connection behavior unchanged** (`ws` treats `{ agent: undefined }` as no agent)

Pass it as the `ws` `agent` at all three call sites:
- `packages/cli/src/modules/ssh/infrastructure/raw-bridge.ts`
- `packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts`
- `packages/cli/src/modules/chat/infrastructure/acp-session-client.ts`

Adds `http-proxy-agent` / `https-proxy-agent` (both already present transitively in the lockfile) to the CLI's deps, and a unit test covering scheme selection, lowercase vars, and `NO_PROXY`.

## Testing

- `mise run check` passes locally (lint, type-check, format, helm render — the full repo gate).
- `mise run cli:test` passes: 150 tests across 25 files, including the 9 new `ws-proxy.test.ts` cases.
- The follow-up commit adds the missing `pnpm-lock.yaml` entries for the two new deps (the original push predated a working `pnpm install`, so CI failed at frozen-lockfile setup) and a prettier line-wrap fix in `ws-proxy.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
