### PR TITLE
fix(invocations): accept stringified report_result payloads

### DIFF
--- a/packages/api-server/src/__tests__/unit/invocations-result-coercion.test.ts
+++ b/packages/api-server/src/__tests__/unit/invocations-result-coercion.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "vitest";
+
+import type {
+  InvocationRow,
+  InvocationsRepository,
+} from "../../modules/invocations/infrastructure/invocations-repository.js";
+import { createInvocationsService } from "../../modules/invocations/services/invocations-service.js";
+
+function makeService(row: InvocationRow) {
+  const rows = new Map<string, InvocationRow>([[row.id, row]]);
+  const repo: InvocationsRepository = {
+    insert: async () => {},
+    get: async (id) => rows.get(id) ?? null,
+    complete: async (id, result) => {
+      const r = rows.get(id);
+      if (!r || r.status !== "running") return false;
+      r.status = "done";
+      r.result = result;
+      return true;
+    },
+    fail: async () => {},
+    listExpiredRunning: async () => [],
+    listRunning: async () => [],
+    listAgedTerminal: async () => [],
+    delete: async () => {},
+  };
+  const service = createInvocationsService({
+    owner: "owner-1",
+    repo,
+    agents: {
+      delete: async () => {},
+    } as never,
+    runtimeMutator: {} as never,
+    wakeAgent: async () => {},
+  });
+  return { rows, service };
+}
+
+function runningRow(resultSchema: unknown): InvocationRow {
+  return {
+    id: "agent-1",
+    driverAgentId: "driver-1",
+    owner: "owner-1",
+    resultSchema,
+    result: null,
+    status: "running",
+    errorReason: null,
+    expiresAt: new Date(Date.now() + 60_000),
+    completedAt: null,
+  };
+}
+
+describe("recordResult tolerates stringified report_result payloads", () => {
+  test('an integer delivered as the string "42" validates and stores 42', async () => {
+    const { rows, service } = makeService(runningRow({ type: "integer" }));
+    const outcome = await service.recordResult("agent-1", "42");
+    expect(outcome.ok).toBe(true);
+    expect(rows.get("agent-1")?.result).toBe(42);
+  });
+
+  test("a native integer still validates and stores unchanged", async () => {
+    const { rows, service } = makeService(runningRow({ type: "integer" }));
+    const outcome = await service.recordResult("agent-1", 42);
+    expect(outcome.ok).toBe(true);
+    expect(rows.get("agent-1")?.result).toBe(42);
+  });
+
+  test("an object delivered as JSON text validates and stores the parsed object", async () => {
+    const schema = {
+      type: "object",
+      properties: { pass: { type: "boolean" }, note: { type: "string" } },
+      required: ["pass", "note"],
+      additionalProperties: false,
+    };
+    const { rows, service } = makeService(runningRow(schema));
+    const outcome = await service.recordResult(
+      "agent-1",
+      '{"pass":true,"note":"ok"}',
+    );
+    expect(outcome.ok).toBe(true);
+    expect(rows.get("agent-1")?.result).toEqual({ pass: true, note: "ok" });
+  });
+
+  test("a genuine string result is stored as-is, not parsed", async () => {
+    const { rows, service } = makeService(runningRow({ type: "string" }));
+    const outcome = await service.recordResult("agent-1", "42");
+    expect(outcome.ok).toBe(true);
+    // Schema is string, so the raw "42" validates first — never JSON-parsed.
+    expect(rows.get("agent-1")?.result).toBe("42");
+  });
+
+  test("a value that can't be made to fit is still rejected", async () => {
+    const { service } = makeService(runningRow({ type: "integer" }));
+    const outcome = await service.recordResult("agent-1", "not a number");
+    expect(outcome.ok).toBe(false);
+    expect(outcome.errors).toBeTruthy();
+  });
+});

--- a/packages/api-server/src/modules/invocations/services/invocations-service.ts
+++ b/packages/api-server/src/modules/invocations/services/invocations-service.ts
@@ -106,6 +106,23 @@ export function createInvocationsService(deps: {
     }
   }
 
+  // The `report_result` tool takes an untyped `result` arg, so some target
+  // harnesses deliver it JSON-encoded: a `42` arrives as the string "42", an
+  // object as its JSON text. Validation is structural, not truth, so accept a
+  // stringified payload when parsing it yields a value that fits the schema.
+  function coerceResult(result: unknown, validate: ValidateFunction): unknown {
+    if (validate(result)) return result;
+    if (typeof result === "string") {
+      try {
+        const parsed: unknown = JSON.parse(result);
+        if (validate(parsed)) return parsed;
+      } catch {
+        // Not JSON — let the original value fail validation with a real error.
+      }
+    }
+    return result;
+  }
+
   return {
     async spawn(input) {
       // Attenuation: a target may only carry a subset of the driver's grants.
@@ -183,10 +200,11 @@ export function createInvocationsService(deps: {
         return { ok: false, errors: `invocation already ${row.status}` };
       }
       const validate = compileSchema(row.resultSchema);
-      if (!validate(result)) {
+      const value = coerceResult(result, validate);
+      if (!validate(value)) {
         return { ok: false, errors: ajv.errorsText(validate.errors) };
       }
-      const stored = await deps.repo.complete(invocationId, result);
+      const stored = await deps.repo.complete(invocationId, value);
       if (!stored) {
         // Lost a race with the liveness sweep — the Invocation was just failed.
         return { ok: false, errors: "invocation is no longer running" };


### PR DESCRIPTION
## Problem

Found while testing #2816 end to end. A target reasoning node computes `6*7`, calls `report_result(42)`, and the platform rejects it in a loop: `report_result rejected: data must be integer`.

Root cause: the `report_result` MCP tool declares `result: z.unknown()`, so the tool's input schema advertised to the model is untyped. The target harness then delivers the scalar JSON-encoded: `42` arrives as the string `"42"` (and an object as its JSON text). ajv validates it against the stashed schema (`{"type":"integer"}`) and rejects it. The node retries forever and eventually hangs to its deadline.

## Fix

`recordResult` now tolerates a stringified payload: if the raw value fails validation and it's a string, parse it as JSON and re-validate before failing. Validation stays structural (never truth) — a value that genuinely can't be made to fit is still rejected, and a legitimate string result validates on the first pass and is never parsed.

## Tests

Added `invocations-result-coercion.test.ts`:
- integer delivered as `"42"` -> validates, stores `42`
- native `42` -> unchanged
- object delivered as JSON text -> parsed and stored
- genuine string result -> stored as-is, not parsed
- unfixable value -> still rejected

api-server: 413/413 pass; tsc, eslint, prettier clean.

https://claude.ai/code/session_014nrAszAAac3WB2LdMv8uBG