### PR TITLE
feat(ui): right-panel teardown and docked file panel

### DIFF
--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -170,7 +170,7 @@ function IconWithBadge({
       {badge > 0 && (
         <Badge
           variant="default"
-          className="absolute -top-1.5 -right-1.5 min-w-[16px] h-[16px] px-1 rounded-full text-[10px] font-bold flex items-center justify-center border-0"
+          className="absolute -top-1.5 -right-1.5 min-w-[16px] h-[16px] px-1 rounded-full text-[10px] font-bold flex items-center justify-center border-0 bg-accent text-white hover:bg-accent"
         >
           {badge > 9 ? "9+" : badge}
         </Badge>

--- a/packages/ui/src/components/truncate-start.tsx
+++ b/packages/ui/src/components/truncate-start.tsx
@@ -22,9 +22,10 @@ export function TruncateStart({
       title={title}
       className={cn("truncate text-left", className)}
     >
-      {"\u200E"}
+      {/* select-none keeps the invisible marks out of copied selections. */}
+      <span className="select-none">{"\u200E"}</span>
       {children}
-      {"\u200E"}
+      <span className="select-none">{"\u200E"}</span>
     </span>
   );
 }

--- a/packages/ui/src/components/truncate-start.tsx
+++ b/packages/ui/src/components/truncate-start.tsx
@@ -1,0 +1,30 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+/** Truncates overflowing text at the start (ellipsis on the left) so the tail
+ *  stays visible — e.g. file paths where the filename matters most. Built on
+ *  the dir=rtl layout trick; the invisible U+200E (LRM) guards stop
+ *  bidi-neutral edge characters (leading dots, bullets) from being reordered
+ *  to the wrong side. */
+export function TruncateStart({
+  className,
+  title,
+  children,
+}: {
+  className?: string;
+  title?: string;
+  children: ReactNode;
+}) {
+  return (
+    <span
+      dir="rtl"
+      title={title}
+      className={cn("truncate text-left", className)}
+    >
+      {"\u200E"}
+      {children}
+      {"\u200E"}
+    </span>
+  );
+}

--- a/packages/ui/src/modules/agents/store.ts
+++ b/packages/ui/src/modules/agents/store.ts
@@ -88,7 +88,6 @@ export const createAgentsSlice: StateCreator<
       selectedAgent: id,
       view: "chat",
       mobileScreen: "sessions",
-      showMobilePanel: false,
     });
   },
 
@@ -99,7 +98,6 @@ export const createAgentsSlice: StateCreator<
       selectedAgent: agentId,
       view: "chat",
       mobileScreen: "chat",
-      showMobilePanel: false,
       pendingResumeSessionId: sessionId,
     });
   },
@@ -107,7 +105,7 @@ export const createAgentsSlice: StateCreator<
   goBack: () => {
     history.pushState(null, "", "/");
     get().resetChatContext();
-    set({ selectedAgent: null, view: "list", showMobilePanel: false });
+    set({ selectedAgent: null, view: "list" });
   },
 });
 

--- a/packages/ui/src/modules/approvals/components/egress-approval-toasts.tsx
+++ b/packages/ui/src/modules/approvals/components/egress-approval-toasts.tsx
@@ -86,7 +86,7 @@ export function EgressApprovalToasts({ agentId }: { agentId: string | null }) {
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget)) setExpanded(false);
       }}
-      className="absolute top-4 max-md:top-[78px] right-4 z-40 w-[400px] max-w-[calc(100vw-32px)]"
+      className="absolute top-4 max-md:top-[78px] right-4 z-40 max-md:z-[60] w-[400px] max-w-[calc(100vw-32px)]"
     >
       {visible.map((row, i) => {
         const rear = i > 0 && !expanded;

--- a/packages/ui/src/modules/files/components/docked-file-panel.tsx
+++ b/packages/ui/src/modules/files/components/docked-file-panel.tsx
@@ -1,17 +1,18 @@
+import { TRPCClientError } from "@trpc/client";
 import { useCallback, useEffect } from "react";
 
 import { useStore } from "../../../store.js";
 import { useFileContentQuery } from "../api/queries.js";
 import { FileViewer } from "./file-viewer.js";
 
+interface Props {
+  onOpenFile: (path: string) => void;
+}
+
 /** Body of the on-demand right file panel: resolves `openFilePath` to content
  *  and hosts the viewer. Closes silently when the file disappears
  *  (rename/delete/git switch); guards a dirty draft on explicit close. */
-export function DockedFilePanel({
-  onOpenFile,
-}: {
-  onOpenFile: (path: string) => void;
-}) {
+export function DockedFilePanel({ onOpenFile }: Props) {
   const selectedAgent = useStore((s) => s.selectedAgent);
   const openFilePath = useStore((s) => s.openFilePath);
   const openFileDirty = useStore((s) => s.openFileDirty);
@@ -23,9 +24,14 @@ export function DockedFilePanel({
     openFilePath,
   );
 
+  // Auto-close only for genuinely gone files, and never over a dirty draft —
+  // the query polls with no retry, so transient errors also land here and
+  // must not discard unsaved edits.
   useEffect(() => {
-    if (error) setOpenFilePath(null);
-  }, [error, setOpenFilePath]);
+    const gone =
+      error instanceof TRPCClientError && error.data?.code === "NOT_FOUND";
+    if (gone && !openFileDirty) setOpenFilePath(null);
+  }, [error, openFileDirty, setOpenFilePath]);
 
   const close = useCallback(async () => {
     if (

--- a/packages/ui/src/modules/files/components/docked-file-panel.tsx
+++ b/packages/ui/src/modules/files/components/docked-file-panel.tsx
@@ -1,0 +1,48 @@
+import { useCallback, useEffect } from "react";
+
+import { useStore } from "../../../store.js";
+import { useFileContentQuery } from "../api/queries.js";
+import { FileViewer } from "./file-viewer.js";
+
+/** Body of the on-demand right file panel: resolves `openFilePath` to content
+ *  and hosts the viewer. Closes silently when the file disappears
+ *  (rename/delete/git switch); guards a dirty draft on explicit close. */
+export function DockedFilePanel({
+  onOpenFile,
+}: {
+  onOpenFile: (path: string) => void;
+}) {
+  const selectedAgent = useStore((s) => s.selectedAgent);
+  const openFilePath = useStore((s) => s.openFilePath);
+  const openFileDirty = useStore((s) => s.openFileDirty);
+  const setOpenFilePath = useStore((s) => s.setOpenFilePath);
+  const showConfirm = useStore((s) => s.showConfirm);
+
+  const { data: openFile, error } = useFileContentQuery(
+    selectedAgent,
+    openFilePath,
+  );
+
+  useEffect(() => {
+    if (error) setOpenFilePath(null);
+  }, [error, setOpenFilePath]);
+
+  const close = useCallback(async () => {
+    if (
+      openFileDirty &&
+      !(await showConfirm("Discard unsaved changes?", "Unsaved changes"))
+    )
+      return;
+    setOpenFilePath(null);
+  }, [openFileDirty, showConfirm, setOpenFilePath]);
+
+  if (!openFile) return null;
+  return (
+    <FileViewer
+      key={openFile.path}
+      file={openFile}
+      onClose={close}
+      onOpenFile={onOpenFile}
+    />
+  );
+}

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -21,6 +21,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
+import { useStore } from "../../../store.js";
 import { Caret } from "../../sessions/components/caret.js";
 import { useFileRowDrag } from "../hooks/use-file-row-drag.js";
 import {
@@ -57,6 +58,7 @@ export function FileRow({
 }: Props) {
   const panel = useFilesPanel();
   const isDir = type === "dir";
+  const isActive = useStore((s) => s.openFilePath) === path && !isDir;
   const targetDir = isDir ? path : parentDirOf(path);
   // Raise the row above its siblings while its menu is open (parity with the
   // previous coordinate menu); Radix portals the menu content itself.
@@ -79,7 +81,7 @@ export function FileRow({
     <ContextMenu onOpenChange={setMenuOpen}>
       <ContextMenuTrigger asChild>
         <div
-          className={`group relative flex items-center h-[32px] text-[14px] cursor-pointer transition-colors ${menuOpen ? "z-20" : ""} ${highlight ? "bg-accent-light ring-1 ring-accent ring-inset" : isDir ? "text-text-secondary font-medium hover:bg-surface-raised" : "text-text-secondary hover:bg-accent-light hover:text-accent"}`}
+          className={`group relative flex items-center h-[32px] text-[14px] cursor-pointer transition-colors ${menuOpen ? "z-20" : ""} ${highlight ? "bg-accent-light ring-1 ring-accent ring-inset" : `text-text-secondary hover:bg-muted ${isDir ? "font-medium" : ""} ${isActive ? "bg-muted" : ""}`}`}
           style={{ paddingLeft: `${12 + depth * 14}px`, paddingRight: 12 }}
           onClick={
             isDir ? () => panel.onToggleDir(path) : () => panel.onOpenFile(path)

--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -1,5 +1,4 @@
 import {
-  ArrowLeft,
   Close as X,
   Download,
   Edit as Pencil,
@@ -10,6 +9,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 
+import { TruncateStart } from "../../../components/truncate-start.js";
 import { useUnsavedGuard } from "../../../hooks/use-unsaved-guard.js";
 import { emitToast } from "../../../lib/toast.js";
 import { useStore } from "../../../store.js";
@@ -188,101 +188,105 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      <div className="flex items-center gap-2 px-3 h-9 border-b border-border shrink-0">
-        <Button
-          variant="ghost"
-          size="sm"
-          className="h-auto px-2 py-1 text-[12px] font-semibold text-muted-foreground hover:text-primary shrink-0"
-          onClick={onClose}
-        >
-          <ArrowLeft size={12} /> Back
-        </Button>
-        <span
-          className="text-[12px] font-mono text-foreground/80 truncate flex-1"
+      <div className="flex items-center gap-2 px-4 h-[48px] border-b border-border-light shrink-0">
+        <TruncateStart
+          className="text-[14px] font-medium text-text flex-1"
           title={path}
         >
           {pathLabel}
-        </span>
-        {editable && !editMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-primary"
-            onClick={() => setEditMode(true)}
-            title="Edit file"
-          >
-            <Pencil size={11} /> Edit
-          </Button>
-        )}
-        {editMode && (
+        </TruncateStart>
+        {editMode ? (
           <>
             <Button
               variant="ghost"
-              size="sm"
-              className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-foreground/80"
+              size="xs"
+              className="text-[14px]"
               onClick={cancelEdit}
               title="Cancel"
             >
-              <X size={11} /> Cancel
+              <X size={14} /> Cancel
             </Button>
             <Button
-              size="sm"
-              className="h-auto px-2 py-0.5 text-[11px] font-semibold text-primary bg-primary/10 hover:bg-primary/20 hover:text-primary"
-              variant="ghost"
+              variant="outline"
+              size="xs"
+              className="text-[14px]"
               onClick={save}
               disabled={!dirty || writeMutation.isPending}
               title="Save (Cmd/Ctrl+S)"
             >
-              <Save size={11} /> {writeMutation.isPending ? "Saving…" : "Save"}
+              <Save size={14} /> {writeMutation.isPending ? "Saving…" : "Save"}
             </Button>
           </>
+        ) : (
+          <>
+            {editable && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="text-[14px]"
+                onClick={() => setEditMode(true)}
+                title="Edit file"
+              >
+                <Pencil size={14} /> Edit
+              </Button>
+            )}
+            {!tooLarge && (
+              <Button
+                variant="outline"
+                size="xs"
+                className="text-[14px]"
+                onClick={downloadFile}
+                title="Download file"
+              >
+                <Download size={14} /> Download
+              </Button>
+            )}
+            {isSvg && (
+              <RenderToggle
+                rendered={renderSvg}
+                onToggle={() => setRenderSvg((p) => !p)}
+                rawTitle="Show raw SVG"
+                renderTitle="Render SVG"
+              />
+            )}
+            {isMarkdown && (
+              <RenderToggle
+                rendered={renderMd}
+                onToggle={() => setRenderMd((p) => !p)}
+                rawTitle="Show raw"
+                renderTitle="Render markdown"
+              />
+            )}
+            {isHtml && (
+              <RenderToggle
+                rendered={renderHtml}
+                onToggle={() => setRenderHtml((p) => !p)}
+                rawTitle="Show raw HTML"
+                renderTitle="Render HTML"
+              />
+            )}
+            {isRenderedPreview && (
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                className="shrink-0"
+                onClick={() => setIsExpanded(true)}
+                title="Open fullscreen"
+              >
+                <Maximize size={14} />
+              </Button>
+            )}
+          </>
         )}
-        {isRenderedPreview && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-primary"
-            onClick={() => setIsExpanded(true)}
-            title="Open fullscreen"
-          >
-            <Maximize size={11} /> Fullscreen
-          </Button>
-        )}
-        {!tooLarge && !editMode && (
-          <Button
-            variant="ghost"
-            size="sm"
-            className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-primary"
-            onClick={downloadFile}
-            title="Download file"
-          >
-            <Download size={11} />
-          </Button>
-        )}
-        {isSvg && !editMode && (
-          <RenderToggle
-            rendered={renderSvg}
-            onToggle={() => setRenderSvg((p) => !p)}
-            rawTitle="Show raw SVG"
-            renderTitle="Render SVG"
-          />
-        )}
-        {isMarkdown && !editMode && (
-          <RenderToggle
-            rendered={renderMd}
-            onToggle={() => setRenderMd((p) => !p)}
-            rawTitle="Show raw"
-            renderTitle="Render markdown"
-          />
-        )}
-        {isHtml && !editMode && (
-          <RenderToggle
-            rendered={renderHtml}
-            onToggle={() => setRenderHtml((p) => !p)}
-            rawTitle="Show raw HTML"
-            renderTitle="Render HTML"
-          />
-        )}
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          className="shrink-0"
+          onClick={onClose}
+          title="Close"
+        >
+          <X size={16} />
+        </Button>
       </div>
       <div
         className={

--- a/packages/ui/src/modules/files/components/files-panel.tsx
+++ b/packages/ui/src/modules/files/components/files-panel.tsx
@@ -11,7 +11,6 @@ import {
 
 import { SidebarSection } from "../../sessions/components/sidebar-section.js";
 import { DirContents } from "./dir-contents.js";
-import { FileViewer } from "./file-viewer.js";
 import {
   FilesPanelContext,
   useFilesPanelController,
@@ -90,53 +89,44 @@ export function FilesPanel({
         className="hidden"
         onChange={controller.handleFolderInputChange}
       />
-      {controller.openFile ? (
-        <FileViewer
-          key={controller.openFile.path}
-          file={controller.openFile}
-          onClose={controller.closeFile}
-          onOpenFile={onOpenFile}
-        />
-      ) : (
-        <div
-          className="relative flex-1 overflow-y-auto py-1"
-          onDragEnter={controller.handlePanelDragEnter}
-          onDragOver={controller.handlePanelDragOver}
-          onDragLeave={controller.handlePanelDragLeave}
-          onDrop={controller.handlePanelDrop}
-        >
-          {controller.ctxValue && (
-            <FilesPanelContext.Provider value={controller.ctxValue}>
-              {controller.pendingNew && controller.pendingNew.dir === "" && (
-                <InlineNameRow
-                  kind={controller.pendingNew.kind}
-                  depth={0}
-                  placeholder={
-                    controller.pendingNew.kind === "dir"
-                      ? "new-folder"
-                      : "new-file.md"
-                  }
-                  onCommit={controller.handleCommitNew}
-                  onCancel={controller.handleCancelNew}
-                />
-              )}
-              {controller.rootIsLoadedEmpty && (
-                <p className="px-4 py-5 text-[12px] text-text-muted">
-                  No files yet
-                </p>
-              )}
-              <DirContents path="" depth={0} />
-            </FilesPanelContext.Provider>
-          )}
-          {controller.showPanelOverlay && (
-            <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-accent-light/80 border-2 border-dashed border-accent rounded">
-              <div className="text-[12px] font-semibold text-accent">
-                Drop files to upload to /home/agent
-              </div>
+      <div
+        className="relative flex-1 overflow-y-auto py-1"
+        onDragEnter={controller.handlePanelDragEnter}
+        onDragOver={controller.handlePanelDragOver}
+        onDragLeave={controller.handlePanelDragLeave}
+        onDrop={controller.handlePanelDrop}
+      >
+        {controller.ctxValue && (
+          <FilesPanelContext.Provider value={controller.ctxValue}>
+            {controller.pendingNew && controller.pendingNew.dir === "" && (
+              <InlineNameRow
+                kind={controller.pendingNew.kind}
+                depth={0}
+                placeholder={
+                  controller.pendingNew.kind === "dir"
+                    ? "new-folder"
+                    : "new-file.md"
+                }
+                onCommit={controller.handleCommitNew}
+                onCancel={controller.handleCancelNew}
+              />
+            )}
+            {controller.rootIsLoadedEmpty && (
+              <p className="px-4 py-5 text-[12px] text-text-muted">
+                No files yet
+              </p>
+            )}
+            <DirContents path="" depth={0} />
+          </FilesPanelContext.Provider>
+        )}
+        {controller.showPanelOverlay && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-accent-light/80 border-2 border-dashed border-accent rounded">
+            <div className="text-[12px] font-semibold text-accent">
+              Drop files to upload to /home/agent
             </div>
-          )}
-        </div>
-      )}
+          </div>
+        )}
+      </div>
     </SidebarSection>
   );
 }

--- a/packages/ui/src/modules/files/components/render-toggle.tsx
+++ b/packages/ui/src/modules/files/components/render-toggle.tsx
@@ -22,13 +22,13 @@ export function RenderToggle({
 }: Props) {
   return (
     <Button
-      variant="ghost"
-      size="sm"
-      className={`h-auto px-2 py-0.5 text-[11px] font-semibold ${rendered ? "text-primary bg-primary/10" : "text-muted-foreground hover:text-foreground/80"}`}
+      variant="outline"
+      size="xs"
+      className="text-[14px]"
       onClick={onToggle}
       title={rendered ? rawTitle : renderTitle}
     >
-      {rendered ? <Code size={11} /> : <Eye size={11} />}
+      {rendered ? <Code size={14} /> : <Eye size={14} />}
       {rendered ? "Raw" : "Render"}
     </Button>
   );

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -22,8 +22,6 @@ export interface NavigationSlice {
   navigateToExperiment: (experimentId: string) => void;
   mobileScreen: "sessions" | "chat";
   setMobileScreen: (screen: "sessions" | "chat") => void;
-  showMobilePanel: boolean;
-  setShowMobilePanel: (show: boolean) => void;
 }
 
 export const createNavigationSlice: StateCreator<
@@ -104,6 +102,4 @@ export const createNavigationSlice: StateCreator<
   },
   mobileScreen: "sessions",
   setMobileScreen: (screen) => set({ mobileScreen: screen }),
-  showMobilePanel: false,
-  setShowMobilePanel: (show) => set({ showMobilePanel: show }),
 });

--- a/packages/ui/src/modules/sessions/components/chat-column.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-column.tsx
@@ -10,7 +10,7 @@ export function ChatColumn({
   children: ReactNode;
 }) {
   return (
-    <div className={cn("mx-auto w-full max-w-[813px]", className)}>
+    <div className={cn("mx-auto w-full max-w-[813px] px-4", className)}>
       {children}
     </div>
   );

--- a/packages/ui/src/modules/sessions/components/temp-config-dialog.tsx
+++ b/packages/ui/src/modules/sessions/components/temp-config-dialog.tsx
@@ -1,0 +1,70 @@
+import { useStore } from "../../../store.js";
+import type { AgentState } from "../../../types.js";
+import { FullscreenPreviewDialog } from "../../files/components/fullscreen-preview-dialog.js";
+import { MetricsPanel } from "../../metrics/components/metrics-panel.js";
+import { prefetchSchedules } from "../../schedules/api/queries.js";
+import { ConfigurationPanel } from "./configuration-panel.js";
+
+/** Temporary home for the torn-down right panel's Config/Metrics content
+ *  (model settings, schedules, channels, skills, metrics) until the sandbox
+ *  config page (#2124) rehomes it. Opened from the chat header. */
+export function TempConfigDialog({
+  agentId,
+  agentState,
+  sessionId,
+  onResumeSession,
+  onOpenFile,
+  onClose,
+}: {
+  agentId: string | null;
+  agentState: AgentState | undefined;
+  sessionId: string | null;
+  onResumeSession: (sessionId: string) => void;
+  onOpenFile: (path: string) => void;
+  onClose: () => void;
+}) {
+  const rightTab = useStore((s) => s.rightTab);
+  const setRightTab = useStore((s) => s.setRightTab);
+  const tabs = ["configuration", "metrics"] as const;
+
+  return (
+    <FullscreenPreviewDialog title="Sandbox configuration" onClose={onClose}>
+      <div className="mx-auto max-w-[720px] flex flex-col h-full">
+        <div className="flex border-b border-border-light shrink-0">
+          {tabs.map((tab) => {
+            const warmCache =
+              tab === "configuration" && agentId
+                ? () => prefetchSchedules(agentId)
+                : undefined;
+            return (
+              <button
+                key={tab}
+                onClick={() => setRightTab(tab)}
+                onMouseEnter={warmCache}
+                onFocus={warmCache}
+                className={`flex-1 h-11 text-[11px] font-bold uppercase tracking-[0.05em] border-b-2 transition-colors ${rightTab === tab ? "text-accent border-accent bg-accent-light" : "text-text-muted border-transparent hover:text-text-secondary"}`}
+              >
+                {tab === "configuration" ? "config" : tab}
+              </button>
+            );
+          })}
+        </div>
+        <div className="flex flex-1 flex-col overflow-hidden">
+          <div
+            className={`flex flex-1 flex-col overflow-hidden ${rightTab === "configuration" ? "" : "hidden"}`}
+          >
+            <ConfigurationPanel
+              onResumeSession={onResumeSession}
+              agentId={agentId}
+              agentState={agentState}
+              onOpenFile={onOpenFile}
+            />
+          </div>
+          {rightTab === "metrics" && (
+            <MetricsPanel agentId={agentId} sessionId={sessionId} />
+          )}
+        </div>
+      </div>
+    </FullscreenPreviewDialog>
+  );
+}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -117,9 +117,10 @@ export function ChatView() {
     () => Number(localStorage.getItem("platform-left-w")) || 220,
   );
   // null = no stored width yet: the file panel splits 50/50 with the chat
-  // column until the user drags the divider.
+  // column until the user drags the divider. The key is new on purpose — the
+  // old panel's stored "platform-right-w" shouldn't override the split.
   const [rightW, setRightW] = useState<number | null>(
-    () => Number(localStorage.getItem("platform-right-w")) || null,
+    () => Number(localStorage.getItem("platform-file-w")) || null,
   );
   const filePanelRef = useRef<HTMLDivElement>(null);
   const [sessionsOpen, setSessionsOpen] = useState(true);
@@ -446,7 +447,7 @@ export function ChatView() {
 
         {/* Main chat column */}
         <div
-          className={`relative flex flex-1 flex-col min-w-0 px-2 ${mobileScreen === "sessions" ? "hidden md:flex" : "flex"}`}
+          className={`relative flex flex-1 flex-col min-w-0 ${mobileScreen === "sessions" ? "hidden md:flex" : "flex"}`}
         >
           {/* Content: Terminal or Chat */}
           {sessionMode === SessionMode.Terminal &&
@@ -481,7 +482,7 @@ export function ChatView() {
             <>
               <div className="relative flex flex-1 flex-col min-h-0">
                 <div ref={messagesRef} className="flex-1 overflow-y-auto">
-                  <ChatColumn className="px-4 md:px-4 py-8 flex flex-col gap-8">
+                  <ChatColumn className="px-4 md:px-8 py-8 flex flex-col gap-8">
                     {loadingSession && (
                       <div className="py-20 flex items-center justify-center gap-3 text-[14px] text-text-muted">
                         <span className="w-5 h-5 rounded-full border-2 border-border-light border-t-accent anim-spin" />
@@ -697,8 +698,10 @@ export function ChatView() {
                 onResize={(d) =>
                   setRightW((w) => {
                     const base = w ?? filePanelRef.current?.offsetWidth ?? 0;
-                    const v = Math.max(240, Math.min(960, base + d));
-                    localStorage.setItem("platform-right-w", String(v));
+                    // Keep at least ~500px for the sidebar + chat column.
+                    const max = Math.min(960, window.innerWidth - 500);
+                    const v = Math.max(240, Math.min(max, base + d));
+                    localStorage.setItem("platform-file-w", String(v));
                     return v;
                   })
                 }
@@ -731,7 +734,11 @@ export function ChatView() {
           agentState={agents.find((a) => a.id === selectedAgent)?.state}
           sessionId={sessionId}
           onResumeSession={mobileResumeSession}
-          onOpenFile={openFileHandler}
+          onOpenFile={(path) => {
+            // The docked panel opens behind this fullscreen dialog — leave.
+            setShowConfigDialog(false);
+            openFileHandler(path);
+          }}
           onClose={() => setShowConfigDialog(false)}
         />
       )}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -6,10 +6,16 @@ import {
   FileText as FileIcon,
   MoreVertical,
   RefreshCw,
-  Settings2,
   Trash2,
 } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -40,11 +46,10 @@ import {
 } from "../../agents/hooks/use-restart-agent.js";
 import { resolveAgentDisplay } from "../../agents/utils/agent-resolver.js";
 import { EgressApprovalToasts } from "../../approvals/components/egress-approval-toasts.js";
+import { DockedFilePanel } from "../../files/components/docked-file-panel.js";
 import { FilesPanel } from "../../files/components/files-panel.js";
 import { ImportInProgressBadge } from "../../files/components/import-in-progress-badge.js";
 import { useFileTree } from "../../files/hooks/use-file-tree.js";
-import { MetricsPanel } from "../../metrics/components/metrics-panel.js";
-import { prefetchSchedules } from "../../schedules/api/queries.js";
 import {
   acpSessionsKeys,
   optimisticInsertSession,
@@ -53,12 +58,12 @@ import {
 import { BusyIndicator } from "../components/busy-indicator.js";
 import { ChatColumn } from "../components/chat-column.js";
 import { ChatInputArea } from "../components/chat-input-area.js";
-import { ConfigurationPanel } from "../components/configuration-panel.js";
 import {
   PermissionStatusLine,
   PermissionVerdictLine,
 } from "../components/permission-prompt.js";
 import { SessionsSidebar } from "../components/sessions-sidebar.js";
+import { TempConfigDialog } from "../components/temp-config-dialog.js";
 import { Terminal } from "../components/terminal.js";
 import { ThoughtBlock } from "../components/thought-block.js";
 import { ToolChip } from "../components/tool-chip.js";
@@ -93,9 +98,8 @@ export function ChatView() {
   const sessionError = useStore((s) => s.sessionError);
   const setSessionError = useStore((s) => s.setSessionError);
   const deleteSession = useStore((s) => s.deleteSession);
-  const rightTab = useStore((s) => s.rightTab);
+  const openFilePath = useStore((s) => s.openFilePath);
   const goBack = useStore((s) => s.goBack);
-  const setRightTab = useStore((s) => s.setRightTab);
   const navigateToSandboxSettings = useStore(
     (s) => s.navigateToSandboxSettings,
   );
@@ -105,17 +109,19 @@ export function ChatView() {
   const hasPendingPermission = useHasPendingPermission();
   const mobileScreen = useStore((s) => s.mobileScreen);
   const setMobileScreen = useStore((s) => s.setMobileScreen);
-  const showMobilePanel = useStore((s) => s.showMobilePanel);
-  const setShowMobilePanel = useStore((s) => s.setShowMobilePanel);
+  const [showConfigDialog, setShowConfigDialog] = useState(false);
   const terminalPaused = useStore((s) => s.terminalPaused);
   const setTerminalPaused = useStore((s) => s.setTerminalPaused);
 
   const [leftW, setLeftW] = useState(
     () => Number(localStorage.getItem("platform-left-w")) || 220,
   );
-  const [rightW, setRightW] = useState(
-    () => Number(localStorage.getItem("platform-right-w")) || 340,
+  // null = no stored width yet: the file panel splits 50/50 with the chat
+  // column until the user drags the divider.
+  const [rightW, setRightW] = useState<number | null>(
+    () => Number(localStorage.getItem("platform-right-w")) || null,
   );
+  const filePanelRef = useRef<HTMLDivElement>(null);
   const [sessionsOpen, setSessionsOpen] = useState(true);
   const [sessionsH, setSessionsH] = useState(
     () => Number(localStorage.getItem("platform-sessions-h")) || 260,
@@ -297,47 +303,6 @@ export function ChatView() {
     goBack();
   }, [mobileScreen, setMobileScreen, resetSession, goBack]);
 
-  // ── Right panel ──
-  const rightTabs = ["configuration", "metrics"] as const;
-  const rightPanelContent = (
-    <>
-      <div className="flex border-b border-border-light shrink-0">
-        {rightTabs.map((tab) => {
-          const warmCache =
-            tab === "configuration" && selectedAgent
-              ? () => prefetchSchedules(selectedAgent)
-              : undefined;
-          return (
-            <button
-              key={tab}
-              onClick={() => setRightTab(tab)}
-              onMouseEnter={warmCache}
-              onFocus={warmCache}
-              className={`flex-1 h-11 text-[11px] font-bold uppercase tracking-[0.05em] border-b-2 transition-colors ${rightTab === tab ? "text-accent border-accent bg-accent-light" : "text-text-muted border-transparent hover:text-text-secondary"}`}
-            >
-              {tab === "configuration" ? "config" : tab}
-            </button>
-          );
-        })}
-      </div>
-      <div className="flex flex-1 flex-col overflow-hidden">
-        <div
-          className={`flex flex-1 flex-col overflow-hidden ${rightTab === "configuration" ? "" : "hidden"}`}
-        >
-          <ConfigurationPanel
-            onResumeSession={mobileResumeSession}
-            agentId={selectedAgent}
-            agentState={agents.find((a) => a.id === selectedAgent)?.state}
-            onOpenFile={openFileHandler}
-          />
-        </div>
-        {rightTab === "metrics" && (
-          <MetricsPanel agentId={selectedAgent} sessionId={sessionId} />
-        )}
-      </div>
-    </>
-  );
-
   const dotColor =
     agentDisplay?.state === "running"
       ? "bg-emerald-500"
@@ -403,13 +368,14 @@ export function ChatView() {
           </DropdownMenu>
         </div>
         <div className="ml-auto flex items-center gap-2">
+          {/* Temporary access to the old right-panel content until #2124. */}
           <Button
-            variant="outline"
+            variant="ghost"
             size="icon-sm"
-            className="md:hidden"
-            onClick={() => setShowMobilePanel(true)}
+            onClick={() => setShowConfigDialog(true)}
+            title="Sandbox configuration"
           >
-            <Settings2 size={14} />
+            <Settings size={16} />
           </Button>
           <ChatHeaderStatus
             selectedAgent={selectedAgent}
@@ -480,7 +446,7 @@ export function ChatView() {
 
         {/* Main chat column */}
         <div
-          className={`relative flex flex-1 flex-col min-w-0 ${mobileScreen === "sessions" ? "hidden md:flex" : "flex"}`}
+          className={`relative flex flex-1 flex-col min-w-0 px-2 ${mobileScreen === "sessions" ? "hidden md:flex" : "flex"}`}
         >
           {/* Content: Terminal or Chat */}
           {sessionMode === SessionMode.Terminal &&
@@ -721,46 +687,53 @@ export function ChatView() {
           )}
         </div>
 
-        {/* Right panel: desktop */}
-        <ResizeHandle
-          side="right"
-          onResize={(d) =>
-            setRightW((w) => {
-              const v = Math.max(240, Math.min(600, w + d));
-              localStorage.setItem("platform-right-w", String(v));
-              return v;
-            })
-          }
-        />
-        <div
-          style={{ width: rightW }}
-          className="hidden md:flex shrink-0 flex-col border-l border-border-light overflow-hidden relative z-10"
-        >
-          {rightPanelContent}
-        </div>
+        {/* Docked file panel — hidden unless a file is open; fullscreen
+            takeover on mobile */}
+        {openFilePath && (
+          <>
+            <div className="hidden md:flex">
+              <ResizeHandle
+                side="right"
+                onResize={(d) =>
+                  setRightW((w) => {
+                    const base = w ?? filePanelRef.current?.offsetWidth ?? 0;
+                    const v = Math.max(240, Math.min(960, base + d));
+                    localStorage.setItem("platform-right-w", String(v));
+                    return v;
+                  })
+                }
+              />
+            </div>
+            <div
+              ref={filePanelRef}
+              style={
+                rightW !== null
+                  ? ({ "--file-w": `${rightW}px` } as CSSProperties)
+                  : undefined
+              }
+              className={cn(
+                "flex flex-col overflow-hidden bg-background relative z-10 max-md:fixed max-md:inset-0 max-md:z-50",
+                rightW !== null
+                  ? "md:shrink-0 md:w-[var(--file-w)]"
+                  : "md:flex-1 md:basis-0 md:min-w-0",
+                "md:border-l md:border-border-light",
+              )}
+            >
+              <DockedFilePanel onOpenFile={openFileHandler} />
+            </div>
+          </>
+        )}
       </div>
 
-      {/* Right panel: mobile overlay */}
-      {showMobilePanel && (
-        <div className="md:hidden fixed inset-0 z-50 flex">
-          <div
-            className="absolute inset-0 bg-black/40"
-            onClick={() => setShowMobilePanel(false)}
-          />
-          <div className="absolute right-0 top-0 bottom-0 w-full max-w-[400px] bg-surface flex flex-col anim-slide-in-right">
-            <div className="flex items-center justify-between px-4 h-11 border-b border-border-light shrink-0">
-              <span className="text-[13px] font-bold text-text">Panel</span>
-              <Button
-                variant="outline"
-                size="icon-sm"
-                onClick={() => setShowMobilePanel(false)}
-              >
-                <ArrowLeft size={14} />
-              </Button>
-            </div>
-            {rightPanelContent}
-          </div>
-        </div>
+      {showConfigDialog && (
+        <TempConfigDialog
+          agentId={selectedAgent}
+          agentState={agents.find((a) => a.id === selectedAgent)?.state}
+          sessionId={sessionId}
+          onResumeSession={mobileResumeSession}
+          onOpenFile={openFileHandler}
+          onClose={() => setShowConfigDialog(false)}
+        />
       )}
 
       <EgressApprovalToasts agentId={selectedAgent} />


### PR DESCRIPTION
Stacked on #2769. Seventh increment of #883 (sub-issue 07).

- The persistent Config/Metrics right panel (and its mobile overlay) is gone — the chat thread uses the full width by default.
- **Opening a file docks a right panel** for view/edit: starts as a 50/50 split with the chat, resizable (the divider persists your width), expandable to the fullscreen dialog, with a dirty-close guard. On mobile an open file takes over the screen. The Files section in the sidebar now always shows the tree.
- The file viewer header follows the design: left-truncated path (filename always visible), bordered Edit / Download / Raw buttons matching the sidebar chrome, close on the right.
- **Temporary escape hatch** replacing the plan's #2124 gate: a Settings button in the chat header opens a fullscreen dialog with the old Config/Metrics content unchanged (model settings incl. auto-approve, schedules, channels, skills, metrics). #2124 removes the button and dialog when it rehomes those surfaces.
- Riders: muted hover/active backgrounds on file rows; the Inbox badge in the icon rail is blue.

Part of #883.