### PR TITLE
fix(e2e): realign specs with sandbox-home nav, chat-shell menus, and connection sections

### DIFF
--- a/packages/e2e/playwright/src/lib/agents.ts
+++ b/packages/e2e/playwright/src/lib/agents.ts
@@ -43,12 +43,24 @@ export async function reloadUntilAgentVisible(page: Page): Promise<void> {
   await expect(page.getByText("Running")).toBeVisible();
 }
 
+/** Chat message input; placeholder flips to "Queue a message..." mid-turn. */
+export function chatInput(page: Page): Locator {
+  return page.getByPlaceholder(/^(queue a )?message\.\.\./i);
+}
+
+/** Selecting an agent lands on its sandbox home; chat is behind the
+ *  "Open in" launch menu. */
 export async function gotoAgentDetail(
   page: Page,
   agentName: string,
   agentId: string,
 ): Promise<void> {
   await page.getByRole("heading", { name: agentName }).click();
+  await expect(page).toHaveURL(
+    new RegExp(`/sandboxes/${encodeURIComponent(agentId)}`),
+  );
+  await page.getByRole("button", { name: /open in/i }).click();
+  await page.getByRole("menuitem", { name: /chat \(browser\)/i }).click();
   await expect(page).toHaveURL(
     new RegExp(`/chat/${encodeURIComponent(agentId)}`),
   );
@@ -58,7 +70,7 @@ export async function sendMessageToAgent(
   page: Page,
   message: string,
 ): Promise<void> {
-  const input = page.getByPlaceholder(/message agent/i);
+  const input = chatInput(page);
   await expect(input).toBeVisible();
   await input.fill(message);
   await input.press("Enter");

--- a/packages/e2e/playwright/src/tests/04-messages.spec.ts
+++ b/packages/e2e/playwright/src/tests/04-messages.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { baseUrl } from "../config.js";
 import {
   agentCardStatus,
+  chatInput,
   gotoAgentDetail,
   readChatMessages,
   sendMessageToAgent,
@@ -37,7 +38,7 @@ test("exchange messages with the agent", async ({ page }) => {
 
     await gotoAgentDetail(page, agentName, agentId);
 
-    await expect(page.getByPlaceholder(/message agent/i)).toBeVisible();
+    await expect(chatInput(page)).toBeVisible();
   });
 
   await test.step("send a message and receive the scripted reply", async () => {
@@ -76,7 +77,7 @@ test("background prompt mid-turn keeps the reply paired with the user message (#
     await expect(page.getByTestId("app-sidebar")).toBeVisible();
     await expect(agentCardStatus(page, agentName, "Running")).toBeVisible();
     await gotoAgentDetail(page, agentName, agentId);
-    await expect(page.getByPlaceholder(/message agent/i)).toBeVisible();
+    await expect(chatInput(page)).toBeVisible();
   });
 
   await test.step("send a prompt and let the interleaved turn stream", async () => {

--- a/packages/e2e/playwright/src/tests/08-session-delete.spec.ts
+++ b/packages/e2e/playwright/src/tests/08-session-delete.spec.ts
@@ -54,7 +54,10 @@ test("deleting the active session clears it and lets a fresh session start (#108
 
   await test.step("(A) deleting the active session removes it without a refresh", async () => {
     await activeRow.hover();
-    await activeRow.getByTestId("session-delete-button").click();
+    // Delete moved behind the row's overflow menu in the chat-shell rework
+    // (#2769); the menu item is portaled, so target it at page scope.
+    await activeRow.getByTestId("session-menu-button").click();
+    await page.getByTestId("session-delete-button").click();
     await page
       .getByRole("alertdialog")
       .getByRole("button", { name: "Confirm" })

--- a/packages/e2e/playwright/src/tests/08-session-delete.spec.ts
+++ b/packages/e2e/playwright/src/tests/08-session-delete.spec.ts
@@ -3,6 +3,7 @@ import { expect, test } from "@playwright/test";
 import { baseUrl } from "../config.js";
 import {
   agentCardStatus,
+  chatInput,
   gotoAgentDetail,
   sendMessageToAgent,
   setMockAgentReply,
@@ -32,7 +33,7 @@ test("deleting the active session clears it and lets a fresh session start (#108
     await expect(page.getByTestId("app-sidebar")).toBeVisible();
     await expect(agentCardStatus(page, agentName, "Running")).toBeVisible();
     await gotoAgentDetail(page, agentName, agentId);
-    await expect(page.getByPlaceholder(/message agent/i)).toBeVisible();
+    await expect(chatInput(page)).toBeVisible();
 
     await sendMessageToAgent(page, firstPrompt);
     await expect(page.getByText(scriptedReply)).toBeVisible({
@@ -64,7 +65,7 @@ test("deleting the active session clears it and lets a fresh session start (#108
   });
 
   await test.step("(B) a session started right after the delete appears in the sidebar", async () => {
-    await expect(page.getByPlaceholder(/message agent/i)).toBeVisible();
+    await expect(chatInput(page)).toBeVisible();
     await sendMessageToAgent(page, secondPrompt);
     await expect(page.getByText(scriptedReply)).toBeVisible({
       timeout: 30_000,

--- a/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
+++ b/packages/e2e/playwright/src/tests/10-connection-regrant.spec.ts
@@ -70,7 +70,8 @@ test("recreating a disconnected connection saves cleanly", async ({ page }) => {
   });
 
   await test.step("open the sandbox settings page", async () => {
-    await page.goto(`${baseUrl}/sandboxes/${agentId}`);
+    // Connections are their own section under the sandbox home now (#2793).
+    await page.goto(`${baseUrl}/sandboxes/${agentId}/connections`);
     await expect(
       page.getByRole("heading", { level: 1, name: agentName }),
     ).toBeVisible();
@@ -119,7 +120,9 @@ test("recreating a disconnected connection saves cleanly", async ({ page }) => {
       page.getByTestId(`connection-grant-${recreatedId}`).getByRole("checkbox"),
     ).toBeChecked();
 
-    await page.getByRole("button", { name: "Save", exact: true }).click();
+    await page
+      .getByRole("button", { name: "Submit changes", exact: true })
+      .click();
 
     await expect
       .poll(


### PR DESCRIPTION
## Why

CI/CD has been red on `main` since #2793 merged. The failing job is `mise e2e`. The root cause is that the e2e suite lagged behind three UI PRs that merged back-to-back (#2768, #2769, #2793); the app changes are intended (UI redesign, epic #102), the specs just weren't updated.

CI only surfaced **3** failures because Playwright *skips* a project whose dependency failed: `04-messages` failing masked its entire downstream chain (`05 → 07 → 10`). Fixing `04` unmasked a previously-hidden breakage in `10`.

## Breakages fixed (all stale tests vs. intended UI — no app code changed)

| Spec | Breakage | Fix |
|------|----------|-----|
| `04-messages` (×2) | agent click now lands on `/sandboxes/<id>`; chat is behind the "Open in" launch menu (#2793); chat input placeholder renamed to `Message...` / `Queue a message...` (#2769) | `gotoAgentDetail` follows the real path (home → Open in → Chat (browser) → `/chat/<id>`); centralized input lookup in a `chatInput()` helper |
| `08-session-delete` | ① same nav ② session delete moved behind the row overflow menu (#2769) | open `session-menu-button` before clicking the portaled `session-delete-button` |
| `10-connection-regrant` | ① connections are now their own section route (#2793) ② footer Save button renamed "Submit changes" | goto `/sandboxes/<id>/connections`; click "Submit changes" |

## Verification

- Full suite green against a warm cluster: **15/15 passed** (`mise run e2e:loop`)
- `mise run check` and e2e lint/type-check clean