### PR TITLE
feat(ui): session filter and row states

### DIFF
--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -1,3 +1,4 @@
+import { Checkmark as Check } from "@carbon/icons-react";
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
 import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
@@ -50,6 +51,31 @@ function DropdownMenuItem({
   );
 }
 
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.CheckboxItem>) {
+  return (
+    <DropdownMenuPrimitive.CheckboxItem
+      className={cn(
+        menuItemVariants({ tone: "default" }),
+        "group relative pl-8",
+        className,
+      )}
+      {...props}
+    >
+      {/* Mirrors the shared Checkbox primitive's box styling */}
+      <span className="absolute left-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary group-data-[state=checked]:bg-primary group-data-[state=checked]:text-primary-foreground">
+        <DropdownMenuPrimitive.ItemIndicator className="flex items-center justify-center text-current">
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  );
+}
+
 function DropdownMenuSeparator({
   className,
   ...props
@@ -64,6 +90,7 @@ function DropdownMenuSeparator({
 
 export {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,

--- a/packages/ui/src/components/ui/menu-styles.ts
+++ b/packages/ui/src/components/ui/menu-styles.ts
@@ -6,7 +6,7 @@ import { cva } from "class-variance-authority";
  * identical-looking menu, so the surface styling lives here once.
  */
 export const menuContentClassName =
-  "z-50 min-w-[160px] rounded-md border border-border bg-popover py-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95";
+  "z-50 min-w-[160px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95";
 
 export const menuSeparatorClassName = "my-1 h-px bg-border";
 

--- a/packages/ui/src/modules/files/components/files-panel.tsx
+++ b/packages/ui/src/modules/files/components/files-panel.tsx
@@ -1,11 +1,4 @@
-import {
-  ChevronDown,
-  FilePlus,
-  FolderPlus,
-  FolderUp,
-  Plus,
-  Upload,
-} from "lucide-react";
+import { FilePlus, FolderPlus, FolderUp, Plus, Upload } from "lucide-react";
 import type { CSSProperties } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -50,7 +43,7 @@ export function FilesPanel({
           disabled={controller.isUploading}
           title={controller.isUploading ? "Upload in progress…" : "Add"}
         >
-          <Plus size={12} /> Add <ChevronDown size={11} />
+          <Plus size={12} /> Add
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end">

--- a/packages/ui/src/modules/sessions/api/queries.ts
+++ b/packages/ui/src/modules/sessions/api/queries.ts
@@ -10,12 +10,17 @@ import { listAgentSessions } from "./acp-session-ops.js";
 
 const STATUS_POLL_MS = 5_000;
 
+export interface SessionListInclude {
+  channels: boolean;
+  scheduled: boolean;
+}
+
 export const acpSessionsKeys = {
   all: ["acp-sessions"] as const,
   agentLists: (agentId: string | null) =>
     [...acpSessionsKeys.all, agentId] as const,
-  list: (agentId: string | null, includeChannel: boolean) =>
-    [...acpSessionsKeys.agentLists(agentId), { includeChannel }] as const,
+  list: (agentId: string | null, include: SessionListInclude) =>
+    [...acpSessionsKeys.agentLists(agentId), include] as const,
 };
 
 // Optimistic insert so the sidebar shows the row immediately; the next refetch reconciles.
@@ -89,7 +94,7 @@ export function setSessionRunning(
  * Sessions list, read straight off the agent over ACP `session/list`
  * and decoded from `_meta.platform`. Regular and experiment-trial sessions are
  * always listed (so an arm's trial is reachable from its agent's sidebar);
- * schedule sessions are excluded; channel sessions are included only when asked. Pass
+ * schedule and channel sessions are included only when asked. Pass
  * `enabled: false` (e.g. while the agent is waking) to keep the query in cache
  * without firing requests.
  *
@@ -98,7 +103,7 @@ export function setSessionRunning(
  */
 export function useAcpSessions(
   agentId: string | null,
-  includeChannel: boolean,
+  include: SessionListInclude,
   options?: {
     enabled?: boolean;
     activeSessionId?: string | null;
@@ -106,7 +111,7 @@ export function useAcpSessions(
 ) {
   const live = !!agentId && (options?.enabled ?? true);
   return useQuery({
-    queryKey: acpSessionsKeys.list(agentId, includeChannel),
+    queryKey: acpSessionsKeys.list(agentId, include),
     queryFn: live
       ? async () => {
           const sessions = await listAgentSessions(agentId);
@@ -114,15 +119,16 @@ export function useAcpSessions(
             SessionType.Regular,
             SessionType.ExperimentTrial,
           ];
-          if (includeChannel)
+          if (include.channels)
             allowed.push(SessionType.ChannelSlack, SessionType.ChannelTelegram);
+          if (include.scheduled) allowed.push(SessionType.ScheduleCron);
           const fresh = sessions.filter((s) => allowed.includes(s.type));
           // Keep the active session's optimistic stub if not fetched so a refetch can't drop it.
           const activeId = options?.activeSessionId;
           if (!activeId || fresh.some((s) => s.sessionId === activeId))
             return fresh;
           const prev = queryClient.getQueryData<SessionView[]>(
-            acpSessionsKeys.list(agentId, includeChannel),
+            acpSessionsKeys.list(agentId, include),
           );
           const stub = prev?.find((s) => s.sessionId === activeId);
           return stub ? [stub, ...fresh] : fresh;

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -1,9 +1,20 @@
-import { Code } from "@carbon/icons-react";
+import {
+  Code,
+  Hashtag,
+  OverflowMenuVertical,
+  Time,
+  TrashCan,
+} from "@carbon/icons-react";
 import { SessionMode, SessionType, type SessionView } from "api-server-api";
-import { Clock, Trash2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
 import { WorkingDots } from "./working-dots.js";
@@ -83,6 +94,9 @@ export function SessionRow({
 
   const scheduled = s.type === SessionType.ScheduleCron || !!s.scheduleId;
   const terminal = s.mode === SessionMode.Terminal;
+  const channel =
+    s.type === SessionType.ChannelSlack ||
+    s.type === SessionType.ChannelTelegram;
 
   return (
     <div
@@ -107,38 +121,42 @@ export function SessionRow({
           <span className={`text-[13px] min-w-0 truncate ${titleClass}`}>
             {titleLabel}
           </span>
-          {(s.type === SessionType.ChannelSlack ||
-            s.type === SessionType.ChannelTelegram) && (
-            <span className="text-[9px] font-bold uppercase tracking-wider text-text-muted bg-border-light rounded px-1 py-0.5 shrink-0">
-              {s.type === SessionType.ChannelSlack ? "slack" : "telegram"}
-            </span>
-          )}
           <SessionIndicators
             scheduled={scheduled}
             terminal={terminal}
+            channel={channel}
             needsApproval={needsApproval}
             working={working}
           />
         </div>
-        <span className="text-[11px] text-text-muted">
+        <span className="text-[11px] text-muted-foreground">
           {new Date(s.updatedAt ?? s.createdAt).toLocaleString()}
         </span>
       </div>
-      {/* Desktop: hover-visible delete button */}
-      <Button
-        data-testid="session-delete-button"
-        variant="ghost"
-        tone="danger"
-        size="icon-xs"
-        className="shrink-0 opacity-0 group-hover:opacity-100"
-        onClick={(e) => {
-          e.stopPropagation();
-          onDelete();
-        }}
-        title="Delete session"
-      >
-        <Trash2 size={12} />
-      </Button>
+      {/* Desktop: hover-visible overflow menu */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            data-testid="session-menu-button"
+            variant="ghost"
+            size="icon-xs"
+            className="shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100"
+            onClick={(e) => e.stopPropagation()}
+            title="More actions"
+          >
+            <OverflowMenuVertical size={16} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem
+            data-testid="session-delete-button"
+            tone="danger"
+            onSelect={onDelete}
+          >
+            <TrashCan size={13} /> Delete session
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
       {/* Context menu — long press (mobile) or right-click */}
       {menuOpen && (
         <div
@@ -156,7 +174,7 @@ export function SessionRow({
               onDelete();
             }}
           >
-            <Trash2 size={13} /> Delete session
+            <TrashCan size={13} /> Delete session
           </Button>
         </div>
       )}
@@ -167,22 +185,28 @@ export function SessionRow({
 function SessionIndicators({
   scheduled,
   terminal,
+  channel,
   needsApproval,
   working,
 }: {
   scheduled: boolean;
   terminal: boolean;
+  channel: boolean;
   needsApproval: boolean;
   working: boolean;
 }) {
-  if (!scheduled && !terminal && !needsApproval && !working) return null;
+  if (!scheduled && !terminal && !channel && !needsApproval && !working)
+    return null;
   return (
     <span className="ml-auto flex items-center gap-1.5 shrink-0 pl-2">
       {terminal && (
         <Code size={16} className="text-text" aria-label="Terminal" />
       )}
+      {channel && (
+        <Hashtag size={16} className="text-text" aria-label="Channel session" />
+      )}
       {scheduled && (
-        <Clock size={16} className="text-text" aria-label="Scheduled" />
+        <Time size={16} className="text-text" aria-label="Scheduled" />
       )}
       {needsApproval ? (
         <span

--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -1,10 +1,12 @@
+import { Filter } from "@carbon/icons-react";
 import { SessionMode } from "api-server-api";
-import { ArrowLeft, ChevronDown, Plus } from "lucide-react";
+import { ArrowLeft, Plus } from "lucide-react";
 import { type CSSProperties, useCallback, useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
+  DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
@@ -15,6 +17,11 @@ import { useAgentRunState } from "../../agents/api/queries.js";
 import { useApprovalsForAgent } from "../../approvals/api/queries.js";
 import { AgentApprovalsTray } from "../../approvals/components/agent-approvals-tray.js";
 import { setSessionSeen, useAcpSessions } from "../api/queries.js";
+import {
+  SESSION_CATEGORIES,
+  SESSION_CATEGORY_LABELS,
+  sessionCategory,
+} from "../lib/session-category.js";
 import { SessionRow } from "./session-row.js";
 import { SidebarSection } from "./sidebar-section.js";
 
@@ -41,8 +48,15 @@ export function SessionsSidebar({
   const sessionId = useStore((s) => s.sessionId);
   const busy = useStore((s) => s.busy);
   const pendingPermissions = useStore((s) => s.pendingPermissions);
-  const includeChannel = useStore((s) => s.includeChannelSessions);
-  const setIncludeChannel = useStore((s) => s.setIncludeChannelSessions);
+  const sessionFilter = useStore((s) => s.sessionFilter);
+  const toggleSessionFilter = useStore((s) => s.toggleSessionFilter);
+  const listInclude = useMemo(
+    () => ({
+      channels: sessionFilter.includes("channels"),
+      scheduled: sessionFilter.includes("scheduled"),
+    }),
+    [sessionFilter],
+  );
   const deleteSession = useStore((s) => s.deleteSession);
   const showConfirm = useStore((s) => s.showConfirm);
   const goBack = useStore((s) => s.goBack);
@@ -50,13 +64,18 @@ export function SessionsSidebar({
   const agentRunState = useAgentRunState(selectedAgent);
   const { data: sessions = [], isFetching } = useAcpSessions(
     selectedAgent,
-    includeChannel,
+    listInclude,
     {
       enabled: agentRunState === "running",
       activeSessionId: sessionId,
     },
   );
   const loading = isFetching;
+
+  const visibleSessions = useMemo(
+    () => sessions.filter((s) => sessionFilter.includes(sessionCategory(s))),
+    [sessions, sessionFilter],
+  );
 
   const { data: approvals = EMPTY } = useApprovalsForAgent(selectedAgent);
   const approvalSessions = useMemo(() => {
@@ -80,8 +99,34 @@ export function SessionsSidebar({
     <>
       <DropdownMenu>
         <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="xs"
+            className="text-[14px] font-normal text-muted-foreground"
+          >
+            <Filter size={14} />
+            {sessionFilter.length === SESSION_CATEGORIES.length
+              ? "All"
+              : `Filter (${sessionFilter.length})`}
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          {SESSION_CATEGORIES.map((category) => (
+            <DropdownMenuCheckboxItem
+              key={category}
+              checked={sessionFilter.includes(category)}
+              onCheckedChange={() => toggleSessionFilter(category)}
+              onSelect={(e) => e.preventDefault()}
+            >
+              {SESSION_CATEGORY_LABELS[category]}
+            </DropdownMenuCheckboxItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
           <Button variant="outline" size="xs" className="text-[14px]">
-            <Plus size={12} /> New <ChevronDown size={11} />
+            <Plus size={12} /> New
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end">
@@ -117,22 +162,18 @@ export function SessionsSidebar({
       className={className}
       style={style}
     >
-      <label className="flex items-center gap-2 cursor-pointer text-[11px] text-text-muted px-4 py-2 border-b border-border-light shrink-0">
-        <input
-          type="checkbox"
-          checked={includeChannel}
-          onChange={(e) => setIncludeChannel(e.target.checked)}
-          className="accent-accent w-3 h-3"
-        />
-        Show channel sessions
-      </label>
       <div className="flex-1 overflow-y-auto">
         {!loading && sessions.length === 0 && (
           <p className="px-4 py-5 text-[12px] text-text-muted">
             No sessions yet
           </p>
         )}
-        {sessions.map((s) => {
+        {!loading && sessions.length > 0 && visibleSessions.length === 0 && (
+          <p className="px-4 py-5 text-[12px] text-text-muted">
+            No sessions match the filter
+          </p>
+        )}
+        {visibleSessions.map((s) => {
           const isOpen = s.sessionId === sessionId;
           // Terminal sessions have no chat turn, so `busy` never applies.
           const working =

--- a/packages/ui/src/modules/sessions/lib/session-category.ts
+++ b/packages/ui/src/modules/sessions/lib/session-category.ts
@@ -1,0 +1,27 @@
+import { SessionMode, SessionType, type SessionView } from "api-server-api";
+
+export const SESSION_CATEGORIES = [
+  "chats",
+  "scheduled",
+  "channels",
+  "terminal",
+] as const;
+export type SessionCategory = (typeof SESSION_CATEGORIES)[number];
+
+export const SESSION_CATEGORY_LABELS: Record<SessionCategory, string> = {
+  chats: "Chats",
+  scheduled: "Scheduled",
+  channels: "Channels",
+  terminal: "Terminal",
+};
+
+export function sessionCategory(session: SessionView): SessionCategory {
+  if (session.mode === SessionMode.Terminal) return "terminal";
+  if (
+    session.type === SessionType.ChannelSlack ||
+    session.type === SessionType.ChannelTelegram
+  )
+    return "channels";
+  if (session.type === SessionType.ScheduleCron) return "scheduled";
+  return "chats";
+}

--- a/packages/ui/src/modules/sessions/store/sessions.ts
+++ b/packages/ui/src/modules/sessions/store/sessions.ts
@@ -8,6 +8,10 @@ import type { PlatformStore } from "../../../store.js";
 import type { Message } from "../../../types.js";
 import { deleteAgentSession } from "../api/acp-session-ops.js";
 import { acpSessionsKeys, removeSessionFromCache } from "../api/queries.js";
+import {
+  SESSION_CATEGORIES,
+  type SessionCategory,
+} from "../lib/session-category.js";
 
 /** A resume-time failure that blocks showing the session chat. Rendered inline. */
 export interface SessionError {
@@ -22,7 +26,7 @@ export interface SessionsSlice {
   sessionMode: SessionMode | null;
   messages: Message[];
   sessionError: SessionError | null;
-  includeChannelSessions: boolean;
+  sessionFilter: SessionCategory[];
   queuedMessage: string | null;
   busy: boolean;
   terminalPaused: boolean;
@@ -34,7 +38,7 @@ export interface SessionsSlice {
   setTerminalPaused: (paused: boolean) => void;
   setMessages: (updater: Message[] | ((prev: Message[]) => Message[])) => void;
   setSessionError: (e: SessionError | null) => void;
-  setIncludeChannelSessions: (v: boolean) => void;
+  toggleSessionFilter: (category: SessionCategory) => void;
   setQueuedMessage: (msg: string | null) => void;
   setBusy: (busy: boolean) => void;
 
@@ -62,7 +66,7 @@ export const createSessionsSlice: StateCreator<
   sessionMode: null,
   messages: [],
   sessionError: null,
-  includeChannelSessions: false,
+  sessionFilter: [...SESSION_CATEGORIES],
   queuedMessage: null,
   busy: false,
   terminalPaused: false,
@@ -77,7 +81,12 @@ export const createSessionsSlice: StateCreator<
       messages: typeof updater === "function" ? updater(s.messages) : updater,
     })),
   setSessionError: (e) => set({ sessionError: e }),
-  setIncludeChannelSessions: (v) => set({ includeChannelSessions: v }),
+  toggleSessionFilter: (category) =>
+    set((s) => ({
+      sessionFilter: s.sessionFilter.includes(category)
+        ? s.sessionFilter.filter((c) => c !== category)
+        : [...s.sessionFilter, category],
+    })),
   setQueuedMessage: (msg) => set({ queuedMessage: msg }),
   setBusy: (busy) => set({ busy }),
 


### PR DESCRIPTION
Stacked on #2769. Third increment of #883.

The sessions list gets a **Filter** dropdown (Chats / Scheduled / Channels / Terminal — all on by default, label shows `All` or `Filter (n)`), replacing the old "Show channel sessions" checkbox. Scheduled sessions, previously never shown in the list, now appear when their category is enabled. Rows carry type icons — clock for scheduled, `#` for channels, `</>` for terminal — and a hover `⋮` menu with Delete session replaces the bare trash button. Small chrome cleanups ride along: checkbox-style menu items, menu padding, Carbon icons for the new glyphs, and caret-less `+ New` / `+ Add` buttons.

Part of #883.