### PR TITLE
feat(ui): show the exact date and time on every session in the list

### DIFF
--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
-import { formatSessionDate } from "../lib/format-session-date.js";
+import { formatSessionTimestamp } from "../lib/format-session-date.js";
 import { WorkingDots } from "./working-dots.js";
 
 const LONG_PRESS_MS = 400;
@@ -130,11 +130,8 @@ export function SessionRow({
             working={working}
           />
         </div>
-        <span
-          className="text-[11px] text-muted-foreground"
-          title={new Date(s.updatedAt ?? s.createdAt).toLocaleString()}
-        >
-          {formatSessionDate(s.updatedAt ?? s.createdAt)}
+        <span className="text-[11px] text-muted-foreground">
+          {formatSessionTimestamp(s.updatedAt ?? s.createdAt)}
         </span>
       </div>
       {/* Desktop: hover-visible overflow menu */}

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -17,7 +17,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
-import { formatSessionTimestamp } from "../lib/format-session-date.js";
+import { formatSessionTimestamp } from "../lib/format-session-timestamp.js";
 import { WorkingDots } from "./working-dots.js";
 
 const LONG_PRESS_MS = 400;

--- a/packages/ui/src/modules/sessions/lib/format-session-date.ts
+++ b/packages/ui/src/modules/sessions/lib/format-session-date.ts
@@ -1,15 +1,5 @@
-const DAY_MS = 86_400_000;
-
-function startOfDay(d: Date): number {
-  return new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
-}
-
-export function formatSessionDate(iso: string, now: Date = new Date()): string {
-  const date = new Date(iso);
-  const dayDiff = Math.round((startOfDay(now) - startOfDay(date)) / DAY_MS);
-  if (dayDiff <= 0) return "Today";
-  if (dayDiff === 1) return "Yesterday";
-  if (dayDiff <= 7) return "Last week";
-  if (dayDiff <= 30) return "Last 30 days";
-  return date.toLocaleDateString();
+export function formatSessionTimestamp(iso: string): string {
+  const d = new Date(iso);
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${p(d.getMonth() + 1)}/${p(d.getDate())}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}`;
 }

--- a/packages/ui/src/modules/sessions/lib/format-session-timestamp.ts
+++ b/packages/ui/src/modules/sessions/lib/format-session-timestamp.ts
@@ -1,5 +1,6 @@
 export function formatSessionTimestamp(iso: string): string {
   const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
   const p = (n: number) => String(n).padStart(2, "0");
   return `${p(d.getMonth() + 1)}/${p(d.getDate())}/${d.getFullYear()} ${p(d.getHours())}:${p(d.getMinutes())}`;
 }


### PR DESCRIPTION
Every session in the list now shows its exact date and time — `MM/DD/YYYY HH:MM`, e.g. `07/22/2026 14:32` — in one consistent format for recent and old sessions alike.

Previously each row showed a vague relative label (*Today*, *Yesterday*, *Last week*, *Last 30 days*), which couldn't tell apart multiple sessions from the same day, never named a day for anything older, and showed no time. Now you can reliably identify and order sessions and jump back to a specific one.

Closes #2901