### PR TITLE
fix(helm): set default 720h TTL on collector-created otel tables

### DIFF
--- a/deploy/helm/platform/templates/clickstack/collector.yaml
+++ b/deploy/helm/platform/templates/clickstack/collector.yaml
@@ -59,6 +59,8 @@ data:
         password: ${env:CLICKHOUSE_PASSWORD}
         database: default
         create_schema: true
+        # Lands in the CREATE TABLE DDL only; existing tables keep their TTL.
+        ttl: {{ .Values.clickstack.collector.ttl }}
     extensions:
       health_check:
         endpoint: 0.0.0.0:13133

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -251,6 +251,10 @@ clickstack:
     annotations: {}
     podAnnotations: {}
     image: quay.io/dam-agents/opentelemetry-collector-contrib:0.146.1
+    # Retention for the otel_* tables, matching the ClickStack bundled collector's
+    # default. Only applied when the exporter creates the tables — changing it later
+    # requires ALTER TABLE ... MODIFY TTL by hand.
+    ttl: 720h
     resources:
       requests:
         cpu: 100m

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -1,6 +1,6 @@
 # Observability (agent telemetry)
 
-Last verified: 2026-07-10
+Last verified: 2026-07-16
 
 ## Overview
 
@@ -26,7 +26,7 @@ flowchart LR
 ```
 
 - **Collector** — an OpenTelemetry collector that receives OTLP and writes the signals into the telemetry store. It is platform-owned (deliberately not the collector ClickStack bundles — see *Access control*) and holds no upstream credentials; it only ingests telemetry.
-- **Telemetry store** — a columnar analytical database built for high-volume, high-cardinality, time-series telemetry. It is the only place telemetry lives.
+- **Telemetry store** — a columnar analytical database built for high-volume, high-cardinality, time-series telemetry. It is the only place telemetry lives. Retention is bounded: when the collector first creates the telemetry tables it stamps them with a TTL — 30 days by default, overridable per install through the chart — so signals age out instead of accumulating until the volume fills. The TTL lands only at table creation; changing it on an existing install means altering the tables by hand.
 - **Exploration UI** — reads the telemetry store directly so an operator can explore signals. Its own application state (dashboards, sources, saved views) lives in a separate document store that holds no telemetry.
 
 The whole stack sits inside the cluster trust boundary.


### PR DESCRIPTION
## Summary

Fixes #2808.

The platform-owned OTel collector's clickhouse exporter created the `otel_logs` / `otel_traces` / `otel_metrics_*` tables with no TTL clause — the exporter's default `ttl` is `0` (no TTL), so retention was unbounded until the ClickHouse PVC filled. The ClickStack bundled collector we disable would have defaulted this to 720h; replacing it with our collector silently dropped that safety.

- Add a `clickstack.collector.ttl` values knob, default `720h`, matching the bundled collector's default. At the pinned collector version this renders in the DDL as `TTL TimestampTime + toIntervalDay(30)`.
- Template it into the exporter block of the collector ConfigMap.
- Document bounded retention in the observability architecture page.

## Caveat (from the issue)

The exporter's `ttl` only lands in the `CREATE TABLE IF NOT EXISTS` DDL — it never alters existing tables. Dev and staging were retro-fitted by hand; this knob gives fresh installs retention from day one. Verified against the exporter source at the version the pinned image ships (image `0.146.1` → contrib `v0.146.0`): the key is `ttl`, it takes a Go duration, and there is no ALTER path in the exporter.

## Verification

- `mise run helm:check:lint` and `mise run helm:check:render` pass.
- `helm template --set clickstack.enabled=true` shows `ttl: 720h` in the rendered exporter config.

Manual verification on a live cluster (not run): fresh install with `clickstack.enabled=true`, then `SHOW CREATE TABLE otel_logs` in ClickHouse should include `TTL TimestampTime + toIntervalDay(30)`.