### PR TITLE
Ralph: UI - Expand Usage to cover spend by day and by agent

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,6 +72,7 @@ Each page is the authoritative, self-contained description of its subsystem — 
 - [usage-tracking](architecture/usage-tracking.md) — append-only activity log in Postgres, SQL views as the read interface, HMAC-pseudonymized identifiers, inspector-role gating.
 - [logging](architecture/logging.md) — Pino structured logging to stdout, and the real-identity security audit trail built on it (the forensic counterpart to pseudonymized usage-tracking).
 - [observability](architecture/observability.md) — the optional, bundled agent-telemetry backend: an OTLP collector writing OpenTelemetry signals into a columnar store with an exploration UI, gated by the mesh rather than ingestion tokens.
+- [metrics](architecture/metrics.md) — the user-facing usage read path behind Settings ▸ Usage: owner-scoped tRPC procedures reading per-agent token/cost spend live from the telemetry store, with deleted agents kept in scope so history never shrinks.
 - [supply-chain](security/supply-chain.md) — how each external dependency type is scanned for CVEs and defended against supply-chain attacks.
 - [code](security/code.md) — CodeQL SAST and pre-commit hardening.
 - [secrets](security/secrets.md) — GitHub secret storage, scanning, and push protection.

--- a/docs/architecture/metrics.md
+++ b/docs/architecture/metrics.md
@@ -1,0 +1,113 @@
+# Metrics (the usage read path)
+
+Last verified: 2026-07-22
+
+## Overview
+
+**Metrics** is the user-facing read path behind Settings ▸ Usage: it answers
+*what have my agents spent* — LLM token consumption and dollar cost, rolled up
+per model, per session, and per call, always scoped to the calling user's own
+agents. It reads live from the telemetry store; it stores nothing of its own
+and does not aggregate ahead of time.
+
+It is the read counterpart to [observability](observability.md), which owns the
+**export** path — how agents emit telemetry and how it lands in the store — and
+deliberately scopes the read side out. This page owns that read side. The two
+never overlap: observability puts signals in the columnar store and guarantees
+who produced them; Metrics reads a slice of those signals back for one user.
+
+Metrics is distinct from [usage-tracking](usage-tracking.md), which is activity
+analytics — an append-only, pseudonymized log of *interactions* (auth, channel
+turns, schedule fires) in Postgres. Tokens and cost are **Spend**, and Spend
+lives here, over telemetry — not in usage-tracking.
+
+## The contract
+
+The api-server exposes Metrics as two owner-scoped, read-only tRPC procedures.
+Both return only data for agents the caller owns; neither ever mutates.
+
+- **Overview** — the whole Usage panel in one read: per-model token/cost
+  totals, a per-session runtime roll-up (call count, summed latency, tokens,
+  cost, first/last timestamps), and the most recent unaggregated per-call rows.
+  Filterable by an optional lookback window, an optional single agent, an
+  optional single session, and a row cap on the per-call slice. A specific
+  agent additionally passes the API-key binding check that gates the rest of
+  the agent-read surface.
+- **Spend** — per-model spend over an absolute, half-open time range across
+  *all* of the caller's agents. The range is passed as instants, not calendar
+  fields, so the client decides what a "month" means in its own timezone; this
+  is what the month-stepper in the Usage view drives.
+
+Field-level shapes live in the contract package
+([`packages/api-server-api/src/modules/metrics/`](../../packages/api-server-api/src/modules/metrics/)) —
+follow the link rather than restating them here.
+
+## Ownership scoping
+
+Scoping is enforced in the **service layer**, not in the store reader. The
+service resolves the caller's owned agent IDs up front and hands the reader a
+fixed allowlist; the reader filters every query on that allowlist and does no
+scoping of its own. Requesting an agent the caller does not own resolves to an
+empty allowlist, and the read then yields nothing — that empty result *is* the
+ownership guarantee, not an error.
+
+The owned-agent set is the **union of two sources**: the user's live agents and
+the Postgres agent registry (the [Agent Mirror](usage-tracking.md)). Live
+agents alone would shrink the set the moment an agent is deleted, so a user who
+deletes an agent would see last month's spend drop retroactively. Unioning in
+the registry keeps deleted agents in scope: **history must not shrink**. Spend
+already incurred stays attributed to the user who incurred it, forever.
+
+## The store reader
+
+The reader queries the same columnar telemetry store the
+[observability](observability.md) export path fills: one telemetry log record
+per LLM API call, emitted by the Claude Code harness. Each record carries, in
+its attribute maps, the counters Metrics rolls up — input/output token counts,
+cache-read and cache-creation token counts, cost in micro-dollars
+(`cost_usd_micros`, divided back to dollars at the boundary), the model name,
+the call duration, and the event timestamp — plus the trusted `platform.agent.id`
+that scopes every query. The exact query text and column mapping live in the
+reader ([`packages/api-server/src/modules/metrics/infrastructure/`](../../packages/api-server/src/modules/metrics/infrastructure/)).
+
+Two shape facts are worth stating because they are couplings, not incidental:
+
+- The store returns 64-bit integers as strings to avoid precision loss, so
+  every numeric column is coerced back to a number at the read boundary.
+- A session query folds in **whole sessions that share a trace** with the
+  target session, not just rows carrying the same session id. This is what
+  makes child harness runs (a `claude -p` subshell, a `dam-run` executor) count
+  under the session that spawned them — they mint their own session id but
+  inherit the parent's W3C trace context. See
+  [observability — agent export](observability.md#agent-export) for why child
+  runs carry the parent trace but a fresh session id.
+
+## When the backend is disabled
+
+The telemetry store is optional and off by default (see
+[observability](observability.md)). When no store URL is configured, the
+api-server wires a **disabled** Metrics service in place of the real one: every
+read fails loud with a `PRECONDITION_FAILED` error rather than returning an
+empty result. Failing is deliberate — an empty success would read as "no spend
+yet" and quietly mislead. The Usage view maps that error to a plain *metrics
+are unavailable on this deployment* message, distinct from the *no spend in
+this range* empty state.
+
+## Trust story
+
+Metrics inherits the trust boundary from [observability](observability.md), and
+the distinction is what makes the numbers safe to show a user:
+
+- **Counters are agent-reported.** Token counts and cost come from the agent's
+  own telemetry. A compromised agent can inflate or understate *its own*
+  numbers — Metrics does not independently verify them. The blast radius is
+  bounded to that agent's own owner: it can pollute its own figures, never
+  anyone else's.
+- **Attribution is gateway-stamped and unforgeable.** The `platform.agent.id`
+  that ties each record to an agent is stamped by the agent's paired gateway on
+  the way out and cannot be set or overwritten by the agent. This is the whole
+  reason owner scoping is sound: a forged attribute never survives, so an
+  agent can never make its spend appear under another user.
+- **Agent name is display-only.** The `platform.agent.name` an agent exports is
+  a self-declared label for finding an instance; it carries no authority and is
+  never used for scoping or attribution. Only the gateway-stamped id is trusted.

--- a/docs/architecture/metrics.md
+++ b/docs/architecture/metrics.md
@@ -23,8 +23,8 @@ lives here, over telemetry — not in usage-tracking.
 
 ## The contract
 
-The api-server exposes Metrics as two owner-scoped, read-only tRPC procedures.
-Both return only data for agents the caller owns; neither ever mutates.
+The api-server exposes Metrics as a set of owner-scoped, read-only tRPC
+procedures. Each returns only data for agents the caller owns; none ever mutate.
 
 - **Overview** — the whole Usage panel in one read: per-model token/cost
   totals, a per-session runtime roll-up (call count, summed latency, tokens,
@@ -44,6 +44,15 @@ Both return only data for agents the caller owns; neither ever mutates.
   `platform.agent.name` observed in range, so a deleted agent keeps a readable
   label. The name is display-only — the id stays the key. The Usage view renders
   it as a horizontal-bar breakdown driven by the same month-stepper.
+- **Spend by day** — the same instant range and ownership scoping as **Spend**,
+  bucketed into local calendar days. The client passes its IANA timezone
+  (`Intl.DateTimeFormat`) alongside the range; the grouping is done in ClickHouse
+  (`toDate(Timestamp, tz)`), so day boundaries are the user's wall-clock
+  midnights. The response is **sparse** — one `{ day, costUsd }` row per day that
+  has Spend, days without it omitted. The client owns calendar semantics: it
+  zero-fills the missing days and, for the current month, renders nothing after
+  today. The Usage view draws it as a hand-rolled column chart under the same
+  month-stepper.
 
 Field-level shapes live in the contract package
 ([`packages/api-server-api/src/modules/metrics/`](../../packages/api-server-api/src/modules/metrics/)) —

--- a/docs/architecture/metrics.md
+++ b/docs/architecture/metrics.md
@@ -1,6 +1,6 @@
 # Metrics (the usage read path)
 
-Last verified: 2026-07-22
+Last verified: 2026-07-23
 
 ## Overview
 
@@ -37,6 +37,13 @@ Both return only data for agents the caller owns; neither ever mutates.
   *all* of the caller's agents. The range is passed as instants, not calendar
   fields, so the client decides what a "month" means in its own timezone; this
   is what the month-stepper in the Usage view drives.
+- **Spend by agent** — the same range and ownership scoping as **Spend**, but
+  rolled up per owning agent instead of per model, sorted by cost descending
+  with no top-N cap. Grouping is on the gateway-stamped `platform.agent.id`
+  (the trusted attribution key); the display name is the latest
+  `platform.agent.name` observed in range, so a deleted agent keeps a readable
+  label. The name is display-only — the id stays the key. The Usage view renders
+  it as a horizontal-bar breakdown driven by the same month-stepper.
 
 Field-level shapes live in the contract package
 ([`packages/api-server-api/src/modules/metrics/`](../../packages/api-server-api/src/modules/metrics/)) —

--- a/docs/architecture/observability.md
+++ b/docs/architecture/observability.md
@@ -4,7 +4,7 @@ Last verified: 2026-07-16
 
 ## Overview
 
-The telemetry backend is an **optional, bundled subsystem** that receives and stores the OpenTelemetry signals (logs, traces, metrics) agents emit — the substrate for answering *how agents run*: token consumption, cost, per-sub-agent breakdown. This page covers the backend (receiving and storage) and the agent **export** path that feeds it (see [Agent export](#agent-export)); the user-facing read path is a separate concern.
+The telemetry backend is an **optional, bundled subsystem** that receives and stores the OpenTelemetry signals (logs, traces, metrics) agents emit — the substrate for answering *how agents run*: token consumption, cost, per-sub-agent breakdown. This page covers the backend (receiving and storage) and the agent **export** path that feeds it (see [Agent export](#agent-export)); the user-facing read path is a separate concern, owned by [metrics](metrics.md).
 
 It is implemented with **ClickStack**: a columnar telemetry store (ClickHouse) fronted by an exploration UI (HyperDX), plus a separate document store backing that UI's own application state. Installing or upgrading the platform brings the stack up when it is enabled, but it is **disabled by default** — it is a heavy, multi-pod stack, and until agents are wired to export it would receive nothing, so operators opt in per install.
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -192,9 +192,19 @@ An Experiment races several AI-driven R&D harnesses against one goal and compare
 | Usage View | A named SQL view (`usage_*`) that aggregates Activity Events into an operator-facing metric. View names form the public read API; consumers never query the raw table |
 | Pilot Metric Filter | The `WHERE actor_sub NOT IN (SELECT … FROM usage_core_actor_subs)` clause (or its `agent_id` / `owner_sub` analogue) applied on every pilot Usage View to exclude core-team activity — keyed on `actor_roles.is_core`, populated from JWT `realm_access.roles` at auth time |
 
+## Metrics (bounded context)
+
+The user-facing usage read path behind Settings ▸ Usage. Reads token/cost telemetry live from the observability store, owner-scoped. Distinct from Usage Tracking (activity analytics in Postgres) and from Observability (which owns the export path). See [`docs/architecture/metrics.md`](architecture/metrics.md).
+
+| Term | Definition |
+|------|-----------|
+| Spend | The dollar cost and token consumption of a user's agents' LLM usage, read from the observability telemetry store. The tokens/cost accounting concept — **not** Usage Tracking, which is activity analytics. Agent-reported (an agent can misreport its own numbers) but agent-attributed by the unforgeable gateway-stamped identity, so it can only ever pollute its own figures |
+| Spend Breakdown | A grouping of Spend along one axis for display: per model, per session, or per individual call. The Usage tab's read shapes — a per-model roll-up, a per-session runtime roll-up, and the recent unaggregated per-call rows |
+| Agent Attribution | Tying each telemetry record to the agent that produced it via the gateway-stamped `platform.agent.id`. This is trusted and unforgeable (the agent cannot set or overwrite it), which is what makes owner-scoped Spend safe. The self-declared agent name is display-only and carries no authority — see [Trusted Attribution in Observability](architecture/observability.md#trusted-attribution) |
+
 ## Budgets (bounded context)
 
-Fair-sharing of the cluster's fixed compute pool between users. Distinct from Usage Tracking (tokens/cost accounting) — a Budget bounds *concurrent reservation*, never spend. Enforcement lives in the controller at the 0→1 scale transition; the api-server only displays and explains.
+Fair-sharing of the cluster's fixed compute pool between users. Distinct from Spend (tokens/cost accounting, owned by Metrics) — a Budget bounds *concurrent compute reservation*, never spend. Enforcement lives in the controller at the 0→1 scale transition; the api-server only displays and explains.
 
 | Term | Definition |
 |------|-----------|

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -221,6 +221,7 @@ export type {
   MetricsSpendQuery,
   MetricsOverview,
   TokenSpendByModel,
+  SpendByAgent,
   SessionRuntime,
   CallContext,
 } from "./modules/metrics/types.js";

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -219,9 +219,11 @@ export type {
   MetricsService,
   MetricsQuery,
   MetricsSpendQuery,
+  MetricsSpendByDayQuery,
   MetricsOverview,
   TokenSpendByModel,
   SpendByAgent,
+  SpendByDay,
   SessionRuntime,
   CallContext,
 } from "./modules/metrics/types.js";

--- a/packages/api-server-api/src/modules/metrics/router.ts
+++ b/packages/api-server-api/src/modules/metrics/router.ts
@@ -21,4 +21,7 @@ export const metricsRouter = t.router({
   spend: readAgentProcedure
     .input(metricsSpendInputSchema)
     .query(({ ctx, input }) => ctx.metrics.spend(input)),
+  spendByAgent: readAgentProcedure
+    .input(metricsSpendInputSchema)
+    .query(({ ctx, input }) => ctx.metrics.spendByAgent(input)),
 });

--- a/packages/api-server-api/src/modules/metrics/router.ts
+++ b/packages/api-server-api/src/modules/metrics/router.ts
@@ -5,6 +5,7 @@ import {
 } from "../../auth-procedures.js";
 import {
   metricsOverviewInputSchema,
+  metricsSpendByDayInputSchema,
   metricsSpendInputSchema,
 } from "./schemas.js";
 
@@ -24,4 +25,7 @@ export const metricsRouter = t.router({
   spendByAgent: readAgentProcedure
     .input(metricsSpendInputSchema)
     .query(({ ctx, input }) => ctx.metrics.spendByAgent(input)),
+  spendByDay: readAgentProcedure
+    .input(metricsSpendByDayInputSchema)
+    .query(({ ctx, input }) => ctx.metrics.spendByDay(input)),
 });

--- a/packages/api-server-api/src/modules/metrics/schemas.ts
+++ b/packages/api-server-api/src/modules/metrics/schemas.ts
@@ -20,3 +20,11 @@ export const metricsSpendInputSchema = z.object({
   from: z.string().datetime(),
   to: z.string().datetime(),
 });
+
+// Spend bucketed into local calendar days over [from, to). Same instant range
+// as `spend`, plus the IANA timezone the day boundaries are cut on — supplied
+// by the client (`Intl.DateTimeFormat().resolvedOptions().timeZone`) so buckets
+// line up with the user's wall-clock days. The grouping happens in ClickHouse.
+export const metricsSpendByDayInputSchema = metricsSpendInputSchema.extend({
+  timeZone: z.string().min(1),
+});

--- a/packages/api-server-api/src/modules/metrics/types.ts
+++ b/packages/api-server-api/src/modules/metrics/types.ts
@@ -18,6 +18,16 @@ export interface TokenSpendByModel {
   costUsd: number;
 }
 
+/** LLM spend rolled up per owning agent over the window, sorted by cost
+ *  descending. Grouped on the gateway-stamped `platform.agent.id` (the trusted
+ *  key); `agentName` is the latest telemetry-observed `platform.agent.name`, so
+ *  a deleted agent still shows its last known name. The name is display-only. */
+export interface SpendByAgent {
+  agentId: string;
+  agentName: string;
+  costUsd: number;
+}
+
 /** One row per Claude Code session: API-call count, summed request latency,
  *  and token/cost totals. The sessionId is the ACP session id — Claude Code
  *  reuses it as its OTel `session.id`, so it joins with the UI's session list. */
@@ -66,4 +76,8 @@ export interface MetricsService {
   /** Per-model spend over [from, to), across all of the caller's agents —
    *  deleted ones included, so history doesn't shrink retroactively. */
   spend(query: MetricsSpendQuery): Promise<TokenSpendByModel[]>;
+  /** Spend over [from, to) rolled up per owning agent, sorted by cost
+   *  descending. Same range and ownership scoping as `spend` (deleted agents
+   *  included); grouped on the trusted agent id with a telemetry-derived name. */
+  spendByAgent(query: MetricsSpendQuery): Promise<SpendByAgent[]>;
 }

--- a/packages/api-server-api/src/modules/metrics/types.ts
+++ b/packages/api-server-api/src/modules/metrics/types.ts
@@ -1,11 +1,15 @@
 import type { z } from "zod";
 import type {
   metricsOverviewInputSchema,
+  metricsSpendByDayInputSchema,
   metricsSpendInputSchema,
 } from "./schemas.js";
 
 export type MetricsQuery = z.infer<typeof metricsOverviewInputSchema>;
 export type MetricsSpendQuery = z.infer<typeof metricsSpendInputSchema>;
+export type MetricsSpendByDayQuery = z.infer<
+  typeof metricsSpendByDayInputSchema
+>;
 
 /** Token counts + cost rolled up per model, over the window. */
 export interface TokenSpendByModel {
@@ -25,6 +29,14 @@ export interface TokenSpendByModel {
 export interface SpendByAgent {
   agentId: string;
   agentName: string;
+  costUsd: number;
+}
+
+/** LLM spend for one local calendar day. Sparse: the reader emits a row only
+ *  for days that have Spend, so the caller (the client) zero-fills the missing
+ *  days itself. `day` is `YYYY-MM-DD` in the query's timezone. */
+export interface SpendByDay {
+  day: string;
   costUsd: number;
 }
 
@@ -80,4 +92,8 @@ export interface MetricsService {
    *  descending. Same range and ownership scoping as `spend` (deleted agents
    *  included); grouped on the trusted agent id with a telemetry-derived name. */
   spendByAgent(query: MetricsSpendQuery): Promise<SpendByAgent[]>;
+  /** Spend over [from, to) bucketed into local calendar days in the query's
+   *  timezone. Same ownership scoping as `spend`. Sparse — one row per day that
+   *  has Spend, days without it omitted; the client zero-fills the calendar. */
+  spendByDay(query: MetricsSpendByDayQuery): Promise<SpendByDay[]>;
 }

--- a/packages/api-server/src/__tests__/unit/metrics-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/metrics-service.test.ts
@@ -13,9 +13,11 @@ function spyReader(): {
   reader: MetricsReader;
   calls: string[][];
   windows: MetricsWindow[];
+  timeZones: string[];
 } {
   const calls: string[][] = [];
   const windows: MetricsWindow[] = [];
+  const timeZones: string[] = [];
   const record = async (agentIds: readonly string[], window: MetricsWindow) => {
     calls.push([...agentIds]);
     windows.push(window);
@@ -24,9 +26,14 @@ function spyReader(): {
   return {
     calls,
     windows,
+    timeZones,
     reader: {
       tokenSpendByModel: (ids, w) => record(ids, w),
       spendByAgent: (ids, w) => record(ids, w),
+      spendByDay: (ids, w, tz) => {
+        timeZones.push(tz);
+        return record(ids, w);
+      },
       runtimeBySession: (ids, w) => record(ids, w),
       contextPerCall: (ids, w) => record(ids, w),
       close: async () => {},
@@ -131,6 +138,40 @@ describe("metrics ownership gate", () => {
     expect(calls).toEqual([]);
   });
 
+  it("spendByDay scopes to all owned agents and passes the range + timezone through", async () => {
+    const { reader, calls, windows, timeZones } = spyReader();
+    const svc = createMetricsService({ reader, listOwnedAgentIds: owned });
+    await svc.spendByDay({
+      from: "2026-07-01T00:00:00.000Z",
+      to: "2026-08-01T00:00:00.000Z",
+      timeZone: "America/New_York",
+    });
+    expect(calls).toEqual([["agent-a", "agent-b"]]);
+    expect(windows).toEqual([
+      {
+        fromIso: "2026-07-01T00:00:00.000Z",
+        toIso: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+    expect(timeZones).toEqual(["America/New_York"]);
+  });
+
+  it("spendByDay returns nothing when the caller owns no agents", async () => {
+    const { reader, calls } = spyReader();
+    const svc = createMetricsService({
+      reader,
+      listOwnedAgentIds: () => Promise.resolve([]),
+    });
+    expect(
+      await svc.spendByDay({
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+        timeZone: "America/New_York",
+      }),
+    ).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
   it("spend returns nothing when the caller owns no agents", async () => {
     const { reader, calls } = spyReader();
     const svc = createMetricsService({
@@ -159,6 +200,13 @@ describe("metrics ownership gate", () => {
       svc.spendByAgent({
         from: "2026-07-01T00:00:00.000Z",
         to: "2026-08-01T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(/not enabled/);
+    await expect(
+      svc.spendByDay({
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+        timeZone: "America/New_York",
       }),
     ).rejects.toThrow(/not enabled/);
   });

--- a/packages/api-server/src/__tests__/unit/metrics-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/metrics-service.test.ts
@@ -26,6 +26,7 @@ function spyReader(): {
     windows,
     reader: {
       tokenSpendByModel: (ids, w) => record(ids, w),
+      spendByAgent: (ids, w) => record(ids, w),
       runtimeBySession: (ids, w) => record(ids, w),
       contextPerCall: (ids, w) => record(ids, w),
       close: async () => {},
@@ -99,6 +100,37 @@ describe("metrics ownership gate", () => {
     ]);
   });
 
+  it("spendByAgent scopes to all owned agents and passes the range through", async () => {
+    const { reader, calls, windows } = spyReader();
+    const svc = createMetricsService({ reader, listOwnedAgentIds: owned });
+    await svc.spendByAgent({
+      from: "2026-07-01T00:00:00.000Z",
+      to: "2026-08-01T00:00:00.000Z",
+    });
+    expect(calls).toEqual([["agent-a", "agent-b"]]);
+    expect(windows).toEqual([
+      {
+        fromIso: "2026-07-01T00:00:00.000Z",
+        toIso: "2026-08-01T00:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("spendByAgent returns nothing when the caller owns no agents", async () => {
+    const { reader, calls } = spyReader();
+    const svc = createMetricsService({
+      reader,
+      listOwnedAgentIds: () => Promise.resolve([]),
+    });
+    expect(
+      await svc.spendByAgent({
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+      }),
+    ).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
   it("spend returns nothing when the caller owns no agents", async () => {
     const { reader, calls } = spyReader();
     const svc = createMetricsService({
@@ -119,6 +151,12 @@ describe("metrics ownership gate", () => {
     await expect(svc.overview(query)).rejects.toThrow(/not enabled/);
     await expect(
       svc.spend({
+        from: "2026-07-01T00:00:00.000Z",
+        to: "2026-08-01T00:00:00.000Z",
+      }),
+    ).rejects.toThrow(/not enabled/);
+    await expect(
+      svc.spendByAgent({
         from: "2026-07-01T00:00:00.000Z",
         to: "2026-08-01T00:00:00.000Z",
       }),

--- a/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
+++ b/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
@@ -3,6 +3,7 @@ import type {
   CallContext,
   SessionRuntime,
   SpendByAgent,
+  SpendByDay,
   TokenSpendByModel,
 } from "api-server-api";
 import type {
@@ -152,6 +153,28 @@ export function createClickhouseReader(
         agentName: String(x.agentName ?? ""),
         costUsd: n(x.costUsd),
       })) satisfies SpendByAgent[];
+    },
+
+    async spendByDay(agentIds, window, timeZone) {
+      // Bucket each call into the local calendar day it falls on in the
+      // caller's timezone — `toDate(Timestamp, tz)` shifts the UTC instant into
+      // that zone before truncating, so the day boundaries are the user's
+      // wall-clock midnights, not UTC's. Sparse by construction: GROUP BY only
+      // emits days that have rows, so the client zero-fills the calendar.
+      const r = await rows(
+        `SELECT
+           toString(toDate(Timestamp, {timeZone:String})) AS day,
+           sum(${COST_USD}) AS costUsd
+         FROM otel_logs
+         WHERE ${ownedApiRequests(window)}
+         GROUP BY day
+         ORDER BY day`,
+        { ...windowParams(agentIds, window), timeZone },
+      );
+      return r.map((x) => ({
+        day: String(x.day ?? ""),
+        costUsd: n(x.costUsd),
+      })) satisfies SpendByDay[];
     },
 
     async runtimeBySession(agentIds, window) {

--- a/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
+++ b/packages/api-server/src/modules/metrics/infrastructure/clickhouse-reader.ts
@@ -2,6 +2,7 @@ import { type ClickHouseClient, createClient } from "@clickhouse/client";
 import type {
   CallContext,
   SessionRuntime,
+  SpendByAgent,
   TokenSpendByModel,
 } from "api-server-api";
 import type {
@@ -128,6 +129,29 @@ export function createClickhouseReader(
         cacheCreationTokens: n(x.cacheCreationTokens),
         costUsd: n(x.costUsd),
       })) satisfies TokenSpendByModel[];
+    },
+
+    async spendByAgent(agentIds, window) {
+      // Group on the gateway-stamped id (the trusted attribution key); the
+      // display name is the latest `platform.agent.name` observed in range
+      // (argMax over Timestamp), so a deleted agent keeps a readable label.
+      // The name is display-only — the id stays the key.
+      const r = await rows(
+        `SELECT
+           ResourceAttributes['platform.agent.id'] AS agentId,
+           argMax(ResourceAttributes['platform.agent.name'], Timestamp) AS agentName,
+           sum(${COST_USD}) AS costUsd
+         FROM otel_logs
+         WHERE ${ownedApiRequests(window)}
+         GROUP BY agentId
+         ORDER BY costUsd DESC`,
+        windowParams(agentIds, window),
+      );
+      return r.map((x) => ({
+        agentId: String(x.agentId ?? ""),
+        agentName: String(x.agentName ?? ""),
+        costUsd: n(x.costUsd),
+      })) satisfies SpendByAgent[];
     },
 
     async runtimeBySession(agentIds, window) {

--- a/packages/api-server/src/modules/metrics/services/metrics-service.ts
+++ b/packages/api-server/src/modules/metrics/services/metrics-service.ts
@@ -5,6 +5,7 @@ import type {
   MetricsQuery,
   MetricsService,
   SpendByAgent,
+  SpendByDay,
   TokenSpendByModel,
 } from "api-server-api";
 
@@ -29,6 +30,11 @@ export interface MetricsReader {
     agentIds: readonly string[],
     window: MetricsWindow,
   ): Promise<SpendByAgent[]>;
+  spendByDay(
+    agentIds: readonly string[],
+    window: MetricsWindow,
+    timeZone: string,
+  ): Promise<SpendByDay[]>;
   runtimeBySession(
     agentIds: readonly string[],
     window: MetricsWindow,
@@ -95,6 +101,16 @@ export function createMetricsService(deps: {
         toIso: query.to,
       });
     },
+
+    async spendByDay(query) {
+      const ids = await ownedScope(deps.listOwnedAgentIds, undefined);
+      if (ids.length === 0) return [];
+      return deps.reader.spendByDay(
+        ids,
+        { fromIso: query.from, toIso: query.to },
+        query.timeZone,
+      );
+    },
   };
 }
 
@@ -107,5 +123,5 @@ export function createDisabledMetricsService(): MetricsService {
       message: "Agent metrics backend is not enabled on this deployment.",
     });
   };
-  return { overview: fail, spend: fail, spendByAgent: fail };
+  return { overview: fail, spend: fail, spendByAgent: fail, spendByDay: fail };
 }

--- a/packages/api-server/src/modules/metrics/services/metrics-service.ts
+++ b/packages/api-server/src/modules/metrics/services/metrics-service.ts
@@ -4,6 +4,7 @@ import type {
   SessionRuntime,
   MetricsQuery,
   MetricsService,
+  SpendByAgent,
   TokenSpendByModel,
 } from "api-server-api";
 
@@ -24,6 +25,10 @@ export interface MetricsReader {
     agentIds: readonly string[],
     window: MetricsWindow,
   ): Promise<TokenSpendByModel[]>;
+  spendByAgent(
+    agentIds: readonly string[],
+    window: MetricsWindow,
+  ): Promise<SpendByAgent[]>;
   runtimeBySession(
     agentIds: readonly string[],
     window: MetricsWindow,
@@ -81,6 +86,15 @@ export function createMetricsService(deps: {
         toIso: query.to,
       });
     },
+
+    async spendByAgent(query) {
+      const ids = await ownedScope(deps.listOwnedAgentIds, undefined);
+      if (ids.length === 0) return [];
+      return deps.reader.spendByAgent(ids, {
+        fromIso: query.from,
+        toIso: query.to,
+      });
+    },
   };
 }
 
@@ -93,5 +107,5 @@ export function createDisabledMetricsService(): MetricsService {
       message: "Agent metrics backend is not enabled on this deployment.",
     });
   };
-  return { overview: fail, spend: fail };
+  return { overview: fail, spend: fail, spendByAgent: fail };
 }

--- a/packages/ui/src/modules/metrics/api/queries.ts
+++ b/packages/ui/src/modules/metrics/api/queries.ts
@@ -11,6 +11,16 @@ export function useModelSpend(from: string, to: string) {
   });
 }
 
+/** Spend rolled up per agent across all of the user's agents over [from, to),
+ *  sorted by cost descending. */
+export function useSpendByAgent(from: string, to: string) {
+  return useQuery({
+    ...trpc.metrics.spendByAgent.queryOptions({ from, to }),
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 /** Metrics overview for one agent. Disabled while no agent is selected. */
 export function useMetricsOverview(
   agentId: string | null,

--- a/packages/ui/src/modules/metrics/api/queries.ts
+++ b/packages/ui/src/modules/metrics/api/queries.ts
@@ -21,6 +21,16 @@ export function useSpendByAgent(from: string, to: string) {
   });
 }
 
+/** Spend bucketed into local calendar days over [from, to), in `timeZone`.
+ *  The response is sparse (only days with Spend); the caller zero-fills. */
+export function useSpendByDay(from: string, to: string, timeZone: string) {
+  return useQuery({
+    ...trpc.metrics.spendByDay.queryOptions({ from, to, timeZone }),
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
 /** Metrics overview for one agent. Disabled while no agent is selected. */
 export function useMetricsOverview(
   agentId: string | null,

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -1,12 +1,16 @@
 import { ChevronLeft, ChevronRight } from "@carbon/icons-react";
-import type { SpendByAgent } from "api-server-api";
+import type { SpendByAgent, SpendByDay } from "api-server-api";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { SectionLabel } from "@/components/ui/section-label";
 
-import { useModelSpend, useSpendByAgent } from "../api/queries.js";
+import {
+  useModelSpend,
+  useSpendByAgent,
+  useSpendByDay,
+} from "../api/queries.js";
 import { ModelSpendTable } from "../components/metrics-panel.js";
 import { formatUsd } from "../lib/format.js";
 
@@ -14,6 +18,35 @@ import { formatUsd } from "../lib/format.js";
 // resulting instants, so "calendar month" means the user's wall-clock month.
 const monthStart = (base: Date, offset: number) =>
   new Date(base.getFullYear(), base.getMonth() + offset, 1);
+
+// The IANA zone the browser is in — passed to the API so day buckets are cut
+// on the same wall-clock midnights the client renders the calendar in.
+const timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+
+const pad2 = (n: number) => String(n).padStart(2, "0");
+const dayKey = (year: number, month0: number, day: number) =>
+  `${year}-${pad2(month0 + 1)}-${pad2(day)}`;
+
+// The server response is sparse (only days with Spend). The client owns the
+// calendar: emit every day of the selected month, zero-filling the gaps, and
+// for the current month stop at today so there are no empty future columns.
+function fillMonthDays(
+  month: Date,
+  isCurrentMonth: boolean,
+  rows: readonly SpendByDay[] | undefined,
+): SpendByDay[] {
+  const spendByDay = new Map((rows ?? []).map((r) => [r.day, r.costUsd]));
+  const year = month.getFullYear();
+  const month0 = month.getMonth();
+  const daysInMonth = new Date(year, month0 + 1, 0).getDate();
+  const lastDay = isCurrentMonth ? new Date().getDate() : daysInMonth;
+  const out: SpendByDay[] = [];
+  for (let day = 1; day <= lastDay; day++) {
+    const key = dayKey(year, month0, day);
+    out.push({ day: key, costUsd: spendByDay.get(key) ?? 0 });
+  }
+  return out;
+}
 
 /** Settings tab: the user's LLM API spend for one calendar month, totalled
  *  and broken down per model across all their agents. */
@@ -28,7 +61,9 @@ export function UsageView() {
   const to = monthStart(month, 1).toISOString();
   const { data, isPending, isError } = useModelSpend(from, to);
   const byAgent = useSpendByAgent(from, to);
+  const byDay = useSpendByDay(from, to, timeZone);
   const total = data?.reduce((sum, row) => sum + row.costUsd, 0) ?? 0;
+  const dailySpend = fillMonthDays(month, isCurrentMonth, byDay.data);
 
   return (
     <div>
@@ -90,6 +125,14 @@ export function UsageView() {
               <ModelSpendTable rows={data} />
             </Card>
           )}
+          {byDay.data && (
+            <>
+              <SectionLabel spaced>Spend by day</SectionLabel>
+              <Card className="p-4">
+                <SpendByDayColumns days={dailySpend} />
+              </Card>
+            </>
+          )}
           {byAgent.data && byAgent.data.length > 0 && (
             <>
               <SectionLabel spaced>Spend by agent</SectionLabel>
@@ -100,6 +143,46 @@ export function UsageView() {
           )}
         </>
       )}
+    </div>
+  );
+}
+
+/** Hand-rolled column chart, one column per calendar day of the selected month
+ *  (already zero-filled and truncated at today by the caller). Column height is
+ *  relative to the biggest day; any nonzero day keeps a visible nub so light
+ *  days don't vanish. Hover a column for its exact date and USD amount. No chart
+ *  library — deliberately just Tailwind. */
+function SpendByDayColumns({ days }: { days: SpendByDay[] }) {
+  const max = days.reduce((m, day) => Math.max(m, day.costUsd), 0);
+  return (
+    <div
+      className="flex h-40 items-end gap-px"
+      role="img"
+      aria-label="LLM spend per day"
+    >
+      {days.map((day) => {
+        const [year, month1, date] = day.day.split("-").map(Number);
+        const label = new Date(year, month1 - 1, date).toLocaleDateString(
+          undefined,
+          { month: "short", day: "numeric" },
+        );
+        const pct =
+          day.costUsd > 0 && max > 0
+            ? Math.max((day.costUsd / max) * 100, 4)
+            : 0;
+        return (
+          <div
+            key={day.day}
+            className="flex h-full flex-1 items-end"
+            title={`${label} · ${formatUsd(day.costUsd)}`}
+          >
+            <div
+              className="w-full rounded-t-sm bg-accent"
+              style={{ height: `${pct}%` }}
+            />
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -1,11 +1,12 @@
 import { ChevronLeft, ChevronRight } from "@carbon/icons-react";
+import type { SpendByAgent } from "api-server-api";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { SectionLabel } from "@/components/ui/section-label";
 
-import { useModelSpend } from "../api/queries.js";
+import { useModelSpend, useSpendByAgent } from "../api/queries.js";
 import { ModelSpendTable } from "../components/metrics-panel.js";
 import { formatUsd } from "../lib/format.js";
 
@@ -23,10 +24,10 @@ export function UsageView() {
     month: "long",
     year: "numeric",
   });
-  const { data, isPending, isError } = useModelSpend(
-    month.toISOString(),
-    monthStart(month, 1).toISOString(),
-  );
+  const from = month.toISOString();
+  const to = monthStart(month, 1).toISOString();
+  const { data, isPending, isError } = useModelSpend(from, to);
+  const byAgent = useSpendByAgent(from, to);
   const total = data?.reduce((sum, row) => sum + row.costUsd, 0) ?? 0;
 
   return (
@@ -89,8 +90,51 @@ export function UsageView() {
               <ModelSpendTable rows={data} />
             </Card>
           )}
+          {byAgent.data && byAgent.data.length > 0 && (
+            <>
+              <SectionLabel spaced>Spend by agent</SectionLabel>
+              <Card className="p-4">
+                <SpendByAgentBars rows={byAgent.data} />
+              </Card>
+            </>
+          )}
         </>
       )}
     </div>
+  );
+}
+
+/** Hand-rolled horizontal bars, one per agent, sorted highest cost first (the
+ *  API already sorts them). Bar length is relative to the biggest spender, so
+ *  the top row is always full-width and the rest read proportionally. No chart
+ *  library — deliberately just Tailwind. */
+function SpendByAgentBars({ rows }: { rows: SpendByAgent[] }) {
+  const max = rows[0]?.costUsd ?? 0;
+  return (
+    <ul className="flex flex-col gap-3">
+      {rows.map((row) => (
+        <li key={row.agentId}>
+          <div className="mb-1 flex items-baseline justify-between gap-3 text-[13px]">
+            <span
+              className="truncate text-foreground"
+              title={row.agentName || row.agentId}
+            >
+              {row.agentName || row.agentId}
+            </span>
+            <span className="shrink-0 font-medium tabular-nums text-foreground">
+              {formatUsd(row.costUsd)}
+            </span>
+          </div>
+          <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+            <div
+              className="h-full rounded-full bg-accent"
+              style={{
+                width: `${max > 0 ? (row.costUsd / max) * 100 : 0}%`,
+              }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
   );
 }


### PR DESCRIPTION
Ralph Loop implementing #2877 — one sub-issue per commit, each built in its own fresh agent context.

**This PR will solve:** UI - Expand Usage to cover spend by day and by agent

### Sub-issues
- [ ] #2896 Document the metrics read path (architecture page + glossary)
- [ ] #2897 UI - Usage spend by day chart
- [ ] #2898 UI - Usage spend by agent chart

Closes #2877.