### PR TITLE
fix(approvals): harden the approvals inbox against the #2324 timestamp bug

### DIFF
--- a/packages/api-server/src/modules/approvals/infrastructure/approvals-repository.ts
+++ b/packages/api-server/src/modules/approvals/infrastructure/approvals-repository.ts
@@ -92,13 +92,15 @@ interface RawPending {
   ownerSub: string;
   sessionId: string | null;
   payload: unknown;
-  createdAt: Date;
-  expiresAt: Date;
-  resolvedAt: Date | null;
+  // Raw `db.execute(sql...)` reads bypass drizzle's timestamptz mapper and
+  // yield strings; typed `.select()`/`.returning()` reads yield Dates.
+  createdAt: Date | string;
+  expiresAt: Date | string;
+  resolvedAt: Date | string | null;
   verdict: string | null;
   decidedBy: string | null;
   status: string;
-  deliveredAt: Date | null;
+  deliveredAt: Date | string | null;
 }
 
 /** Default cap when the caller doesn't specify, and the hard ceiling
@@ -113,6 +115,9 @@ function clampLimit(requested: number | undefined): number {
   return Math.min(requested, MAX_LIST_LIMIT);
 }
 
+const toDate = (v: Date | string): Date =>
+  v instanceof Date ? v : new Date(v);
+
 function toPendingRow(r: RawPending): PendingApprovalRow {
   return {
     id: r.id,
@@ -121,13 +126,13 @@ function toPendingRow(r: RawPending): PendingApprovalRow {
     ownerSub: r.ownerSub,
     sessionId: r.sessionId,
     payload: r.payload as ApprovalPayload,
-    createdAt: r.createdAt,
-    expiresAt: r.expiresAt,
-    resolvedAt: r.resolvedAt,
+    createdAt: toDate(r.createdAt),
+    expiresAt: toDate(r.expiresAt),
+    resolvedAt: r.resolvedAt === null ? null : toDate(r.resolvedAt),
     verdict: r.verdict as PendingApprovalRow["verdict"],
     decidedBy: r.decidedBy,
     status: r.status as ApprovalStatus,
-    deliveredAt: r.deliveredAt,
+    deliveredAt: r.deliveredAt === null ? null : toDate(r.deliveredAt),
   };
 }
 


### PR DESCRIPTION
## What & why

The crash behind #2324 had a general cause: one database read path returned timestamps as plain strings while the surrounding code was promised date objects, so the first thing to format such a timestamp threw an internal error.

The approvals subsystem held an identical **dormant** instance. The lookup that de-duplicates retried held requests returned rows whose timestamps were strings masquerading as dates. Nothing crashed today only because the single consumer of that lookup reads just the row's identifier — but any future change that used more of the row (showing a held request's age, its expiry, sorting by resolution time) would have reproduced the #2324 internal error, this time on the held-requests / inbox path, where a crash means an agent's blocked request can't be actioned.

This change normalizes the timestamps at the same boundary the #2324 fix used, so every read path hands the rest of the system real date values regardless of how the row was fetched. A sweep of the remaining database read paths confirmed this was the last one carrying the same string-vs-date mismatch, so the class of bug is now closed rather than fixed one occurrence at a time.

**No user-visible behavior changes today; this is prevention.**

Closes #2767