### PR TITLE
feat(ui): move files and folders by drag and drop in the Files tree

### DIFF
--- a/packages/agent-runtime/src/modules/files.ts
+++ b/packages/agent-runtime/src/modules/files.ts
@@ -254,7 +254,21 @@ export function createFilesService(workingDir: string): FilesService {
         }
       }
       await mkdir(dirname(toAbs2), { recursive: true });
-      await rename(fromAbs, toAbs2);
+      try {
+        await rename(fromAbs, toAbs2);
+      } catch (e) {
+        // rename(2) can't replace a non-empty directory — surface it as a
+        // domain error instead of an internal one.
+        const code = (e as NodeJS.ErrnoException).code;
+        if (code === "ENOTEMPTY" || code === "EEXIST" || code === "EPERM") {
+          return err(
+            forbidden(
+              `can't overwrite "${to}" — the destination folder is not empty`,
+            ),
+          );
+        }
+        throw e;
+      }
       return ok({ ok: true });
     },
     deleteSafe: async (

--- a/packages/ui/src/modules/files/api/queries.ts
+++ b/packages/ui/src/modules/files/api/queries.ts
@@ -149,6 +149,8 @@ function invalidateFiles(
 export function useFileWriteMutation(agentId: string | null) {
   const qc = useQueryClient();
   return useMutation({
+    // Callers surface errors themselves (conflict confirms, custom toasts).
+    meta: { suppressErrorToast: true },
     mutationFn: async (input: {
       path: string;
       content: string;
@@ -166,6 +168,8 @@ export function useFileWriteMutation(agentId: string | null) {
 export function useFileCreateMutation(agentId: string | null) {
   const qc = useQueryClient();
   return useMutation({
+    // Callers surface errors themselves (conflict confirms, custom toasts).
+    meta: { suppressErrorToast: true },
     mutationFn: async (input: { path: string; content?: string }) => {
       const trpc = getAgentTrpc(agentId!);
       return trpc.files.create.mutate({
@@ -182,6 +186,8 @@ export function useFileCreateMutation(agentId: string | null) {
 export function useFolderCreateMutation(agentId: string | null) {
   const qc = useQueryClient();
   return useMutation({
+    // Callers surface errors themselves (conflict confirms, custom toasts).
+    meta: { suppressErrorToast: true },
     mutationFn: async (input: { path: string }) => {
       const trpc = getAgentTrpc(agentId!);
       return trpc.files.mkdir.mutate(input);
@@ -195,6 +201,8 @@ export function useFolderCreateMutation(agentId: string | null) {
 export function useFileRenameMutation(agentId: string | null) {
   const qc = useQueryClient();
   return useMutation({
+    // Callers surface errors themselves (conflict confirms, custom toasts).
+    meta: { suppressErrorToast: true },
     mutationFn: async (input: {
       from: string;
       to: string;
@@ -217,6 +225,8 @@ export function useFileRenameMutation(agentId: string | null) {
 export function useFileDeleteMutation(agentId: string | null) {
   const qc = useQueryClient();
   return useMutation({
+    // Callers surface errors themselves (conflict confirms, custom toasts).
+    meta: { suppressErrorToast: true },
     mutationFn: async (input: { path: string }) => {
       const trpc = getAgentTrpc(agentId!);
       return trpc.files.remove.mutate(input);
@@ -271,6 +281,8 @@ export async function uploadMessageAttachment(
 export function useFileUploadMutation(agentId: string | null) {
   const qc = useQueryClient();
   return useMutation({
+    // Callers surface errors themselves (conflict confirms, custom toasts).
+    meta: { suppressErrorToast: true },
     mutationFn: (input: {
       path: string;
       contentBase64: string;

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -87,7 +87,7 @@ export function FileRow({
     <ContextMenu onOpenChange={setMenuOpen}>
       <ContextMenuTrigger asChild>
         <div
-          className={`group relative flex items-center h-[32px] text-[14px] cursor-pointer transition-colors ${menuOpen ? "z-20" : ""} ${highlight ? "bg-accent-light ring-1 ring-accent ring-inset" : `text-text-secondary hover:bg-muted ${isDir ? "font-medium" : ""} ${isActive ? "bg-muted" : ""}`}`}
+          className={`group relative flex items-center h-[32px] text-[14px] cursor-pointer transition-colors ${menuOpen ? "z-20" : ""} ${highlight ? "bg-muted ring-1 ring-primary ring-inset text-text-secondary font-medium" : `text-text-secondary hover:bg-muted ${isDir ? "font-medium" : ""} ${isActive ? "bg-muted" : ""}`}`}
           style={{ paddingLeft: `${12 + depth * 14}px`, paddingRight: 12 }}
           onClick={
             isDir ? () => panel.onToggleDir(path) : () => panel.onOpenFile(path)

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -64,11 +64,17 @@ export function FileRow({
   // previous coordinate menu); Radix portals the menu content itself.
   const [menuOpen, setMenuOpen] = useState(false);
 
-  const drag = useFileRowDrag(targetDir, {
-    onEnter: panel.onRowDragEnter,
-    onLeave: panel.onRowDragLeave,
-    onDrop: panel.onRowDrop,
-  });
+  const drag = useFileRowDrag(
+    targetDir,
+    { path, type },
+    {
+      onEnter: panel.onRowDragEnter,
+      onLeave: panel.onRowDragLeave,
+      onEnd: panel.onRowDragEnd,
+      onDrop: panel.onRowDrop,
+      onMove: panel.onRowMove,
+    },
+  );
 
   const dispatch = (action: FileRowMenuAction) =>
     panel.onAction(action, path, type);

--- a/packages/ui/src/modules/files/components/files-panel-controller.ts
+++ b/packages/ui/src/modules/files/components/files-panel-controller.ts
@@ -17,6 +17,11 @@ import {
   type FileEntryKind,
   useFileMutations,
 } from "../hooks/use-file-mutations.js";
+import {
+  type DragSource,
+  MOVE_MIME,
+  readMoveSource,
+} from "../hooks/use-file-row-drag.js";
 import { downloadFileAt } from "../lib/download.js";
 import type { FileRowMenuAction } from "./file-row-menu-items.js";
 
@@ -47,7 +52,9 @@ export interface FilesPanelContextValue {
   ) => void;
   onRowDragEnter: (targetDir: string) => void;
   onRowDragLeave: (targetDir: string) => void;
+  onRowDragEnd: () => void;
   onRowDrop: (targetDir: string, files: FileList) => void;
+  onRowMove: (targetDir: string, source: DragSource) => void;
 }
 
 export const FilesPanelContext = createContext<FilesPanelContextValue | null>(
@@ -90,6 +97,7 @@ export function useFilesPanelController({
   const {
     createEntry,
     renameEntry,
+    moveEntry,
     deleteEntry,
     uploadFiles,
     uploadBundle,
@@ -163,6 +171,22 @@ export function useFilesPanelController({
     // only clear if we haven't already moved into another row.
     setDragTargetPath((prev) => (prev === targetDir ? null : prev));
   }, []);
+
+  // Drag cancel (Escape / drop outside the window) doesn't reliably fire a
+  // final dragleave, so the source's dragend clears any stuck highlight.
+  const handleRowDragEnd = useCallback(() => {
+    setDragTargetPath(null);
+    setPanelDragActive(false);
+  }, []);
+
+  const handleRowMove = useCallback(
+    (targetDir: string, source: DragSource) => {
+      setDragTargetPath(null);
+      setPanelDragActive(false);
+      void moveEntry({ from: source.path, toDir: targetDir });
+    },
+    [moveEntry],
+  );
 
   const handleRowDrop = useCallback(
     (targetDir: string, files: FileList) => {
@@ -273,6 +297,11 @@ export function useFilesPanelController({
     if (e.dataTransfer?.types?.includes("Files")) {
       e.preventDefault();
       e.dataTransfer.dropEffect = "copy";
+    } else if (e.dataTransfer?.types?.includes(MOVE_MIME)) {
+      // In-tree move dropped on empty panel space targets the root; no
+      // upload overlay for these.
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
     }
   }, []);
 
@@ -289,7 +318,12 @@ export function useFilesPanelController({
       setPanelDragActive(false);
       setDragTargetPath(null);
       // Row handlers stopPropagation before this fires, so reaching here
-      // means the drop happened on empty panel space → upload to root.
+      // means the drop happened on empty panel space → root.
+      const moved = readMoveSource(e);
+      if (moved) {
+        void moveEntry({ from: moved.path, toDir: "" });
+        return;
+      }
       const items = e.dataTransfer.items;
       if (items && hasDirectoryItem(items)) {
         void (async () => {
@@ -300,7 +334,7 @@ export function useFilesPanelController({
       }
       if (e.dataTransfer.files?.length) void uploadFiles(e.dataTransfer.files);
     },
-    [uploadBundle, uploadFiles],
+    [moveEntry, uploadBundle, uploadFiles],
   );
 
   const ctxValue = useMemo<FilesPanelContextValue | null>(
@@ -321,7 +355,9 @@ export function useFilesPanelController({
             onAction: handleAction,
             onRowDragEnter: handleRowDragEnter,
             onRowDragLeave: handleRowDragLeave,
+            onRowDragEnd: handleRowDragEnd,
             onRowDrop: handleRowDrop,
+            onRowMove: handleRowMove,
           }
         : null,
     [
@@ -340,6 +376,7 @@ export function useFilesPanelController({
       handleRowDragEnter,
       handleRowDragLeave,
       handleRowDrop,
+      handleRowMove,
     ],
   );
 

--- a/packages/ui/src/modules/files/components/files-panel-controller.ts
+++ b/packages/ui/src/modules/files/components/files-panel-controller.ts
@@ -183,7 +183,11 @@ export function useFilesPanelController({
     (targetDir: string, source: DragSource) => {
       setDragTargetPath(null);
       setPanelDragActive(false);
-      void moveEntry({ from: source.path, toDir: targetDir });
+      void moveEntry({
+        from: source.path,
+        toDir: targetDir,
+        kind: source.type,
+      });
     },
     [moveEntry],
   );
@@ -321,7 +325,7 @@ export function useFilesPanelController({
       // means the drop happened on empty panel space → root.
       const moved = readMoveSource(e);
       if (moved) {
-        void moveEntry({ from: moved.path, toDir: "" });
+        void moveEntry({ from: moved.path, toDir: "", kind: moved.type });
         return;
       }
       const items = e.dataTransfer.items;

--- a/packages/ui/src/modules/files/components/inline-name-row.tsx
+++ b/packages/ui/src/modules/files/components/inline-name-row.tsx
@@ -60,10 +60,28 @@ function InlineNameInput({
   const ref = useRef<HTMLInputElement | null>(null);
   // Guard against double-firing commit from blur + Enter; both paths race.
   const committedRef = useRef(false);
+  // True while the focus grab below is running; blurs during that window are
+  // the menu's focus trap yanking, not user intent — don't commit on them.
+  const grabbingRef = useRef(true);
 
+  // The row is usually spawned from a menu whose focus trap stays alive
+  // through its exit animation and which refocuses its trigger at the end —
+  // a single focus() loses. Re-assert briefly, then behave normally.
   useEffect(() => {
-    ref.current?.focus();
-    ref.current?.select();
+    const el = ref.current;
+    if (!el) return;
+    let raf = 0;
+    let ticks = 0;
+    const tick = () => {
+      if (document.activeElement !== el) {
+        el.focus();
+        el.select();
+      }
+      if (++ticks < 30) raf = requestAnimationFrame(tick);
+      else grabbingRef.current = false;
+    };
+    tick();
+    return () => cancelAnimationFrame(raf);
   }, []);
 
   const commit = () => {
@@ -91,7 +109,9 @@ function InlineNameInput({
           onCancel();
         }
       }}
-      onBlur={commit}
+      onBlur={() => {
+        if (!grabbingRef.current) commit();
+      }}
       onClick={(e) => e.stopPropagation()}
     />
   );

--- a/packages/ui/src/modules/files/components/inline-name-row.tsx
+++ b/packages/ui/src/modules/files/components/inline-name-row.tsx
@@ -1,4 +1,4 @@
-import { Document as FileText, Folder } from "@carbon/icons-react";
+import { FileText, Folder } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Input } from "@/components/ui/input";
@@ -27,11 +27,11 @@ export function InlineNameRow({
       className="flex items-center gap-1.5 py-[5px] text-[12px]"
       style={{ paddingLeft: `${12 + depth * 14}px`, paddingRight: 12 }}
     >
-      <span className="w-[13px] shrink-0" />
+      <span className="w-[16px] shrink-0" />
       {kind === "dir" ? (
-        <Folder size={13} className="shrink-0" />
+        <Folder size={16} className="shrink-0" />
       ) : (
-        <FileText size={13} className="shrink-0" />
+        <FileText size={16} className="shrink-0" />
       )}
       <InlineNameInput
         initial={initial}
@@ -77,7 +77,7 @@ function InlineNameInput({
   return (
     <Input
       ref={ref}
-      className="flex-1 h-6 px-1 py-0 text-[12px] font-mono bg-card border-primary"
+      className="flex-1 h-[26px] px-1 py-0 text-[12px] bg-card border-primary"
       value={value}
       placeholder={placeholder}
       onChange={(e) => setValue(e.target.value)}

--- a/packages/ui/src/modules/files/hooks/use-file-mutations.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-mutations.ts
@@ -27,6 +27,11 @@ interface RenameEntryInput {
   nextName: string;
 }
 
+interface MoveEntryInput {
+  from: string;
+  toDir: string;
+}
+
 function joinPath(dir: string, name: string): string {
   return dir ? `${dir}/${name}` : name;
 }
@@ -34,6 +39,10 @@ function joinPath(dir: string, name: string): string {
 function parentOf(path: string): string {
   const i = path.lastIndexOf("/");
   return i >= 0 ? path.slice(0, i) : "";
+}
+
+function nameOf(path: string): string {
+  return path.split("/").pop() ?? path;
 }
 
 function isConflictError(err: unknown): boolean {
@@ -96,29 +105,27 @@ export function useFileMutations(agentId: string | null) {
     [createFile, createFolder],
   );
 
-  const renameEntry = useCallback(
-    async ({ from, nextName }: RenameEntryInput) => {
-      const to = joinPath(parentOf(from), nextName);
+  const relocate = useCallback(
+    async (from: string, to: string, failLabel: string) => {
       if (to === from) return;
 
       const tryRename = async (overwrite: boolean) => {
         await renameMutation.mutateAsync({ from, to, overwrite });
         if (agentId) renameExpandedDir(agentId, from, to);
         if (openFilePath === from) setOpenFilePath(to);
+        else if (openFilePath?.startsWith(from + "/"))
+          setOpenFilePath(to + openFilePath.slice(from.length));
       };
 
       try {
         await tryRename(false);
       } catch (err) {
         if (!isConflictError(err)) {
-          emitToast({
-            kind: "error",
-            message: errorMessage(err, "Rename failed"),
-          });
+          emitToast({ kind: "error", message: errorMessage(err, failLabel) });
           return;
         }
         const ok = await showConfirm(
-          `"${nextName}" already exists. Overwrite?`,
+          `"${nameOf(to)}" already exists. Overwrite?`,
           "Overwrite",
         );
         if (!ok) return;
@@ -127,7 +134,7 @@ export function useFileMutations(agentId: string | null) {
         } catch (err2) {
           emitToast({
             kind: "error",
-            message: errorMessage(err2, "Rename failed"),
+            message: errorMessage(err2, failLabel),
           });
         }
       }
@@ -140,6 +147,22 @@ export function useFileMutations(agentId: string | null) {
       setOpenFilePath,
       showConfirm,
     ],
+  );
+
+  const renameEntry = useCallback(
+    ({ from, nextName }: RenameEntryInput) =>
+      relocate(from, joinPath(parentOf(from), nextName), "Rename failed"),
+    [relocate],
+  );
+
+  const moveEntry = useCallback(
+    async ({ from, toDir }: MoveEntryInput) => {
+      if (parentOf(from) === toDir) return;
+      // A folder can't move into itself or its own subtree.
+      if (from === toDir || toDir.startsWith(from + "/")) return;
+      await relocate(from, joinPath(toDir, nameOf(from)), "Move failed");
+    },
+    [relocate],
   );
 
   const deleteEntry = useCallback(
@@ -265,6 +288,7 @@ export function useFileMutations(agentId: string | null) {
   return {
     createEntry,
     renameEntry,
+    moveEntry,
     deleteEntry,
     uploadFiles,
     uploadBundle,

--- a/packages/ui/src/modules/files/hooks/use-file-mutations.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-mutations.ts
@@ -133,7 +133,7 @@ export function useFileMutations(agentId: string | null) {
         if (sourceKind === "dir") {
           emitToast({
             kind: "error",
-            message: `"${nameOf(to)}" already exists`,
+            message: `A folder named "${nameOf(to)}" already exists there. Folders can't be overwritten — rename or delete the existing one first.`,
           });
           return;
         }

--- a/packages/ui/src/modules/files/hooks/use-file-mutations.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-mutations.ts
@@ -30,6 +30,7 @@ interface RenameEntryInput {
 interface MoveEntryInput {
   from: string;
   toDir: string;
+  kind: FileEntryKind;
 }
 
 function joinPath(dir: string, name: string): string {
@@ -106,7 +107,12 @@ export function useFileMutations(agentId: string | null) {
   );
 
   const relocate = useCallback(
-    async (from: string, to: string, failLabel: string) => {
+    async (
+      from: string,
+      to: string,
+      failLabel: string,
+      sourceKind?: FileEntryKind,
+    ) => {
       if (to === from) return;
 
       const tryRename = async (overwrite: boolean) => {
@@ -122,6 +128,13 @@ export function useFileMutations(agentId: string | null) {
       } catch (err) {
         if (!isConflictError(err)) {
           emitToast({ kind: "error", message: errorMessage(err, failLabel) });
+          return;
+        }
+        if (sourceKind === "dir") {
+          emitToast({
+            kind: "error",
+            message: `"${nameOf(to)}" already exists`,
+          });
           return;
         }
         const ok = await showConfirm(
@@ -156,11 +169,11 @@ export function useFileMutations(agentId: string | null) {
   );
 
   const moveEntry = useCallback(
-    async ({ from, toDir }: MoveEntryInput) => {
+    async ({ from, toDir, kind }: MoveEntryInput) => {
       if (parentOf(from) === toDir) return;
       // A folder can't move into itself or its own subtree.
       if (from === toDir || toDir.startsWith(from + "/")) return;
-      await relocate(from, joinPath(toDir, nameOf(from)), "Move failed");
+      await relocate(from, joinPath(toDir, nameOf(from)), "Move failed", kind);
     },
     [relocate],
   );

--- a/packages/ui/src/modules/files/hooks/use-file-row-drag.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-row-drag.ts
@@ -1,43 +1,93 @@
 import type { DragEvent as ReactDragEvent } from "react";
 import { useMemo } from "react";
 
+/** DataTransfer type carrying an in-tree move (JSON DragSource). */
+export const MOVE_MIME = "application/x-platform-move";
+
+export interface DragSource {
+  path: string;
+  type: "file" | "dir";
+}
+
 interface RowDragCallbacks {
   onEnter: (targetDir: string) => void;
   onLeave: (targetDir: string) => void;
+  onEnd: () => void;
   onDrop: (targetDir: string, files: FileList) => void;
+  onMove: (targetDir: string, source: DragSource) => void;
 }
 
 function hasFiles(e: ReactDragEvent): boolean {
   return !!e.dataTransfer?.types?.includes("Files");
 }
 
-export function useFileRowDrag(targetDir: string, callbacks: RowDragCallbacks) {
-  const { onEnter, onLeave, onDrop } = callbacks;
+export function hasMove(e: ReactDragEvent): boolean {
+  return !!e.dataTransfer?.types?.includes(MOVE_MIME);
+}
+
+export function readMoveSource(e: ReactDragEvent): DragSource | null {
+  const raw = e.dataTransfer?.getData(MOVE_MIME);
+  if (!raw) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      parsed &&
+      typeof parsed === "object" &&
+      typeof (parsed as DragSource).path === "string" &&
+      ((parsed as DragSource).type === "file" ||
+        (parsed as DragSource).type === "dir")
+    )
+      return parsed as DragSource;
+  } catch {
+    // Foreign payload under our MIME type — ignore.
+  }
+  return null;
+}
+
+export function useFileRowDrag(
+  targetDir: string,
+  { path, type }: DragSource,
+  callbacks: RowDragCallbacks,
+) {
+  const { onEnter, onLeave, onEnd, onDrop, onMove } = callbacks;
   return useMemo(
     () => ({
+      draggable: true,
+      onDragStart: (e: ReactDragEvent) => {
+        e.dataTransfer.setData(MOVE_MIME, JSON.stringify({ path, type }));
+        e.dataTransfer.effectAllowed = "move";
+      },
+      onDragEnd: () => onEnd(),
       onDragEnter: (e: ReactDragEvent) => {
-        if (!hasFiles(e)) return;
+        if (!hasFiles(e) && !hasMove(e)) return;
         e.preventDefault();
         e.stopPropagation();
         onEnter(targetDir);
       },
       onDragOver: (e: ReactDragEvent) => {
-        if (!hasFiles(e)) return;
+        if (!hasFiles(e) && !hasMove(e)) return;
         e.preventDefault();
         e.stopPropagation();
-        e.dataTransfer.dropEffect = "copy";
+        e.dataTransfer.dropEffect = hasMove(e) ? "move" : "copy";
       },
       onDragLeave: (e: ReactDragEvent) => {
         if (e.currentTarget.contains(e.relatedTarget as Node | null)) return;
         onLeave(targetDir);
       },
       onDrop: (e: ReactDragEvent) => {
+        const moved = readMoveSource(e);
+        if (moved) {
+          e.preventDefault();
+          e.stopPropagation();
+          onMove(targetDir, moved);
+          return;
+        }
         if (!e.dataTransfer?.files?.length) return;
         e.preventDefault();
         e.stopPropagation();
         onDrop(targetDir, e.dataTransfer.files);
       },
     }),
-    [targetDir, onEnter, onLeave, onDrop],
+    [targetDir, path, type, onEnter, onLeave, onEnd, onDrop, onMove],
   );
 }

--- a/packages/ui/src/modules/files/hooks/use-file-row-drag.ts
+++ b/packages/ui/src/modules/files/hooks/use-file-row-drag.ts
@@ -1,7 +1,9 @@
 import type { DragEvent as ReactDragEvent } from "react";
 import { useMemo } from "react";
 
-/** DataTransfer type carrying an in-tree move (JSON DragSource). */
+/** DataTransfer type carrying an in-tree move (JSON DragSource). App-private
+ *  on purpose: external drags never carry it, which is what keeps the
+ *  `hasFiles`/`hasMove` branches mutually exclusive on the drop paths. */
 export const MOVE_MIME = "application/x-platform-move";
 
 export interface DragSource {

--- a/packages/ui/src/query-client.ts
+++ b/packages/ui/src/query-client.ts
@@ -15,6 +15,7 @@ declare module "@tanstack/react-query" {
     mutationMeta: {
       invalidates?: QueryKey[];
       errorToast?: string;
+      suppressErrorToast?: boolean;
     };
     queryMeta: {
       errorToast?: string;
@@ -56,6 +57,7 @@ export const queryClient = new QueryClient({
         );
       },
       onError: (error, _vars, _ctx, mutation) => {
+        if (mutation.meta?.suppressErrorToast) return;
         if (getApiHealthSnapshot() === "reconnecting" || isTermsStale()) return;
         const title = mutation.meta?.errorToast;
         const detail =


### PR DESCRIPTION
Files and folders in the chat's Files tree can now be reorganized by dragging: drop onto a folder to move an item into it, onto a file to move it beside that file, or onto empty panel space to move it to the workspace root. Folders bring their contents (and their expanded state) along, and a file open in the viewer follows its moved parent. Name collisions prompt the same overwrite confirmation as rename — and when a folder genuinely can't be overwritten, the error now says so plainly instead of failing opaquely. Dragging files in from your computer still uploads them as before.

Also rides along: the inline new-file/new-folder/rename row now matches the tree's font and icon alignment.

Closes #2795.