### PR TITLE
fix(ui): widen sandbox section nav to 245px

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/sandbox-section-nav.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-section-nav.tsx
@@ -25,7 +25,7 @@ export function SandboxSectionNav({ active, onNavigate, summaries }: Props) {
   return (
     <nav
       aria-label="Sandbox sections"
-      className="flex shrink-0 flex-col gap-1 md:sticky md:top-12 md:w-[200px] md:self-start"
+      className="flex shrink-0 flex-col gap-1 md:sticky md:top-12 md:w-[245px] md:self-start"
     >
       {SECTIONS.map((entry) => (
         <SectionNavItem


### PR DESCRIPTION
Design-review follow-up to #2793: the sandbox home section nav (config tabs) is widened from 200px to **245px** per @kapetr's review.

The `VS Code` capitalization nit from the same review was already applied at merge.

The model-settings form restyle (also raised in review) is tracked separately and out of scope here.

Refs #2775