### PR TITLE
fix(platform-base): put /usr/local/bin on PATH so mise resolves in the build

### DIFF
--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -17,8 +17,10 @@ RUN dnf install -y git tar gzip && dnf clean all &&\
     tar -xzf /tmp/mise.tar.gz -C /tmp; \
     mv /tmp/mise/bin/mise /usr/local/bin/mise; \
     rm -rf /tmp/mise /tmp/mise.tar.gz
+# mise installs to /usr/local/bin; put it on PATH explicitly rather than trust
+# the base image (a mutable tag) to carry it, so `mise` resolves in later steps.
 ENV MISE_DATA_DIR=/usr/local/share/mise \
-    PATH="/usr/local/share/mise/shims:$PATH"
+    PATH="/usr/local/share/mise/shims:/usr/local/bin:$PATH"
 COPY packages/platform-base/mise.toml /etc/mise/config.toml
 RUN --mount=type=cache,target=/root/.cache/mise \
     --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
@@ -91,8 +93,10 @@ FROM registry.access.redhat.com/hi/core-runtime:latest AS runner
 
 USER root
 WORKDIR /app
+# /usr/local/bin holds the mise binary (and dam-run etc.); pin it on PATH so the
+# runtime doesn't depend on the base image providing it (see the base stage).
 ENV MISE_DATA_DIR=/usr/local/share/mise \
-    PATH="/app/node_modules/.bin:/usr/local/share/mise/shims:$PATH:/usr/local/share/lazy-tools"
+    PATH="/app/node_modules/.bin:/usr/local/share/mise/shims:/usr/local/bin:$PATH:/usr/local/share/lazy-tools"
 
 COPY --from=sysroot /sysroot/usr/ /usr/
 COPY --from=sysroot /sysroot/etc/ssh/ /etc/ssh/


### PR DESCRIPTION
## Problem

Building `platform-base` locally fails at the `mise lock` step with:

```
/bin/sh: line 1: mise: command not found  (exit code 127)
```

The Dockerfile installs the mise binary to `/usr/local/bin/mise`, but both the `base` build stage and the `runner` runtime stage set `PATH` by only *prepending* to whatever the base image (`registry.access.redhat.com/…/core-runtime`, a **mutable** tag) provides — they never add `/usr/local/bin`. When the base image ships a `PATH` without `/usr/local/bin`, mise can't be found: the build breaks at `mise lock`, and at runtime the lazy-tool shims that `exec mise` would break the same way.

This is why it reproduces only on branches that force a *local* platform-base build (any change under `platform-base`'s source paths). CI's build environment happens to carry `/usr/local/bin` on PATH, so the published images work and everyone else reuses them — masking the latent fragility.

## Fix

Pin `/usr/local/bin` on `PATH` explicitly in both stages that run mise, so resolution no longer depends on the base image's default PATH. Two-line change, no behavior change where `/usr/local/bin` was already present.

## Testing

**Not build-verified yet** — I could not run the `platform-base` Docker build in my environment (the `core-runtime` base image isn't reachable there). The change is reasoned from the failure: mise lives at `/usr/local/bin/mise` and neither stage put that dir on PATH. Please confirm by building from this branch (`mise run platform-base:image`); CI also builds it in its own environment.