### PR TITLE
feat(ui): per-user monthly LLM spend in settings Usage tab

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -170,6 +170,7 @@ export type { ChannelsService } from "./modules/channels/types.js";
 export type {
   MetricsService,
   MetricsQuery,
+  MetricsSpendQuery,
   MetricsOverview,
   TokenSpendByModel,
   SessionRuntime,

--- a/packages/api-server-api/src/modules/metrics/router.ts
+++ b/packages/api-server-api/src/modules/metrics/router.ts
@@ -3,7 +3,10 @@ import {
   checkAgentBinding,
   readAgentProcedure,
 } from "../../auth-procedures.js";
-import { metricsOverviewInputSchema } from "./schemas.js";
+import {
+  metricsOverviewInputSchema,
+  metricsSpendInputSchema,
+} from "./schemas.js";
 
 // Ownership is enforced in the service (it resolves the caller's owned agent
 // IDs and filters on them). When a specific agentId is requested we also apply
@@ -15,4 +18,7 @@ export const metricsRouter = t.router({
       if (input.agentId) checkAgentBinding(ctx, input.agentId);
       return ctx.metrics.overview(input);
     }),
+  spend: readAgentProcedure
+    .input(metricsSpendInputSchema)
+    .query(({ ctx, input }) => ctx.metrics.spend(input)),
 });

--- a/packages/api-server-api/src/modules/metrics/schemas.ts
+++ b/packages/api-server-api/src/modules/metrics/schemas.ts
@@ -12,3 +12,11 @@ export const metricsOverviewInputSchema = z.object({
   sinceHours: z.coerce.number().int().positive().max(720).optional(),
   limit: z.coerce.number().int().positive().max(1000).default(100),
 });
+
+// Per-model spend over an absolute half-open range [from, to), across all of
+// the caller's agents. Instants (not calendar fields) so the client decides
+// what a "month" means in its own timezone.
+export const metricsSpendInputSchema = z.object({
+  from: z.string().datetime(),
+  to: z.string().datetime(),
+});

--- a/packages/api-server-api/src/modules/metrics/types.ts
+++ b/packages/api-server-api/src/modules/metrics/types.ts
@@ -1,7 +1,11 @@
 import type { z } from "zod";
-import type { metricsOverviewInputSchema } from "./schemas.js";
+import type {
+  metricsOverviewInputSchema,
+  metricsSpendInputSchema,
+} from "./schemas.js";
 
 export type MetricsQuery = z.infer<typeof metricsOverviewInputSchema>;
+export type MetricsSpendQuery = z.infer<typeof metricsSpendInputSchema>;
 
 /** Token counts + cost rolled up per model, over the window. */
 export interface TokenSpendByModel {
@@ -59,4 +63,6 @@ export interface MetricsOverview {
  *  Returns data only for agents the caller owns. */
 export interface MetricsService {
   overview(query: MetricsQuery): Promise<MetricsOverview>;
+  /** Per-model spend over [from, to), across all of the caller's agents. */
+  spend(query: MetricsSpendQuery): Promise<TokenSpendByModel[]>;
 }

--- a/packages/api-server-api/src/modules/metrics/types.ts
+++ b/packages/api-server-api/src/modules/metrics/types.ts
@@ -63,6 +63,7 @@ export interface MetricsOverview {
  *  Returns data only for agents the caller owns. */
 export interface MetricsService {
   overview(query: MetricsQuery): Promise<MetricsOverview>;
-  /** Per-model spend over [from, to), across all of the caller's agents. */
+  /** Per-model spend over [from, to), across all of the caller's agents —
+   *  deleted ones included, so history doesn't shrink retroactively. */
   spend(query: MetricsSpendQuery): Promise<TokenSpendByModel[]>;
 }

--- a/packages/api-server/src/__tests__/unit/metrics-reader-predicate.test.ts
+++ b/packages/api-server/src/__tests__/unit/metrics-reader-predicate.test.ts
@@ -32,6 +32,19 @@ describe("ownedApiRequests", () => {
     expect(sql).not.toContain("ServiceName");
   });
 
+  it("bounds by the absolute range as half-open [from, to)", () => {
+    const sql = ownedApiRequests({
+      fromIso: "2026-07-01",
+      toIso: "2026-08-01",
+    });
+    expect(sql).toContain(
+      "Timestamp >= parseDateTimeBestEffort({fromIso:String})",
+    );
+    expect(sql).toContain(
+      "Timestamp < parseDateTimeBestEffort({toIso:String})",
+    );
+  });
+
   it("applies no session predicate without a sessionId", () => {
     const sql = ownedApiRequests({ hours: 24 });
     expect(sql).not.toContain("sessionId");

--- a/packages/api-server/src/__tests__/unit/metrics-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/metrics-service.test.ts
@@ -83,8 +83,45 @@ describe("metrics ownership gate", () => {
     expect(calls).toEqual([]);
   });
 
+  it("spend scopes to all owned agents and passes the range through", async () => {
+    const { reader, calls, windows } = spyReader();
+    const svc = createMetricsService({ reader, listOwnedAgentIds: owned });
+    await svc.spend({
+      from: "2026-07-01T00:00:00.000Z",
+      to: "2026-08-01T00:00:00.000Z",
+    });
+    expect(calls).toEqual([["agent-a", "agent-b"]]);
+    expect(windows).toEqual([
+      {
+        fromIso: "2026-07-01T00:00:00.000Z",
+        toIso: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("spend returns nothing when the caller owns no agents", async () => {
+    const { reader, calls } = spyReader();
+    const svc = createMetricsService({
+      reader,
+      listOwnedAgentIds: () => Promise.resolve([]),
+    });
+    expect(
+      await svc.spend({
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+      }),
+    ).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
   it("disabled service fails closed", async () => {
     const svc = createDisabledMetricsService();
     await expect(svc.overview(query)).rejects.toThrow(/not enabled/);
+    await expect(
+      svc.spend({
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(/not enabled/);
   });
 });

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -130,6 +130,9 @@ export interface ApiServerAppDeps {
   mountUsageRoutes: (
     app: Hono<{ Variables: { user: UserIdentity; roles: string[] } }>,
   ) => void;
+  /** Agent ids ever registered to an owner (Postgres agent registry,
+   *  soft-deleted included) — keeps deleted agents' spend attributable. */
+  listRegisteredAgentIds: (rawSub: string) => Promise<string[]>;
   /** ClickHouse-backed agent-metrics reader; `null` when the telemetry
    *  backend is disabled (the metrics API then fails closed). */
   metricsReader: MetricsReader | null;
@@ -160,6 +163,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     contributionsSettled,
     getAgentCapabilities,
     schedulesBoot,
+    listRegisteredAgentIds,
     metricsReader,
     terms,
     isTermsAccepted,
@@ -851,11 +855,17 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     });
     // Owner-scoped metrics: resolve this user's agent IDs (narrowed to the
     // key's binding, mirroring agentsRouter.list) and filter ClickHouse on them.
+    // Live CRs are unioned with the Postgres agent registry so spend history
+    // survives agent deletion instead of shrinking retroactively.
     const metrics = metricsReader
       ? createMetricsService({
           reader: metricsReader,
           listOwnedAgentIds: async () => {
-            const ids = (await agents.list()).map((a) => a.id);
+            const [live, registered] = await Promise.all([
+              agents.list(),
+              listRegisteredAgentIds(user.sub),
+            ]);
+            const ids = [...new Set([...live.map((a) => a.id), ...registered])];
             return user.agentIds === "*"
               ? ids
               : ids.filter((id) => user.agentIds.includes(id));

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -72,6 +72,7 @@ import {
   startOnChannelTurnRelayedSaga,
 } from "./modules/forks/index.js";
 import { composeUsageModule } from "./modules/usage/compose.js";
+import { listAgentIdsByOwner } from "./modules/usage/infrastructure/agents-postgres-repository.js";
 import { composeMetricsReader } from "./modules/metrics/index.js";
 import { composeAuditModule } from "./modules/audit/index.js";
 import { createK8sForkOrchestrator } from "./modules/forks/infrastructure/k8s-fork-orchestrator.js";
@@ -604,6 +605,7 @@ const { server: apiServer } = startApiServerApp({
       .then((r) => r?.runtimeCapabilities ?? null),
   schedulesBoot,
   mountUsageRoutes: usage.mount,
+  listRegisteredAgentIds: listAgentIdsByOwner(db, subPseudonymizer),
   metricsReader: composeMetricsReader(config),
   terms: termsService,
   isTermsAccepted,

--- a/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
+++ b/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
@@ -39,6 +39,12 @@ export const ownedApiRequests = (w: MetricsWindow): string => {
     ...(w.hours === undefined
       ? []
       : ["Timestamp >= now() - toIntervalHour({hours:UInt32})"]),
+    ...(w.fromIso === undefined
+      ? []
+      : ["Timestamp >= parseDateTimeBestEffort({fromIso:String})"]),
+    ...(w.toIso === undefined
+      ? []
+      : ["Timestamp < parseDateTimeBestEffort({toIso:String})"]),
   ];
   if (w.sessionId === undefined) return base.join("\n  AND ");
   // Child harness runs (a `claude -p` subshell, a dam-run executor) mint their
@@ -66,6 +72,8 @@ export const ownedApiRequests = (w: MetricsWindow): string => {
 const windowParams = (agentIds: readonly string[], w: MetricsWindow) => ({
   agentIds,
   ...(w.hours === undefined ? {} : { hours: w.hours }),
+  ...(w.fromIso === undefined ? {} : { fromIso: w.fromIso }),
+  ...(w.toIso === undefined ? {} : { toIso: w.toIso }),
   ...(w.sessionId === undefined ? {} : { sessionId: w.sessionId }),
 });
 

--- a/packages/api-server/src/modules/metrics/services/metrics-service.ts
+++ b/packages/api-server/src/modules/metrics/services/metrics-service.ts
@@ -8,9 +8,12 @@ import type {
 } from "api-server-api";
 
 /** Row filters beyond ownership, independent and composable: an optional
- *  lookback window and an optional exact session. Both absent = all rows. */
+ *  lookback window, an optional absolute [fromIso, toIso) range, and an
+ *  optional exact session. All absent = all rows. */
 export interface MetricsWindow {
   hours?: number;
+  fromIso?: string;
+  toIso?: string;
   sessionId?: string;
 }
 
@@ -69,18 +72,26 @@ export function createMetricsService(deps: {
         ]);
       return { tokenSpendByModel, runtimeBySession, contextPerCall };
     },
+
+    async spend(query) {
+      const ids = await ownedScope(deps.listOwnedAgentIds, undefined);
+      if (ids.length === 0) return [];
+      return deps.reader.tokenSpendByModel(ids, {
+        fromIso: query.from,
+        toIso: query.to,
+      });
+    },
   };
 }
 
 /** Wired when the metrics backend (ClickStack) is disabled — every read
  *  fails loud rather than masquerading as "no data yet". */
 export function createDisabledMetricsService(): MetricsService {
-  return {
-    overview: async () => {
-      throw new TRPCError({
-        code: "PRECONDITION_FAILED",
-        message: "Agent metrics backend is not enabled on this deployment.",
-      });
-    },
+  const fail = async (): Promise<never> => {
+    throw new TRPCError({
+      code: "PRECONDITION_FAILED",
+      message: "Agent metrics backend is not enabled on this deployment.",
+    });
   };
+  return { overview: fail, spend: fail };
 }

--- a/packages/api-server/src/modules/usage/infrastructure/agents-postgres-repository.ts
+++ b/packages/api-server/src/modules/usage/infrastructure/agents-postgres-repository.ts
@@ -18,6 +18,19 @@ export function upsertAgent(db: Db, pseudo: SubPseudonymizer) {
   };
 }
 
+/** Every agent id ever registered to `rawSub`, soft-deleted included — the
+ *  historical ownership scope. Rows follow the upsert above: a re-used id
+ *  belongs to its current owner, history and all. */
+export function listAgentIdsByOwner(db: Db, pseudo: SubPseudonymizer) {
+  return async (rawSub: string): Promise<string[]> => {
+    const rows = await db
+      .select({ id: agents.id })
+      .from(agents)
+      .where(eq(agents.ownerSub, pseudo.hashSub(rawSub)));
+    return rows.map((r) => r.id);
+  };
+}
+
 export function markAgentDeleted(db: Db) {
   return async (id: string): Promise<void> => {
     await db

--- a/packages/ui/src/modules/metrics/api/queries.ts
+++ b/packages/ui/src/modules/metrics/api/queries.ts
@@ -2,6 +2,15 @@ import { skipToken, useQuery } from "@tanstack/react-query";
 
 import { trpc } from "../../../trpc.js";
 
+/** Per-model spend across all of the user's agents over [from, to). */
+export function useModelSpend(from: string, to: string) {
+  return useQuery({
+    ...trpc.metrics.spend.queryOptions({ from, to }),
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 /** Metrics overview for one agent. Disabled while no agent is selected. */
 export function useMetricsOverview(
   agentId: string | null,

--- a/packages/ui/src/modules/metrics/components/metrics-panel.tsx
+++ b/packages/ui/src/modules/metrics/components/metrics-panel.tsx
@@ -146,7 +146,7 @@ function SectionHeading({ children }: { children: React.ReactNode }) {
   );
 }
 
-function ModelSpendTable({ rows }: { rows: TokenSpendByModel[] }) {
+export function ModelSpendTable({ rows }: { rows: TokenSpendByModel[] }) {
   return (
     <table className="w-full border-collapse tabular-nums">
       <thead>

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -1,0 +1,95 @@
+import { ChevronLeft, ChevronRight } from "@carbon/icons-react";
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { SectionLabel } from "@/components/ui/section-label";
+
+import { useModelSpend } from "../api/queries.js";
+import { ModelSpendTable } from "../components/metrics-panel.js";
+import { formatUsd } from "../lib/format.js";
+
+// Month boundaries are computed in the browser's timezone; the API takes the
+// resulting instants, so "calendar month" means the user's wall-clock month.
+const monthStart = (base: Date, offset: number) =>
+  new Date(base.getFullYear(), base.getMonth() + offset, 1);
+
+/** Settings tab: the user's LLM API spend for one calendar month, totalled
+ *  and broken down per model across all their agents. */
+export function UsageView() {
+  const [month, setMonth] = useState(() => monthStart(new Date(), 0));
+  const isCurrentMonth = month >= monthStart(new Date(), 0);
+  const monthLabel = month.toLocaleDateString(undefined, {
+    month: "long",
+    year: "numeric",
+  });
+  const { data, isPending, isError } = useModelSpend(
+    month.toISOString(),
+    monthStart(month, 1).toISOString(),
+  );
+  const total = data?.reduce((sum, row) => sum + row.costUsd, 0) ?? 0;
+
+  return (
+    <div>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="mb-1 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
+            Usage
+          </h2>
+          <p className="text-[14px] text-foreground/80 mb-6">
+            LLM API spend across all your agents.
+          </p>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Previous month"
+            onClick={() => setMonth(monthStart(month, -1))}
+          >
+            <ChevronLeft size={16} />
+          </Button>
+          <span className="min-w-[120px] text-center text-[14px] font-medium">
+            {monthLabel}
+          </span>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label="Next month"
+            disabled={isCurrentMonth}
+            onClick={() => setMonth(monthStart(month, 1))}
+          >
+            <ChevronRight size={16} />
+          </Button>
+        </div>
+      </div>
+
+      {isError && (
+        <p className="text-[14px] text-muted-foreground">
+          Usage metrics are unavailable on this deployment.
+        </p>
+      )}
+      {isPending && !isError && (
+        <p className="text-[14px] text-muted-foreground">Loading usage…</p>
+      )}
+      {data && (
+        <>
+          <SectionLabel spaced>Total spend</SectionLabel>
+          <div className="mb-8 text-[32px] font-semibold tabular-nums text-foreground">
+            {formatUsd(total)}
+          </div>
+          <SectionLabel spaced>Spend by model</SectionLabel>
+          {data.length === 0 ? (
+            <p className="text-[14px] text-muted-foreground">
+              No LLM calls in {monthLabel}.
+            </p>
+          ) : (
+            <Card className="p-4 text-[12px]">
+              <ModelSpendTable rows={data} />
+            </Card>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/platform/lib/routes.ts
+++ b/packages/ui/src/modules/platform/lib/routes.ts
@@ -23,6 +23,7 @@ export const settingsTabSchema = z.enum([
   "providers",
   "connections",
   "api-keys",
+  "usage",
   "channels",
 ]);
 export type SettingsTab = z.infer<typeof settingsTabSchema>;

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -21,6 +21,7 @@ import {
   setShowInternalConnections,
 } from "../../connections/internal-only.js";
 import { ConnectionsView } from "../../connections/views/connections-view.js";
+import { UsageView } from "../../metrics/views/usage-view.js";
 import type { SettingsTab } from "../../platform/lib/routes.js";
 import { ChannelsPanel } from "../../sessions/components/channels-panel.js";
 import { useAppVersion } from "../api/queries.js";
@@ -32,6 +33,7 @@ const baseTabs: { id: SettingsTab; label: string }[] = [
   { id: "providers", label: "Providers" },
   { id: "connections", label: "Connections" },
   { id: "api-keys", label: "API keys" },
+  { id: "usage", label: "Usage" },
 ];
 
 const themeOptions = [
@@ -222,6 +224,12 @@ export function SettingsView() {
         {activeTab === "connections" && (
           <div className="anim-in">
             <ConnectionsView />
+          </div>
+        )}
+
+        {activeTab === "usage" && (
+          <div className="anim-in">
+            <UsageView />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary

Adds a **Usage** section to user settings showing per-user LLM API spend, aggregated across all of the user's agents:

- total spend for the selected calendar month
- per-model breakdown (calls folded into in/out tokens + cost, reusing the sessions metrics panel table)
- month name with ‹ / › navigation in the top-right corner (› disabled at the current month; boundaries computed in the browser's timezone)

## Implementation

- **`metrics.spend`** tRPC procedure: per-model token spend over an absolute half-open `[from, to)` range, ownership-scoped like `metrics.overview`. The ClickHouse window predicate gains `fromIso`/`toIso` filters. Fails closed when ClickStack is disabled.
- **Deleted agents stay attributable**: the metrics ownership scope now unions live Agent CRs with the Postgres agent registry (soft-deleted included, matched via the HMAC'd owner sub), so monthly totals don't shrink retroactively when an agent is deleted. Note: a re-used agent id attributes its whole history to the current owner, matching the existing agent-id-keyed attribution model.
- New `usage` settings tab wired through `settingsTabSchema` (deep-linkable at `/settings/usage`).

## Testing

- Unit tests for the spend ownership gate (incl. empty-owner and disabled-service paths) and the ClickHouse range predicate; `mise run check` green, api-server 343/343, UI 77/77.
- Verified end-to-end on a local k3s cluster with ClickStack enabled and seeded `otel_logs` rows: month totals and breakdowns match ClickHouse exactly, month navigation works (populated months, empty-month state, disabled next at current month), OIDC deep-link round-trip works, and spend survives deleting the owning agent (rendered $0 before the registry-union fix).