### PR TITLE
docs(adr): ADR-076 per-channel access modes (shared vs person-scoped)

### DIFF
--- a/docs/adrs/076-channel-access-modes.md
+++ b/docs/adrs/076-channel-access-modes.md
@@ -1,7 +1,7 @@
-# ADR-NNN: Per-Channel Access Modes — Shared and Person-Scoped
+# ADR-076: Per-Channel Access Modes — Shared and Person-Scoped
 
 **Date:** 2026-07-17
-**Status:** Proposed
+**Status:** Accepted
 **Owner:** @pilartomas
 
 ## Context

--- a/docs/adrs/076-channel-access-modes.md
+++ b/docs/adrs/076-channel-access-modes.md
@@ -1,3 +1,11 @@
+---
+id: 076
+title: "Per-channel access modes — shared and person-scoped"
+status: accepted
+subsystem: channels
+summary: Each channel binding picks its access mode at bind time — shared (place-scoped, Agent credentials, open speaker set) or person-scoped (identity linking, allow-list, per-turn forks).
+---
+
 # ADR-076: Per-Channel Access Modes — Shared and Person-Scoped
 
 **Date:** 2026-07-17

--- a/docs/adrs/DRAFT-place-scoped-channels.md
+++ b/docs/adrs/DRAFT-place-scoped-channels.md
@@ -1,6 +1,6 @@
-# ADR-NNN: Place-Scoped Channel Access
+# ADR-NNN: Per-Channel Access Modes — Shared and Person-Scoped
 
-**Date:** 2026-07-14
+**Date:** 2026-07-17
 **Status:** Proposed
 **Owner:** @pilartomas
 
@@ -24,71 +24,104 @@ Anthropic's own Slack product (Claude Tag) validated the opposite
 model at scale: channel-scoped capability, no per-user account linking,
 identical capability for everyone in the channel.
 
+The first draft of this ADR proposed converging every messenger on
+place-scoping and deleting the fork subsystem outright. Review
+concluded the per-speaker credential boundary is worth keeping
+available: some channels want each speaker to act with their own
+authority and appear as themselves in audit and usage records. The
+revised decision keeps both models and makes the choice explicit,
+per channel, at bind time.
+
 ## Decision
 
-Channel access is place-scoped for every messenger: the Agent owner
-consents to a conversation surface — a Slack channel, a Telegram chat —
-and anyone that messenger admits to the surface may drive the Agent,
-every turn running on the main agent pod under the Agent's own
-credentials. Per-user platform identity leaves the channel path
-entirely: Slack identity linking, the per-Agent allowed-users gate, and
-the per-turn foreign-replier fork are dropped.
+Channel access mode is chosen per channel when the channel is bound.
+The Agent owner performing the binding is prompted with a toggle and
+picks one of two modes:
+
+- **Shared ("system Agent") mode — place-scoped.** Anyone the
+  messenger admits to the surface may drive the Agent. Every turn runs
+  on the main agent pod under the Agent's own credentials. No per-user
+  platform identity is resolved on the turn path; turns are attributed
+  by messenger identity (Slack user id, Telegram user id) in the audit
+  trail.
+- **Person-scoped mode.** The existing Slack model, retained as is:
+  members must link a platform identity before the bot answers them,
+  the per-Agent allowed-users gate applies, the owner's turns relay to
+  the main pod, and any other authorized member's turn runs in a
+  per-turn fork under that member's own credentials.
 
 Boundaries of the decision:
 
-- Owner consent is the act of access control. Binding a channel means
-  lending the Agent — credentials included — to everyone in that place.
-  Membership of the place is governed by the messenger, not by the
-  platform.
-- Credential selection is per-Agent, never per-speaker. Who is typing
-  changes nothing about what a turn can reach.
-- Turns are attributed by messenger identity (Slack user id, Telegram
-  user id) in the audit trail; no platform identity is resolved on the
-  channel path.
-- The owner's existing controls — human-in-the-loop approval rules and
-  egress rules — gate every turn, whoever sent it.
-- Both adapters follow the same single-track relay; future channels
-  inherit one model instead of choosing a side.
+- The mode is a property of the binding, set by the binding owner at
+  bind time. The bind flow states plainly what shared mode means:
+  everyone in this place will act with this Agent's credentials.
+- *Proposed default:* person-scoped. Lending the Agent's full
+  authority to a room is the wider grant, so it is the explicit
+  opt-in, not the default.
+- *Proposed switching semantics:* changing mode means unbinding and
+  rebinding. Sessions minted under one mode are never resumed under
+  the other, so a mode flip never mixes credential contexts inside one
+  conversation.
+- The toggle appears only where both models are implemented — Slack
+  today. Telegram remains shared-only: no per-user identity
+  infrastructure exists there and this decision does not build it.
+  Future channel adapters must implement shared mode; person-scoped
+  mode is optional, gated on the messenger having a workable per-user
+  identity story.
+- In shared mode, owner consent is the act of access control:
+  binding lends the Agent — credentials included — to everyone in that
+  place, and membership of the place is governed by the messenger.
+  Credential selection is per-Agent, never per-speaker.
+- In both modes, the owner's existing controls — human-in-the-loop
+  approval rules and egress rules — gate every turn, whoever sent it.
 
 ## Alternatives Considered
 
-- **Status quo (person-scoped Slack, place-scoped Telegram)** — two
-  models to maintain; the fork path keeps its provisioning latency,
-  unbounded concurrency, session race, and restart fragility.
+- **Full convergence on place-scoping (this ADR's first draft)** —
+  deletes the fork subsystem and its defects wholesale; rejected
+  because it removes the per-speaker credential boundary everywhere,
+  and some channels legitimately want speaker-authority turns.
+- **Status quo (person-scoped Slack, place-scoped Telegram)** — the
+  model is an accident of the adapter rather than a choice; Slack
+  channels that want zero-onboarding shared access have no path to it.
 - **Drop forks only, keep identity linking** — foreign turns run under
-  the Agent's credentials but users still must link accounts; keeps the
-  login friction and most of the dual model this decision removes.
+  the Agent's credentials but users still must link accounts; keeps
+  the login friction while giving up the credential boundary that
+  justified it.
 - **Per-speaker credential injection without fork pods** — inject the
   replier's credentials at the main gateway per turn; keeps all
   per-user credential plumbing and adds turn-serialization concerns on
   a single gateway.
 - **Dedicated service-account credentials per channel** — provisioning
   purpose-made non-personal credentials (the full Claude Tag shape) is
-  complementary hardening, not a prerequisite; it can layer on later
-  without reversing this decision.
+  complementary hardening for shared mode, not a prerequisite; it can
+  layer on later without reversing this decision.
 
 ## Consequences
 
-- **Easier:** One relay path serves all channels — the fork subsystem
-  (custom resource, reconciler, per-fork service accounts, network and
-  authorization policies, paired gateway pods, sagas) is deleted
-  outright, and its documented defects (unbounded concurrent forks, the
-  same-thread session race, orphaned fork state after api-server
-  restart) disappear rather than needing fixes. Foreign replies lose
-  the per-turn pod-pair spin-up and its two-minute provisioning window.
-  Slack onboarding drops to zero, matching Telegram and messenger-native
-  expectations.
-- **Harder:** The per-speaker credential boundary is given up — any
-  member of a bound channel can exercise every connection the owner
-  attached, so a compromised or careless channel member acts with the
-  owner's authority, gated only by the owner's approval and egress
-  rules. Per-user usage accounting and platform-identity audit on
-  channels are no longer possible; attribution degrades to messenger
-  identity. There is no platform-side way to exclude one member of a
-  bound channel — exclusion means messenger-side removal or unbinding
-  the channel.
-- **Committed-to:** Owner consent as the load-bearing gate: connecting
-  a channel is understood as lending the Agent's full authority to that
-  place. Reintroducing any per-user capability difference on channels
-  (credentials, gating, quotas) requires reversing this decision, not
-  extending it.
+- **Easier:** Slack channels that opt into shared mode get zero
+  onboarding and a single relay path, which is the structural
+  prerequisite for the open-speaker-set feature class: un-mentioned
+  thread follow-ups, one shared session per thread that anyone can
+  steer, and ambient (non-tagged) replies. Telegram's behavior becomes
+  a named, documented mode instead of an adapter quirk. Channels that
+  keep person-scoped mode lose nothing.
+- **Harder:** Both relay paths are now permanent. The fork subsystem
+  is hardened instead of deleted — its documented defects (unbounded
+  concurrent forks, the same-thread session race, orphaned fork state
+  after api-server restart) become fix-work on a kept code path
+  rather than disappearing. Every future channel capability must
+  either serve both modes or declare itself shared-mode-only; progress
+  streaming and ambient listening are the immediate examples, since a
+  per-turn fork pod has no stable surface to stream from and an
+  unlinked member's message still cannot run a turn on a person-scoped
+  channel. The bind flow grows mode UX, consent copy, and per-mode
+  documentation.
+- **Mode-gated capability:** features that require an open speaker set
+  exist only on shared channels. This is structural, not policy — on a
+  person-scoped channel, a message from an unlinked member has no
+  identity to run under and can only be refused.
+- **Committed-to:** Both models are load-bearing product surface, and
+  the bind-time toggle is the contract with owners. Retiring either
+  mode later is a new decision with a migration for every bound
+  channel, not a cleanup.

--- a/docs/adrs/DRAFT-place-scoped-channels.md
+++ b/docs/adrs/DRAFT-place-scoped-channels.md
@@ -7,121 +7,78 @@
 ## Context
 
 The two channel adapters carry opposite multi-user models. Slack is
-person-scoped: every user must link a platform identity before the bot
-answers, an owner-curated allow-list gates who may drive, and a reply
-from anyone but the Agent owner spins up a per-turn fork — a paired
-pod set running under the replier's own credentials. Telegram is
+person-scoped: every user links a platform identity, an owner-curated
+allow-list gates who may drive, and a non-owner reply runs in a
+per-turn fork under the replier's own credentials. Telegram is
 place-scoped: the owner authorizes a conversation once, and every
-member of that conversation drives the Agent on the main pod under the
-Agent's credentials, with no per-user identity anywhere.
+member drives the Agent on the main pod under the Agent's credentials.
 
-The person-scoped half carries standing costs: login friction for every
-Slack user, a per-turn pod-pair spin-up with a two-minute provisioning
-window, and known defects — concurrent forks are unbounded, two quick
-replies race on the same session file over the shared workspace volume,
-and in-flight fork state is lost on api-server restart. Meanwhile
-Anthropic's own Slack product (Claude Tag) validated the opposite
-model at scale: channel-scoped capability, no per-user account linking,
-identical capability for everyone in the channel.
-
-The first draft of this ADR proposed converging every messenger on
-place-scoping and deleting the fork subsystem outright. Review
-concluded the per-speaker credential boundary is worth keeping
-available: some channels want each speaker to act with their own
-authority and appear as themselves in audit and usage records. The
-revised decision keeps both models and makes the choice explicit,
-per channel, at bind time.
+The person-scoped path carries standing costs — login friction for
+every Slack user, a per-turn pod-pair spin-up with a two-minute
+provisioning window, and three known defects (unbounded concurrent
+forks, a same-thread session race on the shared workspace volume,
+fork state lost on api-server restart) — while Claude Tag validated
+the place-scoped model at scale. The first draft of this ADR proposed
+converging every messenger on place-scoping and deleting the fork
+subsystem; review concluded the per-speaker credential boundary is
+worth keeping available.
 
 ## Decision
 
-Channel access mode is chosen per channel when the channel is bound.
-The Agent owner performing the binding is prompted with a toggle and
-picks one of two modes:
+Each channel chooses its access mode at bind time: the Agent owner
+performing the binding picks, via a toggle, either **shared ("system
+Agent") mode** — place-scoped: anyone the messenger admits drives the
+Agent, every turn on the main pod under the Agent's own credentials,
+attributed by messenger identity — or **person-scoped mode** — today's
+Slack model kept as is: identity linking, the allowed-users gate, and
+per-turn foreign-replier forks.
 
-- **Shared ("system Agent") mode — place-scoped.** Anyone the
-  messenger admits to the surface may drive the Agent. Every turn runs
-  on the main agent pod under the Agent's own credentials. No per-user
-  platform identity is resolved on the turn path; turns are attributed
-  by messenger identity (Slack user id, Telegram user id) in the audit
-  trail.
-- **Person-scoped mode.** The existing Slack model, retained as is:
-  members must link a platform identity before the bot answers them,
-  the per-Agent allowed-users gate applies, the owner's turns relay to
-  the main pod, and any other authorized member's turn runs in a
-  per-turn fork under that member's own credentials.
-
-Boundaries of the decision:
-
-- The mode is a property of the binding, set by the binding owner at
-  bind time. The bind flow states plainly what shared mode means:
-  everyone in this place will act with this Agent's credentials.
-- *Proposed default:* person-scoped. Lending the Agent's full
-  authority to a room is the wider grant, so it is the explicit
-  opt-in, not the default.
-- *Proposed switching semantics:* changing mode means unbinding and
-  rebinding. Sessions minted under one mode are never resumed under
-  the other, so a mode flip never mixes credential contexts inside one
-  conversation.
-- The toggle appears only where both models are implemented — Slack
-  today. Telegram remains shared-only: no per-user identity
-  infrastructure exists there and this decision does not build it.
-  Future channel adapters must implement shared mode; person-scoped
-  mode is optional, gated on the messenger having a workable per-user
-  identity story.
-- In shared mode, owner consent is the act of access control:
-  binding lends the Agent — credentials included — to everyone in that
-  place, and membership of the place is governed by the messenger.
+- *Proposed default:* person-scoped. Lending the Agent's authority to
+  a whole room is the wider grant, so it is the explicit opt-in.
+- *Proposed switching:* changing mode means unbind and rebind;
+  sessions minted under one mode are never resumed under the other.
+- The toggle exists where both models are implemented — Slack today.
+  Telegram stays shared-only; this decision does not build per-user
+  identity for it. New adapters must implement shared mode;
+  person-scoped mode is optional.
+- In shared mode, binding is the act of access control: the consent
+  copy states that everyone in the place will act with the Agent's
+  credentials, and membership is governed by the messenger.
   Credential selection is per-Agent, never per-speaker.
-- In both modes, the owner's existing controls — human-in-the-loop
-  approval rules and egress rules — gate every turn, whoever sent it.
+- In both modes, the owner's human-in-the-loop approval rules and
+  egress rules gate every turn.
 
 ## Alternatives Considered
 
-- **Full convergence on place-scoping (this ADR's first draft)** —
-  deletes the fork subsystem and its defects wholesale; rejected
-  because it removes the per-speaker credential boundary everywhere,
-  and some channels legitimately want speaker-authority turns.
-- **Status quo (person-scoped Slack, place-scoped Telegram)** — the
-  model is an accident of the adapter rather than a choice; Slack
-  channels that want zero-onboarding shared access have no path to it.
-- **Drop forks only, keep identity linking** — foreign turns run under
-  the Agent's credentials but users still must link accounts; keeps
-  the login friction while giving up the credential boundary that
-  justified it.
-- **Per-speaker credential injection without fork pods** — inject the
-  replier's credentials at the main gateway per turn; keeps all
-  per-user credential plumbing and adds turn-serialization concerns on
-  a single gateway.
-- **Dedicated service-account credentials per channel** — provisioning
-  purpose-made non-personal credentials (the full Claude Tag shape) is
-  complementary hardening for shared mode, not a prerequisite; it can
-  layer on later without reversing this decision.
+- **Full place-scoping (first draft)** — deletes the fork subsystem
+  and its defects, but removes the per-speaker credential boundary
+  everywhere.
+- **Status quo** — the model stays an accident of the adapter; Slack
+  channels have no path to zero-onboarding access.
+- **Drop forks, keep identity linking** — keeps the login friction
+  while giving up the credential boundary that justified it.
+- **Per-turn credential injection at the main gateway** — keeps all
+  per-user credential plumbing and adds turn-serialization concerns
+  on a single gateway.
+- **Dedicated service-account credentials per channel** — the full
+  Claude Tag shape; complementary hardening for shared mode that can
+  layer on later.
 
 ## Consequences
 
-- **Easier:** Slack channels that opt into shared mode get zero
-  onboarding and a single relay path, which is the structural
-  prerequisite for the open-speaker-set feature class: un-mentioned
-  thread follow-ups, one shared session per thread that anyone can
-  steer, and ambient (non-tagged) replies. Telegram's behavior becomes
-  a named, documented mode instead of an adapter quirk. Channels that
-  keep person-scoped mode lose nothing.
-- **Harder:** Both relay paths are now permanent. The fork subsystem
-  is hardened instead of deleted — its documented defects (unbounded
-  concurrent forks, the same-thread session race, orphaned fork state
-  after api-server restart) become fix-work on a kept code path
-  rather than disappearing. Every future channel capability must
-  either serve both modes or declare itself shared-mode-only; progress
-  streaming and ambient listening are the immediate examples, since a
-  per-turn fork pod has no stable surface to stream from and an
-  unlinked member's message still cannot run a turn on a person-scoped
-  channel. The bind flow grows mode UX, consent copy, and per-mode
-  documentation.
-- **Mode-gated capability:** features that require an open speaker set
-  exist only on shared channels. This is structural, not policy — on a
-  person-scoped channel, a message from an unlinked member has no
-  identity to run under and can only be refused.
-- **Committed-to:** Both models are load-bearing product surface, and
-  the bind-time toggle is the contract with owners. Retiring either
-  mode later is a new decision with a migration for every bound
-  channel, not a cleanup.
+- **Easier:** Channels that opt into shared mode get zero onboarding
+  and single-path turns — the structural prerequisite for
+  un-mentioned follow-ups, shared thread sessions, and ambient
+  replies, none of which can run under person-scoping because an
+  unlinked member's message has no identity to run under. Telegram's
+  behavior becomes a documented mode instead of an adapter quirk.
+- **Harder:** Both relay paths are permanent. The fork subsystem's
+  three defects become fix-work rather than delete-work, and every
+  future channel capability must either serve both modes or declare
+  itself shared-mode-only. The bind flow grows mode UX and consent
+  copy. On shared channels the per-speaker credential boundary and
+  per-user usage accounting are given up; excluding one member means
+  messenger-side removal or unbinding.
+- **Committed-to:** The bind-time toggle is the contract with owners.
+  Retiring either mode later is a new decision with a migration for
+  every bound channel, not a cleanup.

--- a/docs/adrs/DRAFT-place-scoped-channels.md
+++ b/docs/adrs/DRAFT-place-scoped-channels.md
@@ -18,10 +18,7 @@ every Slack user, a per-turn pod-pair spin-up with a two-minute
 provisioning window, and three known defects (unbounded concurrent
 forks, a same-thread session race on the shared workspace volume,
 fork state lost on api-server restart) — while Claude Tag validated
-the place-scoped model at scale. The first draft of this ADR proposed
-converging every messenger on place-scoping and deleting the fork
-subsystem; review concluded the per-speaker credential boundary is
-worth keeping available.
+the place-scoped model at scale.
 
 ## Decision
 
@@ -50,9 +47,9 @@ per-turn foreign-replier forks.
 
 ## Alternatives Considered
 
-- **Full place-scoping (first draft)** — deletes the fork subsystem
-  and its defects, but removes the per-speaker credential boundary
-  everywhere.
+- **Full place-scoping on every messenger** — deletes the fork
+  subsystem and its defects, but removes the per-speaker credential
+  boundary everywhere.
 - **Status quo** — the model stays an accident of the adapter; Slack
   channels have no path to zero-onboarding access.
 - **Drop forks, keep identity linking** — keeps the login friction

--- a/docs/adrs/DRAFT-place-scoped-channels.md
+++ b/docs/adrs/DRAFT-place-scoped-channels.md
@@ -1,0 +1,94 @@
+# ADR-NNN: Place-Scoped Channel Access
+
+**Date:** 2026-07-14
+**Status:** Proposed
+**Owner:** @pilartomas
+
+## Context
+
+The two channel adapters carry opposite multi-user models. Slack is
+person-scoped: every user must link a platform identity before the bot
+answers, an owner-curated allow-list gates who may drive, and a reply
+from anyone but the Agent owner spins up a per-turn fork — a paired
+pod set running under the replier's own credentials. Telegram is
+place-scoped: the owner authorizes a conversation once, and every
+member of that conversation drives the Agent on the main pod under the
+Agent's credentials, with no per-user identity anywhere.
+
+The person-scoped half carries standing costs: login friction for every
+Slack user, a per-turn pod-pair spin-up with a two-minute provisioning
+window, and known defects — concurrent forks are unbounded, two quick
+replies race on the same session file over the shared workspace volume,
+and in-flight fork state is lost on api-server restart. Meanwhile
+Anthropic's own Slack product (Claude Tag) validated the opposite
+model at scale: channel-scoped capability, no per-user account linking,
+identical capability for everyone in the channel.
+
+## Decision
+
+Channel access is place-scoped for every messenger: the Agent owner
+consents to a conversation surface — a Slack channel, a Telegram chat —
+and anyone that messenger admits to the surface may drive the Agent,
+every turn running on the main agent pod under the Agent's own
+credentials. Per-user platform identity leaves the channel path
+entirely: Slack identity linking, the per-Agent allowed-users gate, and
+the per-turn foreign-replier fork are dropped.
+
+Boundaries of the decision:
+
+- Owner consent is the act of access control. Binding a channel means
+  lending the Agent — credentials included — to everyone in that place.
+  Membership of the place is governed by the messenger, not by the
+  platform.
+- Credential selection is per-Agent, never per-speaker. Who is typing
+  changes nothing about what a turn can reach.
+- Turns are attributed by messenger identity (Slack user id, Telegram
+  user id) in the audit trail; no platform identity is resolved on the
+  channel path.
+- The owner's existing controls — human-in-the-loop approval rules and
+  egress rules — gate every turn, whoever sent it.
+- Both adapters follow the same single-track relay; future channels
+  inherit one model instead of choosing a side.
+
+## Alternatives Considered
+
+- **Status quo (person-scoped Slack, place-scoped Telegram)** — two
+  models to maintain; the fork path keeps its provisioning latency,
+  unbounded concurrency, session race, and restart fragility.
+- **Drop forks only, keep identity linking** — foreign turns run under
+  the Agent's credentials but users still must link accounts; keeps the
+  login friction and most of the dual model this decision removes.
+- **Per-speaker credential injection without fork pods** — inject the
+  replier's credentials at the main gateway per turn; keeps all
+  per-user credential plumbing and adds turn-serialization concerns on
+  a single gateway.
+- **Dedicated service-account credentials per channel** — provisioning
+  purpose-made non-personal credentials (the full Claude Tag shape) is
+  complementary hardening, not a prerequisite; it can layer on later
+  without reversing this decision.
+
+## Consequences
+
+- **Easier:** One relay path serves all channels — the fork subsystem
+  (custom resource, reconciler, per-fork service accounts, network and
+  authorization policies, paired gateway pods, sagas) is deleted
+  outright, and its documented defects (unbounded concurrent forks, the
+  same-thread session race, orphaned fork state after api-server
+  restart) disappear rather than needing fixes. Foreign replies lose
+  the per-turn pod-pair spin-up and its two-minute provisioning window.
+  Slack onboarding drops to zero, matching Telegram and messenger-native
+  expectations.
+- **Harder:** The per-speaker credential boundary is given up — any
+  member of a bound channel can exercise every connection the owner
+  attached, so a compromised or careless channel member acts with the
+  owner's authority, gated only by the owner's approval and egress
+  rules. Per-user usage accounting and platform-identity audit on
+  channels are no longer possible; attribution degrades to messenger
+  identity. There is no platform-side way to exclude one member of a
+  bound channel — exclusion means messenger-side removal or unbinding
+  the channel.
+- **Committed-to:** Owner consent as the load-bearing gate: connecting
+  a channel is understood as lending the Agent's full authority to that
+  place. Reintroducing any per-user capability difference on channels
+  (credentials, gating, quotas) requires reversing this decision, not
+  extending it.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -72,6 +72,7 @@ Generated projection of the ADR log. Read this first when authoring a new decisi
 | 073 | [Per-template scheduling for runtimeClassName and nodeSelector](073-per-template-scheduling.md) |  | agent-lifecycle | runtimeClassName and nodeSelector become per-template overridable agent-spec fields while all other scheduling stays chart-wide. |
 | 074 | [Unified `drivers:` manifest with pluggable events and default-on built-ins](074-unified-drivers.md) |  | agent-lifecycle | The runtime manifest folds contribution and event kinds into one drivers map resolved through the plugin registry, with built-ins on by default and event handlers now externally overridable. |
 | 075 | [Periodic work on BullMQ](075-periodic-jobs-bullmq.md) |  | api-server | Recurring reconciliation ticks run as BullMQ job schedulers on per-job queues instead of per-replica setInterval loops. |
+| 076 | [Per-channel access modes — shared and person-scoped](076-channel-access-modes.md) |  | channels | Each channel binding picks its access mode at bind time — shared (place-scoped, Agent credentials, open speaker set) or person-scoped (identity linking, allow-list, per-turn forks). |
 
 ## Superseded
 


### PR DESCRIPTION
## Summary

ADR-076 (`docs/adrs/076-channel-access-modes.md`, status **Accepted**), revised after review: instead of converging every messenger on place-scoping, **channel access mode is chosen per channel at bind time**. The Agent owner binding the channel picks via a toggle:

- **Shared ("system Agent") mode — place-scoped:** anyone the messenger admits to the surface drives the Agent; every turn runs on the main agent pod under the Agent's own credentials; turns attributed by messenger identity.
- **Person-scoped mode:** the existing Slack model retained as is — identity linking, the allowed-users gate, owner relay, and per-turn foreign-replier forks.

What changed from the first draft:

- The fork subsystem is **kept, not deleted** — its documented defects (unbounded concurrency, same-thread session race, restart-orphaned forks) become fix-work on a permanent code path.
- Telegram remains shared-only; the toggle appears where both models are implemented (Slack today). Future adapters must implement shared mode; person-scoped is optional.
- Features that need an open speaker set (un-mentioned follow-ups, shared thread sessions, ambient replies) are structurally gated on shared mode.

What this keeps:

- Owner consent (channel binding) as the load-bearing access-control act, now with explicit mode consent copy
- The owner's HITL approval rules and egress rules gating every turn in both modes
- Turn attribution in the audit trail (messenger identity in shared mode; platform identity in person-scoped mode)

## Still marked *Proposed* inside the ADR

- **Default mode** — person-scoped (least privilege; shared mode's credential lending is the explicit opt-in).
- **Switching semantics** — mode change = unbind + rebind; sessions never cross modes.

## Notes for reviewers

- Rebased onto main after #2735 (ADR governance rework): the record now carries the required frontmatter and the regenerated `docs/adrs/index.md` row is committed in-branch. `docs:check:adr-index` and `check:adr-immutable` pass.
- Unlike the first draft, existing ADRs covering Slack per-user impersonation are **not** superseded — they remain in force for person-scoped mode.

