### PR TITLE
refactor(ui): standardize page headers with a shared component

### DIFF
--- a/packages/ui/src/components/ui/page-header.tsx
+++ b/packages/ui/src/components/ui/page-header.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/lib/utils";
+
+interface PageHeaderProps {
+  title: ReactNode;
+  description?: ReactNode;
+  actions?: ReactNode;
+  adornment?: ReactNode;
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  description,
+  actions,
+  adornment,
+  className,
+}: PageHeaderProps) {
+  return (
+    <header className={cn("@container mb-8", className)}>
+      <div className="flex flex-col @lg:flex-row @lg:flex-wrap @lg:items-center @lg:justify-between @lg:gap-x-4">
+        <div className="order-1 flex min-w-0 items-center gap-3">
+          <h1
+            title={typeof title === "string" ? title : undefined}
+            className="truncate text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]"
+          >
+            {title}
+          </h1>
+          {adornment}
+        </div>
+        {actions && (
+          <div className="order-3 mt-3 flex shrink-0 items-center gap-2 @lg:order-2 @lg:mt-0">
+            {actions}
+          </div>
+        )}
+        {description && (
+          <p className="order-2 mt-1 text-[14px] text-muted-foreground @lg:order-3 @lg:w-full">
+            {description}
+          </p>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -2,6 +2,7 @@ import { useMemo } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { PageHeader } from "@/components/ui/page-header";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useStore } from "../../../store.js";
@@ -111,14 +112,14 @@ export function ListView() {
 
   return (
     <div className="mx-auto w-full max-w-[666px]">
-      <div className="mb-8 flex items-center justify-between gap-3">
-        <h1 className="text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-          Sandboxes
-        </h1>
-        {agents.length > 0 && (
-          <Button onClick={navigateToCreateSandbox}>Create sandbox</Button>
-        )}
-      </div>
+      <PageHeader
+        title="Sandboxes"
+        actions={
+          agents.length > 0 ? (
+            <Button onClick={navigateToCreateSandbox}>Create sandbox</Button>
+          ) : undefined
+        }
+      />
 
       {initialLoaded && agents.length > 0 && <BudgetMeter />}
 

--- a/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
@@ -3,6 +3,7 @@ import { KeyRound } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { PageHeader } from "@/components/ui/page-header";
 
 import { useRevokeApiKey } from "../api/mutations.js";
 import { useApiKeys } from "../api/queries.js";
@@ -28,16 +29,13 @@ export function ApiKeysList() {
 
   return (
     <div className="anim-in">
-      <h2 className="text-[18px] font-bold mb-1">API Keys</h2>
-      <p className="text-[14px] text-muted-foreground mb-4">
-        Long-lived tokens for headless / CI use. Pass the value as a bearer
-        credential when calling the API. Plaintext is shown once on creation and
-        never recoverable.
-      </p>
-
-      <div className="flex justify-end mb-4">
-        <Button onClick={() => setCreateOpen(true)}>Create key</Button>
-      </div>
+      <PageHeader
+        title="API Keys"
+        description="Long-lived tokens for headless / CI use. Pass the value as a bearer credential when calling the API. Plaintext is shown once on creation and never recoverable."
+        actions={
+          <Button onClick={() => setCreateOpen(true)}>Create key</Button>
+        }
+      />
 
       {isLoading && (
         <p className="text-[13px] text-muted-foreground">Loading…</p>

--- a/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
+++ b/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
+import { PageHeader } from "@/components/ui/page-header";
 
 import { api } from "../../../api.js";
 import { useDeleteArtifact, useDeleteFolder } from "../api/mutations.js";
@@ -85,31 +86,26 @@ export function ArtifactsView() {
 
   return (
     <div className="anim-in">
-      <div className="flex flex-wrap items-start justify-between gap-4">
-        <div className="min-w-[280px] flex-1">
-          <h1 className="text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-            Artifacts
-          </h1>
-          <p className="mt-1 max-w-[520px] text-[14px] text-muted-foreground">
-            Pages and files created by you and your agents. Share with a link,
-            set an expiry.
-          </p>
-        </div>
-        <div className="mt-1 flex shrink-0 gap-2.5">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setFolderDialog({ folder: null })}
-          >
-            <FolderPlus size={16} />
-            New folder
-          </Button>
-          <Button size="sm" onClick={() => setUploadOpen(true)}>
-            <Upload size={16} />
-            Upload artifact
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title="Artifacts"
+        description="Pages and files created by you and your agents. Share with a link, set an expiry."
+        actions={
+          <>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setFolderDialog({ folder: null })}
+            >
+              <FolderPlus size={16} />
+              New folder
+            </Button>
+            <Button size="sm" onClick={() => setUploadOpen(true)}>
+              <Upload size={16} />
+              Upload artifact
+            </Button>
+          </>
+        }
+      />
 
       <div className="relative mt-7">
         <Search

--- a/packages/ui/src/modules/connections/views/connections-view.tsx
+++ b/packages/ui/src/modules/connections/views/connections-view.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Inset } from "@/components/ui/inset";
+import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
@@ -35,15 +36,10 @@ export function ConnectionsView() {
 
   return (
     <div className="w-full max-w-2xl">
-      <div className="flex items-center gap-3 mb-8">
-        <h1 className="text-[24px] md:text-[28px] font-semibold tracking-[-0.65px] text-foreground">
-          Connections
-        </h1>
-      </div>
-
-      <p className="text-[14px] text-muted-foreground mb-8 leading-relaxed">
-        Connections are the services and credentials your agents can reach.
-      </p>
+      <PageHeader
+        title="Connections"
+        description="Connections are the services and credentials your agents can reach."
+      />
 
       {connectionsQ.isPending ? (
         <ListSkeleton />

--- a/packages/ui/src/modules/features/components/features-tab.tsx
+++ b/packages/ui/src/modules/features/components/features-tab.tsx
@@ -1,5 +1,6 @@
 import type { FeatureId } from "api-server-api";
 
+import { PageHeader } from "@/components/ui/page-header";
 import { Switch } from "@/components/ui/switch";
 
 import { useFeatures, useSetFeature } from "../api/queries.js";
@@ -34,12 +35,10 @@ export function FeaturesTab() {
 
   return (
     <div className="anim-in">
-      <h2 className="mb-1 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-        Experimental features
-      </h2>
-      <p className="mb-6 text-[14px] text-foreground/80">
-        Experimental features, toggled per user.
-      </p>
+      <PageHeader
+        title="Experimental features"
+        description="Experimental features, toggled per user."
+      />
 
       <div className="flex flex-col gap-3">
         {FEATURE_ROWS.map((row) => (

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import { useModelSpend } from "../api/queries.js";
@@ -31,39 +32,34 @@ export function UsageView() {
 
   return (
     <div>
-      <div className="flex items-start justify-between gap-4">
-        <div>
-          <h2 className="mb-1 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-            Usage
-          </h2>
-          <p className="text-[14px] text-foreground/80 mb-6">
-            LLM API spend across all supported agents (currently only Claude
-            Code and derivatives).
-          </p>
-        </div>
-        <div className="flex items-center gap-1 shrink-0">
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Previous month"
-            onClick={() => setMonth(monthStart(month, -1))}
-          >
-            <ChevronLeft size={16} />
-          </Button>
-          <span className="min-w-[120px] text-center text-[14px] font-medium">
-            {monthLabel}
-          </span>
-          <Button
-            variant="ghost"
-            size="icon-sm"
-            aria-label="Next month"
-            disabled={isCurrentMonth}
-            onClick={() => setMonth(monthStart(month, 1))}
-          >
-            <ChevronRight size={16} />
-          </Button>
-        </div>
-      </div>
+      <PageHeader
+        title="Usage"
+        description="LLM API spend across all supported agents (currently only Claude Code and derivatives)."
+        actions={
+          <div className="flex items-center gap-1">
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Previous month"
+              onClick={() => setMonth(monthStart(month, -1))}
+            >
+              <ChevronLeft size={16} />
+            </Button>
+            <span className="min-w-[120px] text-center text-[14px] font-medium">
+              {monthLabel}
+            </span>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Next month"
+              disabled={isCurrentMonth}
+              onClick={() => setMonth(monthStart(month, 1))}
+            >
+              <ChevronRight size={16} />
+            </Button>
+          </div>
+        }
+      />
 
       {isError && (
         <p className="text-[14px] text-muted-foreground">

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { PageHeader } from "@/components/ui/page-header";
 
 import { StatusBadge } from "../../../components/status-indicator.js";
 import { useStore } from "../../../store.js";
@@ -69,64 +70,66 @@ export function SandboxHomeHeader({ agent, display }: Props) {
   };
 
   return (
-    <div className="mb-8 flex items-center justify-between gap-3">
-      <div className="flex min-w-0 items-center gap-3">
-        <h1 className="truncate text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-          {agent.name}
-        </h1>
-        <StatusBadge state={display.state} />
-        {agent.templateUpdate && (
-          <Badge
-            variant="accent"
-            className="shrink-0"
-            title={`Template update available: ${agent.templateUpdate.toImage}`}
-          >
-            Update available
-          </Badge>
-        )}
-      </div>
-      <div className="flex shrink-0 items-center gap-2">
-        <OpenInMenu agent={agent} />
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="outline" size="icon" title="Sandbox actions">
-              <OverflowMenuVertical />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            {display.powerAction === "start" ? (
-              <DropdownMenuItem onSelect={() => wakeAgent.wake(agent.id)}>
-                Wake
-              </DropdownMenuItem>
-            ) : (
-              <DropdownMenuItem
-                disabled={display.powerAction === null}
-                onSelect={() => restart(agent.id)}
-              >
-                Restart
-              </DropdownMenuItem>
-            )}
-            {display.state === "running" && (
-              <>
-                <DropdownMenuItem onSelect={() => suspend.pause(agent.id)}>
-                  Pause — wakes on next use
-                </DropdownMenuItem>
-                <DropdownMenuItem onSelect={() => void onStop()}>
-                  Stop — until started again
-                </DropdownMenuItem>
-              </>
-            )}
-            <DropdownMenuSeparator />
-            <DropdownMenuItem
-              tone="danger"
-              disabled={deleteAgent.isPending}
-              onSelect={() => void onDelete()}
+    <PageHeader
+      title={agent.name}
+      adornment={
+        <>
+          <StatusBadge state={display.state} />
+          {agent.templateUpdate && (
+            <Badge
+              variant="accent"
+              className="shrink-0"
+              title={`Template update available: ${agent.templateUpdate.toImage}`}
             >
-              Delete Sandbox
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      </div>
-    </div>
+              Update available
+            </Badge>
+          )}
+        </>
+      }
+      actions={
+        <>
+          <OpenInMenu agent={agent} />
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" size="icon" title="Sandbox actions">
+                <OverflowMenuVertical />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {display.powerAction === "start" ? (
+                <DropdownMenuItem onSelect={() => wakeAgent.wake(agent.id)}>
+                  Wake
+                </DropdownMenuItem>
+              ) : (
+                <DropdownMenuItem
+                  disabled={display.powerAction === null}
+                  onSelect={() => restart(agent.id)}
+                >
+                  Restart
+                </DropdownMenuItem>
+              )}
+              {display.state === "running" && (
+                <>
+                  <DropdownMenuItem onSelect={() => suspend.pause(agent.id)}>
+                    Pause — wakes on next use
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => void onStop()}>
+                    Stop — until started again
+                  </DropdownMenuItem>
+                </>
+              )}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                tone="danger"
+                disabled={deleteAgent.isPending}
+                onSelect={() => void onDelete()}
+              >
+                Delete Sandbox
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </>
+      }
+    />
   );
 }

--- a/packages/ui/src/modules/settings/views/providers-view.tsx
+++ b/packages/ui/src/modules/settings/views/providers-view.tsx
@@ -1,17 +1,14 @@
+import { PageHeader } from "@/components/ui/page-header";
+
 import { ProviderSection } from "../../providers/components/provider-section.js";
 
 export function ProvidersView() {
   return (
     <div className="w-full max-w-2xl">
-      <header className="mb-8">
-        <h1 className="text-[24px] md:text-[28px] font-semibold tracking-[-0.65px] text-foreground">
-          Providers
-        </h1>
-      </header>
-
-      <p className="text-[14px] text-foreground/80 mb-8 leading-relaxed">
-        Agents need an API key from a provider to reach a model.
-      </p>
+      <PageHeader
+        title="Providers"
+        description="Agents need an API key from a provider to reach a model."
+      />
 
       <section className="mb-8">
         <ProviderSection manage />

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -8,6 +8,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
+import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Select } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
@@ -126,12 +127,10 @@ export function SettingsView() {
       <div className="flex-1 min-w-0">
         {activeTab === "appearance" && (
           <div className="anim-in">
-            <h2 className="mb-1 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-              Appearance
-            </h2>
-            <p className="text-[14px] text-foreground/80 mb-6">
-              Customize the look and feel of the interface.
-            </p>
+            <PageHeader
+              title="Appearance"
+              description="Customize the look and feel of the interface."
+            />
 
             {/* Theme selector */}
             <div className="mb-8">
@@ -181,12 +180,10 @@ export function SettingsView() {
 
         {activeTab === "account" && (
           <div className="anim-in">
-            <h2 className="mb-1 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-              Account
-            </h2>
-            <p className="text-[14px] text-foreground/80 mb-6">
-              Manage your account and session.
-            </p>
+            <PageHeader
+              title="Account"
+              description="Manage your account and session."
+            />
 
             <SectionLabel spaced>Profile</SectionLabel>
             <Card className="flex items-center gap-4 p-4">
@@ -265,12 +262,10 @@ function ChannelsSettings() {
 
   return (
     <div className="anim-in">
-      <h2 className="mb-1 text-[24px] font-semibold tracking-[-0.65px] text-foreground md:text-[28px]">
-        Channels
-      </h2>
-      <p className="text-[14px] text-foreground/80 mb-6">
-        Connect an agent to messenger surfaces (Slack channels, Telegram chats).
-      </p>
+      <PageHeader
+        title="Channels"
+        description="Connect an agent to messenger surfaces (Slack channels, Telegram chats)."
+      />
       <div className="mb-4 max-w-90">
         <SectionLabel spaced>Agent</SectionLabel>
         <Select value={agentId} onChange={(e) => setAgentId(e.target.value)}>


### PR DESCRIPTION
Settings pages had inconsistent headers — Providers and Connections opened an oversized gap before their description, and API Keys used a noticeably smaller title than the rest. This standardizes every page header to one look: the same title size and weight, the same spacing between title and description, and the same gap before the page content.

The same treatment extends beyond Settings — the Sandboxes list, Artifacts, and a sandbox's detail page now share the identical header — so titles read consistently everywhere, with their buttons, pickers, and status badges kept in place.

Headers also adapt to the space they're in: in a narrow column the title, description, and actions stack rather than the title being clipped to keep the buttons on one line.

Closes #2880