### PR TITLE
fix(skills): newly-added source is publishable without a reload

### DIFF
--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -263,7 +263,9 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
     },
     async createSource(input: SkillCreateSourceInput) {
       try {
-        return await deps.repo.create(input, deps.owner);
+        const created = await deps.repo.create(input, deps.owner);
+        const [enriched] = enrichSources([created]);
+        return enriched;
       } catch (err) {
         if (isUniqueViolation(err, "skill_sources_owner_git_url_idx")) {
           throw new TRPCError({


### PR DESCRIPTION
## What & why

After adding a GitHub skill source, it showed up in the skills list right away but was **not** offered in the "Publish to" dropdown when publishing a locally-created skill — the dropdown only listed sources that existed at page load. Users had to reload the page before they could publish to a source they'd just added, with nothing on screen explaining the gap.

Now a source added during the session is immediately available as a publish target. No reload required.

Closes #2837