### PR TITLE
feat(platform-base): point Python TLS clients at the CA bundle in all agents

### DIFF
--- a/packages/agents/gepa/Dockerfile
+++ b/packages/agents/gepa/Dockerfile
@@ -31,10 +31,6 @@ RUN uv python install 3.11 &&\
 
 ENV PATH="/opt/gepa-venv/bin:${PATH}"
 
-# httpx/requests default to certifi's bundle and would miss the gateway CA
-ENV SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
 # behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
 COPY AGENTS.md /etc/AGENTS.md
 

--- a/packages/agents/openevolve/Dockerfile
+++ b/packages/agents/openevolve/Dockerfile
@@ -28,15 +28,6 @@ RUN uv python install 3.11 &&\
 # Put the venv (and thus `openevolve-run`, `python`) ahead of the base tools.
 ENV PATH="/opt/openevolve-venv/bin:${PATH}"
 
-# OpenEvolve's loop calls the model endpoint via the OpenAI SDK (httpx), which
-# defaults to certifi's bundle and so misses the egress-gateway CA the platform
-# injects into the system store at runtime (curl and the node driver trust it; a
-# bare Python httpx call wouldn't, failing TLS verification). Point Python's TLS
-# clients at the system bundle — httpx honors SSL_CERT_FILE, requests honors
-# REQUESTS_CA_BUNDLE.
-ENV SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
 # claude-code symlinks /etc/claude-code/CLAUDE.md -> /etc/AGENTS.md; the
 # behavioral policy (pre-launch gate, resume-on-wake, guardrails) lives here.
 COPY AGENTS.md /etc/AGENTS.md

--- a/packages/agents/shinkaevolve/Dockerfile
+++ b/packages/agents/shinkaevolve/Dockerfile
@@ -41,10 +41,6 @@ RUN uv python install 3.11 &&\
 
 ENV PATH="/opt/shinka-venv/bin:${PATH}"
 
-# httpx/requests default to certifi's bundle and would miss the gateway CA
-ENV SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
-    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-
 # behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
 COPY AGENTS.md /etc/AGENTS.md
 

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -166,9 +166,11 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		{Name: "http_proxy", Value: proxyAddr},
 		// Node doesn't read the system trust store, so it gets the cluster CA
 		// through NODE_EXTRA_CA_CERTS (which adds to its built-in CAs). Other
-		// tools (git, curl, Go, Python) read the system store, where the agent
-		// entrypoint installs the CA — so we don't set SSL_CERT_FILE /
-		// GIT_SSL_CAINFO, which would replace and drop the public CAs.
+		// tools (git, curl, Go) read the system store, where the agent
+		// entrypoint installs the CA. Python's certifi-based clients read
+		// neither, so the base image points SSL_CERT_FILE / REQUESTS_CA_BUNDLE
+		// at the merged system bundle — never set those here to the bare CA
+		// file, which would override the image and drop the public CAs.
 		{Name: "NODE_EXTRA_CA_CERTS", Value: caCertPath},
 		{Name: "NODE_USE_ENV_PROXY", Value: "1"},
 		{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -153,14 +153,15 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	for _, e := range c.Env {
 		assert.NotEqual(t, "AGENT_RUNTIME_TOKEN", e.Name)
 	}
-	// Node gets the CA via NODE_EXTRA_CA_CERTS; SSL_CERT_FILE / GIT_SSL_CAINFO
-	// stay unset because the entrypoint installs the CA into the system trust
-	// store for the other tools. See resources.go.
+	// Node gets the CA via NODE_EXTRA_CA_CERTS. SSL_CERT_FILE / GIT_SSL_CAINFO
+	// stay unset at the pod level: the base image points Python at the merged
+	// system bundle, and a pod-level value aimed at the bare CA file would
+	// override it and drop the public CAs. See resources.go.
 	assert.Equal(t, "/etc/platform/ca/ca.crt", envMap["NODE_EXTRA_CA_CERTS"])
 	_, hasSSLCertFile := envMap["SSL_CERT_FILE"]
-	assert.False(t, hasSSLCertFile, "SSL_CERT_FILE must be left to the entrypoint")
+	assert.False(t, hasSSLCertFile, "SSL_CERT_FILE must be left to the base image")
 	_, hasGitCAInfo := envMap["GIT_SSL_CAINFO"]
-	assert.False(t, hasGitCAInfo, "GIT_SSL_CAINFO must be left to the entrypoint")
+	assert.False(t, hasGitCAInfo, "GIT_SSL_CAINFO must be left to the system trust store")
 	assert.Equal(t, "my-instance", envMap["PLATFORM_AGENT_ID"])
 	// User env (spec.env) is no longer projected — it rides the runtime channel.
 	_, hasACPPort := envMap["ACP_PORT"]

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -136,6 +136,13 @@ RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extr
 
 USER 65532
 
+# Python's TLS clients skip the system trust store the entrypoint installs the
+# platform CA into (httpx/certifi honor SSL_CERT_FILE, requests honors
+# REQUESTS_CA_BUNDLE) — point both at the merged system bundle. Never the bare
+# CA file: that would replace and drop the public CAs.
+ENV SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem \
+    REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
 ENV PORT=8080
 EXPOSE 8080
 

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -3,10 +3,12 @@
 # the gateway intercepts the TLS connection and returns a certificate signed by
 # the cluster's own CA (the "platform MITM CA"), so the agent must trust that CA
 # on top of the normal public ones. We add it to the system trust store here
-# (update-ca-trust) instead of via SSL_CERT_FILE / GIT_SSL_CAINFO, because those
-# env vars replace the public CAs rather than add to them. Node is the exception:
-# it doesn't read the system store, so the controller hands it the CA through
-# NODE_EXTRA_CA_CERTS. Runs as the non-root agent user; the trust dirs are made
+# (update-ca-trust) rather than pointing SSL_CERT_FILE / GIT_SSL_CAINFO at the
+# bare CA file, which would replace the public CAs instead of adding to them.
+# Two clients skip the system store: Node gets the CA through NODE_EXTRA_CA_CERTS
+# (set by the controller), and Python's certifi-based libs get SSL_CERT_FILE /
+# REQUESTS_CA_BUNDLE aimed at the merged bundle this extraction rewrites (set in
+# the Dockerfile). Runs as the non-root agent user; the trust dirs are made
 # writable at build time (see Dockerfile).
 set -eu
 

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -37,7 +37,8 @@ export function UsageView() {
             Usage
           </h2>
           <p className="text-[14px] text-foreground/80 mb-6">
-            LLM API spend across all supported agents (currently only Claude Code and derivatives).
+            LLM API spend across all supported agents (currently only Claude
+            Code and derivatives).
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## Summary

Python's certifi-based TLS clients (`httpx`, `requests`, the OpenAI SDK, …) don't read the system trust store, so in any agent image they missed the platform MITM CA that the entrypoint installs at boot and failed TLS verification on intercepted egress. Three Python-heavy agent images (gepa, openevolve, shinkaevolve) each carried a private fix.

This PR moves that fix into the shared `platform-base` runner stage so **every** agent image gets it:

- `SSL_CERT_FILE` and `REQUESTS_CA_BUNDLE` now point at the merged system bundle (`/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem`) — the file `update-ca-trust` rewrites at boot, so it contains the public CAs **plus** the platform CA. Deliberately not the bare mounted CA file, which would replace and drop the public CAs.
- The per-image duplicates in `gepa`, `openevolve`, and `shinkaevolve` are removed.
- Comments in `entrypoint.sh`, `resources.go`, and `resources_test.go` updated to match (the controller still must not set these at the pod level — a pod-level value would override the image env).

Also includes a one-line prettier fix for `usage-view.tsx` (`9ed8d296` landed unformatted, so `mise run check` was failing on main).

## Testing

- `mise run check` — green (was failing on main due to the prettier issue above)
- `mise run controller:test` — green