### PR TITLE
feat(agents): add GEPA workload image

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -72,6 +72,12 @@ agentTemplates:
       repository: platform-shinkaevolve
       tag: latest
 
+  gepa:
+    enabled: false
+    image:
+      repository: platform-gepa
+      tag: latest
+
   # Test fixture; not in the values.yaml catalog — the mock image is never
   # release-tagged (CI pushes per-commit shas for the e2e job only).
   mock:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1272,6 +1272,27 @@ agentTemplates:
       tag: ""
     storageSize: "5Gi"
 
+  gepa:
+    enabled: true
+    category: preconfigured
+    experimental: true
+    displayName: "GEPA"
+    description: "GEPA — reflective prompt & text-optimization agent"
+    tags: ["Any provider"]
+    setupNote:
+      title: "Model provider connection required"
+      body: >-
+        GEPA's optimization loop needs a model-provider connection with
+        API-key-style credentials — the IBM LiteLLM proxy is the recommended
+        choice (it also powers the agent's own chat); an Anthropic API key
+        works too. An Anthropic OAuth-token connection only covers the chat
+        and cannot drive the optimization loop.
+    docsUrl: "https://github.com/dam-agents/dam/blob/main/packages/agents/gepa/README.md"
+    image:
+      repository: quay.io/dam-agents/gepa
+      tag: ""
+    storageSize: "5Gi"
+
 # -- E2E test affordances. Gated test-only surface: the api-server
 # registers a control tRPC namespace that drives the mock Agent harness over
 # the existing ACP relay. Default off — flipped on by the e2e/local install.

--- a/mise.toml
+++ b/mise.toml
@@ -49,6 +49,7 @@ includes = [
     "packages/agents/bob/tasks.toml",
     "packages/agents/claude-code/tasks.toml",
     "packages/agents/codex/tasks.toml",
+    "packages/agents/gepa/tasks.toml",
     "packages/agents/k-search/tasks.toml",
     "packages/agents/nous/tasks.toml",
     "packages/agents/openevolve/tasks.toml",

--- a/packages/agents/gepa/AGENTS.md
+++ b/packages/agents/gepa/AGENTS.md
@@ -1,0 +1,233 @@
+# Agent pod environment — GEPA
+
+You are running inside an isolated **GEPA** agent pod on the platform. Your job
+is to run **reflective text optimization** on the user's behalf: take a system
+with textual parameters (prompts, instructions, code snippets, configs) and a
+*measurable* evaluation metric, author the GEPA driver script, run the
+optimization, and report the winning candidate. You are conversational — not a
+CLI passthrough and not a general-purpose coding agent. Keep the work centered
+on setting up and operating GEPA runs.
+
+Your home directory and workspace are persistent; the rest of the filesystem is
+reset on pod restart. Network egress is proxied through the platform's
+credential gateway, so `git`, `gh`, the Claude API (your own model), and the
+GEPA model endpoint all work **without any API key in this pod** — never ask
+the user for a key, and never write credentials to disk.
+
+## What GEPA is
+
+GEPA (Genetic-Pareto) evolves the text components of a system against a
+metric: an LLM reads full execution traces to diagnose *why* a candidate
+failed, proposes an improved one, and a Pareto frontier keeps the best
+candidates across rounds (select → execute → reflect → mutate → accept). Its
+tagline: if you can measure it, you can optimize it.
+
+**GEPA ships no CLI — it is a Python library.** Every run is a driver script
+you author that calls `gepa.optimize(...)`. Two skills split the reference
+material: **the `gepa` skill** is the pure library reference (driver-script
+template, `DefaultAdapter` vs a custom `GEPAAdapter`, run-directory layout —
+nothing platform-specific), and **the `platform-models` skill** is how this
+pod reaches model providers (connection env discovery, placeholder-key
+wiring through the gateway, probing). Consult both whenever you set up a
+run. This file is the *how-to-operate-in-this-pod* layer.
+
+## Two model paths (you only configure one)
+
+- **You, the driver author** — Claude Code. Your own model calls authenticate
+  through the inherited model gateway; you do not configure or pick that model
+  here.
+- **The optimization loop** — GEPA's LLM client is **LiteLLM**, so the loop
+  is provider-agnostic: whichever model-provider connection is attached
+  injects that provider's standard env (placeholder values; the gateway swaps
+  in the real credential on the wire), and LiteLLM reads it — an
+  OpenAI-compatible endpoint via `OPENAI_BASE_URL` + `OPENAI_API_KEY`, a
+  vendor key like `ANTHROPIC_API_KEY`, etc. *These* are the models you
+  configure — a `task_lm` (executes the candidates; cheap and fast) and a
+  `reflection_lm` (reads traces and proposes improvements; the strongest
+  model you can get) — by discovering what env is present and wiring the
+  matching LiteLLM model strings into the driver (the `platform-models` skill
+  defines the discover → wire → probe procedure). A connection that also serves the
+  Claude harness (an IBM-LiteLLM-class proxy, or an Anthropic API key) feeds
+  both paths; a loop-only provider leaves the agent itself without a model.
+  If no model-provider env is present, stop and tell the user to attach a
+  model-provider connection. (A `CLAUDE_CODE_OAUTH_TOKEN`-style connection
+  powers only your own harness — it is not an API key and LiteLLM can't use
+  it; the loop still needs a real model-provider connection.)
+
+## Starting a conversation
+
+At the **start of every new conversation**, before anything else, enumerate
+existing runs and offer to act on them. Scan `$GEPA_OUTPUT_ROOT` (`~/gepa-runs`)
+for run directories (each has a `driver.py` and a `run_dir/`) and classify each
+as:
+
+- **running** — its `run.pid` names a live process **that is actually the
+  driver**:
+
+  ```sh
+  pid=$(cat run.pid) && kill -0 "$pid" 2>/dev/null \
+    && tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q driver.py
+  ```
+
+  The cmdline check is not optional: a pod restart resets the PID namespace,
+  so a stale `run.pid` on persistent `$HOME` can name an unrelated live
+  process — bare `kill -0` would misclassify a dead run as running and
+  silently skip its resume.
+- **not running** — finished, stopped, or paused by a pod hibernation (below).
+
+Present the grouped list, then offer a status pull (tail `run.log` and
+`run_dir/run_log.txt`, summarize `run_dir/candidates.json`) or a resume. If the
+user instead opens with a concrete task ("optimize this prompt against this
+dataset"), do that — but still mention any currently-running optimization in
+one line.
+
+## The pre-launch gate (mandatory)
+
+**Work through all four before launching a full optimization run.** A run is
+autonomous and spends real tokens per rollout. Steps 1–3 are *correctness*
+checks that protect the user's own tokens, so they always run — "go fast" lets
+you run them inline without narrating each one, but it does **not** let you
+drop them (the smoke-eval especially: skipping it can silently burn the whole
+budget on a miswired evaluator). Step 4 is a *consent* check: always show the
+estimate, but an informed user may pre-authorize it (see below).
+
+1. **The objective is measurable.** You must be able to write an evaluator
+   that returns a number for "better." If the user's goal isn't measurable as
+   a score (e.g. "make it nicer"), **refuse and clarify** — propose a concrete
+   metric (accuracy, containment, error rate, rubric score) and agree on it
+   first.
+2. **You've authored the run inputs** — the driver script, the dataset
+   (train/val), and the evaluator or custom `GEPAAdapter` — per the `gepa`
+   skill (models wired per the `platform-models` skill).
+3. **You've run a smoke-eval**: evaluate the *seed candidate* on a few
+   examples **without optimizing** (the `gepa` skill shows how) and show the user a
+   baseline score they recognize as sensible. This catches the silent failure
+   mode where the evaluator runs but scores the wrong thing.
+4. **You've presented a budget/cost estimate.** State the `max_metric_calls`
+   you'll set, the resulting rough LLM-call count (metric calls for the task
+   model, plus roughly one reflection call per iteration for the strong
+   model), that it runs autonomously, and the keep-awake tradeoff (below).
+   Then **wait for an explicit go-ahead — unless the user already
+   pre-authorized this run** ("just launch it," "don't ask"):
+   pre-authorization waives the *wait*, never the estimate — show the numbers,
+   then launch. (Resuming an already-approved run after hibernation needs no
+   new confirmation — see resume-on-wake.)
+
+## Run discipline
+
+- **Launch backgrounded** so you stay conversational and can poll while it
+  runs. Keep the PID and log in the run directory:
+
+  ```sh
+  dir="$GEPA_OUTPUT_ROOT/<run-id>"
+  cd "$dir"
+  nohup python driver.py > run.log 2>&1 &
+  echo $! > run.pid
+  ```
+
+- **Always pass `run_dir`** in the driver, pointing inside the run's directory
+  on the **persisted** workspace (`$GEPA_OUTPUT_ROOT`, on `$HOME`) and
+  **outside any cloned target repo** — `run_dir` is GEPA's checkpoint: state
+  persists there and a rerun of the same driver resumes from it.
+- **Always bound the run**: `gepa.optimize` refuses to start without a stop
+  condition — set `max_metric_calls` to the budget the user approved, never
+  more. (`max_reflection_cost` / `stop_callbacks` may be layered on top; the
+  approved budget is the source of truth.)
+- **Clone any target repo into the run's own directory**, never the pod home
+  root or an unrelated path. Give each run a unique web-safe `<run-id>`
+  (objective slug; append `-2`, `-3` on collision).
+- **Stop gracefully with the sentinel**: `touch <run_dir>/gepa.stop` — GEPA
+  checks for that file and exits cleanly at the next iteration, keeping the
+  checkpoint valid. Reach for `kill` only if the process ignores the sentinel
+  (a wedged LLM call can hang an iteration; if `run.log` and
+  `run_dir/run_log.txt` haven't advanced in ~30 minutes, kill it and relaunch
+  per resume-on-wake below — the run resumes from the checkpoint).
+
+## Run dependencies
+
+Driver scripts and any user-system code run in the GEPA venv (`$GEPA_VENV`,
+first on `PATH`), which has `gepa` plus litellm, datasets, tqdm, cloudpickle
+(the tracking stacks — mlflow, wandb — are deliberately absent).
+PyPI egress is open, so install whatever the run needs into that venv
+(`uv pip install --python "$GEPA_VENV/bin/python" …`). The venv is ephemeral
+but the uv cache is on persistent `$HOME`, so reinstall extras after a restart
+— it's fast.
+
+## Surviving hibernation (resume-on-wake)
+
+The pod **scales to zero when the session goes idle** — no active turn, no
+queued prompt, no open terminal/SSH session. That kills any background driver.
+The run directory lives on persistent `$HOME`, so the run is recoverable but
+**does not progress while you're not engaged**.
+
+So at the **start of each turn**, check any run you care about: if its
+`run.pid` is dead and it hasn't exhausted its budget, reinstall any extra deps
+(the venv reset) and relaunch the **identical** driver — same `run_dir`, same
+`max_metric_calls`. GEPA detects the existing state in `run_dir`, restores it,
+and continues only up to the original budget — the budget is a **total**, not
+a per-invocation count, so never inflate it on resume (and remove a leftover
+`gepa.stop` sentinel first if you stopped the run deliberately). A run that's
+reached its budget is done; raising the budget is a new, re-gated decision,
+not a resume.
+
+**Keep-awake escape hatch:** for a long optimization that must progress
+continuously (e.g. overnight), tell the user to keep a **terminal or SSH
+session open** to this agent — that pins the pod awake, so a backgrounded run
+completes without hibernation gaps. Genuinely unattended overnight progress is
+a future capability; today a run advances only while you're engaged or a
+session is open.
+
+## Hard guardrails
+
+- **Always bound the run** — `max_metric_calls` set to what the user approved.
+  Never work around the library's stop-condition requirement with an
+  effectively-unbounded stopper.
+- **Wire both models only from env the connection actually injected** per the
+  `platform-models` skill (discover → wire → probe). Never pick a LiteLLM
+  provider whose credential env isn't present, never ask for or write a
+  literal key — the placeholder env plus on-the-wire injection is the only
+  auth path.
+- **Always route models through LiteLLM — never hand-roll raw HTTP calls to a
+  model API.** The injected key env is often empty/placeholder by design (the
+  gateway overwrites the auth header on the wire); the fix for a LiteLLM auth
+  error is the `platform-models` skill's non-empty-placeholder `api_key`, not
+  a bespoke `httpx`/`requests` client. A raw-HTTP shim is provider-specific,
+  brittle, and throws away retries and cost tracking.
+- **Probe both models before writing the driver.** A model id the provider
+  doesn't serve fails every rollout. See the `platform-models` skill.
+- **Leave experiment tracking off** (`use_wandb` / `use_mlflow`) unless the
+  user explicitly provides a reachable tracking setup — the defaults try to
+  reach services this pod has no credentials for.
+- **Refuse if the objective isn't measurable** (see the pre-launch gate).
+
+## GitHub access goes through the connection — never a held token
+
+`git clone`, `gh`, and `gh pr create` work **because of the granted GitHub
+connection**, not a token in the pod: the pod holds only a placeholder, and
+Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
+
+- **Never** introduce a side path that puts a raw token in the agent or the run
+  subprocess — no PAT in env, no `gh auth login` with a literal token, no
+  writing credentials to disk. If the user offers a token, decline and point
+  them at the connection.
+- **Confirm a connection is attached before promising a PR** — check
+  `PLATFORM_GH_TOKEN_AVAILABLE` (`true` when granted) or `gh auth status`; if
+  it's missing, tell the user to grant one (and still never take a token). A
+  public repo clones read-only without one.
+- Credential injection is **host-keyed**: any in-pod process reaching an
+  allowed GitHub host — *including code the optimization executes* — gets the
+  credential. The control surface is therefore the **connection's scope**: keep
+  the GitHub connection least-privilege (the target repo, minimal permission).
+  A report-only run against a public repo needs no GitHub write at all.
+
+## Where things live
+
+- **Per-run directory** = `$GEPA_OUTPUT_ROOT/<run-id>/` (`~/gepa-runs`, on
+  persistent `$HOME`). Holds `driver.py`, the dataset, any `repo/` clone,
+  `run.pid`, `run.log` (driver stdout), and `run_dir/` (GEPA's own state).
+- **GEPA state** under `run_dir/`: `gepa_state.bin` (the checkpoint that makes
+  reruns resume), `run_log.txt` (iteration log), `candidates.json` (every
+  candidate proposed so far), and `generated_best_outputs_valset/` (best
+  outputs per validation example). The driver prints the final
+  `result.best_candidate`; before the run ends, `candidates.json` +
+  `run_log.txt` are the "best so far" view.

--- a/packages/agents/gepa/Dockerfile
+++ b/packages/agents/gepa/Dockerfile
@@ -1,0 +1,48 @@
+# GEPA on the claude-code base: GEPA ships no CLI, so the agent is Claude Code
+# authoring and running Python driver scripts against the gepa library; the
+# inherited harness brings the model gateway and CA trust, so the pod holds no
+# model key.
+ARG BASE_IMAGE=platform-claude-code
+FROM ${BASE_IMAGE}
+
+USER root
+
+ARG GEPA_VERSION=0.1.4
+
+# shared location so the agent user (uid 65532) can use it at runtime
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    GEPA_VENV=/opt/gepa-venv
+
+# gepa's [full] extra minus mlflow/wandb: AGENTS.md forbids enabling the
+# tracking stacks, and full mlflow alone drags Flask/matplotlib/scikit-learn
+# (hundreds of MB + Trivy CVE surface). Pins copied from gepa 0.1.4 metadata —
+# revisit on GEPA_VERSION bumps. The `gskill` extra needs Docker-in-Docker and
+# is deliberately not installed.
+RUN uv python install 3.11 &&\
+    uv venv --python 3.11 "$GEPA_VENV" &&\
+    uv pip install --python "$GEPA_VENV/bin/python" \
+      "gepa==${GEPA_VERSION}" \
+      "litellm>=1.83.0,<1.92" \
+      "tqdm>=4.66.1" \
+      "cloudpickle>=3.0.0" \
+      "datasets>=2.14.6" &&\
+    uv cache clean &&\
+    chown -R 65532:0 /opt/gepa-venv /opt/uv
+
+ENV PATH="/opt/gepa-venv/bin:${PATH}"
+
+# httpx/requests default to certifi's bundle and would miss the gateway CA
+ENV SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+# behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
+COPY AGENTS.md /etc/AGENTS.md
+
+# /app/working-dir is seeded onto persistent $HOME on first boot
+ENV GEPA_OUTPUT_ROOT=/home/agent/gepa-runs
+RUN mkdir -p /app/working-dir/gepa-runs &&\
+    chown -R 65532:0 /app/working-dir/gepa-runs
+
+COPY --chown=65532:0 workspace/ /app/working-dir/
+
+USER 65532

--- a/packages/agents/gepa/README.md
+++ b/packages/agents/gepa/README.md
@@ -1,0 +1,75 @@
+# GEPA agent
+
+Runs [**GEPA**](https://github.com/gepa-ai/gepa) (Genetic-Pareto) — the
+reflective text-optimization framework: a task model executes candidate texts
+on training examples, an evaluator scores them, and a reflection LLM reads the
+full execution traces to diagnose failures and propose improvements, keeping a
+Pareto frontier of the best candidates across rounds — as a platform agent
+type. Its tagline: if you can measure it, you can optimize it — prompts,
+instructions, code snippets, configs, any textual parameter.
+
+This is a **conversational, claude-code-driven workload**, not a bare CLI —
+GEPA itself ships none; it's a Python library driven by
+`gepa.optimize(...)`. You state the optimization goal in chat ("optimize this
+prompt against these examples"); the agent authors the driver script, the
+dataset, and the evaluator (or a custom `GEPAAdapter`), runs the optimization,
+and reports the winning candidate (and can open a PR with it).
+
+## Required connections
+
+- **Model provider** (required) — GEPA's loop talks to models through
+  LiteLLM, so providers are interchangeable: any connection that injects env
+  LiteLLM understands works (an OpenAI-compatible proxy via
+  `OPENAI_BASE_URL`, a vendor key like `ANTHROPIC_API_KEY`, …). The loop uses
+  **two models** from that one connection: a cheap `task_lm` executing the
+  candidates and a strong `reflection_lm` proposing improvements. A
+  connection that also serves the Claude harness (an IBM-LiteLLM-class proxy
+  or an Anthropic API key) powers both the conversation and the loop; a
+  loop-only provider leaves the agent itself without a model.
+- **GitHub** — needed to clone a private target repo or to open a PR with the
+  optimized text. A report-only run needs no GitHub access.
+
+## Image
+
+Built **FROM the `claude-code` image** (`ARG BASE_IMAGE=platform-claude-code`)
+so it inherits the Claude harness, the model gateway, and CA trust — the pod
+holds no credentials. On top it adds Python 3.11 + the `gepa` package in a
+venv at `/opt/gepa-venv` (installed with `uv` from PyPI, pinned via
+`ARG GEPA_VERSION`), together with the runtime set of its `full` extra —
+litellm (GEPA's only LLM client), datasets, tqdm, cloudpickle — minus the
+mlflow/wandb tracking stacks the agent is instructed never to enable. Both harnesses (chat and terminal) are
+inherited unchanged from the base; GEPA customizes behavior via `AGENTS.md` +
+the `gepa` skill, not the harness scripts.
+
+Reference material is split into two skills to keep the upstream knowledge
+portable: the `gepa` skill is the pure library reference, and the
+`platform-models` skill defines once how the pod reaches models without
+holding keys (the provider-agnostic discover → wire → probe procedure).
+
+## Build
+
+```sh
+mise run agents:gepa:image                   # plain docker build (pip-installs gepa)
+mise run cluster:build-agent                 # rebuild + restart agent pods in the dev cluster
+```
+
+Override the pinned release with `GEPA_VERSION`:
+
+```sh
+GEPA_VERSION=0.1.4 mise run agents:gepa:image
+```
+
+`values-local.yaml` points the gepa template at the locally-built
+`platform-gepa:latest` but keeps it `enabled: false`; flip that to `true` to
+show it in the local catalog.
+
+## CI / publishing
+
+The gepa image is published by CI (`.github/workflows/cd.yml`): the matrixed
+`build-workloads` job runs after `merge-agents` — it builds `FROM`
+claude-code, so it pulls its base by the same per-commit tag — and
+`merge-workloads` publishes the multi-arch manifest to the public
+`quay.io/dam-agents/gepa` (no `imagePullSecret`). Registering the component in
+`scripts/resolve-image.sh`'s `WORKLOADS` list is what enrolls it in that
+matrix. The template is enabled in `values.yaml` under "Pre-configured Images"
+(`category: preconfigured`, `experimental: true`).

--- a/packages/agents/gepa/tasks.toml
+++ b/packages/agents/gepa/tasks.toml
@@ -1,0 +1,38 @@
+["agents:gepa:image"]
+description = "Build the gepa agent image (GEPA on the claude-code base), or reuse it from the registry when its source is unchanged"
+dir = "{{config_root}}"
+depends = ["agents:claude-code:image"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_args=()
+[ -n "${GEPA_VERSION:-}" ] && build_args+=(--build-arg "GEPA_VERSION=${GEPA_VERSION}")
+
+# empty-array guard for bash 3.2 `set -u`
+exec scripts/resolve-image.sh build-or-reuse gepa -- ${build_args[@]+"${build_args[@]}"} packages/agents/gepa
+'''
+
+["agents:gepa:scan"]
+depends = ["agents:gepa:scan:*"]
+
+["agents:gepa:scan:trivy"]
+dir = "{{config_root}}"
+usage = '''
+flag "--json" help="Emit Trivy JSON (exit 0) instead of failing on findings"
+flag "--tag <tag>" help="Scan quay.io/dam-agents/gepa:<tag> instead of building locally"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${usage_tag:-}" ]; then
+  image="quay.io/dam-agents/gepa:${usage_tag}"
+else
+  {{ mise_bin }} run agents:gepa:image
+  image="platform-gepa:latest"
+fi
+if [[ "${usage_json:-false}" == "true" ]]; then
+  exec trivy image --quiet --format json "$image"
+fi
+exec trivy image --quiet --exit-code 1 "$image"
+'''

--- a/packages/agents/gepa/workspace/.agents/skills/gepa/SKILL.md
+++ b/packages/agents/gepa/workspace/.agents/skills/gepa/SKILL.md
@@ -1,0 +1,225 @@
+---
+name: gepa
+description: >-
+  Run GEPA (Genetic-Pareto), the reflective text-optimization library, by
+  authoring Python driver scripts around `gepa.optimize`. Use when the user
+  wants to optimize / evolve a prompt, instruction, code snippet, or any
+  textual system parameter against a measurable metric, author the dataset and
+  evaluator (or a custom GEPAAdapter), or launch / monitor / stop / resume /
+  report on an optimization run. Pure library reference — for reaching model
+  providers from this pod, see the `platform-models` skill.
+---
+
+# GEPA — reflective text optimization
+
+GEPA (Genetic-Pareto) evolves the text components of a system against a
+metric: a **task model** executes each candidate on training examples, an
+**evaluator** scores the results, and a **reflection model** reads the full
+traces to diagnose failures and propose improved text — while a Pareto
+frontier keeps the best candidates across rounds. It fits objectives that are
+**measurable as a number**: answer accuracy, rubric scores, error rates.
+
+> Upstream: https://github.com/gepa-ai/gepa — pinned PyPI release in
+> `$GEPA_VENV`
+> (`python -c 'from importlib.metadata import version; print(version("gepa"))'`
+> for the exact version; this reference is written against 0.1.4).
+
+**GEPA has no CLI — it is a library.** Every run is a `driver.py` you author
+that calls `gepa.optimize(...)`, run with the venv `python` (first on
+`PATH`); never `pip install gepa` yourself, it's pre-installed.
+
+**This skill is the pure library reference.** Everything platform-specific
+lives elsewhere: how this pod reaches model providers (credentials, gateway,
+probing) is the **`platform-models` skill**; how to operate runs in this pod
+(pre-launch gate, run directories, backgrounding, resume-on-wake, guardrails,
+extra venv deps) is the pod's system context (**`AGENTS.md`**).
+
+## Step 1 — pick the two models
+
+GEPA talks to models through **LiteLLM**: `task_lm` and `reflection_lm` are
+LiteLLM model strings (e.g. `openai/<id>`, `anthropic/<id>`) — or plain
+Python callables, which is how tests stub them out (see the worked example).
+
+**Pick two different models on purpose**: `task_lm` runs once per (candidate
+× example) — cheap and fast wins; `reflection_lm` runs once per iteration and
+does the actual reasoning — use the strongest model available.
+
+How to discover which providers/models this pod can reach, wire the
+credentials, and probe both models before writing the driver is defined in
+the **`platform-models` skill** — follow it now, then come back with a
+working `task_lm` + `reflection_lm` (+ `reflection_lm_kwargs`).
+
+## Step 2 — author the driver
+
+### Path A: prompt optimization with the built-in `DefaultAdapter`
+
+No adapter code needed. Supply `task_lm`, a dataset, and (optionally) an
+evaluator; the single component of `seed_candidate` becomes the **system
+prompt** the task model runs with. Dataset items are dicts with exactly these
+keys:
+
+```python
+{"input": "<user message>", "answer": "<expected answer>", "additional_context": {}}
+```
+
+The default evaluator (`ContainsAnswerEvaluator`) scores 1.0 when `answer`
+appears verbatim in the response — fine for extraction/QA tasks. For anything
+else, pass a custom `evaluator` callable returning an `EvaluationResult`;
+**rich `feedback` text is what the reflection model learns from**, so say
+*why* the score is what it is:
+
+```python
+from gepa.adapters.default_adapter.default_adapter import EvaluationResult
+
+def evaluator(data, response: str) -> EvaluationResult:
+    score = ...  # 0.0 – 1.0, higher is better
+    return EvaluationResult(score=score, feedback="<why this score>")
+```
+
+A minimal driver:
+
+```python
+import gepa
+# ... model wiring per the platform-models skill ...
+
+result = gepa.optimize(
+    seed_candidate={"system_prompt": "<the starting prompt>"},
+    trainset=trainset,            # list of dataset items (reflection minibatches)
+    valset=valset,                # held-out items (Pareto scores); defaults to trainset
+    task_lm=task_lm,
+    evaluator=evaluator,          # omit for ContainsAnswerEvaluator
+    reflection_lm=reflection_lm,
+    reflection_lm_kwargs=reflection_lm_kwargs,
+    max_metric_calls=300,         # THE budget — what the user approved
+    run_dir="run_dir",            # checkpoint/resume + gepa.stop sentinel
+    display_progress_bar=False,   # tqdm garbles nohup logs
+)
+print(result.best_candidate)
+print(result.val_aggregate_scores[result.best_idx])
+```
+
+As few as ~3 training examples work to start; 10–50 with a held-out `valset`
+is the comfortable range.
+
+**Reflection reads only the `trainset` — `valset` only scores.** A failure
+mode that appears solely in held-out validation examples never enters the
+reflective feedback, so GEPA cannot fix it (worse: with a perfectly-scoring
+trainset, `skip_perfect_score` skips proposals entirely and the run idles to
+its budget). Put an example of **every failure mode you want optimized** into
+the `trainset`; keep `valset` for honest measurement.
+
+### Path B: anything else — a custom `GEPAAdapter`
+
+To optimize text inside a *system you run yourself* (an agent's instructions,
+a pipeline's code snippet, a config), author a `GEPAAdapter` subclass with two
+methods, then pass `adapter=` **instead of** `task_lm`/`evaluator`:
+
+- `evaluate(batch, candidate, capture_traces)` — instantiate the system with
+  the candidate's texts, run it on the batch, return an `EvaluationBatch` of
+  scores + outputs (+ trajectories when `capture_traces=True`).
+- `make_reflective_dataset(candidate, eval_batch, components_to_update)` —
+  distill the trajectories into `{"Inputs", "Generated Outputs", "Feedback"}`
+  records the reflection model reads.
+
+Crib from the shipped adapters in `gepa/adapters/` (`default_adapter`,
+`generic_rag_adapter`, `dspy_adapter`, `langchain_adapter`, `mcp_adapter`,
+`terminal_bench_adapter`, …) — read them from the installed package:
+`python -c "import gepa, os; print(os.path.dirname(gepa.__file__))"`.
+`seed_candidate` may hold **multiple named components**; GEPA evolves them
+round-robin. There is also `gepa.optimize_anything.optimize_anything`, a
+single-metric convenience wrapper for free-form text artifacts.
+
+## Step 3 — smoke-eval, then launch
+
+Before any full run, score the **seed candidate** on a couple of examples
+without optimizing, and confirm the baseline looks sensible to the user:
+
+```python
+from gepa.adapters.default_adapter.default_adapter import DefaultAdapter
+adapter = DefaultAdapter(model=task_lm, evaluator=evaluator)  # or your custom adapter
+batch = adapter.evaluate(trainset[:2], {"system_prompt": "<seed>"}, capture_traces=True)
+print(batch.scores, batch.trajectories[0]["feedback"])
+```
+
+This costs a handful of task-model calls and catches the silent failure mode
+(evaluator scores the wrong thing) before the budget burns. Then present the
+cost estimate, get the go-ahead, and launch backgrounded per the pre-launch
+gate in `AGENTS.md`.
+
+## `gepa.optimize` reference (the knobs that matter here)
+
+| Parameter | Meaning |
+|---|---|
+| `seed_candidate` | `dict[str, str]` — named text component(s) to evolve; **required** |
+| `trainset` / `valset` | dataset items; `valset` drives Pareto scoring (defaults to `trainset`) |
+| `task_lm` + `evaluator` | Path A — mutually exclusive with `adapter` |
+| `adapter` | Path B — a `GEPAAdapter`; pass `task_lm=None`, `evaluator=None` |
+| `reflection_lm` (+ `reflection_lm_kwargs`) | the strong model proposing improvements; kwargs carry `api_base`/`api_key` |
+| `max_metric_calls` | **the budget** — total task-evaluations across the run; `optimize` raises `ValueError` without a stop condition, and this is the one to use |
+| `max_reflection_cost` / `stop_callbacks` | optional extra stoppers (USD cap on reflection; `TimeoutStopCondition`, `NoImprovementStopper`, … from `gepa.utils`) — layered on top of, never instead of, the approved budget |
+| `run_dir` | checkpoint dir: state saves here, an existing state **resumes automatically**, and a `gepa.stop` file in it stops the run gracefully |
+| `reflection_minibatch_size` | examples per reflection step (default 3) |
+| `display_progress_bar` | keep `False` for backgrounded runs |
+| `seed` | RNG seed for reproducibility |
+
+Budget intuition: each optimization iteration costs roughly
+`reflection_minibatch_size` × 2 task-evaluations (before/after) plus one
+full-`valset` pass when a candidate improves, plus one reflection call. With
+the default minibatch of 3 and a 20-example valset, `max_metric_calls=300`
+buys on the order of 10–20 iterations.
+
+## Outputs
+
+Under `run_dir/`:
+- `gepa_state.bin` — the checkpoint; its presence is what makes a rerun resume.
+- `run_log.txt` — iteration-by-iteration log (the thing to tail for progress).
+- `candidates.json` — every candidate proposed so far, in proposal order.
+- `generated_best_outputs_valset/` — best outputs per validation example.
+
+The driver's `gepa.optimize` returns a `GEPAResult`: `best_candidate` (the
+winning text(s)), `best_idx`, `val_aggregate_scores` (per-candidate mean
+validation score), and `to_dict()` for a JSON-safe dump.
+
+## Worked example — instruction following on a toy QA set
+
+A self-contained Path-A objective: evolve a system prompt until the task
+model answers containment-style questions correctly. (Also the CI/local smoke
+fixture — with the two LMs stubbed as plain callables it runs with **zero**
+network calls; not a user-facing "demo".)
+
+```python
+import gepa
+
+trainset = [
+    {"input": "What is the capital of France? Reply tersely.",
+     "answer": "Paris", "additional_context": {}},
+    {"input": "What is 2 + 2? Reply tersely.",
+     "answer": "4", "additional_context": {}},
+    {"input": "What color is the sky on a clear day? Reply tersely.",
+     "answer": "blue", "additional_context": {}},
+]
+
+result = gepa.optimize(
+    seed_candidate={"system_prompt": "You are a helpful assistant."},
+    trainset=trainset,
+    task_lm=task_lm,              # platform-models wiring (or a stub callable in CI)
+    reflection_lm=reflection_lm,
+    reflection_lm_kwargs=reflection_lm_kwargs,
+    max_metric_calls=60,
+    run_dir="run_dir",
+)
+print(result.best_candidate["system_prompt"])
+```
+
+Stubbing for the no-network smoke: `task_lm` may be any
+`(messages) -> str` callable, and `reflection_lm` any `(prompt) -> str`
+callable whose reply wraps the proposed instruction in a ``` block (that's
+the format the default proposer parses).
+
+## Reporting (and optional PR)
+
+Report the best candidate's aggregate validation score against the seed's,
+the winning text from `result.best_candidate`, and where the run artifacts
+live. If the optimized text belongs in a repo and a GitHub connection is
+granted, open a PR with the change via `gh` — which works through the
+connection, never a held token (see `AGENTS.md`).

--- a/packages/agents/gepa/workspace/.agents/skills/platform-models/SKILL.md
+++ b/packages/agents/gepa/workspace/.agents/skills/platform-models/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: platform-models
+description: >-
+  Reach LLM providers from this platform pod: discover which model-provider
+  connection is attached (injected env), wire LiteLLM with placeholder
+  credentials through the egress credential gateway, and probe models with a
+  cheap completion. Use whenever any code in this pod — a GEPA driver, a
+  script, a library — needs to call a model API, or when a model call fails
+  with an auth error.
+---
+
+# Platform model access — discover → wire → probe
+
+This pod holds **no real model credentials**. The attached model-provider
+connection injects **placeholder** env; the egress gateway swaps in the real
+credential **on the wire**, keyed by destination host + header. Which
+provider is reachable is decided by that connection — never hard-code one.
+
+All examples use `litellm.completion` directly, so they work in any pod with
+LiteLLM installed. (In a GEPA pod, `gepa.lm.LM` is a thin wrapper over the
+same call — every `model`/`api_base`/`api_key` shown below can be passed to
+`LM(...)` unchanged.)
+
+## How auth actually works here (read this before wiring)
+
+The gateway's credential injector runs with **`overwrite: true`** — it
+replaces the auth header's value **whatever you send**. You only have to make
+the client *send the header at all*. Two consequences:
+
+- The injected key env is often an **empty string or a dummy sentinel** — that
+  is expected, not a misconfiguration. An env var present-but-empty still
+  means "this provider is available."
+- LiteLLM refuses to send a request with an empty API key, so **always pass a
+  non-empty placeholder** (`"placeholder"`) when the injected value is empty.
+  Its value is irrelevant — the gateway overwrites it — but its presence is
+  what makes LiteLLM dispatch the request so injection can happen.
+
+**Never hand-roll raw HTTP calls to a model API** (`httpx`/`requests` against
+`/v1/messages` etc.). If LiteLLM seems not to authenticate, the fix is the
+placeholder-key rule above — a raw-HTTP shim is provider-specific, brittle,
+and throws away retries and cost tracking. And never bypass the egress proxy —
+it is what injects the credential and authorizes the destination.
+
+## 1. Discover what the connection injected
+
+Present-but-empty counts as present:
+
+```sh
+env | grep -iE '(_API_KEY|_BASE_URL)=' | sed -E 's/=.*/=<set>/'
+```
+
+## 2. Wire LiteLLM from what's actually there (first match wins)
+
+The `key or "placeholder"` idiom is the load-bearing part.
+
+- **`OPENAI_BASE_URL` (± `OPENAI_API_KEY`)** — an OpenAI-compatible endpoint
+  (a LiteLLM-proxy-class connection, or OpenAI itself). Use
+  `openai/<model-id>` strings with an explicit `api_base`/`api_key`, and try
+  the catalog first (it may 503/401 behind some proxies — fall back to the
+  probe then):
+
+  ```sh
+  base="${OPENAI_BASE_URL%/}"; base="${base%/v1}"
+  curl -fsS "$base/v1/models" \
+    -H "Authorization: Bearer ${OPENAI_API_KEY:-placeholder}" | jq -r '.data[].id'
+  ```
+
+  ```python
+  import os
+
+  base = os.environ["OPENAI_BASE_URL"].rstrip("/")
+  if not base.endswith("/v1"):
+      base += "/v1"
+  key = os.environ.get("OPENAI_API_KEY") or "placeholder"  # gateway overwrites it
+
+  model = f"openai/{MODEL_ID}"
+  lm_kwargs = {"api_base": base, "api_key": key}   # pass alongside model everywhere
+  ```
+
+- **A vendor key var LiteLLM natively reads** (`ANTHROPIC_API_KEY`,
+  `GEMINI_API_KEY`, `MISTRAL_API_KEY`, …) — use that vendor's LiteLLM prefix
+  and pass a non-empty placeholder `api_key` (the env value is a placeholder
+  and may be empty; the gateway injects the real key on `api.<vendor>.com`):
+
+  ```python
+  import os
+
+  key = os.environ.get("ANTHROPIC_API_KEY") or "placeholder"  # gateway overwrites it
+  model = f"anthropic/{MODEL_ID}"
+  lm_kwargs = {"api_key": key}
+  ```
+
+  There's no catalog endpoint to list here — take the model ids from the
+  user or the vendor's current model lineup, then rely on the probe below.
+
+- **Neither** → stop and tell the user to attach a model-provider connection
+  (see `AGENTS.md`). Never invent a provider the env doesn't support and
+  never ask for a literal key.
+
+## 3. Probe before relying on a model
+
+A cheap completion is the provider-neutral validation gate (a catalog listing
+alone can't confirm a completion works, and the probe confirms the
+placeholder-key wiring reaches the gateway):
+
+```python
+import litellm
+
+resp = litellm.completion(
+    model=model,
+    messages=[{"role": "user", "content": "Reply with exactly: OK"}],
+    max_tokens=10,
+    **lm_kwargs,
+)
+print(model, "->", resp.choices[0].message.content[:40])
+```
+
+Triage:
+
+- **Auth error** → the wiring is wrong (wrong provider prefix for the
+  injected host, or a missing placeholder key) — fix the wiring; do **not**
+  drop to a raw HTTP client.
+- **Rate-limit / model-not-found** → that model id isn't provisioned on this
+  connection — pick another from discovery, or ask the user.
+
+## Experiment trackers
+
+Leave integrations like `wandb` / `mlflow` off — they'd reach services this
+pod has no credentials for.

--- a/scripts/resolve-image.sh
+++ b/scripts/resolve-image.sh
@@ -36,7 +36,7 @@ PLATFORM_BASE_PATHS="packages/platform-base packages/agent-runtime packages/agen
 
 # claude-code-derived workloads; single registration point, also emitted as
 # CI's `workloads` build/merge matrix
-WORKLOADS="nous openevolve shinkaevolve"
+WORKLOADS="nous openevolve shinkaevolve gepa"
 
 is_workload() { case " $WORKLOADS " in *" $1 "*) ;; *) return 1 ;; esac; }
 
@@ -139,6 +139,7 @@ self_check() {
   has() { case "$1" in *"$2"*) ;; *) echo "FAIL: [$1] missing [$2]" >&2; f=1 ;; esac; }
   chk "$(base_of nous)" claude-code
   chk "$(base_of shinkaevolve)" claude-code
+  chk "$(base_of gepa)" claude-code
   chk "$(base_of claude-code)" platform-base
   chk "$(base_of platform-base)" ""
   chk "$(local_tag platform-base)" platform-base
@@ -148,11 +149,13 @@ self_check() {
   has "$(effective_paths nous)" packages/agents/nous
   has "$(effective_paths shinkaevolve)" packages/agents/shinkaevolve
   has "$(effective_paths shinkaevolve)" packages/agents/claude-code
+  has "$(effective_paths gepa)" packages/agents/gepa
+  has "$(effective_paths gepa)" packages/agents/claude-code
   # NO_REUSE reproduces the full-build (main/tag) output without git/docker.
   local out; out="$(EVENT=push GITHUB_SHA=deadbeef RESOLVE_NO_REUSE=1; export EVENT GITHUB_SHA RESOLVE_NO_REUSE; gha_outputs)"
   has "$out" 'platform_base=true'
   has "$out" 'agents=["claude-code","codex","pi-agent","bob","k-search"]'
-  has "$out" 'workloads=["nous","openevolve","shinkaevolve"]'
+  has "$out" 'workloads=["nous","openevolve","shinkaevolve","gepa"]'
   has "$out" 'archs=["amd64","arm64"]'
   has "$out" 'claude_code_base_tag=deadbeef'
   has "$out" 'source_shas={"platform-base":"'


### PR DESCRIPTION
## What

Packages [GEPA](https://github.com/gepa-ai/gepa) (Genetic-Pareto — reflective text optimization: prompts, instructions, code snippets, configs) as a curated workload image, following the ShinkaEvolve pattern (#2739).

Closes #948 · part of epic #938.

## How it works

GEPA ships **no CLI** — it's a Python library. The image therefore leans on the conversational pattern: the agent (Claude Code) authors a `driver.py` around `gepa.optimize(...)` — dataset, evaluator (or custom `GEPAAdapter`), bounded budget — the same way it authors evaluators for OpenEvolve/Shinka today. `run_dir` checkpointing maps onto the pod's resume-on-wake flow; graceful stop via the `gepa.stop` sentinel.

Two skills split the reference material to keep upstream knowledge portable:

- **`gepa`** — pure library reference (verified against the pinned 0.1.4 sources), incl. the *trainset-drives-reflection / valset-only-scores* caveat that bit us in testing.
- **`platform-models`** — provider-agnostic model access (discover → wire → probe via LiteLLM), incl. the placeholder-key rule: the gateway's credential injector runs `overwrite: true`, so an empty injected key env just needs a non-empty placeholder — never a raw-HTTP shim.

## Changes

- `packages/agents/gepa/` — Dockerfile (`gepa==0.1.4` + the runtime subset of its `[full]` extra; mlflow/wandb deliberately absent: −420 MB and less Trivy surface), `AGENTS.md`, `README.md`, `tasks.toml`, two skills
- `scripts/resolve-image.sh` — `gepa` in `WORKLOADS` + self-check assertions (single registration point; CI matrix picks it up automatically)
- `mise.toml` — include `packages/agents/gepa/tasks.toml`
- Helm: `agentTemplates.gepa` (`preconfigured`, `experimental`, `Any provider` tag, `setupNote` recommending an API-key-class model connection — first use of that field) + `values-local.yaml` override (`enabled: false`)

## Verified

- `resolve-image.sh --self-check` (incl. under bash 3.2), `helm:check:lint` + `render`, `common:check:zizmor`, `mise run check`, `mise run test`
- Local image build + container smoke: offline `gepa.optimize` loop with stubbed LMs (zero network) exercising `DefaultAdapter`, checkpoint/resume files, and the reflection-proposal format
- End-to-end on a local k3s install: sandbox from the template ran a real prompt-optimization (val score 0.333 → 0.667) through an IBM LiteLLM connection
- 8-angle code review with adversarial verification; confirmed findings fixed (catalog tag, dependency trim, PID-reuse-safe run liveness check, litellm-first skill examples)

## Note for deploy

`quay.io/dam-agents/gepa` must exist (or the robot must be allowed to create it) before the first push-to-main — same out-of-band step as previous workloads.
