### PR TITLE
feat: single entry point for adding an MCP server

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-07-17
+Last verified: 2026-07-21
 
 ## Overview
 
@@ -144,9 +144,10 @@ All event kinds are built-in to every agent: the agent advertises the full set o
 
 ### Custom MCP server
 
-An OAuth-authenticated MCP endpoint contributes just two things: an
-`egress-allow` for its host and an `mcp-entry` carrying the server URL and an
-Authorization header whose bearer value is a gateway-substituted placeholder.
+An MCP endpoint contributes an `egress-allow` for its host and an `mcp-entry`
+carrying the server URL. OAuth adds a placeholder Authorization header on the
+`mcp-entry`; a static-header credential instead adds an `egress-inject` (as
+Custom Header does), keeping the secret gateway-side.
 
 ### App preset: Kubernetes / OpenShift
 

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -119,6 +119,10 @@ const noneCreateInput = z.object({
   ...commonFields,
   authKind: z.literal("none"),
   url: z.string().url().optional(),
+  // Optional header credential (API key) for MCP servers guarded by a
+  // static header — injected at the gateway, never written to harness config.
+  headerName: z.string().min(1).optional(),
+  value: z.string().min(1).optional(),
 });
 
 export const connectionCreateInputSchema = z.discriminatedUnion("authKind", [

--- a/packages/api-server/src/__tests__/unit/connections-mcp-template.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-mcp-template.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import type { SecretRef } from "api-server-api";
+import { buildConnection } from "../../modules/connections/domain/build-connection.js";
+import { buildCatalog } from "../../modules/connections/domain/catalog.js";
+
+function mintRef(purpose: string): SecretRef {
+  return { storeId: "k8s", path: `secret-${purpose}`, field: "" };
+}
+
+function mcpNoneTemplate() {
+  const t = buildCatalog().find((t) => t.id === "custom-mcp-none");
+  if (!t) throw new Error("custom-mcp-none template missing from catalog");
+  return t;
+}
+
+describe("custom-mcp-none build", () => {
+  it("without a header credential stays auth-less", async () => {
+    const built = await buildConnection(
+      mcpNoneTemplate(),
+      {
+        templateId: "custom-mcp-none",
+        authKind: "none",
+        name: "plain-mcp",
+        url: "https://mcp.example.com/sse",
+      },
+      mintRef,
+      "http://cb",
+      "Test",
+    );
+
+    expect(built.auth.kind).toBe("none");
+    expect(built.secrets.size).toBe(0);
+    expect(built.contributions).toEqual([
+      { kind: "egress-allow", host: "mcp.example.com" },
+      {
+        kind: "mcp-entry",
+        name: "custom-mcp-none",
+        url: "https://mcp.example.com/sse",
+      },
+    ]);
+  });
+
+  it("with a header credential injects at the gateway, not the mcp-entry", async () => {
+    const built = await buildConnection(
+      mcpNoneTemplate(),
+      {
+        templateId: "custom-mcp-none",
+        authKind: "none",
+        name: "keyed-mcp",
+        url: "https://mcp.example.com:8443/sse",
+        headerName: "X-API-Key",
+        value: "s3cret",
+      },
+      mintRef,
+      "http://cb",
+      "Test",
+    );
+
+    expect(built.auth).toMatchObject({
+      kind: "header",
+      headerName: "X-API-Key",
+      valueFormat: "{value}",
+      valueRef: { path: "secret-connection:custom-mcp-none", field: "value" },
+    });
+
+    const inject = built.contributions.find((c) => c.kind === "egress-inject");
+    expect(inject).toMatchObject({
+      host: "mcp.example.com",
+      port: 8443,
+      headerName: "X-API-Key",
+      valueFormat: "{value}",
+    });
+
+    const mcpEntry = built.contributions.find((c) => c.kind === "mcp-entry");
+    expect(mcpEntry).toMatchObject({ url: "https://mcp.example.com:8443/sse" });
+    expect(mcpEntry).not.toHaveProperty("headers");
+
+    const secret = built.secrets.get("secret-connection:custom-mcp-none");
+    expect(secret?.value).toBe("s3cret");
+    expect(JSON.stringify(built.contributions)).not.toContain("s3cret");
+  });
+});

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -501,7 +501,11 @@ function buildNone(
 
   if (input.url) {
     const url = new URL(input.url);
-    contributions.push({ kind: "egress-allow", host: url.host });
+    contributions.push({
+      kind: "egress-allow",
+      host: url.hostname,
+      ...(url.port ? { port: Number(url.port) } : {}),
+    });
     contributions.push({
       kind: "mcp-entry",
       name: template.id,
@@ -513,8 +517,6 @@ function buildNone(
     if (input.headerName && input.value) {
       const headerName = input.headerName;
       const valueFormat = "{value}";
-      // egress-inject takes hostname + numeric port separately, whereas the
-      // egress-allow above matches the combined host:port string.
       contributions.push({
         kind: "egress-inject",
         host: url.hostname,

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -70,6 +70,7 @@ export async function buildConnection(
       return buildNone(
         template as Extract<ConnectionTemplate, { authKind: "none" }>,
         input,
+        mintSecretRef,
       );
   }
 }
@@ -494,6 +495,7 @@ function buildHeader(
 function buildNone(
   template: Extract<ConnectionTemplate, { authKind: "none" }>,
   input: Extract<ConnectionCreateInput, { authKind: "none" }>,
+  mintSecretRef: (purpose: string) => SecretRef,
 ): BuildResult {
   const contributions: Contribution[] = [...template.contributions];
 
@@ -505,6 +507,34 @@ function buildNone(
       name: template.id,
       url: input.url,
     });
+
+    // Optional header credential: injected at the gateway (egress-inject +
+    // header auth), never written into the mcp-entry the harness sees.
+    if (input.headerName && input.value) {
+      const headerName = input.headerName;
+      const valueFormat = "{value}";
+      contributions.push({
+        kind: "egress-inject",
+        host: url.hostname,
+        ...(url.port ? { port: Number(url.port) } : {}),
+        headerName,
+        valueFormat,
+      });
+      const secretPath = mintSecretRef(`connection:${template.id}`);
+      const sdsFields = buildConnectionSdsFields(contributions, input.value);
+      return {
+        auth: {
+          kind: "header",
+          valueRef: { ...secretPath, field: "value" },
+          headerName,
+          valueFormat,
+        },
+        contributions,
+        secrets: new Map([
+          [secretPath.path, { value: input.value, ...sdsFields }],
+        ]),
+      };
+    }
   }
 
   return {

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -513,6 +513,8 @@ function buildNone(
     if (input.headerName && input.value) {
       const headerName = input.headerName;
       const valueFormat = "{value}";
+      // egress-inject takes hostname + numeric port separately, whereas the
+      // egress-allow above matches the combined host:port string.
       contributions.push({
         kind: "egress-inject",
         host: url.hostname,

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -223,21 +223,32 @@ async function buildOAuthDcr(
   if (!meta) {
     throw new Error(`No OAuth discovery metadata at ${input.url}`);
   }
-  if (!meta.registrationEndpoint) {
-    throw new Error(
-      `MCP server at ${input.url} does not support dynamic client registration`,
-    );
-  }
 
-  const dcr = await registerOAuthClient({
-    registrationEndpoint: meta.registrationEndpoint,
-    clientName: `${brandName} Agent Platform`,
-    redirectUris: [oauthCallbackUrl],
-  });
+  // A supplied client is pre-registered with the server — endpoints come
+  // from discovery, registration is skipped.
+  let clientId: string;
+  let clientSecret: string | undefined;
+  if (input.clientId) {
+    clientId = input.clientId;
+    clientSecret = input.clientSecret;
+  } else {
+    if (!meta.registrationEndpoint) {
+      throw new Error(
+        `MCP server at ${input.url} does not support dynamic client registration`,
+      );
+    }
+    const dcr = await registerOAuthClient({
+      registrationEndpoint: meta.registrationEndpoint,
+      clientName: `${brandName} Agent Platform`,
+      redirectUris: [oauthCallbackUrl],
+    });
+    clientId = dcr.clientId;
+    clientSecret = dcr.clientSecret;
+  }
 
   const secrets = new Map<string, Record<string, string>>();
   const fields: Record<string, string> = {};
-  if (dcr.clientSecret) fields.client_secret = dcr.clientSecret;
+  if (clientSecret) fields.client_secret = clientSecret;
   if (Object.keys(fields).length > 0) secrets.set(secretPath.path, fields);
 
   const contributions: Contribution[] = [
@@ -259,13 +270,13 @@ async function buildOAuthDcr(
   return {
     auth: {
       kind: "oauth",
-      clientId: dcr.clientId,
+      clientId,
       refreshTokenRef: { ...secretPath, field: "refresh_token" },
       accessTokenRef: { ...secretPath, field: "access_token" },
       scopes: meta.scopes ?? template.scopes ?? [],
       authorizationUrl: meta.authorizationEndpoint,
       tokenUrl: meta.tokenEndpoint,
-      ...(dcr.clientSecret
+      ...(clientSecret
         ? { clientSecretRef: { ...secretPath, field: "client_secret" } }
         : {}),
     },

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -180,7 +180,14 @@ function inputsFor(
 
   switch (t.authKind) {
     case "oauth": {
-      if (t.dynamicRegistration) return [required("url")];
+      // A pre-registered client skips dynamic client registration; endpoints
+      // still come from the server's OAuth discovery metadata.
+      if (t.dynamicRegistration)
+        return [
+          required("url"),
+          optional("clientId"),
+          { name: "clientSecret", state: "optional", secret: true },
+        ];
       const out: ConnectionTemplateInput[] = [];
 
       const urlsHavePlaceholder =

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -295,6 +295,14 @@ function inputsFor(
       return out;
     }
     case "none":
-      return t.category === "mcp" ? [required("url")] : [];
+      // Custom MCP servers may carry an optional header credential (API
+      // key) injected at the gateway.
+      return t.category === "mcp"
+        ? [
+            required("url"),
+            optional("headerName"),
+            { name: "value", state: "optional", secret: true },
+          ]
+        : [];
   }
 }

--- a/packages/ui/src/components/form-field.tsx
+++ b/packages/ui/src/components/form-field.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { FIELD_INSET } from "@/components/ui/inset";
+import { FIELD_INSET, LABEL_INSET } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
@@ -14,6 +14,10 @@ interface Props {
    *  Inset). Set to opt out — forms not yet migrated, or containers with no
    *  gutter (nested side panels). */
   disableInset?: boolean;
+  /** Gutter-less containers (modals, bordered boxes): keep the control flush
+   *  inside the container padding and indent the label to it, instead of
+   *  outdenting the control onto the border. Ignored when `disableInset`. */
+  labelInset?: boolean;
   children: ReactNode;
 }
 
@@ -22,12 +26,18 @@ export function FormField({
   hint,
   error,
   disableInset,
+  labelInset,
   children,
 }: Props) {
+  const indentLabel = !disableInset && labelInset;
   return (
     <label className="flex flex-col gap-2">
-      <SectionLabel>{label}</SectionLabel>
-      <div className={cn(!disableInset && FIELD_INSET)}>{children}</div>
+      <SectionLabel className={cn(indentLabel && LABEL_INSET)}>
+        {label}
+      </SectionLabel>
+      <div className={cn(!disableInset && !labelInset && FIELD_INSET)}>
+        {children}
+      </div>
       {hint && (
         <span className="text-[12px] text-muted-foreground">{hint}</span>
       )}

--- a/packages/ui/src/components/ui/inset.tsx
+++ b/packages/ui/src/components/ui/inset.tsx
@@ -12,6 +12,15 @@ import { cn } from "@/lib/utils";
  */
 export const FIELD_INSET = "md:-ml-4";
 
+/**
+ * The inverse strategy for gutter-less containers (modals, bordered boxes):
+ * instead of outdenting the control into a gutter that isn't there — which
+ * would push the input onto the container's border — keep the control flush
+ * and indent the *label* to meet the control's text. Pairs with the control's
+ * 16px inner padding, so the two land at the same x.
+ */
+export const LABEL_INSET = "md:ml-4";
+
 export function Inset({
   className,
   children,

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -6,3 +6,6 @@ export const KEY_GUIDE_URL =
 
 export const CLI_REFERENCE_URL =
   "https://pages.github.ibm.com/dam-agents/docs/reference/cli/";
+
+export const MCP_DOCS_URL =
+  "https://pages.github.ibm.com/dam-agents/docs/core-concepts/connections/#mcp-servers";

--- a/packages/ui/src/modules/connections/api/mutations.ts
+++ b/packages/ui/src/modules/connections/api/mutations.ts
@@ -38,10 +38,14 @@ export function useDeleteConnection() {
   });
 }
 
-export function useDiscoverMcp() {
+// `silent` for background detection (the debounced URL probe), where a
+// transient failure shouldn't pop a global toast.
+export function useDiscoverMcp(opts?: { silent?: boolean }) {
   return useMutation({
     ...trpc.connections.discoverMcp.mutationOptions(),
-    meta: { errorToast: "Couldn't reach MCP server" },
+    meta: opts?.silent
+      ? { suppressErrorToast: true }
+      : { errorToast: "Couldn't reach MCP server" },
   });
 }
 

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -32,9 +32,7 @@ export function McpCreatePane({
   onBack,
   onCreated,
 }: Props) {
-  const [name, setName] = useState(() =>
-    slugifyTemplateName("MCP server"),
-  );
+  const [name, setName] = useState(() => slugifyTemplateName("MCP server"));
   const [url, setUrl] = useState("");
   const [clientId, setClientId] = useState("");
   const [clientSecret, setClientSecret] = useState("");
@@ -127,7 +125,14 @@ export function McpCreatePane({
     if (authorizing) return "Redirecting…";
     if (pending) return "…";
     return needsOAuth ? "Create + Authorize" : "Create";
-  }, [showDetecting, verifying, awaitingPopup, authorizing, pending, needsOAuth]);
+  }, [
+    showDetecting,
+    verifying,
+    awaitingPopup,
+    authorizing,
+    pending,
+    needsOAuth,
+  ]);
 
   return (
     <>

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -12,7 +12,6 @@ import { LabeledInput } from "../forms/labeled-input.js";
 import { useMcpAuthDetection } from "../hooks/use-mcp-auth-detection.js";
 import { useTemplateCreateSubmit } from "../hooks/use-template-create-submit.js";
 import { buildCreatePayload } from "../lib/build-create-payload.js";
-import { slugifyTemplateName } from "../lib/connection-name.js";
 import { validateMcpUrl } from "../lib/mcp-url.js";
 import { CatalogPaneHeader } from "./catalog-pane-header.js";
 
@@ -38,14 +37,14 @@ const mcpFormSchema = z
         path: ["url"],
         message: urlError,
       });
-    // Both-or-neither: a half-filled pair would otherwise be silently dropped,
-    // creating an auth-less connection from credentials the user typed. Attach
-    // the error to the empty field so the missing input lights up.
-    if (filled(v.clientId) !== filled(v.clientSecret))
+    // A pre-registered public/PKCE client is id-only (buildOAuthDcr allows no
+    // secret), so only a secret without an id is invalid. The header pair below
+    // still needs both — an injected header is meaningless without a value.
+    if (filled(v.clientSecret) && !filled(v.clientId))
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: [filled(v.clientId) ? "clientSecret" : "clientId"],
-        message: "Provide both an OAuth ID and secret, or neither.",
+        path: ["clientId"],
+        message: "An OAuth secret needs an OAuth ID.",
       });
     if (filled(v.headerName) !== filled(v.headerValue))
       ctx.addIssue({
@@ -77,7 +76,7 @@ export function McpCreatePane({
     resolver: zodResolver(mcpFormSchema),
     mode: "onChange",
     defaultValues: {
-      name: slugifyTemplateName("MCP server"),
+      name: "",
       url: "",
       clientId: "",
       clientSecret: "",

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -1,5 +1,8 @@
+import { zodResolver } from "@hookform/resolvers/zod";
 import type { ConnectionTemplateView } from "api-server-api";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
+import { type Control, Controller, useForm } from "react-hook-form";
+import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
 import { emitToast } from "@/lib/toast";
@@ -15,6 +18,44 @@ import { CatalogPaneHeader } from "./catalog-pane-header.js";
 
 const MCP_OAUTH_TEMPLATE_ID = "custom-mcp-oauth";
 const MCP_NONE_TEMPLATE_ID = "custom-mcp-none";
+
+const filled = (s: string) => s.trim() !== "";
+
+const mcpFormSchema = z
+  .object({
+    name: z.string().min(1, "Required"),
+    url: z.string(),
+    clientId: z.string(),
+    clientSecret: z.string(),
+    headerName: z.string(),
+    headerValue: z.string(),
+  })
+  .superRefine((v, ctx) => {
+    const urlError = validateMcpUrl(v.url);
+    if (urlError)
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["url"],
+        message: urlError,
+      });
+    // Both-or-neither: a half-filled pair would otherwise be silently dropped,
+    // creating an auth-less connection from credentials the user typed. Attach
+    // the error to the empty field so the missing input lights up.
+    if (filled(v.clientId) !== filled(v.clientSecret))
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [filled(v.clientId) ? "clientSecret" : "clientId"],
+        message: "Provide both an OAuth ID and secret, or neither.",
+      });
+    if (filled(v.headerName) !== filled(v.headerValue))
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: [filled(v.headerName) ? "headerValue" : "headerName"],
+        message: "Provide both a header name and value, or neither.",
+      });
+  });
+
+type McpFormValues = z.infer<typeof mcpFormSchema>;
 
 interface Props {
   templateById: Map<string, ConnectionTemplateView>;
@@ -32,12 +73,21 @@ export function McpCreatePane({
   onBack,
   onCreated,
 }: Props) {
-  const [name, setName] = useState(() => slugifyTemplateName("MCP server"));
-  const [url, setUrl] = useState("");
-  const [clientId, setClientId] = useState("");
-  const [clientSecret, setClientSecret] = useState("");
-  const [headerName, setHeaderName] = useState("");
-  const [headerValue, setHeaderValue] = useState("");
+  const { control, handleSubmit, watch, formState } = useForm<McpFormValues>({
+    resolver: zodResolver(mcpFormSchema),
+    mode: "onChange",
+    defaultValues: {
+      name: slugifyTemplateName("MCP server"),
+      url: "",
+      clientId: "",
+      clientSecret: "",
+      headerName: "",
+      headerValue: "",
+    },
+  });
+  const url = watch("url");
+  const clientId = watch("clientId");
+  const headerValue = watch("headerValue");
 
   // Detection precedes submit so the button label is right and the OAuth
   // popup can open synchronously on click; the submit hook re-verifies.
@@ -45,10 +95,10 @@ export function McpCreatePane({
 
   // Explicit advanced input wins over detection: OAuth creds → OAuth flow,
   // a header credential → no-auth flow with gateway injection.
-  const overriding = clientId.trim() !== "" || headerValue.trim() !== "";
-  const wantsOAuth = clientId.trim()
+  const overriding = filled(clientId) || filled(headerValue);
+  const wantsOAuth = filled(clientId)
     ? true
-    : headerValue.trim()
+    : filled(headerValue)
       ? false
       : detected === "oauth";
   // The button's Create vs Create + Authorize is only settled once detection
@@ -73,41 +123,18 @@ export function McpCreatePane({
     onCreated,
   });
 
-  const onSubmit = () => {
+  const onSubmit = handleSubmit((values) => {
     if (!template) return;
-    const urlError = validateMcpUrl(url);
-    if (urlError) {
-      emitToast({ kind: "error", message: urlError });
-      return;
-    }
-    // Both-or-neither: a half-filled pair would otherwise be silently dropped,
-    // creating an auth-less connection from credentials the user typed.
-    const bothOrNeither = (a: string, b: string) =>
-      (a.trim() === "") === (b.trim() === "");
-    if (!bothOrNeither(clientId, clientSecret)) {
-      emitToast({
-        kind: "error",
-        message: "Provide both an OAuth ID and secret, or neither.",
-      });
-      return;
-    }
-    if (!bothOrNeither(headerName, headerValue)) {
-      emitToast({
-        kind: "error",
-        message: "Provide both a header name and value, or neither.",
-      });
-      return;
-    }
-    const fields: Record<string, string> = { url };
+    const fields: Record<string, string> = { url: values.url };
     if (wantsOAuth) {
-      fields.clientId = clientId;
-      fields.clientSecret = clientSecret;
+      fields.clientId = values.clientId;
+      fields.clientSecret = values.clientSecret;
     } else {
-      fields.headerName = headerName;
-      fields.value = headerValue;
+      fields.headerName = values.headerName;
+      fields.value = values.headerValue;
     }
     const payload = buildCreatePayload(template, {
-      name,
+      name: values.name,
       fields,
       overrideDefaults: true,
     });
@@ -116,7 +143,7 @@ export function McpCreatePane({
       return;
     }
     void submit(payload);
-  };
+  });
 
   const submitLabel = useMemo(() => {
     if (showDetecting) return "Checking URL…";
@@ -125,64 +152,51 @@ export function McpCreatePane({
     if (authorizing) return "Redirecting…";
     if (pending) return "…";
     return needsOAuth ? "Create + Authorize" : "Create";
-  }, [
-    showDetecting,
-    verifying,
-    awaitingPopup,
-    authorizing,
-    pending,
-    needsOAuth,
-  ]);
+  }, [showDetecting, verifying, awaitingPopup, authorizing, pending, needsOAuth]);
 
   return (
     <>
       <CatalogPaneHeader title="Add an MCP server" onBack={onBack} />
       <div className="min-h-0 flex-1 overflow-y-auto p-5">
         <div className="flex flex-col gap-4">
-          <LabeledInput
+          <McpField
+            control={control}
+            name="name"
             label="Name"
-            testId="connection-field-name"
             placeholder="my-mcp-server"
-            value={name}
-            onChange={setName}
             help="Lowercase letters, digits, and single hyphens. Doubles as the MCP slug."
           />
-          <LabeledInput
+          <McpField
+            control={control}
+            name="url"
             label="Remote MCP server URL"
-            testId="connection-field-url"
             placeholder="https://mcp.example.com/sse"
-            value={url}
-            onChange={setUrl}
           />
           <DisclosureBox title="Advanced configuration">
             <div className="flex flex-col gap-4">
-              <LabeledInput
+              <McpField
+                control={control}
+                name="clientId"
                 label="OAuth ID (optional)"
-                testId="connection-field-clientId"
                 placeholder="Client ID"
-                value={clientId}
-                onChange={setClientId}
               />
-              <LabeledInput
+              <McpField
+                control={control}
+                name="clientSecret"
                 label="OAuth secret (optional)"
-                testId="connection-field-clientSecret"
                 type="password"
-                value={clientSecret}
-                onChange={setClientSecret}
               />
-              <LabeledInput
+              <McpField
+                control={control}
+                name="headerName"
                 label="Header name (optional)"
-                testId="connection-field-headerName"
                 placeholder="X-API-Key"
-                value={headerName}
-                onChange={setHeaderName}
               />
-              <LabeledInput
+              <McpField
+                control={control}
+                name="headerValue"
                 label="Header value (optional)"
-                testId="connection-field-value"
                 type="password"
-                value={headerValue}
-                onChange={setHeaderValue}
               />
             </div>
           </DisclosureBox>
@@ -194,7 +208,10 @@ export function McpCreatePane({
         </Button>
         <Button
           onClick={awaitingPopup ? refocusPopup : onSubmit}
-          disabled={(pending && !awaitingPopup) || !template || showDetecting}
+          disabled={
+            !awaitingPopup &&
+            (pending || !template || showDetecting || !formState.isValid)
+          }
           title={
             awaitingPopup
               ? "Bring the authorization window back to the front"
@@ -206,6 +223,42 @@ export function McpCreatePane({
         </Button>
       </div>
     </>
+  );
+}
+
+function McpField({
+  control,
+  name,
+  label,
+  placeholder,
+  type,
+  help,
+}: {
+  control: Control<McpFormValues>;
+  name: keyof McpFormValues;
+  label: string;
+  placeholder?: string;
+  type?: "text" | "password";
+  help?: string;
+}) {
+  return (
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => (
+        <LabeledInput
+          label={label}
+          testId={`connection-field-${name}`}
+          placeholder={placeholder}
+          type={type}
+          value={field.value}
+          onChange={field.onChange}
+          onBlur={field.onBlur}
+          help={help}
+          error={fieldState.error?.message}
+        />
+      )}
+    />
   );
 }
 

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -1,0 +1,216 @@
+import type { ConnectionTemplateView } from "api-server-api";
+import { useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { emitToast } from "@/lib/toast";
+
+import { DisclosureBox } from "../forms/disclosure-box.js";
+import { LabeledInput } from "../forms/labeled-input.js";
+import { useMcpAuthDetection } from "../hooks/use-mcp-auth-detection.js";
+import { useTemplateCreateSubmit } from "../hooks/use-template-create-submit.js";
+import { buildCreatePayload } from "../lib/build-create-payload.js";
+import { slugifyTemplateName } from "../lib/connection-name.js";
+import { validateMcpUrl } from "../lib/mcp-url.js";
+import { CatalogPaneHeader } from "./catalog-pane-header.js";
+
+const MCP_OAUTH_TEMPLATE_ID = "custom-mcp-oauth";
+const MCP_NONE_TEMPLATE_ID = "custom-mcp-none";
+
+interface Props {
+  templateById: Map<string, ConnectionTemplateView>;
+  oauthReturnView?: string;
+  onBack: () => void;
+  onCreated: (id: string) => void;
+}
+
+/** Single entry point for adding an MCP server (#423): Name + URL, with auth
+ *  detected from the URL. The Advanced disclosure lets a power user pin a
+ *  pre-registered OAuth client or a header credential, overriding detection. */
+export function McpCreatePane({
+  templateById,
+  oauthReturnView,
+  onBack,
+  onCreated,
+}: Props) {
+  const [name, setName] = useState(() =>
+    slugifyTemplateName("MCP server"),
+  );
+  const [url, setUrl] = useState("");
+  const [clientId, setClientId] = useState("");
+  const [clientSecret, setClientSecret] = useState("");
+  const [headerName, setHeaderName] = useState("");
+  const [headerValue, setHeaderValue] = useState("");
+
+  // Detection precedes submit so the button label is right and the OAuth
+  // popup can open synchronously on click; the submit hook re-verifies.
+  const { detected, detecting } = useMcpAuthDetection(url);
+
+  // Explicit advanced input wins over detection: OAuth creds → OAuth flow,
+  // a header credential → no-auth flow with gateway injection.
+  const overriding = clientId.trim() !== "" || headerValue.trim() !== "";
+  const wantsOAuth = clientId.trim()
+    ? true
+    : headerValue.trim()
+      ? false
+      : detected === "oauth";
+  // The button's Create vs Create + Authorize is only settled once detection
+  // resolves — hold it in a loading state rather than let it flip abruptly.
+  const showDetecting = detecting && !overriding;
+  const template = templateById.get(
+    wantsOAuth ? MCP_OAUTH_TEMPLATE_ID : MCP_NONE_TEMPLATE_ID,
+  );
+
+  const {
+    submit,
+    pending,
+    authorizing,
+    verifying,
+    needsOAuth,
+    awaitingPopup,
+    refocusPopup,
+  } = useTemplateCreateSubmit({
+    template: template ?? EMPTY_TEMPLATE,
+    popupOAuth: true,
+    oauthReturnView,
+    onCreated,
+  });
+
+  const onSubmit = () => {
+    if (!template) return;
+    const urlError = validateMcpUrl(url);
+    if (urlError) {
+      emitToast({ kind: "error", message: urlError });
+      return;
+    }
+    // Both-or-neither: a half-filled pair would otherwise be silently dropped,
+    // creating an auth-less connection from credentials the user typed.
+    const bothOrNeither = (a: string, b: string) =>
+      (a.trim() === "") === (b.trim() === "");
+    if (!bothOrNeither(clientId, clientSecret)) {
+      emitToast({
+        kind: "error",
+        message: "Provide both an OAuth ID and secret, or neither.",
+      });
+      return;
+    }
+    if (!bothOrNeither(headerName, headerValue)) {
+      emitToast({
+        kind: "error",
+        message: "Provide both a header name and value, or neither.",
+      });
+      return;
+    }
+    const fields: Record<string, string> = { url };
+    if (wantsOAuth) {
+      fields.clientId = clientId;
+      fields.clientSecret = clientSecret;
+    } else {
+      fields.headerName = headerName;
+      fields.value = headerValue;
+    }
+    const payload = buildCreatePayload(template, {
+      name,
+      fields,
+      overrideDefaults: true,
+    });
+    if ("error" in payload) {
+      emitToast({ kind: "error", message: payload.error });
+      return;
+    }
+    void submit(payload);
+  };
+
+  const submitLabel = useMemo(() => {
+    if (showDetecting) return "Checking URL…";
+    if (verifying) return "Verifying…";
+    if (awaitingPopup) return "Waiting for authorization — reopen";
+    if (authorizing) return "Redirecting…";
+    if (pending) return "…";
+    return needsOAuth ? "Create + Authorize" : "Create";
+  }, [showDetecting, verifying, awaitingPopup, authorizing, pending, needsOAuth]);
+
+  return (
+    <>
+      <CatalogPaneHeader title="Add an MCP server" onBack={onBack} />
+      <div className="min-h-0 flex-1 overflow-y-auto p-5">
+        <div className="flex flex-col gap-4">
+          <LabeledInput
+            label="Name"
+            testId="connection-field-name"
+            placeholder="my-mcp-server"
+            value={name}
+            onChange={setName}
+            help="Lowercase letters, digits, and single hyphens. Doubles as the MCP slug."
+          />
+          <LabeledInput
+            label="Remote MCP server URL"
+            testId="connection-field-url"
+            placeholder="https://mcp.example.com/sse"
+            value={url}
+            onChange={setUrl}
+          />
+          <DisclosureBox title="Advanced configuration">
+            <div className="flex flex-col gap-4">
+              <LabeledInput
+                label="OAuth ID (optional)"
+                testId="connection-field-clientId"
+                placeholder="Client ID"
+                value={clientId}
+                onChange={setClientId}
+              />
+              <LabeledInput
+                label="OAuth secret (optional)"
+                testId="connection-field-clientSecret"
+                type="password"
+                value={clientSecret}
+                onChange={setClientSecret}
+              />
+              <LabeledInput
+                label="Header name (optional)"
+                testId="connection-field-headerName"
+                placeholder="X-API-Key"
+                value={headerName}
+                onChange={setHeaderName}
+              />
+              <LabeledInput
+                label="Header value (optional)"
+                testId="connection-field-value"
+                type="password"
+                value={headerValue}
+                onChange={setHeaderValue}
+              />
+            </div>
+          </DisclosureBox>
+        </div>
+      </div>
+      <div className="flex justify-end gap-3 border-t border-border-light px-5 py-4">
+        <Button variant="outline" onClick={onBack} disabled={pending}>
+          Cancel
+        </Button>
+        <Button
+          onClick={awaitingPopup ? refocusPopup : onSubmit}
+          disabled={(pending && !awaitingPopup) || !template || showDetecting}
+          title={
+            awaitingPopup
+              ? "Bring the authorization window back to the front"
+              : undefined
+          }
+          data-testid="connection-create-submit"
+        >
+          {submitLabel}
+        </Button>
+      </div>
+    </>
+  );
+}
+
+// A placeholder while templates load — submit is disabled until the real one
+// resolves, so this is never used to build a payload.
+const EMPTY_TEMPLATE: ConnectionTemplateView = {
+  id: MCP_NONE_TEMPLATE_ID,
+  name: "MCP server",
+  category: "mcp",
+  isCustom: true,
+  authKind: "none",
+  inputs: [],
+};

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -7,11 +7,13 @@ import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { emitToast } from "@/lib/toast";
 
+import { MCP_DOCS_URL } from "../../../constants.js";
 import { DisclosureBox } from "../forms/disclosure-box.js";
 import { LabeledInput } from "../forms/labeled-input.js";
 import { useMcpAuthDetection } from "../hooks/use-mcp-auth-detection.js";
 import { useTemplateCreateSubmit } from "../hooks/use-template-create-submit.js";
 import { buildCreatePayload } from "../lib/build-create-payload.js";
+import { validateConnectionName } from "../lib/connection-name.js";
 import { validateMcpUrl } from "../lib/mcp-url.js";
 import { CatalogPaneHeader } from "./catalog-pane-header.js";
 
@@ -22,7 +24,7 @@ const filled = (s: string) => s.trim() !== "";
 
 const mcpFormSchema = z
   .object({
-    name: z.string().min(1, "Required"),
+    name: z.string(),
     url: z.string(),
     clientId: z.string(),
     clientSecret: z.string(),
@@ -30,6 +32,15 @@ const mcpFormSchema = z
     headerValue: z.string(),
   })
   .superRefine((v, ctx) => {
+    // Reuse the contract name rules so the format error (lowercase, digits,
+    // hyphens) shows live rather than failing server-side on submit.
+    const nameError = validateConnectionName(v.name);
+    if (nameError)
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["name"],
+        message: nameError,
+      });
     const urlError = validateMcpUrl(v.url);
     if (urlError)
       ctx.addIssue({
@@ -170,7 +181,7 @@ export function McpCreatePane({
             name="name"
             label="Name"
             placeholder="my-mcp-server"
-            help="Lowercase letters, digits, and single hyphens. Doubles as the MCP slug."
+            autoFocus
           />
           <McpField
             control={control}
@@ -178,31 +189,50 @@ export function McpCreatePane({
             label="Remote MCP server URL"
             placeholder="https://mcp.example.com/sse"
           />
-          <DisclosureBox title="Advanced configuration">
+          <DisclosureBox
+            title="Advanced configuration"
+            variant="section"
+            description={
+              <>
+                See{" "}
+                <a
+                  href={MCP_DOCS_URL}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="font-medium text-foreground underline underline-offset-2 hover:text-accent"
+                >
+                  documentation
+                </a>{" "}
+                for more details
+              </>
+            }
+          >
             <div className="flex flex-col gap-4">
               <McpField
                 control={control}
                 name="clientId"
-                label="OAuth ID (optional)"
-                placeholder="Client ID"
+                label="OAuth ID"
+                placeholder="Client ID (optional)"
               />
               <McpField
                 control={control}
                 name="clientSecret"
-                label="OAuth secret (optional)"
+                label="OAuth secret"
                 type="password"
+                placeholder="OAuth secret (optional)"
               />
               <McpField
                 control={control}
                 name="headerName"
-                label="Header name (optional)"
-                placeholder="X-API-Key"
+                label="Header name"
+                placeholder="Name (optional)"
               />
               <McpField
                 control={control}
                 name="headerValue"
-                label="Header value (optional)"
+                label="Header value"
                 type="password"
+                placeholder="Value (optional)"
               />
             </div>
           </DisclosureBox>
@@ -239,6 +269,7 @@ function McpField({
   placeholder,
   type,
   help,
+  autoFocus,
 }: {
   control: Control<McpFormValues>;
   name: keyof McpFormValues;
@@ -246,6 +277,7 @@ function McpField({
   placeholder?: string;
   type?: "text" | "password";
   help?: string;
+  autoFocus?: boolean;
 }) {
   return (
     <Controller
@@ -262,6 +294,8 @@ function McpField({
           onBlur={field.onBlur}
           help={help}
           error={fieldState.error?.message}
+          autoFocus={autoFocus}
+          inset
         />
       )}
     />

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -152,7 +152,14 @@ export function McpCreatePane({
     if (authorizing) return "Redirecting…";
     if (pending) return "…";
     return needsOAuth ? "Create + Authorize" : "Create";
-  }, [showDetecting, verifying, awaitingPopup, authorizing, pending, needsOAuth]);
+  }, [
+    showDetecting,
+    verifying,
+    awaitingPopup,
+    authorizing,
+    pending,
+    needsOAuth,
+  ]);
 
   return (
     <>

--- a/packages/ui/src/modules/connections/components/catalog-pane-header.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-pane-header.tsx
@@ -1,0 +1,32 @@
+import { ArrowLeft } from "@carbon/icons-react";
+
+/** Back-arrow header for the catalogue modal's non-browse panes. */
+export function CatalogPaneHeader({
+  title,
+  subtitle,
+  onBack,
+}: {
+  title: string;
+  subtitle?: string;
+  onBack: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-3 border-b border-border-light px-5 py-4">
+      <button
+        type="button"
+        onClick={onBack}
+        aria-label="Back"
+        data-testid="catalog-back"
+        className="text-muted-foreground hover:text-foreground"
+      >
+        <ArrowLeft size={18} />
+      </button>
+      <div>
+        <h3 className="text-[15px] font-semibold text-foreground">{title}</h3>
+        {subtitle && (
+          <p className="mt-0.5 text-[14px] text-muted-foreground">{subtitle}</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/connections/components/connection-catalog-modal.tsx
+++ b/packages/ui/src/modules/connections/components/connection-catalog-modal.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft, Close } from "@carbon/icons-react";
+import { Close } from "@carbon/icons-react";
 import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
 import { useMemo, useState } from "react";
 
@@ -18,18 +18,22 @@ import {
   catalogTabCounts,
   templateCreateHeading,
 } from "../lib/catalog-providers.js";
+import { McpCreatePane } from "./catalog-mcp-create-pane.js";
 import { CatalogMethodChooser } from "./catalog-method-chooser.js";
+import { CatalogPaneHeader } from "./catalog-pane-header.js";
 import {
   CatalogProviderCard,
   type SandboxGrantControls,
 } from "./catalog-provider-card.js";
 
 const NO_CONNECTIONS: ConnectionView[] = [];
+const MCP_PROVIDER_ID = "mcp-server";
 
 type Pane =
   | { kind: "browse" }
   | { kind: "choose"; providerId: string }
-  | { kind: "create"; templateId: string; providerId: string };
+  | { kind: "create"; templateId: string; providerId: string }
+  | { kind: "create-mcp" };
 
 interface Props {
   onClose: () => void;
@@ -62,13 +66,28 @@ export function ConnectionCatalogModal({
 
   const openNew = (group: CatalogProviderGroup) => {
     const providerId = group.provider.id;
-    if (group.templates.length > 1) setPane({ kind: "choose", providerId });
+    // MCP is one guided entry — the platform detects OAuth vs no-auth, so it
+    // skips the auth-method chooser (#423).
+    if (providerId === MCP_PROVIDER_ID) setPane({ kind: "create-mcp" });
+    else if (group.templates.length > 1)
+      setPane({ kind: "choose", providerId });
     else if (group.templates[0])
       setPane({
         kind: "create",
         templateId: group.templates[0].id,
         providerId,
       });
+  };
+
+  const onCreated = (id: string) => {
+    sandbox?.onToggleGrant(id, true);
+    emitToast({
+      kind: "success",
+      message: sandbox
+        ? "Connection added to this sandbox."
+        : "Connection created.",
+    });
+    onClose();
   };
 
   const groupById = (providerId: string) =>
@@ -160,16 +179,15 @@ export function ConnectionCatalogModal({
               template={templateById.get(pane.templateId)}
               oauthReturnView={oauthReturnView}
               onBack={() => backFromCreate(pane.providerId)}
-              onCreated={(id) => {
-                sandbox?.onToggleGrant(id, true);
-                emitToast({
-                  kind: "success",
-                  message: sandbox
-                    ? "Connection added to this sandbox."
-                    : "Connection created.",
-                });
-                onClose();
-              }}
+              onCreated={onCreated}
+            />
+          )}
+          {pane.kind === "create-mcp" && (
+            <McpCreatePane
+              templateById={templateById}
+              oauthReturnView={oauthReturnView}
+              onBack={() => setPane({ kind: "browse" })}
+              onCreated={onCreated}
             />
           )}
         </div>
@@ -190,7 +208,7 @@ function ChoosePane({
   if (!group) return null;
   return (
     <>
-      <PaneHeader
+      <CatalogPaneHeader
         title={`Connect ${group.provider.title}`}
         subtitle="Choose an authentication method"
         onBack={onBack}
@@ -217,7 +235,7 @@ function CreatePane({
   const { title, subtitle } = templateCreateHeading(template);
   return (
     <>
-      <PaneHeader title={title} subtitle={subtitle} onBack={onBack} />
+      <CatalogPaneHeader title={title} subtitle={subtitle} onBack={onBack} />
       <TemplateCreateFormBody
         key={template.id}
         template={template}
@@ -235,35 +253,5 @@ function CreatePane({
         )}
       />
     </>
-  );
-}
-
-function PaneHeader({
-  title,
-  subtitle,
-  onBack,
-}: {
-  title: string;
-  subtitle?: string;
-  onBack: () => void;
-}) {
-  return (
-    <div className="flex items-center gap-3 border-b border-border-light px-5 py-4">
-      <button
-        type="button"
-        onClick={onBack}
-        aria-label="Back"
-        data-testid="catalog-back"
-        className="text-muted-foreground hover:text-foreground"
-      >
-        <ArrowLeft size={18} />
-      </button>
-      <div>
-        <h3 className="text-[15px] font-semibold text-foreground">{title}</h3>
-        {subtitle && (
-          <p className="mt-0.5 text-[14px] text-muted-foreground">{subtitle}</p>
-        )}
-      </div>
-    </div>
   );
 }

--- a/packages/ui/src/modules/connections/forms/disclosure-box.tsx
+++ b/packages/ui/src/modules/connections/forms/disclosure-box.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronRight } from "@carbon/icons-react";
 import { type ReactNode, useState } from "react";
 
+import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -8,6 +9,11 @@ interface Props {
   defaultOpen?: boolean;
   bodyClassName?: string;
   testId?: string;
+  /** `box` (default): boxed header with a divider above the body. `section`:
+   *  an uppercase form-label header, no divider, with an optional description. */
+  variant?: "box" | "section";
+  /** `section` only — a muted line under the header (e.g. a docs link). */
+  description?: ReactNode;
   children: ReactNode;
 }
 
@@ -16,9 +22,36 @@ export function DisclosureBox({
   defaultOpen = false,
   bodyClassName,
   testId,
+  variant = "box",
+  description,
   children,
 }: Props) {
   const [open, setOpen] = useState(defaultOpen);
+  const Chevron = open ? ChevronDown : ChevronRight;
+
+  if (variant === "section") {
+    return (
+      <div className="rounded-lg border border-border p-4">
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          data-testid={testId}
+          className="flex w-full items-center gap-1.5 text-left"
+        >
+          <Chevron size={14} className="text-muted-foreground" />
+          <SectionLabel>{title}</SectionLabel>
+        </button>
+        {description && (
+          <div className="mt-1.5 pl-5 text-[13px] text-muted-foreground">
+            {description}
+          </div>
+        )}
+        {open && <div className={cn("mt-4", bodyClassName)}>{children}</div>}
+      </div>
+    );
+  }
+
   return (
     <div className="rounded-lg border border-border">
       <button
@@ -28,7 +61,7 @@ export function DisclosureBox({
         data-testid={testId}
         className="flex h-[44px] w-full items-center gap-2 px-4 text-[14px] font-medium text-foreground"
       >
-        {open ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+        <Chevron size={16} />
         {title}
       </button>
       {open && (

--- a/packages/ui/src/modules/connections/forms/labeled-input.tsx
+++ b/packages/ui/src/modules/connections/forms/labeled-input.tsx
@@ -8,7 +8,9 @@ export function LabeledInput({
   type,
   value,
   onChange,
+  onBlur,
   help,
+  error,
 }: {
   label: string;
   testId?: string;
@@ -16,16 +18,19 @@ export function LabeledInput({
   type?: "text" | "password";
   value: string;
   onChange: (v: string) => void;
+  onBlur?: () => void;
   help?: string;
+  error?: string;
 }) {
   return (
-    <FormField label={label} hint={help} disableInset>
+    <FormField label={label} hint={help} error={error} disableInset>
       <Input
         type={type ?? "text"}
         data-testid={testId}
         placeholder={placeholder}
         value={value}
         onChange={(e) => onChange(e.target.value)}
+        onBlur={onBlur}
       />
     </FormField>
   );

--- a/packages/ui/src/modules/connections/forms/labeled-input.tsx
+++ b/packages/ui/src/modules/connections/forms/labeled-input.tsx
@@ -11,6 +11,8 @@ export function LabeledInput({
   onBlur,
   help,
   error,
+  autoFocus,
+  inset,
 }: {
   label: string;
   testId?: string;
@@ -21,9 +23,17 @@ export function LabeledInput({
   onBlur?: () => void;
   help?: string;
   error?: string;
+  autoFocus?: boolean;
+  inset?: boolean;
 }) {
   return (
-    <FormField label={label} hint={help} error={error} disableInset>
+    <FormField
+      label={label}
+      hint={help}
+      error={error}
+      disableInset={!inset}
+      labelInset={inset}
+    >
       <Input
         type={type ?? "text"}
         data-testid={testId}
@@ -31,6 +41,7 @@ export function LabeledInput({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         onBlur={onBlur}
+        autoFocus={autoFocus}
       />
     </FormField>
   );

--- a/packages/ui/src/modules/connections/forms/template-create-form-body.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form-body.tsx
@@ -56,13 +56,20 @@ export function TemplateCreateFormBody({
   });
   const [overrideDefaults, setOverrideDefaults] = useState(false);
 
-  const { submit, pending, authorizing, verifying, needsOAuth } =
-    useTemplateCreateSubmit({
-      template,
-      popupOAuth,
-      oauthReturnView,
-      onCreated,
-    });
+  const {
+    submit,
+    pending,
+    authorizing,
+    verifying,
+    needsOAuth,
+    awaitingPopup,
+    refocusPopup,
+  } = useTemplateCreateSubmit({
+    template,
+    popupOAuth,
+    oauthReturnView,
+    onCreated,
+  });
 
   const bringYourOwnApp =
     needsOAuth &&
@@ -182,19 +189,26 @@ export function TemplateCreateFormBody({
         Cancel
       </Button>
       <Button
-        onClick={onSubmit}
-        disabled={pending}
+        onClick={awaitingPopup ? refocusPopup : onSubmit}
+        disabled={pending && !awaitingPopup}
+        title={
+          awaitingPopup
+            ? "Bring the authorization window back to the front"
+            : undefined
+        }
         data-testid="connection-create-submit"
       >
         {verifying
           ? "Verifying…"
-          : authorizing
-            ? "Redirecting…"
-            : pending
-              ? "…"
-              : needsOAuth
-                ? "Create + Authorize"
-                : "Create"}
+          : awaitingPopup
+            ? "Waiting for authorization — reopen"
+            : authorizing
+              ? "Redirecting…"
+              : pending
+                ? "…"
+                : needsOAuth
+                  ? "Create + Authorize"
+                  : "Create"}
       </Button>
     </>
   );

--- a/packages/ui/src/modules/connections/hooks/use-mcp-auth-detection.ts
+++ b/packages/ui/src/modules/connections/hooks/use-mcp-auth-detection.ts
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from "react";
+
+import { useDiscoverMcp } from "../api/mutations.js";
+import { validateMcpUrl } from "../lib/mcp-url.js";
+
+const DETECT_DEBOUNCE_MS = 500;
+
+/** Debounced probe of an MCP server URL so the create button can settle on
+ *  "Create" vs "Create + Authorize" before submit. `detecting` is true while a
+ *  valid URL's probe is in flight; out-of-order results are discarded. */
+export function useMcpAuthDetection(url: string): {
+  detected: "oauth" | "none" | null;
+  detecting: boolean;
+} {
+  const [detected, setDetected] = useState<"oauth" | "none" | null>(null);
+  const [detecting, setDetecting] = useState(false);
+  const discover = useDiscoverMcp({ silent: true });
+  const latestUrlRef = useRef(url);
+  latestUrlRef.current = url;
+
+  useEffect(() => {
+    setDetected(null);
+    if (validateMcpUrl(url) !== null) {
+      setDetecting(false);
+      return;
+    }
+    setDetecting(true);
+    const handle = setTimeout(() => {
+      discover
+        .mutateAsync({ url })
+        .then((r) => {
+          if (latestUrlRef.current === url) setDetected(r.auth);
+        })
+        .catch(() => {
+          if (latestUrlRef.current === url) setDetected(null);
+        })
+        .finally(() => {
+          if (latestUrlRef.current === url) setDetecting(false);
+        });
+    }, DETECT_DEBOUNCE_MS);
+    return () => clearTimeout(handle);
+    // discover is a stable mutation handle; only the URL drives re-probing.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url]);
+
+  return { detected, detecting };
+}

--- a/packages/ui/src/modules/connections/hooks/use-oauth-popup.ts
+++ b/packages/ui/src/modules/connections/hooks/use-oauth-popup.ts
@@ -89,5 +89,12 @@ export function useOAuthPopup(onResult: (result: OAuthPopupResult) => void) {
     teardown();
   }, [teardown]);
 
-  return { open, close };
+  // Bring an open popup back to the front — it easily slips behind the main
+  // window. Best-effort: some browsers ignore programmatic focus of a
+  // background window, and it's a no-op once the popup has closed.
+  const focus = useCallback(() => {
+    if (popupRef.current && !popupRef.current.closed) popupRef.current.focus();
+  }, []);
+
+  return { open, close, focus };
 }

--- a/packages/ui/src/modules/connections/hooks/use-template-create-submit.ts
+++ b/packages/ui/src/modules/connections/hooks/use-template-create-submit.ts
@@ -88,9 +88,11 @@ export function useTemplateCreateSubmit({
     fail(result.message ?? "Authorization was cancelled.");
   };
 
-  const { open: openPopup, close: closePopup } = useOAuthPopup(
-    (result) => void settlePopup(result),
-  );
+  const {
+    open: openPopup,
+    close: closePopup,
+    focus: focusPopup,
+  } = useOAuthPopup((result) => void settlePopup(result));
 
   const needsOAuth = template.authKind === "oauth";
   const pending =
@@ -215,5 +217,9 @@ export function useTemplateCreateSubmit({
     authorizing,
     verifying: discover.isPending,
     needsOAuth,
+    // A popup is open and we're waiting on it — the caller keeps its button
+    // live so a repeat click can bring the strayed popup back to the front.
+    awaitingPopup: !!popupOAuth && authorizing,
+    refocusPopup: focusPopup,
   };
 }

--- a/packages/ui/src/modules/connections/lib/build-create-payload.ts
+++ b/packages/ui/src/modules/connections/lib/build-create-payload.ts
@@ -88,6 +88,8 @@ export function buildCreatePayload(
         ...common,
         authKind: "none" as const,
         url: submitted("url"),
+        headerName: submitted("headerName"),
+        value: submitted("value"),
       });
   }
 }


### PR DESCRIPTION
Adding an MCP server is now one action instead of an upfront auth quiz.

- The MCP entry in the Connection catalogue opens a single **Add an MCP server** pane — name and URL, with the platform detecting whether the server needs OAuth and running the right flow. No more choosing "OAuth" vs "no-auth" before you've done anything.
- An **Advanced configuration** section covers the less-common cases: a pre-registered OAuth client (for providers that don't allow dynamic client registration), or a header credential (API key) injected at the gateway and never written into the agent's config.
- The submit button reflects what will happen — Create, or Create + Authorize — and shows a brief checking state while the URL is probed.

Part of #2759.

Closes #423