### PR TITLE
docs(guidelines): issue types (epic/story/task/bug) with per-type templates

### DIFF
--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -1,23 +1,36 @@
 ---
 name: draft-issue
 description: >
-  Template and writing guidelines for a GitHub issue that defines a problem and proposes a high-level solution from the user's perspective, with no implementation details.
+  Template and writing guidelines for a GitHub issue — a ticket that defines a problem and proposes a high-level solution from the user's perspective, or an epic that defines a chunk of value. Tickets get a proposed parent epic from the project board.
 ---
 
 # Draft an Issue
 
-Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for what to include, what to exclude, style, and the template.
+Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for what to include, what to exclude, style, and the templates. That doc also defines the concepts used here: epics, tickets, the parent relationship, and orphans.
 
 ## Workflow
 
 1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
 
-2. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
+2. **Decide: ticket or epic.** Most requests are tickets — a concrete problem with a concrete fix. If the ask reads like a meaningful chunk of value with several pieces of work inside it (or the user says "epic"), it's probably an epic. When it's not obvious, ask the user which one they mean before drafting. The two use different templates (see the guidelines doc).
+
+3. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
 
    **But keep the research out of the issue itself.** Do not pull file paths, function names, line numbers, data structures, or architectural detail into the draft. The research informs your writing; it does not appear in it. If a sentence only makes sense to someone who's read the code, rewrite it.
 
-3. **Decide output mode from the original prompt.** Read the user's initial ask and pick one:
-   - **Draft only** — produce the draft following the guidelines and present the full title + body inline in the chat. Stop.
+4. **For a ticket: find its epic.** Every ticket needs a parent epic — a ticket without one is an orphan. Fetch the epics from the project board and match the ticket against their titles and bodies:
+
+   ```sh
+   gh project item-list 1 --owner dam-agents --limit 3000 --format json \
+     | jq -r '.items[] | select(.status=="Epics") | "#\(.content.number)  \(.title)"'
+   ```
+
+   Read the body of any plausible candidate (`gh issue view <num> --repo dam-agents/dam`) before committing. Put the recommendation on the draft's **Epic** line with a one-line justification. If no epic fits, say so explicitly, list the closest candidates you rejected, and flag the options: promote the ticket to an epic of its own, or raise it with the Product Owner. Never silently draft an orphan.
+
+   Skip this step when drafting an epic — epics have no parent.
+
+5. **Decide output mode from the original prompt.** Read the user's initial ask and pick one:
+   - **Draft only** — produce the draft following the guidelines and present the full title + body inline in the chat (including the Epic line for tickets). Stop.
    - **File right away** — hand off to the `file-issue` skill, which runs the dedupe → approve → file loop on top of the same draft.
 
    When in doubt, default to draft-only and ask whether to file.

--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -1,36 +1,34 @@
 ---
 name: draft-issue
 description: >
-  Template and writing guidelines for a GitHub issue — a ticket that defines a problem and proposes a high-level solution from the user's perspective, or an epic that defines a chunk of value. Tickets get a proposed parent epic from the project board.
+  Template and writing guidelines for a GitHub issue. Every issue is one of epic, story, task, or bug — the user decides the type, and each type has its own template. Stories, tasks, and bugs can suggest a parent epic from the project board.
 ---
 
 # Draft an Issue
 
-Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for what to include, what to exclude, style, and the templates. That doc also defines the concepts used here: epics, tickets, the parent relationship, and orphans.
+Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for the issue types, what to exclude, style, and the per-type templates.
 
 ## Workflow
 
 1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
 
-2. **Decide: ticket or epic.** Most requests are tickets — a concrete problem with a concrete fix. If the ask reads like a meaningful chunk of value with several pieces of work inside it (or the user says "epic"), it's probably an epic. When it's not obvious, ask the user which one they mean before drafting. The two use different templates (see the guidelines doc).
+2. **Let the user decide the type.** Every issue is an **epic**, **story**, **task**, or **bug** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template. Skip the question only when the type is unmistakable (e.g. the user said "bug" or described a clear defect).
 
 3. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
 
    **But keep the research out of the issue itself.** Do not pull file paths, function names, line numbers, data structures, or architectural detail into the draft. The research informs your writing; it does not appear in it. If a sentence only makes sense to someone who's read the code, rewrite it.
 
-4. **For a ticket: find its epic.** Every ticket needs a parent epic — a ticket without one is an orphan. Fetch the epics from the project board and match the ticket against their titles and bodies:
+4. **For a story, task, or bug: consider an epic.** Fetch the epics from the project board and check whether one clearly fits:
 
    ```sh
    gh project item-list 1 --owner dam-agents --limit 3000 --format json \
      | jq -r '.items[] | select(.status=="Epics") | "#\(.content.number)  \(.title)"'
    ```
 
-   Read the body of any plausible candidate (`gh issue view <num> --repo dam-agents/dam`) before committing. Put the recommendation on the draft's **Epic** line with a one-line justification. If no epic fits, say so explicitly, list the closest candidates you rejected, and flag the options: promote the ticket to an epic of its own, or raise it with the Product Owner. Never silently draft an orphan.
-
-   Skip this step when drafting an epic — epics have no parent.
+   If one does, read its body (`gh issue view <num> --repo dam-agents/dam`) to confirm, then put it on the draft's **Epic** line with a one-line justification. If nothing fits, leave the line out — placement can be decided later in triage. Epics themselves have no parent; skip this step.
 
 5. **Decide output mode from the original prompt.** Read the user's initial ask and pick one:
-   - **Draft only** — produce the draft following the guidelines and present the full title + body inline in the chat (including the Epic line for tickets). Stop.
+   - **Draft only** — produce the draft using the type's template and present the full title + body inline in the chat. Stop.
    - **File right away** — hand off to the `file-issue` skill, which runs the dedupe → approve → file loop on top of the same draft.
 
    When in doubt, default to draft-only and ask whether to file.

--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -6,7 +6,7 @@ description: >
 
 # Draft an Issue
 
-Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for the issue types, what to exclude, style, and the per-type templates.
+Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for the issue types, style, and the per-type templates.
 
 ## Workflow
 

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -8,11 +8,13 @@ argument-hint: "[what the issue is about]"
 
 # File an Issue
 
-Draft a GitHub issue and file it after the user approves. For the content shape — what belongs in an issue, what doesn't, the templates, and the epic/ticket concepts — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → research → dedupe → find epic → draft → approve → file) on top of those guidelines.
+Draft a GitHub issue and file it after the user approves. For the content shape — the issue types (epic, story, task, bug), what to exclude, and the per-type templates — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → decide type → research → dedupe → draft → approve → file) on top of those guidelines.
 
 ## Workflow
 
-1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask. Decide whether this is a **ticket** or an **epic** (see the guidelines doc) — ask if it's not obvious; they use different templates and are filed differently.
+1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
+
+   Then let the user decide the type: every issue is an **epic**, **story**, **task**, or **bug** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template and how the issue is filed. Skip the question only when the type is unmistakable.
 
 2. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
 
@@ -26,18 +28,18 @@ Draft a GitHub issue and file it after the user approves. For the content shape 
 
    Use multiple keyword variations drawn from the user's request. If you find a plausible duplicate or closely-related issue, surface it to the user with a one-line summary and ask how to proceed — options include: add a comment to the existing issue, file a new one anyway with a cross-link, or close the request as already-tracked. Do not silently file a duplicate.
 
-4. **For a ticket: find its epic.** Every ticket needs a parent epic — a ticket without one is an orphan. Fetch the epics from the project board, match against their titles and bodies, and put the recommendation on the draft's **Epic** line:
+4. **For a story, task, or bug: consider an epic.** Fetch the epics from the project board and check whether one clearly fits:
 
    ```sh
    gh project item-list 1 --owner dam-agents --limit 3000 --format json \
      | jq -r '.items[] | select(.status=="Epics") | "#\(.content.number)  \(.title)"'
    ```
 
-   If no epic fits, say so, list the closest candidates you rejected, and ask the user whether to promote the ticket to an epic or file it as an orphan anyway. Skip this step for epics.
+   If one does, put it on the draft's **Epic** line with a one-line justification. If nothing fits, leave the line out — placement can be decided later in triage. Epics themselves have no parent; skip this step.
 
-5. **Draft inline.** Produce the draft following [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md), using the ticket or epic template as decided. Present the full draft (title + body, plus the Epic line for tickets) in the chat. Do not file yet.
+5. **Draft inline.** Produce the draft following [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md), using the decided type's template. Present the full draft (title + body, plus the Epic line if one was suggested) in the chat. Do not file yet.
 
-6. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval. Approval covers the epic recommendation too — if the user picks a different epic, that's a revision.
+6. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval. Approval covers the type and any epic suggestion too — if the user changes either, that's a revision.
 
    **Every revision invalidates the previous approval.** If the user requests any change after approving — even a small one — you must present the revised draft and get a fresh, explicit "file it" before sending to GitHub. Do not assume the original approval carries over.
 
@@ -67,16 +69,16 @@ EOF
 )"
 ```
 
-### After filing a ticket: attach it to its epic
+### After filing: attach to the epic, if one was approved
 
-Set the approved epic as the ticket's parent via the sub-issues API. It takes the child's numeric database `id` (not the issue number, not the node ID):
+If the approved draft carries an **Epic** line, set that epic as the issue's parent via the sub-issues API. It takes the child's numeric database `id` (not the issue number, not the node ID):
 
 ```sh
-CHILD_ID="$(gh api repos/owner/repo/issues/<ticket-number> --jq .id)"
+CHILD_ID="$(gh api repos/owner/repo/issues/<issue-number> --jq .id)"
 gh api repos/owner/repo/issues/<epic-number>/sub_issues -F sub_issue_id="$CHILD_ID"
 ```
 
-If the user approved filing without an epic, skip this and remind them the ticket is an orphan until triage places it.
+If there's no Epic line, skip this.
 
 ### After filing an epic
 
@@ -86,4 +88,4 @@ Add the issue to the project board and tell the user it still needs its board St
 gh project item-add 1 --owner dam-agents --url <issue-url>
 ```
 
-Return the resulting issue URL to the user in one line (for tickets, mention the epic it was attached to). Do not add commentary about what was filed — the draft already conveyed that.
+Return the resulting issue URL to the user in one line (mention the epic it was attached to, if any). Do not add commentary about what was filed — the draft already conveyed that.

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -8,11 +8,11 @@ argument-hint: "[what the issue is about]"
 
 # File an Issue
 
-Draft a GitHub issue and file it after the user approves. For the content shape — what belongs in an issue, what doesn't, and the template — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → research → dedupe → draft → approve → file) on top of those guidelines.
+Draft a GitHub issue and file it after the user approves. For the content shape — what belongs in an issue, what doesn't, the templates, and the epic/ticket concepts — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → research → dedupe → find epic → draft → approve → file) on top of those guidelines.
 
 ## Workflow
 
-1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
+1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask. Decide whether this is a **ticket** or an **epic** (see the guidelines doc) — ask if it's not obvious; they use different templates and are filed differently.
 
 2. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
 
@@ -26,13 +26,22 @@ Draft a GitHub issue and file it after the user approves. For the content shape 
 
    Use multiple keyword variations drawn from the user's request. If you find a plausible duplicate or closely-related issue, surface it to the user with a one-line summary and ask how to proceed — options include: add a comment to the existing issue, file a new one anyway with a cross-link, or close the request as already-tracked. Do not silently file a duplicate.
 
-4. **Draft inline.** Produce the draft following [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). Present the full draft (title + body) in the chat. Do not file yet.
+4. **For a ticket: find its epic.** Every ticket needs a parent epic — a ticket without one is an orphan. Fetch the epics from the project board, match against their titles and bodies, and put the recommendation on the draft's **Epic** line:
 
-5. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval.
+   ```sh
+   gh project item-list 1 --owner dam-agents --limit 3000 --format json \
+     | jq -r '.items[] | select(.status=="Epics") | "#\(.content.number)  \(.title)"'
+   ```
+
+   If no epic fits, say so, list the closest candidates you rejected, and ask the user whether to promote the ticket to an epic or file it as an orphan anyway. Skip this step for epics.
+
+5. **Draft inline.** Produce the draft following [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md), using the ticket or epic template as decided. Present the full draft (title + body, plus the Epic line for tickets) in the chat. Do not file yet.
+
+6. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval. Approval covers the epic recommendation too — if the user picks a different epic, that's a revision.
 
    **Every revision invalidates the previous approval.** If the user requests any change after approving — even a small one — you must present the revised draft and get a fresh, explicit "file it" before sending to GitHub. Do not assume the original approval carries over.
 
-6. **File via `gh` CLI.** Use `gh issue create`. Infer the repo from context (current working directory's git remote, or a repo mentioned earlier in the session). If unclear, ask. Return the issue URL.
+7. **File via `gh` CLI.** Use `gh issue create`. Infer the repo from context (current working directory's git remote, or a repo mentioned earlier in the session). If unclear, ask. Then apply the relationships (below) and return the issue URL.
 
 ## Filing
 
@@ -40,7 +49,7 @@ After approval, file with `gh issue create`. Do not use the GitHub MCP tools (`m
 
 - `--repo owner/repo` — infer from git remote or prior context; ask if ambiguous
 - `--title "..."` — exactly as approved
-- `--body "..."` — exactly as approved; pass via a HEREDOC so markdown formatting survives
+- `--body "..."` — exactly as approved, minus the **Epic** line (it's draft metadata, applied as the parent relationship below, not body text); pass via a HEREDOC so markdown formatting survives
 - `--label foo --label bar` — only if the user specified labels
 
 Example:
@@ -58,4 +67,23 @@ EOF
 )"
 ```
 
-Return the resulting issue URL to the user in one line. Do not add commentary about what was filed — the draft already conveyed that.
+### After filing a ticket: attach it to its epic
+
+Set the approved epic as the ticket's parent via the sub-issues API. It takes the child's numeric database `id` (not the issue number, not the node ID):
+
+```sh
+CHILD_ID="$(gh api repos/owner/repo/issues/<ticket-number> --jq .id)"
+gh api repos/owner/repo/issues/<epic-number>/sub_issues -F sub_issue_id="$CHILD_ID"
+```
+
+If the user approved filing without an epic, skip this and remind them the ticket is an orphan until triage places it.
+
+### After filing an epic
+
+Add the issue to the project board and tell the user it still needs its board Status set to `Epics` and a Focus (Now / Next / Later) — those are set on the board, usually by the Product Owner:
+
+```sh
+gh project item-add 1 --owner dam-agents --url <issue-url>
+```
+
+Return the resulting issue URL to the user in one line (for tickets, mention the epic it was attached to). Do not add commentary about what was filed — the draft already conveyed that.

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[what the issue is about]"
 
 # File an Issue
 
-Draft a GitHub issue and file it after the user approves. For the content shape — the issue types (epic, story, task, bug), what to exclude, and the per-type templates — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → decide type → research → dedupe → draft → approve → file) on top of those guidelines.
+Draft a GitHub issue and file it after the user approves. For the content shape — the issue types (epic, story, task, bug), style, and the per-type templates — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → decide type → research → dedupe → draft → approve → file) on top of those guidelines.
 
 ## Workflow
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -4,25 +4,16 @@ Shared content guidelines for writing GitHub issues.
 
 A GitHub issue should read like a product ticket, not an engineering plan. The reader should understand **what problem exists** and **what the user-visible outcome of fixing it looks like** — nothing more.
 
-## Tickets and epics
+## Issue types
 
-Work is structured in two kinds of issues:
+Decide the type first — it picks the template. Every issue is one of:
 
-- **Epic** — a meaningful chunk of value we want to deliver. Epics are owned by the Product Owner and live on the [project board](https://github.com/orgs/dam-agents/projects/1) in the `Epics` status column. Each epic carries a **Focus** (Now / Next / Later) that sets its priority.
-- **Ticket** — a concrete piece of work that serves an epic's goal. A ticket is attached to its epic through GitHub's **parent** relationship (the epic is the parent issue, the ticket is a sub-issue).
+- **Epic** — a meaningful chunk of value we want to deliver. Epics are owned by the Product Owner and live on the [project board](https://github.com/orgs/dam-agents/projects/1) in the `Epics` status column, each with a **Focus** (Now / Next / Later) that sets its priority.
+- **Story** — a user-facing improvement: new behavior, or a change the user can see.
+- **Task** — work that needs to happen but isn't user-facing: chores, tooling, upgrades, refactors.
+- **Bug** — something that should work but doesn't.
 
-Every ticket must have a parent epic. A ticket with no parent is an **orphan**: it inherits no priority and contributes to no goal, and it will get swept up in triage. So when drafting a ticket, always propose which epic it belongs to. If no epic fits, say so — the options are to promote the ticket to an epic of its own or to raise it with the Product Owner.
-
-## What to include
-
-- **Title** — short, declarative, no jargon. Names the change, not the component.
-- **Problem** — what's wrong or missing today, from the user's point of view. Include a concrete scenario if it sharpens the problem. Explain *why it matters* — what does the user currently have to do, or fail to do, because of this gap.
-- **Proposed solution** — the high-level shape of the fix, described as user-visible behavior ("the agent can do X", "the UI shows Y"). Not the mechanism.
-- **Optional subsections**, only when they add signal:
-  - **Scope** — boundaries of the change (what it does and does *not* cover).
-  - **Transparency / safety** — anything the user needs to see or control for trust.
-  - **Dependencies** — blocked on / blocks other issues (reference by `#NNN`).
-  - **Out of scope** — things a reader will reasonably wonder about, deferred with a brief reason.
+Stories, tasks, and bugs can be attached to an epic through GitHub's **parent** relationship (the epic is the parent issue). If the issue clearly serves an existing epic, suggest it. If nothing fits, leave it out — placement can be decided later in triage.
 
 ## What to exclude
 
@@ -36,6 +27,8 @@ Strip all of these before presenting the draft:
 
 Rule of thumb: if a reader would need to know the codebase to understand a sentence, rewrite or remove it. The issue should make sense to a PM, a designer, or a new contributor who's never opened the repo.
 
+Tasks and bugs get some slack: a task often *is* engineering work, and a bug may need a precise trigger. Name what's necessary to act on the issue, in the plainest terms available, and nothing more.
+
 ## Style
 
 - Prefer plain language over precise language. "Schedules" not "AgentSchedule ConfigMaps."
@@ -44,44 +37,13 @@ Rule of thumb: if a reader would need to know the codebase to understand a sente
 - It's fine to flag open questions or naming uncertainty — invite the reader to push back.
 - Concise but complete. If a subsection has nothing to say, cut it.
 
-## Ticket template
+## Templates
 
-```markdown
-**Title:** <short, declarative>
-**Epic:** <#NNN — epic title, or "none fits — candidates considered: …">
+Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Stories, tasks, and bugs may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied as the parent relationship when the issue is filed.
 
-## Problem
+### Epic
 
-<What's wrong or missing today, from the user's perspective. A concrete scenario if it helps. Why it matters.>
-
-## Proposed solution
-
-<The user-visible shape of the fix. High-level, no mechanism.>
-
-### Scope
-<optional — boundaries>
-
-### Dependencies
-<optional — Blocked on #NNN, blocks #NNN>
-
-### Out of scope
-<optional — deferred things, with a one-line reason each>
-```
-
-The **Epic** line is metadata for the draft, not part of the issue body — the epic link is applied as the parent relationship when the issue is filed.
-
-## Epics
-
-An epic body answers different questions than a ticket. It defines the value, not a single fix, and it should give enough shape that tickets can be attached to it with confidence.
-
-- **Goal** — the value we want to deliver, in one or two sentences. Who benefits and how.
-- **Why now** — what makes this worth prioritizing: the pain today, or the opportunity.
-- **What done looks like** — the observable outcomes when the epic is complete. User-visible behavior, not a task list.
-- **Out of scope** — adjacent things this epic deliberately does not cover.
-
-The same exclusion rules apply: no implementation detail, no internal component names. An epic should make sense to anyone on the team.
-
-## Epic template
+An epic body defines the value, not a single fix, and gives enough shape that issues can be attached to it with confidence. It should make sense to anyone on the team.
 
 ```markdown
 **Title:** <the value delivered, short and declarative>
@@ -100,4 +62,78 @@ The same exclusion rules apply: no implementation detail, no internal component 
 
 ### Out of scope
 <optional — adjacent things deliberately not covered>
+```
+
+### Story
+
+The **Problem** describes what's wrong or missing today, from the user's point of view — include a concrete scenario if it sharpens it, and explain *why it matters*. The **Proposed solution** is the high-level shape of the fix as user-visible behavior ("the agent can do X", "the UI shows Y"), not the mechanism.
+
+```markdown
+**Title:** <short, declarative>
+**Epic:** <#NNN — epic title, if one clearly fits>
+
+## Problem
+
+<What's wrong or missing today, from the user's perspective. A concrete scenario if it helps. Why it matters.>
+
+## Proposed solution
+
+<The user-visible shape of the fix. High-level, no mechanism.>
+
+### Scope
+<optional — boundaries: what it does and does not cover>
+
+### Transparency / safety
+<optional — anything the user needs to see or control for trust>
+
+### Dependencies
+<optional — Blocked on #NNN, blocks #NNN>
+
+### Out of scope
+<optional — deferred things, with a one-line reason each>
+```
+
+### Task
+
+A task states the work and what it unblocks. It's the one type where naming engineering work is expected — keep it as plain as the work allows.
+
+```markdown
+**Title:** <short, declarative>
+**Epic:** <#NNN — epic title, if one clearly fits>
+
+## What
+
+<The work to be done, in plain language.>
+
+## Why
+
+<What it unblocks or improves. Why it's worth doing now.>
+
+## Done when
+
+<The observable end state — how we know it's finished.>
+```
+
+### Bug
+
+Lead with observed vs expected behavior. Reproduction steps should be minimal and numbered.
+
+```markdown
+**Title:** <short, declarative — the misbehavior, not the suspected cause>
+**Epic:** <#NNN — epic title, if one clearly fits>
+
+## What happens
+
+<The observed behavior. A concrete scenario.>
+
+## What should happen
+
+<The expected behavior.>
+
+## Steps to reproduce
+
+1. <minimal, numbered steps>
+
+### Impact
+<optional — who is affected, how badly, any workaround>
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -15,20 +15,6 @@ Decide the type first — it picks the template. Every issue is one of:
 
 Stories, tasks, and bugs can be attached to an epic. If the issue clearly serves an existing epic, suggest it. If nothing fits, leave it out.
 
-## What to exclude
-
-Strip all of these before presenting the draft:
-
-- File paths, line numbers, function/class names, module names.
-- Code snippets, schema definitions, type signatures.
-- Specific API endpoints, database tables, config keys, env var names.
-- Proposals about *how* to implement (which service handles what, what data structure to use, which library to add).
-- Naming of internal components unless they're already user-facing terms.
-
-Rule of thumb: if a reader would need to know the codebase to understand a sentence, rewrite or remove it. The issue should make sense to a PM, a designer, or a new contributor who's never opened the repo.
-
-Tasks and bugs get some slack: a task often *is* engineering work, and a bug may need a precise trigger. Name what's necessary to act on the issue, in the plainest terms available, and nothing more.
-
 ## Style
 
 - Prefer plain language over precise language. "Schedules" not "AgentSchedule ConfigMaps."

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -133,7 +133,4 @@ Lead with observed vs expected behavior. Reproduction steps should be minimal an
 ## Steps to reproduce
 
 1. <minimal, numbered steps>
-
-### Impact
-<optional — who is affected, how badly, any workaround>
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -4,6 +4,15 @@ Shared content guidelines for writing GitHub issues.
 
 A GitHub issue should read like a product ticket, not an engineering plan. The reader should understand **what problem exists** and **what the user-visible outcome of fixing it looks like** — nothing more.
 
+## Tickets and epics
+
+Work is structured in two kinds of issues:
+
+- **Epic** — a meaningful chunk of value we want to deliver. Epics are owned by the Product Owner and live on the [project board](https://github.com/orgs/dam-agents/projects/1) in the `Epics` status column. Each epic carries a **Focus** (Now / Next / Later) that sets its priority.
+- **Ticket** — a concrete piece of work that serves an epic's goal. A ticket is attached to its epic through GitHub's **parent** relationship (the epic is the parent issue, the ticket is a sub-issue).
+
+Every ticket must have a parent epic. A ticket with no parent is an **orphan**: it inherits no priority and contributes to no goal, and it will get swept up in triage. So when drafting a ticket, always propose which epic it belongs to. If no epic fits, say so — the options are to promote the ticket to an epic of its own or to raise it with the Product Owner.
+
 ## What to include
 
 - **Title** — short, declarative, no jargon. Names the change, not the component.
@@ -35,10 +44,11 @@ Rule of thumb: if a reader would need to know the codebase to understand a sente
 - It's fine to flag open questions or naming uncertainty — invite the reader to push back.
 - Concise but complete. If a subsection has nothing to say, cut it.
 
-## Template
+## Ticket template
 
 ```markdown
 **Title:** <short, declarative>
+**Epic:** <#NNN — epic title, or "none fits — candidates considered: …">
 
 ## Problem
 
@@ -56,4 +66,38 @@ Rule of thumb: if a reader would need to know the codebase to understand a sente
 
 ### Out of scope
 <optional — deferred things, with a one-line reason each>
+```
+
+The **Epic** line is metadata for the draft, not part of the issue body — the epic link is applied as the parent relationship when the issue is filed.
+
+## Epics
+
+An epic body answers different questions than a ticket. It defines the value, not a single fix, and it should give enough shape that tickets can be attached to it with confidence.
+
+- **Goal** — the value we want to deliver, in one or two sentences. Who benefits and how.
+- **Why now** — what makes this worth prioritizing: the pain today, or the opportunity.
+- **What done looks like** — the observable outcomes when the epic is complete. User-visible behavior, not a task list.
+- **Out of scope** — adjacent things this epic deliberately does not cover.
+
+The same exclusion rules apply: no implementation detail, no internal component names. An epic should make sense to anyone on the team.
+
+## Epic template
+
+```markdown
+**Title:** <the value delivered, short and declarative>
+
+## Goal
+
+<The chunk of value this epic delivers. Who benefits and how.>
+
+## Why now
+
+<The pain or opportunity that makes this worth prioritizing.>
+
+## What done looks like
+
+<Observable outcomes when this epic is complete. User-visible, not a task list.>
+
+### Out of scope
+<optional — adjacent things deliberately not covered>
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -62,9 +62,6 @@ The **Problem** describes what's wrong or missing today, from the user's point o
 ### Scope
 <optional — boundaries: what it does and does not cover>
 
-### Transparency / safety
-<optional — anything the user needs to see or control for trust>
-
 ### Dependencies
 <optional — Blocked on #NNN, blocks #NNN>
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -43,25 +43,18 @@ Every template starts with a **Title** — short, declarative, no jargon; names 
 
 ### Epic
 
-An epic body defines the value, not a single fix, and gives enough shape that issues can be attached to it with confidence. It should make sense to anyone on the team.
+An epic body defines the value, not a single fix, and gives enough shape that issues can be attached to it with confidence. It should make sense to anyone on the team. The **Problem** is the most important part — spend the effort there.
 
 ```markdown
 **Title:** <the value delivered, short and declarative>
 
+## Problem
+
+<The pain or opportunity this epic addresses. Who is affected and why it matters. This is the most important part.>
+
 ## Goal
 
 <The chunk of value this epic delivers. Who benefits and how.>
-
-## Why now
-
-<The pain or opportunity that makes this worth prioritizing.>
-
-## What done looks like
-
-<Observable outcomes when this epic is complete. User-visible, not a task list.>
-
-### Out of scope
-<optional — adjacent things deliberately not covered>
 ```
 
 ### Story

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -8,12 +8,12 @@ A GitHub issue should read like a product ticket, not an engineering plan. The r
 
 Decide the type first — it picks the template. Every issue is one of:
 
-- **Epic** — a meaningful chunk of value we want to deliver. Epics are owned by the Product Owner and live on the [project board](https://github.com/orgs/dam-agents/projects/1) in the `Epics` status column, each with a **Focus** (Now / Next / Later) that sets its priority.
+- **Epic** — a meaningful chunk of value we want to deliver. Epics are owned by the Product Owner.
 - **Story** — a user-facing improvement: new behavior, or a change the user can see.
 - **Task** — work that needs to happen but isn't user-facing: chores, tooling, upgrades, refactors.
 - **Bug** — something that should work but doesn't.
 
-Stories, tasks, and bugs can be attached to an epic through GitHub's **parent** relationship (the epic is the parent issue). If the issue clearly serves an existing epic, suggest it. If nothing fits, leave it out — placement can be decided later in triage.
+Stories, tasks, and bugs can be attached to an epic. If the issue clearly serves an existing epic, suggest it. If nothing fits, leave it out.
 
 ## What to exclude
 
@@ -39,7 +39,7 @@ Tasks and bugs get some slack: a task often *is* engineering work, and a bug may
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Stories, tasks, and bugs may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied as the parent relationship when the issue is filed.
+Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Stories, tasks, and bugs may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed.
 
 ### Epic
 


### PR DESCRIPTION
Reworks the issue-drafting skills around the project management concepts.

- **issue-guidelines.md**: every issue is an epic, story, task, or bug. New "Issue types" section, and a template per type (story keeps the old Problem/Proposed solution shape; task and bug are new; epic is Goal / Why now / What done looks like). Tasks and bugs get slack on the no-implementation-detail rule where needed.
- **draft-issue skill**: lets the user decide the type (with a recommendation), picks the matching template, and for stories/tasks/bugs checks the project board for an epic that clearly fits. If none fits, the Epic line is left out; placement can happen in triage.
- **file-issue skill**: same type decision and epic step in the workflow; after filing it attaches the issue to the approved epic via the sub-issues API, and adds new epics to the project board.

https://claude.ai/code/session_01Pj6u6ZxDmYgNishVUiNhqi