### PR TITLE
feat(artifacts): promote the artifact library from experimental to production

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -68,7 +68,7 @@ Each page is the authoritative, self-contained description of its subsystem — 
 - [connections](architecture/connections.md) — unified Connection / Contribution model, runtime channel between api-server and agent-runtime, transactional outbox + worker delivery, agent-side driver model.
 - [experiments](architecture/experiments.md) — group competing agent sessions under one goal as arms, and collect the scores and downloadable artifacts each reports for comparison.
 - [artifact-library](architecture/artifact-library.md) — agents and users publish artifacts (HTML/JSX/markdown/code/files) into an owner-scoped library and share them by link on a dedicated share host, with folders, expiry, and versions.
-- [features](architecture/features.md) — per-user experimental-feature flags: server-stored, default off, gating UI surfaces and per-agent MCP tool registration (progressive disclosure, not authorization).
+- [features](architecture/features.md) — per-user experimental-feature flags: server-stored, default off, gating pre-release surfaces (progressive disclosure, not authorization).
 - [usage-tracking](architecture/usage-tracking.md) — append-only activity log in Postgres, SQL views as the read interface, HMAC-pseudonymized identifiers, inspector-role gating.
 - [logging](architecture/logging.md) — Pino structured logging to stdout, and the real-identity security audit trail built on it (the forensic counterpart to pseudonymized usage-tracking).
 - [observability](architecture/observability.md) — the optional, bundled agent-telemetry backend: an OTLP collector writing OpenTelemetry signals into a columnar store with an exploration UI, gated by the mesh rather than ingestion tokens.

--- a/docs/architecture/artifact-library.md
+++ b/docs/architecture/artifact-library.md
@@ -1,6 +1,6 @@
 # Artifact library
 
-Last verified: 2026-07-17
+Last verified: 2026-07-21
 
 ## Overview
 
@@ -145,11 +145,6 @@ and permanently removes artifacts — private ones included — whose expiry
 passed more than the grace window ago. Agent deletion does
 **not** touch artifacts — attribution simply points at a name that no longer
 resolves.
-
-The whole library ships behind a per-user experimental-feature flag (see
-[features](features.md)): the flag reveals the UI surfaces and registers the
-agent MCP tools per session; the underlying endpoints stay owner-scoped and
-are not flag-gated.
 
 ## Where the code lives
 

--- a/docs/architecture/features.md
+++ b/docs/architecture/features.md
@@ -1,34 +1,36 @@
 # Experimental features
 
-Last verified: 2026-07-17
+Last verified: 2026-07-21
 
 ## Overview
 
 **Experimental features** are per-user toggles for pre-release surfaces. Every
 feature defaults **off**; a user opts in through a hidden "Experimental
 features" settings tab (revealed by five taps on the version string). The
-current features are the artifact library, experiments, and advanced
-connection types.
+current features are experiments and advanced connection types.
 
 Flags are stored server-side, per user, in Postgres — not in the browser.
-That is deliberate: feature surfaces are not only UI. The artifact library,
-for example, registers MCP tools on the per-agent platform MCP server, and
-whether those tools exist for an agent's session is decided from the owner's
-flags at session creation. A browser-local flag could not reach that
-decision. (Server-stored flags replaced earlier localStorage-based debug
-toggles for the same surfaces; users who had those set re-enable via the
-menu.)
+That is deliberate: feature surfaces are not necessarily UI-only. A
+pre-release surface can include agent-facing pieces — MCP tools on the
+per-agent platform MCP server, registered per session from the owner's flags
+— and a browser-local flag could not reach that decision. (Server-stored
+flags replaced earlier localStorage-based debug toggles for the same
+surfaces; users who had those set re-enable via the menu.)
 
 ## What a flag does — and does not — gate
 
 A feature flag is **progressive disclosure, not authorization**. It controls
 where a feature *appears*:
 
-- **UI surfaces** — navigation destinations, settings tabs, panels.
+- **UI surfaces** — navigation destinations, settings tabs, panels. All
+  current features gate only these.
 - **Agent surface** — whether the feature's MCP tools are registered into an
-  agent's MCP session. Registration is per session, so a toggle reaches live
-  agents when their session rolls over (bounded by the session TTL) and new
-  sessions immediately.
+  agent's MCP session, decided at session creation. A toggle then reaches
+  live agents when their session rolls over (bounded by the session TTL) and
+  new sessions immediately. No current feature carries an agent surface (the
+  artifact library did before its promotion to a standard surface); the
+  session-creation check is reintroduced with the next feature that needs
+  it.
 
 It does **not** gate the underlying API: the feature's tRPC endpoints remain
 available to the authenticated owner regardless of the flag. Every endpoint

--- a/packages/api-server-api/src/modules/features/schemas.ts
+++ b/packages/api-server-api/src/modules/features/schemas.ts
@@ -3,11 +3,7 @@ import { z } from "zod";
 /** The closed set of toggleable features. Adding one: extend this enum and
  *  give it a row in the UI's Features menu — storage needs no migration
  *  (absent row = off). */
-export const featureIdSchema = z.enum([
-  "advanced-connections",
-  "experiments",
-  "artifacts",
-]);
+export const featureIdSchema = z.enum(["advanced-connections", "experiments"]);
 
 export const featureSetFlagInputSchema = z.object({
   feature: featureIdSchema,

--- a/packages/api-server/src/apps/harness-api-server/app.ts
+++ b/packages/api-server/src/apps/harness-api-server/app.ts
@@ -13,7 +13,6 @@ import {
 } from "../../modules/schedules/index.js";
 import { composeExperimentsForOwner } from "../../modules/experiments/index.js";
 import { composeArtifactLibraryForOwner } from "../../modules/artifact-library/index.js";
-import { isFeatureEnabled } from "../../modules/features/index.js";
 import { composeInvocationsForOwner } from "../../modules/invocations/index.js";
 import type { ArtifactService } from "../../modules/artifacts/services/artifact-service.js";
 import { composeSkillsModule } from "../../modules/skills/compose.js";
@@ -107,8 +106,6 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
         owner,
         shareBaseUrl: config.shareBaseUrl,
       }).artifactLibrary,
-    isArtifactsFeatureEnabled: (owner) =>
-      isFeatureEnabled(db, owner, "artifacts"),
     invocationsServiceFor,
     connectionsServiceFor,
     templates,

--- a/packages/api-server/src/apps/harness-api-server/harness-router.ts
+++ b/packages/api-server/src/apps/harness-api-server/harness-router.ts
@@ -24,7 +24,6 @@ export function createHarnessRouter(deps: {
   schedulesServiceFor: (owner: string) => SchedulesService;
   experimentsServiceFor: (owner: string) => ExperimentsService;
   artifactLibraryFor: (owner: string) => ArtifactLibraryServiceImpl;
-  isArtifactsFeatureEnabled: (owner: string) => Promise<boolean>;
   invocationsServiceFor: (owner: string) => InvocationsService;
   connectionsServiceFor: (owner: string) => ConnectionsService;
   templates: TemplatesService;
@@ -42,7 +41,6 @@ export function createHarnessRouter(deps: {
     schedulesServiceFor: deps.schedulesServiceFor,
     experimentsServiceFor: deps.experimentsServiceFor,
     artifactLibraryFor: deps.artifactLibraryFor,
-    isArtifactsFeatureEnabled: deps.isArtifactsFeatureEnabled,
     invocationsServiceFor: deps.invocationsServiceFor,
     artifacts: deps.artifacts,
     maxArtifactBytes: deps.maxArtifactBytes,

--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -115,11 +115,6 @@ export interface McpSessionDeps {
   schedules: SchedulesService;
   experiments: ExperimentsService;
   artifactLibrary: ArtifactLibraryServiceImpl;
-  /** Per-user feature flag: when off the artifact tools are not registered
-   *  at all — the feature is invisible to the harness, not merely erroring.
-   *  Checked per session; a cached session keeps its tool set until it
-   *  expires (30 min TTL). */
-  artifactsFeatureEnabled: boolean;
   invocations: InvocationsService;
   artifacts: ArtifactService;
   maxArtifactBytes: number;
@@ -707,13 +702,11 @@ export function createMcpSession(
 
   // ---- Artifact-library tools ----------------------------------------------
   // Publish/share/version artifacts; owner-scoped service, creations
-  // attributed to the network-verified caller. Feature-gated per user.
-  if (deps.artifactsFeatureEnabled) {
-    registerArtifactLibraryTools(server, {
-      artifactLibrary: deps.artifactLibrary,
-      agentId,
-    });
-  }
+  // attributed to the network-verified caller.
+  registerArtifactLibraryTools(server, {
+    artifactLibrary: deps.artifactLibrary,
+    agentId,
+  });
 
   server.tool(
     "report_result",
@@ -766,7 +759,6 @@ export interface MountMcpDeps {
   schedulesServiceFor: (owner: string) => SchedulesService;
   experimentsServiceFor: (owner: string) => ExperimentsService;
   artifactLibraryFor: (owner: string) => ArtifactLibraryServiceImpl;
-  isArtifactsFeatureEnabled: (owner: string) => Promise<boolean>;
   invocationsServiceFor: (owner: string) => InvocationsService;
   artifacts: ArtifactService;
   maxArtifactBytes: number;
@@ -825,9 +817,6 @@ export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
     const schedules = deps.schedulesServiceFor(verified.owner);
     const experiments = deps.experimentsServiceFor(verified.owner);
     const artifactLibrary = deps.artifactLibraryFor(verified.owner);
-    const artifactsFeatureEnabled = await deps.isArtifactsFeatureEnabled(
-      verified.owner,
-    );
     const invocations = deps.invocationsServiceFor(verified.owner);
     const session = createMcpSession(agentId, {
       channelManager: deps.channelManager,
@@ -836,7 +825,6 @@ export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
       schedules,
       experiments,
       artifactLibrary,
-      artifactsFeatureEnabled,
       invocations,
       artifacts: deps.artifacts,
       maxArtifactBytes: deps.maxArtifactBytes,

--- a/packages/api-server/src/modules/features/index.ts
+++ b/packages/api-server/src/modules/features/index.ts
@@ -1,2 +1,1 @@
 export { composeFeaturesForOwner } from "./compose.js";
-export { isFeatureEnabled } from "./infrastructure/features-repository.js";

--- a/packages/api-server/src/modules/features/infrastructure/features-repository.ts
+++ b/packages/api-server/src/modules/features/infrastructure/features-repository.ts
@@ -1,4 +1,4 @@
-import { and, eq, sql, type Db, userFeatures } from "db";
+import { eq, sql, type Db, userFeatures } from "db";
 
 export interface FeaturesRepository {
   /** Explicitly toggled features for an owner; absent = default (off). */
@@ -29,21 +29,4 @@ export function createFeaturesRepository(db: Db): FeaturesRepository {
         });
     },
   };
-}
-
-/** Boot-scoped single-flag read for surfaces composed outside a user request
- *  (the per-agent MCP session). */
-export async function isFeatureEnabled(
-  db: Db,
-  owner: string,
-  feature: string,
-): Promise<boolean> {
-  const [row] = await db
-    .select({ enabled: userFeatures.enabled })
-    .from(userFeatures)
-    .where(
-      and(eq(userFeatures.owner, owner), eq(userFeatures.feature, feature)),
-    )
-    .limit(1);
-  return row?.enabled ?? false;
 }

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -64,10 +64,7 @@ function MainApp() {
       view === "experiments" ||
       view === "experiment-new" ||
       view === "experiment-detail";
-    if (
-      (experimentsView && !features.experiments) ||
-      (view === "artifacts" && !features.artifacts)
-    ) {
+    if (experimentsView && !features.experiments) {
       setView("list");
     }
   }, [features, view, setView]);

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -40,7 +40,6 @@ export function IconRail({
   const pendingCount = approvals.filter((r) => r.status === "pending").length;
   const { data: features } = useFeatures();
   const showExperiments = features?.experiments ?? false;
-  const showArtifacts = features?.artifacts ?? false;
 
   const home: Destination = {
     label: "Home",
@@ -100,7 +99,7 @@ export function IconRail({
         </div>
         <div className="flex flex-col items-center gap-1">
           <RailItem {...home} />
-          {showArtifacts && <RailItem {...artifacts} />}
+          <RailItem {...artifacts} />
           {showExperiments && <RailItem {...experiments} />}
         </div>
         <div className="flex-1" />
@@ -115,7 +114,7 @@ export function IconRail({
         <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 flex items-stretch border-t bg-card/95 backdrop-blur-xl safe-bottom">
           {[
             home,
-            ...(showArtifacts ? [artifacts] : []),
+            artifacts,
             ...(showExperiments ? [experiments] : []),
             inbox,
             settings,

--- a/packages/ui/src/modules/artifacts/components/artifact-link-chip.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-link-chip.tsx
@@ -3,7 +3,6 @@ import { Box } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { useStore } from "../../../store.js";
-import { useFeatures } from "../../features/api/queries.js";
 import { useArtifact } from "../api/queries.js";
 import { ArtifactKindBadge } from "./artifact-badges.js";
 
@@ -26,8 +25,7 @@ export function ArtifactLinkChip({
   artifactId: string;
   children?: ReactNode;
 }) {
-  const artifactsEnabled = useFeatures().data?.artifacts ?? false;
-  const { data: artifact } = useArtifact(artifactsEnabled ? artifactId : null);
+  const { data: artifact } = useArtifact(artifactId);
   const openArtifactId = useStore((s) => s.openArtifactId);
   const setOpenArtifactId = useStore((s) => s.setOpenArtifactId);
 
@@ -36,8 +34,6 @@ export function ArtifactLinkChip({
     (typeof children === "string" && children !== artifactId
       ? children
       : "artifact");
-
-  if (!artifactsEnabled) return <span>{label}</span>;
 
   return (
     <button

--- a/packages/ui/src/modules/features/components/features-tab.tsx
+++ b/packages/ui/src/modules/features/components/features-tab.tsx
@@ -12,12 +12,6 @@ interface FeatureRow {
 
 const FEATURE_ROWS: FeatureRow[] = [
   {
-    id: "artifacts",
-    label: "Artifacts",
-    description:
-      "Publish, organize, and share agent work products (HTML, JSX, markdown, code, files) with public links and expiry. Adds the Artifacts pages and the agents' artifact tools.",
-  },
-  {
     id: "experiments",
     label: "Experiments",
     description:
@@ -32,8 +26,8 @@ const FEATURE_ROWS: FeatureRow[] = [
 ];
 
 /** The hidden Features settings tab — per-user, per-feature toggles stored
- *  server-side, because feature surfaces include the agents' MCP tools which
- *  only the server can hide. */
+ *  server-side so feature surfaces beyond the browser (e.g. agents' MCP
+ *  tools) can be gated too. */
 export function FeaturesTab() {
   const { data: flags } = useFeatures();
   const setFeature = useSetFeature();
@@ -44,8 +38,7 @@ export function FeaturesTab() {
         Experimental features
       </h2>
       <p className="mb-6 text-[14px] text-foreground/80">
-        Experimental features, toggled per user. Agents pick up changes on their
-        next session (within about half an hour for live ones).
+        Experimental features, toggled per user.
       </p>
 
       <div className="flex flex-col gap-3">

--- a/packages/ui/src/modules/sandboxes/components/sandbox-section-nav.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-section-nav.tsx
@@ -15,35 +15,20 @@ const SECTIONS: SectionEntry[] = [
   { section: "artifacts", title: "Artifacts" },
 ];
 
-/** Sections hidden while their feature flag is off. */
-const FEATURE_GATED: Partial<Record<SandboxSection, "artifacts">> = {
-  artifacts: "artifacts",
-};
-
 interface Props {
   active: SandboxSection;
   onNavigate: (section: SandboxSection) => void;
   // Live one-line summary per section, keyed by section id (slice 03).
   summaries?: Partial<Record<SandboxSection, string>>;
-  /** Feature-gated sections to include (from the caller's flags). */
-  showArtifacts?: boolean;
 }
 
-export function SandboxSectionNav({
-  active,
-  onNavigate,
-  summaries,
-  showArtifacts = false,
-}: Props) {
-  const sections = SECTIONS.filter(
-    (entry) => !FEATURE_GATED[entry.section] || showArtifacts,
-  );
+export function SandboxSectionNav({ active, onNavigate, summaries }: Props) {
   return (
     <nav
       aria-label="Sandbox sections"
       className="flex shrink-0 flex-col gap-1 md:sticky md:top-12 md:w-[245px] md:self-start"
     >
-      {sections.map((entry) => (
+      {SECTIONS.map((entry) => (
         <SectionNavItem
           key={entry.section}
           title={entry.title}

--- a/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
@@ -15,7 +15,6 @@ import {
 import { useArtifacts } from "../../artifacts/api/queries.js";
 import { useAppConnections } from "../../connections/api/queries.js";
 import { catalogProviderTitle } from "../../connections/lib/catalog-providers.js";
-import { useFeatures } from "../../features/api/queries.js";
 import type { SandboxSection } from "../../platform/lib/routes.js";
 import { useSchedules } from "../../schedules/api/queries.js";
 import { useTemplates } from "../../templates/api/queries.js";
@@ -105,9 +104,8 @@ export function useSectionSummaries(agent: AgentView | null): SectionSummaries {
     return `${running} Schedule${running === 1 ? "" : "s"} running`;
   }, [agent, schedules]);
 
-  const artifactsEnabled = useFeatures().data?.artifacts ?? false;
   const { data: agentArtifacts } = useArtifacts(
-    agent && artifactsEnabled ? { agentId: agent.id } : null,
+    agent ? { agentId: agent.id } : null,
   );
   const artifactsSummary = useMemo(() => {
     if (!agent || !agentArtifacts) return undefined;

--- a/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
@@ -7,7 +7,6 @@ import { useSyncRestartingAgents } from "../../agents/hooks/use-restart-agent.js
 import { useSyncPausingAgents } from "../../agents/hooks/use-suspend-agent.js";
 import { resolveAgentDisplay } from "../../agents/utils/agent-resolver.js";
 import { SandboxArtifactsSection } from "../../artifacts/components/sandbox-artifacts-section.js";
-import { useFeatures } from "../../features/api/queries.js";
 import { ConnectionsSection } from "../components/connections-section.js";
 import { SandboxHomeHeader } from "../components/sandbox-home-header.js";
 import { SandboxSchedulesSection } from "../components/sandbox-schedules-section.js";
@@ -37,7 +36,6 @@ export function SandboxHomeView() {
   );
 
   const summaries = useSectionSummaries(f.agent);
-  const artifactsEnabled = useFeatures().data?.artifacts ?? false;
 
   if (f.status !== "ready" || !f.agent) {
     return (
@@ -86,7 +84,6 @@ export function SandboxHomeView() {
           active={section}
           onNavigate={(s) => navigateToSandboxHome(agent.id, s)}
           summaries={summaries}
-          showArtifacts={artifactsEnabled}
         />
       }
     >
@@ -97,7 +94,7 @@ export function SandboxHomeView() {
         <SandboxSkillsSection agent={agent} />
       ) : section === "schedules" ? (
         <SandboxSchedulesSection agentId={agent.id} />
-      ) : section === "artifacts" && artifactsEnabled ? (
+      ) : section === "artifacts" ? (
         <SandboxArtifactsSection agentId={agent.id} />
       ) : (
         <ConnectionsSection

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -48,7 +48,6 @@ import { resolveAgentDisplay } from "../../agents/utils/agent-resolver.js";
 import { EgressApprovalToasts } from "../../approvals/components/egress-approval-toasts.js";
 import { ChatArtifactsPanel } from "../../artifacts/components/chat-artifacts-panel.js";
 import { DockedArtifactPanel } from "../../artifacts/components/docked-artifact-panel.js";
-import { useFeatures } from "../../features/api/queries.js";
 import { DockedFilePanel } from "../../files/components/docked-file-panel.js";
 import { FilesPanel } from "../../files/components/files-panel.js";
 import { ImportInProgressBadge } from "../../files/components/import-in-progress-badge.js";
@@ -101,9 +100,7 @@ export function ChatView() {
   const setSessionError = useStore((s) => s.setSessionError);
   const deleteSession = useStore((s) => s.deleteSession);
   const openFilePath = useStore((s) => s.openFilePath);
-  const artifactsEnabled = useFeatures().data?.artifacts ?? false;
-  const rawOpenArtifactId = useStore((s) => s.openArtifactId);
-  const openArtifactId = artifactsEnabled ? rawOpenArtifactId : null;
+  const openArtifactId = useStore((s) => s.openArtifactId);
   const artifactsSectionOpen = useStore((s) => s.artifactsSectionOpen);
   const setArtifactsSectionOpen = useStore((s) => s.setArtifactsSectionOpen);
   const goBack = useStore((s) => s.goBack);
@@ -456,15 +453,13 @@ export function ChatView() {
             style={sectionFlex(filesSectionOpen)}
             onOpenFile={openFileHandler}
           />
-          {artifactsEnabled && (
-            <ChatArtifactsPanel
-              agentId={selectedAgent}
-              open={artifactsSectionOpen}
-              onToggle={() => setArtifactsSectionOpen(!artifactsSectionOpen)}
-              className={sectionTransition}
-              style={sectionFlex(artifactsSectionOpen)}
-            />
-          )}
+          <ChatArtifactsPanel
+            agentId={selectedAgent}
+            open={artifactsSectionOpen}
+            onToggle={() => setArtifactsSectionOpen(!artifactsSectionOpen)}
+            className={sectionTransition}
+            style={sectionFlex(artifactsSectionOpen)}
+          />
         </div>
         <ResizeHandle
           side="left"


### PR DESCRIPTION
## Summary

Promotes the artifact library out of the per-user experimental-feature flag: the Artifacts surfaces are now visible to everyone and the artifact MCP tools are registered into every agent session.

- **Contract**: drop the `artifacts` id from the feature-flag enum. No data migration needed — the flags read is built from the enum, so stale stored rows are ignored (as `docs/architecture/features.md` promises for retired features), and `setFlag("artifacts", …)` is now rejected by input validation.
- **api-server**: register the artifact-library MCP tools unconditionally per session; remove the per-owner flag lookup and its plumbing through the harness router. Delete the now-dead `isFeatureEnabled` single-flag read (the MCP session gate was its only caller).
- **UI**: show the Artifacts rail destination, sandbox Artifacts section, chat artifacts panel, link chips, and section summaries unconditionally; drop the Artifacts row from the hidden features tab and its now-stale "agents pick up changes next session" copy (the remaining flags are UI-only).
- **Docs**: update `artifact-library.md`, `features.md`, and the architecture index in the same PR per the drift rule.

## Testing

- `mise run check` passes
- `mise run test` passes (all packages)
- Not exercised on a live cluster; Playwright has no artifacts coverage — a quick manual check of the rail and sandbox Artifacts section on a dev cluster is worthwhile.