### PR TITLE
fix(api-server): report JWKS outages as 503, gate readiness on JWKS warm-up

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -445,9 +445,14 @@ spec:
               readOnly: true
             {{- end }}
           {{- if .Values.probes.enabled }}
+          # Readiness gates on the Keycloak JWKS warm-up (503 until the key
+          # set has been fetched once), so a rolling update keeps the old pod
+          # serving until this pod can verify tokens. Liveness stays on the
+          # static health route — an unreachable Keycloak must degrade, not
+          # restart the pod.
           readinessProbe:
             httpGet:
-              path: /api/health
+              path: /api/ready
               port: http
             initialDelaySeconds: 5
             periodSeconds: 10

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -583,7 +583,10 @@ rm -f "$tar"
 
 echo "Restarting apiserver pod..."
 kubectl --kubeconfig="$KUBECONFIG" rollout restart deployment platform-apiserver
-kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-apiserver --timeout=60s
+# Readiness now gates on the first Keycloak JWKS fetch (warm-up gives up at
+# ~240s), so a fresh pod whose mesh egress is still converging needs headroom
+# past that bound before it reports Ready.
+kubectl --kubeconfig="$KUBECONFIG" rollout status deployment platform-apiserver --timeout=300s
 
 PRUNE_DANGLING='sudo k3s crictl images 2>/dev/null | sed -nE "s/^<none>[[:space:]]+<none>[[:space:]]+([^[:space:]]+).*/\\1/p" | xargs -r sudo k3s crictl rmi >/dev/null 2>&1 || true'
 if [ -n "${IS_SANDBOX:-}" ]; then

--- a/docs/architecture/logging.md
+++ b/docs/architecture/logging.md
@@ -1,6 +1,6 @@
 # Logging
 
-Last verified: 2026-07-15
+Last verified: 2026-07-21
 
 ## Overview
 
@@ -35,8 +35,8 @@ Two disjoint mechanisms feed the one logger:
 
 | Surface | Representative events |
 |---|---|
-| Auth edge | `authn.deny` (bad/missing token), `authz.deny` (missing role). Successful logins are not logged here — the api-server only ever sees already-issued tokens on per-request verification; Keycloak's authentication-event log is the authoritative record of logins. |
-| HTTP / WS edge | `authz.owner_mismatch` (cross-tenant agent access), `ws.authn_deny` / `ws.owner_mismatch` / `ws.terms_block`, `relay.attach` (terminal/ACP attach to a credentialed pod) |
+| Auth edge | `authn.deny` (bad/missing token), `authz.deny` (missing role), `authn.unavailable` (JWKS unreachable — request denied 503 without an authn verdict, no `decision` field). Successful logins are not logged here — the api-server only ever sees already-issued tokens on per-request verification; Keycloak's authentication-event log is the authoritative record of logins. |
+| HTTP / WS edge | `authz.owner_mismatch` (cross-tenant agent access), `ws.authn_deny` / `ws.authn_unavailable` / `ws.owner_mismatch` / `ws.terms_block`, `relay.attach` (terminal/ACP attach to a credentialed pod) |
 | Credentialed egress (HITL) | `egress.decision` (every allow/deny/expired), `egress.hold`; identity-unresolved and ext-authz transport denials |
 | Approvals | `approval.verdict` (approve/deny once/permanent/host) |
 | Authorization lists | `agent.allowed_users_set` (with added/removed diff), `egress_rule.create|update|revoke|preset`, `secret.grants_set`, `connection.grants_set` |

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-07-17
+Last verified: 2026-07-21
 
 ## Overview
 
@@ -124,6 +124,19 @@ user agent flow:
 3. The api-server's `sub` claim becomes `agent-platform.ai/owner=<sub>` on every
    resource the user creates (Agent CR, K8s credential Secret,
    etc.).
+
+If the key set itself cannot be retrieved (Keycloak unreachable, fetch
+timeout, non-200 response), verification fails closed with **503** and
+reason `jwks-unavailable` — never 401: a transient infrastructure failure
+is signalled as retryable, not as a credential rejection. Every
+token-validity failure (expired, bad signature, unknown `kid`, wrong
+audience) remains 401. The api-server also warms the JWKS at boot and
+gates its readiness probe on the first successful fetch, so a rolling
+update keeps the previous pod serving until the new pod can verify
+tokens. The warm-up gives up after a bounded window (so a prolonged
+Keycloak outage cannot wedge a rollout indefinitely): past that, the pod
+reports ready and serves 503s on authenticated routes until Keycloak is
+reachable again.
 
 There is no token exchange — credential storage is K8s-native and label-
 scoped, so the api-server enforces ownership directly when reading and

--- a/packages/api-server/src/__tests__/unit/auth-audit.test.ts
+++ b/packages/api-server/src/__tests__/unit/auth-audit.test.ts
@@ -1,12 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { reloadMock } = vi.hoisted(() => ({ reloadMock: vi.fn() }));
+
 // Stub jose so the middleware can be exercised without a real Keycloak/JWKS.
+// Only the "jose" specifier is stubbed — "jose/errors" stays real, so the
+// classification tests below throw genuine jose error instances.
 vi.mock("jose", () => ({
-  createRemoteJWKSet: () => () => ({}),
+  createRemoteJWKSet: () => Object.assign(() => ({}), { reload: reloadMock }),
   jwtVerify: vi.fn(),
 }));
 
 import { jwtVerify } from "jose";
+import {
+  JOSEError,
+  JWKSInvalid,
+  JWKSNoMatchingKey,
+  JWKSTimeout,
+  JWTExpired,
+} from "jose/errors";
 import { createAuth } from "../../apps/api-server/auth.js";
 import { configureLogger } from "../../core/logger.js";
 
@@ -59,9 +70,9 @@ describe("auth middleware audit", () => {
 
   it("logs authn.deny with the verify-error class (never the token) on a bad JWT", async () => {
     const cap = capture();
-    const err = new Error("expired");
-    err.name = "JWTExpired";
-    verifyMock.mockRejectedValueOnce(err);
+    verifyMock.mockRejectedValueOnce(
+      new JWTExpired('"exp" claim timestamp check failed', {}),
+    );
     const { c, responses } = fakeCtx({
       authorization: "Bearer SECRET.JWT.VAL",
     });
@@ -70,6 +81,116 @@ describe("auth middleware audit", () => {
     const rec = cap.records().find((r) => r.msg === "authn.deny")!;
     expect(rec.reason).toBe("JWTExpired");
     expect(JSON.stringify(cap.records())).not.toContain("SECRET.JWT.VAL");
+  });
+
+  it("returns 503 and logs authn.unavailable when the JWKS fetch fails", async () => {
+    const cap = capture();
+    verifyMock.mockRejectedValueOnce(
+      new TypeError("fetch failed", {
+        cause: Object.assign(new Error("connect ECONNREFUSED"), {
+          code: "ECONNREFUSED",
+        }),
+      }),
+    );
+    const { c, responses } = fakeCtx({
+      authorization: "Bearer SECRET.JWT.VAL",
+    });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]).toEqual({
+      body: { error: "auth unavailable" },
+      status: 503,
+    });
+    const rec = cap.records().find((r) => r.msg === "authn.unavailable")!;
+    expect(rec.reason).toBe("jwks-unavailable");
+    expect(rec.detail.cause).toBe("TypeError: ECONNREFUSED");
+    expect(cap.records().some((r) => r.msg === "authn.deny")).toBe(false);
+    expect(JSON.stringify(cap.records())).not.toContain("SECRET.JWT.VAL");
+  });
+
+  it("keeps a message-only TypeError (jose-internal, attacker-forgeable) at 401", async () => {
+    // jose throws `TypeError('non-ASCII string encountered in encode()')` while
+    // building the signing input from an attacker-supplied payload segment,
+    // BEFORE the signature is checked — a forged token can force it. Unlike
+    // undici's fetch failure it carries no `.cause`, so it must NOT be treated
+    // as a JWKS outage; a forged token stays a credential denial (401), not 503.
+    const cap = capture();
+    verifyMock.mockRejectedValueOnce(
+      new TypeError("non-ASCII string encountered in encode()"),
+    );
+    const { c, responses } = fakeCtx({ authorization: "Bearer x" });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(401);
+    const rec = cap.records().find((r) => r.msg === "authn.deny")!;
+    expect(rec.reason).toBe("TypeError");
+    expect(cap.records().some((r) => r.msg === "authn.unavailable")).toBe(
+      false,
+    );
+  });
+
+  it("returns 503 on a JWKS fetch timeout", async () => {
+    const cap = capture();
+    verifyMock.mockRejectedValueOnce(new JWKSTimeout());
+    const { c, responses } = fakeCtx({ authorization: "Bearer x" });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(503);
+    const rec = cap.records().find((r) => r.msg === "authn.unavailable")!;
+    expect(rec.reason).toBe("jwks-unavailable");
+  });
+
+  it("returns 503 when the JWKS endpoint answers non-200/non-JSON", async () => {
+    const cap = capture();
+    verifyMock.mockRejectedValueOnce(
+      new JOSEError("Expected 200 OK from the JSON Web Key Set HTTP response"),
+    );
+    const { c, responses } = fakeCtx({ authorization: "Bearer x" });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(503);
+    expect(cap.records().some((r) => r.msg === "authn.unavailable")).toBe(true);
+  });
+
+  it("returns 503 when a fetched JWKS body is malformed (200 non-key-set)", async () => {
+    const cap = capture();
+    verifyMock.mockRejectedValueOnce(
+      new JWKSInvalid("JSON Web Key Set malformed"),
+    );
+    const { c, responses } = fakeCtx({ authorization: "Bearer x" });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(503);
+    expect(cap.records().some((r) => r.msg === "authn.unavailable")).toBe(true);
+  });
+
+  it("keeps a fetched-but-unmatched key (kid probing, rotation) at 401", async () => {
+    const cap = capture();
+    verifyMock.mockRejectedValueOnce(new JWKSNoMatchingKey());
+    const { c, responses } = fakeCtx({ authorization: "Bearer x" });
+    await auth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(401);
+    const rec = cap.records().find((r) => r.msg === "authn.deny")!;
+    expect(rec.reason).toBe("JWKSNoMatchingKey");
+  });
+
+  it("keeps API-key denials at 401 with their reason", async () => {
+    const cap = capture();
+    const apiKeyAuth = createAuth(
+      {
+        issuerUrl: "http://kc/realms/platform",
+        jwksUrl: "http://kc/jwks",
+        uiClientId: "platform-ui",
+        cliClientId: "platform-cli",
+      },
+      { verifyApiKey: async () => ({ ok: false, error: "revoked" }) },
+    );
+    const { c, responses } = fakeCtx({ authorization: "Bearer pk_x" });
+    await apiKeyAuth.middleware(c as any, next as any);
+    expect(responses[0]!.status).toBe(401);
+    const rec = cap.records().find((r) => r.msg === "authn.deny")!;
+    expect(rec.reason).toBe("revoked");
+  });
+
+  it("warmJwks delegates to the remote JWK set's reload", async () => {
+    reloadMock.mockResolvedValueOnce(undefined);
+    await auth.warmJwks();
+    expect(reloadMock).toHaveBeenCalled();
   });
 
   it("logs authz.deny against the decoded sub when the required role is missing", async () => {

--- a/packages/api-server/src/__tests__/unit/jwks-warmup.test.ts
+++ b/packages/api-server/src/__tests__/unit/jwks-warmup.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi } from "vitest";
+import { startJwksWarmup } from "../../apps/api-server/jwks-warmup.js";
+import { configureLogger } from "../../core/logger.js";
+
+function capture() {
+  const lines: string[] = [];
+  configureLogger({ level: "info", write: (l) => lines.push(l) });
+  return { records: () => lines.map((l) => JSON.parse(l)) };
+}
+
+describe("startJwksWarmup", () => {
+  it("latches ready after the first successful fetch", async () => {
+    capture();
+    const warm = vi.fn().mockResolvedValue(undefined);
+    const w = startJwksWarmup(warm, {
+      initialMs: 1,
+      maxMs: 1,
+      timeoutMs: 1_000,
+    });
+    await w.done;
+    expect(w.ready()).toBe(true);
+    expect(warm).toHaveBeenCalledTimes(1);
+  });
+
+  it("stays not-ready across failures, then latches on success", async () => {
+    capture();
+    const warm = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockRejectedValueOnce(new Error("fetch failed"))
+      .mockResolvedValueOnce(undefined);
+    const w = startJwksWarmup(warm, {
+      initialMs: 1,
+      maxMs: 1,
+      timeoutMs: 1_000,
+    });
+    expect(w.ready()).toBe(false);
+    await w.done;
+    expect(w.ready()).toBe(true);
+    expect(warm).toHaveBeenCalledTimes(3);
+  });
+
+  it("latches ready on give-up and logs an error", async () => {
+    const cap = capture();
+    const warm = vi.fn().mockRejectedValue(new Error("fetch failed"));
+    const w = startJwksWarmup(warm, { initialMs: 1, maxMs: 1, timeoutMs: 25 });
+    await w.done;
+    expect(w.ready()).toBe(true);
+    expect(
+      cap
+        .records()
+        .some((r) => r.level === "error" && String(r.msg).includes("gave up")),
+    ).toBe(true);
+  });
+});

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -76,7 +76,14 @@ import { createSessionPresence } from "./session-presence.js";
 import { createOAuthRoutes } from "./oauth.js";
 import { mountBrandIconRoutes } from "./brand-icon.js";
 import type { Config } from "../../config.js";
-import { createAuth, ForbiddenError, clientIp } from "./auth.js";
+import {
+  createAuth,
+  AuthUnavailableError,
+  ForbiddenError,
+  UnauthorizedError,
+  clientIp,
+} from "./auth.js";
+import { startJwksWarmup } from "./jwks-warmup.js";
 import { securityLog } from "../../core/security-log.js";
 import { createTermsGate } from "./terms-gate.js";
 import type { IsAcceptedPort } from "../../modules/terms/compose.js";
@@ -265,6 +272,7 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
       verifyOwnerActive: apiKeysModule.verifyOwnerActive,
     },
   );
+  const jwksWarmup = startJwksWarmup(auth.warmJwks);
 
   const slackOauthCallbackUrl =
     config.slackOauthCallbackUrl ??
@@ -288,6 +296,14 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   app.use("*", createShareHostGate(config.shareBaseUrl, shareViewerApp));
 
   app.get("/api/health", (c) => c.json({ status: "ok" }));
+  // Readiness (not liveness): 503 until the Keycloak JWKS has been fetched
+  // once, so a rolling update keeps the old pod serving while this pod's
+  // egress path converges. Latched — never flaps mid-life (see jwks-warmup.ts).
+  app.get("/api/ready", (c) =>
+    jwksWarmup.ready()
+      ? c.json({ status: "ok" })
+      : c.json({ status: "starting", waitingFor: "jwks" }, 503),
+  );
   app.get("/api/version", (c) =>
     c.json({
       serverVersion: config.serverVersion,
@@ -1070,6 +1086,24 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
     try {
       user = (await auth.verify(token)).user;
     } catch (err) {
+      if (err instanceof AuthUnavailableError) {
+        // No credential verdict was reached (hence no `decision` field): the
+        // JWKS fetch failed, so signal a retryable outage, not a rejection.
+        securityLog("warn", "ws.authn_unavailable", {
+          category: "authn",
+          actor: null,
+          actorKind: "external",
+          surface: "ws",
+          agentId,
+          result: "failure",
+          reason: err.reason,
+          sourceIp,
+          detail: { relay: relayKind },
+        });
+        socket.write("HTTP/1.1 503 Service Unavailable\r\n\r\n");
+        socket.destroy();
+        return;
+      }
       const forbidden = err instanceof ForbiddenError;
       securityLog("warn", forbidden ? "ws.authz_deny" : "ws.authn_deny", {
         category: forbidden ? "authz" : "authn",
@@ -1080,9 +1114,11 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
         decision: "deny",
         reason: forbidden
           ? "missing-required-role"
-          : err instanceof Error
-            ? err.name
-            : "verify-failed",
+          : err instanceof UnauthorizedError
+            ? err.reason
+            : err instanceof Error
+              ? err.name
+              : "verify-failed",
         sourceIp,
         detail: { relay: relayKind },
       });

--- a/packages/api-server/src/apps/api-server/auth.ts
+++ b/packages/api-server/src/apps/api-server/auth.ts
@@ -1,4 +1,5 @@
-import { createRemoteJWKSet, jwtVerify } from "jose";
+import { createRemoteJWKSet, jwtVerify, type JWTPayload } from "jose";
+import { JOSEError, JWKSInvalid, JWKSTimeout } from "jose/errors";
 import type { Context, MiddlewareHandler } from "hono";
 import { ALL_SCOPES, type UserIdentity } from "api-server-api";
 import type { Result } from "../../core/result.js";
@@ -33,6 +34,57 @@ export class UnauthorizedError extends Error {
     super(`Unauthorized: ${reason}`);
     this.name = "UnauthorizedError";
   }
+}
+
+/** Token verification could not run: the JWKS could not be retrieved
+ *  (Keycloak unreachable, fetch timeout, non-200/non-JSON response). Not an
+ *  authentication verdict — the token was never evaluated. Mapped to 503 so
+ *  clients retry instead of treating an infra failure as a credential
+ *  rejection; still a deny (fails closed). */
+export class AuthUnavailableError extends Error {
+  readonly reason = "jwks-unavailable";
+  constructor(cause: unknown) {
+    super("Authentication unavailable: JWKS could not be retrieved", {
+      cause,
+    });
+    this.name = "AuthUnavailableError";
+  }
+}
+
+/** Strict allowlist of failures where the JWKS could not be retrieved or
+ *  ingested (jose 6.x): its fetch maps abort timeouts to JWKSTimeout, throws
+ *  bare JOSEError (ERR_JOSE_GENERIC — used nowhere else in the library) on a
+ *  non-200/non-JSON response, throws JWKSInvalid on a fetched-but-malformed
+ *  body (a broken gateway answering 200 with a JSON error), and rethrows
+ *  undici's network `TypeError: fetch failed` unwrapped.
+ *
+ *  The TypeError arm is gated on a `.cause`: undici's fetch failure always
+ *  carries one (ECONNREFUSED, ENOTFOUND, …), whereas jose's own internal
+ *  TypeErrors are message-only. This matters for security — jose can throw a
+ *  bare `TypeError('non-ASCII string encountered in encode()')` while building
+ *  the signing input from an attacker-supplied payload segment, *before* the
+ *  signature is checked; without the `.cause` gate a forged token would be
+ *  misclassified 503/`authn.unavailable` instead of 401/`authn.deny`, letting
+ *  an attacker move forged-token probes out of the deny audit stream. Gating
+ *  on `.cause` (not on the message string, which drifts across Node/undici)
+ *  keeps every real fetch failure a 503 while every token failure — and jose's
+ *  message-only key-material TypeErrors — stays a 401. JWKSNoMatchingKey
+ *  (rotated/foreign kid) is likewise a 401. */
+function isJwksRetrievalFailure(err: unknown): boolean {
+  return (
+    err instanceof JWKSTimeout ||
+    err instanceof JWKSInvalid ||
+    (err instanceof TypeError && err.cause != null) ||
+    (err instanceof JOSEError && err.code === "ERR_JOSE_GENERIC")
+  );
+}
+
+/** Value-free summary for the audit line: error name plus the undici cause
+ *  code (ECONNREFUSED, ENOTFOUND, …) when present. */
+function describeJwksFailure(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const code = (err.cause as { code?: unknown } | undefined)?.code;
+  return typeof code === "string" ? `${err.name}: ${code}` : err.name;
 }
 
 export interface AuthConfig {
@@ -70,6 +122,7 @@ export interface AuthDeps {
 
 const PUBLIC_PATHS = new Set([
   "/api/health",
+  "/api/ready",
   "/api/auth/config",
   "/api/oauth/callback",
   "/api/slack/oauth/callback",
@@ -92,11 +145,17 @@ export function createAuth(config: AuthConfig, deps: AuthDeps = {}) {
   const JWKS = createRemoteJWKSet(new URL(config.jwksUrl));
 
   async function verifyJwt(token: string): Promise<VerifiedPrincipal> {
-    const { payload } = await jwtVerify(token, JWKS, {
-      issuer: config.issuerUrl,
-      audience: config.audience,
-      algorithms: ["RS256"],
-    });
+    let payload: JWTPayload;
+    try {
+      ({ payload } = await jwtVerify(token, JWKS, {
+        issuer: config.issuerUrl,
+        audience: config.audience,
+        algorithms: ["RS256"],
+      }));
+    } catch (err) {
+      if (isJwksRetrievalFailure(err)) throw new AuthUnavailableError(err);
+      throw err;
+    }
 
     const claims = payload as Record<string, unknown>;
     const realmAccess = claims.realm_access as { roles?: string[] } | undefined;
@@ -198,6 +257,21 @@ export function createAuth(config: AuthConfig, deps: AuthDeps = {}) {
       });
       return next();
     } catch (err) {
+      if (err instanceof AuthUnavailableError) {
+        // No credential verdict was reached (hence no `decision` field): the
+        // JWKS fetch failed, so signal a retryable outage, not a rejection.
+        securityLog("warn", "authn.unavailable", {
+          category: "authn",
+          actor: null,
+          actorKind: "external",
+          result: "failure",
+          reason: err.reason,
+          target: c.req.path,
+          sourceIp: clientIp(c),
+          detail: { cause: describeJwksFailure(err.cause) },
+        });
+        return c.json({ error: "auth unavailable" }, 503);
+      }
       if (err instanceof ForbiddenError) {
         // Known principal denied for lack of a required role — the most
         // forensically interesting authz event.
@@ -242,5 +316,7 @@ export function createAuth(config: AuthConfig, deps: AuthDeps = {}) {
     }
   };
 
-  return { middleware, verify };
+  // `reload()` fetches the JWKS immediately and populates jose's cache —
+  // the boot-time warm hook behind `/api/ready` (see jwks-warmup.ts).
+  return { middleware, verify, warmJwks: () => JWKS.reload() };
 }

--- a/packages/api-server/src/apps/api-server/jwks-warmup.ts
+++ b/packages/api-server/src/apps/api-server/jwks-warmup.ts
@@ -1,0 +1,57 @@
+import { getLogger } from "../../core/logger.js";
+import { pollUntilReady } from "../../modules/agents/infrastructure/poll-until-ready.js";
+
+export const JWKS_WARM_INITIAL_MS = 1_000;
+export const JWKS_WARM_MAX_MS = 10_000;
+// Give-up deadline: past the observed mesh-egress convergence window for a
+// fresh pod (~1-5 min), yet under the Deployment progressDeadline (600s) and
+// the e2e rollout timeouts — a dead Keycloak degrades this pod to 503s on
+// authenticated routes instead of wedging the rollout.
+export const JWKS_WARM_TIMEOUT_MS = 240_000;
+
+export interface JwksWarmup {
+  /** Latched true after the first successful JWKS fetch — or after give-up
+   *  (a single-replica deployment must not drop out of every Service
+   *  endpoint, public paths included, over an unreachable Keycloak). */
+  ready: () => boolean;
+  /** Resolves when the loop settles (success or give-up). Exposed for tests. */
+  done: Promise<void>;
+}
+
+/** Fetch the Keycloak JWKS in the background until it succeeds once.
+ *  `/api/ready` reports 503 until then, which under `maxUnavailable: 0`
+ *  keeps the previous pod serving while this pod's mesh egress converges —
+ *  a rolling update never routes users to a pod that can't verify tokens. */
+export function startJwksWarmup(
+  warm: () => Promise<void>,
+  opts: { initialMs?: number; maxMs?: number; timeoutMs?: number } = {},
+): JwksWarmup {
+  let ready = false;
+  getLogger().info("[jwks-warmup] fetching JWKS from Keycloak");
+  const done = pollUntilReady(
+    () =>
+      warm().then(
+        () => true,
+        (err: unknown) => {
+          getLogger().warn(
+            `[jwks-warmup] attempt failed: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          return false;
+        },
+      ),
+    opts.initialMs ?? JWKS_WARM_INITIAL_MS,
+    opts.maxMs ?? JWKS_WARM_MAX_MS,
+    opts.timeoutMs ?? JWKS_WARM_TIMEOUT_MS,
+  ).then((ok) => {
+    ready = true;
+    if (ok) {
+      getLogger().info("[jwks-warmup] JWKS cached; reporting ready");
+    } else {
+      getLogger().error(
+        "[jwks-warmup] gave up waiting for JWKS; reporting ready anyway — " +
+          "authenticated requests will 503 until Keycloak is reachable",
+      );
+    }
+  });
+  return { ready: () => ready, done };
+}

--- a/packages/api-server/src/telemetry.ts
+++ b/packages/api-server/src/telemetry.ts
@@ -73,9 +73,12 @@ if (isOtelEnabled(process.env)) {
     // and its ~90 mostly-inapplicable dependencies.
     instrumentations: [
       new HttpInstrumentation({
-        // Kubelet probes hammer /api/health; not worth a span each.
-        ignoreIncomingRequestHook: (req) =>
-          (req.url ?? "").split("?", 1)[0] === "/api/health",
+        // Kubelet probes hammer /api/health and /api/ready; not worth a
+        // span each (readiness fires every 10s for the pod's whole life).
+        ignoreIncomingRequestHook: (req) => {
+          const path = (req.url ?? "").split("?", 1)[0];
+          return path === "/api/health" || path === "/api/ready";
+        },
       }),
       new UndiciInstrumentation(),
       new GrpcInstrumentation(),

--- a/tasks.toml
+++ b/tasks.toml
@@ -207,7 +207,9 @@ echo "Dropping + recreating the platform database..."
      -c "DROP DATABASE IF EXISTS platform WITH (FORCE);" \
      -c "CREATE DATABASE platform OWNER $POSTGRES_APISERVER_USER;"'
 "${KCTL[@]}" scale deployment platform-apiserver --replicas=1
-"${KCTL[@]}" wait --for=condition=Available deployment/platform-apiserver --timeout=120s
+# Readiness now gates on the first Keycloak JWKS fetch (warm-up gives up at
+# ~240s); allow headroom past that bound for a fresh pod to become Available.
+"${KCTL[@]}" wait --for=condition=Available deployment/platform-apiserver --timeout=300s
 
 # 3. Clear stored Playwright auth so 01-auth re-runs the login + terms flow
 # (terms acceptance lived in the platform DB we just dropped; a fresh browser


### PR DESCRIPTION
## Problem

On every `platform-apiserver` rollout, live UI tRPC calls (`budgets.reserved`, `approvals.listForOwner`, `agents.list`, `channels.available`) received spurious **401 Unauthorized** for ~1–5 min after each new pod started — **187 occurrences over 48h across 4 deploy-correlated bursts, zero between deploys**. A user active during a deploy saw auth errors (and, if their token happened to expire in that window, a forced re-login).

**Root cause:** jose's `createRemoteJWKSet` fetches the Keycloak JWKS lazily on the *first* `jwtVerify`. A freshly-rolled pod's in-mesh (ambient/ztunnel) egress to Keycloak is briefly unreachable, so Node's `fetch` throws `TypeError: fetch failed`. The auth middleware caught that and logged `authn.deny` with `reason: err.name` (`"TypeError"`) → **401** — a transient infrastructure failure reported as a credential rejection, indistinguishable from a bad token. The pod also went `Ready` ~5s after boot on a static `/api/health` probe that checks nothing, so it took 100% of traffic with a cold JWKS.

## Changes

**1. Classify transient JWKS failures as 503, not 401 (fails closed).**
A new `AuthUnavailableError` sentinel is thrown from `verifyJwt` when the key set can't be retrieved/ingested — undici network `TypeError`, `JWKSTimeout`, non-200/non-JSON response (`ERR_JOSE_GENERIC`), or a malformed fetched key set (`JWKSInvalid`). Both the HTTP middleware (→ `503` + `authn.unavailable`) and the WS upgrade handler (→ `503` + `ws.authn_unavailable`) handle it. Every token-validity failure (expired, bad signature, unknown `kid`, wrong audience, API-key denial) stays **401**. The UI already treats 502/503 as a reconnect (suppresses toasts, shows the "Reconnecting…" banner), so 503 degrades gracefully where 401 spammed errors.

**2. Warm the JWKS at boot + real readiness gate.**
`createAuth` exposes `warmJwks = () => JWKS.reload()`; a background loop (`jwks-warmup.ts`) polls it with backoff and a bounded **240s give-up**, then latches ready. A new `/api/ready` returns 503 until latched, and the helm `readinessProbe` points at it (liveness stays on the static `/api/health`). With `maxUnavailable: 0` the old pod keeps serving until the new pod can actually verify tokens; the give-up latch means a prolonged Keycloak outage degrades to 503s instead of wedging the rollout indefinitely.

## Security note (adversarial review finding)

The `TypeError` arm is gated on `.cause`. jose can throw a bare `TypeError('non-ASCII string encountered in encode()')` while building the signing input from an **attacker-supplied payload segment — before the signature is checked**. Without the gate, a forged token could be relabelled `503`/`authn.unavailable` (deny-only, never a bypass — but it would move forged-token probes out of the deny audit/alert stream). undici's fetch failure always carries a `.cause`; jose's internal TypeErrors are message-only — so gating on `.cause != null` keeps every real fetch failure a 503 while every token/key-material TypeError stays a 401. This is more robust than message-matching, which drifts across Node/undici versions.

## ⚠️ Monitoring migration required

Rollout bursts previously showed up in HyperDX as `Body='authn.deny'` with `reason='TypeError'`. They now emit **`authn.unavailable`** (HTTP) / **`ws.authn_unavailable`** (WS) with `reason='jwks-unavailable'` and no `decision` field (no credential verdict was reached). Add a query/alert for the new event names; the old `authn.deny` deny-stream no longer fires on rollout hiccups (that's the point — infra blips stop polluting credential-denial alerting).

## Ops

`/api/ready` now genuinely gates apiserver readiness, so rollout waits that transitively depend on it were bumped past the 240s give-up: `cluster:build-apiserver` `60s → 300s`, `e2e:reset` Available wait `120s → 300s`. The e2e-install `rollout status --timeout=5m` already clears the ~265s worst case (unchanged). The telemetry probe-span filter now also ignores `/api/ready`.

## Tests

`auth-audit.test.ts` extended (15 cases): TypeError-with-cause / JWKSTimeout / ERR_JOSE_GENERIC / JWKSInvalid → 503 `authn.unavailable`; **causeless (attacker-forgeable) TypeError → 401**; JWTExpired / JWKSNoMatchingKey / API-key denial stay 401; `warmJwks` delegates to `reload()`. New `jwks-warmup.test.ts` (3 cases): latch on success, stay-not-ready-then-latch, latch-on-give-up + error log. Full suite: 478 api-server tests pass; `tsc`/eslint/prettier clean; `helm lint`/`render` (kubeconform) pass.

`/api/ready` semantics: a **200 does not guarantee auth is working** after a give-up — it means the startup gate is past. That's intentional (single replica must not drop out of every Service endpoint).

## Verification (manual, not yet run on a live cluster)

1. `cluster:build-apiserver`, scale Keycloak to 0 → authed tRPC returns 503 `{"error":"auth unavailable"}`, logs show `authn.unavailable reason=jwks-unavailable` (not `authn.deny`); `/api/ready` returns 503 on a fresh pod.
2. Scale Keycloak up → warm loop latches, `/api/ready` → 200, auth works.
3. Rollout while the UI polls → old pod serves until the new pod is Ready; no 401 burst; worst case brief 503s → "Reconnecting…" with no error toasts.

## Follow-ups (not in this PR)

- **WS 503 branch has no automated test** — the upgrade handler is an inline closure needing full app deps; the shared classifier is covered via the HTTP path. Extracting a testable `handleRelayUpgrade(deps)` is a reasonable follow-up (matches the pre-existing gap: no WS-upgrade auth tests exist today).
- **UI connection-status flap during a sustained JWKS outage** — 503s flip the health tracker to "reconnecting", but the recovery poll probes the public `/api/health` which recovers before auth does, so status oscillates. The clean fix (gate recovery on an authenticated success, not `/api/health`) is a recovery-probe redesign; the flap self-heals and is strictly better than the old 401 toast-spam.
- **API-key owner-active check** (`verifyOwnerActive`) does per-request Keycloak I/O; its failure during an outage still becomes 401. This PR fixes the JWT path (the UI traffic).