### PR TITLE
fix(metrics): read telemetry from all templates, not just claude-code

### DIFF
--- a/packages/api-server/src/__tests__/unit/metrics-reader-predicate.test.ts
+++ b/packages/api-server/src/__tests__/unit/metrics-reader-predicate.test.ts
@@ -24,6 +24,14 @@ describe("ownedApiRequests", () => {
     expect(gates).toHaveLength(3);
   });
 
+  it("scopes to Claude Code telemetry by Body, not template ServiceName", () => {
+    // ServiceName is the template name (OTEL_SERVICE_NAME), so gating on it
+    // would hide every template not named `claude-code` (e.g. `bugstone`).
+    const sql = ownedApiRequests({ hours: 24 });
+    expect(sql).toContain("Body = 'claude_code.api_request'");
+    expect(sql).not.toContain("ServiceName");
+  });
+
   it("applies no session predicate without a sessionId", () => {
     const sql = ownedApiRequests({ hours: 24 });
     expect(sql).not.toContain("sessionId");

--- a/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
+++ b/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
@@ -28,9 +28,12 @@ export function createClickhouseClient(cfg: {
 // the trusted owner id in ResourceAttributes (stamped by the agent gateway —
 // see docs/architecture/observability.md). Every query is gated on that owner
 // id against the caller's resolved allowlist.
+//
+// `Body` alone scopes to Claude Code harness telemetry: ServiceName carries the
+// template name (OTEL_SERVICE_NAME, _helpers.tpl), so filtering it would hide
+// every template not literally named `claude-code` (e.g. `bugstone`).
 export const ownedApiRequests = (w: MetricsWindow): string => {
   const base = [
-    "ServiceName = 'claude-code'",
     "Body = 'claude_code.api_request'",
     "ResourceAttributes['platform.agent.id'] IN {agentIds:Array(String)}",
     ...(w.hours === undefined


### PR DESCRIPTION
## Problem

Agents running any template **not literally named `claude-code`** (e.g. `bugstone`) show **no metrics** in the UI, even though telemetry is collected and stored correctly in ClickHouse.

Root cause is a mismatch between the write and read paths:

- **Write:** `OTEL_SERVICE_NAME` is set to the *template name* (`deploy/helm/platform/templates/_helpers.tpl`), so a `bugstone` agent exports records with `ServiceName='bugstone'`.
- **Read:** `ownedApiRequests` in `clickhouse-reader.ts` gated every query on `ServiceName = 'claude-code'`, filtering out everything from any other template.

Diagnosed live on `dam-dev`: agent `golden-badger` (template `bugstone`) had 426 `claude_code.api_request` records in ClickHouse, all under `ServiceName='bugstone'` — the reader's `ServiceName='claude-code'` filter matched 0 of them.

## Fix

Scope the queries by `Body = 'claude_code.api_request'` alone. That already identifies Claude Code harness records regardless of template name, and non-Claude harnesses (codex/gemini) still won't match because they don't emit `claude_code.*` bodies. The single predicate feeds all three read queries (`tokenSpendByModel`, `runtimeBySession`, `contextPerCall`), so all are fixed at once.

No data backfill needed — the records were always there; only the read filter excluded them. Takes effect on api-server redeploy.

## Test

Added a regression test asserting the predicate gates on `Body` and contains no `ServiceName` clause. All api-server unit tests pass; `mise run check` clean.