### PR TITLE
fix(egress-rules): make duplicate create idempotent, verdict clash a CONFLICT

### DIFF
--- a/packages/api-server/src/__tests__/unit/egress-rules-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/egress-rules-port.test.ts
@@ -37,6 +37,7 @@ function fakeRepo(overrides: Partial<EgressRulesRepository> = {}) {
     listConnectionDerivedForAgent: async () => [],
     hasUserOwnedRuleForHost: async () => false,
     findMatch: async () => null,
+    getActiveByTuple: async () => null,
     getById: async () => null,
     revoke: async () => {},
     updatePromoteToManual: async () => null,

--- a/packages/api-server/src/modules/egress-rules/infrastructure/egress-rules-repository.ts
+++ b/packages/api-server/src/modules/egress-rules/infrastructure/egress-rules-repository.ts
@@ -41,6 +41,16 @@ export interface EgressRulesRepository {
    *  preset is not stored on the spec — its rules' sources are the truth. */
   getPresetForAgent(agentId: string): Promise<EgressPreset>;
   getById(id: string): Promise<EgressRuleRow | null>;
+  /** Exact lookup on the active-row unique index (`egress_rules_lookup_idx`).
+   *  Used as the insert conflict fallback so callers get *the* conflicting
+   *  row, not a best-match — `findMatch` treats the path as a request path,
+   *  not a pattern. */
+  getActiveByTuple(
+    agentId: string,
+    host: string,
+    method: string,
+    pathPattern: string,
+  ): Promise<EgressRuleRow | null>;
   insert(row: NewEgressRule): Promise<EgressRuleRow>;
   /** Insert-or-promote variant used by the connection-rules sync. If an
    *  existing active row for `(agent, host, method, pathPattern)` is a
@@ -106,7 +116,9 @@ type RawRule = {
   pathPattern: string;
   verdict: string;
   decidedBy: string;
-  decidedAt: Date;
+  // Raw `db.execute(sql...)` reads bypass drizzle's timestamptz mapper and
+  // yield strings; typed `.select()`/`.returning()` reads yield Dates.
+  decidedAt: Date | string;
   status: string;
   source: string;
 } & Record<string, unknown>;
@@ -121,7 +133,8 @@ function toRow(r: RawRule): EgressRuleRow {
     pathPattern: r.pathPattern,
     verdict: r.verdict as RuleVerdict,
     decidedBy: r.decidedBy,
-    decidedAt: r.decidedAt,
+    decidedAt:
+      r.decidedAt instanceof Date ? r.decidedAt : new Date(r.decidedAt),
     status: r.status as "active" | "revoked",
     source: r.source as EgressRuleSource,
   };
@@ -134,6 +147,24 @@ export function createEgressRulesRepository(db: Db): EgressRulesRepository {
         .select()
         .from(egressRules)
         .where(eq(egressRules.id, id));
+      return rows.length ? toRow(rows[0] as RawRule) : null;
+    },
+
+    async getActiveByTuple(agentId, host, method, pathPattern) {
+      // No LIMIT needed — the partial unique index guarantees at most one
+      // active row per tuple.
+      const rows = await db
+        .select()
+        .from(egressRules)
+        .where(
+          and(
+            eq(egressRules.agentId, agentId),
+            eq(egressRules.host, host),
+            eq(egressRules.method, method),
+            eq(egressRules.pathPattern, pathPattern),
+            eq(egressRules.status, "active"),
+          ),
+        );
       return rows.length ? toRow(rows[0] as RawRule) : null;
     },
 
@@ -228,7 +259,7 @@ export function createEgressRulesRepository(db: Db): EgressRulesRepository {
         .onConflictDoNothing()
         .returning();
       if (inserted.length) return toRow(inserted[0] as RawRule);
-      const existing = await this.findMatch(
+      const existing = await this.getActiveByTuple(
         row.agentId,
         row.host,
         row.method,
@@ -276,7 +307,7 @@ export function createEgressRulesRepository(db: Db): EgressRulesRepository {
       `);
       const promotedRows = promoted as unknown as RawRule[];
       if (promotedRows.length) return toRow(promotedRows[0]!);
-      const existing = await this.findMatch(
+      const existing = await this.getActiveByTuple(
         row.agentId,
         row.host,
         row.method,

--- a/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
+++ b/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
@@ -77,7 +77,7 @@ export function createEgressRulesService(
         });
         throw new TRPCError({ code: "NOT_FOUND", message: "agent not found" });
       }
-      const row = await deps.repo.insert({
+      let row = await deps.repo.insert({
         id: randomUUID(),
         agentId: input.agentId,
         host: input.host,
@@ -88,6 +88,38 @@ export function createEgressRulesService(
         decidedBy: deps.ownerSub,
         source: "manual",
       });
+      // Insert conflicted with an existing rule carrying a different verdict.
+      // Nothing changed, so bail before the create audit log and L7 side
+      // effect — changing a verdict is the update/edit path's job.
+      if (row.verdict !== input.verdict) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `an equivalent rule already exists with verdict '${row.verdict}' — edit the existing rule instead`,
+        });
+      }
+      // Port is outside the rule's unique key and not editable, so a
+      // port-differing duplicate can't be stored or fixed by edit — reject
+      // rather than return a rule that misrepresents the requested port.
+      if ((row.port ?? null) !== (input.port ?? null)) {
+        throw new TRPCError({
+          code: "CONFLICT",
+          message: `an equivalent rule already exists ${row.port ? `for port ${row.port}` : "without a port"} — revoke it and create the rule again`,
+        });
+      }
+      // Same-verdict duplicate of a preset/connection row: the manual create
+      // takes ownership (same intent as edit-promotes-to-manual), so a later
+      // preset sweep or connection revoke won't silently drop a rule the
+      // user explicitly asked for.
+      if (row.source !== "manual" && row.source !== "inbox") {
+        row =
+          (await deps.repo.updatePromoteToManual({
+            id: row.id,
+            method: row.method,
+            pathPattern: row.pathPattern,
+            verdict: row.verdict,
+            decidedBy: deps.ownerSub,
+          })) ?? row;
+      }
       securityLog("info", "egress_rule.create", {
         category: "authz-list",
         actor: deps.ownerSub,


### PR DESCRIPTION
Adding a network rule that duplicates an existing one — via `dam network create` or the network panel — used to fail with an internal error (`row.decidedAt.toISOString is not a function`) even though the rule state on the server was fine.

Create is now intent-based:

- **Exact duplicate** (same host/method/path and port, same verdict): succeeds quietly and returns the existing rule. Idempotent — safe for re-run scripts and double-clicks. If the existing rule came from a preset or connection, the manual create takes ownership of it (source becomes `manual`), so a later preset switch won't silently remove a rule the user explicitly asked for.
- **Verdict clash** (same rule, opposite verdict): fails with a clear conflict error telling the user to edit the existing rule instead — create never flips a verdict.
- **Port clash** (same rule, different port): fails with a clear conflict error pointing at revoke-and-recreate, since a rule's port can't be edited — instead of returning a "created" rule that silently lacks the requested port.

The command's success or failure now reflects the actual outcome. No CLI, UI, or API contract changes.

Closes #2324