### PR TITLE
docs(design): orchestrated R&D loops handoff

### DIFF
--- a/docs/design/orchestrated-loops-handoff.md
+++ b/docs/design/orchestrated-loops-handoff.md
@@ -12,6 +12,17 @@ Research, optimization, and software development all run the same loop: set a go
 
 The PRD covers it. In short: one approach iterating in depth, a locked four step loop (Make, Test, Eval, curate), fresh agent per step, one knowledge base, and a UI built on the existing Experiments screens that shows the loop running to an approved result. That slice proves the hard core. Everything below is out of scope for it.
 
+## Prototypes
+
+Clickable UX prototypes (static HTML, mock data) live in [`docs/prototypes/loops/`](../prototypes/loops/). They use the working name "Loop" and a software-engineering example (a Ralph style loop that builds a small todo app).
+
+- [`loop-creation-prototype.html`](../prototypes/loops/loop-creation-prototype.html) is the creation wizard: goal, strategy, the four steps (each an image, its connections, and a prompt), then review. It shows the empty sandbox model, the platform wrapper that hands each step its inputs and captures the result over MCP, and the Findings to Knowledge split. Breadth and the synthesizer are locked, since M1 is depth.
+- [`loop-detail-prototype.html`](../prototypes/loops/loop-detail-prototype.html) is a running depth loop, one candidate per generation, with the per generation Make, Test, Eval, Curate pipeline and the Knowledge rail. The creation wizard's "Create & run loop" opens it.
+- [`loops-evolution-prototype.html`](../prototypes/loops/loops-evolution-prototype.html) sketches the later breadth and synthesizer view (M2, M3), for reference only.
+- [`campaign-ux-prototype.html`](../prototypes/loops/campaign-ux-prototype.html) is an earlier depth detail sketch, kept for history.
+
+The prototypes are ahead of this doc on naming (Loop, Knowledge). Treat them as exploration, not a spec.
+
 ## Decisions that must survive
 
 These are load bearing. If a future change contradicts one of them, that is a real design reversal, not a detail.

--- a/docs/design/orchestrated-loops-handoff.md
+++ b/docs/design/orchestrated-loops-handoff.md
@@ -1,0 +1,52 @@
+# Orchestrated R&D loops: handoff
+
+Status: design handoff, not ratified. Date: 2026-07-14.
+
+The first slice is specified as a PRD: **[#2784](https://github.com/dam-agents/dam/issues/2784) — Campaign tracer slice**. Read that first. This doc does not repeat it. It carries the bigger picture, the decisions a future implementer must not quietly undo, and the work we deliberately left out.
+
+## The idea in one paragraph
+
+Research, optimization, and software development all run the same loop: set a goal, make a candidate, test it, evaluate how close it is, learn, try again. Today the platform can only launch that loop inside a single agent session (Experiments). That breaks the moment two steps have different owners, for example when a reviewer is not the implementer, or a human has to sign off. So we want the platform itself to drive the loop: run each step as its own agent, hold the durable record, and decide when to stop. The intelligence stays in the agents; the structure and durability move to the platform. We call the whole looping effort a **Campaign**.
+
+## What is being built first
+
+The PRD covers it. In short: one approach iterating in depth, a locked four step loop (Make, Test, Eval, curate), fresh agent per step, one knowledge base, and a UI built on the existing Experiments screens that shows the loop running to an approved result. That slice proves the hard core. Everything below is out of scope for it.
+
+## Decisions that must survive
+
+These are load bearing. If a future change contradicts one of them, that is a real design reversal, not a detail.
+
+1. **The platform owns the loop's structure, not the agents.** The reason to move the loop out of a single session is not that a session cannot call other agents. It can. The reason is durability and visibility: rounds, the record, and the process metrics only exist if the platform owns them.
+
+2. **Fresh agent every round is about clean thinking, not cost.** Each round starts from nothing so it is an independent attempt with no hidden carry over from a warm session. Only two things are allowed to cross a round boundary: the candidate (in git or wherever it lives) and the knowledge base. Everything else is thrown away on purpose.
+
+3. **The knowledge base is per approach, never shared.** Parallel approaches must stay independent, so they must not read each other's notes, or they converge into the same answer. The only thing shared across approaches is the goal itself, which every agent already gets in its prompt.
+
+4. **Knowledge base: writing is agentic, reading is static.** An agent maintains the knowledge base like an LLM keeping a wiki up to date. Reading it is a plain data read, like reading files from a repo. No agent calls another agent to read. This is what keeps the system simple: there are no agent to agent calls at all in the first slice.
+
+5. **The conductor is deterministic and blind to content.** It only reads a small fixed signal from each step (approve / request changes / fail, an optional score, a done flag, a pointer to the candidate). It never looks inside the work. That is what makes the process reproducible and measurable.
+
+6. **A candidate is always a pointer, and the pointer is immutable.** The platform stores where a candidate is, not what it means. For software that means an immutable commit reference plus a saved copy of the change, so a later round cannot overwrite what an earlier round produced.
+
+7. **A score is opaque in meaning but comparable in value.** The platform never interprets what a score means and never compares scores across approaches. Within one approach it may compare them as higher is better, which is all the stop rules need. The default stop signal is an "approve" verdict, not a score threshold.
+
+8. **Process metrics come from the platform, not the agents.** Rounds taken, cost, and where time went are all things the platform already knows from launching the steps and metering tokens. Nothing new needs to be reported, and because agents do not report them, they cannot be gamed.
+
+## Caveats and watch outs
+
+- **The knowledge base can overflow.** Reading is a plain read of the curated notes, so the agent that maintains those notes has to keep them small enough to fit. If it does not, reads get too big. This is the first thing that breaks at scale.
+- **A step that ends silently wedges the loop.** Unlike Experiments, where a missing result is just a missing column, here the next step cannot start. Every step must end either by reporting a result or by declaring it is waiting on something (CI, a human). A bare exit is treated as a failed round. This needs per step liveness with timeouts, which Experiments does not have today.
+- **Reproducibility needs a snapshot.** Because the knowledge base changes over time, "what did round 7 actually read" is lost unless the platform saves a copy per round.
+- **`docs/architecture/experiments.md` contradicts this.** It says the platform never loops. When this work is ratified that page needs a new section or a sibling page. Do not silently edit it.
+- **Names are not final.** "Campaign" and "Lineage" (one approach iterated in depth) are working names.
+
+## Deferred work, roughly in order
+
+1. **Multiple approaches in parallel (breadth).** The first slice runs one. Running several competing approaches at once is the next axis.
+2. **Configurable loop shape.** The first slice locks the four step loop. A real need is the software cost ladder (compile, then tests, then AI review, then human review, each gating the next). That needs the loop to become a configurable list of checks so the platform can measure each rung separately.
+3. **Evolutionary generations.** Kill weak approaches, spawn variants of strong ones. Depends on breadth.
+4. **Optimizing the process, not just recording it.** The first slice shows process metrics. The long term goal is feeding them back to improve the loop itself, first by a human editing the config, much later automatically.
+5. **Agent to agent communication.** Not needed while knowledge base reads are static. If a future step genuinely needs to ask another agent something live, this comes back, and the rule that protects it is simple: an agent that can be called must never call another agent, so there can be no loops.
+6. **Domain adapters.** Software specific views like a PR and diff for a candidate. These sit on top of the agnostic core, never inside it.
+7. **Non software domains.** Software is first because its signals are cleanest. The loop is meant to be domain agnostic, so a research or optimization use should drop onto the same machinery later.
+8. **Scale mitigations.** Cheaper models for trivial steps, knowledge base retrieval instead of reading the whole thing, and an escape hatch for steps that are pure code. Do not build these first.

--- a/docs/prototypes/loops/campaign-ux-prototype.html
+++ b/docs/prototypes/loops/campaign-ux-prototype.html
@@ -1,0 +1,602 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Loops — UX prototype</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ── Tokens copied from packages/ui/src/App.css (light theme) ── */
+  :root {
+    --c-bg: #fafaf9;
+    --c-surface: #ffffff;
+    --c-surface-raised: #f5f5f4;
+    --c-border-light: #dde1e6;
+    --c-text: #121619;
+    --c-text-secondary: #57534e;
+    --c-text-muted: #a8a29e;
+    --c-accent: #1d6be1;
+    --c-accent-hover: #1556b8;
+    --c-accent-light: #eaf2fe;
+    --c-success: #24a148;
+    --c-success-light: #defbe6;
+    --c-warning: #ff832b;
+    --c-warning-light: #fffbeb;
+    --c-danger: #dc2626;
+    --c-danger-light: #fef2f2;
+    --c-info: #000000;
+    --c-info-light: #f2f4f8;
+    --c-template: #7c3aed;
+    --c-template-light: #f5f3ff;
+    --muted-foreground: #4d5358;
+    --radius: 8px;
+    --radius-md: 6px;
+    --radius-sm: 4px;
+  }
+
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0;
+    font-family: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+    font-size: 15px;
+    line-height: 1.55;
+    color: var(--c-text);
+    background: var(--c-bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  .mono { font-family: "IBM Plex Mono", ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+  a { color: inherit; text-decoration: none; }
+
+  /* ── App shell ── */
+  .app { display: flex; height: 100vh; overflow: hidden; }
+  .rail {
+    width: 56px; flex-shrink: 0; background: var(--c-surface);
+    border-right: 1px solid var(--c-border-light);
+    display: flex; flex-direction: column; align-items: center; padding: 12px 0; gap: 6px;
+  }
+  .rail-item {
+    width: 40px; height: 40px; border-radius: var(--radius);
+    display: flex; align-items: center; justify-content: center;
+    color: rgba(18,22,25,.8); cursor: pointer;
+  }
+  .rail-item:hover { background: var(--c-info-light); }
+  .rail-item.active { background: var(--c-info-light); color: #000; }
+  .rail-logo { margin-bottom: 8px; }
+  .rail-spacer { flex: 1; }
+
+  .main { flex: 1; overflow-y: auto; }
+  .container { max-width: 1240px; margin: 0 auto; padding: 40px 40px 80px; }
+
+  /* ── Header ── */
+  .backlink {
+    display: inline-flex; align-items: center; gap: 6px;
+    font-size: 13px; color: var(--muted-foreground); margin-bottom: 20px;
+  }
+  .backlink:hover { color: var(--c-text); }
+  .head-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
+  h1.title { font-size: 24px; font-weight: 600; letter-spacing: -.5px; margin: 0; }
+  .goal {
+    margin: 10px 0 0; max-width: 720px; font-size: 14px; color: var(--c-text-secondary);
+    line-height: 1.6;
+  }
+  .meta-row {
+    display: flex; align-items: center; gap: 12px; margin-top: 14px;
+    font-size: 13px; color: var(--muted-foreground);
+  }
+  .dot-sep { color: var(--c-text-muted); }
+
+  /* ── Badges (rounded-full pills) ── */
+  .badge {
+    display: inline-flex; align-items: center; gap: 6px;
+    border-radius: 999px; padding: 2px 10px; font-size: 12px; letter-spacing: .34px;
+    border: 1px solid transparent; white-space: nowrap;
+  }
+  .badge .bdot { width: 7px; height: 7px; border-radius: 999px; background: currentColor; }
+  .badge-info { background: var(--c-info-light); color: #000; }
+  .badge-success { background: var(--c-success-light); color: #15803d; }
+  .badge-danger { background: var(--c-danger-light); color: var(--c-danger); }
+  .badge-muted { background: var(--c-info-light); color: var(--muted-foreground); }
+  .badge-warning { background: var(--c-warning-light); color: #b45309; }
+  .badge-accent { background: var(--c-accent-light); color: var(--c-accent-hover); }
+  .badge-outline { border-color: var(--c-border-light); color: var(--c-text); }
+
+  /* ── Buttons ── */
+  .btn {
+    display: inline-flex; align-items: center; gap: 7px; height: 36px; padding: 0 14px;
+    border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer;
+    border: 1px solid transparent; font-family: inherit;
+  }
+  .btn-primary { background: #000; color: #fff; }
+  .btn-primary:hover { background: rgba(0,0,0,.9); }
+  .btn-outline { background: var(--c-surface); border-color: var(--c-border-light); color: var(--c-text); }
+  .btn-outline:hover { background: var(--c-info-light); }
+  .btn-sm { height: 32px; padding: 0 12px; font-size: 12.5px; }
+  .btn-danger.btn-outline:hover { background: var(--c-danger-light); color: var(--c-danger); border-color: var(--c-danger); }
+
+  /* ── Cards ── */
+  .card {
+    background: var(--c-surface); border: 1px solid var(--c-border-light);
+    border-radius: var(--radius);
+  }
+
+  /* ── Metrics strip ── */
+  .metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 28px 0 8px; }
+  .metric { padding: 16px 18px; }
+  .metric .label {
+    font-size: 11px; text-transform: uppercase; letter-spacing: .04em;
+    color: var(--muted-foreground); font-weight: 500;
+  }
+  .metric .value { font-size: 26px; font-weight: 600; letter-spacing: -.5px; margin-top: 6px; }
+  .metric .value small { font-size: 15px; font-weight: 500; color: var(--c-text-muted); letter-spacing: 0; }
+  .metric .sub { font-size: 12px; color: var(--muted-foreground); margin-top: 3px; }
+
+  /* ── Two-column layout: rounds + logbook rail ── */
+  .layout { display: grid; grid-template-columns: 1fr 340px; gap: 28px; margin-top: 28px; align-items: start; }
+  .section-label {
+    font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em;
+    color: var(--muted-foreground); margin: 0 0 14px;
+  }
+
+  /* ── Round card ── */
+  .round { margin-bottom: 14px; overflow: hidden; }
+  .round-head {
+    display: flex; align-items: center; gap: 12px; padding: 14px 18px;
+    cursor: pointer; user-select: none;
+  }
+  .round-num { font-size: 15px; font-weight: 600; }
+  .round-head .spacer { flex: 1; }
+  .round-head .rmeta { font-size: 12.5px; color: var(--muted-foreground); }
+  .chev { color: var(--c-text-muted); transition: transform .15s ease; }
+  details[open] .chev { transform: rotate(90deg); }
+  summary { list-style: none; }
+  summary::-webkit-details-marker { display: none; }
+
+  /* ── Pipeline strip ── */
+  .pipeline {
+    display: flex; align-items: stretch; gap: 0; padding: 4px 18px 18px;
+  }
+  .stage {
+    flex: 1; display: flex; flex-direction: column; gap: 6px;
+    padding: 12px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md);
+    background: var(--c-surface);
+  }
+  .stage-top { display: flex; align-items: center; gap: 8px; }
+  .stage-icon {
+    width: 22px; height: 22px; border-radius: 999px; flex-shrink: 0;
+    display: flex; align-items: center; justify-content: center; color: #fff;
+  }
+  .si-done { background: var(--c-success); }
+  .si-fail { background: var(--c-danger); }
+  .si-run  { background: var(--c-accent); }
+  .si-skip { background: var(--c-surface-raised); color: var(--c-text-muted); border: 1px solid var(--c-border-light); }
+  .si-pending { background: var(--c-surface); color: var(--c-text-muted); border: 1px dashed var(--c-border-light); }
+  .si-continue { background: var(--c-accent); }
+  .si-hitl { background: var(--c-warning); }
+  .stage-name { font-size: 13px; font-weight: 600; }
+  .stage-desc { font-size: 12px; color: var(--muted-foreground); line-height: 1.45; }
+  .stage-status { font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+  .ss-done { color: var(--c-success); }
+  .ss-fail { color: var(--c-danger); }
+  .ss-run  { color: var(--c-accent); }
+  .ss-muted { color: var(--c-text-muted); }
+  .ss-continue { color: var(--c-accent); }
+  .ss-hitl { color: #b45309; }
+  .connector {
+    align-self: center; width: 22px; flex-shrink: 0; display: flex; align-items: center; justify-content: center;
+    color: var(--c-text-muted);
+  }
+  .pulse { animation: pulse 1.4s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+
+  /* ── Round detail body ── */
+  .round-body { border-top: 1px solid var(--c-border-light); padding: 16px 18px; display: grid; gap: 14px; }
+  .detail-row { display: grid; grid-template-columns: 110px 1fr; gap: 14px; align-items: start; }
+  .detail-key { font-size: 12px; font-weight: 600; color: var(--muted-foreground); text-transform: uppercase; letter-spacing: .04em; padding-top: 2px; }
+  /* Candidate = opaque (connection, locator) pair. Just a link. */
+  .cand-wrap { display: inline-flex; align-items: center; gap: 12px; flex-wrap: wrap; }
+  .cand-link {
+    display: inline-flex; align-items: center; gap: 7px; color: var(--c-accent);
+    font-size: 13px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md);
+    padding: 6px 10px; background: var(--c-surface);
+  }
+  .cand-link:hover { border-color: var(--c-accent); background: var(--c-accent-light); }
+  .cand-src { font-size: 12px; color: var(--muted-foreground); }
+  .cand-dl { color: var(--muted-foreground); }
+  .findings { font-size: 13.5px; color: var(--c-text); line-height: 1.55; }
+  .findings .lead { color: var(--muted-foreground); }
+  .test-line { font-size: 13.5px; display: flex; align-items: center; gap: 8px; }
+  /* Test emits one thing the platform understands: a pass/fail signal. The rest is opaque, verbatim. */
+  .raw-output {
+    font-family: "IBM Plex Mono", monospace; font-size: 12px; color: var(--c-text-secondary);
+    background: var(--c-surface-raised); border: 1px solid var(--c-border-light);
+    border-radius: var(--radius-sm); padding: 8px 10px; margin: 8px 0 0;
+    white-space: pre-wrap; overflow-x: auto; line-height: 1.5;
+  }
+  .raw-note { font-size: 11.5px; color: var(--c-text-muted); margin-top: 6px; line-height: 1.45; }
+  /* HITL: eval can pause the loop for a human to continue or abort */
+  .hitl-panel { background: var(--c-warning-light); border: 1px solid #f0d9b0; border-radius: var(--radius-md); padding: 14px 16px; }
+  .hitl-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; }
+  .hitl-deadline { font-size: 11.5px; color: #b45309; }
+  .hitl-reason { margin: 10px 0 6px; font-size: 13px; color: var(--c-text); }
+  .decision { display: flex; gap: 10px; margin-top: 12px; }
+
+  /* ── Logbook rail ── */
+  .rail-panel { position: sticky; top: 24px; }
+  .logbook-head { padding: 16px 18px; border-bottom: 1px solid var(--c-border-light); }
+  .logbook-title { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 600; }
+  .logbook-sub { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+  .logbook-body { padding: 16px 18px; font-size: 13px; line-height: 1.6; }
+  .lb-h { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted-foreground); margin: 16px 0 6px; }
+  .lb-h:first-child { margin-top: 0; }
+  .logbook-body p { margin: 0 0 8px; color: var(--c-text-secondary); }
+  .logbook-body ul { margin: 0; padding-left: 18px; color: var(--c-text-secondary); }
+  .logbook-body li { margin-bottom: 6px; }
+  .logbook-body code { font-family: "IBM Plex Mono", monospace; font-size: 12px; background: var(--c-surface-raised); padding: 1px 4px; border-radius: 3px; }
+  .rev-tag { color: var(--c-template); font-weight: 500; }
+  .logbook-foot {
+    padding: 12px 18px; border-top: 1px solid var(--c-border-light);
+    font-size: 11.5px; color: var(--muted-foreground); line-height: 1.5;
+  }
+
+  .callout {
+    margin-top: 20px; border: 1px solid var(--c-border-light); background: var(--c-info-light);
+    border-radius: var(--radius-md); padding: 10px 14px; font-size: 12.5px; color: var(--muted-foreground);
+  }
+  .proto-note {
+    position: fixed; bottom: 14px; right: 16px; z-index: 50;
+    background: var(--c-template-light); color: var(--c-template); border: 1px solid #ddd0f7;
+    font-size: 11px; padding: 5px 11px; border-radius: 999px; font-weight: 600; letter-spacing: .03em;
+  }
+</style>
+</head>
+<body>
+<div class="app">
+  <!-- Left icon rail (matches real app chrome) -->
+  <nav class="rail">
+    <div class="rail-item rail-logo" title="Platform">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/></svg>
+    </div>
+    <div class="rail-item" title="Home">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/></svg>
+    </div>
+    <div class="rail-item active" title="Loops">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 3h6"/><path d="M10 3v6l-5 9a2 2 0 0 0 1.8 3h10.4a2 2 0 0 0 1.8-3l-5-9V3"/><path d="M7.5 15h9"/></svg>
+    </div>
+    <div class="rail-spacer"></div>
+    <div class="rail-item" title="Inbox">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 7l9 6 9-6"/><rect x="3" y="5" width="18" height="14" rx="2"/></svg>
+    </div>
+    <div class="rail-item" title="Settings">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19.4 13.5a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 4.2 7.3l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V9a1.6 1.6 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/></svg>
+    </div>
+  </nav>
+
+  <main class="main">
+    <div class="container">
+      <a class="backlink" href="#">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 5l-7 7 7 7"/></svg>
+        Loops
+      </a>
+
+      <!-- Header -->
+      <div class="head-row">
+        <div>
+          <h1 class="title">Idempotent&nbsp;<span class="mono">/checkout</span>&nbsp;endpoint</h1>
+          <p class="goal">
+            Make the <span class="mono">/checkout</span> endpoint safe to retry: two identical requests must never
+            double-charge. The change has to pass CI and clear code review before it's accepted.
+          </p>
+          <div class="meta-row">
+            <span class="badge badge-warning"><span class="bdot pulse"></span>Paused · needs your decision</span>
+            <span class="dot-sep">·</span>
+            <span>Iteration 3 of 8</span>
+            <span class="dot-sep">·</span>
+            <span>Stops on <strong style="color:var(--c-text)">pass</strong>, abort, or iteration cap 8</span>
+          </div>
+        </div>
+        <div style="display:flex;gap:8px;flex-shrink:0">
+          <button class="btn btn-outline btn-sm">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 4v5h-5"/></svg>
+            Refresh
+          </button>
+          <button class="btn btn-outline btn-sm btn-danger">Stop</button>
+        </div>
+      </div>
+
+      <!-- Process metrics (measured by the platform, not self-reported) -->
+      <div class="metrics">
+        <div class="card metric">
+          <div class="label">Iterations</div>
+          <div class="value">3<small> / 8</small></div>
+          <div class="sub">2 continued · 1 needs decision</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Cost</div>
+          <div class="value mono">$4.20</div>
+          <div class="sub">1.9M tokens across iterations</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Elapsed</div>
+          <div class="value mono">2h&nbsp;40m</div>
+          <div class="sub">since loop started</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Awaiting decision</div>
+          <div class="value mono">22m</div>
+          <div class="sub">iteration 3 paused for you</div>
+        </div>
+      </div>
+
+      <div class="layout">
+        <!-- Iterations column -->
+        <div>
+          <p class="section-label">Iterations</p>
+
+          <!-- ITERATION 3 — live, parked on eval -->
+          <details class="card round" open>
+            <summary class="round-head">
+              <span class="round-num">Iteration 3</span>
+              <span class="badge badge-warning"><span class="bdot pulse"></span>Needs your decision</span>
+              <span class="spacer"></span>
+              <span class="rmeta mono">41m · $1.85</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage">
+                <div class="stage-top">
+                  <span class="stage-icon si-done">✓</span><span class="stage-name">Make</span>
+                </div>
+                <div class="stage-desc">Fresh agent wrote the change from the findings.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top">
+                  <span class="stage-icon si-done">✓</span><span class="stage-name">Test</span>
+                </div>
+                <div class="stage-desc">Automated gate returned pass.</div>
+                <div class="stage-status ss-done">Passed</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top">
+                  <span class="stage-icon si-hitl pulse">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2"><path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path d="M5 20a7 7 0 0 1 14 0"/></svg>
+                  </span><span class="stage-name">Eval</span>
+                </div>
+                <div class="stage-desc">Flagged for a human decision. Loop paused.</div>
+                <div class="stage-status ss-hitl">Needs decision</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top">
+                  <span class="stage-icon si-pending">○</span><span class="stage-name">Curate</span>
+                </div>
+                <div class="stage-desc">Runs only if you continue.</div>
+                <div class="stage-status ss-muted">Pending</div>
+              </div>
+            </div>
+
+            <div class="round-body">
+              <div class="detail-row">
+                <div class="detail-key">Candidate</div>
+                <div class="cand-wrap">
+                  <a class="cand-link mono" href="#">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>
+                    c4d5e6f
+                  </a>
+                  <button class="btn btn-outline btn-sm cand-dl">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M7 11l5 5 5-5"/><path d="M5 21h14"/></svg>
+                    Download copy
+                  </button>
+                </div>
+              </div>
+              <div class="detail-row">
+                <div class="detail-key">Test</div>
+                <div>
+                  <span class="badge badge-success">Passed</span>
+                  <pre class="raw-output">$ make test
+ok — 120 passed, 0 failed
+exit 0</pre>
+                  <div class="raw-note">Verbatim output. The platform stores it but never parses it. The one thing it routes on is the pass / fail signal.</div>
+                </div>
+              </div>
+              <div class="detail-row">
+                <div class="detail-key">Eval</div>
+                <div>
+                  <div class="hitl-panel">
+                    <div class="hitl-head">
+                      <span class="badge badge-warning"><span class="bdot pulse"></span>Needs your decision</span>
+                      <span class="hitl-deadline">auto-aborts in 23h if no answer</span>
+                    </div>
+                    <p class="hitl-reason">The candidate didn't pass. This eval is set to check in with you before the loop spends another iteration.</p>
+                    <div class="findings">The narrow row-lock removes the double-charge and the gate is green, but it serializes retries on the same key, which could bottleneck under load.</div>
+                    <div class="decision">
+                      <button class="btn btn-primary">Continue</button>
+                      <button class="btn btn-outline btn-danger">Abort</button>
+                    </div>
+                    <div class="raw-note">Continue runs curate and starts iteration 4. Abort stops the loop for good.</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <!-- ITERATION 2 — test failed, loop continued -->
+          <details class="card round">
+            <summary class="round-head">
+              <span class="round-num">Iteration 2</span>
+              <span class="badge badge-muted"><span class="bdot"></span>Continued · test failed</span>
+              <span class="spacer"></span>
+              <span class="rmeta mono">25m · $0.95</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Make</span></div>
+                <div class="stage-desc">Wrapped the handler in one transaction.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-fail">✕</span><span class="stage-name">Test</span></div>
+                <div class="stage-desc">Automated gate returned fail.</div>
+                <div class="stage-status ss-fail">Failed</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-skip">–</span><span class="stage-name">Eval</span></div>
+                <div class="stage-desc">Skipped — the test gate didn't pass.</div>
+                <div class="stage-status ss-muted">Skipped</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Logged why the transaction approach broke.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+            </div>
+
+            <div class="round-body">
+              <div class="detail-row">
+                <div class="detail-key">Candidate</div>
+                <div class="cand-wrap">
+                  <a class="cand-link mono" href="#">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>
+                    b91e0d4
+                  </a>
+                  <button class="btn btn-outline btn-sm cand-dl">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M7 11l5 5 5-5"/><path d="M5 21h14"/></svg>
+                    Download copy
+                  </button>
+                </div>
+              </div>
+              <div class="detail-row">
+                <div class="detail-key">Test</div>
+                <div>
+                  <span class="badge badge-danger">Failed</span>
+                  <pre class="raw-output">$ make test
+FAIL — 2 failing:
+  checkout_timeout, retry_idempotent
+exit 1</pre>
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <!-- ITERATION 1 — eval returned continue -->
+          <details class="card round">
+            <summary class="round-head">
+              <span class="round-num">Iteration 1</span>
+              <span class="badge badge-muted"><span class="bdot"></span>Continued</span>
+              <span class="spacer"></span>
+              <span class="rmeta mono">38m · $1.40</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Make</span></div>
+                <div class="stage-desc">First attempt — added an idempotency-key table.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Test</span></div>
+                <div class="stage-desc">Automated gate returned pass.</div>
+                <div class="stage-status ss-done">Passed</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-continue">↻</span><span class="stage-name">Eval</span></div>
+                <div class="stage-desc">Returned: continue (didn't pass).</div>
+                <div class="stage-status ss-continue">Continue</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Logged the race condition for the next iteration.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+            </div>
+
+            <div class="round-body">
+              <div class="detail-row">
+                <div class="detail-key">Candidate</div>
+                <div class="cand-wrap">
+                  <a class="cand-link mono" href="#">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>
+                    7f3a1c2
+                  </a>
+                  <button class="btn btn-outline btn-sm cand-dl">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 3v12"/><path d="M7 11l5 5 5-5"/><path d="M5 21h14"/></svg>
+                    Download copy
+                  </button>
+                </div>
+              </div>
+              <div class="detail-row">
+                <div class="detail-key">Test</div>
+                <div>
+                  <span class="badge badge-success">Passed</span>
+                  <pre class="raw-output">$ make test
+ok — 118 passed, 0 failed
+exit 0</pre>
+                </div>
+              </div>
+              <div class="detail-row">
+                <div class="detail-key">Eval</div>
+                <div class="findings">
+                  <span class="badge badge-accent" style="margin-right:6px">Continue</span>
+                  The idempotency check reads the key before taking the row lock, so two concurrent retries can both pass the check and double-charge. Move the existence check inside the transaction that writes the charge.
+                </div>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <!-- Logbook rail -->
+        <aside>
+          <p class="section-label">Findings</p>
+          <div class="card rail-panel">
+            <div class="logbook-head">
+              <div class="logbook-title">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H20v15H6.5A2.5 2.5 0 0 0 4 20.5z"/><path d="M4 5.5V20"/></svg>
+                Findings
+              </div>
+              <div class="logbook-sub">Curated findings for this lineage · updated iteration 3</div>
+            </div>
+            <div class="logbook-body">
+              <div class="lb-h">What works</div>
+              <p>A single idempotency table keyed by request id, written once per charge. Return the stored result on repeat.</p>
+
+              <div class="lb-h">Pitfalls found</div>
+              <ul>
+                <li>The existence check must run <strong>inside</strong> the row lock, or concurrent retries both pass it and double-charge. <span class="rev-tag">iteration 1</span></li>
+                <li>Wrapping the whole handler in one transaction stretches the DB call past the timeout budget and breaks <code>test_checkout_timeout</code>. <span class="rev-tag">iteration 2</span></li>
+              </ul>
+
+              <div class="lb-h">Open question</div>
+              <p>Where to place the lock so it's correct under concurrency without regressing the timeout test. Iteration 3 tries a narrow lock on just the idempotency row.</p>
+            </div>
+            <div class="logbook-foot">
+              Maintained by an agent after each iteration. Every Make reads it as static data. Iteration 3 read revision <span class="rev-tag mono">r3</span>.
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div class="callout">
+        The platform drives this loop end to end. It owns the iterations, the immutable candidate pointers, and every metric above — nothing here is self-reported by an agent. What each step <em>does</em> lives in its prompt; the platform only sees Make → Test → Eval → curate.
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="proto-note">UX PROTOTYPE · MOCK DATA</div>
+</body>
+</html>

--- a/docs/prototypes/loops/loop-creation-prototype.html
+++ b/docs/prototypes/loops/loop-creation-prototype.html
@@ -1,0 +1,697 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>New loop — creation wizard</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ── Tokens copied from packages/ui/src/App.css (light theme) ── */
+  :root {
+    --c-bg: #fafaf9; --c-surface: #ffffff; --c-surface-raised: #f5f5f4;
+    --c-border-light: #dde1e6; --c-text: #121619; --c-text-secondary: #57534e; --c-text-muted: #a8a29e;
+    --c-accent: #1d6be1; --c-accent-hover: #1556b8; --c-accent-light: #eaf2fe;
+    --c-success: #24a148; --c-success-light: #defbe6; --c-warning: #ff832b; --c-warning-light: #fffbeb;
+    --c-danger: #dc2626; --c-danger-light: #fef2f2; --c-info: #000000; --c-info-light: #f2f4f8;
+    --c-template: #7c3aed; --c-template-light: #f5f3ff; --muted-foreground: #4d5358;
+    --radius: 8px; --radius-md: 6px; --radius-sm: 4px;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+    font-size: 15px; line-height: 1.55; color: var(--c-text); background: var(--c-bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  .mono { font-family: "IBM Plex Mono", ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+  a { color: inherit; text-decoration: none; }
+
+  /* ── App shell ── */
+  .app { display: flex; height: 100vh; overflow: hidden; }
+  .rail { width: 56px; flex-shrink: 0; background: var(--c-surface); border-right: 1px solid var(--c-border-light);
+    display: flex; flex-direction: column; align-items: center; padding: 12px 0; gap: 6px; }
+  .rail-item { width: 40px; height: 40px; border-radius: var(--radius); display: flex; align-items: center; justify-content: center; color: rgba(18,22,25,.8); cursor: pointer; }
+  .rail-item:hover { background: var(--c-info-light); }
+  .rail-item.active { background: var(--c-info-light); color: #000; }
+  .rail-logo { margin-bottom: 8px; }
+  .rail-spacer { flex: 1; }
+  .main { flex: 1; overflow-y: auto; display: flex; flex-direction: column; }
+  .container { width: 100%; max-width: 780px; margin: 0 auto; padding: 34px 40px 40px; flex: 1; }
+
+  /* ── Header ── */
+  .backlink { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--muted-foreground); margin-bottom: 16px; }
+  .backlink:hover { color: var(--c-text); }
+  h1.title { font-size: 22px; font-weight: 600; letter-spacing: -.5px; margin: 0; }
+
+  /* ── Badges ── */
+  .badge { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 2px 10px; font-size: 12px; letter-spacing: .34px; border: 1px solid transparent; white-space: nowrap; }
+  .badge-accent { background: var(--c-accent-light); color: var(--c-accent-hover); }
+  .badge-template { background: var(--c-template-light); color: var(--c-template); }
+
+  /* ── Buttons ── */
+  .btn { display: inline-flex; align-items: center; gap: 7px; height: 38px; padding: 0 16px; border-radius: var(--radius-md); font-size: 13.5px; font-weight: 500; cursor: pointer; border: 1px solid transparent; font-family: inherit; }
+  .btn-primary { background: #000; color: #fff; }
+  .btn-primary:hover { background: #1c1c1c; }
+  .btn-outline { background: var(--c-surface); border-color: var(--c-border-light); color: var(--c-text); }
+  .btn-outline:hover { background: var(--c-info-light); }
+  .btn-ghost { background: transparent; color: var(--muted-foreground); }
+  .btn-ghost:hover { color: var(--c-text); }
+  .btn-lg { height: 44px; padding: 0 22px; font-size: 14px; }
+  .btn:disabled { opacity: .4; cursor: default; }
+
+  /* ── Progress stepper ── */
+  .wsteps { display: flex; align-items: flex-start; margin: 22px 0 6px; }
+  .wstep { display: flex; flex-direction: column; align-items: center; gap: 7px; flex: 0 0 auto; cursor: pointer; }
+  .wstep .dot { width: 30px; height: 30px; border-radius: 999px; display: flex; align-items: center; justify-content: center; font-size: 12px; font-weight: 600; background: var(--c-surface); border: 1.5px solid var(--c-border-light); color: var(--c-text-muted); transition: all .15s ease; }
+  .wstep .wlabel { font-size: 11.5px; color: var(--c-text-muted); font-weight: 500; white-space: nowrap; }
+  .wstep.loop .dot { border-style: dashed; }
+  .wstep.done .dot { background: var(--c-text); border-color: var(--c-text); color: #fff; border-style: solid; }
+  .wstep.active .dot { background: #000; border-color: #000; color: #fff; border-style: solid; box-shadow: 0 0 0 4px var(--c-info-light); }
+  .wstep.active .wlabel { color: var(--c-text); font-weight: 600; }
+  .wline { flex: 1 1 auto; height: 1.5px; background: var(--c-border-light); margin: 15px 6px 0; min-width: 10px; }
+  .wline.done { background: var(--c-text); }
+  .wgroup-cap { text-align: center; font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: .08em; color: var(--c-text-muted); margin: 14px 0 -2px; }
+
+  /* ── Screens ── */
+  .screen { display: none; margin-top: 26px; animation: fade .18s ease; }
+  .screen.active { display: block; }
+  @keyframes fade { from { opacity: 0; transform: translateY(4px); } to { opacity: 1; transform: none; } }
+  .screen-lead { margin: 0 0 20px; }
+  .screen-title { font-size: 20px; font-weight: 600; letter-spacing: -.3px; margin: 0; }
+  .screen-sub { font-size: 14px; color: var(--c-text-secondary); margin: 8px 0 0; line-height: 1.6; max-width: 620px; }
+
+  /* step screen header with big badge */
+  .step-hero { display: flex; align-items: center; gap: 14px; margin-bottom: 22px; }
+  .big-badge { width: 46px; height: 46px; border-radius: 12px; background: var(--c-accent); color: #fff; font-size: 20px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .step-hero .st-name { font-size: 20px; font-weight: 600; letter-spacing: -.3px; }
+  .step-hero .st-role { font-size: 13.5px; color: var(--muted-foreground); margin-top: 2px; }
+  .returns-chip { margin-left: auto; font-size: 12px; color: var(--muted-foreground); border: 1px solid var(--c-border-light); background: var(--c-surface); border-radius: 999px; padding: 5px 12px; align-self: center; }
+  .returns-chip code { font-family: "IBM Plex Mono", monospace; color: var(--c-text-secondary); }
+
+  /* ── Fields ── */
+  .field { margin-bottom: 24px; }
+  .field:last-child { margin-bottom: 0; }
+  .field-label { display: block; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: var(--muted-foreground); margin-bottom: 9px; }
+  .field-hint { font-size: 12.5px; color: var(--c-text-muted); margin-top: 8px; line-height: 1.5; }
+  input.inp, textarea.inp {
+    width: 100%; font-family: inherit; font-size: 15px; color: var(--c-text); background: var(--c-surface);
+    border: 1px solid var(--c-border-light); border-radius: var(--radius-md); padding: 11px 13px; line-height: 1.55;
+  }
+  input.inp:focus, textarea.inp:focus { outline: none; border-color: var(--c-accent); box-shadow: 0 0 0 3px var(--c-accent-light); }
+  textarea.inp { resize: vertical; }
+  .goal-input { min-height: 110px; }
+  .prompt-input { min-height: 240px; font-family: "IBM Plex Mono", monospace; font-size: 13.5px; line-height: 1.6; }
+
+  /* per-approach prompt cards (shown when population > 1) */
+  .approach { border: 1px solid var(--c-border-light); border-radius: var(--radius-md); margin-bottom: 12px; overflow: hidden; }
+  .approach:last-child { margin-bottom: 0; }
+  .approach-head { display: flex; align-items: center; gap: 10px; padding: 9px 12px; background: var(--c-surface-raised); border-bottom: 1px solid var(--c-border-light); }
+  .approach-badge { width: 24px; height: 24px; border-radius: 999px; background: var(--c-accent); color: #fff; font-size: 12px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .approach-name { border: none; background: transparent; font-family: inherit; font-size: 14px; font-weight: 600; color: var(--c-text); flex: 1; padding: 0; }
+  .approach-name:focus { outline: none; }
+  .approach-tag { font-size: 11px; color: var(--c-text-muted); }
+  .approach textarea { border: none; border-radius: 0; min-height: 150px; }
+  .approach textarea:focus { box-shadow: none; }
+
+  /* platform-appended loop instruction (locked, not editable) */
+  .prompt-append { margin-top: 8px; border: 1px dashed var(--c-border-light); border-radius: var(--radius-md); background: var(--c-surface-raised); padding: 10px 12px; display: flex; gap: 10px; align-items: flex-start; cursor: not-allowed; }
+  .prompt-append svg { color: var(--c-text-muted); flex-shrink: 0; margin-top: 2px; }
+  .pa-label { font-size: 10.5px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: var(--c-text-muted); }
+  .pa-text { font-size: 12.5px; color: var(--c-text-secondary); font-family: "IBM Plex Mono", monospace; line-height: 1.55; margin-top: 3px; }
+  .pa-text code { background: var(--c-surface); border: 1px solid var(--c-border-light); border-radius: 4px; padding: 0 5px; font-size: 12px; color: var(--c-text); }
+  .pa-text + .pa-text { margin-top: 5px; }
+  .pa-text strong { color: var(--c-text); font-weight: 600; }
+
+  /* image selector (styled dropdown) */
+  .img-select { position: relative; display: inline-flex; align-items: center; gap: 10px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md); padding: 10px 12px; background: var(--c-surface); min-width: 260px; }
+  .img-select svg { color: var(--c-text-muted); flex-shrink: 0; }
+  .img-select select { border: none; background: transparent; font-family: "IBM Plex Mono", monospace; font-size: 14px; font-weight: 500; color: var(--c-text); cursor: pointer; flex: 1; padding: 0; }
+  .img-select select:focus { outline: none; }
+
+  /* connections multi-chip picker */
+  .conn-picker { display: flex; flex-wrap: wrap; gap: 8px; align-items: center; }
+  .conn-chip { display: inline-flex; align-items: center; gap: 8px; padding: 8px 8px 8px 12px; border: 1px solid var(--c-border-light); border-radius: 999px; font-size: 13.5px; font-weight: 500; background: var(--c-surface); }
+  .conn-chip svg { color: var(--c-text-secondary); }
+  .conn-x { border: none; background: transparent; color: var(--c-text-muted); font-size: 17px; line-height: 1; cursor: pointer; padding: 0 2px; }
+  .conn-x:hover { color: var(--c-danger); }
+  .conn-add { border: 1px dashed var(--c-border-light); background: var(--c-surface); border-radius: 999px; padding: 8px 14px; font-size: 13.5px; font-weight: 500; color: var(--c-text-secondary); cursor: pointer; font-family: inherit; }
+  .conn-add:hover { background: var(--c-info-light); }
+  .conn-empty { font-size: 13px; color: var(--c-text-muted); font-style: italic; }
+
+  /* ── Strategy config rows ── */
+  .card { background: var(--c-surface); border: 1px solid var(--c-border-light); border-radius: var(--radius); }
+  .cfg-row { display: flex; align-items: center; gap: 14px; padding: 15px 18px; border-bottom: 1px solid var(--c-border-light); }
+  .cfg-row:last-child { border-bottom: none; }
+  .cfg-main { flex: 1; }
+  .cfg-name { font-size: 14.5px; font-weight: 500; }
+  .cfg-desc { font-size: 13px; color: var(--muted-foreground); margin-top: 3px; }
+  .stepper { display: inline-flex; align-items: center; border: 1px solid var(--c-border-light); border-radius: var(--radius-md); overflow: hidden; background: var(--c-surface); }
+  .stepper button { width: 36px; height: 36px; border: none; background: var(--c-surface); font-size: 18px; cursor: pointer; color: var(--c-text-secondary); font-family: inherit; }
+  .stepper button:hover { background: var(--c-info-light); }
+  .stepper .val { width: 46px; text-align: center; font-family: "IBM Plex Mono", monospace; font-size: 15px; font-weight: 600; border-left: 1px solid var(--c-border-light); border-right: 1px solid var(--c-border-light); height: 36px; display: flex; align-items: center; justify-content: center; }
+  .switch { display: inline-flex; align-items: center; cursor: pointer; user-select: none; }
+  .switch input { position: absolute; opacity: 0; pointer-events: none; }
+  .switch-track { width: 40px; height: 23px; border-radius: 999px; background: var(--c-surface-raised); border: 1px solid var(--c-border-light); position: relative; transition: background .15s ease; }
+  .switch-thumb { position: absolute; top: 2px; left: 2px; width: 17px; height: 17px; border-radius: 999px; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.2); transition: transform .15s ease; }
+  .switch input:checked + .switch-track { background: var(--c-accent); border-color: var(--c-accent); }
+  .switch input:checked + .switch-track .switch-thumb { transform: translateX(17px); }
+
+  .fold-disabled { margin-top: 18px; display: flex; align-items: center; gap: 10px; padding: 14px 16px; border: 1px dashed var(--c-border-light); border-radius: var(--radius-md); background: var(--c-surface-raised); color: var(--c-text-muted); cursor: not-allowed; }
+  .fold-disabled .fd-title { font-size: 13.5px; font-weight: 500; }
+  .fold-disabled svg { color: var(--c-text-muted); flex-shrink: 0; }
+  .fold-disabled .fold-note { margin-left: auto; display: inline-flex; align-items: center; gap: 8px; font-size: 12px; }
+  .fold { margin-top: 18px; border: 1px dashed var(--c-border-light); border-radius: var(--radius-md); overflow: hidden; }
+  .fold > summary { list-style: none; cursor: pointer; padding: 13px 16px; display: flex; align-items: center; gap: 10px; font-size: 13.5px; font-weight: 500; color: var(--c-text-secondary); background: var(--c-surface-raised); }
+  .fold > summary::-webkit-details-marker { display: none; }
+  .fold-chev { color: var(--c-text-muted); transition: transform .15s ease; }
+  .fold[open] .fold-chev { transform: rotate(90deg); }
+  .fold-note { margin-left: auto; font-size: 12px; color: var(--c-text-muted); font-weight: 400; }
+  .fold-body { padding: 2px 4px; }
+  .fold-body .cfg-row { padding-left: 14px; padding-right: 14px; }
+  .radio-cards { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; padding: 4px 14px 14px; }
+  .radio-card { border: 1px solid var(--c-border-light); border-radius: var(--radius-md); padding: 13px 15px; cursor: pointer; background: var(--c-surface); }
+  .radio-card.sel { border-color: var(--c-accent); background: var(--c-accent-light); }
+  .radio-card .rc-top { display: flex; align-items: center; gap: 8px; font-size: 13.5px; font-weight: 600; }
+  .radio-card .rc-desc { font-size: 12.5px; color: var(--muted-foreground); margin-top: 6px; line-height: 1.45; }
+  .rc-dot { width: 15px; height: 15px; border-radius: 999px; border: 2px solid var(--c-border-light); flex-shrink: 0; }
+  .radio-card.sel .rc-dot { border-color: var(--c-accent); background: radial-gradient(circle, var(--c-accent) 0 4px, #fff 5px); }
+  .section-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted-foreground); margin: 0 0 10px; }
+
+  /* ── Review ── */
+  .review-step { display: flex; align-items: flex-start; gap: 13px; padding: 15px 18px; border-bottom: 1px solid var(--c-border-light); }
+  .review-step:last-child { border-bottom: none; }
+  .rs-badge { width: 30px; height: 30px; border-radius: 8px; background: var(--c-accent); color: #fff; font-size: 13px; font-weight: 700; display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+  .rs-name { font-size: 14.5px; font-weight: 600; }
+  .rs-meta { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 6px; }
+  .rs-tag { font-size: 11.5px; color: var(--c-text-secondary); background: var(--c-surface-raised); border: 1px solid var(--c-border-light); border-radius: 999px; padding: 2px 9px; }
+  .rs-tag .mono { font-size: 11.5px; }
+  .rs-prompt { font-size: 12.5px; color: var(--muted-foreground); margin-top: 7px; line-height: 1.5; font-family: "IBM Plex Mono", monospace; display: -webkit-box; -webkit-line-clamp: 2; -webkit-box-orient: vertical; overflow: hidden; }
+  .recap-line { display: flex; gap: 14px; padding: 13px 18px; border-bottom: 1px solid var(--c-border-light); font-size: 14px; }
+  .recap-line:last-child { border-bottom: none; }
+  .recap-k { flex: 0 0 92px; font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: var(--muted-foreground); padding-top: 2px; }
+  .recap-v { flex: 1; }
+  .recap-v .sub { display: block; color: var(--muted-foreground); font-size: 13px; margin-top: 2px; }
+
+  /* ── Wizard footer nav ── */
+  .wnav { position: sticky; bottom: 0; background: var(--c-surface); border-top: 1px solid var(--c-border-light); }
+  .wnav-inner { max-width: 780px; margin: 0 auto; padding: 14px 40px; display: flex; align-items: center; gap: 14px; }
+  .wnav .count { font-size: 12.5px; color: var(--muted-foreground); }
+  .wnav .grow { flex: 1; }
+
+  .proto-note { position: fixed; bottom: 70px; right: 16px; z-index: 50; background: var(--c-template-light); color: var(--c-template); border: 1px solid #ddd0f7; font-size: 11px; padding: 5px 11px; border-radius: 999px; font-weight: 600; letter-spacing: .03em; }
+</style>
+</head>
+<body>
+<div class="app">
+  <nav class="rail">
+    <div class="rail-item rail-logo" title="Platform">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/></svg>
+    </div>
+    <div class="rail-item" title="Home">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/></svg>
+    </div>
+    <div class="rail-item active" title="Loops">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 3h6"/><path d="M10 3v6l-5 9a2 2 0 0 0 1.8 3h10.4a2 2 0 0 0 1.8-3l-5-9V3"/><path d="M7.5 15h9"/></svg>
+    </div>
+    <div class="rail-spacer"></div>
+    <div class="rail-item" title="Settings">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19.4 13.5a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 4.2 7.3l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V9a1.6 1.6 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/></svg>
+    </div>
+  </nav>
+
+  <main class="main">
+    <div class="container">
+      <a class="backlink" href="#">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 5l-7 7 7 7"/></svg>
+        Loops
+      </a>
+      <h1 class="title">New loop</h1>
+
+      <!-- Progress stepper -->
+      <div class="wsteps" id="wsteps">
+        <div class="wstep active" data-i="0"><span class="dot">1</span><span class="wlabel">Goal</span></div>
+        <div class="wline"></div>
+        <div class="wstep" data-i="1"><span class="dot">2</span><span class="wlabel">Strategy</span></div>
+        <div class="wline"></div>
+        <div class="wstep loop" data-i="2"><span class="dot">M</span><span class="wlabel">Make</span></div>
+        <div class="wline"></div>
+        <div class="wstep loop" data-i="3"><span class="dot">T</span><span class="wlabel">Test</span></div>
+        <div class="wline"></div>
+        <div class="wstep loop" data-i="4"><span class="dot">E</span><span class="wlabel">Eval</span></div>
+        <div class="wline"></div>
+        <div class="wstep loop" data-i="5"><span class="dot">C</span><span class="wlabel">Curate</span></div>
+        <div class="wline"></div>
+        <div class="wstep" data-i="6"><span class="dot">7</span><span class="wlabel">Review</span></div>
+      </div>
+
+      <!-- ══ SCREEN 0: GOAL ══ -->
+      <section class="screen active" data-i="0">
+        <div class="screen-lead">
+          <h2 class="screen-title">Goal</h2>
+          <p class="screen-sub">A plain-English objective. Vague is fine. Every agent in every step reads this, and it never changes once the loop runs.</p>
+        </div>
+        <div class="field">
+          <span class="field-label">What should the loop achieve?</span>
+          <textarea class="inp goal-input">Build a small todo app in tomkis/todo-app: a REST API plus a minimal web UI to add, list, complete, and delete todos, persisted in SQLite. Keep it simple.</textarea>
+        </div>
+        <div class="field">
+          <span class="field-label">Loop name</span>
+          <input class="inp" value="Todo Web Application" />
+        </div>
+      </section>
+
+      <!-- ══ SCREEN 2: MAKE ══ -->
+      <section class="screen" data-i="2">
+        <div class="step-hero">
+          <span class="big-badge">M</span>
+          <div>
+            <div class="st-name">Make</div>
+            <div class="st-role" id="makeRole">Produces one candidate each round</div>
+          </div>
+          <span class="returns-chip" id="makeReturns">returns <code>candidate</code> + <code>findings</code></span>
+        </div>
+        <p class="screen-sub" style="margin:-8px 0 24px">The <strong>Build</strong> step. Each round runs in a fresh, empty sandbox. It pulls in the previous candidate and the current Knowledge, then produces the next candidate. Choose what it runs in, what it can reach, and what it should do.</p>
+
+        <div class="field">
+          <span class="field-label">Image</span>
+          <div class="img-select">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+            <select><option>claude-code</option><option>codex</option><option>pi-agent</option><option>bob</option></select>
+          </div>
+          <span class="field-hint">The container this step runs in. Each step can differ.</span>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Connections</span>
+          <div class="conn-picker" data-conn>
+            <span class="conn-chip"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.85 9.73.5.1.68-.22.68-.49v-1.7c-2.79.62-3.38-1.23-3.38-1.23-.46-1.18-1.11-1.5-1.11-1.5-.91-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.57 2.34 1.12 2.91.85.09-.66.35-1.12.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9v2.82c0 .27.18.6.69.49A10.26 10.26 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>GitHub<button class="conn-x" title="Remove">×</button></span>
+            <button class="conn-add">+ Add connection</button>
+          </div>
+          <span class="field-hint">Grants this step can use. A step can have several. The platform never learns which repo or path &mdash; that goes in the prompt.</span>
+        </div>
+
+        <div class="field">
+          <div style="display:flex;align-items:baseline;gap:10px;flex-wrap:wrap">
+            <span class="field-label" id="makePromptLabel" style="margin-bottom:0">Prompt</span>
+            <span class="field-hint" id="approachHint" style="margin-top:0"></span>
+          </div>
+          <div id="approachList" style="margin-top:9px"></div>
+          <div class="prompt-append" title="The platform wraps every step: it hands in the inputs and captures the result. Not editable.">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+            <div>
+              <div class="pa-label">Wrapped by the platform · not editable</div>
+              <div class="pa-text"><strong>Given:</strong> an empty sandbox, the current Knowledge, and the surviving candidate from the last generation (none in the first).</div>
+              <div class="pa-text"><strong>On finish:</strong> call <code>make_done</code> with the PR as the candidate, plus any findings.</div>
+            </div>
+          </div>
+          <span class="field-hint">You write the work, including pulling in the handed-in candidate and Knowledge. The platform hands them in and captures the result; the reporting is its done-tool, not your prompt.</span>
+        </div>
+      </section>
+
+      <!-- ══ SCREEN 3: TEST ══ -->
+      <section class="screen" data-i="3">
+        <div class="step-hero">
+          <span class="big-badge">T</span>
+          <div>
+            <div class="st-name">Test</div>
+            <div class="st-role">Objective gate on each candidate</div>
+          </div>
+          <span class="returns-chip">returns <code>pass</code> / <code>fail</code> + <code>findings</code></span>
+        </div>
+        <p class="screen-sub" style="margin:-8px 0 24px">The <strong>Test</strong> step. A hard, reproducible gate that returns pass or fail, no judgment. A failing candidate does not stop the loop; it just doesn't move forward.</p>
+
+        <div class="field">
+          <span class="field-label">Image</span>
+          <div class="img-select">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+            <select><option>codex</option><option>claude-code</option><option>pi-agent</option><option>bob</option></select>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Connections</span>
+          <div class="conn-picker" data-conn>
+            <span class="conn-chip"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.85 9.73.5.1.68-.22.68-.49v-1.7c-2.79.62-3.38-1.23-3.38-1.23-.46-1.18-1.11-1.5-1.11-1.5-.91-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.57 2.34 1.12 2.91.85.09-.66.35-1.12.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9v2.82c0 .27.18.6.69.49A10.26 10.26 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>GitHub<button class="conn-x" title="Remove">×</button></span>
+            <button class="conn-add">+ Add connection</button>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Prompt</span>
+          <textarea class="inp prompt-input">Work in tomkis/todo-app. You start in an empty sandbox.
+
+Clone the repo and check out the candidate PR the platform hands you. Add unit tests that cover the slice this PR introduces. If it is already covered by tests from an earlier iteration, skip adding new ones.
+
+Run the full test suite.</textarea>
+          <div class="prompt-append" title="The platform wraps every step: it hands in the inputs and captures the result. Not editable.">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+            <div>
+              <div class="pa-label">Wrapped by the platform · not editable</div>
+              <div class="pa-text"><strong>Given:</strong> an empty sandbox and a reference to the candidate PR.</div>
+              <div class="pa-text"><strong>On finish:</strong> call <code>test_done</code> with pass or fail, plus any findings.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══ SCREEN 4: EVAL ══ -->
+      <section class="screen" data-i="4">
+        <div class="step-hero">
+          <span class="big-badge">E</span>
+          <div>
+            <div class="st-name">Eval</div>
+            <div class="st-role">Judges each candidate</div>
+          </div>
+          <span class="returns-chip">returns <code>verdict</code> + <code>score</code> + <code>findings</code></span>
+        </div>
+        <p class="screen-sub" style="margin:-8px 0 24px">Where the loop <strong>learns</strong> whether a candidate is good enough. Judges the candidate and returns a verdict (<span class="mono">passed</span> stops the loop, <span class="mono">continue</span> iterates) plus a score the platform tracks over generations.</p>
+
+        <div class="field">
+          <span class="field-label">Image</span>
+          <div class="img-select">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+            <select><option>claude-code</option><option>codex</option><option>pi-agent</option><option>bob</option></select>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Connections</span>
+          <div class="conn-picker" data-conn>
+            <span class="conn-chip"><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.58 2 12.25c0 4.53 2.87 8.37 6.85 9.73.5.1.68-.22.68-.49v-1.7c-2.79.62-3.38-1.23-3.38-1.23-.46-1.18-1.11-1.5-1.11-1.5-.91-.63.07-.62.07-.62 1 .07 1.53 1.06 1.53 1.06.89 1.57 2.34 1.12 2.91.85.09-.66.35-1.12.63-1.37-2.22-.26-4.56-1.14-4.56-5.07 0-1.12.39-2.03 1.03-2.75-.1-.26-.45-1.31.1-2.72 0 0 .84-.28 2.75 1.05a9.4 9.4 0 0 1 5 0c1.91-1.33 2.75-1.05 2.75-1.05.55 1.41.2 2.46.1 2.72.64.72 1.03 1.63 1.03 2.75 0 3.94-2.34 4.81-4.57 5.06.36.32.68.94.68 1.9v2.82c0 .27.18.6.69.49A10.26 10.26 0 0 0 22 12.25C22 6.58 17.52 2 12 2z"/></svg>GitHub<button class="conn-x" title="Remove">×</button></span>
+            <button class="conn-add">+ Add connection</button>
+          </div>
+          <span class="field-hint">Reads the PR to review it. It never writes.</span>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Prompt</span>
+          <textarea class="inp prompt-input">Work in tomkis/todo-app. You start in an empty sandbox.
+
+Clone the repo and check out the candidate PR the platform hands you. Review it as a senior engineer: correctness, clarity, and whether the slice is properly isolated and tested.
+
+Pass only once the app meets the goal and the PR is clean.</textarea>
+          <div class="prompt-append" title="The platform wraps every step: it hands in the inputs and captures the result. Not editable.">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+            <div>
+              <div class="pa-label">Wrapped by the platform · not editable</div>
+              <div class="pa-text"><strong>Given:</strong> an empty sandbox and a reference to the candidate PR.</div>
+              <div class="pa-text"><strong>On finish:</strong> call <code>eval_done</code> with a verdict (passed / continue) and a score, plus any findings.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══ SCREEN 5: CURATE ══ -->
+      <section class="screen" data-i="5">
+        <div class="step-hero">
+          <span class="big-badge">C</span>
+          <div>
+            <div class="st-name">Curate</div>
+            <div class="st-role">Maps Findings into Knowledge</div>
+          </div>
+          <span class="returns-chip">reads <code>findings</code> · writes <code>Knowledge</code></span>
+        </div>
+        <p class="screen-sub" style="margin:-8px 0 24px">How the loop <strong>remembers</strong> what it learned. The one writer of the Knowledge, it reads the raw Findings every step emitted this round and folds them into the curated Knowledge the next Make reads. Knowledge lives on the platform, so no external connection is needed by default.</p>
+
+        <div class="field">
+          <span class="field-label">Image</span>
+          <div class="img-select">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="3" y="3" width="18" height="18" rx="2"/><path d="M3 9h18M9 21V9"/></svg>
+            <select><option>claude-code</option><option>codex</option><option>pi-agent</option><option>bob</option></select>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Connections</span>
+          <div class="conn-picker" data-conn>
+            <span class="conn-empty">No connections &mdash; Curate only reads Findings and writes Knowledge.</span>
+            <button class="conn-add">+ Add connection</button>
+          </div>
+        </div>
+
+        <div class="field">
+          <span class="field-label">Prompt</span>
+          <textarea class="inp prompt-input">The platform hands you this round's Findings from every step and the current Knowledge.
+
+Fold the Findings into the Knowledge: append what changed (which slice was done, key decisions, anything the next round should know), then re-summarize so the Knowledge stays short — what's built, what's left, and open gotchas.</textarea>
+          <div class="prompt-append" title="The platform wraps every step: it hands in the inputs and captures the result. Not editable.">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+            <div>
+              <div class="pa-label">Wrapped by the platform · not editable</div>
+              <div class="pa-text"><strong>Given:</strong> an empty sandbox, this round's Findings from every step, and the current Knowledge.</div>
+              <div class="pa-text"><strong>On finish:</strong> call <code>curate_done</code> with the updated Knowledge.</div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- ══ SCREEN 1: STRATEGY ══ -->
+      <section class="screen" data-i="1">
+        <div class="screen-lead">
+          <h2 class="screen-title">Strategy</h2>
+          <p class="screen-sub">Set the shape of the loop before you write the steps: when it stops, and how many candidates each round explores. The defaults run one candidate per round in depth.</p>
+        </div>
+
+        <p class="section-label">Stop policy</p>
+        <div class="card">
+          <div class="cfg-row">
+            <div class="cfg-main">
+              <div class="cfg-name">Stop when a candidate passes</div>
+              <div class="cfg-desc">The loop ends the moment Eval returns a <span class="mono">passed</span> verdict.</div>
+            </div>
+            <label class="switch"><input type="checkbox" checked /><span class="switch-track"><span class="switch-thumb"></span></span></label>
+          </div>
+          <div class="cfg-row">
+            <div class="cfg-main">
+              <div class="cfg-name">Generation cap</div>
+              <div class="cfg-desc">Hard stop if nothing passes. Keeps cost bounded.</div>
+            </div>
+            <div class="stepper" data-stepper="cap"><button>−</button><span class="val">6</span><button>+</button></div>
+          </div>
+        </div>
+
+        <div class="fold-disabled" title="Breadth and multiple starting approaches arrive in a later milestone. For now every loop runs one candidate per generation in depth.">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><rect x="4" y="10" width="16" height="10" rx="2"/><path d="M8 10V7a4 4 0 0 1 8 0v3"/></svg>
+          <span class="fd-title">Breadth &amp; selection</span>
+          <span class="fold-note">one candidate per generation <span class="badge badge-template" style="font-size:10px;padding:1px 7px;">later</span></span>
+        </div>
+      </section>
+
+      <!-- ══ SCREEN 6: REVIEW ══ -->
+      <section class="screen" data-i="6">
+        <div class="screen-lead">
+          <h2 class="screen-title">Review</h2>
+          <p class="screen-sub">One last look before the loop starts running.</p>
+        </div>
+
+        <p class="section-label">Loop</p>
+        <div class="card" style="margin-bottom:22px">
+          <div class="recap-line">
+            <div class="recap-k">Name</div>
+            <div class="recap-v">Todo Web Application</div>
+          </div>
+          <div class="recap-line">
+            <div class="recap-k">Goal</div>
+            <div class="recap-v">A small todo app in <span class="mono">tomkis/todo-app</span>: REST API + minimal web UI (add, list, complete, delete), persisted in SQLite.</div>
+          </div>
+          <div class="recap-line">
+            <div class="recap-k">Strategy</div>
+            <div class="recap-v">Depth &mdash; 1 candidate per generation, keep top 1.<span class="sub">Stops on a <span class="mono">passed</span> verdict, cap 6 generations.</span></div>
+          </div>
+        </div>
+
+        <p class="section-label">The four steps</p>
+        <div class="card">
+          <div class="review-step">
+            <span class="rs-badge">M</span>
+            <div>
+              <div class="rs-name">Make</div>
+              <div class="rs-meta" id="revMakeMeta"><span class="rs-tag">image <span class="mono">claude-code</span></span><span class="rs-tag">GitHub</span></div>
+              <div class="rs-prompt" id="revMakePrompt">Work in tomkis/todo-app. Read the Knowledge and the goal. Pick the next unbuilt slice, implement it in isolation so a unit test can cover it, open a PR…</div>
+            </div>
+          </div>
+          <div class="review-step">
+            <span class="rs-badge">T</span>
+            <div>
+              <div class="rs-name">Test</div>
+              <div class="rs-meta"><span class="rs-tag">image <span class="mono">codex</span></span><span class="rs-tag">GitHub</span></div>
+              <div class="rs-prompt">Check out the PR. Add unit tests for the new slice (skip if already covered). Run the full test suite…</div>
+            </div>
+          </div>
+          <div class="review-step">
+            <span class="rs-badge">E</span>
+            <div>
+              <div class="rs-name">Eval</div>
+              <div class="rs-meta"><span class="rs-tag">image <span class="mono">claude-code</span></span><span class="rs-tag">GitHub</span></div>
+              <div class="rs-prompt">Review the PR as a senior engineer: correctness, clarity, isolation, tests. Pass only once the app meets the goal and the PR is clean…</div>
+            </div>
+          </div>
+          <div class="review-step">
+            <span class="rs-badge">C</span>
+            <div>
+              <div class="rs-name">Curate</div>
+              <div class="rs-meta"><span class="rs-tag">image <span class="mono">claude-code</span></span><span class="rs-tag">no connections</span></div>
+              <div class="rs-prompt">Append this round's progress and re-summarize the log: what's built, what's left, open gotchas…</div>
+            </div>
+          </div>
+        </div>
+      </section>
+    </div>
+
+    <!-- Wizard footer -->
+    <div class="wnav">
+      <div class="wnav-inner">
+        <button class="btn btn-ghost" id="backBtn" disabled>
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 5l-7 7 7 7"/></svg>
+          Back
+        </button>
+        <span class="count" id="count">Step 1 of 7</span>
+        <span class="grow"></span>
+        <button class="btn btn-primary" id="nextBtn">
+          Next
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg>
+        </button>
+        <button class="btn btn-primary btn-lg" id="createBtn" style="display:none">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M5 3l14 9-14 9V3z"/></svg>
+          Create &amp; run loop
+        </button>
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="proto-note">UX PROTOTYPE · MOCK DATA</div>
+
+<script>
+  const TOTAL = 7;
+  let cur = 0;
+  const byI = (a, b) => (+a.dataset.i) - (+b.dataset.i);
+  const screens = [...document.querySelectorAll('.screen')].sort(byI);
+  const wsteps = [...document.querySelectorAll('#wsteps .wstep')].sort(byI);
+  const wlines = [...document.querySelectorAll('#wsteps .wline')];
+  const backBtn = document.getElementById('backBtn');
+  const nextBtn = document.getElementById('nextBtn');
+  const createBtn = document.getElementById('createBtn');
+  const count = document.getElementById('count');
+
+  function render() {
+    screens.forEach((s, i) => s.classList.toggle('active', i === cur));
+    wsteps.forEach((w, i) => {
+      w.classList.toggle('active', i === cur);
+      w.classList.toggle('done', i < cur);
+    });
+    wlines.forEach((l, i) => l.classList.toggle('done', i < cur));
+    count.textContent = `Step ${cur + 1} of ${TOTAL}`;
+    backBtn.disabled = cur === 0;
+    const last = cur === TOTAL - 1;
+    nextBtn.style.display = last ? 'none' : '';
+    createBtn.style.display = last ? '' : 'none';
+    document.querySelector('.main').scrollTo({ top: 0, behavior: 'smooth' });
+  }
+  function go(i) { cur = Math.max(0, Math.min(TOTAL - 1, i)); render(); }
+
+  nextBtn.addEventListener('click', () => go(cur + 1));
+  backBtn.addEventListener('click', () => go(cur - 1));
+  createBtn.addEventListener('click', () => { window.location.href = 'loop-detail-prototype.html'; });
+  wsteps.forEach(w => w.addEventListener('click', () => go(+w.dataset.i)));
+
+  // connections: add / remove chips
+  document.querySelectorAll('[data-conn]').forEach(picker => {
+    const addBtn = picker.querySelector('.conn-add');
+    addBtn.addEventListener('click', () => {
+      const empty = picker.querySelector('.conn-empty');
+      if (empty) empty.remove();
+      const chip = document.createElement('span');
+      chip.className = 'conn-chip';
+      chip.innerHTML = 'New connection<button class="conn-x" title="Remove">×</button>';
+      picker.insertBefore(chip, addBtn);
+    });
+    picker.addEventListener('click', e => {
+      if (e.target.classList.contains('conn-x')) e.target.closest('.conn-chip').remove();
+    });
+  });
+
+  // radio-card select mode
+  document.querySelectorAll('.radio-cards').forEach(group => {
+    group.querySelectorAll('.radio-card').forEach(card => {
+      card.addEventListener('click', () => {
+        group.querySelectorAll('.radio-card').forEach(c => c.classList.remove('sel'));
+        card.classList.add('sel');
+      });
+    });
+  });
+
+  // ── Make: population = number of starting approaches ──
+  const SOLO_PROMPT = `Work in tomkis/todo-app. You start in an empty sandbox.
+
+Clone the repo and check out the candidate the platform hands you from the last round (if there's none, start from main). Read the Knowledge to see what already exists and what's left.
+
+Pick ONE small slice of the goal that isn't done yet (the data model, a single API endpoint, one UI action) and implement it on top, in isolation, so a unit test can cover it. Open a pull request for it.`;
+  const APPROACHES = [
+    { name: 'Query batching',        prompt: 'Work in tomkis/search-api. Read the Findings and the goal.\n\nApproach: collapse the per-result lookups /search issues into one batched query to cut round-trips. Results must not change.\n\nCommit on a fresh branch and report the commit as the candidate.' },
+    { name: 'Inverted index',        prompt: 'Work in tomkis/search-api. Read the Findings and the goal.\n\nApproach: build an inverted index over the searchable fields so /search avoids full scans. Results must not change.\n\nCommit on a fresh branch and report the commit as the candidate.' },
+    { name: 'Response caching',      prompt: 'Work in tomkis/search-api. Read the Findings and the goal.\n\nApproach: cache /search responses with correct invalidation on write. Results must not change.\n\nCommit on a fresh branch and report the commit as the candidate.' },
+    { name: 'Precompute hot queries',prompt: 'Work in tomkis/search-api. Read the Findings and the goal.\n\nApproach: precompute and store results for the hottest queries, refreshed in the background. Results must not change.\n\nCommit on a fresh branch and report the commit as the candidate.' },
+  ];
+  const letter = i => String.fromCharCode(65 + i);
+
+  const approachList = document.getElementById('approachList');
+  const makePromptLabel = document.getElementById('makePromptLabel');
+  const approachHint = document.getElementById('approachHint');
+  const makeRole = document.getElementById('makeRole');
+  const makeReturns = document.getElementById('makeReturns');
+  const revMakeMeta = document.getElementById('revMakeMeta');
+  const revMakePrompt = document.getElementById('revMakePrompt');
+
+  function esc(s) { return s.replace(/</g, '&lt;'); }
+
+  function updateMake(pop) {
+    if (pop <= 1) {
+      makePromptLabel.textContent = 'Prompt';
+      approachHint.textContent = '';
+      makeRole.textContent = 'Produces one candidate each round';
+      makeReturns.innerHTML = 'returns <code>candidate</code> + <code>findings</code>';
+      approachList.innerHTML = `<textarea class="inp prompt-input">${esc(SOLO_PROMPT)}</textarea>`;
+      revMakeMeta.innerHTML = '<span class="rs-tag">image <span class="mono">claude-code</span></span><span class="rs-tag">GitHub</span>';
+      revMakePrompt.textContent = SOLO_PROMPT.replace(/\n+/g, ' ');
+    } else {
+      makePromptLabel.textContent = `Starting approaches — ${pop}`;
+      approachHint.textContent = 'one Make sandbox per approach, so each candidate starts from a different idea';
+      makeRole.textContent = `Produces ${pop} candidates each round, one per approach`;
+      makeReturns.innerHTML = `returns <code>${pop} candidates</code> + <code>findings</code>`;
+      let html = '';
+      for (let i = 0; i < pop; i++) {
+        const a = APPROACHES[i] || { name: `Approach ${letter(i)}`, prompt: 'Work in tomkis/search-api. Read the Findings and the goal.\n\nApproach: (describe a distinct line of attack)\n\nCommit on a fresh branch and report the commit as the candidate.' };
+        html += `<div class="approach">
+          <div class="approach-head">
+            <span class="approach-badge">${letter(i)}</span>
+            <input class="approach-name" value="${a.name}" />
+            <span class="approach-tag mono">sandbox ${i + 1}</span>
+          </div>
+          <textarea class="inp prompt-input">${esc(a.prompt)}</textarea>
+        </div>`;
+      }
+      approachList.innerHTML = html;
+      const names = Array.from({ length: pop }, (_, i) => `${letter(i)}: ${(APPROACHES[i] || {}).name || 'Approach ' + letter(i)}`).join(' · ');
+      revMakeMeta.innerHTML = `<span class="rs-tag">image <span class="mono">claude-code</span></span><span class="rs-tag">GitHub</span><span class="rs-tag">${pop} approaches</span>`;
+      revMakePrompt.textContent = names;
+    }
+  }
+
+  // steppers
+  document.querySelectorAll('.stepper').forEach(s => {
+    const val = s.querySelector('.val');
+    const [minus, plus] = s.querySelectorAll('button');
+    const min = s.dataset.stepper === 'cap' ? 1 : (s.dataset.stepper === 'pop' ? 1 : 1);
+    const commit = () => { if (s.dataset.stepper === 'pop') updateMake(+val.textContent); };
+    minus.addEventListener('click', () => { val.textContent = Math.max(min, (+val.textContent) - 1); commit(); });
+    plus.addEventListener('click', () => { val.textContent = (+val.textContent) + 1; commit(); });
+  });
+
+  updateMake(1);
+  render();
+</script>
+</body>
+</html>

--- a/docs/prototypes/loops/loop-detail-prototype.html
+++ b/docs/prototypes/loops/loop-detail-prototype.html
@@ -1,0 +1,466 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Todo Web Application — loop detail</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ── Tokens copied from packages/ui/src/App.css (light theme) ── */
+  :root {
+    --c-bg: #fafaf9; --c-surface: #ffffff; --c-surface-raised: #f5f5f4;
+    --c-border-light: #dde1e6; --c-text: #121619; --c-text-secondary: #57534e; --c-text-muted: #a8a29e;
+    --c-accent: #1d6be1; --c-accent-hover: #1556b8; --c-accent-light: #eaf2fe;
+    --c-success: #24a148; --c-success-light: #defbe6; --c-warning: #ff832b; --c-warning-light: #fffbeb;
+    --c-danger: #dc2626; --c-danger-light: #fef2f2; --c-info: #000000; --c-info-light: #f2f4f8;
+    --c-template: #7c3aed; --c-template-light: #f5f3ff; --muted-foreground: #4d5358;
+    --radius: 8px; --radius-md: 6px; --radius-sm: 4px;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+    font-size: 15px; line-height: 1.55; color: var(--c-text); background: var(--c-bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  .mono { font-family: "IBM Plex Mono", ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+  a { color: inherit; text-decoration: none; }
+
+  /* ── App shell ── */
+  .app { display: flex; height: 100vh; overflow: hidden; }
+  .rail { width: 56px; flex-shrink: 0; background: var(--c-surface); border-right: 1px solid var(--c-border-light);
+    display: flex; flex-direction: column; align-items: center; padding: 12px 0; gap: 6px; }
+  .rail-item { width: 40px; height: 40px; border-radius: var(--radius); display: flex; align-items: center; justify-content: center; color: rgba(18,22,25,.8); cursor: pointer; }
+  .rail-item:hover { background: var(--c-info-light); }
+  .rail-item.active { background: var(--c-info-light); color: #000; }
+  .rail-logo { margin-bottom: 8px; }
+  .rail-spacer { flex: 1; }
+  .main { flex: 1; overflow-y: auto; }
+  .container { max-width: 1240px; margin: 0 auto; padding: 40px 40px 80px; }
+
+  /* ── Header ── */
+  .backlink { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--muted-foreground); margin-bottom: 20px; }
+  .backlink:hover { color: var(--c-text); }
+  .head-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
+  h1.title { font-size: 24px; font-weight: 600; letter-spacing: -.5px; margin: 0; }
+  .goal { margin: 10px 0 0; max-width: 720px; font-size: 14px; color: var(--c-text-secondary); line-height: 1.6; }
+  .meta-row { display: flex; align-items: center; gap: 12px; margin-top: 14px; font-size: 13px; color: var(--muted-foreground); flex-wrap: wrap; }
+  .dot-sep { color: var(--c-text-muted); }
+
+  /* ── Badges ── */
+  .badge { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 2px 10px; font-size: 12px; letter-spacing: .34px; border: 1px solid transparent; white-space: nowrap; }
+  .badge .bdot { width: 7px; height: 7px; border-radius: 999px; background: currentColor; }
+  .badge-info { background: var(--c-info-light); color: #000; }
+  .badge-success { background: var(--c-success-light); color: #15803d; }
+  .badge-danger { background: var(--c-danger-light); color: var(--c-danger); }
+  .badge-muted { background: var(--c-info-light); color: var(--muted-foreground); }
+  .badge-warning { background: var(--c-warning-light); color: #b45309; }
+  .badge-accent { background: var(--c-accent-light); color: var(--c-accent-hover); }
+
+  /* ── Buttons ── */
+  .btn { display: inline-flex; align-items: center; gap: 7px; height: 36px; padding: 0 14px; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; border: 1px solid transparent; font-family: inherit; }
+  .btn-primary { background: #000; color: #fff; }
+  .btn-outline { background: var(--c-surface); border-color: var(--c-border-light); color: var(--c-text); }
+  .btn-outline:hover { background: var(--c-info-light); }
+  .btn-sm { height: 32px; padding: 0 12px; font-size: 12.5px; }
+
+  /* ── Cards ── */
+  .card { background: var(--c-surface); border: 1px solid var(--c-border-light); border-radius: var(--radius); }
+
+  /* ── Config strip ── */
+  .config { display: flex; align-items: center; gap: 14px; margin-top: 18px; padding: 12px 16px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md); background: var(--c-surface); flex-wrap: wrap; }
+  .config .cfg { font-size: 13px; color: var(--muted-foreground); }
+  .config .cfg strong { color: var(--c-text); font-weight: 600; }
+  .config .grow { flex: 1; }
+  .config .repo { display: inline-flex; align-items: center; gap: 6px; font-family: "IBM Plex Mono", monospace; font-size: 12.5px; color: var(--c-text-secondary); }
+
+  /* ── Metrics ── */
+  .metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 16px 0 8px; }
+  .metric { padding: 16px 18px; }
+  .metric .label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted-foreground); font-weight: 500; }
+  .metric .value { font-size: 26px; font-weight: 600; letter-spacing: -.5px; margin-top: 6px; }
+  .metric .value small { font-size: 15px; font-weight: 500; color: var(--c-text-muted); letter-spacing: 0; }
+  .metric .value .up { font-size: 14px; color: var(--c-success); font-weight: 600; }
+  .metric .sub { font-size: 12px; color: var(--muted-foreground); margin-top: 3px; }
+
+  /* ── Two-column layout ── */
+  .layout { display: grid; grid-template-columns: 1fr 340px; gap: 28px; margin-top: 28px; align-items: start; }
+  .section-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted-foreground); margin: 0 0 14px; }
+
+  /* ── Generation card ── */
+  .gen { margin-bottom: 14px; overflow: hidden; }
+  .gen-head { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; user-select: none; }
+  .gen-num { font-size: 15px; font-weight: 600; }
+  .gen-head .spacer { flex: 1; }
+  .gen-head .gmeta { font-size: 12.5px; color: var(--muted-foreground); }
+  .chev { color: var(--c-text-muted); transition: transform .15s ease; }
+  details[open] .chev { transform: rotate(90deg); }
+  summary { list-style: none; } summary::-webkit-details-marker { display: none; }
+
+  /* ── Pipeline (Make → Test → Eval → Curate) ── */
+  .pipeline { display: flex; align-items: stretch; gap: 0; padding: 4px 18px 16px; }
+  .stage { flex: 1; display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md); background: var(--c-surface); }
+  .stage-top { display: flex; align-items: center; gap: 8px; }
+  .stage-icon { width: 22px; height: 22px; border-radius: 999px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 11px; font-weight: 700; }
+  .si-done { background: var(--c-success); } .si-accent { background: var(--c-accent); } .si-pending { background: var(--c-surface); color: var(--c-text-muted); border: 1px dashed var(--c-border-light); }
+  .stage-name { font-size: 13px; font-weight: 600; }
+  .stage-desc { font-size: 12px; color: var(--muted-foreground); line-height: 1.45; }
+  .stage-status { font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+  .ss-done { color: var(--c-success); } .ss-accent { color: var(--c-accent); } .ss-muted { color: var(--c-text-muted); }
+  .connector { align-self: center; width: 22px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: var(--c-text-muted); }
+  .pulse { animation: pulse 1.4s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+
+  /* ── Generation body ── */
+  .gen-body { border-top: 1px solid var(--c-border-light); padding: 16px 18px; }
+  .sub-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: var(--muted-foreground); margin: 0 0 8px; }
+  .sub-label.mt { margin-top: 18px; }
+
+  /* candidate (single, depth) */
+  .cand-solo { display: flex; align-items: center; gap: 12px; padding: 11px 13px; border: 1px solid var(--c-border-light); border-left: 3px solid var(--c-accent); border-radius: var(--radius-md); background: var(--c-accent-light); flex-wrap: wrap; }
+  .cand-link { display: inline-flex; align-items: center; gap: 7px; color: var(--c-accent); font-size: 13.5px; font-weight: 500; }
+  .cand-link:hover { text-decoration: underline; }
+  .cand-slice { font-size: 13px; color: var(--c-text-secondary); }
+  .cand-solo .spacer { flex: 1; }
+  .score { font-family: "IBM Plex Mono", monospace; font-variant-numeric: tabular-nums; font-size: 14px; font-weight: 600; }
+  .review-note { font-size: 13px; color: var(--c-text-secondary); line-height: 1.55; margin: 10px 2px 0; }
+  .review-note strong { color: var(--c-text); }
+
+  /* findings list */
+  .findings { display: flex; flex-direction: column; gap: 7px; }
+  .finding { display: flex; gap: 9px; font-size: 13px; color: var(--c-text-secondary); line-height: 1.5; }
+  .fstep { flex-shrink: 0; font-size: 10.5px; font-weight: 700; letter-spacing: .03em; text-transform: uppercase; color: var(--muted-foreground); background: var(--c-surface-raised); border: 1px solid var(--c-border-light); border-radius: 999px; padding: 1px 8px; height: 19px; display: inline-flex; align-items: center; margin-top: 1px; }
+
+  /* curate result */
+  .curate-note { font-size: 13px; color: var(--c-text-secondary); line-height: 1.55; background: var(--c-surface-raised); border: 1px solid var(--c-border-light); border-radius: var(--radius-md); padding: 10px 13px; }
+  .curate-note .mono { color: var(--c-text); }
+
+  /* ── Knowledge rail ── */
+  .rail-panel { position: sticky; top: 24px; }
+  .fh { padding: 16px 18px; border-bottom: 1px solid var(--c-border-light); }
+  .ft { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 600; }
+  .fs { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+  .fb { padding: 16px 18px; font-size: 13px; line-height: 1.6; }
+  .lb-h { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted-foreground); margin: 16px 0 6px; }
+  .lb-h:first-child { margin-top: 0; }
+  .fb ul { margin: 0; padding-left: 18px; color: var(--c-text-secondary); }
+  .fb li { margin-bottom: 6px; }
+  .fb li.done::marker { content: "✓  "; color: var(--c-success); }
+  .fb code { font-family: "IBM Plex Mono", monospace; font-size: 12px; background: var(--c-surface-raised); padding: 1px 4px; border-radius: 3px; }
+  .rev-tag { color: var(--c-template); font-weight: 500; }
+  .ff { padding: 12px 18px; border-top: 1px solid var(--c-border-light); font-size: 11.5px; color: var(--muted-foreground); line-height: 1.5; }
+
+  .callout { margin-top: 20px; border: 1px solid var(--c-border-light); background: var(--c-info-light); border-radius: var(--radius-md); padding: 10px 14px; font-size: 12.5px; color: var(--muted-foreground); }
+  .proto-note { position: fixed; bottom: 14px; right: 16px; z-index: 50; background: var(--c-template-light); color: var(--c-template); border: 1px solid #ddd0f7; font-size: 11px; padding: 5px 11px; border-radius: 999px; font-weight: 600; letter-spacing: .03em; }
+</style>
+</head>
+<body>
+<div class="app">
+  <nav class="rail">
+    <div class="rail-item rail-logo" title="Platform">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/></svg>
+    </div>
+    <div class="rail-item" title="Home">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/></svg>
+    </div>
+    <div class="rail-item active" title="Loops">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 3h6"/><path d="M10 3v6l-5 9a2 2 0 0 0 1.8 3h10.4a2 2 0 0 0 1.8-3l-5-9V3"/><path d="M7.5 15h9"/></svg>
+    </div>
+    <div class="rail-spacer"></div>
+    <div class="rail-item" title="Settings">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19.4 13.5a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 4.2 7.3l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V9a1.6 1.6 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/></svg>
+    </div>
+  </nav>
+
+  <main class="main">
+    <div class="container">
+      <a class="backlink" href="#">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 5l-7 7 7 7"/></svg>
+        Loops
+      </a>
+
+      <!-- Header -->
+      <div class="head-row">
+        <div>
+          <h1 class="title">Todo Web Application</h1>
+          <p class="goal">
+            Build a small todo app in <span class="mono">tomkis/todo-app</span>: a REST API plus a minimal web UI to add,
+            list, complete, and delete todos, persisted in SQLite. Keep it simple.
+          </p>
+          <div class="meta-row">
+            <span class="badge badge-info"><span class="bdot pulse"></span>Running</span>
+            <span class="dot-sep">·</span>
+            <span>Generation 3 of 6</span>
+            <span class="dot-sep">·</span>
+            <span>Stops when <strong style="color:var(--c-text)">Eval passes</strong>, or generation cap 6</span>
+          </div>
+        </div>
+        <div style="display:flex;gap:8px;flex-shrink:0">
+          <button class="btn btn-outline btn-sm">Pause</button>
+          <button class="btn btn-outline btn-sm">Refresh</button>
+        </div>
+      </div>
+
+      <!-- Config strip -->
+      <div class="config">
+        <span class="cfg"><strong>Depth</strong> · one candidate per generation</span>
+        <span class="dot-sep">·</span>
+        <span class="cfg">Population <strong>1</strong></span>
+      </div>
+
+      <!-- Metrics -->
+      <div class="metrics">
+        <div class="card metric">
+          <div class="label">Generations</div>
+          <div class="value">3<small> / 6</small></div>
+          <div class="sub">one candidate each</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Best score</div>
+          <div class="value mono">0.72 <span class="up">▲ .12</span></div>
+          <div class="sub">up from 0.60 last gen</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Candidates</div>
+          <div class="value mono">3</div>
+          <div class="sub">evaluated so far</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Cost</div>
+          <div class="value mono">$6.20</div>
+          <div class="sub">2.8M tokens</div>
+        </div>
+      </div>
+
+      <div class="layout">
+        <!-- Generations column -->
+        <div>
+          <p class="section-label">Generations</p>
+
+          <!-- GENERATION 3 (current) -->
+          <details class="card gen" open>
+            <summary class="gen-head">
+              <span class="gen-num">Generation 3</span>
+              <span class="badge badge-info"><span class="bdot pulse"></span>Running</span>
+              <span class="spacer"></span>
+              <span class="gmeta mono">PR #3 · continue · 0.72 · $2.10</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">M</span><span class="stage-name">Make</span></div>
+                <div class="stage-desc">Opened PR #3 — complete &amp; delete endpoints.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">T</span><span class="stage-name">Test</span></div>
+                <div class="stage-desc">Added 6 tests, ran the suite.</div>
+                <div class="stage-status ss-done">Pass</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">E</span><span class="stage-name">Eval</span></div>
+                <div class="stage-desc">Reviewed the PR.</div>
+                <div class="stage-status ss-done">continue · 0.72</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-accent pulse">C</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Folding findings into Knowledge <span class="mono">r3</span>.</div>
+                <div class="stage-status ss-accent">Running</div>
+              </div>
+            </div>
+
+            <div class="gen-body">
+              <p class="sub-label">Candidate</p>
+              <div class="cand-solo">
+                <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>PR #3</a>
+                <span class="cand-slice">complete &amp; delete endpoints</span>
+                <span class="spacer"></span>
+                <span class="badge badge-success">Test passed</span>
+                <span class="badge badge-muted">continue</span>
+                <span class="score">0.72</span>
+              </div>
+              <p class="review-note"><strong>Eval:</strong> Endpoints are clean and isolated, tests cover the happy path. <span class="mono">DELETE</span> returns 200 for a missing id — should be a 404. Not blocking, but note it. App still lacks the web UI, so not done yet.</p>
+
+              <p class="sub-label mt">Findings reported this round</p>
+              <div class="findings">
+                <div class="finding"><span class="fstep">Make</span><span>Reused the SQLite store and Todo model from gen 1; no schema change needed.</span></div>
+                <div class="finding"><span class="fstep">Eval</span><span><span class="mono">DELETE /todos/:id</span> is missing a 404 path for unknown ids.</span></div>
+              </div>
+
+              <p class="sub-label mt">Curate</p>
+              <div class="curate-note">Marked complete &amp; delete as built and carried the 404 gap into Knowledge <span class="mono">r3</span> as an open gotcha for the next Make. <span class="ss-accent">Writing…</span></div>
+            </div>
+          </details>
+
+          <!-- GENERATION 2 -->
+          <details class="card gen">
+            <summary class="gen-head">
+              <span class="gen-num">Generation 2</span>
+              <span class="badge badge-muted"><span class="bdot"></span>Completed</span>
+              <span class="spacer"></span>
+              <span class="gmeta mono">PR #2 · continue · 0.60 · $2.00</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">M</span><span class="stage-name">Make</span></div>
+                <div class="stage-desc">Opened PR #2 — create &amp; list endpoints.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">T</span><span class="stage-name">Test</span></div>
+                <div class="stage-desc">Added 5 tests, ran the suite.</div>
+                <div class="stage-status ss-done">Pass</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">E</span><span class="stage-name">Eval</span></div>
+                <div class="stage-desc">Reviewed the PR.</div>
+                <div class="stage-status ss-done">continue · 0.60</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">C</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Wrote Knowledge <span class="mono">r2</span>.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+            </div>
+
+            <div class="gen-body">
+              <p class="sub-label">Candidate</p>
+              <div class="cand-solo">
+                <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>PR #2</a>
+                <span class="cand-slice">POST /todos and GET /todos</span>
+                <span class="spacer"></span>
+                <span class="badge badge-success">Test passed</span>
+                <span class="badge badge-muted">continue</span>
+                <span class="score">0.60</span>
+              </div>
+              <p class="review-note"><strong>Eval:</strong> Solid create and list endpoints on top of the gen 1 store. Validation is thin but acceptable for now. Still no way to complete or delete a todo, and no UI.</p>
+
+              <p class="sub-label mt">Findings reported this round</p>
+              <div class="findings">
+                <div class="finding"><span class="fstep">Make</span><span>Wired the endpoints straight onto the gen 1 store; kept the handler layer thin.</span></div>
+                <div class="finding"><span class="fstep">Test</span><span>Added a fixture that resets the SQLite file per test.</span></div>
+              </div>
+
+              <p class="sub-label mt">Curate</p>
+              <div class="curate-note">Added create &amp; list to what's built in Knowledge <span class="mono">r2</span>; flagged complete, delete, and the UI as still open.</div>
+            </div>
+          </details>
+
+          <!-- GENERATION 1 -->
+          <details class="card gen">
+            <summary class="gen-head">
+              <span class="gen-num">Generation 1</span>
+              <span class="badge badge-muted"><span class="bdot"></span>Completed</span>
+              <span class="spacer"></span>
+              <span class="gmeta mono">PR #1 · continue · 0.40 · $2.10</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">M</span><span class="stage-name">Make</span></div>
+                <div class="stage-desc">Opened PR #1 — data model &amp; storage. Started from main; Knowledge was empty.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">T</span><span class="stage-name">Test</span></div>
+                <div class="stage-desc">Added 4 tests, ran the suite.</div>
+                <div class="stage-status ss-done">Pass</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">E</span><span class="stage-name">Eval</span></div>
+                <div class="stage-desc">Reviewed the PR.</div>
+                <div class="stage-status ss-done">continue · 0.40</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">C</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Wrote Knowledge <span class="mono">r1</span> from scratch.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+            </div>
+
+            <div class="gen-body">
+              <p class="sub-label">Candidate</p>
+              <div class="cand-solo">
+                <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>PR #1</a>
+                <span class="cand-slice">Todo model + SQLite store</span>
+                <span class="spacer"></span>
+                <span class="badge badge-success">Test passed</span>
+                <span class="badge badge-muted">continue</span>
+                <span class="score">0.40</span>
+              </div>
+              <p class="review-note"><strong>Eval:</strong> Clean foundation. A Todo record and a small store with migrations, nicely isolated and testable. Nothing user-facing yet, as expected for a first slice.</p>
+
+              <p class="sub-label mt">Findings reported this round</p>
+              <div class="findings">
+                <div class="finding"><span class="fstep">Make</span><span>Chose SQLite via a thin repository so later endpoints don't touch SQL directly.</span></div>
+              </div>
+
+              <p class="sub-label mt">Curate</p>
+              <div class="curate-note">Created Knowledge <span class="mono">r1</span>: recorded the store choice and listed every remaining slice as not started.</div>
+            </div>
+          </details>
+        </div>
+
+        <!-- Knowledge rail -->
+        <aside>
+          <p class="section-label">Knowledge</p>
+          <div class="card rail-panel">
+            <div class="fh">
+              <div class="ft">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H20v15H6.5A2.5 2.5 0 0 0 4 20.5z"/><path d="M4 5.5V20"/></svg>
+                Knowledge
+              </div>
+              <div class="fs">Curated by Curate each generation · writing <span class="rev-tag mono">r3</span></div>
+            </div>
+            <div class="fb">
+              <div class="lb-h">What's built</div>
+              <ul>
+                <li class="done">Todo model + SQLite store <span class="rev-tag">gen 1</span></li>
+                <li class="done"><code>POST /todos</code>, <code>GET /todos</code> <span class="rev-tag">gen 2</span></li>
+                <li class="done">complete &amp; delete endpoints <span class="rev-tag">gen 3, in review</span></li>
+              </ul>
+
+              <div class="lb-h">What's left</div>
+              <ul>
+                <li>Minimal web UI: add, list, complete, delete</li>
+                <li>Wire the UI to the API</li>
+              </ul>
+
+              <div class="lb-h">Gotchas</div>
+              <ul>
+                <li><code>DELETE</code> returns 200 for unknown ids — add a 404. <span class="rev-tag">gen 3</span></li>
+                <li>Keep each slice isolated and unit-tested.</li>
+              </ul>
+            </div>
+            <div class="ff">
+              The next Make reads this as static data, no agent-to-agent call. Gen 3's Make read revision <span class="rev-tag mono">r2</span>.
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div class="callout">
+        This is the depth loop: population 1, one candidate per generation. Each generation is a fresh Make → Test → Eval → Curate over a single candidate, so Select is trivial (the one survivor carries forward). Turn population up and the same screen grows a ranked population per generation; the four-step core is unchanged.
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="proto-note">UX PROTOTYPE · MOCK DATA</div>
+</body>
+</html>

--- a/docs/prototypes/loops/loops-evolution-prototype.html
+++ b/docs/prototypes/loops/loops-evolution-prototype.html
@@ -1,0 +1,534 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Loops — evolution prototype</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500;600&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet" />
+<style>
+  /* ── Tokens copied from packages/ui/src/App.css (light theme) ── */
+  :root {
+    --c-bg: #fafaf9; --c-surface: #ffffff; --c-surface-raised: #f5f5f4;
+    --c-border-light: #dde1e6; --c-text: #121619; --c-text-secondary: #57534e; --c-text-muted: #a8a29e;
+    --c-accent: #1d6be1; --c-accent-hover: #1556b8; --c-accent-light: #eaf2fe;
+    --c-success: #24a148; --c-success-light: #defbe6; --c-warning: #ff832b; --c-warning-light: #fffbeb;
+    --c-danger: #dc2626; --c-danger-light: #fef2f2; --c-info: #000000; --c-info-light: #f2f4f8;
+    --c-template: #7c3aed; --c-template-light: #f5f3ff; --muted-foreground: #4d5358;
+    --radius: 8px; --radius-md: 6px; --radius-sm: 4px;
+  }
+  * { box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    margin: 0; font-family: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+    font-size: 15px; line-height: 1.55; color: var(--c-text); background: var(--c-bg);
+    -webkit-font-smoothing: antialiased;
+  }
+  .mono { font-family: "IBM Plex Mono", ui-monospace, monospace; font-variant-numeric: tabular-nums; }
+  a { color: inherit; text-decoration: none; }
+
+  /* ── App shell ── */
+  .app { display: flex; height: 100vh; overflow: hidden; }
+  .rail { width: 56px; flex-shrink: 0; background: var(--c-surface); border-right: 1px solid var(--c-border-light);
+    display: flex; flex-direction: column; align-items: center; padding: 12px 0; gap: 6px; }
+  .rail-item { width: 40px; height: 40px; border-radius: var(--radius); display: flex; align-items: center; justify-content: center; color: rgba(18,22,25,.8); cursor: pointer; }
+  .rail-item:hover { background: var(--c-info-light); }
+  .rail-item.active { background: var(--c-info-light); color: #000; }
+  .rail-logo { margin-bottom: 8px; }
+  .rail-spacer { flex: 1; }
+  .main { flex: 1; overflow-y: auto; }
+  .container { max-width: 1240px; margin: 0 auto; padding: 40px 40px 80px; }
+
+  /* ── Header ── */
+  .backlink { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--muted-foreground); margin-bottom: 20px; }
+  .backlink:hover { color: var(--c-text); }
+  .head-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; }
+  h1.title { font-size: 24px; font-weight: 600; letter-spacing: -.5px; margin: 0; }
+  .goal { margin: 10px 0 0; max-width: 720px; font-size: 14px; color: var(--c-text-secondary); line-height: 1.6; }
+  .meta-row { display: flex; align-items: center; gap: 12px; margin-top: 14px; font-size: 13px; color: var(--muted-foreground); }
+  .dot-sep { color: var(--c-text-muted); }
+
+  /* ── Badges ── */
+  .badge { display: inline-flex; align-items: center; gap: 6px; border-radius: 999px; padding: 2px 10px; font-size: 12px; letter-spacing: .34px; border: 1px solid transparent; white-space: nowrap; }
+  .badge .bdot { width: 7px; height: 7px; border-radius: 999px; background: currentColor; }
+  .badge-info { background: var(--c-info-light); color: #000; }
+  .badge-success { background: var(--c-success-light); color: #15803d; }
+  .badge-danger { background: var(--c-danger-light); color: var(--c-danger); }
+  .badge-muted { background: var(--c-info-light); color: var(--muted-foreground); }
+  .badge-warning { background: var(--c-warning-light); color: #b45309; }
+  .badge-accent { background: var(--c-accent-light); color: var(--c-accent-hover); }
+
+  /* ── Buttons ── */
+  .btn { display: inline-flex; align-items: center; gap: 7px; height: 36px; padding: 0 14px; border-radius: var(--radius-md); font-size: 13px; font-weight: 500; cursor: pointer; border: 1px solid transparent; font-family: inherit; }
+  .btn-primary { background: #000; color: #fff; }
+  .btn-outline { background: var(--c-surface); border-color: var(--c-border-light); color: var(--c-text); }
+  .btn-outline:hover { background: var(--c-info-light); }
+  .btn-sm { height: 32px; padding: 0 12px; font-size: 12.5px; }
+
+  /* ── Cards ── */
+  .card { background: var(--c-surface); border: 1px solid var(--c-border-light); border-radius: var(--radius); }
+
+  /* ── Config strip (population / synthesizer toggle) ── */
+  .config { display: flex; align-items: center; gap: 18px; margin-top: 18px; padding: 12px 16px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md); background: var(--c-surface); flex-wrap: wrap; }
+  .config .cfg { font-size: 13px; color: var(--muted-foreground); }
+  .config .cfg strong { color: var(--c-text); font-weight: 600; }
+  .config .grow { flex: 1; }
+  /* toggle switch */
+  .switch { display: inline-flex; align-items: center; gap: 10px; cursor: pointer; user-select: none; }
+  .switch input { position: absolute; opacity: 0; pointer-events: none; }
+  .switch-track { width: 38px; height: 22px; border-radius: 999px; background: var(--c-surface-raised); border: 1px solid var(--c-border-light); position: relative; transition: background .15s ease; }
+  .switch-thumb { position: absolute; top: 2px; left: 2px; width: 16px; height: 16px; border-radius: 999px; background: #fff; box-shadow: 0 1px 2px rgba(0,0,0,.2); transition: transform .15s ease; }
+  .switch input:checked + .switch-track { background: var(--c-accent); border-color: var(--c-accent); }
+  .switch input:checked + .switch-track .switch-thumb { transform: translateX(16px); }
+  .switch-label { font-size: 13px; font-weight: 600; }
+  .mode-hint { font-size: 12.5px; color: var(--muted-foreground); }
+  .mode-on { display: none; }
+  .syn-on .mode-on { display: inline; }
+  .syn-on .mode-off { display: none; }
+
+  /* ── Metrics ── */
+  .metrics { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin: 16px 0 8px; }
+  .metric { padding: 16px 18px; }
+  .metric .label { font-size: 11px; text-transform: uppercase; letter-spacing: .04em; color: var(--muted-foreground); font-weight: 500; }
+  .metric .value { font-size: 26px; font-weight: 600; letter-spacing: -.5px; margin-top: 6px; }
+  .metric .value small { font-size: 15px; font-weight: 500; color: var(--c-text-muted); letter-spacing: 0; }
+  .metric .value .up { font-size: 14px; color: var(--c-success); font-weight: 600; }
+  .metric .sub { font-size: 12px; color: var(--muted-foreground); margin-top: 3px; }
+
+  /* ── Two-column layout ── */
+  .layout { display: grid; grid-template-columns: 1fr 340px; gap: 28px; margin-top: 28px; align-items: start; }
+  .section-label { font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted-foreground); margin: 0 0 14px; }
+
+  /* ── Generation card ── */
+  .gen { margin-bottom: 14px; overflow: hidden; }
+  .gen-head { display: flex; align-items: center; gap: 12px; padding: 14px 18px; cursor: pointer; user-select: none; }
+  .gen-num { font-size: 15px; font-weight: 600; }
+  .gen-head .spacer { flex: 1; }
+  .gen-head .gmeta { font-size: 12.5px; color: var(--muted-foreground); }
+  .chev { color: var(--c-text-muted); transition: transform .15s ease; }
+  details[open] .chev { transform: rotate(90deg); }
+  summary { list-style: none; } summary::-webkit-details-marker { display: none; }
+
+  /* ── Fan-out pipeline ── */
+  .pipeline { display: flex; align-items: stretch; gap: 0; padding: 4px 18px 16px; }
+  .stage { flex: 1; display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid var(--c-border-light); border-radius: var(--radius-md); background: var(--c-surface); }
+  .stage.stacked { box-shadow: 4px 4px 0 -1px var(--c-surface), 4px 4px 0 0 var(--c-border-light); margin-right: 5px; }
+  .stage.join { border-color: var(--c-accent); background: var(--c-accent-light); }
+  .stage-top { display: flex; align-items: center; gap: 8px; }
+  .stage-icon { width: 22px; height: 22px; border-radius: 999px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: #fff; }
+  .si-done { background: var(--c-success); } .si-accent { background: var(--c-accent); } .si-pending { background: var(--c-surface); color: var(--c-text-muted); border: 1px dashed var(--c-border-light); }
+  .stage-name { font-size: 13px; font-weight: 600; }
+  .stage-desc { font-size: 12px; color: var(--muted-foreground); line-height: 1.45; }
+  .stage-status { font-size: 11px; font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+  .ss-done { color: var(--c-success); } .ss-accent { color: var(--c-accent); } .ss-muted { color: var(--c-text-muted); }
+  .count { margin-left: auto; font-size: 10px; font-weight: 600; background: var(--c-surface-raised); color: var(--muted-foreground); border-radius: 999px; padding: 1px 7px; }
+  .connector { align-self: center; width: 22px; flex-shrink: 0; display: flex; align-items: center; justify-content: center; color: var(--c-text-muted); }
+  .pulse { animation: pulse 1.4s ease-in-out infinite; }
+  @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: .35; } }
+
+  /* ── Generation body: population + select ── */
+  .gen-body { border-top: 1px solid var(--c-border-light); padding: 16px 18px; }
+  .sub-label { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .04em; color: var(--muted-foreground); margin: 0 0 8px; }
+  .pop { display: flex; flex-direction: column; gap: 6px; }
+  .cand-row { display: grid; grid-template-columns: 22px 1fr auto 58px 132px; gap: 12px; align-items: center;
+    padding: 9px 12px 9px 9px; border: 1px solid var(--c-border-light); border-left: 3px solid transparent; border-radius: var(--radius-md); background: var(--c-surface); }
+  .cand-rank { font-size: 12px; font-weight: 600; color: var(--c-text-muted); text-align: center; }
+  .cand-link { display: inline-flex; align-items: center; gap: 7px; color: var(--c-accent); font-size: 13px; }
+  .cand-link:hover { text-decoration: underline; }
+  .score { font-family: "IBM Plex Mono", monospace; font-variant-numeric: tabular-nums; font-size: 14px; font-weight: 600; text-align: right; }
+  .score.none { color: var(--c-text-muted); font-weight: 400; }
+  .carried-pill { display: none; align-items: center; gap: 5px; font-size: 11px; font-weight: 600; color: var(--c-accent-hover); background: var(--c-accent-light); border-radius: 999px; padding: 2px 9px; justify-self: end; }
+  .dropped-tag { font-size: 11px; color: var(--c-text-muted); justify-self: end; }
+  /* survivor highlight + carried pill, driven by mode */
+  .cand-row.surv-score { border-left-color: var(--c-accent); background: var(--c-accent-light); }
+  .cand-row.surv-score .carried-pill { display: inline-flex; }
+  .cand-row.surv-score .dropped-tag { display: none; }
+  .syn-on .cand-row.surv-score { border-left-color: transparent; background: var(--c-surface); }
+  .syn-on .cand-row .carried-pill { display: none; }
+  .syn-on .cand-row.surv-score .dropped-tag { display: inline; }
+  .syn-on .cand-row.surv-syn { border-left-color: var(--c-accent); background: var(--c-accent-light); }
+  .syn-on .cand-row.surv-syn .carried-pill { display: inline-flex; }
+  .syn-on .cand-row.surv-syn .dropped-tag { display: none; }
+
+  /* ── Select detail (mode-dependent) ── */
+  .select-wrap { margin-top: 16px; }
+  .block-off { display: block; } .block-on { display: none; }
+  .syn-on .block-off { display: none; } .syn-on .block-on { display: block; }
+  .select-det { border: 1px solid var(--c-border-light); border-radius: var(--radius-md); padding: 12px 14px; background: var(--c-surface-raised); }
+  .select-det.agent { background: var(--c-accent-light); border-color: #bcd6fb; }
+  .sd-head { display: flex; align-items: center; gap: 8px; font-size: 13px; font-weight: 600; }
+  .sd-body { font-size: 13px; color: var(--c-text-secondary); line-height: 1.55; margin-top: 8px; }
+  .sd-body .seed { color: var(--c-text); }
+  .sd-note { font-size: 11.5px; color: var(--c-text-muted); margin-top: 8px; }
+
+  /* ── Findings rail ── */
+  .rail-panel { position: sticky; top: 24px; }
+  .fh { padding: 16px 18px; border-bottom: 1px solid var(--c-border-light); }
+  .ft { display: flex; align-items: center; gap: 8px; font-size: 15px; font-weight: 600; }
+  .fs { font-size: 12px; color: var(--muted-foreground); margin-top: 4px; }
+  .fb { padding: 16px 18px; font-size: 13px; line-height: 1.6; }
+  .lb-h { font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: .05em; color: var(--muted-foreground); margin: 16px 0 6px; }
+  .lb-h:first-child { margin-top: 0; }
+  .fb p { margin: 0 0 8px; color: var(--c-text-secondary); }
+  .fb ul { margin: 0; padding-left: 18px; color: var(--c-text-secondary); }
+  .fb li { margin-bottom: 6px; }
+  .fb code { font-family: "IBM Plex Mono", monospace; font-size: 12px; background: var(--c-surface-raised); padding: 1px 4px; border-radius: 3px; }
+  .rev-tag { color: var(--c-template); font-weight: 500; }
+  .ff { padding: 12px 18px; border-top: 1px solid var(--c-border-light); font-size: 11.5px; color: var(--muted-foreground); line-height: 1.5; }
+
+  .callout { margin-top: 20px; border: 1px solid var(--c-border-light); background: var(--c-info-light); border-radius: var(--radius-md); padding: 10px 14px; font-size: 12.5px; color: var(--muted-foreground); }
+  .proto-note { position: fixed; bottom: 14px; right: 16px; z-index: 50; background: var(--c-template-light); color: var(--c-template); border: 1px solid #ddd0f7; font-size: 11px; padding: 5px 11px; border-radius: 999px; font-weight: 600; letter-spacing: .03em; }
+</style>
+</head>
+<body>
+<div class="app">
+  <nav class="rail">
+    <div class="rail-item rail-logo" title="Platform">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><rect x="3" y="3" width="8" height="8" rx="1.5"/><rect x="13" y="3" width="8" height="8" rx="1.5"/><rect x="3" y="13" width="8" height="8" rx="1.5"/><rect x="13" y="13" width="8" height="8" rx="1.5"/></svg>
+    </div>
+    <div class="rail-item" title="Home">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 10.5 12 3l9 7.5"/><path d="M5 9.5V20h14V9.5"/></svg>
+    </div>
+    <div class="rail-item active" title="Loops">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M9 3h6"/><path d="M10 3v6l-5 9a2 2 0 0 0 1.8 3h10.4a2 2 0 0 0 1.8-3l-5-9V3"/><path d="M7.5 15h9"/></svg>
+    </div>
+    <div class="rail-spacer"></div>
+    <div class="rail-item" title="Inbox">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M3 7l9 6 9-6"/><rect x="3" y="5" width="18" height="14" rx="2"/></svg>
+    </div>
+    <div class="rail-item" title="Settings">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="3"/><path d="M19.4 13.5a1.6 1.6 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.6 1.6 0 0 0-2.7 1.1V21a2 2 0 1 1-4 0v-.1a1.6 1.6 0 0 0-2.7-1.1l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.6 1.6 0 0 0-1.1-2.7H3a2 2 0 1 1 0-4h.1A1.6 1.6 0 0 0 4.2 7.3l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.6 1.6 0 0 0 1.8.3H9a1.6 1.6 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.6 1.6 0 0 0 2.7 1.1l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.6 1.6 0 0 0-.3 1.8V9a1.6 1.6 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.6 1.6 0 0 0-1.5 1z"/></svg>
+    </div>
+  </nav>
+
+  <main class="main">
+    <div class="container">
+      <a class="backlink" href="#">
+        <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 5l-7 7 7 7"/></svg>
+        Loops
+      </a>
+
+      <!-- Header -->
+      <div class="head-row">
+        <div>
+          <h1 class="title">Speed up&nbsp;<span class="mono">/search</span></h1>
+          <p class="goal">
+            Cut the p95 latency of the <span class="mono">/search</span> endpoint without breaking result correctness.
+            Each generation makes several candidates, keeps the ones that still pass, and evolves toward the fastest.
+          </p>
+          <div class="meta-row">
+            <span class="badge badge-info"><span class="bdot pulse"></span>Running</span>
+            <span class="dot-sep">·</span>
+            <span>Generation 2 of 6</span>
+            <span class="dot-sep">·</span>
+            <span>Stops when a candidate <strong style="color:var(--c-text)">passes the target</strong>, or generation cap 6</span>
+          </div>
+        </div>
+        <div style="display:flex;gap:8px;flex-shrink:0">
+          <button class="btn btn-outline btn-sm">Refresh</button>
+        </div>
+      </div>
+
+      <!-- Config: population + synthesizer toggle -->
+      <div class="config">
+        <span class="cfg">Population <strong>4</strong> per generation</span>
+        <span class="dot-sep">·</span>
+        <span class="cfg">Keep top <strong>2</strong></span>
+        <span class="grow"></span>
+        <label class="switch">
+          <input type="checkbox" id="synToggle" />
+          <span class="switch-track"><span class="switch-thumb"></span></span>
+          <span class="switch-label">Synthesizer</span>
+        </label>
+        <span class="mode-hint">
+          <span class="mode-off">off — selection is a blind top-k by score</span>
+          <span class="mode-on">on — an agent selects and recombines the population</span>
+        </span>
+      </div>
+
+      <!-- Metrics -->
+      <div class="metrics">
+        <div class="card metric">
+          <div class="label">Generations</div>
+          <div class="value">2<small> / 6</small></div>
+          <div class="sub">4 candidates each</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Best score</div>
+          <div class="value mono">0.81 <span class="up">▲ .19</span></div>
+          <div class="sub">up from 0.62 last gen</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Candidates</div>
+          <div class="value mono">8</div>
+          <div class="sub">evaluated so far</div>
+        </div>
+        <div class="card metric">
+          <div class="label">Cost</div>
+          <div class="value mono">$9.60</div>
+          <div class="sub">4.3M tokens</div>
+        </div>
+      </div>
+
+      <div class="layout">
+        <!-- Generations column -->
+        <div>
+          <p class="section-label">Generations</p>
+
+          <!-- GENERATION 2 (current) -->
+          <details class="card gen" open>
+            <summary class="gen-head">
+              <span class="gen-num">Generation 2</span>
+              <span class="badge badge-accent"><span class="bdot"></span>Selected</span>
+              <span class="spacer"></span>
+              <span class="gmeta mono">best 0.81 · $5.10</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <!-- Fan-out pipeline -->
+            <div class="pipeline">
+              <div class="stage stacked">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Make</span><span class="count">×4</span></div>
+                <div class="stage-desc">Fresh agents, seeded from gen 1 survivors.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage stacked">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Test</span><span class="count">×4</span></div>
+                <div class="stage-desc">Correctness gate per candidate.</div>
+                <div class="stage-status ss-done">3 pass</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage stacked">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Eval</span><span class="count">×4</span></div>
+                <div class="stage-desc">Scores each passing candidate.</div>
+                <div class="stage-status ss-done">Scored</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage join">
+                <div class="stage-top"><span class="stage-icon si-accent">⤵</span><span class="stage-name">Select</span></div>
+                <div class="stage-desc"><span class="mode-off">Top-k by score (conductor).</span><span class="mode-on">Synthesizer agent.</span></div>
+                <div class="stage-status ss-accent">Fan-in</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Distills the whole gen into findings.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+            </div>
+
+            <div class="gen-body">
+              <p class="sub-label">Population — 4 candidates, ranked by score</p>
+              <div class="pop">
+                <div class="cand-row surv-score surv-syn">
+                  <span class="cand-rank">1</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>e7d2a1c</a>
+                  <span class="badge badge-success">Passed</span>
+                  <span class="score">0.81</span>
+                  <span class="carried-pill">carried →</span><span class="dropped-tag">carried →</span>
+                </div>
+                <div class="cand-row surv-score">
+                  <span class="cand-rank">2</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>b3c9104</a>
+                  <span class="badge badge-success">Passed</span>
+                  <span class="score">0.74</span>
+                  <span class="carried-pill">carried →</span><span class="dropped-tag">dropped</span>
+                </div>
+                <div class="cand-row surv-syn">
+                  <span class="cand-rank">3</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>9f4e0b8</a>
+                  <span class="badge badge-success">Passed</span>
+                  <span class="score">0.69</span>
+                  <span class="carried-pill">carried →</span><span class="dropped-tag">dropped</span>
+                </div>
+                <div class="cand-row">
+                  <span class="cand-rank">—</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>2a8d7f3</a>
+                  <span class="badge badge-danger">Failed</span>
+                  <span class="score none">—</span>
+                  <span class="dropped-tag">test failed</span>
+                </div>
+              </div>
+
+              <div class="select-wrap">
+                <p class="sub-label">Select — carry 2 into generation 3</p>
+                <!-- Synthesizer OFF: deterministic -->
+                <div class="block-off">
+                  <div class="select-det">
+                    <div class="sd-head">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--muted-foreground)" stroke-width="1.8"><path d="M4 18h6M4 12h10M4 6h16"/></svg>
+                      Top-2 by score
+                    </div>
+                    <div class="sd-body">Kept <span class="mono">e7d2a1c</span> (0.81) and <span class="mono">b3c9104</span> (0.74), the two highest scores. Selection is a blind ranking; the conductor never reads the candidates.</div>
+                    <div class="sd-note">Deterministic and reproducible. Only as good as the score.</div>
+                  </div>
+                </div>
+                <!-- Synthesizer ON: agent -->
+                <div class="block-on">
+                  <div class="select-det agent">
+                    <div class="sd-head">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--c-accent)" stroke-width="1.8"><path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path d="M5 20a7 7 0 0 1 14 0"/></svg>
+                      Synthesizer · kept 2 of 4
+                    </div>
+                    <div class="sd-body">
+                      Kept <span class="mono">e7d2a1c</span> (0.81, the leader). Dropped <span class="mono">b3c9104</span> despite its higher score and kept <span class="mono">9f4e0b8</span> (0.69) instead: b3c9104 only tunes constants and is near its ceiling, while 9f4e0b8's inverted-index approach scores lower now but has far more headroom.
+                      <div style="margin-top:8px" class="seed"><strong>Seed for gen 3:</strong> combine e7d2a1c's query batching with 9f4e0b8's index structure.</div>
+                    </div>
+                    <div class="sd-note">Content-aware. Can override score, and recombines ideas across candidates. Costs a run, less reproducible.</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </details>
+
+          <!-- GENERATION 1 -->
+          <details class="card gen">
+            <summary class="gen-head">
+              <span class="gen-num">Generation 1</span>
+              <span class="badge badge-muted"><span class="bdot"></span>Completed</span>
+              <span class="spacer"></span>
+              <span class="gmeta mono">best 0.62 · $4.50</span>
+              <span class="chev"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 5l7 7-7 7"/></svg></span>
+            </summary>
+
+            <div class="pipeline">
+              <div class="stage stacked">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Make</span><span class="count">×4</span></div>
+                <div class="stage-desc">First population from the goal alone.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage stacked">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Test</span><span class="count">×4</span></div>
+                <div class="stage-desc">Correctness gate per candidate.</div>
+                <div class="stage-status ss-done">3 pass</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage stacked">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Eval</span><span class="count">×4</span></div>
+                <div class="stage-desc">Scores each passing candidate.</div>
+                <div class="stage-status ss-done">Scored</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage join">
+                <div class="stage-top"><span class="stage-icon si-accent">⤵</span><span class="stage-name">Select</span></div>
+                <div class="stage-desc"><span class="mode-off">Top-k by score (conductor).</span><span class="mode-on">Synthesizer agent.</span></div>
+                <div class="stage-status ss-accent">Fan-in</div>
+              </div>
+              <div class="connector">→</div>
+              <div class="stage">
+                <div class="stage-top"><span class="stage-icon si-done">✓</span><span class="stage-name">Curate</span></div>
+                <div class="stage-desc">Distills the whole gen into findings.</div>
+                <div class="stage-status ss-done">Done</div>
+              </div>
+            </div>
+
+            <div class="gen-body">
+              <p class="sub-label">Population — 4 candidates, ranked by score</p>
+              <div class="pop">
+                <div class="cand-row surv-score surv-syn">
+                  <span class="cand-rank">1</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>4b1c802</a>
+                  <span class="badge badge-success">Passed</span>
+                  <span class="score">0.62</span>
+                  <span class="carried-pill">carried →</span><span class="dropped-tag">carried →</span>
+                </div>
+                <div class="cand-row surv-score surv-syn">
+                  <span class="cand-rank">2</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>d90f312</a>
+                  <span class="badge badge-success">Passed</span>
+                  <span class="score">0.55</span>
+                  <span class="carried-pill">carried →</span><span class="dropped-tag">carried →</span>
+                </div>
+                <div class="cand-row">
+                  <span class="cand-rank">3</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>71ea4d6</a>
+                  <span class="badge badge-success">Passed</span>
+                  <span class="score">0.41</span>
+                  <span class="dropped-tag">dropped</span>
+                </div>
+                <div class="cand-row">
+                  <span class="cand-rank">—</span>
+                  <a class="cand-link mono" href="#"><svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 4h6v6"/><path d="M20 4l-9 9"/><path d="M18 14v5a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1V7a1 1 0 0 1 1-1h5"/></svg>c5b2091</a>
+                  <span class="badge badge-danger">Failed</span>
+                  <span class="score none">—</span>
+                  <span class="dropped-tag">test failed</span>
+                </div>
+              </div>
+
+              <div class="select-wrap">
+                <p class="sub-label">Select — carried 2 into generation 2</p>
+                <div class="block-off">
+                  <div class="select-det">
+                    <div class="sd-head">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--muted-foreground)" stroke-width="1.8"><path d="M4 18h6M4 12h10M4 6h16"/></svg>
+                      Top-2 by score
+                    </div>
+                    <div class="sd-body">Kept <span class="mono">4b1c802</span> (0.62) and <span class="mono">d90f312</span> (0.55).</div>
+                  </div>
+                </div>
+                <div class="block-on">
+                  <div class="select-det agent">
+                    <div class="sd-head">
+                      <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--c-accent)" stroke-width="1.8"><path d="M12 12a4 4 0 1 0 0-8 4 4 0 0 0 0 8z"/><path d="M5 20a7 7 0 0 1 14 0"/></svg>
+                      Synthesizer · kept 2 of 4
+                    </div>
+                    <div class="sd-body">Kept the top two, <span class="mono">4b1c802</span> and <span class="mono">d90f312</span>. Agreed with the score ranking this generation; nothing lower down looked worth rescuing yet.</div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </details>
+        </div>
+
+        <!-- Findings rail -->
+        <aside>
+          <p class="section-label">Findings</p>
+          <div class="card rail-panel">
+            <div class="fh">
+              <div class="ft">
+                <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 5.5A2.5 2.5 0 0 1 6.5 3H20v15H6.5A2.5 2.5 0 0 0 4 20.5z"/><path d="M4 5.5V20"/></svg>
+                Findings
+              </div>
+              <div class="fs">Curated across the whole population · updated gen 2</div>
+            </div>
+            <div class="fb">
+              <div class="lb-h">What's working</div>
+              <p>Query batching cuts round-trips and is the biggest win so far. Every high scorer uses it.</p>
+
+              <div class="lb-h">Promising but unproven</div>
+              <ul>
+                <li>An inverted index scores lower today but scales better as the corpus grows. <span class="rev-tag">gen 2</span></li>
+              </ul>
+
+              <div class="lb-h">Dead ends</div>
+              <ul>
+                <li>Aggressive result caching breaks correctness under concurrent writes. <span class="rev-tag">gen 1</span></li>
+                <li>Tuning constants alone plateaus around 0.75. <span class="rev-tag">gen 2</span></li>
+              </ul>
+            </div>
+            <div class="ff">
+              Maintained by an agent after each generation from the whole population. Every Make reads it as static data. Gen 2 read revision <span class="rev-tag mono">r2</span>.
+            </div>
+          </div>
+        </aside>
+      </div>
+
+      <div class="callout">
+        Breadth sits on the Learn to Design edge. Eval scores each candidate; <strong>Select</strong> is the fan-in. With the synthesizer off it's a blind top-k ranking the conductor runs on opaque scores. With it on, an agent selects and recombines. Either way the conductor never reads a candidate, and the four-step core is untouched.
+      </div>
+    </div>
+  </main>
+</div>
+
+<div class="proto-note">UX PROTOTYPE · MOCK DATA</div>
+
+<script>
+  document.getElementById('synToggle').addEventListener('change', function () {
+    document.body.classList.toggle('syn-on', this.checked);
+  });
+</script>
+</body>
+</html>


### PR DESCRIPTION
Companion to PRD #2784 (Campaign tracer slice).

Adds a short handoff doc for the platform-orchestrated DBTL loop work. Covers the vision in one paragraph, the load-bearing decisions that must not be silently reversed, the caveats, and the deferred work. Deliberately does not repeat the PRD.

Note: `docs/architecture/experiments.md` still states the platform never loops, which this work reverses. Flagged in the handoff as a follow-up for when this is ratified, not touched here.