### PR TITLE
feat(channels): let a Slack-bound agent act across the workspace as itself

### DIFF
--- a/deploy/slack-app-manifest.yaml
+++ b/deploy/slack-app-manifest.yaml
@@ -27,6 +27,11 @@ oauth_config:
     bot:
       - commands
       - chat:write
+      # Cross-workspace outbound: list the channels the bot is in, check
+      # membership before posting, and open direct messages.
+      - channels:read
+      - groups:read
+      - im:write
       - users:read
       - users:read.email
       - app_mentions:read

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-Last verified: 2026-07-20
+Last verified: 2026-07-21
 
 ## Overview
 
@@ -203,8 +203,9 @@ sequenceDiagram
 
 What the agent sees:
 
-- **Two tools** are registered on the per-Agent MCP server: `describe_channel` returns the authorized chats (DMs / threads / groups) for a given channel type, and `send_channel_message` posts text to a chat. The agent picks the channel by argument (`slack` or `telegram`); `chatId` addresses a specific chat. Omitting `chatId` resolves per channel type: Telegram posts to the worker's last-active thread (error if none); Slack posts to the single channel bound to the Agent, and rejects a `chatId` that isn't that bound channel.
-- **Tools are always registered.** Calls are rejected at invocation time when no channel is connected for the Agent — no dynamic tool list, no per-session toggle.
+- **Two tools** are registered on the per-Agent MCP server: `describe_channel` returns the reachable chats for a given channel type, and `send_channel_message` posts text to a chat. The agent picks the channel by argument (`slack` or `telegram`); `chatId` addresses a specific chat. Omitting `chatId` resolves per channel type: Telegram posts to the worker's last-active thread (error if none); Slack posts to the channel bound to the Agent.
+- **Slack reach is the bot's own membership.** A bound Agent may post beyond its bound channel: any workspace channel the (install-wide) bot is a member of is a valid `chatId`, and a Slack user id opens a direct message with that person. `describe_channel` lists the bound channel first, then the other bot-member channels with their `#names` (degrading to the bound channel alone if discovery fails, e.g. on an app missing the read scopes). Membership is verified at send time — posting to a channel the bot is not in is refused with a pointer at `/invite` (private channels are invisible to the bot until invited, so they refuse as not-found, with the same pointer). The bound channel itself short-circuits every check, so it keeps working regardless of app scopes. Every outbound post is made by the bot and attributed to the Agent via the context block; the Slack workspace (who invites the bot where) is the reach boundary, and the app's granted scopes are the ceiling. This applies to both access modes — the mode governs who may drive the Agent inbound, not what the Agent does outbound. Telegram has no analogue: its outbound targets stay the conversations bound to the Agent.
+- **Tools are always registered.** Calls are rejected at invocation time when no channel is connected for the Agent — no dynamic tool list, no per-session toggle. The binding is also the gate for the widened Slack reach: an unbound Agent cannot post anywhere, even though the workspace bot exists.
 - **Bidirectional channel.** If a channel is connected to an Agent, every session on that Agent can post — interactive sessions and scheduled sessions alike. There is no per-session outbound flag.
 
 Why the dedicated MCP endpoint:
@@ -221,7 +222,7 @@ Outbound posts are **fire-and-forget at the thread level**. The agent posts a to
 
 The two messengers diverge slightly on what a top-level post means:
 
-- **Slack:** the worker posts to the channel id (or the last-active channel for the Agent) with no `thread_ts`, producing a new top-level message. A reply from a Slack user is a new mention.
+- **Slack:** the worker posts to the resolved target (bound channel by default) with no `thread_ts`, producing a new top-level message. A reply from a Slack user is a new mention, routed by the *reply channel's own* binding — in the posting Agent's bound channel it reaches that Agent; in a channel bound to a different Agent it drives that other Agent; in unbound channels and DMs it reaches no Agent today.
 - **Telegram:** there is no thread primitive in DMs and only weak threading in groups. The worker posts to the chat id; if the agent's prompt was triggered by a previous message in the same chat, that chat is still the conversation.
 
 ## Per-Agent vs. platform channel

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -63,7 +63,7 @@ Artifact bytes move directly: agents upload candidates to the store through thei
 
 Platform runs a single Slack app (Socket Mode) for the entire installation. A Slack channel binds to at most one instance globally; the binding routes every mention in that channel.
 
-1. [Create a Slack app](https://api.slack.com/apps) with Socket Mode enabled and bot/user token scopes: `app_mentions:read`, `channels:history`, `chat:write`, `files:read`, `files:write`, `reactions:write`, `commands`, `users:read`.
+1. [Create a Slack app](https://api.slack.com/apps) with Socket Mode enabled and bot/user token scopes: `app_mentions:read`, `channels:history`, `channels:read`, `chat:write`, `files:read`, `files:write`, `groups:read`, `im:write`, `reactions:write`, `commands`, `users:read`. (`channels:read`, `groups:read`, and `im:write` power agent-initiated posts to other bot-member channels and direct messages; without them agents can still post to their bound channel.)
 2. Add slash command `/platform` pointing to your app.
 3. Generate an app-level token (`xapp-...`) with `connections:write` scope. Deploy with both tokens:
 

--- a/packages/api-server/src/__tests__/unit/slack-outbound.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-outbound.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from "vitest";
+import type { AgentsService } from "api-server-api";
+import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
+import {
+  createFakeSlackGateway,
+  type FakeSlackChannel,
+} from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import type { AcpClient } from "../../core/acp-client.js";
+import { configureLogger } from "../../core/logger.js";
+import type { StoredChannelConfig } from "../../modules/channels/stored-channel.js";
+
+const OWNER = "kc|owner-1";
+const BOUND = "C-BOUND";
+configureLogger({ level: "error", write: () => {} });
+
+function harness(opts: {
+  /** null = agent has no Slack binding. */
+  boundChannelId: string | null;
+  /** Workspace channel directory; unlisted ids resolve as not found. */
+  channels?: FakeSlackChannel[];
+  /** Make the gateway fail to start, so ensureGateway yields null. */
+  gatewayDown?: boolean;
+}) {
+  const gw = createFakeSlackGateway();
+  gw.setChannels(opts.channels ?? []);
+  if (opts.gatewayDown) {
+    gw.start = async () => false;
+  }
+  const acp = {
+    listSessions: async () => [],
+    sendPrompt: async () => "x",
+    triggerSession: () => Promise.reject(new Error("unused")),
+  } as unknown as AcpClient;
+  const agents = {
+    ensureReady: async () => {},
+    isAllowedUser: async () => false,
+  } as unknown as AgentsService;
+
+  const worker = createSlackWorker(
+    () => acp,
+    () => gw,
+    () => agents,
+    { resolve: async () => null } as never,
+    { authUrl: "http://kc", clientId: "c" } as never,
+    new Map(),
+    async () => OWNER,
+    {
+      resolveSlackBinding: async () => null,
+      resolveSlackChannelByInstance: async () => opts.boundChannelId,
+    },
+    async () => {},
+    async () => {},
+    { name: "DAM", short: "dam" },
+    async () => true,
+    "http://ui",
+    () => acp,
+    () => {},
+  );
+
+  return {
+    gw,
+    worker,
+    async post(
+      text: string,
+      options?: Parameters<typeof worker.postMessage>[2],
+    ) {
+      await worker.start("agent-1", {} as StoredChannelConfig);
+      return worker.postMessage("agent-1", text, options);
+    },
+    async list() {
+      await worker.start("agent-1", {} as StoredChannelConfig);
+      return worker.listConversations("agent-1");
+    },
+    messages: () => gw.readOutbound().filter((r) => r.kind === "message"),
+    uploads: () => gw.readOutbound().filter((r) => r.kind === "upload"),
+  };
+}
+
+const workspace: FakeSlackChannel[] = [
+  { id: BOUND, name: "agent-home", botIsMember: true },
+  { id: "C-GENERAL", name: "general", botIsMember: true },
+  { id: "C-ALERTS", name: "alerts", botIsMember: true },
+  // A visible channel the bot is not in (public, not yet invited). Private
+  // channels are invisible to the bot entirely and resolve as not found.
+  { id: "C-STAFF", name: "staff", botIsMember: false },
+];
+
+describe("slack outbound — cross-workspace reach", () => {
+  it("unbound agent: post errors and lists nothing — the binding is the gate", async () => {
+    const h = harness({ boundChannelId: null, channels: workspace });
+    expect(await h.post("hi")).toEqual({ error: "no channel connected" });
+    expect(await h.list()).toEqual([]);
+    expect(h.gw.readOutbound()).toHaveLength(0);
+  });
+
+  it("gateway down: post errors as a value", async () => {
+    const h = harness({
+      boundChannelId: BOUND,
+      channels: workspace,
+      gatewayDown: true,
+    });
+    expect(await h.post("hi")).toEqual({ error: "slack bot not running" });
+  });
+
+  it("omitted chatId still posts to the bound channel", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    expect(await h.post("hello")).toEqual({ ok: true });
+    expect(h.messages()).toMatchObject([{ channel: BOUND, text: "hello" }]);
+  });
+
+  it("bound-channel chatId short-circuits — works even when discovery knows nothing", async () => {
+    // Empty directory = conversations.info would fail (e.g. missing scopes);
+    // the bound channel must keep working regardless.
+    const h = harness({ boundChannelId: BOUND, channels: [] });
+    expect(await h.post("hello", { conversationId: BOUND })).toEqual({
+      ok: true,
+    });
+    expect(h.messages()).toMatchObject([{ channel: BOUND }]);
+  });
+
+  it("posts into another channel the bot is a member of", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    expect(await h.post("update", { conversationId: "C-GENERAL" })).toEqual({
+      ok: true,
+    });
+    expect(h.messages()).toMatchObject([{ channel: "C-GENERAL" }]);
+  });
+
+  it("refuses a channel the bot is not a member of, pointing at /invite", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    const result = await h.post("nope", { conversationId: "C-STAFF" });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("not a member"),
+    });
+    expect((result as { error: string }).error).toContain("/invite");
+    expect(h.gw.readOutbound()).toHaveLength(0);
+  });
+
+  it("refuses an unknown or invisible (private) conversation", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    const result = await h.post("nope", { conversationId: "C-NOWHERE" });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("conversation C-NOWHERE not found"),
+    });
+    expect((result as { error: string }).error).toContain("/invite");
+    expect(h.gw.readOutbound()).toHaveLength(0);
+  });
+
+  it("a user id opens a direct message and posts into it", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    expect(await h.post("psst", { conversationId: "UTEAMMATE" })).toEqual({
+      ok: true,
+    });
+    expect(h.messages()).toMatchObject([{ channel: "D-UTEAMMATE" }]);
+  });
+
+  it("refuses a comma-separated user list — DMs are single-user, never group DMs", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    const result = await h.post("psst", { conversationId: "UAAA,UBBB" });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("not found"),
+    });
+    expect(h.gw.readOutbound()).toHaveLength(0);
+  });
+
+  it("refuses an empty send — no DM gets opened as a side effect", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    expect(await h.post("", { conversationId: "UTEAMMATE" })).toEqual({
+      error: "nothing to send — pass text or an attachment",
+    });
+    expect(h.gw.readOutbound()).toHaveLength(0);
+  });
+
+  it("an existing DM conversation id passes through untouched", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    expect(await h.post("again", { conversationId: "D-EXISTING" })).toEqual({
+      ok: true,
+    });
+    expect(h.messages()).toMatchObject([{ channel: "D-EXISTING" }]);
+  });
+
+  it("attachments follow the resolved target", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    const result = await h.post("report attached", {
+      conversationId: "C-ALERTS",
+      attachment: { filename: "report.md", data: Buffer.from("x") },
+    });
+    expect(result).toEqual({ ok: true });
+    expect(h.messages()).toMatchObject([{ channel: "C-ALERTS" }]);
+    expect(h.uploads()).toMatchObject([
+      { channelId: "C-ALERTS", filename: "report.md" },
+    ]);
+  });
+
+  it("a failed upload after a delivered text message says the text landed", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    h.gw.uploadFile = async () => {
+      throw new Error("upload_error");
+    };
+    const result = await h.post("report attached", {
+      conversationId: "C-ALERTS",
+      attachment: { filename: "report.md", data: Buffer.from("x") },
+    });
+    expect(result).toMatchObject({
+      error: expect.stringContaining("message posted, but"),
+    });
+    expect(h.messages()).toMatchObject([{ channel: "C-ALERTS" }]);
+  });
+
+  it("listConversations: bound channel first with its #name, then member channels by name", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    expect(await h.list()).toEqual([
+      { id: BOUND, title: "#agent-home" },
+      { id: "C-ALERTS", title: "#alerts" },
+      { id: "C-GENERAL", title: "#general" },
+    ]);
+  });
+
+  it("listConversations degrades to the bound channel when discovery fails", async () => {
+    const h = harness({ boundChannelId: BOUND, channels: workspace });
+    h.gw.listBotChannels = async () => {
+      throw new Error("missing_scope");
+    };
+    expect(await h.list()).toEqual([{ id: BOUND, title: BOUND }]);
+  });
+});

--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -168,7 +168,7 @@ export function createMcpSession(
 
   server.tool(
     "describe_channel",
-    "Describe a channel on this agent. Returns { chats: [{ id, title }] } listing authorized chats (DMs/threads/rooms). Use the id as chatId in send_channel_message.",
+    "Describe a channel on this agent. Returns { chats: [{ id, title }] } listing reachable chats — on Slack the agent's bound channel first, then every other workspace channel the bot is a member of; on Telegram the bound conversations. Use the id as chatId in send_channel_message.",
     { channel: z.enum([ChannelType.Slack, ChannelType.Telegram]) },
     async ({ channel }) => {
       const chats = await deps.channelManager.listConversations(
@@ -181,11 +181,16 @@ export function createMcpSession(
 
   server.tool(
     "send_channel_message",
-    `Send a message to a connected channel (slack or telegram) for this agent. Pass chatId to address a specific chat (get ids from describe_channel); omit to use the last-active chat. Optionally attach a single file by setting attachment.path — accepts an absolute path on the agent pod (e.g. ${agentHome}/work/report.md) or a path relative to your workspace (e.g. report.md). 10 MiB cap.`,
+    `Send a message to a connected channel (slack or telegram) for this agent. Pass chatId to address a specific chat: an id from describe_channel, or on Slack a user id (U…) to send that person a direct message. Omit chatId for the default chat (Slack: the agent's bound channel; Telegram: the last-active chat). Messages are posted as the bot, attributed to this agent. Optionally attach a single file by setting attachment.path — accepts an absolute path on the agent pod (e.g. ${agentHome}/work/report.md) or a path relative to your workspace (e.g. report.md). 10 MiB cap.`,
     {
       channel: z.enum([ChannelType.Slack, ChannelType.Telegram]),
       text: z.string(),
-      chatId: z.string().optional(),
+      chatId: z
+        .string()
+        .optional()
+        .describe(
+          "Target chat: an id from describe_channel, or a Slack user id (U…) for a direct message.",
+        ),
       attachment: z
         .object({
           path: z

--- a/packages/api-server/src/modules/channels/infrastructure/bolt-slack-gateway.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/bolt-slack-gateway.ts
@@ -1,6 +1,7 @@
 import { App, LogLevel } from "@slack/bolt";
 import { formatError } from "../../../core/format-error.js";
 import type {
+  SlackChannelInfo,
   SlackGateway,
   SlackGatewayHandlers,
   SlackImageFile,
@@ -187,6 +188,47 @@ export function createBoltSlackGateway(
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       return res.arrayBuffer();
+    },
+
+    async listBotChannels(): Promise<SlackChannelInfo[]> {
+      if (!app) return [];
+      const channels: SlackChannelInfo[] = [];
+      let cursor: string | undefined;
+      do {
+        const page = await app.client.users.conversations({
+          types: "public_channel,private_channel",
+          exclude_archived: true,
+          limit: 200,
+          cursor,
+        });
+        for (const c of page.channels ?? []) {
+          if (c.id) channels.push({ id: c.id, name: c.name ?? c.id });
+        }
+        cursor = page.response_metadata?.next_cursor || undefined;
+      } while (cursor);
+      return channels;
+    },
+
+    async getConversationInfo(channelId: string) {
+      if (!app) return null;
+      try {
+        const info = await app.client.conversations.info({
+          channel: channelId,
+        });
+        if (!info.channel) return null;
+        return { isMember: !!info.channel.is_member };
+      } catch (err) {
+        if (formatError(err).includes("channel_not_found")) return null;
+        throw err;
+      }
+    },
+
+    async openDirectMessage(userId: string): Promise<string> {
+      if (!app) throw new Error("slack bot not running");
+      const opened = await app.client.conversations.open({ users: userId });
+      const id = opened.channel?.id;
+      if (!id) throw new Error("Slack returned no conversation id");
+      return id;
     },
   };
 }

--- a/packages/api-server/src/modules/channels/infrastructure/fake-slack-gateway.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/fake-slack-gateway.ts
@@ -7,6 +7,12 @@ import type {
   SlackSlashCommand,
 } from "./slack-gateway.js";
 
+export interface FakeSlackChannel {
+  id: string;
+  name: string;
+  botIsMember: boolean;
+}
+
 export interface FakeSlackGateway extends SlackGateway {
   fireMention(event: SlackMentionEvent): Promise<void>;
   /** A plain (non-mention) channel message, as the real gateway would deliver
@@ -15,11 +21,14 @@ export interface FakeSlackGateway extends SlackGateway {
   fireCommand(command: SlackSlashCommand): Promise<string>;
   readOutbound(): SlackOutboundRecord[];
   resetOutbound(): void;
+  /** Workspace channel directory; unlisted ids resolve as not found. */
+  setChannels(channels: FakeSlackChannel[]): void;
 }
 
 export function createFakeSlackGateway(): FakeSlackGateway {
   let handlers: SlackGatewayHandlers | null = null;
   const outbound: SlackOutboundRecord[] = [];
+  let channels: FakeSlackChannel[] = [];
 
   function requireHandlers(): SlackGatewayHandlers {
     if (!handlers) {
@@ -88,6 +97,21 @@ export function createFakeSlackGateway(): FakeSlackGateway {
       throw new Error("downloadFile is not supported by the fake gateway");
     },
 
+    async listBotChannels() {
+      return channels
+        .filter((c) => c.botIsMember)
+        .map(({ id, name }) => ({ id, name }));
+    },
+
+    async getConversationInfo(channelId) {
+      const channel = channels.find((c) => c.id === channelId);
+      return channel ? { isMember: channel.botIsMember } : null;
+    },
+
+    async openDirectMessage(userId) {
+      return `D-${userId}`;
+    },
+
     async fireMention(event) {
       await requireHandlers().onMention(event);
     },
@@ -110,6 +134,10 @@ export function createFakeSlackGateway(): FakeSlackGateway {
 
     resetOutbound() {
       outbound.length = 0;
+    },
+
+    setChannels(next) {
+      channels = [...next];
     },
   };
 }

--- a/packages/api-server/src/modules/channels/infrastructure/slack-gateway.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack-gateway.ts
@@ -66,6 +66,11 @@ export interface SlackUpload {
   initialComment?: string;
 }
 
+export interface SlackChannelInfo {
+  id: string;
+  name: string;
+}
+
 export interface SlackGateway {
   start(handlers: SlackGatewayHandlers): Promise<boolean>;
   stop(): Promise<void>;
@@ -87,4 +92,10 @@ export interface SlackGateway {
   }): Promise<SlackMessage[]>;
   uploadFile(args: SlackUpload): Promise<void>;
   downloadFile(urlPrivate: string): Promise<ArrayBuffer>;
+  /** Channels (public + private) the bot is a member of. */
+  listBotChannels(): Promise<SlackChannelInfo[]>;
+  /** Membership lookup for one conversation; null when Slack can't resolve it. */
+  getConversationInfo(channelId: string): Promise<{ isMember: boolean } | null>;
+  /** Open (or reuse) the bot's DM with a user; returns the conversation id. */
+  openDirectMessage(userId: string): Promise<string>;
 }

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -37,6 +37,7 @@ import {
 import { wakeFailureUserCopy } from "./wake-failure-copy.js";
 import type {
   SlackAck,
+  SlackChannelInfo,
   SlackChannelMessageEvent,
   SlackGateway,
   SlackImageFile,
@@ -230,6 +231,58 @@ export interface SlackOAuthPending {
    *  flow and hands off to the agent picker (`bind`). */
   intent: "login" | "bind";
   createdAt: number;
+}
+
+/** Resolve an outbound conversationId to the Slack conversation to post into.
+ *  The bound channel passes untouched; a user id opens a DM; any other
+ *  channel must have the bot as a member. The one workspace bot is shared by
+ *  all Agents, so its membership — governed Slack-side via /invite — is the
+ *  reach boundary. */
+async function resolveOutboundTarget(
+  gateway: SlackGateway,
+  boundChannelId: string,
+  conversationId: string | undefined,
+): Promise<{ id: string } | { error: string }> {
+  if (!conversationId || conversationId === boundChannelId) {
+    return { id: boundChannelId };
+  }
+  // Exactly one well-formed user id — conversations.open would accept a
+  // comma-separated list and mint a group DM, which is not on offer here.
+  if (/^[UW][A-Z0-9]+$/.test(conversationId)) {
+    try {
+      return { id: await gateway.openDirectMessage(conversationId) };
+    } catch (err) {
+      return {
+        error: `could not open a direct message with ${conversationId}: ${formatError(err)}`,
+      };
+    }
+  }
+  // An existing DM conversation — Slack itself rejects DMs the bot is not
+  // party to, and conversations.info carries no membership flag for them.
+  if (conversationId.startsWith("D")) {
+    return { id: conversationId };
+  }
+  let info: { isMember: boolean } | null;
+  try {
+    info = await gateway.getConversationInfo(conversationId);
+  } catch (err) {
+    return {
+      error: `could not resolve conversation ${conversationId}: ${formatError(err)}`,
+    };
+  }
+  if (!info) {
+    // Private channels are invisible to the bot until it is invited, so
+    // they surface here rather than on the membership branch below.
+    return {
+      error: `conversation ${conversationId} not found — if it is a private channel, the bot must be invited to it first (/invite)`,
+    };
+  }
+  if (!info.isMember) {
+    return {
+      error: `the bot is not a member of ${conversationId} — invite it to the channel first (/invite), or pick a chat from describe_channel`,
+    };
+  }
+  return { id: conversationId };
 }
 
 export function createSlackWorker(
@@ -1511,9 +1564,37 @@ export function createSlackWorker(
     async listConversations(instanceName: string) {
       const slackChannelId =
         await channelRegistry.resolveSlackChannelByInstance(instanceName);
-      return slackChannelId
-        ? [{ id: slackChannelId, title: slackChannelId }]
-        : [];
+      if (!slackChannelId) return [];
+
+      // The bound channel leads (agents treat chats[0] as their home
+      // surface), then every other channel the bot is a member of.
+      // Discovery failure (bot down, missing scopes) degrades to the
+      // bound channel alone. ensureGateway: like outbound posts, a
+      // describe_channel can arrive before any inbound event started
+      // the gateway.
+      let botChannels: SlackChannelInfo[] = [];
+      const gw = await ensureGateway();
+      if (gw) {
+        try {
+          botChannels = await gw.listBotChannels();
+        } catch (err) {
+          process.stderr.write(
+            `[slack] listBotChannels failed: ${formatError(err)}\n`,
+          );
+        }
+      }
+      const bound = botChannels.find((c) => c.id === slackChannelId);
+      const others = botChannels
+        .filter((c) => c.id !== slackChannelId)
+        .sort((a, b) => a.name.localeCompare(b.name))
+        .map((c) => ({ id: c.id, title: `#${c.name}` }));
+      return [
+        {
+          id: slackChannelId,
+          title: bound ? `#${bound.name}` : slackChannelId,
+        },
+        ...others,
+      ];
     },
 
     async postMessage(
@@ -1521,17 +1602,12 @@ export function createSlackWorker(
       text: string,
       options?: PostMessageOptions,
     ) {
+      // The binding is the Agent's membership card into the workspace: no
+      // binding, no Slack outbound — even though the workspace bot exists.
       const slackChannelId =
         await channelRegistry.resolveSlackChannelByInstance(instanceName);
       if (!slackChannelId) {
         return { error: "no channel connected" };
-      }
-
-      const { conversationId, attachment } = options ?? {};
-      if (conversationId && conversationId !== slackChannelId) {
-        return {
-          error: `conversationId ${conversationId} does not match the channel bound to this instance (${slackChannelId})`,
-        };
       }
 
       // Outbound may arrive before any inbound event started the gateway —
@@ -1540,6 +1616,21 @@ export function createSlackWorker(
       const gw = await ensureGateway();
       if (!gw) {
         return { error: "slack bot not running" };
+      }
+
+      const { conversationId, attachment } = options ?? {};
+      // Refuse before resolving: an empty send to a user id would still
+      // open a DM conversation as a side effect.
+      if (!text && !attachment) {
+        return { error: "nothing to send — pass text or an attachment" };
+      }
+      const target = await resolveOutboundTarget(
+        gw,
+        slackChannelId,
+        conversationId,
+      );
+      if ("error" in target) {
+        return target;
       }
 
       const contextBlock = {
@@ -1556,19 +1647,30 @@ export function createSlackWorker(
         // and gives consistent text formatting in either path.
         if (text) {
           await gw.postMessage({
-            channel: slackChannelId,
+            channel: target.id,
             text,
             blocks: [{ type: "markdown", text }, contextBlock],
           });
         }
         if (attachment) {
-          await gw.uploadFile({
-            channelId: slackChannelId,
-            file: attachment.data,
-            filename: attachment.filename,
-            title: attachment.title,
-            initialComment: text ? undefined : `_${instanceName}_`,
-          });
+          try {
+            await gw.uploadFile({
+              channelId: target.id,
+              file: attachment.data,
+              filename: attachment.filename,
+              title: attachment.title,
+              initialComment: text ? undefined : `_${instanceName}_`,
+            });
+          } catch (err) {
+            // The text message (if any) already landed — say so, or the
+            // caller (and the audit trail reading its result) would take
+            // the whole send for undelivered.
+            return {
+              error: text
+                ? `message posted, but the attachment upload failed: ${formatError(err)}`
+                : formatError(err),
+            };
+          }
         }
         return { ok: true as const };
       } catch (err) {


### PR DESCRIPTION
Closes #2838.

## What

An agent bound to a Slack channel could only post back into that one channel — `send_channel_message` rejected any other `chatId`, and `describe_channel` returned just the bound channel id. Broader reach required the personal-Slack-connection workaround (acting as a *person*). This PR lets the agent act across the workspace **as itself** (the bot, attributed per message via the `_agentname_` context block):

- **Other channels:** any workspace channel the bot is a member of is a valid `chatId`. Membership is verified at send time (`conversations.info`); a channel the bot isn't in is refused with a pointer at `/invite` (private channels are invisible to the bot until invited and refuse as not-found, same pointer).
- **Direct messages:** a Slack user id (`U…`/`W…`) as `chatId` opens the bot's DM with that person (`conversations.open`) and posts there. Strictly one well-formed id — comma-separated lists are refused so `conversations.open` can never mint a group DM. Existing `D…` conversation ids pass through (Slack itself rejects DMs the bot isn't party to).
- **Discovery:** `describe_channel` lists the bound channel first (keeping the "empty ⇔ unbound" and "chats[0] = home surface" heuristics agents already rely on), then the other bot-member channels with their `#names`; if discovery fails (e.g. an app without the new read scopes) it degrades to today's bound-channel-only list.

## Boundaries

- **The binding is the gate.** An unbound agent still cannot post anywhere, even though the workspace bot exists.
- **The bound channel short-circuits every new check** — existing behavior (including the in-chat bind confirmation post and installs whose Slack app lacks the new scopes) cannot regress.
- **Both access modes** get the reach: the mode governs who may drive the agent inbound, not what the agent does outbound (per the ADR-076 requirement that new channel capabilities declare their mode stance).
- Cross-agent posting (into a channel bound to a different agent) is deliberately allowed — bot membership, governed Slack-side via `/invite`, is the boundary, and every post is attributed to its agent.
- Threading stays fire-and-forget; replies route by the *reply channel's own* binding, as before.
- Empty sends are refused (previously silently "ok"; now also avoids opening a DM as a side effect), and a failed upload after a delivered text message reports partial delivery instead of a blanket failure.
- The personal Slack connection template is untouched — retiring it is a separate call per the issue.

## Slack app scopes

`channels:read`, `groups:read`, `im:write` added to `deploy/slack-app-manifest.yaml` and `docs/configuration.md`. Existing installs keep working without them (bound-channel posting is unaffected); cross-channel/DM sends surface the missing-scope error until the app is updated.

## Implementation

New `SlackGateway` port methods (`listBotChannels` — first cursor-paginated call, `getConversationInfo`, `openDirectMessage`) implemented on the Bolt gateway and the in-process fake (which doubles as the e2e mock and now carries a channel directory with a `setChannels` control). Target resolution lives in `resolveOutboundTarget` in the Slack worker, mirroring the Telegram worker's errors-as-values validation. `docs/architecture/channels.md` outbound section updated.

## Testing

- New `slack-outbound.test.ts` (15 tests): first direct coverage of `SlackWorker.postMessage`/`listConversations` — binding gate, bound-channel short-circuit, member/non-member/unknown channels, DM open + comma-list refusal, empty-send refusal, attachment targeting, partial-delivery copy, list ordering and degrade.
- `mise run check` (api-server format/lint/tsc, docs checks) and full `mise run test` pass. The `controller:check:crd-backwards-compatibility` task fails *in any git worktree* (crdify's go-git cannot resolve refs through a worktree gitdir) — verified it passes from the primary checkout; no CRDs are touched here.

## Manual verification (not yet run)

On a cluster with real Slack tokens and the updated app manifest: bind an agent to a channel, invite the bot to a second channel, then have the agent (a) `describe_channel` — expect both channels, bound first; (b) post to the second channel; (c) post to a non-member channel — expect the `/invite` refusal; (d) DM your Slack user id. Each message should carry the agent-name context block.