### PR TITLE
refactor(driver-sdk): rename SandboxFailed -> InvocationFailed

### DIFF
--- a/packages/agents/claude-code/workspace/.agents/skills/dam-invoke/SKILL.md
+++ b/packages/agents/claude-code/workspace/.agents/skills/dam-invoke/SKILL.md
@@ -104,7 +104,7 @@ then resolves with that result. Progress lines (`[invoke] spawned ... -> agent-x
 | `pollMs` | Poll interval, default 5000. |
 | `timeoutMs` | Client backstop. Defaults to just past `ttlMs` so the server fails first. |
 
-Returns the validated result. Throws `SandboxFailed` if it fails (silent exit
+Returns the validated result. Throws `InvocationFailed` if it fails (silent exit
 past its deadline, or an internal error). Let it throw to abort, or wrap in
 `try/catch` to retry.
 

--- a/packages/agents/claude-code/workspace/.agents/skills/dam-loop/SKILL.md
+++ b/packages/agents/claude-code/workspace/.agents/skills/dam-loop/SKILL.md
@@ -52,13 +52,13 @@ Eval returns `verdict`:
 - `continue` -> the loop iterates with the curated knowledge and latest candidate.
 
 There is no "fail" verdict. Not passing simply continues. Hard stops are `passed`,
-the generation cap, or a thrown `SandboxFailed`.
+the generation cap, or a thrown `InvocationFailed`.
 
 ## When a node fails — spawn() THROWS
 
 A sandbox can fail: it runs past its ~60-minute liveness deadline without
 reporting, exits silently, or never starts. When that happens **`spawn()` throws
-`SandboxFailed`**. An uncaught throw propagates to the top and **kills the whole
+`InvocationFailed`**. An uncaught throw propagates to the top and **kills the whole
 `node workflow.ts` process** — one failed node takes down every remaining ticket
 and generation. This is the single most common way these workflows die.
 
@@ -130,7 +130,7 @@ Also don't ask a sandbox for tooling its image can't reach (an egress-denied
 // threaded below). No resumability: if the run crashes, knowledge is lost and
 // you rerun from generation 1 — candidates already pushed survive as git refs.
 
-import { spawn, s, SandboxFailed } from "/usr/local/lib/driver-sdk.mjs";
+import { spawn, s, InvocationFailed } from "/usr/local/lib/driver-sdk.mjs";
 
 const IMAGE = "<template-id from listImages()>";
 const CONNECTIONS = ["<repo-connection-id>", "<model-connection-id>"]; // subset of your grants
@@ -171,7 +171,7 @@ let candidate: string | null = null;
 for (let gen = 1; gen <= MAX_GENERATIONS; gen++) {
   console.log(`\n=== generation ${gen} ===`);
 
-  // These spawns THROW SandboxFailed on failure, which aborts the run — fine for
+  // These spawns THROW InvocationFailed on failure, which aborts the run — fine for
   // a depth loop (rerun is cheap). For best-effort or multi-item loops, wrap each
   // spawn in withRetry (see "When a node fails" above) and handle a null return.
   const make = await spawn({
@@ -227,7 +227,7 @@ breadth — depth is breadth with a population of one.
 - **No resumability.** A crash loses `knowledge` and the loop position. Candidates
   survive as git refs, so a rerun re-sees earlier branches. Design the passing bar
   and Make prompt so a rerun is cheap.
-- **spawn() throws on failure.** One uncaught `SandboxFailed` kills the whole run.
+- **spawn() throws on failure.** One uncaught `InvocationFailed` kills the whole run.
   Choose abort vs retry deliberately (see "When a node fails"); never claim retry
   you did not code.
 - **~60-minute node ceiling.** A sandbox that runs past its liveness deadline is

--- a/packages/driver-sdk/src/index.ts
+++ b/packages/driver-sdk/src/index.ts
@@ -16,7 +16,7 @@ export {
   spawn,
   listImages,
   listConnections,
-  SandboxFailed,
+  InvocationFailed,
   type SpawnOptions,
   type ImageInfo,
   type ConnectionInfo,

--- a/packages/driver-sdk/src/spawn.ts
+++ b/packages/driver-sdk/src/spawn.ts
@@ -41,12 +41,12 @@ export async function listConnections(): Promise<ConnectionInfo[]> {
 /** Thrown when an Invocation reports a `failed` status (silent exit past its
  *  liveness deadline, or an internal error). The loop author decides whether to
  *  retry (own try/catch) or abort (let it throw). */
-export class SandboxFailed extends Error {
-  readonly sandboxId: string;
+export class InvocationFailed extends Error {
+  readonly invocationId: string;
   constructor(id: string, label: string) {
     super(`invocation ${label} (${id}) failed`);
-    this.name = "SandboxFailed";
-    this.sandboxId = id;
+    this.name = "InvocationFailed";
+    this.invocationId = id;
   }
 }
 
@@ -157,7 +157,7 @@ export async function spawn<T = unknown>(opts: SpawnOptions): Promise<T> {
     }
     if (view.status === "failed") {
       log(`failed ${tag} (${id})`);
-      throw new SandboxFailed(id, tag);
+      throw new InvocationFailed(id, tag);
     }
     if (Date.now() > deadline) {
       throw new Error(


### PR DESCRIPTION
Aligns the driver SDK public API with the Invocation ubiquitous language (docs/ubiquitous-language.md), which retired "Sandbox" as a domain term in favor of "Invocation" (see commits d44757e4, 46aee0e1 on the parent branch).

The SDK was the last place still leaking the old term:

- `SandboxFailed` -> `InvocationFailed` (the thrown error class)
- `sandboxId` -> `invocationId` (its field)
- Updated the `dam-invoke` and `dam-loop` skill docs that reference the class, including the import example

`spawn()` stays as the verb (the skills teach it and the counterproposal names it), and `driverAgentId` is already the consistent term. No behavior change.

tsc, eslint, prettier clean. 11/11 unit tests pass. tsup bundle rebuilds and exports `InvocationFailed`.

Follow-up to #2816.