### PR TITLE
fix(cluster): skip k3s-selinux RPM when SELinux is disabled

### DIFF
--- a/deploy/lima-k3s-test.yaml
+++ b/deploy/lima-k3s-test.yaml
@@ -41,6 +41,11 @@ provision:
       if [ ! -d /var/lib/rancher/k3s ]; then
         # Pinned: v1.36.2+k3s1 bumped bundled Traefik to chart v40.x, whose validate-install-crd
         # rejects our pre-applied Gateway API v1.2.0/standard CRDs. v1.36.1 ships Traefik v3.6.13.
+        # Skip the k3s-selinux RPM when SELinux isn't active (absent or Disabled):
+        # its binary relabel step fails under set -e on a disabled-SELinux host.
+        if ! { command -v getenforce >/dev/null 2>&1 && [ "$(getenforce)" != Disabled ]; }; then
+          export INSTALL_K3S_SKIP_SELINUX_RPM=true
+        fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.36.1+k3s1" INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644 --https-listen-port 16445" sh -
       fi
       mkdir -p /var/lib/rancher/k3s/server/manifests

--- a/deploy/lima-k3s.yaml
+++ b/deploy/lima-k3s.yaml
@@ -43,6 +43,11 @@ provision:
       if [ ! -d /var/lib/rancher/k3s ]; then
         # Pinned: v1.36.2+k3s1 bumped bundled Traefik to chart v40.x, whose validate-install-crd
         # rejects our pre-applied Gateway API v1.2.0/standard CRDs. v1.36.1 ships Traefik v3.6.13.
+        # Skip the k3s-selinux RPM when SELinux isn't active (absent or Disabled):
+        # its binary relabel step fails under set -e on a disabled-SELinux host.
+        if ! { command -v getenforce >/dev/null 2>&1 && [ "$(getenforce)" != Disabled ]; }; then
+          export INSTALL_K3S_SKIP_SELINUX_RPM=true
+        fi
         curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.36.1+k3s1" INSTALL_K3S_EXEC="server --write-kubeconfig-mode 644 --https-listen-port 16443" sh -
       fi
       # Configure Traefik to also listen on port 4444 (auto-forwarded by lima)


### PR DESCRIPTION
## Problem

`mise run cluster:install` aborts at k3s host-install on a host where **SELinux is present but Disabled at runtime**: the k3s installer relabels its binary when it detects SELinux tooling, that step fails, and under `set -e` it takes down provisioning. (Reported from a real run; manual workaround was `INSTALL_K3S_SKIP_SELINUX_RPM=true`.)

## Fix

Both lima templates (`deploy/lima-k3s.yaml`, `deploy/lima-k3s-test.yaml`) now check SELinux state before running the installer and `export INSTALL_K3S_SKIP_SELINUX_RPM=true` when it isn't active:

```sh
if ! { command -v getenforce >/dev/null 2>&1 && [ "$(getenforce)" != Disabled ]; }; then
  export INSTALL_K3S_SKIP_SELINUX_RPM=true
fi
curl -sfL https://get.k3s.io | INSTALL_K3S_VERSION="v1.36.1+k3s1" INSTALL_K3S_EXEC="server …" sh -
```

- **Disabled, or `getenforce` absent** → skip the k3s-selinux RPM (avoids the failing relabel).
- **Enforcing / Permissive** → unchanged; the policy installs and labels apply as before.

Same pinned k3s version and listen-port args. Scoped to DAM's own k3s provisioning — not the dam-vm VPS/VM.

## Testing

Verified the detection across all four cases (absent / Disabled → skip; Enforcing / Permissive → keep) and that both templates still parse.