### PR TITLE
fix(ui): correct unread state on the sessions list

### DIFF
--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -120,10 +120,12 @@ export function SessionsSidebar({
           const needsApproval =
             approvalSessions.has(s.sessionId) ||
             pendingPermissions.some((p) => p.sessionId === s.sessionId);
-          // No stamp means the runtime never tracked the session (legacy,
-          // harness-minted) — read, not unread.
+          // Terminals have no meaningful unread — their updatedAt tracks the
+          // harness file mtime (bumped by restarts and TUI repaints), not
+          // reading. No seenAt means an untracked (legacy) session — also read.
           const unread = Boolean(
             !isOpen &&
+            s.mode !== SessionMode.Terminal &&
             s.seenAt &&
             s.updatedAt &&
             Date.parse(s.updatedAt) > Date.parse(s.seenAt),

--- a/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
@@ -291,11 +291,13 @@ export function useAcpConnection(
     setState("idle");
   }, [clearEngagement]);
 
-  // Tear the connection down and drop the engagement binding — otherwise the channel stays bound to the gone session
+  // Tear the channel down when we leave the session — including switching to a
+  // terminal (no ACP), which otherwise stays engaged and marks the chat "seen"
+  // on turn completion, so it never shows unread.
   useEffect(() => {
-    if (sessionId) return;
+    if (sessionId && sessionMode !== SessionMode.Terminal) return;
     reset();
-  }, [sessionId, reset]);
+  }, [sessionId, sessionMode, reset]);
 
   return { state, ensureLive, connectionRef, reset };
 }


### PR DESCRIPTION
Two small fixes to the sessions-list unread indicator:

- Chat sessions now go unread after you switch to a terminal — the chat's live channel is torn down on the switch, so its turn completes with no viewer attached. Closes #2779
- Terminal sessions no longer falsely show unread — their `updatedAt` follows the harness file mtime (bumped by pod restarts and TUI repaints), which isn't a reading signal, so terminals are excluded from the unread check. Closes #2771