### PR TITLE
feat(ui): chat thread and composer restyle

### DIFF
--- a/packages/ui/src/modules/sessions/components/activity-block.tsx
+++ b/packages/ui/src/modules/sessions/components/activity-block.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { Caret } from "./caret";
+
+/** Left-bordered agent-activity row in the chat thread (thinking, tool runs):
+ *  a label line plus optional collapsible detail. */
+export function ActivityBlock({
+  label,
+  onToggle,
+  open,
+  className,
+  children,
+}: {
+  label: ReactNode;
+  /** Omit when there is no detail to expand — the label renders inert. */
+  onToggle?: () => void;
+  open?: boolean;
+  className?: string;
+  children?: ReactNode;
+}) {
+  return (
+    <div
+      className={cn(
+        "border-l-2 border-border-light pl-3 max-w-full text-[14px] font-normal text-muted-foreground",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        className={cn(
+          "flex items-center gap-1.5 max-w-full min-w-0 min-h-[27px]",
+          onToggle
+            ? "cursor-pointer hover:text-text transition-colors"
+            : "cursor-default",
+        )}
+        onClick={onToggle}
+      >
+        {onToggle && (
+          <Caret
+            className={cn("transition-transform", !open && "-rotate-90")}
+          />
+        )}
+        {label}
+      </button>
+      {open && children && <div className="mt-1">{children}</div>}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/chat-column.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-column.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+export function ChatColumn({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className={cn("mx-auto w-full max-w-[813px]", className)}>
+      {children}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -1,8 +1,8 @@
 import {
-  Attachment as Paperclip,
+  Add,
   Close as X,
   Document as FileIcon,
-  Send as SendIcon,
+  SendAltFilled as SendIcon,
   Stop as Square,
 } from "@carbon/icons-react";
 import {
@@ -22,6 +22,7 @@ import { isMobile } from "../../../lib/breakpoints.js";
 import { emitToast } from "../../../lib/toast.js";
 import type { Attachment } from "../../../types.js";
 import { MAX_UPLOAD_BYTES } from "../../files/api/queries.js";
+import { ChatColumn } from "./chat-column.js";
 import { WorkingDots } from "./working-dots.js";
 
 const IMAGE_MIME = ["image/png", "image/jpeg", "image/gif", "image/webp"];
@@ -203,16 +204,16 @@ export function ChatInput({
     }
   };
 
-  const placeholder = isComputing ? "Queue a message..." : "Message agent...";
+  const placeholder = isComputing ? "Queue a message..." : "Message...";
 
   return (
     <div
-      className={`border-t bg-card/50 backdrop-blur-xl px-4 md:px-8 py-3 transition-colors ${dragOver ? "border-primary bg-primary/10" : "border-border"}`}
+      className="px-4 md:px-8 pt-3 pb-1"
       onDragOver={onDragOver}
       onDragLeave={onDragLeave}
       onDrop={onDrop}
     >
-      <div className="mx-auto max-w-[760px] flex flex-col gap-1.5">
+      <ChatColumn className="flex flex-col gap-1.5">
         <input
           ref={fileInputRef}
           type="file"
@@ -223,44 +224,34 @@ export function ChatInput({
             e.target.value = "";
           }}
         />
-        <div className="flex items-end gap-2">
-          <Button
-            variant="outline"
-            size="icon"
-            className="h-[44px] w-[44px] text-muted-foreground hover:text-primary hover:border-primary shrink-0 disabled:opacity-40"
-            onClick={() => fileInputRef.current?.click()}
-            disabled={loadingSession}
-            title="Attach file"
-          >
-            <Paperclip size={16} />
-          </Button>
-          {attachments.length > 0 ? (
-            <div className="flex-1 rounded-lg border border-primary bg-background shadow-[0_0_0_3px_var(--color-accent-glow)] transition-all focus-within:border-primary focus-within:shadow-[0_0_0_3px_var(--color-accent-glow)]">
-              <div className="flex gap-2 flex-wrap px-3 pt-3">
-                {attachments.map((a, i) => (
-                  <AttachmentChip
-                    key={i}
-                    attachment={a}
-                    onRemove={() => removeAttachment(i)}
-                  />
-                ))}
-              </div>
-              <Textarea
-                ref={textareaRef}
-                className="w-full bg-transparent border-0 px-4 py-2 text-[14px] text-foreground resize-none min-h-0 max-h-[50vh] overflow-hidden placeholder:text-muted-foreground disabled:opacity-40 focus-visible:ring-0 focus-visible:ring-offset-0"
-                value={input}
-                onChange={(e) => setInput(e.target.value)}
-                onKeyDown={onKeyDown}
-                onPaste={onPaste}
-                placeholder={placeholder}
-                rows={1}
-                disabled={loadingSession}
-              />
+        <div
+          className={`flex flex-col rounded-xl border bg-background transition-colors focus-within:border-primary ${dragOver ? "border-primary bg-accent-light/30" : "border-border"}`}
+        >
+          {attachments.length > 0 && (
+            <div className="flex gap-2 flex-wrap px-3 pt-3">
+              {attachments.map((a, i) => (
+                <AttachmentChip
+                  key={i}
+                  attachment={a}
+                  onRemove={() => removeAttachment(i)}
+                />
+              ))}
             </div>
-          ) : (
+          )}
+          <div className="flex items-end gap-1 px-2 min-h-[56px]">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className="shrink-0 mb-[9px] h-[40px] w-[40px] text-muted-foreground hover:text-primary disabled:opacity-40"
+              onClick={() => fileInputRef.current?.click()}
+              disabled={loadingSession}
+              title="Attach file"
+            >
+              <Add size={16} />
+            </Button>
             <Textarea
               ref={textareaRef}
-              className="flex-1 rounded-lg border border-border bg-background px-4 py-3 text-[14px] text-foreground resize-none min-h-[44px] max-h-[50vh] overflow-hidden transition-all focus-visible:border-primary focus-visible:shadow-[0_0_0_3px_var(--color-accent-glow)] placeholder:text-muted-foreground disabled:opacity-40"
+              className="flex-1 bg-transparent border-0 px-2 py-[17px] text-[14px] leading-[22px] text-foreground resize-none min-h-0 max-h-[50vh] overflow-hidden placeholder:text-muted-foreground disabled:opacity-40 focus-visible:ring-0 focus-visible:ring-offset-0"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={onKeyDown}
@@ -269,36 +260,38 @@ export function ChatInput({
               rows={1}
               disabled={loadingSession}
             />
-          )}
-          {showStop && (
-            <Button
-              variant="destructive"
-              size="icon"
-              className="h-[44px] w-[44px] shrink-0"
-              onClick={onStop}
-              title="Stop"
-            >
-              <Square size={16} />
-            </Button>
-          )}
-          {showSend && (
-            <Button
-              size="icon"
-              className="h-[44px] w-[44px] disabled:opacity-40 shrink-0"
-              onClick={send}
-              disabled={sendDisabled || loadingSession}
-              title={isComputing ? "Queue" : "Send"}
-            >
-              <SendIcon size={16} />
-            </Button>
-          )}
+            {showStop && (
+              <Button
+                variant="ghost"
+                tone="danger"
+                size="icon-sm"
+                className="shrink-0 mb-[9px] h-[40px] w-[40px]"
+                onClick={onStop}
+                title="Stop"
+              >
+                <Square size={16} />
+              </Button>
+            )}
+            {showSend && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className={`shrink-0 mb-[9px] h-[40px] w-[40px] ${hasContent ? "text-text" : "text-muted-foreground"} disabled:opacity-40`}
+                onClick={send}
+                disabled={sendDisabled || loadingSession}
+                title={isComputing ? "Queue" : "Send"}
+              >
+                <SendIcon size={16} />
+              </Button>
+            )}
+          </div>
         </div>
         {isComputing && (
           <div className="flex items-center gap-3">
             <BusyIndicator />
           </div>
         )}
-      </div>
+      </ChatColumn>
     </div>
   );
 }

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -4,6 +4,7 @@ import { Button } from "@/components/ui/button";
 
 import type { PermissionOption } from "../../../store.js";
 import { useStore } from "../../../store.js";
+import { ChatColumn } from "./chat-column.js";
 
 function toolTitle(toolCall: unknown): string {
   if (toolCall && typeof toolCall === "object") {
@@ -85,7 +86,7 @@ export function PermissionPrompt() {
 
   return (
     <div className="border-t bg-card/50 backdrop-blur-xl px-4 md:px-8 py-3">
-      <div className="mx-auto max-w-[760px] rounded-lg border-2 border-primary bg-background p-3.5 flex flex-col gap-2 shadow-sm">
+      <ChatColumn className="rounded-lg border-2 border-primary bg-background p-3.5 flex flex-col gap-2 shadow-sm">
         <div className="text-[14px] font-bold text-foreground break-all">
           Allow{" "}
           <span className="text-primary">{toolTitle(current.toolCall)}</span>?
@@ -111,7 +112,7 @@ export function PermissionPrompt() {
             {pending.length - 1 === 1 ? "" : "s"} queued
           </div>
         )}
-      </div>
+      </ChatColumn>
     </div>
   );
 }

--- a/packages/ui/src/modules/sessions/components/thought-block.tsx
+++ b/packages/ui/src/modules/sessions/components/thought-block.tsx
@@ -1,13 +1,7 @@
-import {
-  ChevronDown,
-  ChevronRight,
-  MachineLearning as Brain,
-} from "@carbon/icons-react";
 import { useEffect, useRef, useState } from "react";
 
-import { Button } from "@/components/ui/button";
-
 import { Markdown } from "../../../components/markdown.js";
+import { ActivityBlock } from "./activity-block.js";
 
 export function ThoughtBlock({
   text,
@@ -29,26 +23,8 @@ export function ThoughtBlock({
   };
 
   return (
-    <div className="text-[12px] max-w-full">
-      <Button
-        variant="outline"
-        size="sm"
-        className="h-auto gap-1.5 py-1 px-2 text-muted-foreground cursor-pointer"
-        onClick={toggle}
-      >
-        {open ? (
-          <ChevronDown size={12} className="shrink-0" />
-        ) : (
-          <ChevronRight size={12} className="shrink-0" />
-        )}
-        <Brain size={12} className="shrink-0" />
-        <span className="font-semibold">Thinking</span>
-      </Button>
-      {open && (
-        <div className="mt-1 px-3 py-1.5 rounded-lg bg-muted border border-border opacity-70 text-[13px]">
-          <Markdown>{text}</Markdown>
-        </div>
-      )}
-    </div>
+    <ActivityBlock label="Thinking" open={open} onToggle={toggle}>
+      <Markdown>{text}</Markdown>
+    </ActivityBlock>
   );
 }

--- a/packages/ui/src/modules/sessions/components/tool-chip.tsx
+++ b/packages/ui/src/modules/sessions/components/tool-chip.tsx
@@ -1,73 +1,40 @@
-import {
-  Checkmark as Check,
-  ChevronDown,
-  ChevronRight,
-  Close as X,
-  Renew as Loader,
-} from "@carbon/icons-react";
+import { Renew as Loader } from "@carbon/icons-react";
 import { useState } from "react";
 
-import { Button } from "@/components/ui/button";
-
 import type { ToolChip as T } from "../../../types.js";
-
-const statusColor: Record<string, string> = {
-  pending: "text-muted-foreground",
-  in_progress: "text-warning",
-  running: "text-warning",
-  completed: "text-success",
-  failed: "text-destructive",
-};
+import { ActivityBlock } from "./activity-block.js";
 
 function stripFences(text: string): string {
   return text.replace(/^```\w*\n?/, "").replace(/\n?```\s*$/, "");
 }
 
-const statusIcon = (status: string) => {
-  if (status === "completed") return <Check size={12} className="shrink-0" />;
-  if (status === "failed") return <X size={12} className="shrink-0" />;
-  if (status === "in_progress" || status === "running")
-    return <Loader size={11} className="anim-spin shrink-0" />;
-  return null;
-};
-
 export function ToolChip({ chip }: { chip: T }) {
   const [open, setOpen] = useState(false);
   const hasContent = chip.content && chip.content.length > 0;
-  const color = statusColor[chip.status] ?? statusColor.pending;
+  const running = chip.status === "in_progress" || chip.status === "running";
 
   return (
-    <div className="text-[12px] max-w-full">
-      <Button
-        variant="outline"
-        size="sm"
-        className={`h-auto gap-1.5 py-1 px-2 font-medium ${color} max-w-full ${hasContent ? "cursor-pointer" : "cursor-default"}`}
-        onClick={hasContent ? () => setOpen((o) => !o) : undefined}
-      >
-        {hasContent ? (
-          open ? (
-            <ChevronDown size={12} className="shrink-0" />
-          ) : (
-            <ChevronRight size={12} className="shrink-0" />
-          )
-        ) : null}
-        {statusIcon(chip.status)}
-        <span className="font-semibold truncate">{chip.title}</span>
-      </Button>
-      {open && chip.content && (
-        <div className="mt-1 rounded-lg bg-muted border border-border overflow-hidden">
-          {chip.content.map((c, i) =>
-            c.text ? (
-              <pre
-                key={i}
-                className="px-3 py-1.5 text-[11px] font-mono text-foreground/80 whitespace-pre-wrap break-words overflow-x-auto w-full leading-[1.5]"
-              >
-                {stripFences(c.text)}
-              </pre>
-            ) : null,
-          )}
-        </div>
+    <ActivityBlock
+      className={chip.status === "failed" ? "text-destructive" : undefined}
+      label={
+        <>
+          {running && <Loader size={12} className="anim-spin shrink-0" />}
+          <span className="truncate">{chip.title}</span>
+        </>
+      }
+      onToggle={hasContent ? () => setOpen((o) => !o) : undefined}
+      open={open}
+    >
+      {chip.content?.map((c, i) =>
+        c.text ? (
+          <pre
+            key={i}
+            className="py-1 text-[11px] font-mono whitespace-pre-wrap break-words overflow-x-auto w-full leading-[1.5]"
+          >
+            {stripFences(c.text)}
+          </pre>
+        ) : null,
       )}
-    </div>
+    </ActivityBlock>
   );
 }

--- a/packages/ui/src/modules/sessions/components/working-dots.tsx
+++ b/packages/ui/src/modules/sessions/components/working-dots.tsx
@@ -5,22 +5,29 @@ import { cn } from "@/lib/utils";
 export function WorkingDots({
   className,
   title,
+  size = "sm",
 }: {
   className?: string;
   title?: string;
+  size?: "sm" | "md";
 }) {
+  const dot = cn(
+    "rounded-full bg-current",
+    size === "md" ? "w-[5px] h-[5px]" : "w-[4px] h-[4px]",
+  );
   return (
     <span
       className={cn(
-        "working-dots inline-flex items-center gap-[1px]",
+        "working-dots inline-flex items-center",
+        size === "md" ? "gap-[2px]" : "gap-[1px]",
         className,
       )}
       title={title}
       data-testid="working-dots"
     >
-      <span className="w-[4px] h-[4px] rounded-full bg-current" />
-      <span className="w-[4px] h-[4px] rounded-full bg-current" />
-      <span className="w-[4px] h-[4px] rounded-full bg-current" />
+      <span className={dot} />
+      <span className={dot} />
+      <span className={dot} />
     </span>
   );
 }

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -1,9 +1,9 @@
+import { Settings } from "@carbon/icons-react";
 import { SessionMode } from "api-server-api";
 import {
   AlertCircle,
   ArrowDown,
   ArrowLeft,
-  ChevronUp,
   FileText as FileIcon,
   MoreVertical,
   RefreshCw,
@@ -50,6 +50,7 @@ import {
   optimisticInsertSession,
   setSessionRunning,
 } from "../api/queries.js";
+import { ChatColumn } from "../components/chat-column.js";
 import { ChatInput } from "../components/chat-input.js";
 import { ConfigurationPanel } from "../components/configuration-panel.js";
 import { PermissionPrompt } from "../components/permission-prompt.js";
@@ -57,6 +58,7 @@ import { SessionsSidebar } from "../components/sessions-sidebar.js";
 import { Terminal } from "../components/terminal.js";
 import { ThoughtBlock } from "../components/thought-block.js";
 import { ToolChip } from "../components/tool-chip.js";
+import { WorkingDots } from "../components/working-dots.js";
 import type { ConnectionState } from "../hooks/use-acp-connection.js";
 import { useAcpSession } from "../hooks/use-acp-session.js";
 
@@ -347,14 +349,10 @@ export function ChatView() {
 
   // ── Layout ──
   return (
-    <div className="flex flex-col h-dvh bg-bg relative overflow-hidden">
-      <div className="blob blob-1" />
-      <div className="blob blob-2" />
-      <div className="blob blob-3" />
-
+    <div className="flex flex-col h-dvh bg-background relative overflow-hidden">
       {/* Header spans the full width; on mobile it belongs to the chat screen only */}
       <header
-        className={`${mobileScreen === "sessions" ? "hidden md:flex" : "flex"} items-center gap-3 px-6 h-11 border-b border-border-light bg-surface/50 backdrop-blur-xl shrink-0 relative z-10`}
+        className={`${mobileScreen === "sessions" ? "hidden md:flex" : "flex"} items-center gap-3 px-6 h-[70px] border-b border-border-light shrink-0 relative z-10`}
       >
         <button
           className="md:hidden flex items-center gap-1 text-[13px] font-medium text-text-secondary hover:text-accent transition-colors"
@@ -420,7 +418,7 @@ export function ChatView() {
         {/* Left: Sessions + Files sections */}
         <div
           style={{ width: leftW }}
-          className={`shrink-0 flex flex-col border-r border-border-light bg-surface/50 backdrop-blur-xl overflow-hidden relative z-10 ${
+          className={`shrink-0 flex flex-col border-r border-border-light overflow-hidden relative z-10 ${
             mobileScreen === "chat" ? "hidden md:flex" : "flex"
           } ${mobileScreen === "sessions" ? "max-md:!w-full" : ""}`}
         >
@@ -510,7 +508,7 @@ export function ChatView() {
             <>
               <div className="relative flex flex-1 flex-col min-h-0">
                 <div ref={messagesRef} className="flex-1 overflow-y-auto">
-                  <div className="mx-auto max-w-[760px] px-4 md:px-8 py-8 flex flex-col gap-6">
+                  <ChatColumn className="px-4 md:px-4 py-8 flex flex-col gap-8">
                     {loadingSession && (
                       <div className="py-20 flex items-center justify-center gap-3 text-[14px] text-text-muted">
                         <span className="w-5 h-5 rounded-full border-2 border-border-light border-t-accent anim-spin" />
@@ -567,7 +565,7 @@ export function ChatView() {
                           data-role={m.role}
                           className={`flex flex-col gap-1 anim-in ${m.role === "user" ? "items-end" : "items-start"}`}
                         >
-                          <span className="text-[11px] font-bold uppercase tracking-[0.05em] text-text-muted mb-0.5">
+                          <span className="text-[11px] font-medium text-muted-foreground mb-0.5">
                             {m.role === "user" ? "You" : "Agent"}
                           </span>
                           {m.error ? (
@@ -587,8 +585,8 @@ export function ChatView() {
                             <div
                               className={
                                 m.role === "user"
-                                  ? "flex flex-col gap-2 rounded-xl rounded-br-sm border border-accent/30 bg-accent-light px-5 py-3 text-[14px] text-text max-w-[620px]"
-                                  : "flex flex-col gap-2 max-w-full"
+                                  ? "flex flex-col gap-2 rounded-xl border border-border-light bg-surface px-4 py-3 text-[14px] text-text"
+                                  : "flex flex-col gap-4 max-w-full"
                               }
                             >
                               {m.parts.map((p, i) =>
@@ -656,14 +654,17 @@ export function ChatView() {
                                     Waiting for previous prompt…
                                   </span>
                                 ) : (
-                                  <span className="inline-block w-[7px] h-4 bg-accent anim-blink rounded-sm" />
+                                  <WorkingDots
+                                    size="md"
+                                    className="text-accent py-3"
+                                  />
                                 ))}
                             </div>
                           )}
                         </div>
                       ),
                     )}
-                  </div>
+                  </ChatColumn>
                 </div>
 
                 {showJump && (
@@ -689,15 +690,19 @@ export function ChatView() {
                 />
               )}
               {harnessCurrent?.model && (
-                <button
-                  type="button"
-                  onClick={handleConfigureSandbox}
-                  title="Model — change in sandbox configuration"
-                  className="flex items-center gap-1 px-4 md:px-8 py-1.5 text-[12px] text-text-muted hover:text-text transition-colors"
-                >
-                  {harnessCurrent.model}
-                  <ChevronUp size={12} />
-                </button>
+                <div className="px-4 md:px-8 pb-[16px]">
+                  <ChatColumn>
+                    <button
+                      type="button"
+                      onClick={handleConfigureSandbox}
+                      title="Model — change in sandbox configuration"
+                      className="flex items-center gap-1 pl-3 text-[14px] text-muted-foreground hover:text-text transition-colors"
+                    >
+                      {harnessCurrent.model}
+                      <Settings size={12} />
+                    </button>
+                  </ChatColumn>
+                </div>
               )}
             </>
           )}
@@ -716,7 +721,7 @@ export function ChatView() {
         />
         <div
           style={{ width: rightW }}
-          className="hidden md:flex shrink-0 flex-col border-l border-border-light bg-surface/50 backdrop-blur-xl overflow-hidden relative z-10"
+          className="hidden md:flex shrink-0 flex-col border-l border-border-light overflow-hidden relative z-10"
         >
           {rightPanelContent}
         </div>


### PR DESCRIPTION
Stacked on #2769. Fourth increment of #883 (sub-issue 04) — visual pass on the chat thread per the Figma, no behavior changes.

- The composer is a single rounded container: plain `+` attach button, borderless input, and an icon-only send button; the stop control is a subtle red icon while the agent works. The model name sits directly beneath, aligned with the composer.
- User messages are neutral bubbles (white, light border); role labels are small and muted; the thread is wider with more space between turns.
- Agent activity — thinking and tool calls — shares one quiet treatment: a thin left border with a caret to expand details. Failed tools stay red and running tools keep a spinner. While the agent hasn't produced content yet, the thread shows the jumping-dots indicator instead of a blinking caret.
- The chat screen is flat white end to end (header, panels, thread) with a taller 70px header.

Part of #883.