### PR TITLE
feat(channels): in-chat Slack bind/unbind (stacked on #2790)

### DIFF
--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-Last verified: 2026-07-17
+Last verified: 2026-07-20
 
 ## Overview
 
@@ -108,6 +108,7 @@ Both workers implement the same internal contract — `start`, `stop`, `stopAll`
 - **Transport.** Socket Mode, one workspace-level WebSocket from the api-server to Slack. The api-server has no inbound network access requirement; events arrive over the socket the api-server itself opened. Slack caps Socket Mode at ten concurrent connections per app, which is the install-level scale ceiling for Slack.
 - **Token provenance.** App-Level Token (`xapp-…`) and Bot Token come from Helm values, set at install time. Not stored per-Agent.
 - **Identity linking** (person-scoped bindings). A `/platform login` slash command starts a Keycloak OAuth flow; on callback the api-server stores `slack_user_id ↔ keycloak_sub`. All subsequent interactions require a linked identity; unlinked users get an ephemeral prompt to log in. The link table is the source of truth for "who is this Slack user in Platform terms." Shared bindings never consult it.
+- **In-chat binding** (creates a shared binding). Beyond the platform UI and CLI, a channel can be bound from inside Slack, mirroring Telegram: anyone runs `/platform bind`, authenticates through the same Keycloak OAuth flow, and picks one of *their own* Agents on a web picker — the binding lends that Agent, under its own credentials, to the whole channel. There is no admin gate (unlike Telegram's group-admin check); the ownership check on the picked Agent is the control, and the bind also links the initiator's identity so they can later release it. A bind never overrides an existing one — an already-bound channel is refused until it is unbound. `/platform unbind` releases the binding and is allowed for the binder or the Agent's owner; the owner can also disconnect from the platform UI/CLI as an escape hatch.
 - **Access control.** Decided by the binding's access mode. Person-scoped: two tiers — channel membership is the coarse gate (users must be in the Slack channel to see the bot's interactions); per-Agent allowed users is the fine gate (each Agent optionally declares the subs that may *trigger* work; non-listed users in the channel still see responses but cannot drive a session). Combined with foreign-replier forking, this lets a thread have multiple authorized drivers whose actions land under their own identities. Shared: channel membership is the only per-person gate, and Slack owns it — the platform never resolves who is typing; binding the channel is the consent that lends the Agent to the channel.
 - **Agent resolution.** A channel binds to at most one Agent globally, so a mention resolves to exactly one Agent by channel id; a mention in an unbound channel is refused with an ephemeral.
 
@@ -215,7 +216,7 @@ The two messengers diverge slightly on what a top-level post means:
 
 ## Per-Agent vs. platform channel
 
-Both messengers are platform channels: install-wide credentials from Helm and a conversation→Agent binding table, differing only in where the binding is gestured (the UI for Slack, in-chat `/login` + the web agent picker for Telegram). Future channels (WhatsApp Business, Discord, SMS) follow the same pattern — the Telegram flow is the template for messengers without a workspace identity to anchor per-user links against.
+Both messengers are platform channels: install-wide credentials from Helm and a conversation→Agent binding table, differing mainly in where the binding is gestured — Slack from the UI/CLI (person-scoped or shared) or an in-chat `/platform bind` (shared), Telegram from an in-chat `/login` plus the web agent picker. Future channels (WhatsApp Business, Discord, SMS) follow the same pattern — the Telegram flow is the template for messengers without a workspace identity to anchor per-user links against.
 
 ## Persistence touchpoints
 

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -42,6 +42,8 @@ export type {
   AgentUpdateInput,
   ConnectSlackError,
   ConnectSlackResult,
+  BindSlackChannelError,
+  BindSlackChannelResult,
   BindTelegramChatError,
   BindTelegramChatResult,
   ListTelegramChatsError,
@@ -54,6 +56,7 @@ export type {
   ChannelConfig,
 } from "./modules/agents/types.js";
 export {
+  agentBindSlackChannelInputSchema,
   agentBindTelegramChatInputSchema,
   agentListTelegramChatsInputSchema,
   agentUnbindTelegramChatInputSchema,

--- a/packages/api-server-api/src/modules/agents/router.ts
+++ b/packages/api-server-api/src/modules/agents/router.ts
@@ -6,6 +6,7 @@ import {
   readAgentProcedure,
 } from "../../auth-procedures.js";
 import {
+  agentBindSlackChannelInputSchema,
   agentBindTelegramChatInputSchema,
   agentListTelegramChatsInputSchema,
   agentUnbindTelegramChatInputSchema,
@@ -159,6 +160,36 @@ export const agentsRouter = t.router({
       const agent = await ctx.agents.disconnectSlack(input.id);
       if (!agent) throw new TRPCError({ code: "NOT_FOUND" });
       return toView(agent);
+    }),
+
+  bindSlackChannel: manageAgentsProcedure
+    .input(agentBindSlackChannelInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.channels.available.slack)
+        throw new TRPCError({
+          code: "PRECONDITION_FAILED",
+          message: "Slack app token not configured",
+        });
+      const res = await ctx.agents.bindSlackChannel(
+        input.agentId,
+        input.flowId,
+      );
+      if (res.ok) return res.value;
+      switch (res.error.type) {
+        case "FlowInvalid":
+          throw new TRPCError({
+            code: "BAD_REQUEST",
+            message:
+              "Bind link is invalid or expired — run the bind command again in Slack",
+          });
+        case "AgentNotFound":
+          throw new TRPCError({ code: "NOT_FOUND" });
+        case "ChannelAlreadyBound":
+          throw new TRPCError({
+            code: "CONFLICT",
+            message: "This channel is already connected to an agent",
+          });
+      }
     }),
 
   listTelegramChats: manageAgentsProcedure

--- a/packages/api-server-api/src/modules/agents/schemas.ts
+++ b/packages/api-server-api/src/modules/agents/schemas.ts
@@ -126,6 +126,12 @@ export const agentBindTelegramChatInputSchema = z.object({
   flowId: z.string().min(1),
 });
 
+export const agentBindSlackChannelInputSchema = z.object({
+  agentId: z.string().min(1),
+  // Opaque bind-flow id minted by the Slack in-chat bind OAuth callback.
+  flowId: z.string().min(1),
+});
+
 // The Agent CR spec shape is the generated AgentSpecCR (crd-types.gen.ts, from
 // the controller's CRD); the public AgentSpec (types.ts) derives from it. K8s
 // validates it at admission, so there's no Zod re-validation here.

--- a/packages/api-server-api/src/modules/agents/types.ts
+++ b/packages/api-server-api/src/modules/agents/types.ts
@@ -91,6 +91,17 @@ export type ConnectSlackResult =
   | { ok: true; value: Agent }
   | { ok: false; error: ConnectSlackError };
 
+export type BindSlackChannelError =
+  /** Unknown, expired, or not-your-flow — deliberately one bucket so the
+   *  error is no oracle for whether a flow id exists. */
+  | { type: "FlowInvalid" }
+  | { type: "AgentNotFound" }
+  | { type: "ChannelAlreadyBound" };
+
+export type BindSlackChannelResult =
+  | { ok: true; value: { channelTitle: string | null } }
+  | { ok: false; error: BindSlackChannelError };
+
 export type BindTelegramChatError =
   /** Unknown, expired, or not-your-flow — deliberately one bucket so the
    *  error is no oracle for whether a flow id exists. */
@@ -156,6 +167,12 @@ export interface AgentsService {
     mode?: "shared" | "person-scoped",
   ) => Promise<ConnectSlackResult>;
   disconnectSlack: (id: string) => Promise<Agent | null>;
+  /** Consume a Slack bind flow (minted by the in-chat bind OAuth callback) and
+   *  bind that channel to the caller's agent in shared mode. */
+  bindSlackChannel: (
+    agentId: string,
+    flowId: string,
+  ) => Promise<BindSlackChannelResult>;
   /** Consume a Telegram bind flow (minted by the /login OAuth callback) and
    *  bind that conversation to the caller's agent. */
   bindTelegramChat: (

--- a/packages/api-server/src/__tests__/unit/slack-bind.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-bind.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from "vitest";
+import type { ConnectSlackResult } from "api-server-api";
+import { configureLogger } from "../../core/logger.js";
+import {
+  executeSlackBind,
+  type SlackBindingPort,
+} from "../../modules/agents/services/agents-service.js";
+import { createSlackBindFlowStore } from "../../modules/channels/infrastructure/slack-flows.js";
+
+// Swallow securityLog output from the deny/notify paths under test.
+configureLogger({ level: "error", write: () => {} });
+
+const OWNER = "kc|owner-1";
+
+function harness(opts?: {
+  owner?: string;
+  boundTo?: string | null;
+  connectOk?: boolean;
+  postError?: string;
+}) {
+  const store = createSlackBindFlowStore({ now: () => 1_000 });
+  const flowId = store.create({
+    slackChannelId: "C-1",
+    slackUserId: "U-7",
+    keycloakSub: OWNER,
+    channelTitle: "general",
+  });
+
+  const binding: SlackBindingPort = {
+    peekFlow: store.peek,
+    consumeFlow: store.consume,
+    postMessage: vi.fn(async () =>
+      opts?.postError ? { error: opts.postError } : { ok: true as const },
+    ),
+  };
+  const findChannelBinding = vi.fn(async () =>
+    opts?.boundTo ? { agentId: opts.boundTo } : null,
+  );
+  const connectShared = vi.fn(
+    async (): Promise<ConnectSlackResult> =>
+      opts?.connectOk === false
+        ? { ok: false, error: { type: "ChannelAlreadyBound" } }
+        : { ok: true, value: { id: "agent-1" } as never },
+  );
+
+  const run = executeSlackBind({
+    owner: opts?.owner === undefined ? OWNER : opts.owner,
+    getAgent: async (id) =>
+      id === "agent-1" ? { id: "agent-1", name: "my-agent" } : null,
+    findChannelBinding,
+    connectShared,
+    binding,
+  });
+
+  return { run, store, flowId, binding, findChannelBinding, connectShared };
+}
+
+describe("slack bind flow", () => {
+  it("binds via connectShared, consumes the flow, posts confirmation, returns the channel title", async () => {
+    const h = harness();
+    const res = await h.run("agent-1", h.flowId);
+    expect(res).toEqual({ ok: true, value: { channelTitle: "general" } });
+    expect(h.connectShared).toHaveBeenCalledWith("agent-1", "C-1");
+    expect(h.store.peek(h.flowId)).toBe(null);
+    expect(h.binding.postMessage).toHaveBeenCalledWith(
+      "agent-1",
+      "C-1",
+      expect.stringContaining("my-agent"),
+    );
+  });
+
+  it("rejects an unknown flow id", async () => {
+    const h = harness();
+    expect(await h.run("agent-1", "no-such-flow")).toEqual({
+      ok: false,
+      error: { type: "FlowInvalid" },
+    });
+  });
+
+  it("rejects a different signed-in user WITHOUT consuming the flow", async () => {
+    const h = harness({ owner: "kc|someone-else" });
+    expect(await h.run("agent-1", h.flowId)).toEqual({
+      ok: false,
+      error: { type: "FlowInvalid" },
+    });
+    expect(h.store.peek(h.flowId)).not.toBe(null);
+    expect(h.connectShared).not.toHaveBeenCalled();
+  });
+
+  it("rejects an agent the caller does not own", async () => {
+    const h = harness();
+    expect(await h.run("agent-of-someone-else", h.flowId)).toEqual({
+      ok: false,
+      error: { type: "AgentNotFound" },
+    });
+  });
+
+  it("rejects an already-bound channel outright, keeping the flow alive", async () => {
+    const h = harness({ boundTo: "agent-2" });
+    expect(await h.run("agent-1", h.flowId)).toEqual({
+      ok: false,
+      error: { type: "ChannelAlreadyBound" },
+    });
+    expect(h.connectShared).not.toHaveBeenCalled();
+    expect(h.store.peek(h.flowId)).not.toBe(null);
+  });
+
+  it("also refuses re-binding the SAME agent (no in-place override)", async () => {
+    const h = harness({ boundTo: "agent-1" });
+    expect(await h.run("agent-1", h.flowId)).toEqual({
+      ok: false,
+      error: { type: "ChannelAlreadyBound" },
+    });
+    expect(h.connectShared).not.toHaveBeenCalled();
+  });
+
+  it("maps a lost connect race to ChannelAlreadyBound", async () => {
+    const h = harness({ connectOk: false });
+    expect(await h.run("agent-1", h.flowId)).toEqual({
+      ok: false,
+      error: { type: "ChannelAlreadyBound" },
+    });
+  });
+
+  it("still succeeds when the in-chat confirmation fails", async () => {
+    const h = harness({ postError: "bot not running" });
+    expect(await h.run("agent-1", h.flowId)).toEqual({
+      ok: true,
+      value: { channelTitle: "general" },
+    });
+  });
+});

--- a/packages/api-server/src/__tests__/unit/slack-command-bind.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-command-bind.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import type { AgentsService } from "api-server-api";
+import {
+  createSlackWorker,
+  type SlackOAuthPending,
+} from "../../modules/channels/infrastructure/slack.js";
+import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import type { AcpClient } from "../../core/acp-client.js";
+import { configureLogger } from "../../core/logger.js";
+import { EventType, type DomainEvent } from "../../events.js";
+import type { StoredChannelConfig } from "../../modules/channels/stored-channel.js";
+
+const OWNER = "kc|owner-1";
+configureLogger({ level: "error", write: () => {} });
+
+type Binding = {
+  instanceName: string;
+  owner: string;
+  mode?: "shared" | "person-scoped";
+} | null;
+
+function harness(opts: {
+  binding: Binding;
+  /** identityLinks.resolve result — null = unlinked Slack user. */
+  linkedSub?: string | null;
+  /** getInstanceOwner result — the agent's owner. */
+  agentOwner?: string | null;
+}) {
+  const gw = createFakeSlackGateway();
+  const events: DomainEvent[] = [];
+  const pending = new Map<string, SlackOAuthPending>();
+  const unbindCalls: string[] = [];
+  const acp = {
+    listSessions: async () => [],
+    sendPrompt: async () => "x",
+    triggerSession: () => Promise.reject(new Error("unused")),
+  } as unknown as AcpClient;
+  const agents = {
+    ensureReady: async () => {},
+    isAllowedUser: async () => false,
+  } as unknown as AgentsService;
+
+  const worker = createSlackWorker(
+    () => acp,
+    () => gw,
+    () => agents,
+    { resolve: async () => opts.linkedSub ?? null } as never,
+    {
+      keycloakExternalUrl: "http://kc",
+      keycloakUrl: "http://kc",
+      keycloakRealm: "platform",
+      keycloakClientId: "c",
+      callbackUrl: "http://ui/api/slack/oauth/callback",
+    },
+    pending,
+    async () => opts.agentOwner ?? OWNER,
+    { resolveSlackBinding: async () => opts.binding } as never,
+    async (ch) => {
+      unbindCalls.push(ch);
+    },
+    "dam",
+    async () => true,
+    "http://ui",
+    () => acp,
+    (e) => events.push(e),
+  );
+
+  return {
+    gw,
+    events,
+    pending,
+    unbindCalls,
+    async command(text: string, userId = "U-1", channelId = "C-1") {
+      await worker.start("agent-1", {} as StoredChannelConfig);
+      return gw.fireCommand({ text, userId, channelId });
+    },
+  };
+}
+
+const bound: Binding = {
+  instanceName: "agent-1",
+  owner: OWNER,
+  mode: "shared",
+};
+
+describe("slack /bind command", () => {
+  it("on an unbound channel acks a connect link and stores a bind-intent pending flow", async () => {
+    const h = harness({ binding: null });
+    const ack = await h.command("bind", "U-7", "C-9");
+    expect(ack).toContain("Connect an agent");
+    const entries = [...h.pending.values()];
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      intent: "bind",
+      channelId: "C-9",
+      slackUserId: "U-7",
+    });
+  });
+
+  it("on an already-bound channel refuses and creates no pending flow", async () => {
+    const h = harness({ binding: bound });
+    const ack = await h.command("bind");
+    expect(ack).toContain("already connected");
+    expect(h.pending.size).toBe(0);
+  });
+});
+
+describe("slack /unbind command", () => {
+  it("refuses an unlinked invoker and leaves the binding", async () => {
+    const h = harness({ binding: bound, linkedSub: null });
+    const ack = await h.command("unbind");
+    expect(ack).toContain("Link your account");
+    expect(h.unbindCalls).toEqual([]);
+  });
+
+  it("refuses a linked user who is neither binder nor agent owner", async () => {
+    const h = harness({
+      binding: bound,
+      linkedSub: "kc|stranger",
+      agentOwner: "kc|other",
+    });
+    const ack = await h.command("unbind");
+    expect(ack).toContain("Only the person");
+    expect(h.unbindCalls).toEqual([]);
+  });
+
+  it("lets the binder unbind: deletes the binding and emits SlackDisconnected", async () => {
+    const h = harness({ binding: bound, linkedSub: OWNER });
+    const ack = await h.command("unbind", "U-1", "C-1");
+    expect(ack).toContain("disconnected");
+    expect(h.unbindCalls).toEqual(["C-1"]);
+    expect(h.events.some((e) => e.type === EventType.SlackDisconnected)).toBe(
+      true,
+    );
+  });
+
+  it("lets the agent owner unbind even when they aren't the binder", async () => {
+    const h = harness({
+      binding: { instanceName: "agent-1", owner: "kc|binder", mode: "shared" },
+      linkedSub: "kc|owner-2",
+      agentOwner: "kc|owner-2",
+    });
+    const ack = await h.command("unbind");
+    expect(ack).toContain("disconnected");
+    expect(h.unbindCalls).toEqual(["C-1"]);
+  });
+
+  it("says nothing is connected when the channel is unbound", async () => {
+    const h = harness({ binding: null, linkedSub: OWNER });
+    const ack = await h.command("unbind");
+    expect(ack).toContain("isn't connected");
+    expect(h.unbindCalls).toEqual([]);
+  });
+});

--- a/packages/api-server/src/__tests__/unit/slack-oauth-callback.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-oauth-callback.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createSlackOAuthRoutes } from "../../modules/channels/infrastructure/slack-oauth.js";
+import { createSlackBindFlowStore } from "../../modules/channels/infrastructure/slack-flows.js";
+import type { SlackOAuthPending } from "../../modules/channels/infrastructure/slack.js";
+import type { IdentityLinkService } from "../../modules/channels/services/identity-link-service.js";
+import type { KeycloakOAuthConfig } from "../../modules/channels/infrastructure/identity-oauth.js";
+import { configureLogger } from "../../core/logger.js";
+
+const exchangeCodeForTokens = vi.fn();
+
+vi.mock("../../modules/channels/infrastructure/identity-oauth.js", () => ({
+  exchangeCodeForTokens: (...args: unknown[]) => exchangeCodeForTokens(...args),
+}));
+
+configureLogger({ level: "error", write: () => {} });
+
+const SLACK_USER_ID = "U-42";
+const KEYCLOAK_SUB = "kc-sub-abc";
+const UI = "https://app.example";
+
+const oauthConfig: KeycloakOAuthConfig = {
+  keycloakExternalUrl: "https://kc.example",
+  keycloakUrl: "https://kc.internal",
+  keycloakRealm: "platform",
+  keycloakClientId: "slack",
+  callbackUrl: `${UI}/api/slack/oauth/callback`,
+};
+
+function makeHarness(opts: {
+  intent: "login" | "bind";
+  pendingCreatedAt?: number;
+}) {
+  const pendingFlows = new Map<string, SlackOAuthPending>();
+  pendingFlows.set("state-1", {
+    slackUserId: SLACK_USER_ID,
+    channelId: "C-123",
+    codeVerifier: "verifier",
+    intent: opts.intent,
+    createdAt: opts.pendingCreatedAt ?? Date.now(),
+  });
+
+  const bindFlows = createSlackBindFlowStore();
+  const link = vi.fn(async () => {});
+  const identityLinks = { link } as unknown as IdentityLinkService;
+
+  const routes = createSlackOAuthRoutes({
+    pendingFlows,
+    bindFlows,
+    identityLinks,
+    oauthConfig,
+    uiBaseUrl: UI,
+    brandShort: "dam",
+  });
+
+  return { routes, pendingFlows, bindFlows, link };
+}
+
+describe("slack oauth callback — bind intent", () => {
+  beforeEach(() => exchangeCodeForTokens.mockReset());
+
+  it("links identity, mints a sub-pinned bind flow, and redirects to the picker", async () => {
+    const h = makeHarness({ intent: "bind" });
+    exchangeCodeForTokens.mockResolvedValue({ keycloakSub: KEYCLOAK_SUB });
+
+    const res = await h.routes.request(
+      "/api/slack/oauth/callback?code=abc&state=state-1",
+    );
+
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location")!;
+    expect(location.startsWith(`${UI}/slack/bind?flow=`)).toBe(true);
+
+    const flowId = new URL(location).searchParams.get("flow")!;
+    expect(h.bindFlows.peek(flowId)).toMatchObject({
+      slackChannelId: "C-123",
+      slackUserId: SLACK_USER_ID,
+      keycloakSub: KEYCLOAK_SUB,
+    });
+    // The binder is identity-linked too, so they can later /unbind in-chat.
+    expect(h.link).toHaveBeenCalledWith("slack", SLACK_USER_ID, KEYCLOAK_SUB);
+    expect(h.pendingFlows.has("state-1")).toBe(false);
+  });
+
+  it("redirects to the picker error page on token-exchange failure", async () => {
+    const h = makeHarness({ intent: "bind" });
+    exchangeCodeForTokens.mockResolvedValue({ error: "invalid_grant" });
+
+    const res = await h.routes.request(
+      "/api/slack/oauth/callback?code=abc&state=state-1",
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(
+      `${UI}/slack/bind?error=exchange_failed`,
+    );
+    expect(h.pendingFlows.has("state-1")).toBe(false);
+  });
+
+  it("expires a stale bind pending flow to the picker error page", async () => {
+    const h = makeHarness({
+      intent: "bind",
+      pendingCreatedAt: Date.now() - 11 * 60 * 1000,
+    });
+
+    const res = await h.routes.request(
+      "/api/slack/oauth/callback?code=abc&state=state-1",
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe(`${UI}/slack/bind?error=expired`);
+  });
+});
+
+describe("slack oauth callback — login intent (unchanged)", () => {
+  beforeEach(() => exchangeCodeForTokens.mockReset());
+
+  it("links identity and returns the HTML page, minting no bind flow", async () => {
+    const h = makeHarness({ intent: "login" });
+    exchangeCodeForTokens.mockResolvedValue({ keycloakSub: KEYCLOAK_SUB });
+
+    const res = await h.routes.request(
+      "/api/slack/oauth/callback?code=abc&state=state-1",
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.text()).toContain("Account linked");
+    expect(h.link).toHaveBeenCalledWith("slack", SLACK_USER_ID, KEYCLOAK_SUB);
+  });
+
+  it("keeps the plain-text failure for a login token-exchange failure", async () => {
+    const h = makeHarness({ intent: "login" });
+    exchangeCodeForTokens.mockResolvedValue({ error: "invalid_grant" });
+
+    const res = await h.routes.request(
+      "/api/slack/oauth/callback?code=abc&state=state-1",
+    );
+
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("Token exchange failed");
+  });
+});
+
+describe("slack oauth callback — shared guards", () => {
+  beforeEach(() => exchangeCodeForTokens.mockReset());
+
+  it("rejects an unknown/replayed state without exchanging", async () => {
+    const h = makeHarness({ intent: "bind" });
+
+    const res = await h.routes.request(
+      "/api/slack/oauth/callback?code=abc&state=nope",
+    );
+
+    expect(res.status).toBe(400);
+    expect(exchangeCodeForTokens).not.toHaveBeenCalled();
+  });
+});

--- a/packages/api-server/src/__tests__/unit/slack-shared-mode.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-shared-mode.test.ts
@@ -62,6 +62,7 @@ function harness(opts: {
     new Map(),
     async () => OWNER,
     { resolveSlackBinding: async () => opts.binding } as never,
+    async () => {},
     "dam",
     async (sub) => opts.termsAccepted?.(sub) ?? true,
     "http://ui",

--- a/packages/api-server/src/__tests__/unit/slack-wake-failure.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-wake-failure.test.ts
@@ -48,6 +48,7 @@ function harness(ensureReady: AgentsService["ensureReady"]) {
         owner: OWNER,
       }),
     } as never,
+    async () => {},
     "dam",
     async () => true,
     "http://ui",

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -55,6 +55,7 @@ import type {
   TelegramOAuthPending,
   TelegramBindFlowStore,
 } from "../../modules/channels/infrastructure/telegram-flows.js";
+import type { SlackBindFlowStore } from "../../modules/channels/infrastructure/slack-flows.js";
 import {
   findAgentByConversation,
   bindConversation,
@@ -110,6 +111,8 @@ export interface ApiServerAppDeps {
   pendingTelegramOAuthFlows: Map<string, TelegramOAuthPending>;
   /** Present when Telegram is enabled; backs the chat→agent bind handoff. */
   telegramBindFlows?: TelegramBindFlowStore;
+  /** Backs the Slack in-chat bind handoff (OAuth callback → agent picker). */
+  slackBindFlows: SlackBindFlowStore;
   /** Present when Telegram is enabled; backs the one-time connect links. */
   seedSources: SkillSourceSeed[];
   redisBus: RedisBus;
@@ -153,6 +156,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     pendingSlackOAuthFlows,
     pendingTelegramOAuthFlows,
     telegramBindFlows,
+    slackBindFlows,
     seedSources,
     redisBus,
     approvalsRelay,
@@ -364,8 +368,10 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       "/",
       createSlackOAuthRoutes({
         pendingFlows: pendingSlackOAuthFlows,
+        bindFlows: slackBindFlows,
         identityLinks: identityLinkService,
         brandShort: config.brand.short,
+        uiBaseUrl: config.uiBaseUrl,
         oauthConfig: {
           keycloakExternalUrl: config.keycloakExternalUrl,
           keycloakUrl: config.keycloakUrl,
@@ -786,6 +792,14 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
             unbind: unbindConversation(db),
           }
         : undefined,
+      slackBinding: {
+        peekFlow: slackBindFlows.peek,
+        consumeFlow: slackBindFlows.consume,
+        postMessage: (agentId, slackChannelId, text) =>
+          channelManager.postMessage(agentId, ChannelType.Slack, text, {
+            conversationId: slackChannelId,
+          }),
+      },
       readTemplateSpec,
       presetSeeder,
       cleanupHooks: agentCleanupHooks,

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -17,6 +17,7 @@ import {
   listChannelsByOwner,
   findBySlackChannelId,
   findSlackChannelByAgent,
+  deleteSlackChannelBinding,
 } from "./modules/agents/index.js";
 import {
   createAgentSkillsRepository,
@@ -57,6 +58,7 @@ import {
   createTelegramBindFlowStore,
   type TelegramOAuthPending,
 } from "./modules/channels/infrastructure/telegram-flows.js";
+import { createSlackBindFlowStore } from "./modules/channels/infrastructure/slack-flows.js";
 import {
   composeRuntimeDelivery,
   createBullConnection,
@@ -364,6 +366,9 @@ const pendingTelegramOAuthFlows = new Map<string, TelegramOAuthPending>();
 const telegramBindFlows = config.telegramBotToken
   ? createTelegramBindFlowStore()
   : undefined;
+// Unconditional: a trivial in-memory store, needed whenever the Slack OAuth
+// callback is mounted (real tokens or e2e). The bind command mints entries.
+const slackBindFlows = createSlackBindFlowStore();
 const slackOauthCallbackUrl =
   config.slackOauthCallbackUrl ??
   `${config.uiBaseUrl}/api/slack/oauth/callback`;
@@ -436,6 +441,7 @@ const slackWorker = slackGatewayFactory
       pendingSlackOAuthFlows,
       (agentId) => agentsRepo.getOwner(agentId),
       channelRegistry,
+      deleteSlackChannelBinding(db),
       config.brand.short,
       isTermsAccepted,
       config.uiBaseUrl,
@@ -629,6 +635,7 @@ const { server: apiServer } = startApiServerApp({
   pendingSlackOAuthFlows,
   pendingTelegramOAuthFlows,
   telegramBindFlows,
+  slackBindFlows,
   seedSources,
   redisBus,
   approvalsRelay,

--- a/packages/api-server/src/modules/agents/compose.ts
+++ b/packages/api-server/src/modules/agents/compose.ts
@@ -16,6 +16,7 @@ import {
   type ContributionsSettledPort,
   type ResizeGatePort,
   type TelegramBindingPort,
+  type SlackBindingPort,
 } from "./services/agents-service.js";
 import {
   listChannelsByOwner,
@@ -63,6 +64,8 @@ export function composeAgentsModule(deps: {
   contributionsSettled: ContributionsSettledPort;
   /** Telegram chat→agent binding flow; omitted system-side. */
   telegramBinding?: TelegramBindingPort;
+  /** Slack in-chat channel→agent binding flow; omitted system-side. */
+  slackBinding?: SlackBindingPort;
   /** Single-shot create; wired from connections. Omitted system-side. */
   grantProvisioner?: {
     resolveSpecGrants(sel: {
@@ -114,6 +117,7 @@ export function composeAgentsModule(deps: {
       },
       findSlackChannelBinding: findBySlackChannelId(deps.db),
       telegramBinding: deps.telegramBinding,
+      slackBinding: deps.slackBinding,
       listAllowedUsersByOwner: listAllowedUsersByOwner(deps.db, owner),
       listAllowedUsersByAgent: listAllowedUsersByAgent(deps.db, owner),
       setAllowedUsers: setAllowedUsers(deps.db, owner),

--- a/packages/api-server/src/modules/agents/index.ts
+++ b/packages/api-server/src/modules/agents/index.ts
@@ -39,4 +39,5 @@ export {
   listChannelsByOwner,
   findBySlackChannelId,
   findSlackChannelByAgent,
+  deleteSlackChannelBinding,
 } from "./infrastructure/channel-bindings-repository.js";

--- a/packages/api-server/src/modules/agents/infrastructure/channel-bindings-repository.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/channel-bindings-repository.ts
@@ -153,6 +153,23 @@ export function isSlackChannelUniqueViolation(e: unknown): boolean {
   return isUniqueViolation(e, "channels_slack_channel_unique_idx");
 }
 
+/** Delete the Slack binding for a channel id, regardless of owner. The in-chat
+ *  unbind runs system-side (it has no owner scope) and authorizes the caller
+ *  itself, so — unlike the owner-scoped `deleteChannelByType` — this keys only
+ *  on the globally-unique Slack channel id. */
+export function deleteSlackChannelBinding(db: Db) {
+  return async (slackChannelId: string): Promise<void> => {
+    await db
+      .delete(channels)
+      .where(
+        and(
+          eq(channels.type, ChannelType.Slack),
+          sql`${channels.config}->>'slackChannelId' = ${slackChannelId}`,
+        ),
+      );
+  };
+}
+
 export function findSlackChannelByAgent(db: Db) {
   return async (agentId: string): Promise<string | null> => {
     const rows = await db

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -9,6 +9,8 @@ import {
   type ChannelConfig,
   type DriverFailure,
   type BindTelegramChatResult,
+  type BindSlackChannelResult,
+  type ConnectSlackResult,
   type ListTelegramChatsResult,
   type UnbindTelegramChatResult,
   ChannelType,
@@ -248,6 +250,122 @@ export function executeTelegramUnbind(deps: {
 }
 
 /**
+ * Port consumed by `bindSlackChannel()`. Unlike Telegram, the durable write
+ * is the shared `channels` row (owner + config.mode), so the port only carries
+ * the bind-flow bearer store and the confirmation post; the ownership check
+ * and the write reuse the service's own `connectSlack` path.
+ */
+export interface SlackBindingPort {
+  peekFlow(flowId: string): {
+    slackChannelId: string;
+    slackUserId: string;
+    keycloakSub: string;
+    channelTitle?: string;
+  } | null;
+  consumeFlow(flowId: string): void;
+  /** Best-effort confirmation into the channel, via the channel manager. */
+  postMessage(
+    agentId: string,
+    slackChannelId: string,
+    text: string,
+  ): Promise<{ ok: true } | { error: string }>;
+}
+
+/**
+ * The in-chat Slack bind flow, extracted like `executeTelegramBind` so tests
+ * can drive it with narrow deps. The binder must own the agent (`getAgent` is
+ * owner-scoped) and must be the flow's authenticated user; an already-bound
+ * channel is rejected outright (no in-place override).
+ */
+export function executeSlackBind(deps: {
+  owner: string | undefined;
+  getAgent: (agentId: string) => Promise<{ id: string; name: string } | null>;
+  findChannelBinding: (
+    slackChannelId: string,
+  ) => Promise<{ agentId: string } | null>;
+  connectShared: (
+    agentId: string,
+    slackChannelId: string,
+  ) => Promise<ConnectSlackResult>;
+  binding: SlackBindingPort;
+}) {
+  return async (
+    agentId: string,
+    flowId: string,
+  ): Promise<BindSlackChannelResult> => {
+    const flow = deps.binding.peekFlow(flowId);
+    if (!flow) return err({ type: "FlowInvalid" as const });
+
+    if (!deps.owner || flow.keycloakSub !== deps.owner) {
+      // A different signed-in user is trying to consume the flow. Same error
+      // as an unknown flow — no oracle; the flow stays alive within its TTL.
+      securityLog("warn", "authz.owner_mismatch", {
+        category: "authz",
+        actor: deps.owner ?? null,
+        actorKind: "user",
+        decision: "deny",
+        reason: "slack-bind-sub-mismatch",
+        detail: { slackChannelId: flow.slackChannelId },
+      });
+      return err({ type: "FlowInvalid" as const });
+    }
+
+    const agent = await deps.getAgent(agentId);
+    if (!agent) return err({ type: "AgentNotFound" as const });
+
+    // No override: reject if the channel is already bound to any agent — the
+    // prior binder must unbind first.
+    const existing = await deps.findChannelBinding(flow.slackChannelId);
+    if (existing) return err({ type: "ChannelAlreadyBound" as const });
+
+    const connected = await deps.connectShared(agentId, flow.slackChannelId);
+    if (!connected.ok) {
+      // Ownership was already proven by getAgent, so a non-ok here is a lost
+      // race (the channel was bound between the check and the write).
+      return err({ type: "ChannelAlreadyBound" as const });
+    }
+
+    deps.binding.consumeFlow(flowId);
+
+    // The binding IS the consent grant: the binder lends this agent — its
+    // credentials included — to everyone in the channel.
+    securityLog("info", "channel.chat_bound", {
+      category: "authz-list",
+      actor: deps.owner,
+      actorKind: "user",
+      surface: "slack",
+      agentId,
+      result: "success",
+      detail: {
+        slackChannelId: flow.slackChannelId,
+        slackUserId: flow.slackUserId,
+      },
+    });
+
+    const post = await deps.binding.postMessage(
+      agentId,
+      flow.slackChannelId,
+      `This channel is now connected to ${agent.name}. Everyone here can use it; run the unbind command to disconnect.`,
+    );
+    if ("error" in post) {
+      // Best-effort: the binding is committed; the confirmation is courtesy.
+      securityLog("warn", "channel.chat_bound.notify_failed", {
+        category: "channel",
+        actor: deps.owner,
+        actorKind: "user",
+        surface: "slack",
+        agentId,
+        result: "failure",
+        reason: post.error,
+        detail: { slackChannelId: flow.slackChannelId },
+      });
+    }
+
+    return ok({ channelTitle: flow.channelTitle ?? null });
+  };
+}
+
+/**
  * Cleanup hook invoked after a successful K8s ConfigMap delete. Each
  * registered hook clears its module's per-agent durable state — egress
  * rules, pending approvals, anything else keyed by `agent_id` in
@@ -360,6 +478,9 @@ export function createAgentsService(deps: {
   ) => Promise<{ agentId: string; mode?: "shared" | "person-scoped" } | null>;
   /** Absent in the system-wide composition — binding is a user-facing flow. */
   telegramBinding?: TelegramBindingPort;
+  /** Absent in the system-wide composition — the in-chat Slack bind is a
+   *  user-facing flow driven from the authenticated UI picker. */
+  slackBinding?: SlackBindingPort;
   listAllowedUsersByOwner: () => Promise<Map<string, string[]>>;
   listAllowedUsersByAgent: (agentId: string) => Promise<string[]>;
   setAllowedUsers: (agentId: string, subs: string[]) => Promise<void>;
@@ -419,6 +540,74 @@ export function createAgentsService(deps: {
       status.preparingWorkspace,
     );
   }
+
+  // Shared by the public connectSlack method and the in-chat bind flow, so
+  // both take the same transactional-uniqueness, mode-guard, and event path.
+  const connectSlackImpl = async (
+    id: string,
+    slackChannelId: string,
+    mode?: "shared" | "person-scoped",
+  ): Promise<ConnectSlackResult> => {
+    const infra = await deps.repo.get(id, deps.owner);
+    if (!infra) return err({ type: "AgentNotFound" });
+
+    // One Slack channel binds to one Agent globally. Pre-check rather than
+    // relying on the unique-index violation: catching it inside the
+    // transaction below doesn't work — the aborted tx rethrows the raw error
+    // as it unwinds — so a channel bound to a different Agent would otherwise
+    // surface as a generic 500 instead of ChannelAlreadyBound. The in-tx
+    // catch stays as a backstop for the (accepted) concurrent-connect race.
+    const existing = await deps.findSlackChannelBinding(slackChannelId);
+    if (existing && existing.agentId !== id)
+      return err({ type: "ChannelAlreadyBound" as const });
+
+    // Mode is fixed per binding: flipping it must be a deliberate
+    // disconnect + reconnect, never a side effect of re-connecting.
+    const requestedMode = mode ?? "person-scoped";
+    if (existing && (existing.mode ?? "person-scoped") !== requestedMode)
+      return err({ type: "ModeChangeRequiresRebind" as const });
+
+    const txResult = await deps.unitOfWork(async (tx) => {
+      try {
+        await deps.channelsTxRepo.upsertChannel(tx, id, {
+          type: ChannelType.Slack,
+          slackChannelId,
+          // Only the non-default is stored; absent = person-scoped.
+          ...(requestedMode === "shared" ? { mode: "shared" as const } : {}),
+        });
+      } catch (e) {
+        if (isSlackChannelUniqueViolation(e)) {
+          return err({ type: "ChannelAlreadyBound" as const });
+        }
+        throw e;
+      }
+      const channels = await deps.channelsTxRepo.listByAgent(tx, id);
+      return ok({ channels });
+    });
+
+    if (!txResult.ok) return txResult;
+
+    emit({
+      type: EventType.SlackConnected,
+      agentId: id,
+      slackChannelId,
+      ...(requestedMode === "shared" ? { mode: "shared" as const } : {}),
+    });
+
+    const allowedSubs = await deps.listAllowedUsersByAgent(id);
+    const emails = await subsToEmails(allowedSubs);
+    const status = await safeStatus(id);
+    return ok(
+      assembleAgent(
+        infra,
+        txResult.value.channels,
+        emails,
+        status.failures,
+        deps.agentIdleTimeoutMinutes,
+        status.preparingWorkspace,
+      ),
+    );
+  };
 
   return {
     async list() {
@@ -937,65 +1126,7 @@ export function createAgentsService(deps: {
     },
 
     async connectSlack(id, slackChannelId, mode) {
-      const infra = await deps.repo.get(id, deps.owner);
-      if (!infra) return err({ type: "AgentNotFound" });
-
-      // One Slack channel binds to one Agent globally. Pre-check rather than
-      // relying on the unique-index violation: catching it inside the
-      // transaction below doesn't work — the aborted tx rethrows the raw error
-      // as it unwinds — so a channel bound to a different Agent would otherwise
-      // surface as a generic 500 instead of ChannelAlreadyBound. The in-tx
-      // catch stays as a backstop for the (accepted) concurrent-connect race.
-      const existing = await deps.findSlackChannelBinding(slackChannelId);
-      if (existing && existing.agentId !== id)
-        return err({ type: "ChannelAlreadyBound" as const });
-
-      // Mode is fixed per binding: flipping it must be a deliberate
-      // disconnect + reconnect, never a side effect of re-connecting.
-      const requestedMode = mode ?? "person-scoped";
-      if (existing && (existing.mode ?? "person-scoped") !== requestedMode)
-        return err({ type: "ModeChangeRequiresRebind" as const });
-
-      const txResult = await deps.unitOfWork(async (tx) => {
-        try {
-          await deps.channelsTxRepo.upsertChannel(tx, id, {
-            type: ChannelType.Slack,
-            slackChannelId,
-            // Only the non-default is stored; absent = person-scoped.
-            ...(requestedMode === "shared" ? { mode: "shared" as const } : {}),
-          });
-        } catch (e) {
-          if (isSlackChannelUniqueViolation(e)) {
-            return err({ type: "ChannelAlreadyBound" as const });
-          }
-          throw e;
-        }
-        const channels = await deps.channelsTxRepo.listByAgent(tx, id);
-        return ok({ channels });
-      });
-
-      if (!txResult.ok) return txResult;
-
-      emit({
-        type: EventType.SlackConnected,
-        agentId: id,
-        slackChannelId,
-        ...(requestedMode === "shared" ? { mode: "shared" as const } : {}),
-      });
-
-      const allowedSubs = await deps.listAllowedUsersByAgent(id);
-      const emails = await subsToEmails(allowedSubs);
-      const status = await safeStatus(id);
-      return ok(
-        assembleAgent(
-          infra,
-          txResult.value.channels,
-          emails,
-          status.failures,
-          deps.agentIdleTimeoutMinutes,
-          status.preparingWorkspace,
-        ),
-      );
+      return connectSlackImpl(id, slackChannelId, mode);
     },
 
     async disconnectSlack(id) {
@@ -1041,6 +1172,22 @@ export function createAgentsService(deps: {
           const infra = await deps.repo.get(id, deps.owner);
           return infra ? { id: infra.id, name: infra.name } : null;
         },
+        binding,
+      })(agentId, flowId);
+    },
+
+    async bindSlackChannel(agentId, flowId) {
+      const binding = deps.slackBinding;
+      if (!binding) return err({ type: "FlowInvalid" as const });
+      return executeSlackBind({
+        owner: deps.owner,
+        getAgent: async (id) => {
+          const infra = await deps.repo.get(id, deps.owner);
+          return infra ? { id: infra.id, name: infra.name } : null;
+        },
+        findChannelBinding: deps.findSlackChannelBinding,
+        connectShared: (id, slackChannelId) =>
+          connectSlackImpl(id, slackChannelId, "shared"),
         binding,
       })(agentId, flowId);
     },

--- a/packages/api-server/src/modules/channels/infrastructure/slack-flows.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack-flows.ts
@@ -1,0 +1,22 @@
+import { createFlowStore, type FlowStore } from "./telegram-flows.js";
+
+/** A completed Keycloak login for an in-chat Slack bind, waiting for the owner
+ *  to pick an Agent in the UI. The record is the bearer capability behind
+ *  `?flow=<id>`: it pins the authenticated sub, so only that user's session can
+ *  consume it. Mirrors {@link TelegramPendingBind}. */
+export interface SlackPendingBind {
+  slackChannelId: string;
+  slackUserId: string;
+  keycloakSub: string;
+  channelTitle?: string;
+  createdAt: number;
+}
+
+export type SlackBindFlowStore = FlowStore<SlackPendingBind>;
+
+export function createSlackBindFlowStore(opts?: {
+  now?: () => number;
+  ttlMs?: number;
+}): SlackBindFlowStore {
+  return createFlowStore<SlackPendingBind>(opts);
+}

--- a/packages/api-server/src/modules/channels/infrastructure/slack-oauth.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack-oauth.ts
@@ -1,5 +1,6 @@
 import { Hono } from "hono";
 import type { SlackOAuthPending } from "./slack.js";
+import type { SlackBindFlowStore } from "./slack-flows.js";
 import type { IdentityLinkService } from "./../services/identity-link-service.js";
 import {
   exchangeCodeForTokens,
@@ -9,15 +10,24 @@ import { securityLog } from "../../../core/security-log.js";
 
 const FLOW_TTL_MS = 10 * 60 * 1000;
 
+/** Completes the Slack Keycloak roundtrip for both the `login` intent (identity
+ *  linking, today's behavior) and the `bind` intent (in-chat channel bind). A
+ *  bind callback links the identity too — so the binder can later run the
+ *  unbind command without re-authenticating — then mints a bind flow pinned to
+ *  the authenticated sub and hands the user to the UI agent picker, which does
+ *  the ownership check and the write. */
 export function createSlackOAuthRoutes(deps: {
   pendingFlows: Map<string, SlackOAuthPending>;
+  bindFlows: SlackBindFlowStore;
   identityLinks: IdentityLinkService;
   oauthConfig: KeycloakOAuthConfig;
+  uiBaseUrl: string;
   /** Lowercase brand identifier — used to render the slash command name in
    *  user-facing error messages ("Run `/<brandShort> login` again"). */
   brandShort: string;
 }) {
   const routes = new Hono();
+  const bindPage = `${deps.uiBaseUrl}/slack/bind`;
 
   routes.get("/api/slack/oauth/callback", async (c) => {
     const code = c.req.query("code");
@@ -46,12 +56,18 @@ export function createSlackOAuthRoutes(deps: {
       return c.text("Invalid or expired state", 400);
     }
 
+    // From here the intent is known, so bind failures land on the picker page
+    // (with an ?error=) while login failures keep the plain-text response.
+    const isBind = pending.intent === "bind";
+
     if (Date.now() - pending.createdAt > FLOW_TTL_MS) {
       deps.pendingFlows.delete(state);
-      return c.text(
-        `Login link expired. Run \`/${deps.brandShort} login\` again.`,
-        400,
-      );
+      return isBind
+        ? c.redirect(`${bindPage}?error=expired`)
+        : c.text(
+            `Login link expired. Run \`/${deps.brandShort} login\` again.`,
+            400,
+          );
     }
 
     deps.pendingFlows.delete(state);
@@ -63,10 +79,12 @@ export function createSlackOAuthRoutes(deps: {
     );
     if ("error" in result) {
       process.stderr.write(`[slack-oauth] ${result.error}\n`);
-      return c.text(
-        `Token exchange failed. Run \`/${deps.brandShort} login\` again.`,
-        400,
-      );
+      return isBind
+        ? c.redirect(`${bindPage}?error=exchange_failed`)
+        : c.text(
+            `Token exchange failed. Run \`/${deps.brandShort} login\` again.`,
+            400,
+          );
     }
 
     await deps.identityLinks.link(
@@ -74,7 +92,8 @@ export function createSlackOAuthRoutes(deps: {
       pending.slackUserId,
       result.keycloakSub,
     );
-    // The primary "who got bound to which Keycloak account" record.
+    // The primary "who got bound to which Keycloak account" record. A bind
+    // callback links the identity too so the binder can later unbind in-chat.
     securityLog("info", "identity.link", {
       category: "channel",
       actor: result.keycloakSub,
@@ -85,6 +104,15 @@ export function createSlackOAuthRoutes(deps: {
         externalUserId: pending.slackUserId,
       },
     });
+
+    if (isBind) {
+      const flowId = deps.bindFlows.create({
+        slackChannelId: pending.channelId,
+        slackUserId: pending.slackUserId,
+        keycloakSub: result.keycloakSub,
+      });
+      return c.redirect(`${bindPage}?flow=${flowId}`);
+    }
 
     return c.html(
       "<html><body><h2>Account linked!</h2><p>You can close this window and return to Slack.</p></body></html>",

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -176,6 +176,9 @@ export interface SlackOAuthPending {
   slackUserId: string;
   channelId: string;
   codeVerifier: string;
+  /** Whether the callback just links identity (`login`) or also mints a bind
+   *  flow and hands off to the agent picker (`bind`). */
+  intent: "login" | "bind";
   createdAt: number;
 }
 
@@ -188,6 +191,11 @@ export function createSlackWorker(
   pendingOAuthFlows: Map<string, SlackOAuthPending>,
   getInstanceOwner: (agentId: string) => Promise<string | null>,
   channelRegistry: ChannelRegistry,
+  /** Delete the shared binding for a Slack channel, owner-agnostic. The in-chat
+   *  unbind command authorizes the caller (binder or agent owner) before
+   *  calling this; unlike the owner-scoped platform disconnect it runs
+   *  system-side. */
+  unbindSlackChannel: (slackChannelId: string) => Promise<void>,
   /** Lowercase brand identifier used in slash-command help text (e.g.
    *  brandShort="name" → /name login). Sourced from BRAND_SHORT env var. */
   brandShort: string,
@@ -641,6 +649,7 @@ export function createSlackWorker(
           slackUserId: command.userId,
           channelId: command.channelId,
           codeVerifier,
+          intent: "login",
           createdAt: Date.now(),
         });
 
@@ -659,9 +668,107 @@ export function createSlackWorker(
         await identityLinks.unlink("slack", command.userId);
         await ack({ text: "Account unlinked." });
       })
+      .with("bind", async () => {
+        // Anyone in the channel may start a bind (no admin gate) — but the
+        // agent picker that follows only lists the signed-in user's own
+        // agents, so a channel only ever runs under an agent its binder owns.
+        const binding = await channelRegistry.resolveSlackBinding(
+          command.channelId,
+        );
+        if (binding) {
+          await ack({
+            text: `This channel is already connected to \`${binding.instanceName}\`. The person who connected it, or the agent's owner, must run \`/${brandShort} unbind\` first.`,
+          });
+          return;
+        }
+
+        const { state, codeVerifier, codeChallenge } = generatePkce();
+        pendingOAuthFlows.set(state, {
+          slackUserId: command.userId,
+          channelId: command.channelId,
+          codeVerifier,
+          intent: "bind",
+          createdAt: Date.now(),
+        });
+
+        const bindUrl = buildAuthorizeUrl(oauthConfig, state, codeChallenge);
+        await ack({
+          text: `<${bindUrl}|Connect an agent to this channel>. Everyone here will be able to drive it under the agent's own connected accounts and API tokens.`,
+        });
+      })
+      .with("unbind", async () => {
+        const binding = await channelRegistry.resolveSlackBinding(
+          command.channelId,
+        );
+        if (!binding) {
+          await ack({ text: "This channel isn't connected to an agent." });
+          return;
+        }
+
+        const invoker = await identityLinks.resolve("slack", command.userId);
+        if (!invoker) {
+          securityLog("warn", "channel.authz_deny", {
+            category: "channel",
+            actor: null,
+            actorKind: "external",
+            surface: "slack",
+            agentId: binding.instanceName,
+            decision: "deny",
+            reason: "unlinked",
+            detail: {
+              slackUserId: command.userId,
+              channelId: command.channelId,
+            },
+          });
+          await ack({
+            text: `Link your account first — run \`/${brandShort} login\`, then \`/${brandShort} unbind\` again.`,
+          });
+          return;
+        }
+
+        const agentOwner = await getInstanceOwner(binding.instanceName);
+        const allowed = invoker === binding.owner || invoker === agentOwner;
+        if (!allowed) {
+          securityLog("warn", "channel.authz_deny", {
+            category: "channel",
+            actor: invoker,
+            actorKind: "user",
+            surface: "slack",
+            agentId: binding.instanceName,
+            decision: "deny",
+            reason: "not-binder-or-owner",
+            detail: {
+              slackUserId: command.userId,
+              channelId: command.channelId,
+            },
+          });
+          await ack({
+            text: "Only the person who connected this channel, or the agent's owner, can disconnect it.",
+          });
+          return;
+        }
+
+        await unbindSlackChannel(command.channelId);
+        securityLog("info", "channel.chat_unbound", {
+          category: "authz-list",
+          actor: invoker,
+          actorKind: "user",
+          surface: "slack",
+          agentId: binding.instanceName,
+          result: "success",
+          detail: { slackUserId: command.userId, channelId: command.channelId },
+        });
+        emit({
+          type: EventType.SlackDisconnected,
+          agentId: binding.instanceName,
+        });
+        await ack({
+          text: `Channel disconnected. Run \`/${brandShort} bind\` to connect an agent again.`,
+        });
+      })
       .with(P.string, async () => {
         await ack({
-          text: `Usage: \`/${brandShort} login\` or \`/${brandShort} logout\``,
+          text: `Usage: \`/${brandShort} bind\`, \`/${brandShort} unbind\`, \`/${brandShort} login\`, or \`/${brandShort} logout\``,
         });
       })
       .exhaustive();

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -73,6 +73,14 @@ export default defineConfig({
       use: { ...devices["Desktop Chrome"] },
     },
     {
+      // In-chat bind/unbind slash commands (pure API, no storageState); runs
+      // after "slack-shared" because it too replaces the single Slack binding.
+      name: "slack-inchat",
+      testMatch: /09-slack-inchat-bind\.spec\.ts$/,
+      dependencies: ["slack-shared"],
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
       // Creates and deletes its own session, so it leaves no residue for other
       // specs; depends on "agent" only to gate on a provisioned running agent.
       name: "session-delete",

--- a/packages/e2e/playwright/src/tests/09-slack-inchat-bind.spec.ts
+++ b/packages/e2e/playwright/src/tests/09-slack-inchat-bind.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from "@playwright/test";
+
+import { waitForAgentRunning } from "../lib/agents.js";
+import { createApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+import { agentName } from "../lib/fixtures.js";
+
+// This spec exercises the in-chat bind/unbind slash commands at the command
+// level (deterministic, no OAuth round-trip). It replaces the agent's single
+// Slack binding, so it runs as its own project after "slack-shared".
+const inchatChannelId = "C-E2E-INCHAT";
+const freshChannelId = "C-E2E-INCHAT-FRESH";
+// A Slack user with no linked platform identity — channel membership only.
+const strangerSlackUserId = "U-E2E-INCHAT-STRANGER";
+
+test("in-chat /bind offers a connect link on an unbound channel", async () => {
+  test.setTimeout(120_000);
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+  await waitForAgentRunning(api, agentName);
+
+  const { ack } = await api.e2e.slackFireCommand.mutate({
+    text: "bind",
+    userId: strangerSlackUserId,
+    channelId: freshChannelId,
+  });
+  // Anyone may start a bind; the agent picker (behind the link) is where
+  // ownership is enforced.
+  expect(ack).toContain("Connect an agent");
+});
+
+test("a bind cannot override an existing binding (prior binder must unbind first)", async () => {
+  test.setTimeout(120_000);
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+  const agentId = await waitForAgentRunning(api, agentName);
+
+  await test.step("owner binds the channel in shared mode", async () => {
+    await api.agents.connectSlack.mutate({
+      id: agentId,
+      slackChannelId: inchatChannelId,
+      mode: "shared",
+    });
+  });
+
+  await test.step("/bind on the bound channel is refused", async () => {
+    const { ack } = await api.e2e.slackFireCommand.mutate({
+      text: "bind",
+      userId: strangerSlackUserId,
+      channelId: inchatChannelId,
+    });
+    expect(ack).toContain("already connected");
+  });
+
+  await test.step("an unlinked user cannot /unbind, and the binding survives", async () => {
+    const unbind = await api.e2e.slackFireCommand.mutate({
+      text: "unbind",
+      userId: strangerSlackUserId,
+      channelId: inchatChannelId,
+    });
+    expect(unbind.ack).toContain("Link your account");
+
+    // Still bound: a second /bind is still refused.
+    const rebind = await api.e2e.slackFireCommand.mutate({
+      text: "bind",
+      userId: strangerSlackUserId,
+      channelId: inchatChannelId,
+    });
+    expect(rebind.ack).toContain("already connected");
+  });
+
+  await test.step("owner disconnects via the platform (leaves no residue)", async () => {
+    await api.agents.disconnectSlack.mutate({ id: agentId });
+  });
+});

--- a/packages/ui/src/__tests__/unit/slack-bind-flow.test.ts
+++ b/packages/ui/src/__tests__/unit/slack-bind-flow.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import { pathToState, viewToPath } from "../../modules/platform/lib/routes.js";
+import {
+  bindErrorCopy,
+  callbackErrorCopy,
+  readCallbackErrorFromSearch,
+  readFlowIdFromSearch,
+} from "../../modules/slack/lib/bind-flow.js";
+
+const BRAND = "acme";
+
+describe("slack bind flow helpers", () => {
+  it("reads the flow id from the search string", () => {
+    expect(readFlowIdFromSearch("?flow=abc-123")).toBe("abc-123");
+    expect(readFlowIdFromSearch("?flow=abc&x=1")).toBe("abc");
+    expect(readFlowIdFromSearch("?x=1")).toBe(null);
+    expect(readFlowIdFromSearch("?flow=")).toBe(null);
+    expect(readFlowIdFromSearch("")).toBe(null);
+  });
+
+  it("reads the callback error", () => {
+    expect(readCallbackErrorFromSearch("?error=expired")).toBe("expired");
+    expect(readCallbackErrorFromSearch("?flow=abc")).toBe(null);
+  });
+
+  it("maps bind mutation error codes to brand-aware copy", () => {
+    expect(bindErrorCopy("BAD_REQUEST", BRAND).terminal).toBe(true);
+    expect(bindErrorCopy("CONFLICT", BRAND).terminal).toBe(true);
+    expect(bindErrorCopy("CONFLICT", BRAND).hint).toContain(`/${BRAND} unbind`);
+    expect(bindErrorCopy("NOT_FOUND", BRAND).terminal).toBe(false);
+    expect(bindErrorCopy(undefined, BRAND).terminal).toBe(false);
+  });
+
+  it("maps callback error codes to terminal copy that names the brand command", () => {
+    for (const code of ["denied", "expired", "exchange_failed"]) {
+      const copy = callbackErrorCopy(code, BRAND);
+      expect(copy.terminal).toBe(true);
+      expect(copy.hint).toContain(`/${BRAND} bind`);
+    }
+  });
+});
+
+describe("slack bind route", () => {
+  it("round-trips /slack/bind", () => {
+    expect(pathToState("/slack/bind")).toEqual({ view: "slack-bind" });
+    expect(viewToPath("slack-bind")).toBe("/slack/bind");
+  });
+});

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -15,6 +15,7 @@ import { SandboxHomeView } from "./modules/sandboxes/views/sandbox-home-view.js"
 import { SandboxWizardView } from "./modules/sandboxes/views/sandbox-wizard-view.js";
 import { ChatView } from "./modules/sessions/views/chat-view.js";
 import { SettingsView } from "./modules/settings/views/settings-view.js";
+import { SlackBindView } from "./modules/slack/views/slack-bind-view.js";
 import { TelegramBindView } from "./modules/telegram/views/telegram-bind-view.js";
 import { TermsView } from "./modules/terms/views/terms-view.js";
 import { pathToState, useStore } from "./store.js";
@@ -41,6 +42,7 @@ export default function App() {
 
   if (view === "terms") return <TermsView />;
   if (view === "telegram-bind") return <TelegramBindView />;
+  if (view === "slack-bind") return <SlackBindView />;
   return <MainApp />;
 }
 

--- a/packages/ui/src/modules/platform/lib/routes.ts
+++ b/packages/ui/src/modules/platform/lib/routes.ts
@@ -9,6 +9,7 @@ export const viewSchema = z.enum([
   "inbox",
   "terms",
   "telegram-bind",
+  "slack-bind",
   "sandbox-new",
   "sandbox-home",
   "experiments",
@@ -52,6 +53,7 @@ export function viewToPath(
   if (view === "inbox") return "/inbox";
   if (view === "terms") return "/terms";
   if (view === "telegram-bind") return "/telegram/bind";
+  if (view === "slack-bind") return "/slack/bind";
   if (view === "sandbox-new") return "/sandboxes/new";
   if (view === "sandbox-home" && agentId) {
     const base = `/sandboxes/${encodeURIComponent(agentId)}`;
@@ -88,6 +90,7 @@ export function pathToState(path: string): {
   if (path === "/inbox") return { view: "inbox" };
   if (path === "/terms") return { view: "terms" };
   if (path === "/telegram/bind") return { view: "telegram-bind" };
+  if (path === "/slack/bind") return { view: "slack-bind" };
   if (path === "/sandboxes/new") return { view: "sandbox-new" };
   const sandboxHomeMatch = path.match(
     /^\/sandboxes\/([^/]+)(?:\/(setup|connections|skills|schedules))?$/,

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -33,9 +33,13 @@ export const createNavigationSlice: StateCreator<
   NavigationSlice
 > = (set) => ({
   view: (() => {
-    // The Telegram bind page is entered via an external redirect carrying a
-    // one-shot ?flow= param — a stale OAuth return-view must not replace it.
-    if (window.location.pathname === "/telegram/bind")
+    // The Telegram/Slack bind pages are entered via an external redirect
+    // carrying a one-shot ?flow= param — a stale OAuth return-view must not
+    // replace them.
+    if (
+      window.location.pathname === "/telegram/bind" ||
+      window.location.pathname === "/slack/bind"
+    )
       return pathToState(window.location.pathname).view;
     // Holds the path to restore after an OAuth roundtrip (e.g. /settings/connections).
     const saved = sessionStorage.getItem("platform-return-view");

--- a/packages/ui/src/modules/slack/api/mutations.ts
+++ b/packages/ui/src/modules/slack/api/mutations.ts
@@ -1,0 +1,14 @@
+import { useMutation } from "@tanstack/react-query";
+
+import { trpc } from "../../../trpc.js";
+import { agentsKeys } from "../../agents/api/queries.js";
+
+/** No errorToast on purpose — the bind page maps failures to inline states. */
+export function useBindSlackChannel() {
+  return useMutation({
+    ...trpc.agents.bindSlackChannel.mutationOptions(),
+    meta: {
+      invalidates: [agentsKeys.listWithChannels(), trpc.agents.list.queryKey()],
+    },
+  });
+}

--- a/packages/ui/src/modules/slack/lib/bind-flow.ts
+++ b/packages/ui/src/modules/slack/lib/bind-flow.ts
@@ -1,0 +1,79 @@
+/** Pure helpers for the /slack/bind page — node-testable, no DOM. The brand
+ *  short is threaded in (rather than read from getBrand) so these stay pure and
+ *  never hardcode the brand. */
+
+export function readFlowIdFromSearch(search: string): string | null {
+  const flow = new URLSearchParams(search).get("flow");
+  return flow && flow.length > 0 ? flow : null;
+}
+
+/** Error the OAuth callback redirected with (?error=…), if any. */
+export function readCallbackErrorFromSearch(search: string): string | null {
+  return new URLSearchParams(search).get("error");
+}
+
+export interface BindErrorCopy {
+  title: string;
+  hint: string;
+  /** Terminal errors hide the picker — only a fresh bind command recovers. */
+  terminal: boolean;
+}
+
+export function callbackErrorCopy(
+  code: string,
+  brandShort: string,
+): BindErrorCopy {
+  switch (code) {
+    case "denied":
+      return {
+        title: "Login was cancelled",
+        hint: `Run \`/${brandShort} bind\` in the Slack channel to try again.`,
+        terminal: true,
+      };
+    case "expired":
+      return {
+        title: "This bind link has expired",
+        hint: `Run \`/${brandShort} bind\` in the Slack channel to get a fresh link.`,
+        terminal: true,
+      };
+    default:
+      return {
+        title: "Login failed",
+        hint: `Run \`/${brandShort} bind\` in the Slack channel to try again.`,
+        terminal: true,
+      };
+  }
+}
+
+/** Maps a failed bind mutation's tRPC error code to page copy. */
+export function bindErrorCopy(
+  code: string | undefined,
+  brandShort: string,
+): BindErrorCopy {
+  switch (code) {
+    case "BAD_REQUEST":
+      return {
+        title: "This link is invalid or has expired",
+        hint: `Run \`/${brandShort} bind\` in the Slack channel to get a fresh link.`,
+        terminal: true,
+      };
+    case "CONFLICT":
+      return {
+        title: "This channel is already connected to an agent",
+        hint: `Run \`/${brandShort} unbind\` in the channel first, then \`/${brandShort} bind\` again.`,
+        terminal: true,
+      };
+    case "NOT_FOUND":
+      return {
+        title: "That agent no longer exists",
+        hint: "Pick a different agent.",
+        terminal: false,
+      };
+    default:
+      return {
+        title: "Something went wrong",
+        hint: `Try again — or run \`/${brandShort} bind\` in the channel for a fresh link.`,
+        terminal: false,
+      };
+  }
+}

--- a/packages/ui/src/modules/slack/views/slack-bind-view.tsx
+++ b/packages/ui/src/modules/slack/views/slack-bind-view.tsx
@@ -1,0 +1,216 @@
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+
+import { getBrand } from "../../../brand.js";
+import { ListSkeleton } from "../../../components/list-skeleton.js";
+import type { AgentView } from "../../../types.js";
+import { useAgents, useAgentsList } from "../../agents/api/queries.js";
+import { useBindSlackChannel } from "../api/mutations.js";
+import {
+  type BindErrorCopy,
+  bindErrorCopy,
+  callbackErrorCopy,
+  readCallbackErrorFromSearch,
+  readFlowIdFromSearch,
+} from "../lib/bind-flow.js";
+
+// URL-owned inputs, read once: a refresh keeps working within the flow TTL.
+const flowId = readFlowIdFromSearch(window.location.search);
+const callbackError = readCallbackErrorFromSearch(window.location.search);
+
+export function SlackBindView() {
+  const brandShort = getBrand().short;
+  const agents = useAgents();
+  const list = useAgentsList();
+  const bind = useBindSlackChannel();
+  const [error, setError] = useState<BindErrorCopy | null>(null);
+  const [bound, setBound] = useState<{
+    agentName: string;
+    channelTitle: string | null;
+  } | null>(null);
+
+  if (callbackError) {
+    return (
+      <TerminalError copy={callbackErrorCopy(callbackError, brandShort)} />
+    );
+  }
+  if (!flowId) {
+    return (
+      <TerminalError
+        copy={{
+          title: "This page is opened from Slack",
+          hint: `Run \`/${brandShort} bind\` in your channel to get a fresh link.`,
+          terminal: true,
+        }}
+      />
+    );
+  }
+  if (bound) {
+    return (
+      <BindSuccess
+        agentName={bound.agentName}
+        channelTitle={bound.channelTitle}
+        brandShort={brandShort}
+      />
+    );
+  }
+  if (error?.terminal) {
+    return <TerminalError copy={error} />;
+  }
+  if (agents.isLoading) {
+    return (
+      <Page title="Connect this channel to an agent">
+        <ListSkeleton rows={3} />
+      </Page>
+    );
+  }
+  if (list.length === 0) {
+    return (
+      <Page title="Connect this channel to an agent">
+        <p className="text-sm text-muted-foreground">
+          You don&apos;t own any agents yet. Create an agent first, then run{" "}
+          <code>/{brandShort} bind</code> in the channel again.
+        </p>
+        <DashboardButton label="Go to dashboard" />
+      </Page>
+    );
+  }
+
+  const pick = (agent: AgentView) => {
+    setError(null);
+    bind.mutate(
+      { agentId: agent.id, flowId },
+      {
+        onSuccess: (res) =>
+          setBound({ agentName: agent.name, channelTitle: res.channelTitle }),
+        onError: (e) => {
+          const code = (e as { data?: { code?: string } }).data?.code;
+          setError(bindErrorCopy(code, brandShort));
+        },
+      },
+    );
+  };
+
+  return (
+    <Page title="Connect this channel to an agent">
+      <p className="text-sm text-muted-foreground">
+        Everyone in this Slack channel will be able to use the agent you pick.
+        Turns run under the agent&apos;s own connected accounts and API tokens,
+        and your acceptance of the Terms of Use covers every turn.
+      </p>
+      {error && (
+        <p className="text-sm text-red-600">
+          {error.title} — {error.hint}
+        </p>
+      )}
+      <div className="flex flex-col gap-2">
+        {list.map((agent) => (
+          <BindAgentRow
+            key={agent.id}
+            agent={agent}
+            disabled={bind.isPending}
+            pending={bind.isPending && bind.variables?.agentId === agent.id}
+            onPick={() => pick(agent)}
+          />
+        ))}
+      </div>
+    </Page>
+  );
+}
+
+function BindAgentRow({
+  agent,
+  disabled,
+  pending,
+  onPick,
+}: {
+  agent: AgentView;
+  disabled: boolean;
+  pending: boolean;
+  onPick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onPick}
+      className="flex flex-col items-start gap-0.5 rounded-lg border border-border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60"
+    >
+      <span className="text-[14px] font-semibold text-foreground">
+        {pending ? `Connecting ${agent.name}…` : agent.name}
+      </span>
+      {agent.description && (
+        <span className="text-[12px] text-muted-foreground">
+          {agent.description}
+        </span>
+      )}
+      {agent.templateId && (
+        <span className="text-[11px] font-mono text-muted-foreground">
+          {agent.templateId}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function BindSuccess({
+  agentName,
+  channelTitle,
+  brandShort,
+}: {
+  agentName: string;
+  channelTitle: string | null;
+  brandShort: string;
+}) {
+  return (
+    <Page
+      title={
+        channelTitle ? `“${channelTitle}” is connected` : "Channel connected"
+      }
+    >
+      <p className="text-sm text-muted-foreground">
+        This channel is now connected to <strong>{agentName}</strong>. Return to
+        Slack — the bot has posted a confirmation. Run{" "}
+        <code>/{brandShort} unbind</code> there to disconnect.
+      </p>
+      <DashboardButton label="Go to dashboard" />
+    </Page>
+  );
+}
+
+function TerminalError({ copy }: { copy: BindErrorCopy }) {
+  return (
+    <Page title={copy.title}>
+      <p className="text-sm text-muted-foreground">{copy.hint}</p>
+      <DashboardButton label="Go to dashboard" />
+    </Page>
+  );
+}
+
+function DashboardButton({ label }: { label: string }) {
+  return (
+    <Button
+      type="button"
+      className="self-start"
+      onClick={() => window.location.assign("/")}
+    >
+      {label}
+    </Button>
+  );
+}
+
+function Page({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="mx-auto w-full max-w-140 px-4 py-10 flex flex-col gap-4">
+      <h1 className="text-2xl font-semibold">{title}</h1>
+      {children}
+    </div>
+  );
+}


### PR DESCRIPTION
Stacked on #2790 (targets `feat/place-scoped-channels`; merge that first). Extends ADR-076's per-channel access modes with an **in-chat binding surface for Slack**, mirroring Telegram.

## What
- `/<brand> bind` in a Slack channel → Keycloak OAuth → a `/slack/bind` web picker listing the signed-in user's **own** agents → the channel is bound in **shared** mode under that agent's credentials, and a confirmation posts back to the channel.
- `/<brand> unbind` releases the binding.

## Rules (as agreed)
- **Anyone** in the channel may start `/bind` — no admin gate. The control is the `owner == flow-sub` check on the picker: you can only lend an agent you own. The bind also links the initiator's Slack identity so they can later unbind.
- **No override:** a bind is refused on an already-bound channel until someone unbinds first (checked in-chat *and* server-side).
- **Unbind auth:** the binder **or** the agent's owner. The owner-scoped platform UI/CLI `disconnectSlack` stays as an escape hatch.
- **Coexists** with #2790's platform UI/CLI shared-mode bind — nothing there is removed.

## How
- Mirrors the Telegram flow: a `SlackBindFlowStore`, an `intent`-tagged OAuth callback branch, a `bindSlackChannel` tRPC procedure + `executeSlackBind` service flow, a `/slack/bind` UI module, and the worker's `bind`/`unbind` command arms.
- The bind write reuses the existing `connectSlack` path (so `channels.owner` = the binder's sub, which the shared-mode ToU gate reads).
- In-chat unbind uses a new **owner-agnostic** channel delete because the worker runs system-side (the platform `disconnectSlack` delete is owner-filtered and would not match).
- No DB migration; no new ADR (additive surface consistent with ADR-076 — captured in `docs/architecture/channels.md`).

## Tests
- Unit: `executeSlackBind` (own-agent gate, no-override, lost-race, best-effort confirm), the bind/unbind command handlers (unbind requires a linked identity, binder-or-owner authorization, `SlackDisconnected` emit), the OAuth callback intent branch (bind mints flow + links + redirects; login unchanged), and the UI helper/route.
- E2E: `09-slack-inchat-bind.spec.ts` (own project after `slack-shared`) — connect-link ack, no-override refusal, unlinked-can't-unbind.
- `mise run check` green for every touched package; full `api-server` (407) and `ui` (82) suites pass. `docs:check:doc-size` fails only on `connections.md` (untouched, pre-existing on the base — clears on rebase onto main).

## Not covered here
- The full browser OAuth round-trip e2e (optional per plan; the OAuth branch + bind logic are unit-covered).
- Slack channel *title* on the picker (the gateway has no `conversations.info` yet) — a follow-up.
