### PR TITLE
feat(cli): accept the Terms of Use from the CLI

### DIFF
--- a/docs/architecture/cli.md
+++ b/docs/architecture/cli.md
@@ -1,6 +1,6 @@
 # CLI
 
-Last verified: 2026-07-17
+Last verified: 2026-07-20
 
 ## Overview
 
@@ -41,7 +41,7 @@ Credentials are keyed by host URL, so switching between deployments never clobbe
 
 The `auth` module exposes one seam — **`TokenProvider`** — that every authenticated verb consumes. Its precedence: the `DAM_TOKEN` env var (used verbatim, never refreshed) > the stored per-host credential (refreshed proactively near expiry, with rotated refresh tokens persisted) > a not-logged-in error. A refresh that fails with an invalid grant clears the entry and surfaces a session-expired signal directing the user back to `dam auth login`.
 
-Those are the client-side signals. The server can also reject a request that looked valid locally, and the CLI surfaces that distinctly rather than as a transport failure: it maps the api-server's raw 401/403 (alongside the existing 412 Terms gate) to typed errors. A 401 becomes session-expired — with a hint that switches to "check `DAM_TOKEN`" when that variable is set, because a bearer supplied that way lives outside the credential store and re-login can't fix it. A 403 becomes access-denied with no login hint: the caller is authenticated but not authorized (e.g. a pending-approval account), so the remedy is an admin, not re-authentication. Any other reached-but-rejected request surfaces the server's own reason; "cannot reach server" is reserved for genuine connectivity failures.
+Those are the client-side signals. The server can also reject a request that looked valid locally, and the CLI surfaces that distinctly rather than as a transport failure: it maps the api-server's raw 401/403 (alongside the existing 412 Terms gate) to typed errors. A 401 becomes session-expired — with a hint that switches to "check `DAM_TOKEN`" when that variable is set, because a bearer supplied that way lives outside the credential store and re-login can't fix it. A 403 becomes access-denied with no login hint: the caller is authenticated but not authorized (e.g. a pending-approval account), so the remedy is an admin, not re-authentication. Any other reached-but-rejected request surfaces the server's own reason; "cannot reach server" is reserved for genuine connectivity failures. The 412 Terms gate's remedy is now `dam terms accept` (see the `terms` group), so a headless/CI caller can review and clear the gate entirely from the CLI with no browser.
 
 For headless / CI use, `DAM_TOKEN=<bearer>` is used verbatim and bypasses the credential store. It accepts either a Keycloak access token or a Platform **API key** (`pk_…` prefix); the CLI does not branch — the server's bearer middleware dispatches by prefix. There is no `--token` flag, to keep tokens out of shell history and `ps`.
 
@@ -71,6 +71,7 @@ The CLI is at parity with the web UI across these groups. Each concept's depth l
 - **`channel`** — Slack channel bindings and the per-agent allow-list, owned by [channels.md](channels.md). Slack connect takes the binding's access mode (`--mode`, person-scoped by default; fixed per binding, so changing it is disconnect + reconnect), and the channel listing shows each binding's mode — Telegram rows always shared, since the mode is structural there. A shared connect against a server that doesn't understand modes is verified and rolled back rather than silently landing person-scoped. Telegram binds in-chat (`/login`), so it has no CLI verb.
 - **`skill`** — git-based skill sources, install/uninstall, and publish, owned by [skills.md](skills.md).
 - **`schedule`** — time-triggered task recurrences on an agent, owned by [agent-lifecycle.md](agent-lifecycle.md).
+- **`terms`** — view the current Terms of Use and accept them from the CLI (`show` / `status` / `accept`), owned by the terms gate in [security-and-credentials.md](security-and-credentials.md).
 
 ## Shared conventions
 

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -11,7 +11,7 @@ try {
 } catch (err) {
   if (err instanceof TermsStaleAtTransportError) {
     process.stderr.write(
-      `error: Terms of Use acceptance required\nhint: open ${err.host} to accept\n`,
+      "error: Terms of Use acceptance required\nhint: run `dam terms accept` to review and accept\n",
     );
     process.exit(1);
   }

--- a/packages/cli/src/compose.ts
+++ b/packages/cli/src/compose.ts
@@ -15,6 +15,7 @@ import { composeSkillModule } from "./modules/skill/compose.js";
 import { composeSshModule } from "./modules/ssh/compose.js";
 import { composeMetricsModule } from "./modules/metrics/compose.js";
 import { composeTemplateModule } from "./modules/template/compose.js";
+import { composeTermsModule } from "./modules/terms/compose.js";
 import { createTrpcClient } from "./modules/shared/trpc/trpc-client.js";
 
 export interface ComposeOptions {
@@ -141,6 +142,12 @@ export function compose(opts: ComposeOptions = {}): Command {
     createAgentService: agent.exports.createService,
   });
 
+  const terms = composeTermsModule({
+    tokenProvider: auth.exports.tokenProvider,
+    configService: cli.services.configService,
+    compatService: cli.services.compatService,
+  });
+
   const program = new Command();
   program
     .name("dam")
@@ -162,6 +169,7 @@ export function compose(opts: ComposeOptions = {}): Command {
   for (const command of ssh.commands) program.addCommand(command);
   for (const command of channel.commands) program.addCommand(command);
   for (const command of metrics.commands) program.addCommand(command);
+  for (const command of terms.commands) program.addCommand(command);
 
   return program;
 }

--- a/packages/cli/src/modules/shared/exit-codes.ts
+++ b/packages/cli/src/modules/shared/exit-codes.ts
@@ -31,5 +31,10 @@ export const EXIT_APPROVAL_NOT_ACTIONABLE = 8;
  *  schedule id (delete is idempotent — exits 0). Classified via data.code === "NOT_FOUND". */
 export const EXIT_SCHEDULE_NOT_FOUND = 9;
 
+/** `dam terms status` — the current Terms of Use haven't been accepted. Distinct
+ *  from EXIT_RUNTIME_FAILURE so a CI gate can tell "accept the terms" (actionable)
+ *  apart from a broken call (server unreachable, host resolution failure). */
+export const EXIT_TERMS_NOT_ACCEPTED = 10;
+
 /** POSIX convention: 128 + SIGINT(2). Emitted on Ctrl+C during bundle pack/upload. */
 export const EXIT_SIGINT = 130;

--- a/packages/cli/src/modules/terms/commands/accept.ts
+++ b/packages/cli/src/modules/terms/commands/accept.ts
@@ -1,0 +1,119 @@
+import { Command } from "commander";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { confirm, exitCancelled } from "../../shared/prompt.js";
+import { writeStdoutAndExit } from "../../shared/stdout.js";
+import { printServiceError } from "../../shared/trpc/print.js";
+import type { TermsService } from "../services/terms-service.js";
+
+export function buildAcceptCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createTermsService: (host: string) => TermsService;
+}): Command {
+  return new Command("accept")
+    .description(
+      "Accept the current Terms of Use — interactive on a TTY, use --yes for CI/headless",
+    )
+    .option(
+      "--yes",
+      "accept without the interactive confirmation (required on a non-TTY)",
+    )
+    .option(
+      "--expect-version <version>",
+      "assert the version you reviewed; fails if it differs from the server's current version (not named --version, which is reserved for the CLI's own version)",
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit the acceptance result as JSON")
+    .action(
+      async (opts: {
+        yes?: boolean;
+        expectVersion?: string;
+        server?: string;
+        json?: boolean;
+      }) => {
+        const host = await resolveActiveHost(deps, {
+          flag: opts.server ? { server: opts.server } : undefined,
+          exitCodes: {
+            runtimeFailure: EXIT_RUNTIME_FAILURE,
+            belowFloor: EXIT_BELOW_FLOOR,
+          },
+        });
+        // Refuse a non-interactive accept before any network work: CI can't
+        // answer the prompt, so --yes is the only scripted path.
+        if (!opts.yes && !process.stdin.isTTY) {
+          process.stderr.write(
+            "error: refusing to accept the Terms of Use non-interactively without --yes\nhint: re-run with --yes to accept in a script or CI\n",
+          );
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        const service = deps.createTermsService(host);
+        const doc = await service.document();
+        if (!doc.ok) {
+          printServiceError(doc.error, host);
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+        const currentVersion = doc.value.version;
+
+        if (opts.expectVersion && opts.expectVersion !== currentVersion) {
+          process.stderr.write(
+            `error: reviewed version ${opts.expectVersion} does not match the server's current version ${currentVersion}; re-review before accepting\n`,
+          );
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (!opts.yes) {
+          process.stderr.write(
+            `Terms of Use — version ${currentVersion}\n\n${doc.value.text}\n\n`,
+          );
+          // Generous idle window: the user is expected to read the full text
+          // before answering, so the default 30s destructive-prompt timeout
+          // would wrongly auto-decline a careful reader.
+          if (
+            !(await confirm("Accept the Terms of Use?", {
+              timeoutMs: 15 * 60_000,
+            }))
+          )
+            exitCancelled({ json: opts.json });
+        }
+
+        const accepted = await service.accept(currentVersion);
+        if (!accepted.ok) {
+          // The version bumped between our document fetch and the accept —
+          // the user reviewed the old text, so surface it and stop rather
+          // than silently accepting the new version.
+          if (
+            accepted.error.kind === "transport" &&
+            accepted.error.serverCode === "PRECONDITION_FAILED"
+          ) {
+            process.stderr.write(
+              "error: the Terms of Use changed while you were reviewing; re-run `dam terms accept` to review the current version\n",
+            );
+          } else {
+            printServiceError(accepted.error, host);
+          }
+          process.exit(EXIT_RUNTIME_FAILURE);
+        }
+
+        if (opts.json) {
+          return writeStdoutAndExit(
+            `${JSON.stringify({ accepted: true, version: currentVersion })}\n`,
+            EXIT_SUCCESS,
+          );
+        }
+        return writeStdoutAndExit(
+          `Accepted Terms of Use ${currentVersion}.\n`,
+          EXIT_SUCCESS,
+        );
+      },
+    );
+}

--- a/packages/cli/src/modules/terms/commands/show.ts
+++ b/packages/cli/src/modules/terms/commands/show.ts
@@ -1,0 +1,66 @@
+import { Command } from "commander";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { writeStdoutAndExit } from "../../shared/stdout.js";
+import { printServiceError } from "../../shared/trpc/print.js";
+import type { TermsService } from "../services/terms-service.js";
+
+export function buildShowCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createTermsService: (host: string) => TermsService;
+}): Command {
+  return new Command("show")
+    .description(
+      "Print the current Terms of Use text, version, and your acceptance state",
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit the raw Terms of Use document as JSON")
+    .action(async (opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+      const service = deps.createTermsService(host);
+      const [doc, latest] = await Promise.all([
+        service.document(),
+        service.latestAcceptance(),
+      ]);
+      if (!doc.ok) {
+        printServiceError(doc.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+      if (!latest.ok) {
+        printServiceError(latest.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      if (opts.json) {
+        return writeStdoutAndExit(
+          `${JSON.stringify(doc.value)}\n`,
+          EXIT_SUCCESS,
+        );
+      }
+
+      const acceptState = !latest.value
+        ? "Not accepted."
+        : latest.value.version === doc.value.version
+          ? `Accepted on ${new Date(latest.value.acceptedAt).toISOString()}.`
+          : `You accepted version ${latest.value.version}; version ${doc.value.version} is current and not yet accepted.`;
+      return writeStdoutAndExit(
+        `Terms of Use — version ${doc.value.version}\n${acceptState}\n\n${doc.value.text}\n`,
+        EXIT_SUCCESS,
+      );
+    });
+}

--- a/packages/cli/src/modules/terms/commands/status.ts
+++ b/packages/cli/src/modules/terms/commands/status.ts
@@ -1,0 +1,67 @@
+import { Command } from "commander";
+import type { CompatService, ConfigService } from "../../cli/index.js";
+import {
+  EXIT_BELOW_FLOOR,
+  EXIT_RUNTIME_FAILURE,
+  EXIT_SUCCESS,
+} from "../../shared/exit-codes.js";
+import { resolveActiveHost } from "../../shared/preflight.js";
+import { writeStdoutAndExit } from "../../shared/stdout.js";
+import { printServiceError } from "../../shared/trpc/print.js";
+import type { TermsService } from "../services/terms-service.js";
+
+export function buildStatusCommand(deps: {
+  compatService: CompatService;
+  configService: ConfigService;
+  createTermsService: (host: string) => TermsService;
+}): Command {
+  return new Command("status")
+    .description(
+      "Check whether you've accepted the current Terms of Use — no text dump; exits non-zero when not accepted, so it works as a CI gate",
+    )
+    .option(
+      "--server <url>",
+      "override the configured server URL for this call",
+    )
+    .option("--json", "emit the acceptance state as JSON")
+    .action(async (opts: { server?: string; json?: boolean }) => {
+      const host = await resolveActiveHost(deps, {
+        flag: opts.server ? { server: opts.server } : undefined,
+        exitCodes: {
+          runtimeFailure: EXIT_RUNTIME_FAILURE,
+          belowFloor: EXIT_BELOW_FLOOR,
+        },
+      });
+      const service = deps.createTermsService(host);
+      const [current, latest] = await Promise.all([
+        service.current(),
+        service.latestAcceptance(),
+      ]);
+      if (!current.ok) {
+        printServiceError(current.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+      if (!latest.ok) {
+        printServiceError(latest.error, host);
+        process.exit(EXIT_RUNTIME_FAILURE);
+      }
+
+      const acceptedVersion = latest.value?.version ?? null;
+      const accepted = acceptedVersion === current.value.version;
+      const exitCode = accepted ? EXIT_SUCCESS : EXIT_RUNTIME_FAILURE;
+
+      if (opts.json) {
+        return writeStdoutAndExit(
+          `${JSON.stringify({ currentVersion: current.value.version, acceptedVersion, accepted })}\n`,
+          exitCode,
+        );
+      }
+
+      const line = accepted
+        ? `Terms of Use ${current.value.version}: accepted.`
+        : acceptedVersion
+          ? `Terms of Use ${current.value.version}: NOT accepted (you accepted ${acceptedVersion}).`
+          : `Terms of Use ${current.value.version}: NOT accepted (no acceptance on record).`;
+      return writeStdoutAndExit(`${line}\n`, exitCode);
+    });
+}

--- a/packages/cli/src/modules/terms/commands/status.ts
+++ b/packages/cli/src/modules/terms/commands/status.ts
@@ -4,6 +4,7 @@ import {
   EXIT_BELOW_FLOOR,
   EXIT_RUNTIME_FAILURE,
   EXIT_SUCCESS,
+  EXIT_TERMS_NOT_ACCEPTED,
 } from "../../shared/exit-codes.js";
 import { resolveActiveHost } from "../../shared/preflight.js";
 import { writeStdoutAndExit } from "../../shared/stdout.js";
@@ -48,7 +49,7 @@ export function buildStatusCommand(deps: {
 
       const acceptedVersion = latest.value?.version ?? null;
       const accepted = acceptedVersion === current.value.version;
-      const exitCode = accepted ? EXIT_SUCCESS : EXIT_RUNTIME_FAILURE;
+      const exitCode = accepted ? EXIT_SUCCESS : EXIT_TERMS_NOT_ACCEPTED;
 
       if (opts.json) {
         return writeStdoutAndExit(

--- a/packages/cli/src/modules/terms/compose.ts
+++ b/packages/cli/src/modules/terms/compose.ts
@@ -1,0 +1,43 @@
+import { Command } from "commander";
+import type { TokenProvider } from "../auth/index.js";
+import type { CompatService, ConfigService } from "../cli/index.js";
+import { createTrpcClient } from "../shared/trpc/trpc-client.js";
+import { buildAcceptCommand } from "./commands/accept.js";
+import { buildShowCommand } from "./commands/show.js";
+import { buildStatusCommand } from "./commands/status.js";
+import {
+  createTermsService,
+  type TermsService,
+} from "./services/terms-service.js";
+
+export interface TermsModuleOptions {
+  tokenProvider: TokenProvider;
+  configService: ConfigService;
+  compatService: CompatService;
+}
+
+export interface TermsModule {
+  commands: ReadonlyArray<Command>;
+}
+
+export function composeTermsModule(opts: TermsModuleOptions): TermsModule {
+  const createService = (host: string): TermsService =>
+    createTermsService({
+      trpc: createTrpcClient({ host, tokenProvider: opts.tokenProvider }),
+      host,
+    });
+  const scoped = {
+    compatService: opts.compatService,
+    configService: opts.configService,
+    createTermsService: createService,
+  };
+
+  const parent = new Command("terms").description(
+    "View and accept the deployment's Terms of Use",
+  );
+  parent.addCommand(buildShowCommand(scoped));
+  parent.addCommand(buildStatusCommand(scoped));
+  parent.addCommand(buildAcceptCommand(scoped));
+
+  return { commands: [parent] };
+}

--- a/packages/cli/src/modules/terms/index.ts
+++ b/packages/cli/src/modules/terms/index.ts
@@ -1,0 +1,2 @@
+export { composeTermsModule } from "./compose.js";
+export type { TermsModule } from "./compose.js";

--- a/packages/cli/src/modules/terms/services/terms-service.ts
+++ b/packages/cli/src/modules/terms/services/terms-service.ts
@@ -1,0 +1,85 @@
+import {
+  termsDocumentSchema,
+  type TermsCurrent,
+  type TermsDocument,
+} from "api-server-api";
+import { err, ok, type Result } from "../../../result.js";
+import type { AuthRequiredError, TransportError } from "../../shared/errors.js";
+import { trpcCall } from "../../shared/trpc/classify.js";
+import type { TrpcClient } from "../../shared/trpc/trpc-client.js";
+
+/** The caller's latest acceptance as it arrives over the wire — the tRPC
+ *  surface uses no date transformer, so `acceptedAt` is an ISO string here,
+ *  not the server-side `Date`. */
+export type LatestAcceptance = Awaited<
+  ReturnType<TrpcClient["terms"]["latestAcceptance"]["query"]>
+>;
+
+/**
+ * CLI-side view of the terms surface. Metadata and acceptance go over tRPC
+ * (`terms.*`, exempt from the 412 gate so they run while the caller is still
+ * gated); the document text is served only at the plain, auth-exempt
+ * `GET /api/terms`, so it is fetched directly rather than over tRPC.
+ */
+export interface TermsService {
+  document(): Promise<Result<TermsDocument, TransportError>>;
+  current(): Promise<Result<TermsCurrent, TransportError | AuthRequiredError>>;
+  latestAcceptance(): Promise<
+    Result<LatestAcceptance, TransportError | AuthRequiredError>
+  >;
+  accept(
+    version: string,
+  ): Promise<Result<void, TransportError | AuthRequiredError>>;
+}
+
+export function createTermsService(deps: {
+  trpc: TrpcClient;
+  host: string;
+  fetch?: typeof fetch;
+}): TermsService {
+  const doFetch = deps.fetch ?? fetch;
+  const base = deps.host.replace(/\/+$/, "");
+  return {
+    async document() {
+      let res: Response;
+      try {
+        res = await doFetch(`${base}/api/terms`);
+      } catch (e) {
+        return err({
+          kind: "transport",
+          reason: e instanceof Error ? e.message : "cannot reach server",
+        });
+      }
+      if (!res.ok)
+        return err({
+          kind: "transport",
+          reason: `GET /api/terms returned ${res.status}`,
+        });
+      let body: unknown;
+      try {
+        body = await res.json();
+      } catch {
+        return err({
+          kind: "transport",
+          reason: "malformed Terms of Use document from server",
+        });
+      }
+      const parsed = termsDocumentSchema.safeParse(body);
+      if (!parsed.success)
+        return err({
+          kind: "transport",
+          reason: "malformed Terms of Use document from server",
+        });
+      return ok(parsed.data);
+    },
+    async current() {
+      return trpcCall(() => deps.trpc.terms.current.query());
+    },
+    async latestAcceptance() {
+      return trpcCall(() => deps.trpc.terms.latestAcceptance.query());
+    },
+    async accept(version) {
+      return trpcCall(() => deps.trpc.terms.accept.mutate({ version }));
+    },
+  };
+}


### PR DESCRIPTION
## What this does

A user who signs in through the `dam` CLI device flow (no browser) can now review and accept the Terms of Use entirely from the CLI. Previously the first command after login could hit the Terms-of-Use gate whose only remedy was "open the browser to accept" — a dead end in headless/CI/no-browser setups.

A new `dam terms` command group:

- **`dam terms show`** — print the current Terms of Use text, version, and your acceptance state.
- **`dam terms status`** — a quick, script-friendly check (no text dump) that exits non-zero when you haven't accepted the current version, so it works as a CI gate.
- **`dam terms accept`** — accept the current terms; interactive with a confirmation prompt on a terminal, `--yes` for non-interactive/CI use, and `--expect-version` to assert the version you reviewed before accepting.

When a command is blocked by the Terms-of-Use gate, the error now points at `dam terms accept` instead of the browser.

Verified end-to-end against a live cluster: the gated → review → accept → unblocked flow, interactive and `--yes` acceptance, the version-mismatch guard, and the rewritten gate hint.

Closes #2755