### PR TITLE
perf(platform-base): symlink ~/.cache to pod-local disk

### DIFF
--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -1,6 +1,6 @@
 # Persistence
 
-Last verified: 2026-07-15
+Last verified: 2026-07-22
 
 ## Overview
 
@@ -110,7 +110,7 @@ The default Claude Code template persists the workspace and `$HOME`. Together th
 
 PVCs survive hibernation — when a StatefulSet scales to zero replicas, the volume detaches but is retained. The controller explicitly deletes PVCs on Agent deletion (the standard StatefulSet behavior is to retain them to prevent data loss; Platform opts back into reclamation because Agent deletion is intentional).
 
-What does **not** survive hibernation: anything written to the container's ephemeral filesystem outside the persisted mounts — OS-level changes, packages installed at runtime, files in `/tmp`. Tools and dependencies the agent relies on must be baked into the image at build time.
+What does **not** survive hibernation: anything written to the container's ephemeral filesystem outside the persisted mounts — OS-level changes, packages installed at runtime, files in `/tmp`. `$HOME/.cache` is deliberately in this category: the base-image entrypoint symlinks it to pod-local disk (`/tmp/agent-cache`) so tool caches don't load the shared RWX volume. Tools and dependencies the agent relies on must be baked into the image at build time.
 
 ### Warm PVC pool
 

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -20,6 +20,20 @@ if [ -s "$mitm_ca" ]; then
 		|| echo "agent-entrypoint: WARNING: could not trust the platform CA; intercepted hosts may fail TLS" >&2
 fi
 
+# $HOME is a shared RWX network volume; cache traffic (mise, uv, npm, ...)
+# would hammer it, so ~/.cache points at pod-local disk (/tmp is an emptyDir)
+# instead. Caches are disposable, so a pre-existing real directory (older
+# volumes, or anything a harness recreated) is discarded. `ln -sfn` keeps the
+# swap idempotent when the owner pod and a fork pod boot the volume together.
+# The symlink persists on the volume but /tmp is fresh every pod, so the
+# target is (re)created each boot to keep the link from dangling.
+home="${HOME:-/home/agent}"
+mkdir -p /tmp/agent-cache
+if [ ! -L "$home/.cache" ]; then
+	rm -rf "$home/.cache"
+	ln -sfn /tmp/agent-cache "$home/.cache"
+fi
+
 # `dam-vm` only works when the deployment has a VM host configured (the
 # controller sets DAM_VM_ENABLED then). Drop the whole dam-vm block from the
 # agent instructions otherwise, so we don't advertise a command that would just

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -37,7 +37,8 @@ export function UsageView() {
             Usage
           </h2>
           <p className="text-[14px] text-foreground/80 mb-6">
-            LLM API spend across all supported agents (currently only Claude Code and derivatives).
+            LLM API spend across all supported agents (currently only Claude
+            Code and derivatives).
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## Why

`/home/agent` is a shared RWX network volume (owner pod + fork pods mount it concurrently). Tool caches — mise, uv wheels, npm — are high-churn disposable data that load the storage backend for no benefit.

## What

- `entrypoint.sh` ensures `$HOME/.cache` is a symlink to `/tmp/agent-cache` (`/tmp` is the non-persisted emptyDir from the default mounts, i.e. node-local disk). Runtime is the only place this works — a build-time symlink would be shadowed by the PVC mount.
- The symlink persists on the volume but `/tmp` is fresh per pod, so the target is (re)created every boot to keep the link from dangling.
- A pre-existing real `.cache` directory (older volumes) is discarded — caches are disposable. `ln -sfn` keeps the swap idempotent when the owner pod and a fork pod boot the same volume together; each pod then resolves the link to its own emptyDir, so pods stop contending on a shared cache dir.
- `docs/architecture/persistence.md` notes the carve-out in the hibernation section.

## Trade-off

Cache-backed state under `~/.cache` now dies with the pod — first use after a restart re-downloads (uv wheels, mise tool downloads).

## Testing

Simulated the three boot scenarios against the snippet: legacy real dir replaced by symlink, restart re-creates the target while keeping the link, second concurrent pod is a no-op.