### PR TITLE
refactor(invocations): rename driver /sandboxes endpoint to /invocations

### DIFF
--- a/packages/agents/claude-code/workspace/.agents/skills/dam-sandbox/sandbox-sdk.mjs
+++ b/packages/agents/claude-code/workspace/.agents/skills/dam-sandbox/sandbox-sdk.mjs
@@ -215,7 +215,7 @@ export async function spawn(opts = {}) {
   if (memory !== undefined) body.memory = memory;
   if (cpu !== undefined) body.cpu = cpu;
 
-  const { id } = await req("POST", "/sandboxes", body);
+  const { id } = await req("POST", "/invocations", body);
   const tag = label ?? template ?? image;
   log(`spawned ${tag} -> ${id}`);
 
@@ -224,7 +224,7 @@ export async function spawn(opts = {}) {
   for (;;) {
     let view;
     try {
-      view = await req("GET", `/sandboxes/${encodeURIComponent(id)}`);
+      view = await req("GET", `/invocations/${encodeURIComponent(id)}`);
       consecutiveErrors = 0;
     } catch (err) {
       // A transient poll failure shouldn't kill a long loop; give up only after

--- a/packages/api-server/src/apps/harness-api-server/invocation-endpoints.ts
+++ b/packages/api-server/src/apps/harness-api-server/invocation-endpoints.ts
@@ -56,15 +56,15 @@ const spawnBody = z
 /** Mounts the driver-facing spawn primitive on the harness surface. Every route
  *  is scoped to the driver's identity — the `:id` the waypoint already
  *  authenticated. Create-then-poll: POST returns an id, GET reports status +
- *  the schema-validated result. The path stays `/sandboxes` (the driver SDK's
- *  wire contract); the domain term is Invocation. */
+ *  the schema-validated result. The path is `/invocations`, matching the
+ *  domain term; the driver SDK is wired to the same path. */
 export function mountInvocationRoutes(
   app: Hono,
   deps: InvocationEndpointsDeps,
 ): void {
   // Spawn an Invocation as the driver (:id). The driver's own connection grants
   // are the attenuation ceiling for the requested subset.
-  app.post("/api/agents/:id/sandboxes", async (c) => {
+  app.post("/api/agents/:id/invocations", async (c) => {
     const driverId = c.req.param("id")!;
     const verified = await resolveAgent(deps.k8s, driverId);
     if (!verified) return c.json({ error: "not found" }, 404);
@@ -123,9 +123,9 @@ export function mountInvocationRoutes(
   });
 
   // Poll an Invocation the driver spawned.
-  app.get("/api/agents/:id/sandboxes/:sandboxId", async (c) => {
+  app.get("/api/agents/:id/invocations/:invocationId", async (c) => {
     const driverId = c.req.param("id")!;
-    const invocationId = c.req.param("sandboxId")!;
+    const invocationId = c.req.param("invocationId")!;
     const verified = await resolveAgent(deps.k8s, driverId);
     if (!verified) return c.json({ error: "not found" }, 404);
 


### PR DESCRIPTION
Follow-up to #2816. Picks up one leftover item: the driver-facing `/sandboxes` HTTP path was left as-is when `modules/sandboxes` became `modules/invocations`. This aligns the wire path with the domain term.

## What changed (code building block only)

- `invocation-endpoints.ts`: `POST /api/agents/:id/sandboxes` -> `/invocations`, `GET .../sandboxes/:sandboxId` -> `.../invocations/:invocationId`.
- `sandbox-sdk.mjs`: the two request URLs it POSTs/GETs, so the SDK stays wired to the renamed endpoint. Nothing else in the SDK touched.

## Left alone on purpose

Per the scoping call: the skills (`dam-sandbox`, `dam-loop`) and the SDK's `sandbox`/`spawn` vocabulary stay. That layer is the user-facing "workflow" concept whose naming is still open. The #892 "running sandbox" copy (= Agent) and the UI `/sandboxes/:agentId` browser route are unrelated and untouched.

## Checks

api-server `tsc` + eslint + prettier clean, tests 408/408. No tests hit the harness `/sandboxes` path, so nothing broke.

https://claude.ai/code/session_013WtNxqvCpVYr1z6tKDYRDC