### PR TITLE
fix(connections): back off failing OAuth token refreshes

### DIFF
--- a/packages/api-server/src/__tests__/unit/oauth-refresh-backoff.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-backoff.test.ts
@@ -1,0 +1,241 @@
+import { describe, it, expect } from "vitest";
+import type { Db } from "db";
+import type { ConnectionAuthConfig } from "api-server-api";
+import {
+  backoffDelayMs,
+  createOAuthRefreshLoop,
+} from "../../modules/connections/services/oauth-refresh.js";
+import { createOAuthEngine } from "../../modules/connections/infrastructure/oauth-engine.js";
+import type { ConnectionTemplateRegistry } from "../../modules/connections/domain/connection-template.js";
+import type { SecretStore } from "../../modules/secret-store/index.js";
+
+const AUTH: Extract<ConnectionAuthConfig, { kind: "oauth" }> = {
+  kind: "oauth",
+  clientId: "cid",
+  refreshTokenRef: {
+    storeId: "test",
+    path: "secret-p",
+    field: "refresh_token",
+  },
+  accessTokenRef: { storeId: "test", path: "secret-p", field: "access_token" },
+  scopes: ["read"],
+  tokenUrl: "https://auth.example.com/token",
+  authorizationUrl: "https://auth.example.com/authorize",
+  expiresAt: 1000,
+  connectedAt: 900,
+};
+
+const CC_AUTH: Extract<ConnectionAuthConfig, { kind: "client-credentials" }> = {
+  kind: "client-credentials",
+  clientId: "cid",
+  clientSecretRef: {
+    storeId: "test",
+    path: "secret-p",
+    field: "client_secret",
+  },
+  accessTokenRef: { storeId: "test", path: "secret-p", field: "access_token" },
+  issuerUrl: "https://auth.example.com/realms/main",
+  tokenUrl: "https://auth.example.com/token",
+  scopes: ["read"],
+  expiresAt: 1000,
+  connectedAt: 900,
+};
+
+interface RawRow {
+  id: string;
+  owner: string;
+  templateId: string;
+  name: string;
+  inputs: unknown;
+  auth: unknown;
+  contributions: unknown;
+}
+
+const rowFor = (id: string, auth: ConnectionAuthConfig = AUTH): RawRow => ({
+  id,
+  owner: "owner-sub",
+  templateId: "custom-oauth",
+  name: id,
+  inputs: {},
+  auth,
+  contributions: [],
+});
+
+function makeLoop(opts?: {
+  baseMs?: number;
+  maxMs?: number;
+  auth?: ConnectionAuthConfig;
+}) {
+  const auth = opts?.auth ?? AUTH;
+  let clock = 0;
+  let mode: "fail" | "ok" = "fail";
+  let fetchCount = 0;
+  let rows: RawRow[] = [rowFor("conn-1", auth)];
+
+  const fetchImpl = (async () => {
+    fetchCount++;
+    if (mode === "fail") {
+      // What Google returns for a revoked refresh token.
+      return new Response("error=invalid_grant", { status: 400 });
+    }
+    return new Response(
+      JSON.stringify({ access_token: "tok", expires_in: 3600 }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  }) as typeof fetch;
+
+  // dueConnections' SQL predicate is exercised against Postgres elsewhere; the
+  // fake returns the current row set verbatim so these tests isolate the
+  // loop's backoff bookkeeping.
+  const db = {
+    select: () => ({ from: () => ({ where: () => Promise.resolve(rows) }) }),
+    update: () => ({
+      set: () => ({ where: () => Promise.resolve(undefined) }),
+    }),
+  } as unknown as Db;
+
+  const loop = createOAuthRefreshLoop({
+    db,
+    engine: createOAuthEngine({ now: () => clock, fetchImpl }),
+    templates: {
+      get: () => undefined,
+    } as unknown as ConnectionTemplateRegistry,
+    secretStore: {
+      getField: async () => "refresh-tok",
+      putFields: async () => {},
+    } as unknown as SecretStore,
+    backoffBaseMs: opts?.baseMs ?? 60_000,
+    backoffMaxMs: opts?.maxMs ?? 30 * 60_000,
+    now: () => clock,
+    log: () => {},
+  });
+
+  return {
+    loop,
+    setClock: (t: number) => (clock = t),
+    setMode: (m: "fail" | "ok") => (mode = m),
+    setRows: (ids: string[]) => (rows = ids.map((id) => rowFor(id, auth))),
+    fetchCount: () => fetchCount,
+  };
+}
+
+describe("backoffDelayMs", () => {
+  it("doubles per consecutive failure and caps at max", () => {
+    expect(backoffDelayMs(1, 1000, 100_000)).toBe(1000);
+    expect(backoffDelayMs(2, 1000, 100_000)).toBe(2000);
+    expect(backoffDelayMs(3, 1000, 100_000)).toBe(4000);
+    expect(backoffDelayMs(100, 1000, 100_000)).toBe(100_000);
+  });
+
+  it("treats a zero/negative failure count as the base delay", () => {
+    expect(backoffDelayMs(0, 1000, 100_000)).toBe(1000);
+  });
+});
+
+describe("oauth refresh loop backoff", () => {
+  it("backs off exponentially and skips a failing connection until due", async () => {
+    const h = makeLoop({ baseMs: 60_000 });
+
+    h.setClock(0);
+    expect(await h.loop.tickOnce()).toEqual({
+      refreshed: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(h.fetchCount()).toBe(1);
+
+    // Same instant: inside the 60s backoff window → skipped, no network call.
+    expect(await h.loop.tickOnce()).toEqual({
+      refreshed: 0,
+      failed: 0,
+      skipped: 1,
+    });
+    expect(h.fetchCount()).toBe(1);
+
+    // Just before the window elapses: still skipped.
+    h.setClock(59_999);
+    expect((await h.loop.tickOnce()).skipped).toBe(1);
+    expect(h.fetchCount()).toBe(1);
+
+    // Window elapsed: retry (still failing) → next window doubles to 120s.
+    h.setClock(60_000);
+    expect(await h.loop.tickOnce()).toEqual({
+      refreshed: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(h.fetchCount()).toBe(2);
+
+    // 60_000 + 120_000 = 180_000 is the next attempt; 120_000 is still early.
+    h.setClock(120_000);
+    expect((await h.loop.tickOnce()).skipped).toBe(1);
+    expect(h.fetchCount()).toBe(2);
+  });
+
+  it("resets the failure counter (not just the timer) after a success", async () => {
+    const h = makeLoop({ baseMs: 60_000 });
+
+    // First failure → failures=1, nextAttempt = 0 + 60_000.
+    h.setClock(0);
+    await h.loop.tickOnce();
+
+    // Succeeds once the window elapses → the entry must be fully cleared.
+    h.setClock(60_000);
+    h.setMode("ok");
+    expect((await h.loop.tickOnce()).refreshed).toBe(1);
+
+    // Fails again. If the counter reset this is failures=1 → a 60s window
+    // (nextAttempt = 60_001 + 60_000 = 120_001). Had the entry survived the
+    // success, it would be failures=2 → a 120s window (nextAttempt = 180_001).
+    h.setClock(60_001);
+    h.setMode("fail");
+    expect((await h.loop.tickOnce()).failed).toBe(1);
+    const afterSecondFailure = h.fetchCount();
+
+    // At 150_000 the 60s window has elapsed but a doubled 120s window has not:
+    // a retry here is only possible if the success reset the counter to base.
+    // (If the entry had survived, this tick would be skipped instead.)
+    h.setClock(150_000);
+    expect((await h.loop.tickOnce()).failed).toBe(1);
+    expect(h.fetchCount()).toBe(afterSecondFailure + 1);
+  });
+
+  it("applies the same backoff to a failing client-credentials remint", async () => {
+    const h = makeLoop({ baseMs: 60_000, auth: CC_AUTH });
+
+    h.setClock(0);
+    expect(await h.loop.tickOnce()).toEqual({
+      refreshed: 0,
+      failed: 1,
+      skipped: 0,
+    });
+    expect(h.fetchCount()).toBe(1);
+
+    // Inside the backoff window → skipped, no second remint attempt.
+    expect((await h.loop.tickOnce()).skipped).toBe(1);
+    expect(h.fetchCount()).toBe(1);
+  });
+
+  it("prunes backoff state once a connection leaves the due set", async () => {
+    const h = makeLoop({ baseMs: 100_000 });
+
+    h.setClock(0);
+    await h.loop.tickOnce(); // fail → nextAttempt = 100_000
+    expect(h.fetchCount()).toBe(1);
+
+    // Connection no longer due (refreshed elsewhere / deleted) → entry pruned.
+    h.setRows([]);
+    expect(await h.loop.tickOnce()).toEqual({
+      refreshed: 0,
+      failed: 0,
+      skipped: 0,
+    });
+
+    // It reappears well before the old window: a stale entry would skip it,
+    // but the pruned state means it is attempted immediately.
+    h.setRows(["conn-1"]);
+    h.setClock(50_000);
+    expect((await h.loop.tickOnce()).failed).toBe(1);
+    expect(h.fetchCount()).toBe(2);
+  });
+});

--- a/packages/api-server/src/modules/connections/services/oauth-refresh.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh.ts
@@ -25,7 +25,7 @@ import { mintClientCredentialsToken } from "./client-credentials.js";
 export interface OAuthRefreshLoop {
   start(): void;
   stop(): Promise<void>;
-  tickOnce(): Promise<{ refreshed: number; failed: number }>;
+  tickOnce(): Promise<{ refreshed: number; failed: number; skipped: number }>;
 }
 
 interface RefreshDeps {
@@ -35,26 +35,70 @@ interface RefreshDeps {
   secretStore: SecretStore;
   intervalMs?: number;
   refreshSkewSeconds?: number;
+  /** First-failure retry delay; doubles per consecutive failure. */
+  backoffBaseMs?: number;
+  /** Ceiling for the exponential retry backoff. */
+  backoffMaxMs?: number;
+  now?: () => number;
   log?: (msg: string) => void;
+}
+
+/**
+ * Exponential backoff: `base·2^(n-1)` for the n-th consecutive failure,
+ * capped at `max`. The exponent is clamped so a long-dead connection can't
+ * overflow the multiplication into `NaN`.
+ */
+export function backoffDelayMs(
+  failures: number,
+  baseMs: number,
+  maxMs: number,
+): number {
+  const exponent = Math.min(Math.max(failures - 1, 0), 30);
+  return Math.min(baseMs * 2 ** exponent, maxMs);
 }
 
 export function createOAuthRefreshLoop(deps: RefreshDeps): OAuthRefreshLoop {
   const intervalMs = deps.intervalMs ?? 60_000;
   const skewSec = deps.refreshSkewSeconds ?? 5 * 60;
+  const backoffBaseMs = deps.backoffBaseMs ?? 60_000;
+  const backoffMaxMs = deps.backoffMaxMs ?? 30 * 60_000;
+  const now = deps.now ?? (() => Date.now());
   const log =
     deps.log ?? ((m) => process.stderr.write(`[oauth-refresh] ${m}\n`));
   let timer: ReturnType<typeof setInterval> | null = null;
   let running = false;
 
-  async function tick(): Promise<{ refreshed: number; failed: number }> {
-    if (running) return { refreshed: 0, failed: 0 };
+  // Per-connection failure backoff. A connection whose token can't be
+  // refreshed (e.g. a revoked refresh token) stays in the due set on every
+  // tick; without this it would be retried every `intervalMs` forever. An
+  // entry is cleared on the first success and pruned once its connection
+  // leaves the due set. State is in-memory — a process restart re-attempts.
+  const backoff = new Map<string, { failures: number; nextAttempt: number }>();
+
+  async function tick(): Promise<{
+    refreshed: number;
+    failed: number;
+    skipped: number;
+  }> {
+    if (running) return { refreshed: 0, failed: 0, skipped: 0 };
     running = true;
     let refreshed = 0;
     let failed = 0;
+    let skipped = 0;
+    const startedAt = now();
     try {
       const due = await dueConnections(deps.db, skewSec);
+      const dueIds = new Set(due.map((c) => c.id));
+      for (const id of backoff.keys()) {
+        if (!dueIds.has(id)) backoff.delete(id);
+      }
       for (const conn of due) {
         if (conn.auth.kind === "oauth" && !conn.auth.refreshTokenRef) continue;
+        const state = backoff.get(conn.id);
+        if (state && startedAt < state.nextAttempt) {
+          skipped++;
+          continue;
+        }
         try {
           if (conn.auth.kind === "oauth") {
             await refreshOne(conn, conn.auth, deps);
@@ -63,18 +107,23 @@ export function createOAuthRefreshLoop(deps: RefreshDeps): OAuthRefreshLoop {
           } else {
             continue;
           }
+          backoff.delete(conn.id);
           refreshed++;
         } catch (err) {
           failed++;
+          const failures = (state?.failures ?? 0) + 1;
+          const delay = backoffDelayMs(failures, backoffBaseMs, backoffMaxMs);
+          backoff.set(conn.id, { failures, nextAttempt: startedAt + delay });
           log(
-            `connection ${conn.id} refresh failed: ${(err as Error).message}`,
+            `connection ${conn.id} refresh failed (attempt ${failures}, ` +
+              `retry in ${Math.round(delay / 1000)}s): ${(err as Error).message}`,
           );
         }
       }
     } finally {
       running = false;
     }
-    return { refreshed, failed };
+    return { refreshed, failed, skipped };
   }
 
   return {


### PR DESCRIPTION
## Problem

The OAuth token-refresh loop (`createOAuthRefreshLoop`) re-queries every *due* connection (token expiring within the 5-minute skew) on each ~60s tick and, on failure, only incremented a counter and logged. A connection whose token can no longer be refreshed — a revoked/expired refresh token, a `invalid_grant` from the provider — stays in the due set forever, so it was retried against the provider's token endpoint **every 60 seconds indefinitely**, flooding the logs and hammering the IdP.

## Change

Adds a per-connection failure backoff, held in-memory in the loop's closure (the loop is a boot-time singleton):

- On failure, record consecutive failures and an exponential `nextAttempt` — `base·2^(n-1)` capped at max (defaults: **base 60s, cap 30m**). A dead token now settles to ~1 attempt / 30 min instead of ~1440 / day.
- A due connection is **skipped** while `now < nextAttempt` (surfaced as a new `skipped` count on `tickOnce`).
- The entry is **cleared on the first success** (resetting the failure counter) and **pruned** once the connection drops out of the due set — no unbounded map growth.
- Applies to both the OAuth refresh and the client-credentials remint paths.

The backoff computation is a small pure exported helper (`backoffDelayMs`) so it's unit-testable in isolation.

## Scope / non-goals

This is the minimal, safe fix — pure backoff, **no error-model or schema change**. Deliberately *not* included (filed as follow-ups):

1. Classifying permanent (`invalid_grant`) vs transient (network/5xx) failures to fast-path dead tokens.
2. A `status` / `lastError` column on `connections` so a "needs re-auth" state is visible in the UI instead of only inferrable from logs.

State is in-memory, so a process restart re-attempts immediately — acceptable for this fix; persistence is part of follow-up (2).

## Tests

New `oauth-refresh-backoff.test.ts`:
- `backoffDelayMs` — doubling, cap, and zero-failure guard.
- Loop: exponential skip/retry across a controllable clock; **failure-counter reset on success** (mutation-verified: the test fails if the success-clear is removed); prune-on-leave; and the client-credentials remint branch backs off identically.

`mise run` gates green for the package: unit tests (9), `tsc --noEmit`, eslint, prettier.