### PR TITLE
fix(dam-vm): binary-safe non-interactive runs so redirected output survives

### DIFF
--- a/packages/api-server/src/__tests__/unit/harness-vm-relay.test.ts
+++ b/packages/api-server/src/__tests__/unit/harness-vm-relay.test.ts
@@ -14,6 +14,7 @@ import { createVmRelay } from "../../apps/harness-api-server/harness-vm-relay.js
 const OP_INPUT = 0x00;
 const OP_OUTPUT = 0x01;
 const OP_EXIT = 0x03;
+const OP_EOF = 0x05; // dam-vm's raw (no-PTY) stdin-EOF signal
 
 // dam-vm is dam-run.mjs invoked under the vm name (a symlink in the image);
 // recreate that here — the script picks its mode from argv[1]'s basename.
@@ -26,7 +27,7 @@ symlinkSync(
 );
 
 // Stands in for dam-vm-server on the VM host: records the auth headers the
-// relay attached, echoes input frames back as output, and treats EOT (what
+// relay attached, echoes input frames back as output, and treats OP_EOF (what
 // dam-vm sends on piped-stdin end) as "command read to EOF", exiting 0.
 async function fakeVmHost(): Promise<{
   wss: WebSocketServer;
@@ -41,13 +42,11 @@ async function fakeVmHost(): Promise<{
   wss.on("connection", (ws, req) => {
     seen.push({ agent: req.headers["x-dam-vm-agent"] });
     ws.on("message", (raw: Buffer) => {
-      if (raw[0] !== OP_INPUT) return;
-      const data = raw.subarray(1);
-      if (data.includes(0x04)) {
+      if (raw[0] === OP_EOF) {
         ws.send(Buffer.from([OP_EXIT, 0]));
         ws.close(1000);
-      } else {
-        ws.send(Buffer.concat([Buffer.from([OP_OUTPUT]), data]));
+      } else if (raw[0] === OP_INPUT) {
+        ws.send(Buffer.concat([Buffer.from([OP_OUTPUT]), raw.subarray(1)]));
       }
     });
   });

--- a/packages/dam-vm/container-init.sh
+++ b/packages/dam-vm/container-init.sh
@@ -91,6 +91,24 @@ exec "\$(command-real-or-autoinstalled $bin)" "\$@"
 EOF
 done
 
+# agent-browser (vercel-labs/agent-browser) drives a real Chromium. Install
+# chromium from Fedora repos — it brings the graphics/X shared libs the browser
+# needs, which agent-browser's own Chrome-for-Testing download does not — plus
+# the tool via mise/aqua, then point the tool at the system browser so it skips
+# its own download.
+cat > /opt/shims/high/agent-browser << 'EOF'
+#!/bin/sh
+# Fedora's `chromium` package installs the launcher as `chromium-browser`.
+_chromium=$(command-real chromium-browser 2>/dev/null || command-real chromium 2>/dev/null) || {
+  auto-install chromium dnf install -yq chromium || exit 1
+  _chromium=$(command-real chromium-browser 2>/dev/null || command-real chromium 2>/dev/null)
+}
+command-real agent-browser >/dev/null 2>&1 \
+  || auto-install agent-browser sh -c 'MISE_AUTO_INSTALL=false MISE_NO_HOOKS=true mise use -g "aqua:vercel-labs/agent-browser" && mise install "aqua:vercel-labs/agent-browser"' || exit 1
+export AGENT_BROWSER_EXECUTABLE_PATH="$_chromium"
+exec "$(command-real-or-autoinstalled agent-browser)" "$@"
+EOF
+
 chmod +x /opt/shims/high/*
 
 # ── low shims (fill in tools that aren't installed) ──────────────────────────

--- a/packages/dam-vm/dam-vm-server.mjs
+++ b/packages/dam-vm/dam-vm-server.mjs
@@ -30,7 +30,9 @@ import { createServer as createHttpsServer } from "node:https";
 const OP_INPUT = 0x00,
   OP_OUTPUT = 0x01,
   OP_RESIZE = 0x02,
-  OP_EXIT = 0x03;
+  OP_EXIT = 0x03,
+  OP_STDERR = 0x04, // raw (no-PTY) path only: stderr kept separate from stdout
+  OP_EOF = 0x05; // raw path only: close the command's stdin
 
 const LISTEN_HOST = process.env.DAM_VM_LISTEN_HOST || "0.0.0.0";
 const LISTEN_PORT = process.env.DAM_VM_PORT
@@ -249,6 +251,10 @@ wss.on("connection", async (ws, req) => {
   if (argv.length === 0) argv = ["bash", "-l"];
   const cols = Math.min(500, parseInt(url.searchParams.get("cols"), 10) || 80);
   const rows = Math.min(300, parseInt(url.searchParams.get("rows"), 10) || 24);
+  // Interactive (client stdin+stdout are TTYs) → PTY. Otherwise raw pipes, so
+  // binary stdout survives redirection (`dam-vm cat x > x`). Default to PTY for
+  // an older client that doesn't send the flag.
+  const wantTty = url.searchParams.get("tty") !== "0";
   // W3C trace context forwarded by dam-vm so the command joins the session's
   // trace (same contract as the dam-run exec server).
   const traceEnv = ["traceparent", "tracestate"].flatMap((k) => {
@@ -266,47 +272,71 @@ wss.on("connection", async (ws, req) => {
   active.set(name, (active.get(name) || 0) + 1);
 
   // argv goes to incus as an array — nothing is ever interpreted by a host shell
-  const term = ptySpawn(
-    "incus",
-    [
-      "exec",
-      name,
-      "--env",
-      "TERM=xterm-256color",
-      ...traceEnv,
-      "--cwd",
-      "/root",
-      "--",
-      ...argv,
-    ],
-    { name: "xterm-256color", cols, rows },
-  );
-
-  term.onData((data) => {
-    if (ws.readyState !== ws.OPEN) return;
-    const buf = Buffer.from(data);
-    ws.send(Buffer.concat([Buffer.from([OP_OUTPUT]), buf]));
-  });
-  term.onExit(({ exitCode }) => {
+  const execArgs = [
+    "exec",
+    name,
+    "--env",
+    "TERM=xterm-256color",
+    ...traceEnv,
+    "--cwd",
+    "/root",
+    "--",
+    ...argv,
+  ];
+  const send = (op, data) => {
+    if (ws.readyState === ws.OPEN)
+      ws.send(Buffer.concat([Buffer.from([op]), Buffer.from(data)]));
+  };
+  const exit = (code) => {
     if (ws.readyState === ws.OPEN) {
-      ws.send(Buffer.from([OP_EXIT, exitCode & 0xff]));
+      ws.send(Buffer.from([OP_EXIT, code & 0xff]));
       ws.close(1000);
     }
-  });
+  };
+
+  // Interactive → PTY (incus sees a tty on its stdio and allocates one in the
+  // container). Otherwise a plain child with pipes: incus runs non-interactive
+  // and streams raw bytes, so redirected binary output isn't CRLF-mangled.
+  let onInput, onEof, onResize, kill;
+  if (wantTty) {
+    const term = ptySpawn("incus", execArgs, {
+      name: "xterm-256color",
+      cols,
+      rows,
+    });
+    term.onData((d) => send(OP_OUTPUT, d));
+    term.onExit(({ exitCode }) => exit(exitCode));
+    onInput = (payload) => term.write(payload.toString("binary"));
+    onEof = () => {}; // a PTY has no EOF; interactive clients don't send OP_EOF
+    onResize = (c, r) => term.resize(c, r);
+    kill = () => term.kill();
+  } else {
+    const child = spawn("incus", execArgs); // stdio pipes → incus non-interactive
+    child.stdout.on("data", (d) => send(OP_OUTPUT, d));
+    child.stderr.on("data", (d) => send(OP_STDERR, d));
+    child.stdin.on("error", () => {}); // swallow EPIPE if the command already exited
+    child.on("error", () => exit(1));
+    child.on("exit", (code, signal) => exit(code ?? (signal ? 1 : 0)));
+    onInput = (payload) => child.stdin.write(payload);
+    onEof = () => child.stdin.end();
+    onResize = () => {}; // no tty to resize
+    kill = () => child.kill();
+  }
 
   ws.on("message", (data) => {
     const buf = Buffer.from(data);
     if (buf.length === 0) return;
-    if (buf[0] === OP_INPUT) term.write(buf.subarray(1).toString("binary"));
+    if (buf[0] === OP_INPUT) onInput(buf.subarray(1));
+    else if (buf[0] === OP_EOF) onEof();
     else if (buf[0] === OP_RESIZE && buf.length >= 5)
-      term.resize(
+      onResize(
         Math.min(500, (buf[1] << 8) | buf[2]) || 80,
         Math.min(300, (buf[3] << 8) | buf[4]) || 24,
       );
   });
   ws.on("close", () => {
     try {
-      term.kill();
+      kill();
     } catch {}
     const n = (active.get(name) || 1) - 1;
     n > 0 ? active.set(name, n) : active.delete(name);

--- a/packages/dam-vm/dam-vm-server.mjs
+++ b/packages/dam-vm/dam-vm-server.mjs
@@ -316,7 +316,9 @@ wss.on("connection", async (ws, req) => {
     child.stderr.on("data", (d) => send(OP_STDERR, d));
     child.stdin.on("error", () => {}); // swallow EPIPE if the command already exited
     child.on("error", () => exit(1));
-    child.on("exit", (code, signal) => exit(code ?? (signal ? 1 : 0)));
+    // "close" (not "exit"): fires after stdout/stderr have flushed to EOF, so
+    // the OP_EXIT close can't race past trailing output and truncate it.
+    child.on("close", (code, signal) => exit(code ?? (signal ? 1 : 0)));
     onInput = (payload) => child.stdin.write(payload);
     onEof = () => child.stdin.end();
     onResize = () => {}; // no tty to resize

--- a/packages/platform-base/AGENTS.md
+++ b/packages/platform-base/AGENTS.md
@@ -30,8 +30,11 @@ directory is persistent; the rest of the filesystem is reset on pod restart.
   it has its own filesystem (you are root, cwd `/root`), no credentials, no
   gateway, no `/home/agent`. It persists across invocations while in active
   use but is deleted after ~1 hour idle — copy results out before you're
-  done. Use it for work a sandbox pod can't do: systemd, docker/k3s, nested
-  containers, kernel-adjacent tooling. With no command it opens an
-  interactive login shell.
+  done: `dam-vm cat <vm-path> > <local-path>` streams a file back byte-exact
+  (binary included). Use it for work a sandbox pod can't do: systemd,
+  docker/k3s, nested containers, kernel-adjacent tooling. With no command it
+  opens an interactive login shell. The VM's ports aren't reachable from this
+  pod, so to drive a web app or GUI running inside the VM, run your browser
+  tooling from inside the VM (e.g. `dam-vm agent-browser …`).
 <!-- dam-vm:end -->
 

--- a/packages/platform-base/dam-run.mjs
+++ b/packages/platform-base/dam-run.mjs
@@ -10,8 +10,10 @@
 //     survives across invocations while in active use but is deleted after
 //     ~1 h idle — an ephemeral machine, not durable storage.
 // Both ride the same rails: derive the harness URL from PLATFORM_MCP_URL, open
-// one WebSocket (/run or /vm), and stream stdio through a PTY via the shared
-// frame protocol so it reads like a local invocation.
+// one WebSocket (/run or /vm), and stream stdio via the shared frame protocol.
+// Interactive invocations get a remote PTY (reads like a local shell);
+// non-interactive dam-vm runs raw (no PTY) so e.g. `dam-vm cat x > x` preserves
+// binary output instead of getting terminal (CRLF) translation applied.
 //
 // Dependency-free: uses Node's global WebSocket (which honors NODE_USE_ENV_PROXY
 // + NODE_EXTRA_CA_CERTS already set in the agent env, so it routes through the
@@ -19,11 +21,17 @@
 // headers, so args ride the URL query; the api-server relay forwards them.
 import { basename } from "node:path";
 
-// Frame opcodes — must match packages/api-server-api/src/modules/terminal/protocol.ts.
+// Frame opcodes 0x00–0x03 match packages/api-server-api/src/modules/terminal/protocol.ts.
 const OP_INPUT = 0x00;
 const OP_OUTPUT = 0x01;
 const OP_RESIZE = 0x02;
 const OP_EXIT = 0x03;
+// dam-vm-only extensions for the non-interactive (no-PTY) path, so binary
+// stdout survives redirection: stderr is a separate stream, and stdin EOF is a
+// real close (a PTY has neither). The /vm relay splices frames byte-for-byte,
+// so only the CLI and dam-vm-server need to agree on these.
+const OP_STDERR = 0x04;
+const OP_EOF = 0x05;
 
 const NAME = basename(process.argv[1], ".mjs"); // dam-run | dam-vm
 const IS_VM = NAME === "dam-vm";
@@ -39,6 +47,15 @@ if (!mcpUrl || !/\/mcp$/.test(mcpUrl)) {
   process.stderr.write(`${NAME}: PLATFORM_MCP_URL not set; not inside a sandbox pod?\n`);
   process.exit(1);
 }
+
+// Allocate a remote PTY only when interactive. dam-vm additionally requires
+// stdout to be a terminal, so `dam-vm cat x > x` runs without a PTY and binary
+// output survives redirection (no CRLF translation); dam-run keeps its
+// stdin-only heuristic since its executor always uses a PTY.
+const interactive = IS_VM
+  ? Boolean(process.stdin.isTTY && process.stdout.isTTY)
+  : Boolean(process.stdin.isTTY);
+
 const runUrl =
   mcpUrl.replace(/\/mcp$/, IS_VM ? "/vm" : "/run").replace(/^http/, "ws") +
   "?argv=" +
@@ -46,6 +63,7 @@ const runUrl =
   // no cwd for the VM: its filesystem is its own, commands run in /root
   (IS_VM ? "" : "&cwd=" + encodeURIComponent(process.cwd())) +
   `&cols=${process.stdout.columns || 80}&rows=${process.stdout.rows || 24}` +
+  `&tty=${interactive ? 1 : 0}` +
   // Forward the caller's W3C trace context (the harness sets TRACEPARENT for
   // its subprocesses) so the remote command joins the session's trace and
   // its telemetry folds into the session's metrics.
@@ -58,13 +76,12 @@ const runUrl =
 
 const ws = new WebSocket(runUrl);
 ws.binaryType = "arraybuffer";
-const isTty = Boolean(process.stdin.isTTY);
 
 let exited = false;
 const finish = (code) => {
   if (exited) return;
   exited = true;
-  if (isTty) {
+  if (interactive) {
     try {
       process.stdin.setRawMode(false);
     } catch {}
@@ -96,14 +113,21 @@ const resizeFrame = () => {
 ws.onopen = () => {
   clearTimeout(dialTimeout);
   send(resizeFrame());
-  if (isTty) {
+  if (interactive) {
     process.stdin.setRawMode(true);
     process.stdout.on("resize", () => send(resizeFrame()));
   } else {
-    // Piped stdin: a PTY has no true EOF, so signal it the terminal way, with
-    // EOT — twice, since the first only flushes a partial line (a raw-mode
-    // command would read the 0x04 bytes as data, same as in a real terminal).
-    process.stdin.on("end", () => send(new Uint8Array([OP_INPUT, 0x04, 0x04])));
+    // Non-interactive stdin end → EOF. dam-vm runs raw (no PTY) so close its
+    // stdin for real; dam-run's executor uses a PTY (no true EOF), so signal
+    // it the terminal way with EOT — twice, since the first only flushes a
+    // partial line (the command reads the 0x04 bytes as data, as in a tty).
+    process.stdin.on("end", () =>
+      send(
+        IS_VM
+          ? new Uint8Array([OP_EOF])
+          : new Uint8Array([OP_INPUT, 0x04, 0x04]),
+      ),
+    );
   }
   process.stdin.on("data", (chunk) => {
     const frame = new Uint8Array(chunk.length + 1);
@@ -118,6 +142,7 @@ ws.onmessage = (ev) => {
   const buf = new Uint8Array(ev.data);
   if (buf.length === 0) return;
   if (buf[0] === OP_OUTPUT) process.stdout.write(buf.subarray(1));
+  else if (buf[0] === OP_STDERR) process.stderr.write(buf.subarray(1));
   // finish() exits the process; no need to close the socket
   else if (buf[0] === OP_EXIT) finish(buf.length > 1 ? buf[1] : 0);
 };


### PR DESCRIPTION
## Problem

`dam-vm cat file.png > file.png` corrupted the file: every non-interactive
`dam-vm` invocation ran through a remote PTY, whose ONLCR translation rewrote
`\n`→`\r\n` in the byte stream and folded stderr into stdout.

## Fix

Allocate a PTY only when the run is genuinely interactive; otherwise use raw
pipes end-to-end.

- **CLI (`dam-run.mjs`, shared with `dam-vm`)**: `interactive` now requires
  stdin *and* stdout to be TTYs for `dam-vm` (so a redirect drops the PTY). It
  passes `&tty=0|1`, and on the raw path prints `OP_STDERR` to stderr and sends
  a real `OP_EOF` on stdin end (a PTY has neither).
- **Server (`dam-vm-server.mjs`)**: branches on `tty`. Interactive → `ptySpawn`
  (unchanged behavior). Non-interactive → a plain piped `spawn`, so `incus exec`
  runs non-interactive and streams bytes verbatim; stderr rides `OP_STDERR`,
  `OP_EOF` closes the command's stdin.

Two new opcodes (`OP_STDERR=0x04`, `OP_EOF=0x05`) are relay-transparent — the
`/vm` relay splices frames byte-for-byte, so only the CLI and server agree on
them.

## Verification (real VPS, dam-dev cluster CA)

- Raw path (`tty=0`): 100 KB `/dev/urandom` round-trip is **byte-exact**
  (client sha256 == in-container sha256); stdout keeps LF, stderr arrives
  separately on `OP_STDERR`.
- Interactive path (`tty=1`): still gets CRLF + merged stderr, exits cleanly.