### PR TITLE
feat(ui): inline tool-call approvals

### DIFF
--- a/packages/ui/src/modules/sessions/components/busy-indicator.tsx
+++ b/packages/ui/src/modules/sessions/components/busy-indicator.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+import { cn } from "@/lib/utils";
+
+import { WorkingDots } from "./working-dots.js";
+
+const BUSY_VERBS = [
+  "Bamboozling",
+  "Bamming",
+  "Cowabunga-ing",
+  "Gadzooksing",
+  "Gee whizzing",
+  "Gee willikering",
+  "Gollying",
+  "Great Scotting",
+  "Holy guacamoleing",
+  "Holy mackereling",
+  "Holy moleying",
+  "Hot diggitying",
+  "Jeepersing",
+  "Jiminy cricketing",
+  "Kablooeying",
+  "Kabooming",
+  "Kapowing",
+  "Kersplatting",
+  "Klonking",
+  "Leapin' lizarding",
+  "Powieing",
+  "Sakes aliving",
+  "Shazaming",
+  "Thwacking",
+  "Up-up-and-awaying",
+  "Vrooming",
+  "Whamming",
+  "Whiz-banging",
+  "Whomping",
+  "Zlonking",
+  "Zonking",
+  "Zwapping",
+];
+
+export function BusyIndicator({ className }: { className?: string }) {
+  const [verb, setVerb] = useState(
+    () => BUSY_VERBS[Math.floor(Math.random() * BUSY_VERBS.length)],
+  );
+  useEffect(() => {
+    const id = setInterval(() => {
+      setVerb(BUSY_VERBS[Math.floor(Math.random() * BUSY_VERBS.length)]);
+    }, 2500);
+    return () => clearInterval(id);
+  }, []);
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-2 text-[14px] font-normal text-muted-foreground",
+        className,
+      )}
+    >
+      <WorkingDots size="md" className="text-accent" />
+      {verb}…
+    </span>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/chat-input-area.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input-area.tsx
@@ -1,38 +1,47 @@
 import { useCallback } from "react";
 
 import { useStore } from "../../../store.js";
-import type { VerdictPart } from "../../../types.js";
+import type { Message, VerdictPart } from "../../../types.js";
+import { useHasPendingPermission } from "../hooks/use-pending-permissions.js";
 import { ChatInput, type ChatInputProps } from "./chat-input.js";
 import {
   PermissionPrompt,
   type PermissionVerdict,
 } from "./permission-prompt.js";
 
+function ownsToolCall(m: Message, toolCallId: string): boolean {
+  return m.parts.some((p) => p.kind === "tool" && p.toolCallId === toolCallId);
+}
+
 /** The slot below the thread: the blocking permission prompt while a
  *  tool-call approval is pending, the chat input otherwise. Resolved verdicts
  *  are appended to the transcript as message parts. */
 export function ChatInputArea(props: ChatInputProps) {
-  const hasPending = useStore((s) =>
-    s.sessionId
-      ? s.pendingPermissions.some((p) => p.sessionId === s.sessionId)
-      : false,
-  );
+  const hasPending = useHasPendingPermission();
   const setMessages = useStore((s) => s.setMessages);
 
-  // Anchor the verdict on the assistant message it interrupted, so it stays
-  // in place as the response continues streaming below it.
+  // Anchor the verdict on the assistant message owning the approved tool
+  // call, so it stays in place as the response continues streaming below it.
+  // Falls back to the last assistant message when no tool part matches (the
+  // harness may request permission before emitting the tool-call update).
   const appendVerdict = useCallback(
-    (verdict: PermissionVerdict) => {
+    (verdict: PermissionVerdict, toolCallId: string) => {
       setMessages((prev) => {
+        let anchor = -1;
         for (let i = prev.length - 1; i >= 0; i--) {
           const m = prev[i];
           if (m.role !== "assistant" || m.notice) continue;
-          const part: VerdictPart = { kind: "verdict", ...verdict };
-          return prev.map((x, j) =>
-            j === i ? { ...x, parts: [...x.parts, part] } : x,
-          );
+          if (anchor === -1) anchor = i;
+          if (ownsToolCall(m, toolCallId)) {
+            anchor = i;
+            break;
+          }
         }
-        return prev;
+        if (anchor === -1) return prev;
+        const part: VerdictPart = { kind: "verdict", ...verdict };
+        return prev.map((m, j) =>
+          j === anchor ? { ...m, parts: [...m.parts, part] } : m,
+        );
       });
     },
     [setMessages],

--- a/packages/ui/src/modules/sessions/components/chat-input-area.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input-area.tsx
@@ -1,0 +1,43 @@
+import { useCallback } from "react";
+
+import { useStore } from "../../../store.js";
+import type { VerdictPart } from "../../../types.js";
+import { ChatInput, type ChatInputProps } from "./chat-input.js";
+import {
+  PermissionPrompt,
+  type PermissionVerdict,
+} from "./permission-prompt.js";
+
+/** The slot below the thread: the blocking permission prompt while a
+ *  tool-call approval is pending, the chat input otherwise. Resolved verdicts
+ *  are appended to the transcript as message parts. */
+export function ChatInputArea(props: ChatInputProps) {
+  const hasPending = useStore((s) =>
+    s.sessionId
+      ? s.pendingPermissions.some((p) => p.sessionId === s.sessionId)
+      : false,
+  );
+  const setMessages = useStore((s) => s.setMessages);
+
+  // Anchor the verdict on the assistant message it interrupted, so it stays
+  // in place as the response continues streaming below it.
+  const appendVerdict = useCallback(
+    (verdict: PermissionVerdict) => {
+      setMessages((prev) => {
+        for (let i = prev.length - 1; i >= 0; i--) {
+          const m = prev[i];
+          if (m.role !== "assistant" || m.notice) continue;
+          const part: VerdictPart = { kind: "verdict", ...verdict };
+          return prev.map((x, j) =>
+            j === i ? { ...x, parts: [...x.parts, part] } : x,
+          );
+        }
+        return prev;
+      });
+    },
+    [setMessages],
+  );
+
+  if (hasPending) return <PermissionPrompt onResolved={appendVerdict} />;
+  return <ChatInput {...props} />;
+}

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -9,7 +9,6 @@ import {
   type KeyboardEvent,
   type RefObject,
   useCallback,
-  useEffect,
   useRef,
   useState,
 } from "react";
@@ -23,62 +22,8 @@ import { emitToast } from "../../../lib/toast.js";
 import type { Attachment } from "../../../types.js";
 import { MAX_UPLOAD_BYTES } from "../../files/api/queries.js";
 import { ChatColumn } from "./chat-column.js";
-import { WorkingDots } from "./working-dots.js";
 
 const IMAGE_MIME = ["image/png", "image/jpeg", "image/gif", "image/webp"];
-
-const BUSY_VERBS = [
-  "Bamboozling",
-  "Bamming",
-  "Cowabunga-ing",
-  "Gadzooksing",
-  "Gee whizzing",
-  "Gee willikering",
-  "Gollying",
-  "Great Scotting",
-  "Holy guacamoleing",
-  "Holy mackereling",
-  "Holy moleying",
-  "Hot diggitying",
-  "Jeepersing",
-  "Jiminy cricketing",
-  "Kablooeying",
-  "Kabooming",
-  "Kapowing",
-  "Kersplatting",
-  "Klonking",
-  "Leapin' lizarding",
-  "Powieing",
-  "Sakes aliving",
-  "Shazaming",
-  "Thwacking",
-  "Up-up-and-awaying",
-  "Vrooming",
-  "Whamming",
-  "Whiz-banging",
-  "Whomping",
-  "Zlonking",
-  "Zonking",
-  "Zwapping",
-];
-
-function BusyIndicator() {
-  const [verb, setVerb] = useState(
-    () => BUSY_VERBS[Math.floor(Math.random() * BUSY_VERBS.length)],
-  );
-  useEffect(() => {
-    const id = setInterval(() => {
-      setVerb(BUSY_VERBS[Math.floor(Math.random() * BUSY_VERBS.length)]);
-    }, 2500);
-    return () => clearInterval(id);
-  }, []);
-  return (
-    <span className="inline-flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground">
-      <WorkingDots />
-      {verb}…
-    </span>
-  );
-}
 
 export interface ChatInputProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>;
@@ -286,11 +231,6 @@ export function ChatInput({
             )}
           </div>
         </div>
-        {isComputing && (
-          <div className="flex items-center gap-3">
-            <BusyIndicator />
-          </div>
-        )}
       </ChatColumn>
     </div>
   );

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -80,7 +80,7 @@ function BusyIndicator() {
   );
 }
 
-interface ChatInputProps {
+export interface ChatInputProps {
   textareaRef: RefObject<HTMLTextAreaElement | null>;
   busy: boolean;
   loadingSession: boolean;

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -196,7 +196,7 @@ export function ChatInput({
             </Button>
             <Textarea
               ref={textareaRef}
-              className="flex-1 bg-transparent border-0 px-2 py-[17px] text-[14px] leading-[22px] text-foreground resize-none min-h-0 max-h-[50vh] overflow-hidden placeholder:text-muted-foreground disabled:opacity-40 focus-visible:ring-0 focus-visible:ring-offset-0"
+              className="flex-1 bg-transparent border-0 pl-0 pr-2 py-[17px] text-[14px] leading-[22px] text-foreground resize-none min-h-0 max-h-[50vh] overflow-hidden placeholder:text-muted-foreground disabled:opacity-40 focus-visible:ring-0 focus-visible:ring-offset-0"
               value={input}
               onChange={(e) => setInput(e.target.value)}
               onKeyDown={onKeyDown}

--- a/packages/ui/src/modules/sessions/components/configuration-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/configuration-panel.tsx
@@ -2,6 +2,7 @@ import type { AgentState } from "../../../types.js";
 import { SchedulesPanel } from "../../schedules/components/schedules-panel.js";
 import { ChannelsPanel } from "./channels-panel.js";
 import { Section } from "./config-section.js";
+import { ModelSettingsPanel } from "./model-settings-panel.js";
 import { SkillsPanel } from "./skills-panel.js";
 
 export function ConfigurationPanel({
@@ -18,6 +19,8 @@ export function ConfigurationPanel({
 }) {
   return (
     <div className="flex flex-1 flex-col overflow-y-auto">
+      <ModelSettingsPanel agentId={agentId} />
+
       <Section title="Schedules">
         <SchedulesPanel onResumeSession={onResumeSession} />
       </Section>

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -159,9 +159,11 @@ export function PermissionPrompt({
     <div className="px-4 md:px-8 pt-3 pb-4">
       <ChatColumn className="flex flex-col gap-2">
         <div className="rounded-xl border border-border-light bg-muted/30 px-4 py-3.5 flex flex-col gap-3">
-          <div className="flex items-center gap-2 text-[14px] font-semibold text-text break-all">
-            <span className="h-2 w-2 rounded-full bg-accent shrink-0" />
-            Allow {title}?
+          <div className="flex items-start gap-2 text-[14px] font-semibold text-text">
+            <span className="h-2 w-2 rounded-full bg-accent shrink-0 mt-1.5" />
+            <span className="line-clamp-6 break-all min-w-0" title={title}>
+              Allow {title}?
+            </span>
           </div>
           {location && (
             <div className="pl-4 text-[14px] text-muted-foreground break-all">

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -1,7 +1,8 @@
 import { Checkmark, Close } from "@carbon/icons-react";
-import { useCallback, useEffect } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 import type { PermissionOption } from "../../../store.js";
 import { useStore } from "../../../store.js";
@@ -113,6 +114,21 @@ export function PermissionPrompt({
     : [];
   const current = pending[0];
 
+  const titleRef = useRef<HTMLSpanElement>(null);
+  const [expanded, setExpanded] = useState(false);
+  const [clampable, setClampable] = useState(false);
+
+  useEffect(() => setExpanded(false), [current?.toolCallId]);
+
+  // Show the toggle only when the title actually overflows the clamp. Skip
+  // measuring while expanded (scrollHeight equals clientHeight then), so the
+  // "Show less" affordance doesn't vanish.
+  useEffect(() => {
+    if (expanded) return;
+    const el = titleRef.current;
+    setClampable(!!el && el.scrollHeight > el.clientHeight + 1);
+  }, [expanded, current?.toolCallId]);
+
   const pick = useCallback(
     (opt: PermissionOption) => {
       if (!current) return;
@@ -161,10 +177,22 @@ export function PermissionPrompt({
         <div className="rounded-xl border border-border-light bg-muted/30 px-4 py-3.5 flex flex-col gap-3">
           <div className="flex items-start gap-2 text-[14px] font-semibold text-text">
             <span className="h-2 w-2 rounded-full bg-accent shrink-0 mt-1.5" />
-            <span className="line-clamp-6 break-all min-w-0" title={title}>
+            <span
+              ref={titleRef}
+              className={cn("break-all min-w-0", !expanded && "line-clamp-3")}
+            >
               Allow {title}?
             </span>
           </div>
+          {(clampable || expanded) && (
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              className="self-start pl-4 text-[12px] text-muted-foreground hover:text-text transition-colors"
+            >
+              {expanded ? "Show less" : "Show more"}
+            </button>
+          )}
           {location && (
             <div className="pl-4 text-[14px] text-muted-foreground break-all">
               {location}

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -97,7 +97,7 @@ export function PermissionVerdictLine({ verdict }: { verdict: VerdictPart }) {
 export function PermissionPrompt({
   onResolved,
 }: {
-  onResolved?: (verdict: PermissionVerdict) => void;
+  onResolved?: (verdict: PermissionVerdict, toolCallId: string) => void;
 }) {
   // Only show requests tied to the session the user is currently viewing.
   // Other sessions may have pending permissions buffered on the runtime and
@@ -132,11 +132,14 @@ export function PermissionPrompt({
   const pick = useCallback(
     (opt: PermissionOption) => {
       if (!current) return;
-      onResolved?.({
-        label: verdictLabel(opt),
-        subject: toolTitle(current.toolCall),
-        allowed: opt.kind?.startsWith("allow") ?? false,
-      });
+      onResolved?.(
+        {
+          label: verdictLabel(opt),
+          subject: toolTitle(current.toolCall),
+          allowed: opt.kind?.startsWith("allow") ?? false,
+        },
+        current.toolCallId,
+      );
       resolve(current.toolCallId, {
         outcome: { outcome: "selected", optionId: opt.optionId },
       });

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -1,10 +1,14 @@
-import { useEffect } from "react";
+import { Checkmark, Close } from "@carbon/icons-react";
+import { useCallback, useEffect } from "react";
 
 import { Button } from "@/components/ui/button";
 
 import type { PermissionOption } from "../../../store.js";
 import { useStore } from "../../../store.js";
+import type { VerdictPart } from "../../../types.js";
 import { ChatColumn } from "./chat-column.js";
+
+export type PermissionVerdict = Omit<VerdictPart, "kind">;
 
 function toolTitle(toolCall: unknown): string {
   if (toolCall && typeof toolCall === "object") {
@@ -18,14 +22,67 @@ function toolTitle(toolCall: unknown): string {
   return "this tool call";
 }
 
-function optionAccent(kind?: string): string {
-  if (kind === "allow_always" || kind === "allow_once") {
-    return "hover:border-primary hover:text-primary";
+function toolLocation(toolCall: unknown): string | null {
+  if (toolCall && typeof toolCall === "object") {
+    const tc = toolCall as { locations?: { path?: string }[] };
+    return tc.locations?.[0]?.path ?? null;
   }
-  if (kind === "reject_always" || kind === "reject_once") {
-    return "hover:border-destructive hover:text-destructive";
+  return null;
+}
+
+function verdictLabel(opt: PermissionOption): string {
+  switch (opt.kind) {
+    case "allow_once":
+      return "Allowed once";
+    case "allow_always":
+      return "Always allowed";
+    case "reject_once":
+      return "Denied";
+    case "reject_always":
+      return "Always denied";
+    default:
+      return opt.name;
   }
-  return "hover:border-primary hover:text-primary";
+}
+
+/** Transcript-side note for a pending approval — rendered at the end of the
+ *  agent response while the blocking prompt occupies the input slot. Renders
+ *  nothing when the viewed session has no pending request. */
+export function PermissionStatusLine() {
+  const sessionId = useStore((s) => s.sessionId);
+  const pendingPermissions = useStore((s) => s.pendingPermissions);
+  const current = sessionId
+    ? pendingPermissions.find((p) => p.sessionId === sessionId)
+    : undefined;
+  if (!current) return null;
+  return (
+    <div className="flex items-center gap-2 rounded-lg border border-border-light bg-muted/30 px-4 min-h-[44px] text-[14px] anim-in">
+      <span className="h-2 w-2 rounded-full bg-accent shrink-0" />
+      <span className="text-muted-foreground shrink-0">
+        Awaiting approval —
+      </span>
+      <span className="font-semibold text-text truncate">
+        Allow {toolTitle(current.toolCall)}
+      </span>
+    </div>
+  );
+}
+
+/** A resolved verdict, rendered in the transcript where the user decided it. */
+export function PermissionVerdictLine({ verdict }: { verdict: VerdictPart }) {
+  return (
+    <div className="flex w-full items-center gap-2 rounded-lg bg-muted px-4 min-h-[44px] text-[14px] anim-in">
+      {verdict.allowed ? (
+        <Checkmark size={16} className="text-success shrink-0" />
+      ) : (
+        <Close size={16} className="text-destructive shrink-0" />
+      )}
+      <span className="text-muted-foreground shrink-0">{verdict.label} —</span>
+      <span className="font-semibold text-text truncate">
+        {verdict.subject}
+      </span>
+    </div>
+  );
 }
 
 /**
@@ -36,7 +93,11 @@ function optionAccent(kind?: string): string {
  * prompt on the next attach. Only clicking an option (or pressing its number)
  * sends a response to the agent.
  */
-export function PermissionPrompt() {
+export function PermissionPrompt({
+  onResolved,
+}: {
+  onResolved?: (verdict: PermissionVerdict) => void;
+}) {
   // Only show requests tied to the session the user is currently viewing.
   // Other sessions may have pending permissions buffered on the runtime and
   // replayed into this global list; those belong to their own chat views.
@@ -51,6 +112,21 @@ export function PermissionPrompt() {
     ? pendingPermissions.filter((p) => p.sessionId === sessionId)
     : [];
   const current = pending[0];
+
+  const pick = useCallback(
+    (opt: PermissionOption) => {
+      if (!current) return;
+      onResolved?.({
+        label: verdictLabel(opt),
+        subject: toolTitle(current.toolCall),
+        allowed: opt.kind?.startsWith("allow") ?? false,
+      });
+      resolve(current.toolCallId, {
+        outcome: { outcome: "selected", optionId: opt.optionId },
+      });
+    },
+    [current, resolve, onResolved],
+  );
 
   useEffect(() => {
     if (!current) return;
@@ -68,50 +144,51 @@ export function PermissionPrompt() {
       if (Number.isNaN(num)) return;
       if (num < 1 || num > current.options.length) return;
       e.preventDefault();
-      const opt = current.options[num - 1];
-      resolve(current.toolCallId, {
-        outcome: { outcome: "selected", optionId: opt.optionId },
-      });
+      pick(current.options[num - 1]);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [current, resolve]);
+  }, [current, pick]);
 
   if (!current) return null;
 
-  const pick = (opt: PermissionOption) =>
-    resolve(current.toolCallId, {
-      outcome: { outcome: "selected", optionId: opt.optionId },
-    });
+  const title = toolTitle(current.toolCall);
+  const location = toolLocation(current.toolCall);
 
   return (
-    <div className="border-t bg-card/50 backdrop-blur-xl px-4 md:px-8 py-3">
-      <ChatColumn className="rounded-lg border-2 border-primary bg-background p-3.5 flex flex-col gap-2 shadow-sm">
-        <div className="text-[14px] font-bold text-foreground break-all">
-          Allow{" "}
-          <span className="text-primary">{toolTitle(current.toolCall)}</span>?
-        </div>
-        <div className="flex flex-col gap-1.5">
-          {current.options.map((opt, i) => (
-            <Button
-              key={opt.optionId}
-              variant="outline"
-              onClick={() => pick(opt)}
-              className={`h-auto items-start justify-start gap-3 whitespace-normal rounded-md border-2 border-border bg-card px-3 py-2 text-left text-[13px] text-foreground ${optionAccent(opt.kind)}`}
-            >
-              <span className="text-muted-foreground font-mono text-[11px] w-4 shrink-0">
-                {i + 1}
-              </span>
-              <span className="min-w-0 flex-1 break-words">{opt.name}</span>
-            </Button>
-          ))}
-        </div>
-        {pending.length > 1 && (
-          <div className="text-[11px] text-muted-foreground">
-            {pending.length - 1} more request
-            {pending.length - 1 === 1 ? "" : "s"} queued
+    <div className="px-4 md:px-8 pt-3 pb-4">
+      <ChatColumn className="flex flex-col gap-2">
+        <div className="rounded-xl border border-border-light bg-muted/30 px-4 py-3.5 flex flex-col gap-3">
+          <div className="flex items-center gap-2 text-[14px] font-semibold text-text break-all">
+            <span className="h-2 w-2 rounded-full bg-accent shrink-0" />
+            Allow {title}?
           </div>
-        )}
+          {location && (
+            <div className="pl-4 text-[14px] text-muted-foreground break-all">
+              {location}
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2">
+            {current.options.map((opt, i) => (
+              <Button
+                key={opt.optionId}
+                variant="outline"
+                size="sm"
+                onClick={() => pick(opt)}
+                className="bg-background h-[26px] text-[14px] font-medium max-w-full"
+                title={`${opt.name} — press ${i + 1}`}
+              >
+                <span className="truncate">{opt.name}</span>
+              </Button>
+            ))}
+          </div>
+          {pending.length > 1 && (
+            <div className="text-[11px] text-muted-foreground">
+              {pending.length - 1} more request
+              {pending.length - 1 === 1 ? "" : "s"} queued
+            </div>
+          )}
+        </div>
       </ChatColumn>
     </div>
   );

--- a/packages/ui/src/modules/sessions/components/tool-chip.tsx
+++ b/packages/ui/src/modules/sessions/components/tool-chip.tsx
@@ -19,7 +19,9 @@ export function ToolChip({ chip }: { chip: T }) {
       label={
         <>
           {running && <Loader size={12} className="anim-spin shrink-0" />}
-          <span className="truncate">{chip.title}</span>
+          <span className="truncate min-w-0" title={chip.title}>
+            {chip.title}
+          </span>
         </>
       }
       onToggle={hasContent ? () => setOpen((o) => !o) : undefined}

--- a/packages/ui/src/modules/sessions/hooks/use-pending-permissions.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-pending-permissions.ts
@@ -1,0 +1,10 @@
+import { useStore } from "../../../store.js";
+
+/** Whether the currently viewed session has a pending tool-call approval. */
+export function useHasPendingPermission(): boolean {
+  return useStore((s) =>
+    s.sessionId
+      ? s.pendingPermissions.some((p) => p.sessionId === s.sessionId)
+      : false,
+  );
+}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -49,6 +49,7 @@ import {
   optimisticInsertSession,
   setSessionRunning,
 } from "../api/queries.js";
+import { BusyIndicator } from "../components/busy-indicator.js";
 import { ChatColumn } from "../components/chat-column.js";
 import { ChatInputArea } from "../components/chat-input-area.js";
 import { ConfigurationPanel } from "../components/configuration-panel.js";
@@ -60,7 +61,6 @@ import { SessionsSidebar } from "../components/sessions-sidebar.js";
 import { Terminal } from "../components/terminal.js";
 import { ThoughtBlock } from "../components/thought-block.js";
 import { ToolChip } from "../components/tool-chip.js";
-import { WorkingDots } from "../components/working-dots.js";
 import type { ConnectionState } from "../hooks/use-acp-connection.js";
 import { useAcpSession } from "../hooks/use-acp-session.js";
 
@@ -652,20 +652,20 @@ export function ChatView() {
                                 ),
                               )}
                               {m.streaming &&
-                                m.parts.length === 0 &&
-                                (m.queued ? (
+                                m.queued &&
+                                m.parts.length === 0 && (
                                   <span className="text-[12px] text-text-muted italic">
                                     Waiting for previous prompt…
                                   </span>
-                                ) : (
-                                  <WorkingDots
-                                    size="md"
-                                    className="text-accent py-3"
-                                  />
-                                ))}
+                                )}
                               {m.role === "assistant" &&
                                 mi === messages.length - 1 && (
                                   <PermissionStatusLine />
+                                )}
+                              {m.streaming &&
+                                !m.queued &&
+                                !hasPendingPermission && (
+                                  <BusyIndicator className="py-1" />
                                 )}
                             </div>
                           )}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -1,8 +1,7 @@
-import { Settings } from "@carbon/icons-react";
+import { ArrowDown, Settings } from "@carbon/icons-react";
 import { SessionMode } from "api-server-api";
 import {
   AlertCircle,
-  ArrowDown,
   ArrowLeft,
   FileText as FileIcon,
   MoreVertical,
@@ -51,9 +50,12 @@ import {
   setSessionRunning,
 } from "../api/queries.js";
 import { ChatColumn } from "../components/chat-column.js";
-import { ChatInput } from "../components/chat-input.js";
+import { ChatInputArea } from "../components/chat-input-area.js";
 import { ConfigurationPanel } from "../components/configuration-panel.js";
-import { PermissionPrompt } from "../components/permission-prompt.js";
+import {
+  PermissionStatusLine,
+  PermissionVerdictLine,
+} from "../components/permission-prompt.js";
 import { SessionsSidebar } from "../components/sessions-sidebar.js";
 import { Terminal } from "../components/terminal.js";
 import { ThoughtBlock } from "../components/thought-block.js";
@@ -544,7 +546,7 @@ export function ChatView() {
                           </p>
                         </div>
                       )}
-                    {messages.map((m) =>
+                    {messages.map((m, mi) =>
                       m.notice ? (
                         <div key={m.id} className="flex justify-center anim-in">
                           <span className="text-[11px] italic text-text-muted px-3 py-1 border-t border-b border-border-light/60">
@@ -586,7 +588,7 @@ export function ChatView() {
                               className={
                                 m.role === "user"
                                   ? "flex flex-col gap-2 rounded-xl border border-border-light bg-surface px-4 py-3 text-[14px] text-text"
-                                  : "flex flex-col gap-4 max-w-full"
+                                  : "flex flex-col gap-4 w-full max-w-full"
                               }
                             >
                               {m.parts.map((p, i) =>
@@ -623,6 +625,8 @@ export function ChatView() {
                                     alt="image"
                                     className="max-w-[400px] max-h-[400px] rounded-lg border border-border-light object-contain"
                                   />
+                                ) : p.kind === "verdict" ? (
+                                  <PermissionVerdictLine key={i} verdict={p} />
                                 ) : p.kind === "file" ? (
                                   <div
                                     key={i}
@@ -659,6 +663,10 @@ export function ChatView() {
                                     className="text-accent py-3"
                                   />
                                 ))}
+                              {m.role === "assistant" &&
+                                mi === messages.length - 1 && (
+                                  <PermissionStatusLine />
+                                )}
                             </div>
                           )}
                         </div>
@@ -670,40 +678,38 @@ export function ChatView() {
                 {showJump && (
                   <button
                     onClick={scrollToBottom}
-                    className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 inline-flex items-center gap-1.5 rounded-full border border-border-light bg-surface-raised px-3 py-1.5 text-[12px] text-text-secondary shadow-md hover:text-accent hover:border-accent transition-colors"
+                    className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 inline-flex items-center gap-1.5 h-[35px] rounded-full border border-border-light bg-background px-3 text-[14px] font-normal text-text shadow-[0_1px_2px_rgba(0,0,0,0.08)] hover:bg-muted/30 transition-colors"
                   >
-                    <ArrowDown size={12} />
+                    <ArrowDown size={16} />
                     Jump to latest
                   </button>
                 )}
               </div>
 
-              {hasPendingPermission ? (
-                <PermissionPrompt />
-              ) : (
-                <ChatInput
+              <div className="pb-[16px]">
+                <ChatInputArea
                   textareaRef={textareaRef}
                   busy={busy}
                   loadingSession={loadingSession}
                   onSend={sendPrompt}
                   onStop={stopAgent}
                 />
-              )}
-              {harnessCurrent?.model && (
-                <div className="px-4 md:px-8 pb-[16px]">
-                  <ChatColumn>
-                    <button
-                      type="button"
-                      onClick={handleConfigureSandbox}
-                      title="Model — change in sandbox configuration"
-                      className="flex items-center gap-1 pl-3 text-[14px] text-muted-foreground hover:text-text transition-colors"
-                    >
-                      {harnessCurrent.model}
-                      <Settings size={12} />
-                    </button>
-                  </ChatColumn>
-                </div>
-              )}
+                {!hasPendingPermission && harnessCurrent?.model && (
+                  <div className="px-4 md:px-8">
+                    <ChatColumn>
+                      <button
+                        type="button"
+                        onClick={handleConfigureSandbox}
+                        title="Model — change in sandbox configuration"
+                        className="flex items-center gap-1 pl-3 text-[14px] text-muted-foreground hover:text-text transition-colors"
+                      >
+                        {harnessCurrent.model}
+                        <Settings size={12} />
+                      </button>
+                    </ChatColumn>
+                  </div>
+                )}
+              </div>
             </>
           )}
         </div>

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -63,6 +63,7 @@ import { ThoughtBlock } from "../components/thought-block.js";
 import { ToolChip } from "../components/tool-chip.js";
 import type { ConnectionState } from "../hooks/use-acp-connection.js";
 import { useAcpSession } from "../hooks/use-acp-session.js";
+import { useHasPendingPermission } from "../hooks/use-pending-permissions.js";
 
 export function ChatView() {
   const selectedAgent = useStore((s) => s.selectedAgent);
@@ -100,11 +101,7 @@ export function ChatView() {
   const setView = useStore((s) => s.setView);
   const filesSectionOpen = useStore((s) => s.filesSectionOpen);
   const setFilesSectionOpen = useStore((s) => s.setFilesSectionOpen);
-  const hasPendingPermission = useStore((s) =>
-    s.sessionId
-      ? s.pendingPermissions.some((p) => p.sessionId === s.sessionId)
-      : false,
-  );
+  const hasPendingPermission = useHasPendingPermission();
   const mobileScreen = useStore((s) => s.mobileScreen);
   const setMobileScreen = useStore((s) => s.setMobileScreen);
   const showMobilePanel = useStore((s) => s.showMobilePanel);
@@ -348,6 +345,13 @@ export function ChatView() {
         : agentDisplay?.state === "hibernated"
           ? "bg-zinc-400"
           : "bg-amber-500";
+
+  // The status line normally renders inside the last assistant message; when
+  // the transcript ends on something else (replay edge), fall back to a
+  // standalone trailing line so the blocked input always has its anchor.
+  const lastMessage = messages[messages.length - 1];
+  const statusLineInThread =
+    lastMessage?.role === "assistant" && !lastMessage.notice;
 
   // ── Layout ──
   return (
@@ -662,7 +666,8 @@ export function ChatView() {
                                 mi === messages.length - 1 && (
                                   <PermissionStatusLine />
                                 )}
-                              {m.streaming &&
+                              {m.role === "assistant" &&
+                                m.streaming &&
                                 !m.queued &&
                                 !hasPendingPermission && (
                                   <BusyIndicator className="py-1" />
@@ -672,6 +677,7 @@ export function ChatView() {
                         </div>
                       ),
                     )}
+                    {!statusLineInThread && <PermissionStatusLine />}
                   </ChatColumn>
                 </div>
 

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -48,12 +48,22 @@ export interface UploadedFilePart extends FilePart {
 
 export type Attachment = ImagePart | UploadedFilePart;
 
+/** Client-minted record of a tool-approval verdict, anchored where the user
+ *  decided it. Not part of the runtime log — it vanishes on session replay. */
+export interface VerdictPart {
+  kind: "verdict";
+  label: string;
+  subject: string;
+  allowed: boolean;
+}
+
 export type MessagePart =
   | TextPart
   | ThoughtPart
   | ImagePart
   | FilePart
-  | ToolChip;
+  | ToolChip
+  | VerdictPart;
 
 export interface Message {
   id: string;


### PR DESCRIPTION
Stacked on #2769. Fifth increment of #883 (sub-issue 05) — aligns the in-session tool-call approval flow with the design.

- While a tool-call approval is pending, the agent message ends with an **"Awaiting approval"** status line, and the approval card replaces the composer: the request title (clamped for long shell commands, full text on hover), its file location when known, and the options as buttons — number-key shortcuts and the queued-requests count preserved. The model row hides while blocked.
- Resolving leaves a **verdict bar anchored in the transcript** where the decision happened ("Allowed once — …" with ✓, denials with ✗); the composer returns immediately.
- The busy indicator (jumping dots + rotating verb) moved from the input bar to the end of the streaming agent message, where it stays for the whole turn.
- Rider: the model settings panel is restored to the right-panel Config tab so auto-approve can be toggled until the sandbox config page (#2124) lands.

Known limitation: verdict bars are client-side only — they don't survive a reload/session replay, since the runtime log has no verdict record. Can be a follow-up if wanted.

Part of #883.