### PR TITLE
ci: cut CI critical path and fix image-reuse hit-rate

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,8 +21,6 @@ concurrency:
 
 env:
   IMAGE_PREFIX: quay.io/dam-agents
-  # early opt-in, remove after 2026-06-16:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   check:
@@ -92,6 +90,7 @@ jobs:
       nous: ${{ steps.d.outputs.nous }}
       openevolve: ${{ steps.d.outputs.openevolve }}
       claude_code_base_tag: ${{ steps.d.outputs.claude_code_base_tag }}
+      source_shas: ${{ steps.d.outputs.source_shas }}
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -115,18 +114,18 @@ jobs:
           printf '::notice::%s\n' "$(printf '%s' "$out" | tr '\n' ' ')"
 
   build-images:
-    needs: [check]
-    runs-on: ${{ matrix.runner }}
+    # Deliberately not gated on `check`: builds run in parallel with it and
+    # push by digest only (no tags), so broken code never becomes referencable
+    # — merge-images, which creates the tags, requires `check`. PRs build
+    # amd64 only (changes.archs): PR sha tags feed nothing but the amd64 e2e.
+    needs: [changes]
+    runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
     strategy:
       matrix:
         component: [controller, api-server, ui, keycloak]
-        arch: [amd64, arm64]
+        arch: ${{ fromJSON(needs.changes.outputs.archs) }}
         include:
-          - arch: amd64
-            runner: ubuntu-latest
-          - arch: arm64
-            runner: ubuntu-24.04-arm
           - component: controller
             dockerfile: packages/controller/Dockerfile
             context: packages/controller
@@ -177,7 +176,7 @@ jobs:
 
   merge-images:
     name: merge multi-arch manifests
-    needs: [build-images, appversion]
+    needs: [build-images, appversion, check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -216,7 +215,9 @@ jobs:
             $(printf "$IMAGE@sha256:%s " *)
 
   build-platform-base:
-    needs: [check, changes]
+    # Not gated on `check` either — see build-images. merge-platform-base
+    # carries the gate for the whole agent-image chain.
+    needs: [changes]
     if: ${{ needs.changes.outputs.platform_base == 'true' }}
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
     timeout-minutes: 30
@@ -257,7 +258,7 @@ jobs:
 
   merge-platform-base:
     name: merge multi-arch platform-base manifest
-    needs: [build-platform-base, appversion, changes]
+    needs: [build-platform-base, appversion, changes, check]
     if: ${{ needs.changes.outputs.platform_base == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -277,12 +278,19 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_PREFIX }}/platform-base
+          # The source-sha tag (last commit touching the component's effective
+          # source) is the exact ref the build-vs-reuse resolver probes.
+          # github.sha-only tagging made reuse depend on that commit being a
+          # green push tip; this keeps reuse alive across multi-commit pushes
+          # and red main runs. PR runs don't tag it (untrusted-ish, and PRs
+          # only ever reuse what non-PR runs published).
           tags: |
             type=sha,prefix=,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=${{ needs.appversion.outputs.composite }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ fromJSON(needs.changes.outputs.source_shas)['platform-base'] }},enable=${{ github.event_name != 'pull_request' }}
       - name: Create manifest list and push
         env:
           IMAGE: ${{ env.IMAGE_PREFIX }}/platform-base
@@ -365,12 +373,14 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.component }}
+          # source-sha tag: see merge-platform-base.
           tags: |
             type=sha,prefix=,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=${{ needs.appversion.outputs.composite }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ fromJSON(needs.changes.outputs.source_shas)[matrix.component] }},enable=${{ github.event_name != 'pull_request' }}
       - name: Create manifest list and push
         env:
           IMAGE: ${{ env.IMAGE_PREFIX }}/${{ matrix.component }}
@@ -445,12 +455,14 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_PREFIX }}/nous
+          # source-sha tag: see merge-platform-base.
           tags: |
             type=sha,prefix=,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=${{ needs.appversion.outputs.composite }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ fromJSON(needs.changes.outputs.source_shas)['nous'] }},enable=${{ github.event_name != 'pull_request' }}
       - name: Create manifest list and push
         env:
           IMAGE: ${{ env.IMAGE_PREFIX }}/nous
@@ -525,12 +537,14 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_PREFIX }}/openevolve
+          # source-sha tag: see merge-platform-base.
           tags: |
             type=sha,prefix=,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=${{ needs.appversion.outputs.composite }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ fromJSON(needs.changes.outputs.source_shas)['openevolve'] }},enable=${{ github.event_name != 'pull_request' }}
       - name: Create manifest list and push
         env:
           IMAGE: ${{ env.IMAGE_PREFIX }}/openevolve

--- a/scripts/resolve-image.sh
+++ b/scripts/resolve-image.sh
@@ -16,7 +16,7 @@
 #   resolve-image.sh build-or-reuse <c> -- ...  -> pull+tag locally, or `docker build ... -t <local-tag>`
 #   resolve-image.sh gha-outputs                -> key=value lines for $GITHUB_OUTPUT (all components)
 #   resolve-image.sh paths <component>          -> effective source paths (debug)
-#   resolve-image.sh --self-check               -> run assertions (no docker/git/network)
+#   resolve-image.sh --self-check               -> run assertions (no docker/network; git optional)
 #
 # Env: IMAGE_PREFIX (default quay.io/dam-agents), GITHUB_SHA, EVENT (gha-outputs
 # archs), RESOLVE_NO_REUSE=1 forces BUILD everywhere (CI main/tag: publish all).
@@ -24,6 +24,11 @@
 set -euo pipefail
 
 IMAGE_PREFIX="${IMAGE_PREFIX:-quay.io/dam-agents}"
+
+# Test-only files never ship (final images copy dist/ + node_modules), so they
+# don't move the last-touching commit. Ceiling: a reused image may differ in
+# builder-stage test sources; runtime content is identical.
+TEST_EXCLUDES=':(exclude)*__tests__* :(exclude)*.test.ts :(exclude)*vitest.config.ts'
 
 # platform-base's build context is the repo root but it only COPYs these paths;
 # keep in sync with packages/platform-base/Dockerfile.
@@ -57,13 +62,17 @@ effective_paths() {
 
 registry_has() { docker manifest inspect "$1" >/dev/null 2>&1 || docker buildx imagetools inspect "$1" >/dev/null 2>&1; }
 
+# Last commit touching the component's effective source (tests excluded).
+# Empty when git/history is unavailable — callers pick their own fallback.
+source_sha() { git log -1 --format=%H -- $(effective_paths "$1") $TEST_EXCLUDES 2>/dev/null || true; }
+
 resolve() {
   local comp="$1" paths sha ref
   [ -n "${RESOLVE_NO_REUSE:-}" ] && { echo BUILD; return; }
   paths="$(effective_paths "$comp")"
   # Uncommitted change (or untracked file) in the effective source ⇒ must build.
-  [ -n "$(git status --porcelain -- $paths 2>/dev/null)" ] && { echo BUILD; return; }
-  sha="$(git log -1 --format=%H -- $paths 2>/dev/null || true)"
+  [ -n "$(git status --porcelain -- $paths $TEST_EXCLUDES 2>/dev/null)" ] && { echo BUILD; return; }
+  sha="$(source_sha "$comp")"
   [ -z "$sha" ] && { echo BUILD; return; }
   ref="${IMAGE_PREFIX}/${comp}:${sha}"
   if registry_has "$ref"; then echo "REUSE $ref"; else echo BUILD; fi
@@ -92,8 +101,14 @@ tag_for() {
 }
 
 gha_outputs() {
-  local archs pb pb_tag built a agents_json cc_tag nous oe
+  local archs pb pb_tag built a agents_json cc_tag nous oe s src
   archs='["amd64","arm64"]'; [ "${EVENT:-}" = pull_request ] && archs='["amd64"]'
+  # source_shas: per-component last-touching-source sha — non-PR runs tag their
+  # images with it so PR reuse hits even when that commit was never a green
+  # push tip. Falls back to GITHUB_SHA (a duplicate of the sha tag, harmless).
+  src="$(for a in platform-base claude-code codex pi-agent bob k-search nous openevolve; do
+    s="$(source_sha "$a")"; printf '%s=%s\n' "$a" "${s:-${GITHUB_SHA:-}}"
+  done | jq -cRn '[inputs | split("=") | {(.[0]): .[1]}] | add')"
   if [ "$(resolve platform-base | cut -d' ' -f1)" = REUSE ]; then pb=false; else pb=true; fi
   pb_tag="$(tag_for platform-base)"
   built=()
@@ -104,8 +119,8 @@ gha_outputs() {
   cc_tag="$(tag_for claude-code)"
   nous=false; [ "$(resolve nous | cut -d' ' -f1)" = BUILD ] && nous=true
   oe=false;   [ "$(resolve openevolve | cut -d' ' -f1)" = BUILD ] && oe=true
-  printf 'platform_base=%s\nplatform_base_tag=%s\nagents=%s\narchs=%s\nnous=%s\nopenevolve=%s\nclaude_code_base_tag=%s\n' \
-    "$pb" "$pb_tag" "$agents_json" "$archs" "$nous" "$oe" "$cc_tag"
+  printf 'platform_base=%s\nplatform_base_tag=%s\nagents=%s\narchs=%s\nnous=%s\nopenevolve=%s\nclaude_code_base_tag=%s\nsource_shas=%s\n' \
+    "$pb" "$pb_tag" "$agents_json" "$archs" "$nous" "$oe" "$cc_tag" "$src"
 }
 
 self_check() {
@@ -126,6 +141,7 @@ self_check() {
   has "$out" 'agents=["claude-code","codex","pi-agent","bob","k-search"]'
   has "$out" 'archs=["amd64","arm64"]'
   has "$out" 'claude_code_base_tag=deadbeef'
+  has "$out" 'source_shas={"platform-base":"'
   [ "$f" = 0 ] && echo "self-check OK" || exit 1
 }
 


### PR DESCRIPTION
- build images in parallel with `check`: builds push by digest only, so the tag-creating merge jobs can carry the check gate instead (~3-5 min saved)
- PRs build amd64 core images only; main/tag/schedule runs keep both arches
- resolver: exclude test files from image invalidation (they never ship in the final images) — a test-only PR no longer rebuilds all agent images
- non-PR runs additionally tag images with the last-touching-source sha, the exact ref the resolver probes, so PR reuse survives multi-commit pushes and red main runs
- drop expired FORCE_JAVASCRIPT_ACTIONS_TO_NODE24 opt-in