### PR TITLE
test(agent-runtime): de-flake "treats EOT input as EOF" PTY test

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/exec.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/exec.test.ts
@@ -76,7 +76,16 @@ describe("attachExec (PTY)", () => {
     const ws = run(["cat"]);
     ws.emit("message", Buffer.from(encodeDataFrame(OP_INPUT, "hi\n")));
     ws.emit("message", Buffer.from(encodeDataFrame(OP_INPUT, "\x04\x04")));
-    expect(await ws.exited).toBe(0);
+    // ^D (EOT) on an empty line makes the tty line discipline signal EOF, so
+    // `cat` stops reading and terminates. If EOT were NOT treated as EOF it
+    // would be echoed as data and `cat` would run forever — this await would
+    // then hang until the test times out, which is the real regression this
+    // guards against. How the kernel reports the EOF-driven teardown is racy:
+    // `cat`'s clean exit (0) races the controlling-terminal hangup (SIGHUP ->
+    // 128+1 = 129), and either can win under load — so we assert on
+    // termination + relayed output, not on an exact exit code.
+    const exitCode = await ws.exited;
+    expect([0, 129]).toContain(exitCode);
     expect(output(ws)).toContain("hi");
   });
 


### PR DESCRIPTION
## What

De-flakes `packages/agent-runtime/src/__tests__/unit/exec.test.ts > attachExec (PTY) > treats EOT input as EOF`, which has been intermittently reddening `main` and PRs with:

```
AssertionError: expected 129 to be +0 // Object.is equality
```

## Root cause

The test asserted `cat` exits **exactly 0** after EOT-as-EOF. But a PTY reports EOF-driven teardown **nondeterministically**: `cat`'s clean exit (`0`) races the controlling-terminal hangup (`SIGHUP` → `128 + 1 = 129`). Either can win depending on kernel/node-pty reap ordering, and load makes SIGHUP win more often — which is why it surfaces on busy CI runners.

This is **not** an `attachExec` bug: in the test nothing closes the socket, so `pty.kill()` is never invoked. `attachExec` faithfully reports whatever the PTY layer returns (`exitCode || (signal ? 128 + signal : 0)`). So the correct fix is the test assertion, not the code.

I verified no timing tweak removes the race — the residual flake persists through all of them, confirming it lives in the reap ordering, not in *when* EOT is sent:

| variant | exit-129 rate |
|---|---|
| two EOT, sync writes (current) | ~20–23% |
| single EOT | ~22% |
| combined `"hi\n\x04"` write | ~3% |
| wait for `hi` echo, then EOT | ~2.5% |
| EOT delayed 5ms | ~0.8% |

## Fix

Assert the **deterministic contract** the test actually cares about:
- EOT causes the command to **terminate** — if EOT were *not* treated as EOF it would be echoed as data and `cat` would run forever, hanging the test (this is the real regression the test guards against);
- the relayed input (`hi`) is echoed back;
- the exit code is `0` **or** `129` (clean EOF exit vs. SIGHUP hangup) — both mean "terminated via EOF-driven teardown".

## Evidence

- **Repro (standalone `@lydell/node-pty@1.1.0`, exact write sequence):** 70/300 (~23%) exited `129` (`exitCode=0, signal=1`), `hi` echoed in every case.
- **Repro (real test under CPU load):** 18/40 (45%) failed with `expected 129 to be +0`.
- **After fix (real test, same load):** 40/40 green. Full `exec.test.ts` suite: 6/6 pass.

Observability context that motivated this: reported flaking on main push #2807 (run `29488131019`) and PR #2811 (run `29496011441`) — PR #2811 passed at 11:22 then failed at 11:52 with no relevant change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)