### PR TITLE
fix(dam-run): close error-handling and timeout gaps across the run stack

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/exec.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/exec.test.ts
@@ -70,6 +70,16 @@ describe("attachExec (PTY)", () => {
     expect(output(ws)).toContain("got-hi");
   });
 
+  // dam-run signals piped-stdin EOF as EOT×2 (a PTY has no true EOF); a
+  // command reading to EOF must exit instead of hanging until the reaper.
+  it("treats EOT input as EOF", async () => {
+    const ws = run(["cat"]);
+    ws.emit("message", Buffer.from(encodeDataFrame(OP_INPUT, "hi\n")));
+    ws.emit("message", Buffer.from(encodeDataFrame(OP_INPUT, "\x04\x04")));
+    expect(await ws.exited).toBe(0);
+    expect(output(ws)).toContain("hi");
+  });
+
   it("reports a missing command as a non-zero exit", async () => {
     const ws = run(["definitely-not-a-real-cmd-xyz-42"]);
     expect(await ws.exited).toBeGreaterThan(0);

--- a/packages/api-server/src/__tests__/unit/harness-run-relay.test.ts
+++ b/packages/api-server/src/__tests__/unit/harness-run-relay.test.ts
@@ -1,0 +1,140 @@
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { spawn } from "node:child_process";
+import { once } from "node:events";
+import { fileURLToPath } from "node:url";
+import { WebSocket, WebSocketServer } from "ws";
+import { afterAll, describe, expect, it, vi } from "vitest";
+import { createRunRelay } from "../../apps/harness-api-server/harness-run-relay.js";
+import type { RunsService } from "../../modules/runs/services/runs-service.js";
+import type {
+  K8sClient,
+  KubeObject,
+} from "../../modules/agents/infrastructure/k8s.js";
+import { LABEL_OWNER } from "../../modules/agents/infrastructure/labels.js";
+
+// Terminal-protocol opcodes (see api-server-api terminal/protocol.ts).
+const OP_INPUT = 0x00;
+const OP_OUTPUT = 0x01;
+const OP_EXIT = 0x03;
+
+const DAM_RUN = fileURLToPath(
+  new URL("../../../../platform-base/dam-run.mjs", import.meta.url),
+);
+
+const agentCR: KubeObject = {
+  metadata: { name: "a1", uid: "uid-a1", labels: { [LABEL_OWNER]: "owner" } },
+};
+
+// Stands in for the executor pod's agent-runtime: echoes stdin frames back as
+// output and treats EOT (what dam-run sends on piped-stdin end) as "command
+// read to EOF", exiting 0 like the real PTY would.
+async function fakeExec(): Promise<{ wss: WebSocketServer; port: number }> {
+  const wss = new WebSocketServer({ port: 0 });
+  wss.on("connection", (ws) => {
+    ws.on("message", (raw: Buffer) => {
+      if (raw[0] !== OP_INPUT) return;
+      const data = raw.subarray(1);
+      if (data.includes(0x04)) {
+        ws.send(Buffer.from([OP_EXIT, 0]));
+        ws.close(1000, "exec exited");
+      } else {
+        ws.send(Buffer.concat([Buffer.from([OP_OUTPUT]), data]));
+      }
+    });
+  });
+  await once(wss, "listening");
+  return { wss, port: (wss.address() as AddressInfo).port };
+}
+
+async function relayServer(deps: {
+  k8s: K8sClient;
+  runs: RunsService;
+  executorPort: number;
+}): Promise<Server> {
+  const relay = createRunRelay(deps);
+  const server = createServer();
+  server.on("upgrade", (req, socket, head) =>
+    relay.handleUpgrade(req, socket, head, "a1"),
+  );
+  server.listen(0);
+  await once(server, "listening");
+  return server;
+}
+
+const cleanups: (() => void)[] = [];
+afterAll(() => cleanups.forEach((fn) => fn()));
+
+describe("harness-run-relay", () => {
+  it("relays a full dam-run session and deletes the Run CR on close", async () => {
+    const exec = await fakeExec();
+    const deleted: string[] = [];
+    const runs: RunsService = {
+      newRunId: () => "run-happy",
+      create: async () => {},
+      waitReady: async () => "127.0.0.1",
+      delete: async (id) => {
+        deleted.push(id);
+      },
+      listRunIds: async () => [],
+    };
+    const k8s = {
+      getCustomObject: async () => agentCR,
+    } as unknown as K8sClient;
+    const server = await relayServer({ k8s, runs, executorPort: exec.port });
+    cleanups.push(() => {
+      server.close();
+      exec.wss.close();
+    });
+
+    const port = (server.address() as AddressInfo).port;
+    // The real CLI as the client: covers its framing, EOT-on-stdin-end, and
+    // exit-code propagation against the real relay.
+    const child = spawn(process.execPath, [DAM_RUN, "cat"], {
+      env: {
+        ...process.env,
+        PLATFORM_MCP_URL: `http://127.0.0.1:${port}/api/agents/a1/mcp`,
+      },
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    child.stdin.end("hi\n");
+    let stdout = "";
+    child.stdout.on("data", (d: Buffer) => (stdout += d.toString()));
+    let stderr = "";
+    child.stderr.on("data", (d: Buffer) => (stderr += d.toString()));
+
+    const [code] = (await once(child, "exit")) as [number];
+    expect(stderr).toBe("");
+    expect(code).toBe(0);
+    expect(stdout).toContain("hi");
+    await vi.waitFor(() => expect(deleted).toContain("run-happy"));
+  });
+
+  it("releases the run when the client disconnects during agent resolution", async () => {
+    const deleted: string[] = [];
+    const runs: RunsService = {
+      newRunId: () => "run-early-close",
+      create: async () => {
+        throw new Error("create must not run for a gone client");
+      },
+      waitReady: () => new Promise<string>(() => {}),
+      delete: async (id) => {
+        deleted.push(id);
+      },
+      listRunIds: async () => [],
+    };
+    const k8s = {
+      // Slow resolve: the client's close lands inside this window.
+      getCustomObject: () =>
+        new Promise<KubeObject>((r) => setTimeout(() => r(agentCR), 100)),
+    } as unknown as K8sClient;
+    const server = await relayServer({ k8s, runs, executorPort: 1 });
+    cleanups.push(() => server.close());
+
+    const port = (server.address() as AddressInfo).port;
+    const client = new WebSocket(`ws://127.0.0.1:${port}/api/agents/a1/run`);
+    client.on("open", () => client.close());
+
+    await vi.waitFor(() => expect(deleted).toContain("run-early-close"));
+  });
+});

--- a/packages/api-server/src/apps/harness-api-server/app.ts
+++ b/packages/api-server/src/apps/harness-api-server/app.ts
@@ -106,7 +106,11 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
   });
 
   // A fresh harness process holds no live relays, so any Run CR that survived a
-  // crash is leaked — its executor pod would run untethered. Sweep them.
+  // crash is leaked — its executor pod would run untethered. Sweep them. Two
+  // accepted imperfections: during a RollingUpdate the outgoing replica may
+  // still hold live relays this sweep kills early (those streams die seconds
+  // later with the old pod anyway), and the sweep is one-shot best-effort —
+  // the controller's over-age reaper covers anything it misses.
   void runs
     .listRunIds()
     .then(async (ids) => {
@@ -117,7 +121,9 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
         );
       }
     })
-    .catch(() => {});
+    .catch((err) => {
+      process.stderr.write(`harness-api run sweep failed: ${err}\n`);
+    });
 
   return { server };
 }

--- a/packages/api-server/src/apps/harness-api-server/harness-run-relay.ts
+++ b/packages/api-server/src/apps/harness-api-server/harness-run-relay.ts
@@ -21,7 +21,41 @@ const MAX_CONCURRENT_RUNS_PER_AGENT = 16;
 
 const PENDING_BUFFER_MAX_BYTES = 4 * 1024 * 1024;
 
-export function createRunRelay(deps: { k8s: K8sClient; runs: RunsService }) {
+// Ping cadence for both relay legs. Pings serve two jobs at once: the frames
+// reset every Envoy stream-idle timer on the agent↔api-server path (5-min
+// default when the gateway's CONNECT-route override isn't rendered), so a
+// quiet long-running command isn't cut mid-stream; and a missed pong detects a
+// half-open peer (node died without FIN), releasing the Run CR and the
+// concurrency slot promptly instead of waiting for the 60-min reaper. Both
+// peers (undici in dam-run, ws in agent-runtime) auto-pong per RFC 6455.
+const KEEPALIVE_INTERVAL_MS = 30_000;
+
+// Bounds the relay→executor dial: waitReady proved the pod Ready, so a
+// handshake that still hangs means a wedged runtime — fail the run rather
+// than sit silent.
+const EXECUTOR_HANDSHAKE_TIMEOUT_MS = 10_000;
+
+function keepalive(sock: WebSocket) {
+  let alive = true;
+  sock.on("pong", () => {
+    alive = true;
+  });
+  const timer = setInterval(() => {
+    if (sock.readyState !== WebSocket.OPEN) return;
+    if (!alive) return sock.terminate();
+    alive = false;
+    sock.ping();
+  }, KEEPALIVE_INTERVAL_MS);
+  sock.on("close", () => clearInterval(timer));
+}
+
+export function createRunRelay(deps: {
+  k8s: K8sClient;
+  runs: RunsService;
+  /** agent-runtime port on the executor pod; injectable for tests. */
+  executorPort?: number;
+}) {
+  const executorPort = deps.executorPort ?? 8080;
   const wss = new WebSocketServer({ noServer: true, perMessageDeflate: false });
   const livePerAgent = new Map<string, number>();
 
@@ -33,14 +67,6 @@ export function createRunRelay(deps: { k8s: K8sClient; runs: RunsService }) {
   ) {
     wss.handleUpgrade(req, socket, head, async (client) => {
       client.on("error", () => client.terminate());
-
-      // The waypoint AuthorizationPolicy already proved the caller is this
-      // agent; resolveAgent just confirms the Agent exists.
-      const identity = await resolveAgent(deps.k8s, agentId);
-      if (!identity) {
-        client.close(1011, "agent not found");
-        return;
-      }
 
       const live = livePerAgent.get(agentId) ?? 0;
       if (live >= MAX_CONCURRENT_RUNS_PER_AGENT) {
@@ -88,22 +114,44 @@ export function createRunRelay(deps: { k8s: K8sClient; runs: RunsService }) {
         }
         pending.push([d, b]);
       };
+      // Attached before the first await: the socket is live from the upgrade,
+      // and a close (or frame) emitted while we resolve/create/wait must not
+      // be missed — a missed close would leave the executor running
+      // untethered until the reaper, pinning a concurrency slot.
       client.on("message", buffer);
       client.on("close", () => {
         clientGone = true;
         release();
       });
+      keepalive(client);
 
       try {
+        // The waypoint AuthorizationPolicy already proved the caller is this
+        // agent; resolveAgent just confirms the Agent exists.
+        const identity = await resolveAgent(deps.k8s, agentId);
+        if (!identity) {
+          client.close(1011, "agent not found");
+          return release();
+        }
+        if (clientGone || overflow) return release();
+
         await deps.runs.create(runId, agentId, identity.uid);
+        // A close that raced create(): release() already ran and its delete
+        // may have preceded the write — re-delete what create just wrote.
+        if (released) return void deps.runs.delete(runId);
+
         const podIP = await deps.runs.waitReady(runId, abort.signal);
         if (clientGone || overflow) return release();
 
         // dam-run passed the exec params (argv/cwd/cols/rows) as query on the
         // upgrade URL; forward that query verbatim to the executor's /api/exec.
         const search = new URL(req.url ?? "/", "http://localhost").search;
-        upstream = new WebSocket(`ws://${podIP}:8080/api/exec${search}`);
+        upstream = new WebSocket(
+          `ws://${podIP}:${executorPort}/api/exec${search}`,
+          { handshakeTimeout: EXECUTOR_HANDSHAKE_TIMEOUT_MS },
+        );
         const us = upstream;
+        keepalive(us);
         us.on("open", () => {
           if (clientGone || overflow) return release();
           client.off("message", buffer);
@@ -116,12 +164,16 @@ export function createRunRelay(deps: { k8s: K8sClient; runs: RunsService }) {
             if (client.readyState === WebSocket.OPEN)
               client.send(d, { binary: isBinary });
           });
-          us.on("close", () => {
-            try {
-              client.close();
-            } catch {}
-            release();
-          });
+        });
+        us.on("close", (code) => {
+          // Normally the exec side sent OP_EXIT and closed 1000, and dam-run
+          // already exited on the OP_EXIT. Anything else (pod died, reaper,
+          // runtime crash) surfaces as a reason so dam-run isn't silent.
+          try {
+            if (code === 1000) client.close(1000);
+            else client.close(1011, "executor connection lost");
+          } catch {}
+          release();
         });
         us.on("error", () => {
           if (client.readyState === WebSocket.OPEN)

--- a/packages/api-server/src/modules/runs/services/runs-service.ts
+++ b/packages/api-server/src/modules/runs/services/runs-service.ts
@@ -5,9 +5,11 @@ import type { K8sClient } from "../../agents/infrastructure/k8s.js";
 const RUNS_PLURAL = "runs";
 const API_VERSION = "agent-platform.ai/v1";
 
-// Slightly over the controller's RunPodReadyTimeout (120s) so a controller-set
-// Failed/Timeout status surfaces as the error rather than our own generic one.
-const READY_TIMEOUT_MS = 125_000;
+// Past the controller's worst case, so a controller-set Failed/Timeout status
+// surfaces as the error rather than our own generic one: it fails a Run at
+// RunPodReadyTimeout (120s) but only notices on a pod event or its 30s
+// informer resync, so the status can land ~150s in.
+const READY_TIMEOUT_MS = 155_000;
 const POLL_INTERVAL_MS = 500;
 
 const runStatusSchema = z
@@ -97,7 +99,11 @@ export function createRunsService(k8s: K8sClient): RunsService {
     },
 
     async delete(runId) {
-      await k8s.deleteCustomObject(RUNS_PLURAL, runId).catch(() => {});
+      // Non-fatal (the controller's over-age reaper is the backstop), but a
+      // failed delete leaves the executor running for up to an hour — log it.
+      await k8s.deleteCustomObject(RUNS_PLURAL, runId).catch((err) => {
+        process.stderr.write(`runs: deleting ${runId} failed: ${err}\n`);
+      });
     },
 
     async listRunIds() {

--- a/packages/controller/pkg/reconciler/run.go
+++ b/packages/controller/pkg/reconciler/run.go
@@ -59,19 +59,22 @@ func (r *RunReconciler) Reconcile(ctx context.Context, run *apiv1.Run) error {
 	runName := run.Name
 	ownerRef := runOwnerRef(run)
 
-	phase := run.Status.Phase
-	if phase == apiv1.RunPhaseFailed || phase == apiv1.RunPhaseCompleted {
-		return nil
-	}
-
 	// Hard GC backstop for a Run the api-server never cleaned up. Deleting the
 	// CR cascades to the executor pod + egress NetworkPolicy via ownerRefs.
+	// Runs before the terminal-phase short-circuit (mirroring the Fork reaper)
+	// so a Failed CR the api-server never deleted — whose pod may sit
+	// Running-but-unready indefinitely — is reaped too.
 	if age := r.now().Sub(run.CreationTimestamp.Time); age > RunMaxLifetime {
 		slog.Warn("reaping over-age run", "run", runName, "age", age.String())
 		if err := r.dynamic.Resource(RunsGVR).Namespace(r.config.Namespace).
 			Delete(ctx, runName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
 			return fmt.Errorf("reaping run %s: %w", runName, err)
 		}
+		return nil
+	}
+
+	phase := run.Status.Phase
+	if phase == apiv1.RunPhaseFailed || phase == apiv1.RunPhaseCompleted {
 		return nil
 	}
 
@@ -115,7 +118,10 @@ func (r *RunReconciler) Reconcile(ctx context.Context, run *apiv1.Run) error {
 		return r.setRunFailed(ctx, runName, types.ForkReasonOrchestrationFailed, fmt.Sprintf("applying executor pod: %v", err))
 	}
 
-	pod, _ := findEphemeralPod(ctx, r.client, r.config.Namespace, RunLabelRunID, runName)
+	pod, err := findEphemeralPod(ctx, r.client, r.config.Namespace, RunLabelRunID, runName)
+	if err != nil {
+		return fmt.Errorf("run %s: listing executor pod: %w", runName, err)
+	}
 	if pod != nil && isPodReady(*pod) && pod.Status.PodIP != "" {
 		return writeRunStatus(ctx, r.dynamic, r.config.Namespace, runName, apiv1.RunStatus{
 			Phase: apiv1.RunPhaseReady, PodIP: pod.Status.PodIP,

--- a/packages/controller/pkg/reconciler/run_test.go
+++ b/packages/controller/pkg/reconciler/run_test.go
@@ -152,3 +152,17 @@ func TestRunReconcile_ReapsOverAgeRun(t *testing.T) {
 		Get(context.Background(), "run-stale", metav1.GetOptions{})
 	assert.True(t, errors.IsNotFound(err), "over-age run should be deleted")
 }
+
+// A Failed Run the api-server never deleted (crash mid-run, lost delete) must
+// still be reaped — the reaper runs before the terminal-phase short-circuit.
+func TestRunReconcile_ReapsOverAgeFailedRun(t *testing.T) {
+	run := runCR("run-stale-failed", time.Unix(1_000_000, 0).Add(-2*RunMaxLifetime))
+	run.Status = apiv1.RunStatus{Phase: apiv1.RunPhaseFailed}
+	r, _ := setupRunReconciler(t, run)
+
+	require.NoError(t, r.Reconcile(context.Background(), run))
+
+	_, err := r.dynamic.Resource(RunsGVR).Namespace("test-agents").
+		Get(context.Background(), "run-stale-failed", metav1.GetOptions{})
+	assert.True(t, errors.IsNotFound(err), "over-age failed run should be deleted")
+}

--- a/packages/platform-base/dam-run.mjs
+++ b/packages/platform-base/dam-run.mjs
@@ -58,8 +58,18 @@ const finish = (code) => {
     } catch {}
   }
   process.stdin.pause();
-  process.exit(code);
+  // Flush stdout before exiting — process.exit truncates a backpressured
+  // pipe. The timer is a backstop for a wedged stdout consumer.
+  process.stdout.write("", () => process.exit(code));
+  setTimeout(() => process.exit(code), 2000);
 };
+
+// The relay completes the upgrade before it starts the executor, so a slow
+// handshake means the path to the api-server is broken, not a slow pod.
+const dialTimeout = setTimeout(() => {
+  process.stderr.write("dam-run: timed out connecting to the platform relay\n");
+  finish(1);
+}, 30_000);
 
 const send = (frame) => {
   if (ws.readyState === WebSocket.OPEN) ws.send(frame);
@@ -71,10 +81,16 @@ const resizeFrame = () => {
 };
 
 ws.onopen = () => {
+  clearTimeout(dialTimeout);
   send(resizeFrame());
   if (isTty) {
     process.stdin.setRawMode(true);
     process.stdout.on("resize", () => send(resizeFrame()));
+  } else {
+    // Piped stdin: a PTY has no true EOF, so signal it the terminal way, with
+    // EOT — twice, since the first only flushes a partial line (a raw-mode
+    // command would read the 0x04 bytes as data, same as in a real terminal).
+    process.stdin.on("end", () => send(new Uint8Array([OP_INPUT, 0x04, 0x04])));
   }
   process.stdin.on("data", (chunk) => {
     const frame = new Uint8Array(chunk.length + 1);


### PR DESCRIPTION
## What

Review of the `dam-run` feature's error handling found several gaps in the crash/timeout story; this PR fixes all of them.

- **controller**: reap over-age Runs before the terminal-phase short-circuit (mirrors the Fork reaper) — previously a `Failed` Run CR the api-server never deleted leaked its executor pod until the next api-server restart. Executor-pod list errors now requeue instead of being swallowed.
- **relay**: attach `close`/`message` handlers before the first `await` — a client disconnecting during agent resolution used to leave the executor running untethered (until the 60-min reaper) with a concurrency slot pinned; a close racing `create()` now re-deletes the CR.
- **relay**: WebSocket ping/pong keepalive (30s) on both legs — keeps quiet long-running commands alive through Envoy's default 5-min stream-idle timer (previously survival depended on the unrelated `AnyUpgrades` egress config) and detects half-open peers (node died without FIN) within ~60s instead of hours. Executor dial bounded by a 10s handshake timeout; executor loss now surfaces to dam-run as a close reason instead of a silent exit 1.
- **runs-service**: `waitReady` polls to 155s (past the controller's 120s pod-ready timeout + 30s resync worst case) so the controller's specific error message surfaces; Run delete failures are logged.
- **dam-run**: piped-stdin EOF now propagates as EOT so `echo hi | dam-run cat` exits instead of hanging until the reaper; 30s relay dial timeout; stdout flushed before exit so fast output isn't truncated.
- **harness app**: boot-sweep failures logged; RollingUpdate overlap documented.

## Tests

- `TestRunReconcile_ReapsOverAgeFailedRun` — Failed-phase reaper regression.
- New `harness-run-relay.test.ts` — drives the **real `dam-run.mjs`** as a child process through the real relay to a fake exec server (framing, EOT-on-EOF, exit code, CR deletion), plus the early-disconnect release regression.
- `exec.test.ts`: EOT-as-EOF against a real PTY.
- All package suites green (controller Go, agent-runtime 165, api-server 295).

Note: `controller:check:crd-backwards-compatibility` fails on this baseline with or without these changes (pre-existing `userbudgets.yaml` removal vs v0.2.7-rc1).