### PR TITLE
fix(egress): enforce path-scoped HTTPS rules on credential-less hosts

### DIFF
--- a/packages/api-server/src/__tests__/unit/approvals-service-expired.test.ts
+++ b/packages/api-server/src/__tests__/unit/approvals-service-expired.test.ts
@@ -32,7 +32,7 @@ function extAuthzRow(
 
 function makeService(seed: PendingApprovalRow) {
   const rows = [seed];
-  const inserts: { verdict: string }[] = [];
+  const inserts: { verdict: string; ownerSub: string }[] = [];
   const repo: ApprovalsRepository = {
     insertPending: async () => {},
     getPending: async (id) => rows.find((r) => r.id === id) ?? null,
@@ -68,7 +68,7 @@ function makeService(seed: PendingApprovalRow) {
     repo,
     egressRuleWriter: {
       insert: async (input) => {
-        inserts.push({ verdict: input.verdict });
+        inserts.push({ verdict: input.verdict, ownerSub: input.ownerSub });
       },
     },
     notifier: { notifyResolved: async () => {} },
@@ -85,6 +85,9 @@ describe("approvals verdicts on expired requests (#2125)", () => {
     const { rows, service, inserts } = makeService(extAuthzRow());
     const outcome = await service.approvePermanent("appr-1");
     expect(inserts).toHaveLength(1);
+    // The row's owner sub (the agent owner) labels the allow-only Secret
+    // when the written rule needs L7 promotion (#2322).
+    expect(inserts[0].ownerSub).toBe("owner-1");
     expect(outcome.outcome).toBe("rule_written_expired");
     expect(rows[0].status).toBe("resolved");
     expect(rows[0].deliveredAt).not.toBeNull();

--- a/packages/api-server/src/__tests__/unit/egress-rules-port.test.ts
+++ b/packages/api-server/src/__tests__/unit/egress-rules-port.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { createEgressRulesService } from "../../modules/egress-rules/services/egress-rules-service.js";
+import { createEgressRuleWriter } from "../../modules/egress-rules/services/egress-rule-writer.js";
 import { createConnectionRulesSync } from "../../modules/egress-rules/services/connection-rules-sync.js";
 import type { EgressRulesRepository } from "../../modules/egress-rules/infrastructure/egress-rules-repository.js";
 import type { NewEgressRule } from "../../modules/egress-rules/infrastructure/egress-rules-repository.js";
@@ -103,6 +104,69 @@ describe("egress-rules-service: port promotes a manual rule onto the L7 chain", 
       verdict: "allow",
     });
 
+    expect(ensureCalls).toBe(0);
+  });
+});
+
+describe("egress-rule-writer: inbox verdicts get the same L7 promotion (#2322)", () => {
+  it("promotes a narrow rule, labeling the Secret with the agent owner's sub", async () => {
+    const { repo, inserted } = fakeRepo();
+    const ensured: Array<{ owner: string; host: string }> = [];
+    const writer = createEgressRuleWriter({
+      repo,
+      allowOnlySecrets: {
+        ensure: async (owner, host) => {
+          ensured.push({ owner, host });
+        },
+      },
+    });
+
+    // A narrow rule can be born from an inbox verdict when the held request
+    // was plain HTTP (method/path visible without MITM). Without promotion
+    // its HTTPS half is silently unenforced.
+    await writer.insert({
+      id: "r1",
+      agentId: "a1",
+      ownerSub: "agent-owner",
+      host: "api.example.com",
+      method: "GET",
+      pathPattern: "/status/*",
+      verdict: "allow",
+      decidedBy: "agent-owner",
+      source: "inbox",
+    });
+
+    expect(inserted).toHaveLength(1);
+    expect(ensured).toEqual([
+      { owner: "agent-owner", host: "api.example.com" },
+    ]);
+  });
+
+  it("does NOT promote a host-wide rule (stays on the L4 path)", async () => {
+    const { repo, inserted } = fakeRepo();
+    let ensureCalls = 0;
+    const writer = createEgressRuleWriter({
+      repo,
+      allowOnlySecrets: {
+        ensure: async () => {
+          ensureCalls++;
+        },
+      },
+    });
+
+    await writer.insert({
+      id: "r1",
+      agentId: "a1",
+      ownerSub: "agent-owner",
+      host: "api.example.com",
+      method: "*",
+      pathPattern: "*",
+      verdict: "allow",
+      decidedBy: "agent-owner",
+      source: "inbox",
+    });
+
+    expect(inserted).toHaveLength(1);
     expect(ensureCalls).toBe(0);
   });
 });

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -874,11 +874,12 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     );
     const isAgentOwnedBy = async (agentId: string, ownerSub: string) =>
       (await agents.get(agentId)) !== null && ownerSub === user.sub;
+    const allowOnlySecrets = createK8sAllowOnlySecretsPort(k8sClient);
     const { service: egressRules } = composeEgressRulesModule({
       db,
       ownerSub: user.sub,
       isAgentOwnedBy,
-      allowOnlySecrets: createK8sAllowOnlySecretsPort(k8sClient),
+      allowOnlySecrets,
       presetSeeder,
       trustedHosts,
     });
@@ -888,7 +889,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       agentBinding: user.agentIds,
       isAgentOwnedBy: (agentId, ownerSub) =>
         agentsRepo.isOwnedBy(agentId, ownerSub),
-      egressRuleWriter: createEgressRuleWriterAdapter(db),
+      egressRuleWriter: createEgressRuleWriterAdapter(db, allowOnlySecrets),
       bus: redisBus,
       wrapperFrameSender,
     });

--- a/packages/api-server/src/modules/approvals/services/approvals-service.ts
+++ b/packages/api-server/src/modules/approvals/services/approvals-service.ts
@@ -25,11 +25,14 @@ export interface ApprovalsNotifier {
 /** Narrow port the approvals service consumes for the
  *  approve-permanent / deny-forever paths. The egress-rules module's
  *  `compose.ts` provides an adapter; the approvals service never sees the
- *  full `EgressRulesRepository`. */
+ *  full `EgressRulesRepository`. `ownerSub` is the agent owner's sub (the
+ *  pending row's owner) — the writer needs it to label the allow-only
+ *  Secret when a narrow rule requires L7 promotion (#2322). */
 export interface EgressRuleWriter {
   insert(input: {
     id: string;
     agentId: string;
+    ownerSub: string;
     host: string;
     method: string;
     pathPattern: string;
@@ -193,6 +196,7 @@ export function createApprovalsService(
         await deps.egressRuleWriter.insert({
           id: randomUUID(),
           agentId: row.agentId,
+          ownerSub: row.ownerSub,
           ...rule,
           decidedBy: deps.ownerSub,
           source: "inbox",
@@ -238,6 +242,7 @@ export function createApprovalsService(
         await deps.egressRuleWriter.insert({
           id: randomUUID(),
           agentId: row.agentId,
+          ownerSub: row.ownerSub,
           ...rule,
           decidedBy: deps.ownerSub,
           source: "inbox",
@@ -276,6 +281,7 @@ export function createApprovalsService(
         await deps.egressRuleWriter.insert({
           id: randomUUID(),
           agentId: row.agentId,
+          ownerSub: row.ownerSub,
           ...rule,
           decidedBy: deps.ownerSub,
           source: "inbox",

--- a/packages/api-server/src/modules/egress-rules/compose.ts
+++ b/packages/api-server/src/modules/egress-rules/compose.ts
@@ -13,6 +13,7 @@ import {
   createConnectionRulesSync,
   type ConnectionRulesSync,
 } from "./services/connection-rules-sync.js";
+import { createEgressRuleWriter } from "./services/egress-rule-writer.js";
 import type { K8sAllowOnlySecretsPort } from "./infrastructure/k8s-allow-only-secrets-port.js";
 
 export interface ComposeEgressRulesDeps {
@@ -74,11 +75,13 @@ export function createEgressRuleMatchAdapter(db: Db): EgressRuleMatchAdapter {
  * System-level write adapter consumed by the approvals module's
  * approve-permanent / deny-forever paths. Narrow port — only `insert`,
  * matching the `EgressRuleWriter` interface declared on the consumer side.
+ * `ownerSub` labels the allow-only Secret when the rule needs L7 promotion.
  */
 export interface EgressRuleWriterAdapter {
   insert(input: {
     id: string;
     agentId: string;
+    ownerSub: string;
     host: string;
     method: string;
     pathPattern: string;
@@ -88,13 +91,14 @@ export interface EgressRuleWriterAdapter {
   }): Promise<void>;
 }
 
-export function createEgressRuleWriterAdapter(db: Db): EgressRuleWriterAdapter {
-  const repo = createEgressRulesRepository(db);
-  return {
-    async insert(input) {
-      await repo.insert(input);
-    },
-  };
+export function createEgressRuleWriterAdapter(
+  db: Db,
+  allowOnlySecrets?: K8sAllowOnlySecretsPort,
+): EgressRuleWriterAdapter {
+  return createEgressRuleWriter({
+    repo: createEgressRulesRepository(db),
+    allowOnlySecrets,
+  });
 }
 
 /**

--- a/packages/api-server/src/modules/egress-rules/domain/l7-promotion.ts
+++ b/packages/api-server/src/modules/egress-rules/domain/l7-promotion.ts
@@ -1,0 +1,15 @@
+/**
+ * Whether a rule needs its host promoted onto Envoy's L7 (MITM) chain to be
+ * enforceable over HTTPS. The L4 catch-all sees only SNI, so any rule that
+ * constrains method or path — or dials a non-443 port — is invisible to it;
+ * wildcard 443 rules stay on the L4 path. Every surface that writes rules
+ * (manual create/update, inbox verdicts) must apply this, or the rule shows
+ * as active while HTTPS traffic bypasses it (#2322).
+ */
+export function needsL7Promotion(
+  method: string,
+  pathPattern: string,
+  port?: number,
+): boolean {
+  return method !== "*" || pathPattern !== "*" || port != null;
+}

--- a/packages/api-server/src/modules/egress-rules/services/egress-rule-writer.ts
+++ b/packages/api-server/src/modules/egress-rules/services/egress-rule-writer.ts
@@ -1,0 +1,38 @@
+import type {
+  EgressRulesRepository,
+  NewEgressRule,
+} from "../infrastructure/egress-rules-repository.js";
+import { needsL7Promotion } from "../domain/l7-promotion.js";
+import type { K8sAllowOnlySecretsPort } from "../infrastructure/k8s-allow-only-secrets-port.js";
+
+/**
+ * Insert path for rules born from inbox verdicts (approve-permanent /
+ * deny-forever). Unlike the user-scoped service, it takes the agent owner's
+ * sub per call — the approvals module resolves it from the pending row.
+ *
+ * Mirrors the manual-create path's L7 promotion: a narrow rule written from
+ * an inbox verdict (possible when the held request was plain HTTP, where
+ * method/path are visible without MITM) must promote its host onto the L7
+ * chain, or the rule's HTTPS half is silently unenforced (#2322).
+ */
+export interface CreateEgressRuleWriterDeps {
+  repo: EgressRulesRepository;
+  /** Optional so non-cluster contexts (tests) can skip the side effect. */
+  allowOnlySecrets?: K8sAllowOnlySecretsPort;
+}
+
+export function createEgressRuleWriter(deps: CreateEgressRuleWriterDeps): {
+  insert(input: NewEgressRule & { ownerSub: string }): Promise<void>;
+} {
+  return {
+    async insert({ ownerSub, ...row }) {
+      await deps.repo.insert(row);
+      if (
+        needsL7Promotion(row.method, row.pathPattern, row.port) &&
+        deps.allowOnlySecrets
+      ) {
+        await deps.allowOnlySecrets.ensure(ownerSub, row.host);
+      }
+    },
+  };
+}

--- a/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
+++ b/packages/api-server/src/modules/egress-rules/services/egress-rules-service.ts
@@ -9,6 +9,7 @@ import type {
 } from "api-server-api";
 import type { EgressRulesRepository } from "../infrastructure/egress-rules-repository.js";
 import type { EgressRuleRow } from "../domain/types.js";
+import { needsL7Promotion } from "../domain/l7-promotion.js";
 import type { K8sAllowOnlySecretsPort } from "../infrastructure/k8s-allow-only-secrets-port.js";
 import type { PresetSeeder } from "./preset-seeder.js";
 import { securityLog } from "../../../core/security-log.js";
@@ -27,16 +28,6 @@ export interface CreateEgressRulesServiceDeps {
   trustedHosts: readonly string[];
   isAgentOwnedBy(agentId: string, ownerSub: string): Promise<boolean>;
   ownerSub: string;
-}
-
-/** Needs the L7/MITM path when it constrains method/path or a non-443 port;
- *  wildcard 443 rules stay on the L4 (SNI-only) path. */
-function needsL7Promotion(
-  method: string,
-  pathPattern: string,
-  port?: number,
-): boolean {
-  return method !== "*" || pathPattern !== "*" || port != null;
 }
 
 function toView(row: EgressRuleRow): EgressRuleView {

--- a/packages/controller/pkg/reconciler/envoy.go
+++ b/packages/controller/pkg/reconciler/envoy.go
@@ -181,6 +181,11 @@ func listAgentCredentialSecrets(ctx context.Context, client kubernetes.Interface
 //   - Connection secrets (`agent-platform.ai/secret-type` = connection):
 //     keyed by `agent-platform.ai/connection`, looked up in the granted
 //     connection IDs.
+//   - Allow-only secrets (`agent-platform.ai/secret-type` = allow-only) pass
+//     through ungated: they carry no credential — they exist to promote a
+//     host onto the L7 chain so path-scoped egress rules are enforceable
+//     over HTTPS. Grants gate credential access, not rule enforcement;
+//     filtering these out silently voids the owner's rules (#2322).
 //
 // An empty grant slice results in an empty intersection.
 func filterByGrants(secrets []corev1.Secret, grantedSecretIDs, grantedConnectionIDs []string) []corev1.Secret {
@@ -193,6 +198,8 @@ func filterByGrants(secrets []corev1.Secret, grantedSecretIDs, grantedConnection
 	out := secrets[:0:0]
 	for _, s := range secrets {
 		switch s.Labels[envoySecretTypeLabel] {
+		case envoySecretTypeAllowOnly:
+			out = append(out, s)
 		case "connection":
 			connKey := s.Labels[envoyConnectionLabel]
 			if grantedConnIds[connKey] {

--- a/packages/controller/pkg/reconciler/envoy_test.go
+++ b/packages/controller/pkg/reconciler/envoy_test.go
@@ -97,6 +97,26 @@ func TestFilterByGrants_ConnectionGrantsByList(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+// Allow-only Secrets are enforcement plumbing, not credentials: dropping
+// them silently voids path-scoped egress rules over HTTPS (#2322 — the #109
+// always-selective grants rework did exactly that). They must survive the
+// filter regardless of grant lists.
+func TestFilterByGrants_AllowOnlyPassesThroughUngranted(t *testing.T) {
+	secrets := []corev1.Secret{
+		ownerSecret("platform-allow-abc12345-api-example-com", envoySecretTypeAllowOnly, ""),
+		ownerSecret("platform-cred-aaa", "anthropic", ""),
+		ownerSecret("platform-conn-github", "connection", "github"),
+	}
+
+	got := filterByGrants(secrets, nil, nil)
+	assert.Equal(t, []string{"platform-allow-abc12345-api-example-com"}, names(got))
+
+	got = filterByGrants(secrets, []string{"aaa"}, []string{"github"})
+	assert.ElementsMatch(t,
+		[]string{"platform-allow-abc12345-api-example-com", "platform-cred-aaa", "platform-conn-github"},
+		names(got))
+}
+
 func TestFilterByGrants_SecretAndConnectionAxesAreIndependent(t *testing.T) {
 	secrets := []corev1.Secret{
 		ownerSecret("platform-cred-aaa", "anthropic", ""),

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -83,9 +83,21 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
+      // Rolls the shared agent's gateway (path rules force a MITM chain), so
+      // it runs after every spec that drives the agent's chat/egress flows.
+      name: "egress-path-rules",
+      testMatch: /11-.*\.spec\.ts$/,
+      dependencies: ["slack"],
+      use: { ...devices["Desktop Chrome"], storageState },
+    },
+    {
+      // Deleting + recreating a connection can wedge the gateway rollout on
+      // the deleted Secret (stuck ContainerCreating; the StatefulSet's
+      // maxUnavailable needs an alpha feature gate to evict it). Nothing here
+      // needs the agent Ready afterwards, so this runs last.
       name: "connection-regrant",
       testMatch: /10-.*\.spec\.ts$/,
-      dependencies: ["slack"],
+      dependencies: ["egress-path-rules"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
   ],

--- a/packages/e2e/playwright/src/tests/11-egress-path-rules.spec.ts
+++ b/packages/e2e/playwright/src/tests/11-egress-path-rules.spec.ts
@@ -1,0 +1,151 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAgentRunning } from "../lib/agents.js";
+import { createApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+import { agentName } from "../lib/fixtures.js";
+
+// Path-scoped egress rules over HTTPS on a host the platform holds no
+// credential for (#2322). The rule must promote the host onto the gateway's
+// L7 (MITM) chain — the SNI-only L4 catch-all cannot see method/path, so
+// without promotion the narrow rule is silently ignored, the inbox prompts
+// for the whole site, and approving writes a hidden host-wide allow.
+//
+// postman-echo.com is a public echo service (same external-dependency class
+// as 05-injection's httpbingo.org). It deliberately has NO connection: the
+// gateway starts with no chain for it, which is the broken configuration.
+const host = "postman-echo.com";
+const allowedUrl = `https://${host}/status/204`;
+const uncoveredUrl = `https://${host}/get`;
+const stillGatedUrl = `https://${host}/headers`;
+
+test("path-scoped HTTPS rules are enforced and approvals stay narrow", async ({
+  page,
+}) => {
+  test.setTimeout(420_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+  const agentId = await waitForAgentRunning(api, agentName);
+
+  await test.step("add a narrow allow rule in the network panel", async () => {
+    await page.goto(`/sandboxes/${encodeURIComponent(agentId)}`);
+    const net = page.locator("section").filter({ hasText: "Network access" });
+    await net.getByLabel("Host").fill(host);
+    await net.getByLabel("Method").selectOption("GET");
+    await net.getByLabel("Path").fill("/status/*");
+    await net.getByLabel("Verdict").selectOption("allow");
+    await net.getByRole("button", { name: "Add rule" }).click();
+    await page.getByRole("button", { name: "Submit changes" }).click();
+    // Path rules roll the gateway; the save flow confirms before committing.
+    await page.getByRole("button", { name: "Save & restart" }).click();
+    await expect
+      .poll(
+        async () =>
+          (await api.egressRules.listForAgent.query({ agentId })).some(
+            (r) => r.host === host && r.pathPattern === "/status/*",
+          ),
+        { timeout: 30_000, message: "panel-created rule did not persist" },
+      )
+      .toBe(true);
+  });
+
+  await test.step("a request matching the rule passes without a prompt", async () => {
+    // The poll absorbs the gateway roll (allow-only Secret → leaf cert SAN →
+    // new MITM chain, ≤30s informer resync + pod restart). Before the fix
+    // this never converges: the request holds for a human verdict instead.
+    await expect
+      .poll(
+        async () => {
+          try {
+            const { status } = await api.e2e.performFetch.mutate({
+              agentId,
+              url: allowedUrl,
+            });
+            return status;
+          } catch {
+            return 0;
+          }
+        },
+        {
+          timeout: 120_000,
+          intervals: [3_000],
+          message: "allowed path did not go through without approval",
+        },
+      )
+      .toBe(204);
+  });
+
+  await test.step("an uncovered path prompts with method+path, not the whole site", async () => {
+    // Fire and forget: Envoy holds the request for a verdict; the mock
+    // agent's fetch gives up client-side long before the hold expires.
+    void api.e2e.performFetch
+      .mutate({ agentId, url: uncoveredUrl })
+      .catch(() => {});
+    await page.goto("/inbox");
+    const row = page
+      .locator("li")
+      .filter({ hasText: `GET ${host}` })
+      .first();
+    await expect(row).toBeVisible({ timeout: 30_000 });
+    // The L7 chain saw the decrypted request — an SNI-only hold would render
+    // the path as "*" and approving it would open the whole site.
+    await expect(row.getByText("/get", { exact: true })).toBeVisible();
+    await row.getByRole("button", { name: "Allow permanently" }).click();
+  });
+
+  await test.step("the approval unlocks exactly the approved path", async () => {
+    await expect
+      .poll(
+        async () => {
+          try {
+            const { status } = await api.e2e.performFetch.mutate({
+              agentId,
+              url: uncoveredUrl,
+            });
+            return status;
+          } catch {
+            return 0;
+          }
+        },
+        {
+          timeout: 60_000,
+          intervals: [3_000],
+          message: "approved path did not unlock",
+        },
+      )
+      .toBe(200);
+  });
+
+  await test.step("no hidden host-wide rule was written", async () => {
+    const forHost = (
+      await api.egressRules.listForAgent.query({ agentId })
+    ).filter((r) => r.host === host);
+    expect(
+      forHost.map(({ method, pathPattern, verdict }) => ({
+        method,
+        pathPattern,
+        verdict,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        { method: "GET", pathPattern: "/status/*", verdict: "allow" },
+        { method: "GET", pathPattern: "/get", verdict: "allow" },
+      ]),
+    );
+    expect(
+      forHost.some((r) => r.method === "*" && r.pathPattern === "*"),
+      "approving a narrow prompt must not write a host-wide rule",
+    ).toBe(false);
+
+    // Behavioral double-check: a path outside both rules is still gated
+    // (held → the agent-side fetch times out, or fails closed — never 200).
+    const gated = await api.e2e.performFetch
+      .mutate({ agentId, url: stillGatedUrl })
+      .then(
+        (r) => r.status,
+        () => 0,
+      );
+    expect(gated).not.toBe(200);
+  });
+});


### PR DESCRIPTION
Fixes #2322 — method/path-scoped network rules were silently ignored for HTTPS traffic to hosts the platform holds no credential for, and approving a blocked request quietly opened the whole site.

## Root cause

#109's always-selective grants rework dropped **allow-only Secrets** in the controller's grant filter — they are never in any grant list — so path-scoped rules on credential-less hosts never got their L7 MITM chain. HTTPS to those hosts stayed on the SNI-only L4 catch-all: the rules could never match, holds prompted host-wide, and approve-permanent persisted the hold payload verbatim as a hidden `(host, *, *)` allow that then won every future check.

## Fix

- **controller** — allow-only Secrets pass through `filterByGrants` unconditionally: they are enforcement plumbing, not credentials, so grants don't apply.
- **api-server** — inbox-written rules (approve-permanent / deny-forever) now run the same L7 promotion as the manual create/update path: a new egress-rule writer in the egress-rules module ensures the allow-only Secret for narrow rules, and approvals thread the agent owner's sub through for the Secret label.

## Tests

- Go: allow-only Secrets survive grant filtering regardless of grant lists.
- TS: writer promotes narrow rules (and skips host-wide ones); approvals pass the row's owner sub.
- New e2e browser spec (`11-egress-path-rules.spec.ts`) closing the coverage gap the issue calls out: a panel-created `GET /status/*` rule on a credential-less host is enforced over HTTPS without a prompt; an uncovered path prompts with the real method+path; "Allow permanently" unlocks exactly that path; no hidden host-wide rule is written; a third path stays gated.

Verified on a fresh cluster built from this branch: full Playwright suite **16 passed (2.9m)**, `mise run check` green, controller + api-server unit suites pass.

## Also in this PR

- e2e suite reorder: `connection-regrant` now runs last — recreating a connection can wedge the gateway rollout on the deleted Secret (pre-existing race, tracked separately), and nothing after that spec needs the agent.