### PR TITLE
fix(skills): clear "grant access" message for failed private-source scans

### DIFF
--- a/packages/agent-runtime-api/src/modules/skills/router.ts
+++ b/packages/agent-runtime-api/src/modules/skills/router.ts
@@ -45,6 +45,21 @@ function toTrpcError(error: SkillsDomainError): TRPCError {
         message: `github ${error.method} ${error.path} → ${error.status}: ${error.body.message ?? error.body.error ?? "upstream error"}`,
         cause: { upstream: { status: error.status, body: error.body } },
       });
+    // status 0 = no HTTP response ever arrived (XHR convention). Carried as a
+    // structured envelope so the api-server can tell "the pod couldn't reach
+    // GitHub" apart from its own transport failures without sniffing message
+    // strings.
+    case "UpstreamUnreachable":
+      return new TRPCError({
+        code: "BAD_GATEWAY",
+        message: `github ${error.method} ${error.path} unreachable: ${error.detail}`,
+        cause: {
+          upstream: {
+            status: 0,
+            body: { error: "upstream_unreachable", message: error.detail },
+          },
+        },
+      });
   }
 }
 

--- a/packages/agent-runtime-api/src/modules/skills/types.ts
+++ b/packages/agent-runtime-api/src/modules/skills/types.ts
@@ -68,6 +68,15 @@ export type SkillsDomainError =
       path: string;
       status: number;
       body: GitHubErrorBody;
+    }
+  /** The request to GitHub never produced an HTTP response — the pod's only
+   *  route there is the paired gateway, so this means egress was denied or
+   *  the gateway is down, never a GitHub-side verdict. */
+  | {
+      kind: "UpstreamUnreachable";
+      method: string;
+      path: string;
+      detail: string;
     };
 
 export interface SkillsService {

--- a/packages/agent-runtime/src/__tests__/unit/github-rest-client.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/github-rest-client.test.ts
@@ -5,8 +5,13 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("createGitHubRestClient — transport failures", () => {
-  it("returns UpstreamUnreachable when fetch throws (JSON endpoint)", async () => {
+describe("createGitHubRestClient", () => {
+  // Pins the pod-side half of the unreachable-GitHub contract: a transport
+  // throw never escapes raw — it becomes the structured domain error the
+  // api-server's grant-access classification keys on. Without this, dropping
+  // the catch would silently regress egress-blocked scans to a raw
+  // "fetch failed" (#2836).
+  it("returns UpstreamUnreachable with the cause chain when fetch throws", async () => {
     const cause = new Error("Connect Timeout Error");
     vi.stubGlobal(
       "fetch",
@@ -25,21 +30,5 @@ describe("createGitHubRestClient — transport failures", () => {
         detail: "fetch failed: Connect Timeout Error",
       },
     });
-  });
-
-  it("returns UpstreamUnreachable when fetch throws (bytes endpoint)", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn().mockRejectedValue(new TypeError("fetch failed")),
-    );
-    const res = await createGitHubRestClient().fetchTarball(
-      { owner: "acme", repo: "private" },
-      "abc123",
-    );
-    expect(res.ok).toBe(false);
-    if (!res.ok) {
-      expect(res.error.kind).toBe("UpstreamUnreachable");
-      expect(res.error).toMatchObject({ detail: "fetch failed" });
-    }
   });
 });

--- a/packages/agent-runtime/src/__tests__/unit/github-rest-client.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/github-rest-client.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createGitHubRestClient } from "../../modules/skills/infrastructure/github-rest-client.js";
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createGitHubRestClient — transport failures", () => {
+  it("returns UpstreamUnreachable when fetch throws (JSON endpoint)", async () => {
+    const cause = new Error("Connect Timeout Error");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("fetch failed", { cause })),
+    );
+    const res = await createGitHubRestClient().getCommitHead({
+      owner: "acme",
+      repo: "private",
+    });
+    expect(res).toEqual({
+      ok: false,
+      error: {
+        kind: "UpstreamUnreachable",
+        method: "GET",
+        path: "/repos/acme/private/commits/HEAD",
+        detail: "fetch failed: Connect Timeout Error",
+      },
+    });
+  });
+
+  it("returns UpstreamUnreachable when fetch throws (bytes endpoint)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockRejectedValue(new TypeError("fetch failed")),
+    );
+    const res = await createGitHubRestClient().fetchTarball(
+      { owner: "acme", repo: "private" },
+      "abc123",
+    );
+    expect(res.ok).toBe(false);
+    if (!res.ok) {
+      expect(res.error.kind).toBe("UpstreamUnreachable");
+      expect(res.error).toMatchObject({ detail: "fetch failed" });
+    }
+  });
+});

--- a/packages/agent-runtime/src/modules/skills/infrastructure/github-rest-client.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/github-rest-client.ts
@@ -222,22 +222,26 @@ async function ghJson<T>(
   opts: GithubFetchOpts = {},
 ): Promise<Result<T, SkillsDomainError>> {
   const withAuth = opts.withAuth ?? true;
-  const res = await fetch(`${GITHUB_API}${endpoint}`, {
-    method,
-    headers: ghHeaders(withAuth, body !== undefined),
-    body: body !== undefined ? JSON.stringify(body) : undefined,
-  });
-  const text = await res.text();
-  let parsed: unknown = null;
   try {
-    parsed = text ? JSON.parse(text) : null;
-  } catch {
-    parsed = text;
+    const res = await fetch(`${GITHUB_API}${endpoint}`, {
+      method,
+      headers: ghHeaders(withAuth, body !== undefined),
+      body: body !== undefined ? JSON.stringify(body) : undefined,
+    });
+    const text = await res.text();
+    let parsed: unknown = null;
+    try {
+      parsed = text ? JSON.parse(text) : null;
+    } catch {
+      parsed = text;
+    }
+    if (!res.ok) {
+      return err(toUpstreamError(method, endpoint, res.status, parsed));
+    }
+    return ok(parsed as T);
+  } catch (e) {
+    return err(toUnreachableError(method, endpoint, e));
   }
-  if (!res.ok) {
-    return err(toUpstreamError(method, endpoint, res.status, parsed));
-  }
-  return ok(parsed as T);
 }
 
 async function ghBytes(
@@ -246,21 +250,43 @@ async function ghBytes(
   opts: GithubFetchOpts = {},
 ): Promise<Result<Uint8Array, SkillsDomainError>> {
   const withAuth = opts.withAuth ?? true;
-  const res = await fetch(`${GITHUB_API}${endpoint}`, {
-    method,
-    headers: ghHeaders(withAuth, false),
-  });
-  if (!res.ok) {
-    let parsed: unknown = null;
-    const text = await res.text().catch(() => "");
-    try {
-      parsed = text ? JSON.parse(text) : text;
-    } catch {
-      parsed = text;
+  try {
+    const res = await fetch(`${GITHUB_API}${endpoint}`, {
+      method,
+      headers: ghHeaders(withAuth, false),
+    });
+    if (!res.ok) {
+      let parsed: unknown = null;
+      const text = await res.text().catch(() => "");
+      try {
+        parsed = text ? JSON.parse(text) : text;
+      } catch {
+        parsed = text;
+      }
+      return err(toUpstreamError(method, endpoint, res.status, parsed));
     }
-    return err(toUpstreamError(method, endpoint, res.status, parsed));
+    return ok(new Uint8Array(await res.arrayBuffer()));
+  } catch (e) {
+    return err(toUnreachableError(method, endpoint, e));
   }
-  return ok(new Uint8Array(await res.arrayBuffer()));
+}
+
+/** A throw from fetch (or a mid-body read) means the request died in
+ *  transit — undici reports it as `TypeError: fetch failed` with the real
+ *  reason (connect/headers timeout, reset) on `cause`. Both hops of that
+ *  cause chain go into `detail` for diagnosability. */
+function toUnreachableError(
+  method: string,
+  path: string,
+  e: unknown,
+): SkillsDomainError {
+  const detail =
+    e instanceof Error
+      ? e.cause instanceof Error
+        ? `${e.message}: ${e.cause.message}`
+        : e.message
+      : String(e);
+  return { kind: "UpstreamUnreachable", method, path, detail };
 }
 
 function toUpstreamError(

--- a/packages/api-server/src/__tests__/unit/skills-scan-errors.test.ts
+++ b/packages/api-server/src/__tests__/unit/skills-scan-errors.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import {
+  AgentRuntimeUnreachableError,
+  AgentRuntimeUpstreamError,
+} from "../../modules/skills/infrastructure/agent-runtime-client.js";
+import {
+  privateScanErrorToTrpc,
+  SCAN_ACCESS_MESSAGE,
+} from "../../modules/skills/infrastructure/upstream-to-trpc.js";
+
+function upstream(status: number, body?: Record<string, string>) {
+  return new AgentRuntimeUpstreamError("agent-runtime scan a: boom", {
+    status,
+    ...(body !== undefined ? { body } : {}),
+  });
+}
+
+describe("privateScanErrorToTrpc", () => {
+  it.each([
+    ["404 (ungranted or nonexistent repo)", upstream(404)],
+    ["401 (no connection — sentinel reached GitHub unswapped)", upstream(401)],
+    [
+      "upstream_unreachable (pod couldn't reach GitHub)",
+      upstream(0, { error: "upstream_unreachable", message: "fetch failed" }),
+    ],
+  ])("maps %s to the hedged grant-access FORBIDDEN", (_label, err) => {
+    const trpc = privateScanErrorToTrpc(err);
+    expect(trpc?.code).toBe("FORBIDDEN");
+    expect(trpc?.message).toBe(SCAN_ACCESS_MESSAGE);
+  });
+
+  it("keeps other upstream statuses on the upstreamToTrpc translation", () => {
+    const trpc = privateScanErrorToTrpc(
+      upstream(403, { message: "scope missing" }),
+    );
+    expect(trpc?.code).toBe("FORBIDDEN");
+    expect(trpc?.message).toMatch(/Reconnect GitHub/);
+  });
+
+  it("maps a pod that never answered to a retryable error, not grant-access", () => {
+    const trpc = privateScanErrorToTrpc(
+      new AgentRuntimeUnreachableError("agent-runtime scan a: fetch failed"),
+    );
+    expect(trpc?.code).toBe("INTERNAL_SERVER_ERROR");
+    expect(trpc?.message).not.toBe(SCAN_ACCESS_MESSAGE);
+    expect(trpc?.message).toMatch(/re-scan/);
+  });
+
+  it("declines errors it doesn't own so callers rethrow them raw", () => {
+    expect(privateScanErrorToTrpc(new Error("fetch failed"))).toBeNull();
+  });
+});

--- a/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/agent-runtime-client.ts
@@ -51,6 +51,17 @@ export class AgentRuntimeUpstreamError extends Error {
   }
 }
 
+/** The api-server → pod hop itself failed: no tRPC response ever arrived
+ *  (pod restarting, mesh outage). Distinct from errors the pod *returned* —
+ *  a transport failure inside the pod (e.g. GitHub egress blocked) comes
+ *  back as a structured `upstream_unreachable` envelope, never as this. */
+export class AgentRuntimeUnreachableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "AgentRuntimeUnreachableError";
+  }
+}
+
 // Auth on the api-server → agent-runtime hop is enforced at the kernel by
 // the agent pod's NetworkPolicy (ingress admitted only from the api-server
 // pod). No Bearer header is sent.
@@ -76,8 +87,10 @@ function isUpstreamGatewayError(value: unknown): value is UpstreamGatewayError {
 /**
  * Run a tRPC call and translate `data.upstream` (set by agent-runtime's
  * errorFormatter for upstream gateway errors) into an
- * AgentRuntimeUpstreamError so callers can extract the CTA URL. Other tRPC
- * errors propagate as plain Error.
+ * AgentRuntimeUpstreamError so callers can extract the CTA URL. A response
+ * with no `data` at all means the pod never answered — the error envelope is
+ * built server-side, so its absence is a transport failure on this hop, not
+ * something the pod threw. Other tRPC errors propagate as plain Error.
  */
 async function runWithUpstreamMapping<T>(
   label: string,
@@ -88,7 +101,10 @@ async function runWithUpstreamMapping<T>(
   } catch (e) {
     if (e instanceof TRPCClientError) {
       const data = (e.data as { upstream?: unknown } | null) ?? null;
-      const upstream = data?.upstream;
+      if (data === null) {
+        throw new AgentRuntimeUnreachableError(`${label}: ${e.message}`);
+      }
+      const upstream = data.upstream;
       if (isUpstreamGatewayError(upstream)) {
         throw new AgentRuntimeUpstreamError(`${label}: ${e.message}`, upstream);
       }

--- a/packages/api-server/src/modules/skills/infrastructure/upstream-to-trpc.ts
+++ b/packages/api-server/src/modules/skills/infrastructure/upstream-to-trpc.ts
@@ -1,5 +1,9 @@
 import { TRPCError } from "@trpc/server";
-import { AgentRuntimeUpstreamError } from "./agent-runtime-client.js";
+import {
+  AgentRuntimeUnreachableError,
+  AgentRuntimeUpstreamError,
+  type UpstreamGatewayError,
+} from "./agent-runtime-client.js";
 
 /**
  * Translate a structured upstream error (relayed by agent-runtime as HTTP
@@ -24,6 +28,12 @@ export function upstreamToTrpc(err: AgentRuntimeUpstreamError): TRPCError {
   ) {
     return new TRPCError({ code: "PRECONDITION_FAILED", message: encoded });
   }
+  if (isUnreachableUpstream(err.upstream)) {
+    return new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message: `GitHub is unreachable from the agent (${message}); try again in a moment.`,
+    });
+  }
   if (status === 403) {
     return new TRPCError({
       code: "FORBIDDEN",
@@ -37,4 +47,57 @@ export function upstreamToTrpc(err: AgentRuntimeUpstreamError): TRPCError {
     code: "INTERNAL_SERVER_ERROR",
     message: `GitHub ${status}: ${message}`,
   });
+}
+
+/** All private-scan failure shapes that mean "the connection can't reach the
+ *  repo" to the user. Hedged because a 404 can't distinguish "private,
+ *  ungranted" from "doesn't exist". */
+export const SCAN_ACCESS_MESSAGE =
+  "Can't access this repository. If it's private, grant your GitHub connection access to it, " +
+  "then re-scan — otherwise, double-check the repo URL.";
+
+/** agent-runtime relays this envelope (status 0, no HTTP response) when the
+ *  pod's request to GitHub died in transit — egress denied at the gateway or
+ *  the gateway down. Never produced by GitHub itself. */
+function isUnreachableUpstream(u: UpstreamGatewayError): boolean {
+  return u.status === 0 || u.body?.error === "upstream_unreachable";
+}
+
+/**
+ * Translate a private-scan failure from the agent-runtime client into the
+ * tRPC error the catalog UI renders, or return null for errors this flow
+ * doesn't own (the caller rethrows those raw so genuine bugs stay visible).
+ *
+ * The "can't reach the repo" family — one hedged FORBIDDEN whose message the
+ * UI pairs with a Manage-connections affordance:
+ * - 404: egress reached GitHub but the repo isn't in the connection's grant
+ *   (or doesn't exist).
+ * - 401: the injected credential is invalid — no GitHub connection for this
+ *   agent (the sentinel bearer reached GitHub unswapped) or a revoked token.
+ * - `upstream_unreachable`: the pod couldn't reach GitHub at all.
+ *
+ * A pod that never answered (AgentRuntimeUnreachableError) is deliberately
+ * NOT in that family: GitHub was never involved, so it maps to a plain
+ * retryable error instead of a misleading "grant access" CTA.
+ */
+export function privateScanErrorToTrpc(err: unknown): TRPCError | null {
+  if (err instanceof AgentRuntimeUpstreamError) {
+    const { status } = err.upstream;
+    if (
+      status === 404 ||
+      status === 401 ||
+      isUnreachableUpstream(err.upstream)
+    ) {
+      return new TRPCError({ code: "FORBIDDEN", message: SCAN_ACCESS_MESSAGE });
+    }
+    return upstreamToTrpc(err);
+  }
+  if (err instanceof AgentRuntimeUnreachableError) {
+    return new TRPCError({
+      code: "INTERNAL_SERVER_ERROR",
+      message:
+        "The agent couldn't be reached to scan this source; try re-scanning in a moment.",
+    });
+  }
+  return null;
 }

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -50,6 +50,28 @@ export function templateSourceId(templateId: string, gitUrl: string): string {
 
 export const TEMPLATE_SOURCE_ID_PREFIX = "template:";
 
+/** Both real private-scan failure shapes — a bare GitHub 404 (repo not in the
+ *  connection's grant, or a typo) and a transport-level throw (egress rejected
+ *  at the gateway, no HTTP response) — mean the same thing to the user: the
+ *  connection can't reach the repo. Hedged because a 404 can't distinguish
+ *  "private, ungranted" from "doesn't exist". */
+const SCAN_ACCESS_MESSAGE =
+  "Can't access this repository. If it's private, grant your GitHub connection access to it, " +
+  "then re-scan — otherwise, double-check the repo URL.";
+
+function scanAccessError(): TRPCError {
+  return new TRPCError({ code: "FORBIDDEN", message: SCAN_ACCESS_MESSAGE });
+}
+
+/** A private-scan failure that arrived as a plain Error (not a structured
+ *  upstream envelope) is only the "can't reach the repo" case when it carries a
+ *  transport signature. Anything else rethrows raw so genuine bugs stay
+ *  visible rather than being masked by the friendly message. */
+function isTransportError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  return /fetch failed|econn|socket|network/i.test(err.message);
+}
+
 export interface SkillsServiceDeps {
   repo: SkillsRepository;
   agentSkillsRepo: AgentSkillsRepository;
@@ -354,7 +376,16 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
           deps.runtimeClient.scan(agentId, gitUrl, src.path),
         );
       } catch (err) {
-        if (err instanceof AgentRuntimeUpstreamError) throw upstreamToTrpc(err);
+        // A bare 404 means egress reached GitHub but the repo isn't in the
+        // connection's grant (or doesn't exist) — a "grant access" case, not
+        // the raw "GitHub: Not Found" upstreamToTrpc would produce. Every
+        // other upstream status (403 scope message, 5xx, structured body)
+        // keeps its existing translation.
+        if (err instanceof AgentRuntimeUpstreamError) {
+          if (err.upstream.status === 404) throw scanAccessError();
+          throw upstreamToTrpc(err);
+        }
+        if (isTransportError(err)) throw scanAccessError();
         throw err;
       }
     },

--- a/packages/api-server/src/modules/skills/services/skills-service.ts
+++ b/packages/api-server/src/modules/skills/services/skills-service.ts
@@ -25,16 +25,13 @@ import type { SkillSourceSeed } from "../infrastructure/seed-sources.js";
 import { seedToSkillSource } from "../infrastructure/seed-sources.js";
 import { securityLog } from "../../../core/security-log.js";
 import { isUniqueViolation } from "../../../core/db-errors.js";
-import {
-  AgentRuntimeUpstreamError,
-  type AgentRuntimeSkillsClient,
-} from "../infrastructure/agent-runtime-client.js";
+import type { AgentRuntimeSkillsClient } from "../infrastructure/agent-runtime-client.js";
 import type { RuntimeMutator } from "../../runtime-delivery/index.js";
 import { detectHost } from "../infrastructure/git-host.js";
 import { PublicArchiveNotFoundError } from "../infrastructure/public-archive-scanner.js";
 import { publishSkill as runPublishSkill } from "./publish-service.js";
 import { ensureAgentReachable } from "./ensure-agent-reachable.js";
-import { upstreamToTrpc } from "../infrastructure/upstream-to-trpc.js";
+import { privateScanErrorToTrpc } from "../infrastructure/upstream-to-trpc.js";
 
 /** Stable, deterministic id for a template-derived source row. The hash
  *  prefix keeps the id compact while avoiding collisions when a template
@@ -49,28 +46,6 @@ export function templateSourceId(templateId: string, gitUrl: string): string {
 }
 
 export const TEMPLATE_SOURCE_ID_PREFIX = "template:";
-
-/** Both real private-scan failure shapes — a bare GitHub 404 (repo not in the
- *  connection's grant, or a typo) and a transport-level throw (egress rejected
- *  at the gateway, no HTTP response) — mean the same thing to the user: the
- *  connection can't reach the repo. Hedged because a 404 can't distinguish
- *  "private, ungranted" from "doesn't exist". */
-const SCAN_ACCESS_MESSAGE =
-  "Can't access this repository. If it's private, grant your GitHub connection access to it, " +
-  "then re-scan — otherwise, double-check the repo URL.";
-
-function scanAccessError(): TRPCError {
-  return new TRPCError({ code: "FORBIDDEN", message: SCAN_ACCESS_MESSAGE });
-}
-
-/** A private-scan failure that arrived as a plain Error (not a structured
- *  upstream envelope) is only the "can't reach the repo" case when it carries a
- *  transport signature. Anything else rethrows raw so genuine bugs stay
- *  visible rather than being masked by the friendly message. */
-function isTransportError(err: unknown): boolean {
-  if (!(err instanceof Error)) return false;
-  return /fetch failed|econn|socket|network/i.test(err.message);
-}
 
 export interface SkillsServiceDeps {
   repo: SkillsRepository;
@@ -376,17 +351,7 @@ export function createSkillsService(deps: SkillsServiceDeps): SkillsService {
           deps.runtimeClient.scan(agentId, gitUrl, src.path),
         );
       } catch (err) {
-        // A bare 404 means egress reached GitHub but the repo isn't in the
-        // connection's grant (or doesn't exist) — a "grant access" case, not
-        // the raw "GitHub: Not Found" upstreamToTrpc would produce. Every
-        // other upstream status (403 scope message, 5xx, structured body)
-        // keeps its existing translation.
-        if (err instanceof AgentRuntimeUpstreamError) {
-          if (err.upstream.status === 404) throw scanAccessError();
-          throw upstreamToTrpc(err);
-        }
-        if (isTransportError(err)) throw scanAccessError();
-        throw err;
+        throw privateScanErrorToTrpc(err) ?? err;
       }
     },
 

--- a/packages/cli/src/modules/skill/services/skills-service.ts
+++ b/packages/cli/src/modules/skill/services/skills-service.ts
@@ -264,6 +264,16 @@ export function createSkillsService(deps: { trpc: TrpcClient }): SkillsService {
             .trim();
           return err({ kind: "source-needs-connection", message, cta });
         }
+        // A FORBIDDEN carries no cta (the server owns only the message): the
+        // "grant access, then re-scan" scan failure and the pre-existing
+        // "reconnect with the repo scope" 403 both land here — surface the
+        // server message verbatim as the same actionable output (exit 2).
+        if ((e as { data?: { code?: string } })?.data?.code === "FORBIDDEN") {
+          return err({
+            kind: "source-needs-connection",
+            message: e instanceof Error ? e.message : String(e),
+          });
+        }
         return classifyWakeError(e);
       }
     },

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
@@ -30,13 +30,21 @@ function repoLabel(source: SkillSource): string {
 
 /** Splits a scan/publish error into its message and an optional call-to-action
  *  URL, which the services encode as `\nplatform-cta:<url>` (not connected /
- *  access not granted / repo not allow-listed). */
-function SourceError({ error }: { error: string }) {
+ *  access not granted / repo not allow-listed). When there's no server CTA, an
+ *  errored source with sandbox context gets a client-built "Manage connections"
+ *  affordance instead — the server owns only the message. */
+function SourceError({
+  error,
+  onManageConnections,
+}: {
+  error: string;
+  onManageConnections?: () => void;
+}) {
   const { message, cta } = parsePlatformCta(error);
   return (
     <div className="flex items-center gap-2 border-t border-border bg-danger-light px-4 py-2 text-[13px] text-danger">
       <span className="flex-1">{message}</span>
-      {cta && (
+      {cta ? (
         <a
           href={cta}
           target="_blank"
@@ -45,6 +53,16 @@ function SourceError({ error }: { error: string }) {
         >
           Fix it →
         </a>
+      ) : (
+        onManageConnections && (
+          <button
+            type="button"
+            onClick={onManageConnections}
+            className="shrink-0 font-semibold underline hover:opacity-80"
+          >
+            Manage connections
+          </button>
+        )
       )}
     </div>
   );
@@ -72,6 +90,7 @@ export function SkillSourceCard({
   onRemove,
   onUpdate,
   onOpenSkill,
+  onManageConnections,
 }: {
   source: SkillSource;
   /** `undefined` until this source's scan resolves — distinct from an empty
@@ -95,6 +114,9 @@ export function SkillSourceCard({
   onUpdate: (skill: Skill) => void;
   /** Open a skill's SKILL.md render modal (05). */
   onOpenSkill: (skill: Skill) => void;
+  /** Navigate to the sandbox's Connections tab — shown as a "Manage
+   *  connections" affordance on a scan error with no server CTA. */
+  onManageConnections?: () => void;
 }) {
   const loaded = skills !== undefined;
   const list = skills ?? [];
@@ -189,7 +211,9 @@ export function SkillSourceCard({
       </div>
 
       {!loaded && !error && <SkillRowsSkeleton />}
-      {error && <SourceError error={error} />}
+      {error && (
+        <SourceError error={error} onManageConnections={onManageConnections} />
+      )}
       {loaded && !error && list.length === 0 && (
         <p className="border-t border-border px-4 py-3 text-[13px] text-muted-foreground">
           No skills in this source.

--- a/packages/ui/src/modules/sandboxes/components/skills/skills-surface.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skills-surface.tsx
@@ -44,6 +44,7 @@ export function SkillsSurface({
 }) {
   const isError = agentState === "error";
   const showConfirm = useStore((s) => s.showConfirm);
+  const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
   const [addOpen, setAddOpen] = useState(false);
   const [publishFor, setPublishFor] = useState<LocalSkill | null>(null);
   const [renderFor, setRenderFor] = useState<{
@@ -171,6 +172,11 @@ export function SkillsSurface({
                     onRemove={() => void removeWithConfirm(src)}
                     onOpenSkill={(skill) =>
                       setRenderFor({ source: src, skill })
+                    }
+                    onManageConnections={
+                      agentId
+                        ? () => navigateToSandboxHome(agentId, "connections")
+                        : undefined
                     }
                   />
                 ))}


### PR DESCRIPTION
When you add a private GitHub repo as a skill source but your GitHub connection hasn't been granted access to it, the scan used to fail with a cryptic internal string (`fetch failed` / `GitHub: Not Found`) — leaving you with no idea that the fix is simply to grant the repo.

Now the source shows a clear, actionable message instead:

> Can't access this repository. If it's private, grant your GitHub connection access to it, then re-scan — otherwise, double-check the repo URL.

In the UI, the errored source card pairs this with a **Manage connections** button that takes you straight to the sandbox's Connections tab. The CLI prints the same message and exits with a distinct code so scripts can tell "needs a connection" apart from other failures.

Once access is granted and the source is re-scanned, skills load as normal.

Closes #2836