### PR TITLE
refactor(ui): migrate the connection template form to React Hook Form + Zod

### DIFF
--- a/packages/ui/src/modules/connections/forms/field-copy.ts
+++ b/packages/ui/src/modules/connections/forms/field-copy.ts
@@ -14,7 +14,7 @@ const FIELD_LABELS: Record<string, string> = {
   installationId: "Installation ID",
   privateKey: "Private key (PEM)",
   envName: "Environment variable",
-  caData: "Server CA certificate (optional)",
+  caData: "Server CA certificate",
 };
 
 const FIELD_PLACEHOLDERS: Record<string, string> = {

--- a/packages/ui/src/modules/connections/forms/labeled-input.tsx
+++ b/packages/ui/src/modules/connections/forms/labeled-input.tsx
@@ -40,7 +40,8 @@ export function LabeledInput({
     >
       {multiline ? (
         <Textarea
-          variant="monospace"
+          variant={error ? "invalid" : "monospace"}
+          className="font-mono"
           rows={8}
           data-testid={testId}
           placeholder={placeholder}
@@ -52,6 +53,7 @@ export function LabeledInput({
       ) : (
         <Input
           type={type ?? "text"}
+          variant={error ? "invalid" : undefined}
           data-testid={testId}
           placeholder={placeholder}
           value={value}

--- a/packages/ui/src/modules/connections/forms/overridable-section.tsx
+++ b/packages/ui/src/modules/connections/forms/overridable-section.tsx
@@ -1,26 +1,25 @@
 import type { ConnectionTemplateInput } from "api-server-api";
+import { type Control, Controller, useWatch } from "react-hook-form";
 
 import { Switch } from "@/components/ui/switch";
 
+import type { TemplateFormValues } from "../lib/template-form-schema.js";
 import { DisclosureBox } from "./disclosure-box.js";
-import { labelFor, placeholderFor } from "./field-copy.js";
-import { LabeledInput } from "./labeled-input.js";
+import { labelFor } from "./field-copy.js";
+import { TemplateFieldInput } from "./template-field-input.js";
 
 export function OverridableSection({
   inputs,
-  fields,
-  overriding,
+  control,
+  templateId,
   fromFamily,
-  setF,
-  setOverriding,
 }: {
   inputs: ConnectionTemplateInput[];
-  fields: Record<string, string>;
-  overriding: boolean;
+  control: Control<TemplateFormValues>;
+  templateId: string;
   fromFamily?: boolean;
-  setF: (k: string, v: string) => void;
-  setOverriding: (v: boolean) => void;
 }) {
+  const overriding = useWatch({ control, name: "overrideDefaults" });
   // A single toggle flips the whole overridable group: the fields only make
   // sense overridden together (your own app means all of its credentials, not
   // a mix of presets and custom values), so we don't expose them per-field.
@@ -33,23 +32,27 @@ export function OverridableSection({
               ? "Reused from another connection you've already set up. Leave off to share the same app, or turn on to use your own."
               : "These values are pre-configured by your administrator. Leave off to use the defaults, or turn on to supply your own."}
           </p>
-          <Switch
-            checked={overriding}
-            onCheckedChange={setOverriding}
-            testId="override-defaults-toggle"
-            label="Customize defaults"
+          <Controller
+            control={control}
+            name="overrideDefaults"
+            render={({ field }) => (
+              <Switch
+                checked={field.value}
+                onCheckedChange={field.onChange}
+                testId="override-defaults-toggle"
+                label="Customize defaults"
+              />
+            )}
           />
         </div>
         {overriding ? (
           <div className="flex flex-col gap-3">
             {inputs.map((input) => (
-              <LabeledInput
+              <TemplateFieldInput
                 key={input.name}
-                label={input.label ?? labelFor(input.name)}
-                placeholder={placeholderFor(input.name)}
-                type={input.secret ? "password" : "text"}
-                value={fields[input.name] ?? ""}
-                onChange={(v) => setF(input.name, v)}
+                control={control}
+                templateId={templateId}
+                input={input}
               />
             ))}
           </div>

--- a/packages/ui/src/modules/connections/forms/template-create-form-body.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form-body.tsx
@@ -1,21 +1,24 @@
-import type {
-  ConnectionTemplateInput,
-  ConnectionTemplateView,
-} from "api-server-api";
-import { type ReactNode, useState } from "react";
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { ConnectionTemplateView } from "api-server-api";
+import { type ReactNode, useMemo } from "react";
+import { Controller, useForm } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
 import { emitToast } from "@/lib/toast";
 
 import { useTemplateCreateSubmit } from "../hooks/use-template-create-submit.js";
 import { buildCreatePayload } from "../lib/build-create-payload.js";
-import { slugifyTemplateName } from "../lib/connection-name.js";
+import {
+  buildTemplateFormSchema,
+  templateFormDefaults,
+  type TemplateFormValues,
+} from "../lib/template-form-schema.js";
 import { DisclosureBox } from "./disclosure-box.js";
-import { hintFor, labelFor, placeholderFor } from "./field-copy.js";
 import { LabeledInput } from "./labeled-input.js";
 import { OAuthAppHint } from "./oauth-app-hint.js";
 import { OverridableSection } from "./overridable-section.js";
 import { TemplateExplainer } from "./template-explainer.js";
+import { TemplateFieldInput } from "./template-field-input.js";
 
 export interface TemplateCreateFormProps {
   template: ConnectionTemplateView;
@@ -45,16 +48,12 @@ export function TemplateCreateFormBody({
 }: TemplateCreateFormProps & {
   layout?: (fields: ReactNode, footer: ReactNode) => ReactNode;
 }) {
-  const [name, setName] = useState(() => slugifyTemplateName(template.name));
-  const [fields, setFields] = useState<Record<string, string>>(() => {
-    const init: Record<string, string> = {};
-    for (const i of template.inputs) {
-      if (i.presetValue !== undefined && !i.secret)
-        init[i.name] = i.presetValue;
-    }
-    return init;
+  const schema = useMemo(() => buildTemplateFormSchema(template), [template]);
+  const { control, handleSubmit } = useForm<TemplateFormValues>({
+    resolver: zodResolver(schema),
+    mode: "onChange",
+    defaultValues: templateFormDefaults(template),
   });
-  const [overrideDefaults, setOverrideDefaults] = useState(false);
 
   const {
     submit,
@@ -84,21 +83,14 @@ export function TemplateCreateFormBody({
   // from a sibling connection in the same credential family — the copy differs.
   const credentialsFromFamily = template.extras?.credentialsFromFamily === true;
 
-  const setF = (k: string, v: string) =>
-    setFields((prev) => ({ ...prev, [k]: v }));
-
-  const onSubmit = () => {
-    const payload = buildCreatePayload(template, {
-      name,
-      fields,
-      overrideDefaults,
-    });
+  const onSubmit = handleSubmit((values) => {
+    const payload = buildCreatePayload(template, values);
     if ("error" in payload) {
       emitToast({ kind: "error", message: payload.error });
       return;
     }
     void submit(payload);
-  };
+  });
 
   const required = template.inputs.filter((i) => i.state === "required");
   const optional = template.inputs.filter((i) => i.state === "optional");
@@ -109,13 +101,22 @@ export function TemplateCreateFormBody({
 
   const fieldsRegion = (
     <div className="flex flex-col gap-4">
-      <LabeledInput
-        label="Name"
-        testId="connection-field-name"
-        placeholder="my-connection"
-        value={name}
-        onChange={setName}
-        help="Lowercase letters, digits, and single hyphens (e.g. my-mcp-server). Doubles as the MCP slug."
+      <Controller
+        control={control}
+        name="name"
+        render={({ field, fieldState }) => (
+          <LabeledInput
+            label="Name"
+            testId="connection-field-name"
+            placeholder="my-connection"
+            autoFocus
+            value={field.value}
+            onChange={field.onChange}
+            onBlur={field.onBlur}
+            error={fieldState.error?.message}
+            inset
+          />
+        )}
       />
 
       {bringYourOwnApp && (
@@ -128,10 +129,9 @@ export function TemplateCreateFormBody({
       {required.map((input) => (
         <TemplateFieldInput
           key={input.name}
+          control={control}
           templateId={template.id}
           input={input}
-          value={fields[input.name] ?? ""}
-          onChange={(v) => setF(input.name, v)}
         />
       ))}
 
@@ -139,10 +139,9 @@ export function TemplateCreateFormBody({
         optional.map((input) => (
           <TemplateFieldInput
             key={input.name}
+            control={control}
             templateId={template.id}
             input={input}
-            value={fields[input.name] ?? ""}
-            onChange={(v) => setF(input.name, v)}
           />
         ))}
 
@@ -152,10 +151,9 @@ export function TemplateCreateFormBody({
             {optional.map((input) => (
               <TemplateFieldInput
                 key={input.name}
+                control={control}
                 templateId={template.id}
                 input={input}
-                value={fields[input.name] ?? ""}
-                onChange={(v) => setF(input.name, v)}
               />
             ))}
           </div>
@@ -165,11 +163,9 @@ export function TemplateCreateFormBody({
       {overridable.length > 0 && (
         <OverridableSection
           inputs={overridable}
-          fields={fields}
-          overriding={overrideDefaults}
+          control={control}
+          templateId={template.id}
           fromFamily={credentialsFromFamily}
-          setF={setF}
-          setOverriding={setOverrideDefaults}
         />
       )}
 
@@ -214,32 +210,4 @@ export function TemplateCreateFormBody({
   );
 
   return <>{layout(fieldsRegion, footerRegion)}</>;
-}
-
-function TemplateFieldInput({
-  templateId,
-  input,
-  value,
-  onChange,
-}: {
-  templateId: string;
-  input: ConnectionTemplateInput;
-  value: string;
-  onChange: (v: string) => void;
-}) {
-  return (
-    <LabeledInput
-      label={
-        (input.label ?? labelFor(input.name)) +
-        (input.state === "optional" ? " (optional)" : "")
-      }
-      testId={`connection-field-${input.name}`}
-      placeholder={placeholderFor(input.name)}
-      type={input.secret ? "password" : "text"}
-      multiline={input.multiline}
-      value={value}
-      onChange={onChange}
-      help={hintFor(templateId, input.name) ?? input.hint}
-    />
-  );
 }

--- a/packages/ui/src/modules/connections/forms/template-field-input.tsx
+++ b/packages/ui/src/modules/connections/forms/template-field-input.tsx
@@ -1,0 +1,43 @@
+import type { ConnectionTemplateInput } from "api-server-api";
+import { type Control, Controller } from "react-hook-form";
+
+import type { TemplateFormValues } from "../lib/template-form-schema.js";
+import { hintFor, labelFor, placeholderFor } from "./field-copy.js";
+import { LabeledInput } from "./labeled-input.js";
+
+export function TemplateFieldInput({
+  control,
+  templateId,
+  input,
+}: {
+  control: Control<TemplateFormValues>;
+  templateId: string;
+  input: ConnectionTemplateInput;
+}) {
+  const optional = input.state === "optional";
+  const basePlaceholder = placeholderFor(input.name);
+  const placeholder = optional
+    ? [basePlaceholder, "(optional)"].filter(Boolean).join(" ")
+    : basePlaceholder;
+  return (
+    <Controller
+      control={control}
+      name={`fields.${input.name}`}
+      render={({ field, fieldState }) => (
+        <LabeledInput
+          label={input.label ?? labelFor(input.name)}
+          testId={`connection-field-${input.name}`}
+          placeholder={placeholder}
+          type={input.secret ? "password" : "text"}
+          multiline={input.multiline}
+          value={field.value ?? ""}
+          onChange={field.onChange}
+          onBlur={field.onBlur}
+          error={fieldState.error?.message}
+          help={hintFor(templateId, input.name) ?? input.hint}
+          inset
+        />
+      )}
+    />
+  );
+}

--- a/packages/ui/src/modules/connections/lib/template-form-schema.ts
+++ b/packages/ui/src/modules/connections/lib/template-form-schema.ts
@@ -1,0 +1,73 @@
+import type { ConnectionTemplateView } from "api-server-api";
+import { z } from "zod";
+
+import {
+  slugifyTemplateName,
+  validateConnectionName,
+} from "./connection-name.js";
+
+/** Mirrors the validation the server enforces on the same template inputs,
+ *  so violations surface inline before submit. */
+export function buildTemplateFormSchema(template: ConnectionTemplateView) {
+  const patterns = new Map<string, RegExp>();
+  for (const input of template.inputs) {
+    if (!input.pattern) continue;
+    try {
+      patterns.set(input.name, new RegExp(input.pattern));
+    } catch {
+      // A malformed template pattern must not take down the form.
+    }
+  }
+  return z
+    .object({
+      name: z.string(),
+      overrideDefaults: z.boolean(),
+      fields: z.record(z.string(), z.string()),
+    })
+    .superRefine((v, ctx) => {
+      const nameError = validateConnectionName(v.name.trim());
+      if (nameError)
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["name"],
+          message: nameError,
+        });
+      for (const input of template.inputs) {
+        if (input.state === "overridable" && !v.overrideDefaults) continue;
+        const raw = (v.fields[input.name] ?? "").trim();
+        const issue = (message: string) =>
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ["fields", input.name],
+            message,
+          });
+        if (raw === "") {
+          if (input.state === "required") issue("Required");
+          continue;
+        }
+        const pattern = patterns.get(input.name);
+        if (pattern && !pattern.test(raw))
+          issue(input.patternHint ?? "Invalid format");
+        if (input.enumValues && !input.enumValues.includes(raw))
+          issue(`Must be one of: ${input.enumValues.join(", ")}`);
+      }
+    });
+}
+
+export type TemplateFormValues = z.infer<
+  ReturnType<typeof buildTemplateFormSchema>
+>;
+
+export function templateFormDefaults(
+  template: ConnectionTemplateView,
+): TemplateFormValues {
+  const fields: Record<string, string> = {};
+  for (const i of template.inputs)
+    fields[i.name] =
+      !i.secret && i.presetValue !== undefined ? i.presetValue : "";
+  return {
+    name: slugifyTemplateName(template.name),
+    overrideDefaults: false,
+    fields,
+  };
+}


### PR DESCRIPTION
## What

Migrates the connection catalogue's template create form from hand-rolled controlled state to React Hook Form + Zod, matching the MCP pane's existing form idiom. Behavior is preserved — preset values, the Customize-defaults toggle, and the popup OAuth submission are untouched.

What users notice:

- Required fields, format rules, and allowed values now validate **inline, before submit**, with per-field messages and a red border on the offending input — previously most of this only failed server-side or as a toast.
- The Name field behaves like the MCP pane's: live format validation instead of always-visible help text.
- "(optional)" moved from field labels into placeholders.

Side benefit: the MCP pane's field errors also gain the red border, since the shared field component now paints it.

Closes #2812

https://claude.ai/code/session_01EQ7eHrr6USd3T1dddzRCFw