### PR TITLE
fix(agents): replace invalid max effort with xhigh in claude-code manifest

### DIFF
--- a/packages/agents/claude-code/runtime-manifest.yaml
+++ b/packages/agents/claude-code/runtime-manifest.yaml
@@ -51,6 +51,10 @@ drivers:
             - value: bypassPermissions
               name: "Bypass Permissions"
               description: "Bypass all permission checks"
+        # Claude Code's persisted effortLevel setting accepts low|medium|high|xhigh.
+        # "max" is session-only (/effort, --effort, CLAUDE_CODE_EFFORT_LEVEL accept
+        # it, gated to Opus 4.7+/Fable): Claude Code never persists it, and its
+        # settings.json schema silently drops it — so it must not be offered here.
         - id: effort
           name: Effort
           description: Reasoning effort level
@@ -62,8 +66,9 @@ drivers:
               name: "Medium"
             - value: high
               name: "High"
-            - value: max
-              name: "Max"
+            - value: xhigh
+              name: "Extra High"
+              description: "May use excessive tokens. Use sparingly for the hardest tasks."
       # Haiku supports neither "auto" mode nor effort levels.
       modelConstraints:
         haiku:


### PR DESCRIPTION
## Problem

The claude-code harness-config catalog offered a **Max** effort level, but writing `effortLevel: "max"` to `settings.json` — the only channel the harness-config driver uses — is silently dropped by Claude Code, so anyone selecting Max got the model default (`high`) instead.

**`max` is a real effort level, but session-only.** Verified in the decompiled binaries of both the pinned 2.1.173 and current 2.1.209:

- The session channels (`/effort`, `--effort`, `CLAUDE_CODE_EFFORT_LEVEL`) validate against the full ladder `["low","medium","high","xhigh","max"]`, model-gated at resolution time (max: Opus 4.7+/Fable; xhigh: Opus 4.6+/Sonnet 4.6+; unsupported → downgrade to `high`).
- The **persistence** path uses a separate filter in both directions:
  ```js
  function i4e(e){ if(e==="low"||e==="medium"||e==="high"||e==="xhigh") return e; return }
  ```
  Claude Code itself never persists `max` (picking it via `/effort` applies to the session only), and on load the settings schema is `effortLevel: enum(["low","medium","high","xhigh"]).optional().catch(void 0)` — an external `"max"` is coerced to `undefined`, falling back to the model's `default_effort ?? "high"`.

Meanwhile `xhigh` — the highest persistable level — was missing from the catalog.

## Change

- Add `xhigh` ("Extra High") to the effort choices, with Claude Code's own caution as the description
- Remove the dead `max` choice, with a comment explaining why it must not be re-added
- Haiku remains excluded from effort via the existing `modelConstraints`

## Follow-up (not in this PR)

True `max` could be offered via the `CLAUDE_CODE_EFFORT_LEVEL` env var (accepted by both versions), but that's an env-channel config the manifest driver doesn't support today, and it would need per-model constraints (only `opus` qualifies on 2.1.173).

## Testing

- `manifest-resolve` unit tests (load + validate the real manifest) pass 11/11
- Full `mise run check` passes (pre-commit hook)