### PR TITLE
style(ui): fix prettier formatting in usage-view

### DIFF
--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -37,7 +37,8 @@ export function UsageView() {
             Usage
           </h2>
           <p className="text-[14px] text-foreground/80 mb-6">
-            LLM API spend across all supported agents (currently only Claude Code and derivatives).
+            LLM API spend across all supported agents (currently only Claude
+            Code and derivatives).
           </p>
         </div>
         <div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## What

`mise run check` (specifically `ui:check:format`) fails on `main` because `packages/ui/src/modules/metrics/views/usage-view.tsx` isn't prettier-clean — a paragraph string exceeds the configured print-width.

Introduced by `9ed8d296 fix: wording for usage tab`.

## Fix

Ran `mise run ui:fix:format`, which line-wraps the usage description paragraph. Single-file, formatting-only change.

## Verification

- `mise run ui:check:format` → "All matched files use Prettier code style!"