### PR TITLE
fix(dam-vm): dockerd runc + gate the dam-vm agent doc on VM-host config

### DIFF
--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -106,6 +106,12 @@ spec:
             - name: PLATFORM_OBJECT_STORE_AUTHORITY
               value: {{ . | quote }}
             {{- end }}
+            {{- if .Values.apiServer.vmHost.url }}
+            # A VM host is configured (dam-vm), so agent pods keep the dam-vm
+            # tool in their instructions; the entrypoint strips it otherwise.
+            - name: AGENT_VM_ENABLED
+              value: "1"
+            {{- end }}
             {{- if .Values.clickstack.enabled }}
             # Telemetry attribution: when the bundled telemetry backend is on,
             # each gateway gains a collector egress chain that MITM-terminates

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -75,6 +75,7 @@ type Config struct {
 	LegacyAgentMemoryLimit resource.Quantity
 
 	AgentProbesEnabled       bool          // Render startup/readiness/liveness probes on agent pods (default: true; matches the chart's probes.enabled)
+	VMEnabled                bool          // dam-vm has a VM host configured (api-server's apiServer.vmHost.url); injected as DAM_VM_ENABLED so the entrypoint keeps the dam-vm tool doc
 	HarnessServerURL         string        // Harness API server internal URL (separate port, agent-facing)
 	HarnessServerPort        int           // Harness API server port (for network policy egress rule)
 	EnvoyImage               string        // Image for the Envoy credential-injector sidecar
@@ -347,6 +348,7 @@ func LoadFromEnv() (*Config, error) {
 	cfg.HarnessServerURL = os.Getenv("PLATFORM_HARNESS_SERVER_URL")
 	cfg.HarnessServerPort = envOrDefaultInt("PLATFORM_HARNESS_SERVER_PORT", 4001)
 	cfg.AgentProbesEnabled = envOrDefaultBool("AGENT_PROBES_ENABLED", true)
+	cfg.VMEnabled = envOrDefaultBool("AGENT_VM_ENABLED", false)
 	// AGENT_HOME mirrors AgentTemplateDefaults.AgentHome for environments
 	// that ship only the env var (e.g. tests). The chart's deployment.yaml
 	// always sets both from the same `templateDefaults.agentHome` value;

--- a/packages/controller/pkg/reconciler/ephemeral_pod.go
+++ b/packages/controller/pkg/reconciler/ephemeral_pod.go
@@ -168,6 +168,13 @@ func buildEphemeralAgentPod(c ephemeralPodConfig) (objLabels map[string]string, 
 		{Name: "HOME", Value: agentHome},
 		{Name: "PLATFORM_MCP_URL", Value: fmt.Sprintf("%s/api/agents/%s/mcp", c.cfg.HarnessServerURL, c.parentAgentID)},
 	}
+	// Keep the dam-vm tool doc in the instructions when a VM host is configured
+	// (entrypoint strips it otherwise). Run executors borrow the parent's
+	// gateway and can use dam-vm; forks can't reach /vm but matching keeps the
+	// image behavior uniform.
+	if c.cfg.VMEnabled {
+		env = append(env, corev1.EnvVar{Name: "DAM_VM_ENABLED", Value: "1"})
+	}
 	env = append(env, c.extraEnv...)
 	// Placeholder credential envs from the K8s Secrets — same purpose as the
 	// long-lived shape: satisfy the harness's is-env-set check; the gateway's

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -181,6 +181,11 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		// Forks deliberately do NOT receive this env — see fork_resources.go.
 		{Name: "PLATFORM_POD_FILES_EVENTS_URL", Value: fmt.Sprintf("%s/api/agents/%s/pod-files/events", cfg.HarnessServerURL, name)},
 	}
+	// Keeps the dam-vm tool doc in the agent's instructions; the entrypoint
+	// strips it otherwise (no VM host configured for this deployment).
+	if cfg.VMEnabled {
+		env = append(env, corev1.EnvVar{Name: "DAM_VM_ENABLED", Value: "1"})
+	}
 
 	// Chart-level platform default env; user env arrives via the runtime channel.
 	for _, e := range specEnv {

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -337,6 +337,19 @@ func TestBuildAgentStatefulSet_PodFilesEventsURL(t *testing.T) {
 		envMap["PLATFORM_POD_FILES_EVENTS_URL"])
 }
 
+func TestBuildAgentStatefulSet_VMEnabledEnv(t *testing.T) {
+	// DAM_VM_ENABLED is injected only when a VM host is configured; the agent
+	// entrypoint keys the dam-vm tool doc off it.
+	off := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
+	_, present := envToMap(off.Spec.Template.Spec.Containers[0].Env)["DAM_VM_ENABLED"]
+	assert.False(t, present, "no DAM_VM_ENABLED when VM host unconfigured")
+
+	cfg := *testConfig
+	cfg.VMEnabled = true
+	on := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "")
+	assert.Equal(t, "1", envToMap(on.Spec.Template.Spec.Containers[0].Env)["DAM_VM_ENABLED"])
+}
+
 func TestBuildAgentStatefulSet_NoSecretRef(t *testing.T) {
 	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	assert.Empty(t, ss.Spec.Template.Spec.Containers[0].EnvFrom)

--- a/packages/dam-vm/container-init.sh
+++ b/packages/dam-vm/container-init.sh
@@ -53,16 +53,25 @@ EOF
 
 # ── high shims (shadow real binaries) ────────────────────────────────────────
 
-# docker: install the engine + build tooling from Fedora repos, run the daemon.
+# docker: install the engine + build tooling from Fedora repos, then start the
+# daemon. runc is explicit — moby-engine doesn't pull it in and dockerd's
+# buildkit init hard-fails without it. Install and daemon-start are separate so
+# a failure surfaces immediately instead of hanging then "cannot connect".
 cat > /opt/shims/high/docker << 'EOF'
 #!/bin/sh
 if ! command-real docker >/dev/null 2>&1; then
-  auto-install docker sh -c '
-    dnf install -yq moby-engine docker-compose docker-buildx &&
-    systemctl enable --now containerd docker'
+  auto-install docker dnf install -yq moby-engine docker-compose docker-buildx runc || exit 1
 fi
 _real=$(command-real docker)
-timeout 60 sh -c 'until "$0" info >/dev/null 2>&1; do sleep 0.5; done' "$_real" || true
+if ! "$_real" info >/dev/null 2>&1; then
+  auto-install dockerd systemctl enable --now containerd docker || exit 1
+  i=0
+  until "$_real" info >/dev/null 2>&1; do
+    i=$((i + 1))
+    [ "$i" -gt 40 ] && { echo "docker: daemon not ready — see journalctl -xeu docker.service" >&2; exit 1; }
+    sleep 0.5
+  done
+fi
 exec "$_real" "$@"
 EOF
 

--- a/packages/platform-base/AGENTS.md
+++ b/packages/platform-base/AGENTS.md
@@ -24,12 +24,14 @@ directory is persistent; the rest of the filesystem is reset on pod restart.
   Use it to offload heavy or long-running work (builds, scans, test suites) off
   the chat pod, or to fan parallel jobs out across pods that all read/write the
   same `/home/agent` workspace.
+<!-- dam-vm:start — agent-entrypoint strips this block unless DAM_VM_ENABLED=1 -->
 - `dam-vm <cmd>` — run a command in this agent's own virtual machine on the
-  deployment's VM host (only when the operator has configured one — it fails
-  fast otherwise). Unlike `dam-run`, the VM shares nothing with this pod: it
-  has its own filesystem (you are root, cwd `/root`), no credentials, no
+  deployment's VM host. Unlike `dam-run`, the VM shares nothing with this pod:
+  it has its own filesystem (you are root, cwd `/root`), no credentials, no
   gateway, no `/home/agent`. It persists across invocations while in active
   use but is deleted after ~1 hour idle — copy results out before you're
   done. Use it for work a sandbox pod can't do: systemd, docker/k3s, nested
   containers, kernel-adjacent tooling. With no command it opens an
   interactive login shell.
+<!-- dam-vm:end -->
+

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -125,6 +125,7 @@ COPY packages/platform-base/runtime-manifest.yaml /app/runtime-manifest.yaml
 COPY packages/platform-base/AGENTS.md /etc/AGENTS.md
 
 RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs &&\
+    chown 65532 /etc/AGENTS.md &&\
     chown -R 65532 /etc/mise /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs /app /home/agent /usr/local/share/mise &&\
     ldconfig &&\
     echo 'sshd:x:74:' >> /etc/group &&\

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -20,4 +20,19 @@ if [ -s "$mitm_ca" ]; then
 		|| echo "agent-entrypoint: WARNING: could not trust the platform CA; intercepted hosts may fail TLS" >&2
 fi
 
+# `dam-vm` only works when the deployment has a VM host configured (the
+# controller sets DAM_VM_ENABLED then). Drop the whole dam-vm block from the
+# agent instructions otherwise, so we don't advertise a command that would just
+# fail; when enabled, drop only the marker comments and keep the tool doc.
+# /etc is reset from the image each boot, so this re-runs cleanly; the file is
+# made agent-writable at build time (see Dockerfile).
+agents_md=/etc/AGENTS.md
+if [ -w "$agents_md" ]; then
+	if [ "${DAM_VM_ENABLED:-}" = "1" ]; then
+		sed -i '/<!-- dam-vm:start/d; /<!-- dam-vm:end -->/d' "$agents_md" 2>/dev/null || true
+	else
+		sed -i '/<!-- dam-vm:start/,/<!-- dam-vm:end -->/d' "$agents_md" 2>/dev/null || true
+	fi
+fi
+
 exec "$@"


### PR DESCRIPTION
Two dam-vm follow-ups found while wiring dam-dev to the Incus VPS.

## 1. `fix(dam-vm)`: dockerd wouldn't start in the container

`dam-vm docker …` installed moby-engine but the daemon failed to start, then the shim hung ~60 s and printed "cannot connect to the Docker daemon".

**Cause:** Fedora's `moby-engine` doesn't pull in `runc`, and dockerd's buildkit init hard-fails with `failed to find runc binary`. (The nftables warnings in the journal were red herrings.)

**Fix:** add `runc` to the docker shim's install, and split install from daemon-start so a real daemon failure surfaces immediately (`docker: daemon not ready — see journalctl -xeu docker.service`) instead of hanging.

Verified end-to-end on the live VPS: `dam-vm docker run --rm hello-world` from a dam-dev agent → `installing docker… installed docker… installing dockerd… installed dockerd… Hello from Docker!`.

## 2. `feat(dam-vm)`: only advertise `dam-vm` to agents when a VM host is configured

`dam-vm` fails fast on deployments with no VM host, so listing it in the agent instructions there is noise. Now gated:

- helm sets `AGENT_VM_ENABLED=1` on the controller **only when `apiServer.vmHost.url` is configured**.
- controller reads it (`cfg.VMEnabled`) and injects `DAM_VM_ENABLED=1` into agent pods (long-lived + ephemeral).
- the `dam-vm` block in `AGENTS.md` is wrapped in strip markers; the base `entrypoint.sh` drops the whole block unless `DAM_VM_ENABLED=1` (and drops just the marker comments when it is). `/etc/AGENTS.md` is made agent-writable so the non-root entrypoint can rewrite it. `/etc` resets from the image each boot, so the strip is idempotent per start.

## Testing

- `TestBuildAgentStatefulSet_VMEnabledEnv`: `DAM_VM_ENABLED` absent when unconfigured, `"1"` when `VMEnabled`.
- Controller build/vet/staticcheck/tests, helm lint + kubeconform render all pass; `AGENT_VM_ENABLED` renders only when `vmHost.url` is set.
- Strip patterns verified: disabled → 0 `dam-vm` mentions (dam-run untouched); enabled → bullet kept, markers gone.
- Docker fix verified live (above).

## Deploy note

Live effect needs the new **controller + platform-base/agent images** deployed. dam-dev has `vmHost.url` set (in its `dam-values`), so once deployed its agents keep the `dam-vm` doc and Docker works inside the VM; clusters without a VM host won't mention `dam-vm`.
