### PR TITLE
fix(ui): guard against missing sandbox size in settings form

### DIFF
--- a/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
@@ -147,8 +147,8 @@ export function useSandboxSettingsForm() {
         .sort(),
       envVars: userInitialEnv,
       hibernationTimeoutMin: agent.hibernationTimeoutMin,
-      sizeCpuMilli: parseCpuMilli(agent.size.cpu) ?? 1000,
-      sizeMemoryMi: parseMemoryMi(agent.size.memory) ?? 1024,
+      sizeCpuMilli: parseCpuMilli(agent.size?.cpu) ?? 1000,
+      sizeMemoryMi: parseMemoryMi(agent.size?.memory) ?? 1024,
     });
     setFormReady(true);
   }, [


### PR DESCRIPTION
## Problem

Opening any sandbox created before the compute-budget/size feature (#2768) shows a **blank page**. The sandbox home view crashes with `Cannot read properties of undefined (reading 'cpu')` because such sandboxes have no `size`, and the settings form reads `agent.size.cpu` directly. This blanks the whole home view for every section (Setup, Connections, Skills, Schedules), not just one.

## Fix

Guard the access with optional chaining (`agent.size?.cpu` / `agent.size?.memory`). The existing `?? 1000 / 1024` fallbacks already handle the absent values, so pre-size sandboxes now fall back to the defaults instead of crashing.