### PR TITLE
fix: heal main CI — e2e deep-link failure, cross-spec contamination, scheduled-run blind spot

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -42,7 +42,7 @@ jobs:
 
   test:
     name: mise test
-    if: github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/v')
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -544,7 +544,7 @@ jobs:
   build-mock:
     name: build mock (e2e fixture)
     needs: [merge-platform-base, changes]
-    if: ${{ github.event_name != 'schedule' && !startsWith(github.ref, 'refs/tags/v') && !cancelled() && !failure() }}
+    if: ${{ !startsWith(github.ref, 'refs/tags/v') && !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -578,8 +578,7 @@ jobs:
     # most PRs. Require the direct needs explicitly instead: e2e pulls exactly
     # the images those two jobs push.
     if: >-
-      ${{ github.event_name != 'schedule' &&
-          !startsWith(github.ref, 'refs/tags/v') &&
+      ${{ !startsWith(github.ref, 'refs/tags/v') &&
           !cancelled() &&
           needs.merge-images.result == 'success' &&
           needs.build-mock.result == 'success' }}

--- a/packages/agent-runtime/src/__tests__/unit/exec-server-runtime-env.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/exec-server-runtime-env.test.ts
@@ -28,7 +28,7 @@ async function connectExec(argv: string[], extra = ""): Promise<WebSocket> {
     encodeURIComponent(Buffer.from(JSON.stringify(argv)).toString("base64")) +
     `&cwd=${encodeURIComponent(homeDir)}&cols=80&rows=24` +
     extra;
-  for (let i = 0; i < 100; i++) {
+  for (let i = 0; i < 250; i++) {
     try {
       return await new Promise<WebSocket>((resolve, reject) => {
         const ws = new WebSocket(url);

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -83,11 +83,9 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
-      // Churns its own dedicated connection on the shared agent; listed last
-      // so the delete/recreate can't disturb the injection/slack suites.
       name: "connection-regrant",
       testMatch: /10-.*\.spec\.ts$/,
-      dependencies: ["agent"],
+      dependencies: ["slack"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
   ],

--- a/packages/e2e/playwright/src/tests/09-user-env.spec.ts
+++ b/packages/e2e/playwright/src/tests/09-user-env.spec.ts
@@ -51,10 +51,16 @@ test("user env rides the contribution rail", async () => {
   await api.agents.wake.mutate({ id: listed!.id });
   const agentId = await waitForAgentRunning(api, agentName);
 
+  // agents.update replaces the whole agent_env list, which also carries the
+  // template-seeded env (e.g. the mock's MOCK_DEFAULT_REPLY). Keep the
+  // baseline in every update and restore it at the end — wiping it strips
+  // the default reply from forks and breaks 07-slack.
+  const baselineEnv = (await api.agents.get.query({ id: agentId })).env ?? [];
+
   await test.step("setting user env reaches the agent — no pod roll", async () => {
     await api.agents.update.mutate({
       id: agentId,
-      env: [{ name: userEnvName, value: userEnvValue }],
+      env: [...baselineEnv, { name: userEnvName, value: userEnvValue }],
     });
     await expectAgentEnv(
       api,
@@ -76,7 +82,7 @@ test("user env rides the contribution rail", async () => {
   await test.step("editing the value applies at the next turn", async () => {
     await api.agents.update.mutate({
       id: agentId,
-      env: [{ name: userEnvName, value: userEnvEdited }],
+      env: [...baselineEnv, { name: userEnvName, value: userEnvEdited }],
     });
     await expectAgentEnv(
       api,
@@ -91,6 +97,7 @@ test("user env rides the contribution rail", async () => {
     await api.agents.update.mutate({
       id: agentId,
       env: [
+        ...baselineEnv,
         { name: userEnvName, value: userEnvEdited },
         { name: envName, value: shadowValue },
       ],
@@ -105,7 +112,7 @@ test("user env rides the contribution rail", async () => {
   });
 
   await test.step("clearing user env reverts to the connection env", async () => {
-    await api.agents.update.mutate({ id: agentId, env: [] });
+    await api.agents.update.mutate({ id: agentId, env: baselineEnv });
     await expectAgentEnv(
       api,
       agentId,

--- a/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
+++ b/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
@@ -93,7 +93,12 @@ test("recreating a disconnected connection saves cleanly", async ({ page }) => {
   });
 
   await test.step("create a replacement of the same type", async () => {
-    await page.getByRole("button", { name: /show all/i }).click();
+    // The provider section renders its own "Show all" toggle — scope to the
+    // connections section.
+    await page
+      .locator("section", { hasText: "My connections" })
+      .getByRole("button", { name: /show all/i })
+      .click();
     await page.getByTestId("connection-template-custom-header").click();
 
     await page.getByTestId("connection-field-name").fill(recreatedName);

--- a/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
+++ b/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
@@ -8,17 +8,14 @@ import {
   ensureCustomHeaderConnection,
   getConnectionId,
 } from "../lib/connections.js";
-import {
-  agentName,
-  connectionHost,
-  headerName,
-  valueFormat,
-} from "../lib/fixtures.js";
+import { agentName, valueFormat } from "../lib/fixtures.js";
 
 const originalName = "e2e-regrant-original";
 const recreatedName = "e2e-regrant-recreated";
 const regrantEnvName = "E2E_REGRANT_KEY";
 const regrantValue = "e2e-regrant-secret-5e1c";
+const regrantHost = "regrant.example.com";
+const regrantHeaderName = "x-regrant-key";
 
 // Regression for #2426: disconnecting a granted connection on the sandbox
 // settings page and creating a replacement of the same type left the deleted
@@ -53,8 +50,8 @@ test("recreating a disconnected connection saves cleanly", async ({ page }) => {
 
     originalId = await ensureCustomHeaderConnection(api, {
       name: originalName,
-      host: connectionHost,
-      headerName,
+      host: regrantHost,
+      headerName: regrantHeaderName,
       valueFormat,
       value: regrantValue,
       envName: regrantEnvName,
@@ -74,7 +71,9 @@ test("recreating a disconnected connection saves cleanly", async ({ page }) => {
 
   await test.step("open the sandbox settings page", async () => {
     await page.goto(`${baseUrl}/sandboxes/${agentId}`);
-    await expect(page.getByRole("heading", { name: agentName })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { level: 1, name: agentName }),
+    ).toBeVisible();
     await expect(
       page.getByTestId(`connection-grant-${originalId}`).getByRole("checkbox"),
     ).toBeChecked();
@@ -98,8 +97,10 @@ test("recreating a disconnected connection saves cleanly", async ({ page }) => {
     await page.getByTestId("connection-template-custom-header").click();
 
     await page.getByTestId("connection-field-name").fill(recreatedName);
-    await page.getByTestId("connection-field-host").fill(connectionHost);
-    await page.getByTestId("connection-field-headerName").fill(headerName);
+    await page.getByTestId("connection-field-host").fill(regrantHost);
+    await page
+      .getByTestId("connection-field-headerName")
+      .fill(regrantHeaderName);
     await page.getByTestId("connection-field-valueFormat").fill(valueFormat);
     await page.getByTestId("connection-field-value").fill(regrantValue);
     await page.getByTestId("connection-field-envName").fill(regrantEnvName);

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -120,9 +120,7 @@ function MainApp() {
         });
       else leaveChat();
     };
-    // Handle initial URL (e.g. direct link to /chat/foo) — setState to avoid pushing duplicate history
-    const path = window.location.pathname;
-    if (path.startsWith("/chat/")) enterChat(decodeURIComponent(path.slice(6)));
+    onPopState();
     window.addEventListener("popstate", onPopState);
     return () => window.removeEventListener("popstate", onPopState);
   }, []);


### PR DESCRIPTION
Main has been red since #2753 merged (its own final CI run already showed the failure). Three independent problems, root-caused from the CI artifacts — see the failing runs' Playwright page snapshot for the smoking gun.

## 1. Deep links render the wrong view after the OIDC roundtrip (product bug)

`10-connection-regrant.spec.ts` deep-links to `/sandboxes/:id` — the only spec that deep-links at all. The artifact's page snapshot shows it landed on the sandboxes **list**:

- The OIDC user lives in `sessionStorage`, which a fresh tab (or Playwright context) doesn't have, so every fresh context bounces through Keycloak and returns on `/auth/callback`.
- The zustand store initializes `view` from that path → `"list"`.
- `initAuth` then `history.replaceState`s back to the deep link — but `replaceState` fires no `popstate`, and the mount effect in `app.tsx` only re-synced `/chat/…` paths.

**Fix:** run the full popstate handler once at mount, so every view syncs from the URL. The spec's heading assertion also gets `level: 1` — it previously passed on the wrong page because the list card shows the agent name as an `h2`.

## 2. The failed regrant spec poisoned 05-injection

The regrant connection reused the injection fixture's host (`httpbingo.org`) + header (`x-api-key`), overwriting the injection credential in Envoy on the shared agent. When the spec died before its cleanup step, `05-injection` deterministically received `e2e-regrant-secret-5e1c` instead of its sentinel.

**Fix:** dedicated `regrant.example.com` + `x-regrant-key`, and the project now depends on `slack` — listing order does not schedule (the spec actually ran *before* injection despite the "listed last" comment).

## 3. Scheduled runs republish all images without testing them

The nightly run rebuilds and republishes every image (`RESOLVE_NO_REUSE`) but skipped `mise test` and `mise e2e` — the 07-13 scheduled run reported green while main was broken.

**Fix:** drop the schedule exclusion from `test`/`build-mock`/`e2e`. Tags stay excluded (the tagged commit was already tested on main).

## Bonus: `exec-server-runtime-env.test.ts` flake

Failed three consecutive main runs with "server never became reachable": cold tsx boot on a loaded runner exceeded the 10s reachability poll (the sibling test passed once the server came up late). Widened to 25s, within the 30s test timeout.

## Verification

- `mise run check` green; UI unit tests (64) and the exec-server test pass locally.
- e2e not run locally (slow); this PR's CI run exercises the whole chain — including the deep-link fix, since the regrant spec is itself the deep-link regression test.

Process note: #2753 was merged with a failing CI run. If `mise e2e` isn't a required status check on `main`, this will recur.