### PR TITLE
fix(ui): dedupe the GitHub App install hint across connections

### DIFF
--- a/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
@@ -10,7 +10,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 
-import { GithubAppInstallHint } from "./github-app-install-hint.js";
+import { GithubAppInstallLink } from "./github-app-install-hint.js";
 
 export interface RowGrantControls {
   granted: boolean;
@@ -58,6 +58,7 @@ export function CatalogConnectionRow({
             {subtitle}
           </p>
         </div>
+        <GithubAppInstallLink connection={connection} />
         {grant &&
           !grant.actionHidden &&
           (grant.granted ? (
@@ -110,7 +111,6 @@ export function CatalogConnectionRow({
           </DropdownMenuContent>
         </DropdownMenu>
       </div>
-      <GithubAppInstallHint connection={connection} />
     </div>
   );
 }

--- a/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
@@ -44,8 +44,8 @@ export function CatalogConnectionRow({
       data-testid={`catalog-connection-${connection.id}`}
       className="px-4 py-3"
     >
-      <div className="flex items-center gap-2">
-        <div className="min-w-0 flex-1">
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
+        <div className="min-w-0 flex-1 basis-[180px]">
           <div className="flex items-center gap-2">
             <p className="truncate text-[15px] text-foreground">
               {connection.name}
@@ -58,58 +58,60 @@ export function CatalogConnectionRow({
             {subtitle}
           </p>
         </div>
-        <GithubAppInstallLink connection={connection} />
-        {grant &&
-          !grant.actionHidden &&
-          (grant.granted ? (
-            <span className="inline-flex h-[32px] shrink-0 items-center gap-1.5 rounded-full bg-muted px-3 text-[14px] text-foreground">
-              <Checkmark size={16} className="text-success" />
-              In this sandbox
-            </span>
-          ) : (
-            <Button
-              variant="outline"
-              className="h-[32px] shrink-0 px-3 text-[14px] font-normal"
-              onClick={() => grant.onToggle(true)}
-              data-testid={`catalog-add-${connection.id}`}
-            >
-              <Add size={16} />
-              Add to sandbox
-            </Button>
-          ))}
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button
-              variant="ghost"
-              size="icon-sm"
-              aria-label={`Actions for ${connection.name}`}
-              data-testid={`catalog-menu-${connection.id}`}
-            >
-              <OverflowMenuHorizontal size={16} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            {grant?.granted && (
-              <DropdownMenuItem onSelect={() => grant.onToggle(false)}>
-                Remove from this sandbox
-              </DropdownMenuItem>
-            )}
-            {onManage && (
-              <DropdownMenuItem onSelect={onManage}>
-                Manage connections
-              </DropdownMenuItem>
-            )}
-            {onDelete && (
-              <DropdownMenuItem
-                tone="danger"
-                disabled={deleting}
-                onSelect={onDelete}
+        <div className="ml-auto flex shrink-0 items-center gap-2">
+          <GithubAppInstallLink connection={connection} />
+          {grant &&
+            !grant.actionHidden &&
+            (grant.granted ? (
+              <span className="inline-flex h-[32px] shrink-0 items-center gap-1.5 rounded-full bg-muted px-3 text-[14px] text-foreground">
+                <Checkmark size={16} className="text-success" />
+                In this sandbox
+              </span>
+            ) : (
+              <Button
+                variant="outline"
+                className="h-[32px] shrink-0 px-3 text-[14px] font-normal"
+                onClick={() => grant.onToggle(true)}
+                data-testid={`catalog-add-${connection.id}`}
               >
-                Delete this connection
-              </DropdownMenuItem>
-            )}
-          </DropdownMenuContent>
-        </DropdownMenu>
+                <Add size={16} />
+                Add to sandbox
+              </Button>
+            ))}
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label={`Actions for ${connection.name}`}
+                data-testid={`catalog-menu-${connection.id}`}
+              >
+                <OverflowMenuHorizontal size={16} />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent>
+              {grant?.granted && (
+                <DropdownMenuItem onSelect={() => grant.onToggle(false)}>
+                  Remove from this sandbox
+                </DropdownMenuItem>
+              )}
+              {onManage && (
+                <DropdownMenuItem onSelect={onManage}>
+                  Manage connections
+                </DropdownMenuItem>
+              )}
+              {onDelete && (
+                <DropdownMenuItem
+                  tone="danger"
+                  disabled={deleting}
+                  onSelect={onDelete}
+                >
+                  Delete this connection
+                </DropdownMenuItem>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
       </div>
     </div>
   );

--- a/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
@@ -44,8 +44,8 @@ export function CatalogConnectionRow({
       data-testid={`catalog-connection-${connection.id}`}
       className="px-4 py-3"
     >
-      <div className="flex flex-wrap items-center gap-x-2 gap-y-1.5">
-        <div className="min-w-0 flex-1 basis-[180px]">
+      <div className="flex items-center gap-2">
+        <div className="min-w-[160px] flex-1">
           <div className="flex items-center gap-2">
             <p className="truncate text-[15px] text-foreground">
               {connection.name}
@@ -58,7 +58,7 @@ export function CatalogConnectionRow({
             {subtitle}
           </p>
         </div>
-        <div className="ml-auto flex shrink-0 items-center gap-2">
+        <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-1.5">
           <GithubAppInstallLink connection={connection} />
           {grant &&
             !grant.actionHidden &&
@@ -78,40 +78,40 @@ export function CatalogConnectionRow({
                 Add to sandbox
               </Button>
             ))}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label={`Actions for ${connection.name}`}
-                data-testid={`catalog-menu-${connection.id}`}
-              >
-                <OverflowMenuHorizontal size={16} />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent>
-              {grant?.granted && (
-                <DropdownMenuItem onSelect={() => grant.onToggle(false)}>
-                  Remove from this sandbox
-                </DropdownMenuItem>
-              )}
-              {onManage && (
-                <DropdownMenuItem onSelect={onManage}>
-                  Manage connections
-                </DropdownMenuItem>
-              )}
-              {onDelete && (
-                <DropdownMenuItem
-                  tone="danger"
-                  disabled={deleting}
-                  onSelect={onDelete}
-                >
-                  Delete this connection
-                </DropdownMenuItem>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label={`Actions for ${connection.name}`}
+              data-testid={`catalog-menu-${connection.id}`}
+            >
+              <OverflowMenuHorizontal size={16} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            {grant?.granted && (
+              <DropdownMenuItem onSelect={() => grant.onToggle(false)}>
+                Remove from this sandbox
+              </DropdownMenuItem>
+            )}
+            {onManage && (
+              <DropdownMenuItem onSelect={onManage}>
+                Manage connections
+              </DropdownMenuItem>
+            )}
+            {onDelete && (
+              <DropdownMenuItem
+                tone="danger"
+                disabled={deleting}
+                onSelect={onDelete}
+              >
+                Delete this connection
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
     </div>
   );

--- a/packages/ui/src/modules/connections/components/catalog-provider-card.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-provider-card.tsx
@@ -7,6 +7,7 @@ import type { CatalogProviderGroup } from "../lib/catalog-providers.js";
 import { connectionKindSubtitle } from "../lib/catalog-providers.js";
 import { CatalogConnectionRow } from "./catalog-connection-row.js";
 import { ConnectionIcon } from "./connection-icon.js";
+import { GithubAppInstallHint } from "./github-app-install-hint.js";
 
 export interface SandboxGrantControls {
   grantedIds: ReadonlySet<string>;
@@ -62,26 +63,29 @@ export function CatalogProviderCard({
         {connections.length > 0 && newButton}
       </header>
       {connections.length > 0 ? (
-        <div className="divide-y divide-border">
-          {connections.map((c) => (
-            <CatalogConnectionRow
-              key={c.id}
-              connection={c}
-              subtitle={connectionKindSubtitle(
-                c,
-                templateById.get(c.templateId),
-              )}
-              grant={
-                sandbox && {
-                  granted: sandbox.grantedIds.has(c.id),
-                  onToggle: (on) => sandbox.onToggleGrant(c.id, on),
+        <>
+          <GithubAppInstallHint connections={connections} />
+          <div className="divide-y divide-border">
+            {connections.map((c) => (
+              <CatalogConnectionRow
+                key={c.id}
+                connection={c}
+                subtitle={connectionKindSubtitle(
+                  c,
+                  templateById.get(c.templateId),
+                )}
+                grant={
+                  sandbox && {
+                    granted: sandbox.grantedIds.has(c.id),
+                    onToggle: (on) => sandbox.onToggleGrant(c.id, on),
+                  }
                 }
-              }
-              onDelete={() => onDelete(c.id, c.name)}
-              deleting={deletingId === c.id}
-            />
-          ))}
-        </div>
+                onDelete={() => onDelete(c.id, c.name)}
+                deleting={deletingId === c.id}
+              />
+            ))}
+          </div>
+        </>
       ) : (
         <div className="flex flex-col items-start gap-3 px-4 py-4">
           <p className="text-[14px] text-muted-foreground">

--- a/packages/ui/src/modules/connections/components/connection-group-card.tsx
+++ b/packages/ui/src/modules/connections/components/connection-group-card.tsx
@@ -5,6 +5,7 @@ import { connectionKindSubtitle } from "../lib/catalog-providers.js";
 import type { RowGrantControls } from "./catalog-connection-row.js";
 import { CatalogConnectionRow } from "./catalog-connection-row.js";
 import { ConnectionIcon } from "./connection-icon.js";
+import { GithubAppInstallHint } from "./github-app-install-hint.js";
 
 interface Props {
   group: CatalogProviderGroup;
@@ -49,6 +50,7 @@ export function ConnectionGroupCard({
           </span>
         )}
       </header>
+      <GithubAppInstallHint connections={connections} />
       <div className="divide-y divide-border">
         {connections.map((c) => (
           <CatalogConnectionRow

--- a/packages/ui/src/modules/connections/components/github-app-install-hint.tsx
+++ b/packages/ui/src/modules/connections/components/github-app-install-hint.tsx
@@ -4,31 +4,51 @@ import type { ConnectionView } from "api-server-api";
 import { getBrand } from "../../../brand.js";
 import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
 
+type InstallHintConnection = Pick<
+  ConnectionView,
+  "templateId" | "host" | "appSlug" | "status"
+>;
+
+function activeInstallUrl(connection: InstallHintConnection): string | null {
+  if (connection.status !== "active") return null;
+  return githubAppInstallUrl(connection);
+}
+
+/** Shared banner shown once per provider group when at least one connection
+ *  has a GitHub App install step. */
 export function GithubAppInstallHint({
+  connections,
+}: {
+  connections: readonly InstallHintConnection[];
+}) {
+  if (!connections.some((c) => activeInstallUrl(c) !== null)) return null;
+  return (
+    <p className="mx-4 mt-3 rounded-md border border-border bg-muted/40 px-3.5 py-2.5 text-[13px] leading-relaxed text-muted-foreground">
+      <strong className="text-foreground/80">
+        GitHub App connections need one more step.
+      </strong>{" "}
+      To let {getBrand().name} work with your private repos, install the app on
+      the organization that owns them.
+    </p>
+  );
+}
+
+/** Per-row link to the connection's GitHub App installation page. */
+export function GithubAppInstallLink({
   connection,
 }: {
-  connection: Pick<
-    ConnectionView,
-    "templateId" | "host" | "appSlug" | "status"
-  >;
+  connection: InstallHintConnection;
 }) {
-  const url = githubAppInstallUrl(connection);
-  if (!url || connection.status !== "active") return null;
+  const url = activeInstallUrl(connection);
+  if (!url) return null;
   return (
-    <div className="mt-2.5 flex flex-wrap items-center gap-x-10 gap-y-1.5 rounded-md border border-border bg-muted/40 px-3.5 py-2.5">
-      <p className="min-w-0 flex-1 basis-[280px] text-[13px] leading-relaxed text-muted-foreground">
-        <strong className="text-foreground/80">Connecting is step one.</strong>{" "}
-        To let {getBrand().name} work with your private repos, install the app
-        on the organization that owns them.
-      </p>
-      <a
-        href={url}
-        target="_blank"
-        rel="noreferrer noopener"
-        className="inline-flex shrink-0 items-center gap-1.5 text-[13px] font-medium text-accent hover:underline"
-      >
-        Install on GitHub <Launch size={13} aria-hidden />
-      </a>
-    </div>
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer noopener"
+      className="inline-flex shrink-0 items-center gap-1.5 text-[13px] font-medium text-accent hover:underline"
+    >
+      Install on GitHub <Launch size={13} aria-hidden />
+    </a>
   );
 }


### PR DESCRIPTION
Closes #2879

## Summary

When multiple GitHub (or GitHub Enterprise) connections were configured, the App-install info box repeated under every row. This implements the design agreed in the issue thread: one shared banner per provider group, with the per-connection **Install on GitHub ↗** link kept inline in each row (the link target differs per connection — host/app slug).

- `GithubAppInstallHint` now takes the group's connection list and renders a single banner between the card header and the rows, only when at least one active connection has an install step (`appSlug` set). Copy updated to "**GitHub App connections need one more step.** …" per the design.
- `GithubAppInstallLink` (new) renders the compact per-row link on the right side of the row, next to the row actions; hidden for connections without an install URL or not active.
- Both group cards get the banner: the settings "My connections" card (`ConnectionGroupCard`) and the catalogue card (`CatalogProviderCard`).

## Testing

- `mise run ui:check` passes (one pre-existing warning in an unrelated file)
- `mise run ui:test` — 92/92 pass