### PR TITLE
feat(agents): per-agent template upgrade to the current image

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1075,6 +1075,11 @@ controller:
 # per entry; set an entry to `null` to drop it. Fields named identically to
 # `controller.agent.templateDefaults.*` override the chart-wide default for
 # agents created from this template.
+# The rendered image ref (`repository:tag`, tag defaulting to the chart
+# appVersion) is the template's version identity: existing agents are offered
+# an upgrade when it differs from what they captured at create. Pinning `tag`
+# across releases therefore opts that template out of upgrade detection, and
+# non-image drift (mounts/env/resources) is never detected.
 # `$HOME` in mount paths is substituted at chart render time
 # using this entry's `agentHome` if set, else `templateDefaults.agentHome`.
 # `category` groups the entry in the creation wizard's Step 1: "harness"

--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-07-14
+Last verified: 2026-07-20
 
 ## Overview
 
@@ -68,6 +68,10 @@ Pod env at start is composed by the controller from platform wiring only — las
 Everything tied to an Agent's *configuration* rides the runtime channel as `env`-kind contributions instead, never the pod spec: connection-derived env (credential placeholders the gateway swaps on the wire), user-typed env (the Environment editor), and template env. The api-server stores user-typed and template env in Postgres `agent_env` and delivers all of it at the next idle turn with no pod roll, ordering user env ahead of connection/secret env so it wins on a name collision. Template env is seeded into `agent_env` at create time only, so editing a Template never re-flows into a running Agent. The Agent CR's `spec.env` field is retained but no longer read. See [connections](connections.md).
 
 Connector state that doesn't fit the env model (per-host CLI configs, allowlists, and similar) is materialized as files directly under HOME by `agent-runtime` itself, which holds an SSE connection to the api-server and merges declarative file fragments without restarting the pod. Image-baked content under the same paths participates in the merge — `agent-runtime` writes to the real PVC path, not a shadowing `emptyDir`.
+
+### Template upgrade
+
+Because a Template is captured at create time, a helm upgrade that advances a template (a newer agent image) never re-flows into existing Agents. The template-upgrade path (#1077) is the sanctioned catch-up: on every Agent read the api-server compares the Agent's captured image against the current image of the template it came from — templates ship a fully-resolved image reference whose tag defaults to the chart's app version, so the image reference doubles as the template's version identity — and surfaces a pending update on the Agent when they differ. Applying it is an explicit per-Agent user action, never automatic: the user is shown the exact image movement and confirms, the api-server re-points the Agent spec at the template's current image, and the reconciler rolls a running pair onto it (a hibernated Agent just wakes on the new image). The upgrade is deliberately image-only: template env stays frozen in `agent_env` (re-seeding would clobber user edits), and mount/storage changes cannot ride a spec patch (the StatefulSet's volume layout is immutable once created) — those still require recreating the Agent.
 
 ### Wake
 

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -55,6 +55,9 @@ export type {
   AgentsService,
   AgentCreateInput,
   AgentUpdateInput,
+  TemplateUpdate,
+  UpgradeAgentError,
+  UpgradeAgentResult,
   ConnectSlackError,
   ConnectSlackResult,
   BindSlackChannelError,
@@ -84,6 +87,7 @@ export {
   agentUpdateInputSchema,
   agentPauseInputSchema,
   agentStopInputSchema,
+  agentUpgradeInputSchema,
   agentWakeInputSchema,
 } from "./modules/agents/schemas.js";
 export {

--- a/packages/api-server-api/src/modules/agents/router.ts
+++ b/packages/api-server-api/src/modules/agents/router.ts
@@ -126,7 +126,7 @@ export const agentsRouter = t.router({
   upgrade: manageAgentsProcedure
     .input(agentUpgradeInputSchema)
     .mutation(async ({ ctx, input }) => {
-      const res = await ctx.agents.upgrade(input.id);
+      const res = await ctx.agents.upgrade(input.id, input.expectedToImage);
       if (res.ok) return toView(res.value);
       switch (res.error.type) {
         case "AgentNotFound":
@@ -135,6 +135,12 @@ export const agentsRouter = t.router({
           throw new TRPCError({
             code: "PRECONDITION_FAILED",
             message: "No template to upgrade from",
+          });
+        case "TemplateMoved":
+          throw new TRPCError({
+            code: "CONFLICT",
+            message:
+              "The template changed since you reviewed the upgrade — check the new version and retry",
           });
       }
     }),

--- a/packages/api-server-api/src/modules/agents/router.ts
+++ b/packages/api-server-api/src/modules/agents/router.ts
@@ -19,6 +19,7 @@ import {
   agentUpdateInputSchema,
   agentPauseInputSchema,
   agentStopInputSchema,
+  agentUpgradeInputSchema,
   agentWakeInputSchema,
 } from "./schemas.js";
 import type { Agent } from "./types.js";
@@ -28,6 +29,7 @@ function toView(agent: Agent) {
     id: agent.id,
     name: agent.name,
     templateId: agent.templateId ?? null,
+    templateUpdate: agent.templateUpdate ?? null,
     image: agent.spec.image,
     description: agent.spec.description,
     env: agent.spec.env,
@@ -119,6 +121,22 @@ export const agentsRouter = t.router({
       const agent = await ctx.agents.pause(input.id);
       if (!agent) throw new TRPCError({ code: "NOT_FOUND" });
       return toView(agent);
+    }),
+
+  upgrade: manageAgentsProcedure
+    .input(agentUpgradeInputSchema)
+    .mutation(async ({ ctx, input }) => {
+      const res = await ctx.agents.upgrade(input.id);
+      if (res.ok) return toView(res.value);
+      switch (res.error.type) {
+        case "AgentNotFound":
+          throw new TRPCError({ code: "NOT_FOUND" });
+        case "TemplateNotFound":
+          throw new TRPCError({
+            code: "PRECONDITION_FAILED",
+            message: "No template to upgrade from",
+          });
+      }
     }),
 
   connectSlack: manageAgentsProcedure

--- a/packages/api-server-api/src/modules/agents/schemas.ts
+++ b/packages/api-server-api/src/modules/agents/schemas.ts
@@ -40,7 +40,11 @@ export const agentRestartInputSchema = idSchema;
 export const agentWakeInputSchema = idSchema;
 export const agentStopInputSchema = idSchema;
 export const agentPauseInputSchema = idSchema;
-export const agentUpgradeInputSchema = idSchema;
+// expectedToImage makes the confirmed diff binding: the server applies the
+// upgrade only if the template still ships that image (compare-and-swap).
+export const agentUpgradeInputSchema = idSchema.extend({
+  expectedToImage: z.string().min(1).optional(),
+});
 export const agentDisconnectSlackInputSchema = idSchema;
 
 export const agentCreateInputSchema = z

--- a/packages/api-server-api/src/modules/agents/schemas.ts
+++ b/packages/api-server-api/src/modules/agents/schemas.ts
@@ -40,6 +40,7 @@ export const agentRestartInputSchema = idSchema;
 export const agentWakeInputSchema = idSchema;
 export const agentStopInputSchema = idSchema;
 export const agentPauseInputSchema = idSchema;
+export const agentUpgradeInputSchema = idSchema;
 export const agentDisconnectSlackInputSchema = idSchema;
 
 export const agentCreateInputSchema = z

--- a/packages/api-server-api/src/modules/agents/types.ts
+++ b/packages/api-server-api/src/modules/agents/types.ts
@@ -99,7 +99,10 @@ export type UpgradeAgentError =
   | { type: "AgentNotFound" }
   /** Created from a raw image, or the template is no longer installed —
    *  deliberately one bucket: either way there is nothing to upgrade to. */
-  | { type: "TemplateNotFound" };
+  | { type: "TemplateNotFound" }
+  /** The template no longer ships the image the user consented to
+   *  (moved between showing the diff and confirming) — re-review. */
+  | { type: "TemplateMoved" };
 
 export type UpgradeAgentResult =
   | { ok: true; value: Agent }
@@ -178,8 +181,13 @@ export interface AgentsService {
   pause: (id: string) => Promise<Agent | null>;
   /** Re-apply the current template's image to this agent (#1077). A running
    *  agent rolls onto the new image; a hibernated one picks it up on its
-   *  next wake. Idempotent — an already-current agent succeeds unchanged. */
-  upgrade: (id: string) => Promise<UpgradeAgentResult>;
+   *  next wake. Idempotent — an already-current agent succeeds unchanged.
+   *  When `expectedToImage` is given, fails with TemplateMoved unless the
+   *  template still ships exactly that image (binding consent). */
+  upgrade: (
+    id: string,
+    expectedToImage?: string,
+  ) => Promise<UpgradeAgentResult>;
   /**
    * Ensure the agent's pod is reachable. Waits for pod Ready, waking
    * from hibernation if needed. Idempotent; single-flight per id; bumps

--- a/packages/api-server-api/src/modules/agents/types.ts
+++ b/packages/api-server-api/src/modules/agents/types.ts
@@ -54,10 +54,21 @@ export type AgentState =
 // intent, so they belong in the spec.
 export type AgentSpec = AgentSpecCR & { name: string };
 
+/** The pending template upgrade (#1077): the template this agent came from
+ *  now ships a different image than the one captured at create time. v1
+ *  compares the image only — other template-derived fields stay frozen. */
+export interface TemplateUpdate {
+  fromImage: string;
+  toImage: string;
+}
+
 export interface Agent {
   id: string;
   name: string;
   templateId?: string;
+  /** Present when the agent is behind its template; absent when current,
+   *  created from a raw image, or the template is no longer installed. */
+  templateUpdate?: TemplateUpdate;
   spec: AgentSpec;
   /** Observed lifecycle state, synthesized from the controller's status.yaml. */
   state: AgentState;
@@ -83,6 +94,16 @@ export interface Agent {
 
 export type AgentCreateInput = z.infer<typeof agentCreateInputSchema>;
 export type AgentUpdateInput = z.infer<typeof agentUpdateInputSchema>;
+
+export type UpgradeAgentError =
+  | { type: "AgentNotFound" }
+  /** Created from a raw image, or the template is no longer installed —
+   *  deliberately one bucket: either way there is nothing to upgrade to. */
+  | { type: "TemplateNotFound" };
+
+export type UpgradeAgentResult =
+  | { ok: true; value: Agent }
+  | { ok: false; error: UpgradeAgentError };
 
 export type ConnectSlackError =
   | { type: "AgentNotFound" }
@@ -155,6 +176,10 @@ export interface AgentsService {
    *  the agent wakes on its next deliberate use (open chat, message,
    *  schedule), passing back through the budget gate. */
   pause: (id: string) => Promise<Agent | null>;
+  /** Re-apply the current template's image to this agent (#1077). A running
+   *  agent rolls onto the new image; a hibernated one picks it up on its
+   *  next wake. Idempotent — an already-current agent succeeds unchanged. */
+  upgrade: (id: string) => Promise<UpgradeAgentResult>;
   /**
    * Ensure the agent's pod is reachable. Waits for pod Ready, waking
    * from hibernation if needed. Idempotent; single-flight per id; bumps

--- a/packages/api-server/src/__tests__/unit/template-upgrade.test.ts
+++ b/packages/api-server/src/__tests__/unit/template-upgrade.test.ts
@@ -127,4 +127,25 @@ describe("template upgrade flow", () => {
       error: { type: "AgentNotFound" },
     });
   });
+
+  it("applies when the template still ships the confirmed image", async () => {
+    const h = harness();
+    const res = await h.run("agent-1", "quay.io/dam-agents/claude-code:0.2.8");
+    expect(res.ok && res.value.spec.image).toBe(
+      "quay.io/dam-agents/claude-code:0.2.8",
+    );
+  });
+
+  it("rejects a confirmation for an image the template no longer ships", async () => {
+    const h = harness({
+      templateImage: "quay.io/dam-agents/claude-code:0.2.9",
+    });
+    expect(
+      await h.run("agent-1", "quay.io/dam-agents/claude-code:0.2.8"),
+    ).toEqual({
+      ok: false,
+      error: { type: "TemplateMoved" },
+    });
+    expect(h.patchImage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/api-server/src/__tests__/unit/template-upgrade.test.ts
+++ b/packages/api-server/src/__tests__/unit/template-upgrade.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi } from "vitest";
+import type { TemplateSpec } from "api-server-api";
+import { configureLogger } from "../../core/logger.js";
+import { templateImageUpdate } from "../../modules/agents/domain/template-update.js";
+import { executeTemplateUpgrade } from "../../modules/agents/services/agents-service.js";
+import type { InfraAgent } from "../../modules/agents/infrastructure/agent-mappers.js";
+
+// Swallow securityLog output from the upgrade path under test.
+configureLogger({ level: "error", write: () => {} });
+
+const OWNER = "kc|owner-1";
+
+function infraAgent(overrides?: Partial<InfraAgent>): InfraAgent {
+  return {
+    id: "agent-1",
+    name: "my-agent",
+    templateId: "claude-code",
+    spec: { name: "my-agent", image: "quay.io/dam-agents/claude-code:0.2.7" },
+    ready: false,
+    hibernated: true,
+    overBudget: false,
+    ...overrides,
+  };
+}
+
+function templateSpec(image: string): TemplateSpec {
+  return { version: "agent-platform.ai/v1", image, category: "harness" };
+}
+
+function harness(opts?: {
+  agent?: InfraAgent | null;
+  templateImage?: string | null;
+}) {
+  const agent = opts?.agent === undefined ? infraAgent() : opts.agent;
+  const patchImage = vi.fn(async (_id: string, image: string) =>
+    agent ? { ...agent, spec: { ...agent.spec, image } } : null,
+  );
+  const run = executeTemplateUpgrade({
+    owner: OWNER,
+    getAgent: async () => agent,
+    readTemplateSpec: async () =>
+      opts?.templateImage === null
+        ? null
+        : {
+            spec: templateSpec(
+              opts?.templateImage ?? "quay.io/dam-agents/claude-code:0.2.8",
+            ),
+            isOwned: false,
+          },
+    patchImage,
+  });
+  return { run, patchImage };
+}
+
+describe("templateImageUpdate", () => {
+  it("reports the image movement when the template moved on", () => {
+    expect(templateImageUpdate("repo:0.2.7", "repo:0.2.8")).toEqual({
+      fromImage: "repo:0.2.7",
+      toImage: "repo:0.2.8",
+    });
+  });
+
+  it("is absent when the agent is current", () => {
+    expect(templateImageUpdate("repo:0.2.8", "repo:0.2.8")).toBeUndefined();
+  });
+
+  it("is absent when the agent has no image captured", () => {
+    expect(templateImageUpdate(undefined, "repo:0.2.8")).toBeUndefined();
+  });
+});
+
+describe("template upgrade flow", () => {
+  it("patches the agent onto the template's current image", async () => {
+    const h = harness();
+    const res = await h.run("agent-1");
+    expect(h.patchImage).toHaveBeenCalledWith(
+      "agent-1",
+      "quay.io/dam-agents/claude-code:0.2.8",
+    );
+    expect(res.ok && res.value.spec.image).toBe(
+      "quay.io/dam-agents/claude-code:0.2.8",
+    );
+  });
+
+  it("succeeds without patching when already current (idempotent)", async () => {
+    const h = harness({
+      templateImage: "quay.io/dam-agents/claude-code:0.2.7",
+    });
+    const res = await h.run("agent-1");
+    expect(res.ok && res.value.spec.image).toBe(
+      "quay.io/dam-agents/claude-code:0.2.7",
+    );
+    expect(h.patchImage).not.toHaveBeenCalled();
+  });
+
+  it("rejects an unknown or unowned agent", async () => {
+    const h = harness({ agent: null });
+    expect(await h.run("agent-1")).toEqual({
+      ok: false,
+      error: { type: "AgentNotFound" },
+    });
+  });
+
+  it("rejects a bare-image agent (no template to upgrade from)", async () => {
+    const h = harness({ agent: infraAgent({ templateId: undefined }) });
+    expect(await h.run("agent-1")).toEqual({
+      ok: false,
+      error: { type: "TemplateNotFound" },
+    });
+    expect(h.patchImage).not.toHaveBeenCalled();
+  });
+
+  it("rejects when the template is no longer installed", async () => {
+    const h = harness({ templateImage: null });
+    expect(await h.run("agent-1")).toEqual({
+      ok: false,
+      error: { type: "TemplateNotFound" },
+    });
+    expect(h.patchImage).not.toHaveBeenCalled();
+  });
+
+  it("maps a patch-time disappearance to AgentNotFound", async () => {
+    const h = harness();
+    h.patchImage.mockResolvedValueOnce(null);
+    expect(await h.run("agent-1")).toEqual({
+      ok: false,
+      error: { type: "AgentNotFound" },
+    });
+  });
+});

--- a/packages/api-server/src/__tests__/unit/template-upgrade.test.ts
+++ b/packages/api-server/src/__tests__/unit/template-upgrade.test.ts
@@ -16,6 +16,8 @@ function infraAgent(overrides?: Partial<InfraAgent>): InfraAgent {
     name: "my-agent",
     templateId: "claude-code",
     spec: { name: "my-agent", image: "quay.io/dam-agents/claude-code:0.2.7" },
+    sweepable: false,
+    lifetimeMs: 0,
     ready: false,
     hibernated: true,
     overBudget: false,

--- a/packages/api-server/src/modules/agents/domain/template-update.ts
+++ b/packages/api-server/src/modules/agents/domain/template-update.ts
@@ -1,0 +1,13 @@
+import type { TemplateUpdate } from "api-server-api";
+
+/** The pending template upgrade (#1077), or undefined when the agent is
+ *  current. The image ref is the template's version identity — templates
+ *  ship a fully-resolved `repo:tag` (tag defaults to the chart appVersion),
+ *  so any difference from the create-time capture means the template moved. */
+export function templateImageUpdate(
+  agentImage: string | undefined,
+  templateImage: string,
+): TemplateUpdate | undefined {
+  if (!agentImage || agentImage === templateImage) return undefined;
+  return { fromImage: agentImage, toImage: templateImage };
+}

--- a/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
@@ -5,6 +5,7 @@ import type {
   AgentState,
   ChannelConfig,
   DriverFailure,
+  TemplateUpdate,
 } from "api-server-api";
 import type { KubeObject } from "./k8s.js";
 import {
@@ -199,11 +200,13 @@ export function assembleAgent(
   contributionFailures: DriverFailure[],
   globalIdleTimeoutMin: number,
   preparingWorkspace = false,
+  templateUpdate?: TemplateUpdate,
 ): Agent {
   return {
     id: infra.id,
     name: infra.name,
     templateId: infra.templateId,
+    templateUpdate,
     spec: infra.spec,
     state: computeAgentState(infra, preparingWorkspace),
     effectiveHibernationTimeoutMin: resolveEffectiveHibernationTimeoutMin(

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -385,6 +385,7 @@ export function executeTemplateUpgrade(deps: {
 }) {
   return async (
     id: string,
+    expectedToImage?: string,
   ): Promise<
     { ok: true; value: InfraAgent } | { ok: false; error: UpgradeAgentError }
   > => {
@@ -393,6 +394,11 @@ export function executeTemplateUpgrade(deps: {
     if (!infra.templateId) return err({ type: "TemplateNotFound" as const });
     const tmpl = await deps.readTemplateSpec(infra.templateId);
     if (!tmpl) return err({ type: "TemplateNotFound" as const });
+
+    // Binding consent: the confirmed image must still be what the template
+    // ships, or the user would apply a movement they never reviewed.
+    if (expectedToImage !== undefined && expectedToImage !== tmpl.spec.image)
+      return err({ type: "TemplateMoved" as const });
 
     const update = templateImageUpdate(infra.spec.image, tmpl.spec.image);
     // Already current — idempotent success, no patch, no pod roll.
@@ -1266,14 +1272,14 @@ export function createAgentsService(deps: {
       return project(infra);
     },
 
-    async upgrade(id) {
+    async upgrade(id, expectedToImage) {
       const result = await executeTemplateUpgrade({
         owner: deps.owner,
         getAgent: (agentId) => deps.repo.get(agentId, deps.owner),
         readTemplateSpec: deps.readTemplateSpec,
         patchImage: (agentId, image) =>
           deps.repo.updateSpec(agentId, deps.owner, { image }),
-      })(id);
+      })(id, expectedToImage);
       if (!result.ok) return result;
       emit({ type: EventType.AgentUpdated, agentId: id });
       return ok(await project(result.value));

--- a/packages/api-server/src/modules/agents/services/agents-service.ts
+++ b/packages/api-server/src/modules/agents/services/agents-service.ts
@@ -13,6 +13,8 @@ import {
   type ConnectSlackResult,
   type ListTelegramChatsResult,
   type UnbindTelegramChatResult,
+  type TemplateUpdate,
+  type UpgradeAgentError,
   ChannelType,
 } from "api-server-api";
 import { TRPCError } from "@trpc/server";
@@ -47,6 +49,7 @@ import {
   seedTelemetryIdentity,
   renamedTelemetryIdentity,
 } from "../domain/telemetry-env.js";
+import { templateImageUpdate } from "../domain/template-update.js";
 import { generateK8sName } from "../infrastructure/configmap-mappers.js";
 import type { AgentRegistrySecretPort } from "../infrastructure/agent-registry-secret-port.js";
 import type { KeycloakUserDirectory } from "../infrastructure/keycloak-user-directory.js";
@@ -367,6 +370,54 @@ export function executeSlackBind(deps: {
 }
 
 /**
+ * The template-upgrade flow (#1077), extracted like the bind flows so tests
+ * can drive it with narrow deps. v1 re-applies the template's image only —
+ * template env/mounts stay frozen at create time by design (re-flowing them
+ * risks clobbering user edits / immutable volumeClaimTemplates).
+ */
+export function executeTemplateUpgrade(deps: {
+  owner: string | undefined;
+  getAgent: (id: string) => Promise<InfraAgent | null>;
+  readTemplateSpec: (
+    id: string,
+  ) => Promise<{ spec: TemplateSpec; isOwned: boolean } | null>;
+  patchImage: (id: string, image: string) => Promise<InfraAgent | null>;
+}) {
+  return async (
+    id: string,
+  ): Promise<
+    { ok: true; value: InfraAgent } | { ok: false; error: UpgradeAgentError }
+  > => {
+    const infra = await deps.getAgent(id);
+    if (!infra) return err({ type: "AgentNotFound" as const });
+    if (!infra.templateId) return err({ type: "TemplateNotFound" as const });
+    const tmpl = await deps.readTemplateSpec(infra.templateId);
+    if (!tmpl) return err({ type: "TemplateNotFound" as const });
+
+    const update = templateImageUpdate(infra.spec.image, tmpl.spec.image);
+    // Already current — idempotent success, no patch, no pod roll.
+    if (!update) return ok(infra);
+
+    const patched = await deps.patchImage(id, update.toImage);
+    if (!patched) return err({ type: "AgentNotFound" as const });
+    // Swaps what code the pod runs — record the exact image movement.
+    securityLog("info", "agent.upgrade", {
+      category: "resource",
+      actor: deps.owner ?? null,
+      actorKind: "user",
+      agentId: id,
+      result: "success",
+      detail: {
+        templateId: infra.templateId,
+        fromImage: update.fromImage,
+        toImage: update.toImage,
+      },
+    });
+    return ok(patched);
+  };
+}
+
+/**
  * Cleanup hook invoked after a successful K8s ConfigMap delete. Each
  * registered hook clears its module's per-agent durable state — egress
  * rules, pending approvals, anything else keyed by `agent_id` in
@@ -524,15 +575,28 @@ export function createAgentsService(deps: {
     }
   }
 
+  // Behind-the-template check (#1077): compares the create-time image capture
+  // against the boot-loaded template. Memory-backed, so fine on every read.
+  async function templateUpdateFor(
+    infra: InfraAgent,
+  ): Promise<TemplateUpdate | undefined> {
+    if (!infra.templateId) return undefined;
+    const tmpl = await deps.readTemplateSpec(infra.templateId);
+    if (!tmpl) return undefined;
+    return templateImageUpdate(infra.spec.image, tmpl.spec.image);
+  }
+
   async function project(
     infra: InfraAgent,
   ): Promise<ReturnType<typeof assembleAgent>> {
-    const [channels, allowedSubs, status, userEnv] = await Promise.all([
-      deps.listChannelsByAgent(infra.id),
-      deps.listAllowedUsersByAgent(infra.id),
-      safeStatus(infra.id),
-      deps.agentEnvRepo.list(infra.id),
-    ]);
+    const [channels, allowedSubs, status, userEnv, templateUpdate] =
+      await Promise.all([
+        deps.listChannelsByAgent(infra.id),
+        deps.listAllowedUsersByAgent(infra.id),
+        safeStatus(infra.id),
+        deps.agentEnvRepo.list(infra.id),
+        templateUpdateFor(infra),
+      ]);
     const emails = await subsToEmails(allowedSubs);
     return assembleAgent(
       withUserEnv(infra, userEnv),
@@ -541,6 +605,7 @@ export function createAgentsService(deps: {
       status.failures,
       deps.agentIdleTimeoutMinutes,
       status.preparingWorkspace,
+      templateUpdate,
     );
   }
 
@@ -652,6 +717,7 @@ export function createAgentsService(deps: {
         status.failures,
         deps.agentIdleTimeoutMinutes,
         status.preparingWorkspace,
+        await templateUpdateFor(infra),
       ),
     );
   };
@@ -701,10 +767,26 @@ export function createAgentsService(deps: {
         deps.agentEnvRepo.listMany([...infraIds]),
       ]);
 
+      // One template lookup per distinct id; agents from the same template
+      // share the resolved image for the behind-the-template check (#1077).
+      const templateIds = [
+        ...new Set(infraAgents.flatMap((a) => a.templateId ?? [])),
+      ];
+      const templateImages = new Map<string, string>();
+      await Promise.all(
+        templateIds.map(async (tid) => {
+          const tmpl = await deps.readTemplateSpec(tid);
+          if (tmpl) templateImages.set(tid, tmpl.spec.image);
+        }),
+      );
+
       return infraAgents.map((infra) => {
         const subs = allowedUsersMap.get(infra.id) ?? [];
         const emails = subs.map((s) => subEmailMap.get(s) ?? s);
         const status = failuresMap.get(infra.id);
+        const templateImage = infra.templateId
+          ? templateImages.get(infra.templateId)
+          : undefined;
         return assembleAgent(
           withUserEnv(infra, envMap.get(infra.id) ?? []),
           channelMap.get(infra.id) ?? [],
@@ -712,6 +794,9 @@ export function createAgentsService(deps: {
           status?.failures ?? [],
           deps.agentIdleTimeoutMinutes,
           status?.preparingWorkspace ?? false,
+          templateImage
+            ? templateImageUpdate(infra.spec.image, templateImage)
+            : undefined,
         );
       });
     },
@@ -1179,6 +1264,19 @@ export function createAgentsService(deps: {
         result: "success",
       });
       return project(infra);
+    },
+
+    async upgrade(id) {
+      const result = await executeTemplateUpgrade({
+        owner: deps.owner,
+        getAgent: (agentId) => deps.repo.get(agentId, deps.owner),
+        readTemplateSpec: deps.readTemplateSpec,
+        patchImage: (agentId, image) =>
+          deps.repo.updateSpec(agentId, deps.owner, { image }),
+      })(id);
+      if (!result.ok) return result;
+      emit({ type: EventType.AgentUpdated, agentId: id });
+      return ok(await project(result.value));
     },
 
     async ensureReady(id, opts) {

--- a/packages/ui/src/__tests__/unit/agent-resolver.test.ts
+++ b/packages/ui/src/__tests__/unit/agent-resolver.test.ts
@@ -11,6 +11,7 @@ const agent = (id: string, state: AgentView["state"]): AgentView => ({
   id,
   name: id,
   templateId: null,
+  templateUpdate: null,
   image: "x:latest",
   hibernationTimeoutMin: 60,
   grantedSecretIds: [],

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -196,8 +196,8 @@ export function useRestartAgentMutation() {
   });
 }
 
-// Upgrading rolls a running pod onto the new image, so it moves Reserved
-// like a restart does.
+// Upgrading rolls a running pod onto the new image — refresh the budget
+// meter alongside, like the other lifecycle mutations.
 export function useUpgradeAgentMutation() {
   return useMutation({
     ...trpc.agents.upgrade.mutationOptions(),

--- a/packages/ui/src/modules/agents/api/mutations.ts
+++ b/packages/ui/src/modules/agents/api/mutations.ts
@@ -196,6 +196,18 @@ export function useRestartAgentMutation() {
   });
 }
 
+// Upgrading rolls a running pod onto the new image, so it moves Reserved
+// like a restart does.
+export function useUpgradeAgentMutation() {
+  return useMutation({
+    ...trpc.agents.upgrade.mutationOptions(),
+    meta: {
+      ...invalidatesAgentsAndBudget,
+      errorToast: "Failed to upgrade sandbox",
+    },
+  });
+}
+
 export function useConnectSlack() {
   return useMutation({
     ...trpc.agents.connectSlack.mutationOptions(),

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -1,5 +1,6 @@
 import { OverflowMenuVertical } from "@carbon/icons-react";
 
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
@@ -74,6 +75,15 @@ export function SandboxHomeHeader({ agent, display }: Props) {
           {agent.name}
         </h1>
         <StatusBadge state={display.state} />
+        {agent.templateUpdate && (
+          <Badge
+            variant="info"
+            className="shrink-0"
+            title={`Template update available: ${agent.templateUpdate.toImage}`}
+          >
+            Update available
+          </Badge>
+        )}
       </div>
       <div className="flex shrink-0 items-center gap-2">
         <OpenInMenu agent={agent} />

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -77,7 +77,7 @@ export function SandboxHomeHeader({ agent, display }: Props) {
         <StatusBadge state={display.state} />
         {agent.templateUpdate && (
           <Badge
-            variant="info"
+            variant="accent"
             className="shrink-0"
             title={`Template update available: ${agent.templateUpdate.toImage}`}
           >

--- a/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
@@ -12,6 +12,7 @@ import type { useSandboxSettingsForm } from "../hooks/use-sandbox-settings-form.
 import { HibernationTimeoutField } from "./hibernation-timeout-field.js";
 import { SandboxModelSettings } from "./sandbox-model-settings.js";
 import { SandboxSizeSection } from "./sandbox-size-section.js";
+import { TemplateUpdateNotice } from "./template-update-notice.js";
 
 const READ_ONLY_FIELD =
   "flex h-10 w-full items-center rounded-md border border-input bg-muted/40 px-4 text-sm text-muted-foreground";
@@ -49,7 +50,8 @@ export function SandboxSetupSection({ f }: Props) {
 
       <section className="mb-8">
         {/* Read-only: image/template are create-only — changing them would mean
-            delete+recreate, destroying the workspace PVC. */}
+            delete+recreate, destroying the workspace PVC. The one sanctioned
+            move is the template-upgrade path below (#1077). */}
         <FormField
           label="Image"
           hint={
@@ -64,6 +66,7 @@ export function SandboxSetupSection({ f }: Props) {
             </span>
           </div>
         </FormField>
+        <TemplateUpdateNotice agent={agent} />
       </section>
 
       <section className="mb-8">

--- a/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
+++ b/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
@@ -33,7 +33,9 @@ export function TemplateUpdateNotice({ agent }: Props) {
       </>
     );
     if (!(await showConfirm(msg, "Upgrade Sandbox"))) return;
-    upgrade.mutate({ id: agent.id });
+    // expectedToImage binds the confirmation to the diff shown above: if the
+    // template moves meanwhile, the server rejects instead of surprising.
+    upgrade.mutate({ id: agent.id, expectedToImage: update.toImage });
   };
 
   return (

--- a/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
+++ b/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
@@ -1,0 +1,56 @@
+import { Button } from "@/components/ui/button";
+
+import { useStore } from "../../../store.js";
+import type { AgentView } from "../../../types.js";
+import { useUpgradeAgentMutation } from "../../agents/api/mutations.js";
+
+interface Props {
+  agent: AgentView;
+}
+
+/** "Update available" banner under the Image field (#1077): the sandbox's
+ *  template now ships a different image than the one captured at create. */
+export function TemplateUpdateNotice({ agent }: Props) {
+  const showConfirm = useStore((s) => s.showConfirm);
+  const upgrade = useUpgradeAgentMutation();
+  const update = agent.templateUpdate;
+  if (!update) return null;
+
+  // Mirrors sizeRestartsAgent: only a sandbox that's down applies lazily.
+  const restartsOnUpgrade = !(agent.state === "hibernated" || agent.overBudget);
+
+  const onUpgrade = async () => {
+    const msg = (
+      <>
+        Upgrade sandbox{" "}
+        <strong className="text-foreground">"{agent.name}"</strong> to its
+        template's current version? The image moves from{" "}
+        <span className="font-mono text-[12px]">{update.fromImage}</span> to{" "}
+        <span className="font-mono text-[12px]">{update.toImage}</span>.{" "}
+        {restartsOnUpgrade
+          ? "The sandbox restarts to apply it — in-flight work is interrupted."
+          : "It applies when the sandbox next starts."}
+      </>
+    );
+    if (!(await showConfirm(msg, "Upgrade Sandbox"))) return;
+    upgrade.mutate({ id: agent.id });
+  };
+
+  return (
+    <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-info/30 bg-info-light px-3 py-2">
+      <span className="min-w-0 text-[12px] text-info">
+        Update available — the template now ships{" "}
+        <span className="break-all font-mono">{update.toImage}</span>
+      </span>
+      <Button
+        variant="outline"
+        size="sm"
+        className="shrink-0"
+        disabled={upgrade.isPending}
+        onClick={() => void onUpgrade()}
+      >
+        {upgrade.isPending ? "Upgrading…" : "Upgrade"}
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
+++ b/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { Inset } from "@/components/ui/inset";
 
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
@@ -39,20 +40,27 @@ export function TemplateUpdateNotice({ agent }: Props) {
   };
 
   return (
-    <div className="mt-2 flex items-center justify-between gap-3 rounded-md border border-info/30 bg-info-light px-3 py-2">
-      <span className="min-w-0 text-[12px] text-info">
-        Update available — the template now ships{" "}
-        <span className="break-all font-mono">{update.toImage}</span>
-      </span>
-      <Button
-        variant="outline"
-        size="sm"
-        className="shrink-0"
-        disabled={upgrade.isPending}
-        onClick={() => void onUpgrade()}
-      >
-        {upgrade.isPending ? "Upgrading…" : "Upgrade"}
-      </Button>
-    </div>
+    <Inset className="mt-3">
+      <div className="flex flex-wrap items-center gap-x-10 gap-y-1.5 rounded-md border border-border bg-muted/40 px-3.5 py-2.5">
+        <p className="min-w-0 flex-1 basis-[280px] text-[13px] leading-relaxed text-muted-foreground">
+          <strong className="font-medium text-foreground/80">
+            Update available.
+          </strong>{" "}
+          The template now ships{" "}
+          <span className="break-all font-mono text-[12px] text-foreground">
+            {update.toImage}
+          </span>
+        </p>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="shrink-0 font-medium text-accent hover:bg-accent-light hover:text-accent-hover"
+          disabled={upgrade.isPending}
+          onClick={() => void onUpgrade()}
+        >
+          {upgrade.isPending ? "Upgrading…" : "Upgrade"}
+        </Button>
+      </div>
+    </Inset>
   );
 }

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -119,6 +119,9 @@ export interface AgentView {
   id: string;
   name: string;
   templateId: string | null;
+  /** Present when the sandbox is behind its template (#1077): the template
+   *  now ships a different image than the one captured at create time. */
+  templateUpdate: { fromImage: string; toImage: string } | null;
   image: string;
   description?: string;
   env?: EnvVar[];


### PR DESCRIPTION
Part of #1077 (v1: detection + manual per-agent upgrade).

## What

When an agent's template moves on (a helm upgrade shipping a newer agent image), existing agents keep the image they captured at create time — invisibly and, until now, unfixably. This PR adds:

- **Detection**: every agent read compares the captured `spec.image` against the current template's image (templates are boot-loaded, so it's a memory lookup; `list()` resolves each distinct template once). Surfaced as `templateUpdate: { fromImage, toImage }` on the agent projection.
- **`agents.upgrade` mutation**: re-points `spec.image` at the template's current image via merge-patch. The reconciler rolls a running pair onto the new image; a hibernated agent picks it up on next wake. Idempotent when current; typed `AgentNotFound` / `TemplateNotFound` / `TemplateMoved` errors.
- **Binding consent**: the mutation carries `expectedToImage` — the server compare-and-swaps against the template's current image and rejects with `CONFLICT` if the template moved after the user reviewed the diff.
- **UI**: "Update available" badge on the sandbox header; banner under the Image field showing the incoming image, with a confirm dialog spelling out the exact from→to movement and the restart consequence.

The image ref doubles as the template's version identity: templates render `repository:tag` with the tag defaulting to the chart appVersion, so any create-time capture that differs from the current template means the template advanced. (Pinning a template's `tag` across releases opts it out of detection — documented in `values.yaml`.)

## Deliberately image-only (v1)

- Template env stays frozen in `agent_env` — re-seeding would clobber user edits.
- Mount/storage changes can't ride a spec patch (immutable StatefulSet volume layout) — those still mean recreate.
- No bulk upgrade, no automatic upgrade. Semver-gated auto-upgrade for patch versions is the planned follow-up per the issue's edit.

## Verification

- `mise run check` green; 11 new unit tests on the compare + upgrade flow (idempotency, not-found paths, compare-and-swap mismatch); all package suites pass.
- K8s leg driven live on a cluster: merge-patched `spec.image` on a running Agent CR (the exact operation the endpoint issues) → controller rolled the pod onto the new image and republished `Ready/AllPodsReady` in ~20s.
- Architecture page `docs/architecture/agent-lifecycle.md` updated in the same PR (drift rule).

## Not covered

- e2e Playwright spec for badge → upgrade → cleared (needs mock-template mutation plumbing; follow-up together with semver auto-upgrade).