### PR TITLE
fix(dam-vm): stop low-shim self-reference causing infinite exec recursion

### DIFF
--- a/packages/dam-vm/container-init.sh
+++ b/packages/dam-vm/container-init.sh
@@ -34,13 +34,18 @@ PATH=$(printf %s "$PATH" | tr : '\n' | grep -v -e '^/opt/shims/' -e '/mise/shims
   command -v "$1" 2>/dev/null || { [ -x "$_mise" ] && "$_mise" which "$1" 2>/dev/null; } || exit 1
 EOF
 
-# command-real-or-autoinstalled <bin>: like command-real but keeps low/ shims
-# reachable, so a tool that was just installed resolves on this call.
+# command-real-or-autoinstalled <bin>: like command-real, but tries the
+# mise-managed copy FIRST so a tool just auto-installed via mise resolves on
+# this call, then falls back to the real binary on PATH. Both shim dirs must be
+# stripped from that fallback (same as command-real) — leaving /opt/shims/low
+# in PATH makes a low shim for a tool mise can't resolve (e.g. kubectl, provided
+# by k3s rather than mise) resolve to itself, so the caller's `exec` recurses
+# forever.
 cat > /opt/shims/high/command-real-or-autoinstalled << 'EOF'
 #!/bin/sh
 _mise=/usr/local/bin/mise
 { [ -x "$_mise" ] && "$_mise" which "$1" 2>/dev/null; } \
-  || PATH=$(printf %s "${PATH#*/opt/shims/high:}" | tr : '\n' | grep -v '/mise/shims' | paste -sd:) command -v "$1" 2>/dev/null \
+  || PATH=$(printf %s "$PATH" | tr : '\n' | grep -v -e '^/opt/shims/' -e '/mise/shims' | paste -sd:) command -v "$1" 2>/dev/null \
   || exit 1
 EOF
 


### PR DESCRIPTION
## Problem

`mise run cluster:install` in a `dam-vm` container (Fedora, `IS_SANDBOX=1`) wedges silently at `Waiting for k3s to be ready...`. The stuck process is a single `kubectl get nodes` that never returns.

## Root cause

The `command-real-or-autoinstalled` helper in `packages/dam-vm/container-init.sh` stripped only the **first** `/opt/shims/high:` segment from PATH:

```sh
PATH=$(printf %s "${PATH#*/opt/shims/high:}" | ...) command -v "$1"
```

That leaves `/opt/shims/low` in PATH. Every low shim ends with `exec "$(command-real-or-autoinstalled <bin>)" "$@"`, so when `mise which <bin>` fails for a low-shim tool, the fallback `command -v <bin>` resolves to **the low shim itself** → the shim re-execs itself → **infinite recursion**.

`kubectl` triggers it because in the k3s flow kubectl is provided by k3s (`/usr/local/bin/kubectl`), not mise, so `mise which kubectl` fails. The bug was latent for **every** low-shim tool (jq, yq, rg, fd, k9s, uv, uvx, poetry, bun, python) whenever mise couldn't resolve it.

The sibling helper `command-real` already does this correctly (`grep -v -e '^/opt/shims/'`, stripping both dirs) — the two had drifted.

## Fix

Strip **both** shim dirs from the fallback PATH, matching `command-real`. The only intended difference from `command-real` — trying the mise-managed copy first — is preserved.

## Verification (in a dam-vm container)

- **Before:** `timeout 8 /opt/shims/low/kubectl version --client` → **rc=124** (killed, looping).
- **After:** bare `kubectl get nodes` through the low shim returns the node, **rc=0**.
- **No regression:** `jq` still auto-installs via mise and resolves (`jq-1.8.2`); `git` (2.55.0), `node` (v24.18.0), and `agent-browser` high shims unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)