### PR TITLE
feat(invocations): egress aliasing — invocation network access follows the host agent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ mise run e2e:reset    # data wipe only: drop+recreate platform DB, delete agents
 
 `e2e:loop` runs on a dedicated persistent `platform-k3s-test` VM that it never deletes, so reruns skip VM/Istio/cert-manager/Keycloak provisioning. Running `mise run e2e` nukes that VM (shared name); the next `e2e:loop` bootstraps a fresh one. `e2e:loop` does not heal a wedged cluster — if the warm cluster is broken, it fails loud; use `mise run e2e` or `cluster:fix-certs`. Use `e2e:loop` for iteration, `e2e` after helm/realm/infra changes.
 
+**Suite tiers.** **Smoke** (`src/tests/smoke/`) is the always-on tier — CI and plain `e2e` / `e2e:loop` run exactly it. **Full** = smoke plus the slow, scenario-heavy specs under `src/tests/full/`, run on demand only: `mise run e2e:loop -- --full` (or `mise run e2e -- --full` for the fresh-cluster path). Conventions for `src/tests/full/` specs: one `<area>-full` Playwright project per area, self-contained (own agents, own token via `getAccessToken` + `acceptTerms`, no smoke-chain fixtures), each spec references its motivating ticket in the test title.
+
 ### Cluster debugging (pre-approved in .claude/settings.json)
 
 Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` instead of raw `kubectl` or `export KUBECONFIG=...`. These are auto-approved.

--- a/docs/adrs/078-invocation-egress-aliasing.md
+++ b/docs/adrs/078-invocation-egress-aliasing.md
@@ -1,0 +1,43 @@
+---
+id: 078
+title: Invocation egress follows the driver (Egress Aliasing)
+status: accepted
+subsystem: security-and-credentials
+tags: [invocations, egress, hitl]
+summary: The ext_authz gate resolves an Invocation target to its driver before every egress decision; the target has no egress identity of its own, and deleting a driver cascades to its targets.
+---
+
+# ADR-078: Invocation egress follows the driver (Egress Aliasing)
+
+**Date:** 2026-07-23
+**Status:** Accepted
+**Owner:** @tomkis
+
+## Context
+
+Invocation targets were created with the default trusted egress preset regardless of the driver's posture (#2930). A permissive driver spawned more-restricted targets whose work tripped approval prompts the user had already answered; a locked-down driver spawned *wider* targets, silently bypassing the restriction. Targets are short-lived and spawned on the fly, so per-target egress management by the user is not realistic.
+
+## Decision
+
+An Invocation target has no egress identity of its own. The ext_authz gate resolves the calling agent to its driver — recursively for chained Invocations, up to the root non-target agent — before rule match, HITL hold, and approval write; every egress decision for target traffic is made against the driver's live rules.
+
+Boundaries of the decision:
+
+- **Application-layer only.** The aliasing happens inside the gate's identity resolution, never via the agent label that drives gateway credential mounting. The target keeps its own attenuated credential set; it gains the driver's network reach, not the driver's credentials.
+- **Approvals are the driver's.** Prompts raised by target traffic surface as the driver's, stamped with the originating target for audit; approving permanently updates the driver's rules, so the same request never re-asks — including from a future target.
+- **Driver Cascade.** Deleting a driver fails its running Invocations and eagerly reaps their targets, transitively for chains, so a target aliased to a deleted driver is structurally unreachable; one that slips through fails closed at the gate.
+- Target-side egress settings are dead by construction; targets are seeded with the empty preset and are expected to disappear from the user-facing agent list (tracked separately).
+
+## Alternatives Considered
+
+- **Copy the driver's preset at spawn** — static: misses manual rules and later changes, and preset derivation lies once preset rows are user-edited into manual ones.
+- **Union matcher (target rules first, driver fallback)** — leaves approval rows written on a soon-dead target and two places where a decision can land; full aliasing has one.
+- **Label aliasing (fork-style agent label)** — the label also drives gateway credential mounting, so it would hand the target the driver's full credential set and defeat the connection attenuation spawn enforces.
+
+## Consequences
+
+- **Easier:** the user manages exactly one egress surface per workload — the host agent. Tightening it applies to running targets on the next request, because rules are matched per request from the database.
+- **Easier:** no zombie prompts. Before the cascade, a deleted driver left targets whose every request became an inbox prompt for up to the 6h liveness ceiling.
+- **Harder:** the target gains network reach to hosts of driver connections it was not granted — reach without credentials, since the gateway injects per-agent, but a wider set of dialable hosts than its own grants imply.
+- **Harder:** per-target narrowing is impossible; the driver's access is both ceiling and floor. No known need today, and adding it later means revisiting this record.
+- **Committed-to:** the gate's identity resolution consults the Invocations chain on every credentialed egress request — one extra lookup per request on the hot path, and the invocations table becomes load-bearing for egress policy.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -74,6 +74,7 @@ Generated projection of the ADR log. Read this first when authoring a new decisi
 | 075 | [Periodic work on BullMQ](075-periodic-jobs-bullmq.md) |  | api-server | Recurring reconciliation ticks run as BullMQ job schedulers on per-job queues instead of per-replica setInterval loops. |
 | 076 | [Per-channel access modes — shared and person-scoped](076-channel-access-modes.md) |  | channels | Each channel binding picks its access mode at bind time — shared (place-scoped, Agent credentials, open speaker set) or person-scoped (identity linking, allow-list, per-turn forks). |
 | 077 | [The spawn primitive is an ephemeral Agent; lifecycle and result contract are separate concerns](077-sandbox-as-ephemeral-agent.md) |  | agent-lifecycle | A spawnable node is a normal ephemeral Agent a driver creates, prompts once, and polls; its autosweep lifecycle lives on the Agent (Sweepable + Agent Sweep) and its run-once result contract lives in a separate Invocations context. |
+| 078 | [Invocation egress follows the driver (Egress Aliasing)](078-invocation-egress-aliasing.md) |  | security-and-credentials | The ext_authz gate resolves an Invocation target to its driver before every egress decision; the target has no egress identity of its own, and deleting a driver cascades to its targets. |
 
 ## Superseded
 

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -473,6 +473,22 @@ header are gone.
 The HTTP filter on TLS-terminated chains sees method/path; the network
 filter on the catch-all chain sees SNI only.
 
+**Egress Aliasing.** An Invocation target has no egress identity of its
+own: before any decision, the gate resolves the calling agent to its
+driver — recursively for chained Invocations, up to the root non-target
+agent — and runs rule match, hold, and approval against the driver. The
+link is live: rules are matched per request, so tightening or loosening
+the driver applies to its running targets immediately. Approval prompts
+raised by target traffic surface as the driver's, stamped with the
+originating target, and approving permanently updates the driver's
+rules. The aliasing is application-layer only — the target's gateway
+still mounts and injects credentials for the target's own (attenuated)
+connection grants, so the target gains the driver's network *reach*,
+never its credential set. Deleting a driver cascades: its running
+Invocations are failed and their targets eagerly reaped (transitively
+for chains), and a target that slips past the cascade fails closed at
+the gate because its driver no longer resolves.
+
 ## Per-turn fork pods (Slack foreign replier)
 
 This section covers person-scoped Slack bindings — the default access

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -68,6 +68,8 @@ Replaces the first-cut "Sandbox" spawn record. The word *Sandbox* is retired as 
 | report_result | The fixed MCP tool the target Agent calls to report its result; the server validates it against the stashed Result Schema (structural only, never truth) and flips the Invocation terminal. Attribution is by the reporting agent's own id. *(renamed from the spawn/loop-era `node_done`)* |
 | Result Schema | The driver-supplied JSON Schema an Invocation's result must match; stored on the Invocation record, never on any Kubernetes resource, so the platform stays blind to content |
 | Liveness Deadline | The per-Invocation deadline (driver-set `ttlMs`, clamped ~1min..6h) after which a still-running Invocation is failed, so a target that exits silently can't wedge the driver's poll. Distinct from Agent Lifetime |
+| Egress Aliasing | *(proposed, #2930)* An Invocation target has no egress identity of its own: the ext_authz gate resolves the target to its Driver — recursively, up to the root non-target Agent — before rule match, HITL hold, and approval write. All egress policy lives on the Driver and applies live to its running targets; approvals raised by target traffic belong to the Driver, stamped with the originating target for audit. Reach without credentials: the target gains the Driver's network reach, but the gateway still injects credentials per-agent |
+| Driver Cascade | *(proposed, #2930)* Deleting a Driver fails its running Invocations and eagerly reaps their targets — transitively for chains — so no target keeps running or prompting against a deleted Driver's egress identity. Makes the dangling-driver state structurally unreachable; a target that slips through fails closed at the gate |
 
 ## Skills — api-server side (bounded context)
 

--- a/packages/api-server-api/src/modules/approvals/format.ts
+++ b/packages/api-server-api/src/modules/approvals/format.ts
@@ -7,7 +7,9 @@ export function describeApprovalPayload(payload: ApprovalPayload): {
   if (payload.kind === "ext_authz") {
     return {
       title: `${payload.method} ${payload.host}`,
-      subtitle: payload.path,
+      subtitle: payload.viaAgentId
+        ? `${payload.path} · via ${payload.viaAgentId}`
+        : payload.path,
     };
   }
   return { title: payload.toolName ?? "tool call", subtitle: "" };

--- a/packages/api-server-api/src/modules/approvals/types.ts
+++ b/packages/api-server-api/src/modules/approvals/types.ts
@@ -21,6 +21,11 @@ export interface ExtAuthzPayload {
   host: string;
   method: string;
   path: string;
+  /** Set when the request came from an Invocation target aliased to its
+   *  driver (Egress Aliasing): the target agent id the request originated
+   *  from. The row's `agentId` is the driver — the agent whose rules gate
+   *  the request and receive the verdict. */
+  viaAgentId?: string;
 }
 
 /** ACP `PermissionOption.kind` values the harness emits. */

--- a/packages/api-server-api/src/modules/e2e/router.ts
+++ b/packages/api-server-api/src/modules/e2e/router.ts
@@ -5,6 +5,8 @@ import {
   e2eGetEnvInputSchema,
   e2ePerformFetchInputSchema,
   e2eSetScriptInputSchema,
+  e2eSpawnInvocationInputSchema,
+  spawnInvocationResultSchema,
   getEnvResultSchema,
   getReceivedPromptsResultSchema,
   performFetchResultSchema,
@@ -51,6 +53,15 @@ export const e2eRouter = t.router({
     .query(({ ctx, input }) => {
       gate(ctx);
       return ctx.e2e.getEnv(input.agentId, input.name);
+    }),
+
+  spawnInvocation: t.procedure
+    .input(e2eSpawnInvocationInputSchema)
+    .output(spawnInvocationResultSchema)
+    .mutation(({ ctx, input }) => {
+      gate(ctx);
+      const { agentId, ...rest } = input;
+      return ctx.e2e.spawnInvocation(agentId, rest);
     }),
 
   performFetch: t.procedure

--- a/packages/api-server-api/src/modules/e2e/schemas.ts
+++ b/packages/api-server-api/src/modules/e2e/schemas.ts
@@ -75,6 +75,22 @@ export const e2ePerformFetchInputSchema = z
   })
   .strict();
 
+export const e2eSpawnInvocationInputSchema = z
+  .object({
+    agentId: z.string().min(1),
+    prompt: z.string().min(1),
+    schema: z.record(z.string(), z.unknown()),
+    templateId: z.string().min(1).optional(),
+    image: z.string().min(1).optional(),
+    connections: z.array(z.string()).optional(),
+    ttlMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const spawnInvocationResultSchema = z
+  .object({ id: z.string().min(1) })
+  .strict();
+
 export const slackFireMentionInputSchema = z
   .object({
     user: z.string().min(1),

--- a/packages/api-server-api/src/modules/e2e/types.ts
+++ b/packages/api-server-api/src/modules/e2e/types.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type {
   e2ePerformFetchInputSchema,
+  e2eSpawnInvocationInputSchema,
   getEnvResultSchema,
   getReceivedPromptsResultSchema,
   performFetchResultSchema,
@@ -11,6 +12,7 @@ import type {
   slackFireMentionInputSchema,
   slackOutboundRecordSchema,
   slackReadOutboundResultSchema,
+  spawnInvocationResultSchema,
 } from "./schemas.js";
 
 export type SetScriptInput = z.infer<typeof setScriptInputSchema>;
@@ -24,6 +26,11 @@ export type PerformFetchInput = Omit<
   z.infer<typeof e2ePerformFetchInputSchema>,
   "agentId"
 >;
+export type SpawnInvocationInput = Omit<
+  z.infer<typeof e2eSpawnInvocationInputSchema>,
+  "agentId"
+>;
+export type SpawnInvocationResult = z.infer<typeof spawnInvocationResultSchema>;
 
 export type SlackFireMentionInput = z.infer<typeof slackFireMentionInputSchema>;
 /** Same wire shape as a mention — only the trigger differs (ambient mode). */
@@ -46,6 +53,12 @@ export interface E2eService {
     agentId: string,
     input: PerformFetchInput,
   ): Promise<PerformFetchResult>;
+  /** Make the mock agent spawn an Invocation as the driver, through the same
+   *  harness POST the driver SDK uses. Returns the target agent id. */
+  spawnInvocation(
+    agentId: string,
+    input: SpawnInvocationInput,
+  ): Promise<SpawnInvocationResult>;
   slackFireMention(input: SlackFireMentionInput): Promise<ResetResult>;
   slackFireMessage(input: SlackFireMessageInput): Promise<ResetResult>;
   slackFireCommand(

--- a/packages/api-server/src/__tests__/unit/ext-authz-gate.test.ts
+++ b/packages/api-server/src/__tests__/unit/ext-authz-gate.test.ts
@@ -210,7 +210,9 @@ describe("ext-authz gate", () => {
 
     expect(repo.inserts).toBe(1);
     expect(bus.publishes).toHaveLength(1);
-    expect(bus.publishes[0].channel).toBe("inject:inst-1");
+    // The synth frame fans out on the policy-bearing agent's channel (the
+    // resolved identity), not the raw caller's.
+    expect(bus.publishes[0].channel).toBe("inject:agent-1");
 
     const id = repo.rows[0].id;
     repo.resolve(id, "allow");

--- a/packages/api-server/src/__tests__/unit/invocations-result-coercion.test.ts
+++ b/packages/api-server/src/__tests__/unit/invocations-result-coercion.test.ts
@@ -21,6 +21,8 @@ function makeService(row: InvocationRow) {
     fail: async () => {},
     listExpiredRunning: async () => [],
     listRunning: async () => [],
+    listRunningByDriver: async () => [],
+    listRunningAgentIds: async () => [],
     listAgedTerminal: async () => [],
     delete: async () => {},
   };

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -89,7 +89,12 @@ import { startHarnessApiServerApp } from "./apps/harness-api-server/app.js";
 import { composeArtifactsModule } from "./modules/artifacts/compose.js";
 import { createTemplatesRepository } from "./modules/templates/infrastructure/templates-repository.js";
 import { composeTemplatesModule } from "./modules/templates/compose.js";
-import { composeInvocationLivenessSweep } from "./modules/invocations/index.js";
+import {
+  composeInvocationLivenessSweep,
+  createDriverResolutionAdapter,
+  createInvocationsCleanupHook,
+  listInvocationAgentIds,
+} from "./modules/invocations/index.js";
 import { startExtAuthzGrpcApp } from "./apps/ext-authz/grpc.js";
 import {
   composeApprovalsSystem,
@@ -499,6 +504,10 @@ const channelManager = createChannelManager({
 const trustedHosts = loadTrustedHosts(config.trustedHostsPath);
 const presetSeeder = createPresetSeederAdapter(db, trustedHosts);
 
+// Egress Aliasing resolution for the ext_authz gate: Invocation target →
+// root driver, consulted before every identity resolve on the egress path.
+const invocationDriverResolution = createDriverResolutionAdapter(db);
+
 const wrapperFrameSender = createWrapperFrameSender({
   resolveWrapperUrl: (agentId) =>
     `ws://${podBaseUrl(agentId, config.namespace)}/api/acp`,
@@ -516,8 +525,14 @@ const {
   db,
   bus: redisBus,
   identityResolver: {
+    // Egress Aliasing: an Invocation target has no egress identity of its
+    // own — resolve the caller to its root driver first, so rule match,
+    // HITL hold, and approval writes all land on the driver. A target whose
+    // driver is gone resolves to nothing and the gate fails closed.
     resolve: async (agentId) => {
-      const r = await agentsRepo.resolveIdentity(agentId);
+      const rootId = await invocationDriverResolution.resolveRoot(agentId);
+      if (!rootId) return null;
+      const r = await agentsRepo.resolveIdentity(rootId);
       return r ? { ownerSub: r.owner, agentId: r.agentId } : null;
     },
   },
@@ -553,12 +568,23 @@ const connectionGrantsCleanupHook = createConnectionGrantsCleanupHook(db);
 const agentEnvCleanupHook = (agentId: string) =>
   agentEnvRepo.deleteForAgent(agentId);
 
+// Driver Cascade: deleting an agent fails its running Invocations and reaps
+// their targets, so no dangling target keeps running against a deleted
+// driver's egress identity. `agentsFor` binds lazily — the factory below is
+// declared later and composes these same hooks, which is what makes chained
+// Invocations unwind transitively.
+const invocationsCleanupHook = createInvocationsCleanupHook({
+  db,
+  agentsFor: (owner) => harnessAgentsServiceFor(owner),
+});
+
 const agentCleanupHooks = [
   createEgressRulesCleanupHook(db),
   createApprovalsCleanupHook(db),
   (agentId: string) => registrySecretPort.delete(agentId),
   connectionGrantsCleanupHook,
   agentEnvCleanupHook,
+  invocationsCleanupHook,
 ];
 
 // Cross-store orphan reaper. Lists live agent CRs, finds DB rows keyed by
@@ -591,6 +617,11 @@ const agentArtifactsSweeper = createAgentArtifactsSweeper({
       name: "agent-env",
       listAgentIds: () => agentEnvRepo.listAgentIds(),
       cleanup: agentEnvCleanupHook,
+    },
+    {
+      name: "invocations",
+      listAgentIds: () => listInvocationAgentIds(db),
+      cleanup: invocationsCleanupHook,
     },
   ],
   batchSize: 200,

--- a/packages/api-server/src/modules/approvals/services/ext-authz-gate.ts
+++ b/packages/api-server/src/modules/approvals/services/ext-authz-gate.ts
@@ -35,6 +35,10 @@ export interface ExtAuthzGate {
  * directly.
  */
 export interface AgentIdentityResolver {
+  /** Resolves the caller to the identity whose egress policy applies. For an
+   *  Invocation target this is its driver (Egress Aliasing, recursively to
+   *  the root non-target agent). Null when no policy-bearing agent exists —
+   *  the gate fails closed. */
   resolve(
     agentId: string,
   ): Promise<{ ownerSub: string; agentId: string } | null>;
@@ -83,6 +87,12 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
         return "deny";
       }
 
+      // Egress Aliasing: when the caller is an Invocation target, `identity`
+      // is its driver — every decision, hold, and rule below runs against the
+      // driver. `via` keeps the originating caller auditable; undefined (the
+      // caller is the policy-bearing agent itself) drops out of JSON.
+      const via = identity.agentId !== agentId ? agentId : undefined;
+
       if (deps.platformAllowedHosts.includes(host)) {
         securityLog("info", "egress.decision", {
           category: "egress",
@@ -94,7 +104,7 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
           decision: "allow",
           // Query stripped: presigned-link signatures ride there (mirrors
           // the gateway access log's REQ_WITHOUT_QUERY).
-          detail: { method, path: path.split("?")[0], basis: "platform" },
+          detail: { method, path: path.split("?")[0], basis: "platform", via },
         });
         return "allow";
       }
@@ -117,7 +127,7 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
             agentId: identity.agentId,
             target: host,
             decision: matched.verdict,
-            detail: { method, path, basis: "rule" },
+            detail: { method, path, basis: "rule", via },
           },
         );
         return matched.verdict;
@@ -143,7 +153,7 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
           agentId: identity.agentId,
           ownerSub: identity.ownerSub,
           sessionId: null,
-          payload: { kind: "ext_authz", host, method, path },
+          payload: { kind: "ext_authz", host, method, path, viaAgentId: via },
           expiresAt: new Date(Date.now() + deps.holdSeconds * 1000),
         });
         const frame = buildExtAuthzSynthFrame({
@@ -152,7 +162,9 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
           method,
           path,
         });
-        void deps.bus.publish(injectChannelOf(agentId), frame);
+        // The prompt surfaces on the policy-bearing agent's channel — under
+        // aliasing that is the driver, whose inbox tray owns the decision.
+        void deps.bus.publish(injectChannelOf(identity.agentId), frame);
         // Agent egress blocked awaiting a human verdict. correlationId ties
         // this to the verdict line written when the hold settles (and to the
         // approval.verdict line in approvals-service).
@@ -165,7 +177,7 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
           target: host,
           decision: "hold",
           correlationId: pendingId,
-          detail: { method, path },
+          detail: { method, path, via },
         });
       }
 
@@ -180,7 +192,7 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
         decision: reason === "hold-expired" ? "expired" : verdict,
         correlationId: pendingId,
         reason,
-        detail: { method, path, basis: "hold" },
+        detail: { method, path, basis: "hold", via },
       });
       return verdict;
     },

--- a/packages/api-server/src/modules/e2e/services/e2e-service.ts
+++ b/packages/api-server/src/modules/e2e/services/e2e-service.ts
@@ -62,6 +62,8 @@ export function createE2eService(deps: {
       withClient(agentId, (c) => c.scriptedMock.getEnv.query({ name })),
     performFetch: (agentId, input) =>
       withClient(agentId, (c) => c.scriptedMock.performFetch.mutate(input)),
+    spawnInvocation: (agentId, input) =>
+      withClient(agentId, (c) => c.scriptedMock.spawnInvocation.mutate(input)),
     slackFireMention: async (input) => {
       await requireSlack().fireMention(input);
       return { ok: true };

--- a/packages/api-server/src/modules/invocations/compose.ts
+++ b/packages/api-server/src/modules/invocations/compose.ts
@@ -10,6 +10,11 @@ import {
   createInvocationLivenessSweep,
   type InvocationLivenessSweep,
 } from "./services/invocation-liveness.js";
+import {
+  createDriverResolution,
+  type DriverResolution,
+} from "./services/driver-resolution.js";
+import { createDriverCascade } from "./services/driver-cascade.js";
 import type { RuntimeMutator } from "../runtime-delivery/index.js";
 
 /** Compose the owner-scoped Invocations service. Owner is bound here so the
@@ -49,3 +54,41 @@ export function composeInvocationLivenessSweep(opts: {
     batchSize: opts.batchSize,
   });
 }
+
+/**
+ * System-level read adapter consumed by the approvals module's ext_authz gate
+ * on the egress hot path (Egress Aliasing): resolves an Invocation target to
+ * the root driver whose egress policy applies. Not owner-scoped — identity
+ * flows from the per-Agent ext-authz Service, and the driver's owner is
+ * resolved by the gate's identity resolver afterwards.
+ */
+export function createDriverResolutionAdapter(db: Db): DriverResolution {
+  return createDriverResolution({ repo: createInvocationsRepository(db) });
+}
+
+/**
+ * Per-agent cleanup hook registered with `composeAgentsModule` (Driver
+ * Cascade): fails the deleted agent's running Invocations — driven and own —
+ * and eagerly reaps the driven targets, unwinding chains transitively via
+ * each target's own delete hooks.
+ */
+export function createInvocationsCleanupHook(opts: {
+  db: Db;
+  agentsFor: (owner: string) => AgentsService;
+}): (agentId: string) => Promise<void> {
+  return createDriverCascade({
+    repo: createInvocationsRepository(opts.db),
+    agentsFor: opts.agentsFor,
+  });
+}
+
+/**
+ * Read primitive used by the orphan sweeper saga: every agent id a running
+ * Invocation references (targets and drivers), so a cascade missed here
+ * (replica died mid-delete) is replayed once the saga sees the agent gone.
+ */
+export function listInvocationAgentIds(db: Db): Promise<string[]> {
+  return createInvocationsRepository(db).listRunningAgentIds();
+}
+
+export type { DriverResolution } from "./services/driver-resolution.js";

--- a/packages/api-server/src/modules/invocations/index.ts
+++ b/packages/api-server/src/modules/invocations/index.ts
@@ -1,6 +1,10 @@
 export {
   composeInvocationsForOwner,
   composeInvocationLivenessSweep,
+  createDriverResolutionAdapter,
+  createInvocationsCleanupHook,
+  listInvocationAgentIds,
+  type DriverResolution,
 } from "./compose.js";
 export {
   AttenuationError,

--- a/packages/api-server/src/modules/invocations/infrastructure/invocations-repository.ts
+++ b/packages/api-server/src/modules/invocations/infrastructure/invocations-repository.ts
@@ -40,6 +40,12 @@ export interface InvocationsRepository {
   listExpiredRunning(now: Date, limit: number): Promise<InvocationRow[]>;
   /** All `running` rows — the restart sweep checks each one's pod for a crash. */
   listRunning(limit: number): Promise<InvocationRow[]>;
+  /** `running` rows spawned by this driver — the Driver Cascade fails and
+   *  reaps these when the driver agent is deleted. */
+  listRunningByDriver(driverAgentId: string): Promise<InvocationRow[]>;
+  /** Every agent id a `running` row references (targets and drivers) — the
+   *  orphan sweeper checks these against live agents and cascades the rest. */
+  listRunningAgentIds(): Promise<string[]>;
   /** Terminal rows whose result is old enough to drop (retention elapsed). */
   listAgedTerminal(before: Date, limit: number): Promise<InvocationRow[]>;
   delete(id: string): Promise<void>;
@@ -128,6 +134,35 @@ export function createInvocationsRepository(db: Db): InvocationsRepository {
         .where(eq(invocationsTable.status, "running"))
         .limit(limit);
       return rows.map(toRow);
+    },
+
+    async listRunningByDriver(driverAgentId) {
+      const rows = await db
+        .select()
+        .from(invocationsTable)
+        .where(
+          and(
+            eq(invocationsTable.status, "running"),
+            eq(invocationsTable.driverAgentId, driverAgentId),
+          ),
+        );
+      return rows.map(toRow);
+    },
+
+    async listRunningAgentIds() {
+      const rows = await db
+        .select({
+          id: invocationsTable.id,
+          driverAgentId: invocationsTable.driverAgentId,
+        })
+        .from(invocationsTable)
+        .where(eq(invocationsTable.status, "running"));
+      const ids = new Set<string>();
+      for (const r of rows) {
+        ids.add(r.id);
+        ids.add(r.driverAgentId);
+      }
+      return Array.from(ids);
     },
 
     async listAgedTerminal(before, limit) {

--- a/packages/api-server/src/modules/invocations/services/driver-cascade.ts
+++ b/packages/api-server/src/modules/invocations/services/driver-cascade.ts
@@ -1,0 +1,46 @@
+import type { AgentsService } from "api-server-api";
+import { securityLog } from "../../../core/security-log.js";
+import type { InvocationsRepository } from "../infrastructure/invocations-repository.js";
+
+/**
+ * Driver Cascade: agent-delete cleanup for the Invocations module. Deleting a
+ * driver fails its running Invocations and eagerly reaps their targets, so a
+ * dangling target — one whose egress would alias to a deleted driver — is
+ * structurally unreachable. Chains unwind transitively: reaping a target runs
+ * its own cleanup hooks, cascading to any Invocations it drives in turn.
+ *
+ * The hook also fails the running Invocation *of* the deleted agent itself
+ * (a target deleted out-of-band), so the driver's poll settles immediately
+ * instead of idling to the liveness deadline. Both writes are conditional on
+ * `running`, so the eager-reap paths (recordResult, liveness sweep), which
+ * flip the row terminal before deleting the target, pass through as no-ops.
+ */
+export function createDriverCascade(deps: {
+  repo: InvocationsRepository;
+  agentsFor: (owner: string) => AgentsService;
+}): (agentId: string) => Promise<void> {
+  return async (agentId) => {
+    await deps.repo.fail(agentId, "target agent deleted");
+    const driven = await deps.repo.listRunningByDriver(agentId);
+    for (const row of driven) {
+      await deps.repo.fail(row.id, "driver agent deleted");
+      securityLog("info", "invocation.driver_cascade", {
+        category: "resource",
+        actor: "system:invocations",
+        actorKind: "system",
+        agentId: row.id,
+        result: "success",
+        detail: { driverAgentId: agentId },
+      });
+      try {
+        await deps.agentsFor(row.owner).delete(row.id);
+      } catch (err) {
+        // Sweepable is the backstop — the Agent Sweep reaps it on hibernate,
+        // and its egress fails closed meanwhile (driver identity unresolved).
+        process.stderr.write(
+          `[driver-cascade] reap ${row.id} failed: ${err instanceof Error ? err.message : err}\n`,
+        );
+      }
+    }
+  };
+}

--- a/packages/api-server/src/modules/invocations/services/driver-resolution.ts
+++ b/packages/api-server/src/modules/invocations/services/driver-resolution.ts
@@ -1,0 +1,34 @@
+import type { InvocationsRepository } from "../infrastructure/invocations-repository.js";
+
+/** Ceiling on Invocation chain depth during resolution. Chains are acyclic by
+ *  construction (a target's id is a freshly-created agent id), so the cap is
+ *  a corruption guard, not a real limit — resolution past it fails closed. */
+const MAX_CHAIN_DEPTH = 16;
+
+/**
+ * Egress Aliasing resolution: an Invocation target has no egress identity of
+ * its own — every request it makes is decided by its driver's rules. Follows
+ * the driver chain from the calling agent up to the root non-target agent.
+ */
+export interface DriverResolution {
+  /** Returns the root agent whose egress policy applies to `agentId` — the
+   *  agent itself when it is no Invocation target. Null when the chain
+   *  exceeds the depth ceiling (unresolvable — callers fail closed). */
+  resolveRoot(agentId: string): Promise<string | null>;
+}
+
+export function createDriverResolution(deps: {
+  repo: InvocationsRepository;
+}): DriverResolution {
+  return {
+    async resolveRoot(agentId) {
+      let current = agentId;
+      for (let depth = 0; depth < MAX_CHAIN_DEPTH; depth++) {
+        const row = await deps.repo.get(current);
+        if (!row) return current;
+        current = row.driverAgentId;
+      }
+      return null;
+    },
+  };
+}

--- a/packages/api-server/src/modules/invocations/services/invocations-service.ts
+++ b/packages/api-server/src/modules/invocations/services/invocations-service.ts
@@ -137,10 +137,14 @@ export function createInvocationsService(deps: {
       // The target is a fresh ephemeral Agent, marked Sweepable so the Agent
       // Sweep reaps it once it hibernates — the backstop for the eager reap on
       // this Invocation reaching terminal. No Lifetime grace: an Invocation
-      // target dies on hibernate.
+      // target dies on hibernate. Preset `none`: under Egress Aliasing the
+      // target has no egress identity of its own — the ext_authz gate resolves
+      // every request to the driver's rules, so seeded target rules would be
+      // dead rows.
       const agent = await deps.agents.create({
         name: `invocation-${randomBytes(6).toString("hex")}`,
         sweepable: true,
+        egressPreset: "none",
         ...(input.templateId ? { templateId: input.templateId } : {}),
         ...(input.image ? { image: input.image } : {}),
         ...(input.connections.length

--- a/packages/e2e/agents/mock-api/src/index.ts
+++ b/packages/e2e/agents/mock-api/src/index.ts
@@ -12,6 +12,8 @@ export {
   scriptEntrySchema,
   scriptFileSchema,
   setScriptInputSchema,
+  spawnInvocationInputSchema,
+  spawnInvocationResultSchema,
 } from "./modules/scripted-mock/schemas.js";
 export type {
   GetEnvInput,
@@ -25,4 +27,6 @@ export type {
   ScriptedMockService,
   ScriptFile,
   SetScriptInput,
+  SpawnInvocationInput,
+  SpawnInvocationResult,
 } from "./modules/scripted-mock/types.js";

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/router.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/router.ts
@@ -7,6 +7,8 @@ import {
   performFetchResultSchema,
   resetResultSchema,
   setScriptInputSchema,
+  spawnInvocationInputSchema,
+  spawnInvocationResultSchema,
 } from "./schemas.js";
 
 export const scriptedMockRouter = t.router({
@@ -32,4 +34,9 @@ export const scriptedMockRouter = t.router({
     .input(performFetchInputSchema)
     .output(performFetchResultSchema)
     .mutation(({ ctx, input }) => ctx.scriptedMock.performFetch(input)),
+
+  spawnInvocation: t.procedure
+    .input(spawnInvocationInputSchema)
+    .output(spawnInvocationResultSchema)
+    .mutation(({ ctx, input }) => ctx.scriptedMock.spawnInvocation(input)),
 });

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/schemas.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/schemas.ts
@@ -57,3 +57,18 @@ export const performFetchResultSchema = z
     body: z.string(),
   })
   .strict();
+
+export const spawnInvocationInputSchema = z
+  .object({
+    prompt: z.string().min(1),
+    schema: z.record(z.string(), z.unknown()),
+    templateId: z.string().min(1).optional(),
+    image: z.string().min(1).optional(),
+    connections: z.array(z.string()).optional(),
+    ttlMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const spawnInvocationResultSchema = z
+  .object({ id: z.string().min(1) })
+  .strict();

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/types.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/types.ts
@@ -10,6 +10,8 @@ import type {
   scriptEntrySchema,
   scriptFileSchema,
   setScriptInputSchema,
+  spawnInvocationInputSchema,
+  spawnInvocationResultSchema,
 } from "./schemas.js";
 
 export type ScriptEntry = z.infer<typeof scriptEntrySchema>;
@@ -24,6 +26,8 @@ export type GetEnvInput = z.infer<typeof getEnvInputSchema>;
 export type GetEnvResult = z.infer<typeof getEnvResultSchema>;
 export type PerformFetchInput = z.infer<typeof performFetchInputSchema>;
 export type PerformFetchResult = z.infer<typeof performFetchResultSchema>;
+export type SpawnInvocationInput = z.infer<typeof spawnInvocationInputSchema>;
+export type SpawnInvocationResult = z.infer<typeof spawnInvocationResultSchema>;
 
 export interface ScriptedMockService {
   setScript(input: SetScriptInput): ResetResult;
@@ -31,4 +35,7 @@ export interface ScriptedMockService {
   reset(): ResetResult;
   getEnv(input: GetEnvInput): GetEnvResult;
   performFetch(input: PerformFetchInput): Promise<PerformFetchResult>;
+  /** Spawn an Invocation as this agent (the driver) via the harness surface —
+   *  the same POST the driver SDK makes from a real agent pod. */
+  spawnInvocation(input: SpawnInvocationInput): Promise<SpawnInvocationResult>;
 }

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
@@ -4,6 +4,7 @@ import { createScriptedMockService } from "./services/control-service.js";
 import { startAcpService } from "./services/acp-service.js";
 import { createTrpcDispatch } from "./services/trpc-dispatch.js";
 import type { AcpChannel } from "./services/ports.js";
+import { createHarnessSpawn } from "./infrastructure/harness-spawn.js";
 import { createProxyFetch } from "./infrastructure/proxy-fetch.js";
 import { createSlackReplyPoster } from "./infrastructure/slack-reply.js";
 import { createStdioChannel } from "./infrastructure/stdio-channel.js";
@@ -19,6 +20,7 @@ export function composeScriptedMock(): ScriptedMockComposition {
   const scriptedMock = createScriptedMockService({
     state,
     proxyFetch,
+    harnessSpawn: createHarnessSpawn(),
   });
   const stdio = createStdioChannel();
 

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/infrastructure/harness-spawn.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/infrastructure/harness-spawn.ts
@@ -1,0 +1,35 @@
+import type {
+  SpawnInvocationInput,
+  SpawnInvocationResult,
+} from "mock-agent-api";
+import type { HarnessSpawn } from "../services/ports.js";
+
+const TIMEOUT_MS = 30_000;
+
+/** Spawns an Invocation through the harness surface, exactly like the driver
+ *  SDK does from a real agent pod: PLATFORM_MCP_URL encodes the harness base
+ *  and this agent's own id, and the mesh proves identity — no token. */
+export function createHarnessSpawn(): HarnessSpawn {
+  return async (
+    input: SpawnInvocationInput,
+  ): Promise<SpawnInvocationResult> => {
+    const mcpUrl = process.env.PLATFORM_MCP_URL;
+    if (!mcpUrl) throw new Error("PLATFORM_MCP_URL is not set");
+    const u = new URL(mcpUrl);
+    const m = u.pathname.match(/^\/api\/agents\/([^/]+)\/mcp$/);
+    if (!m) throw new Error(`unexpected PLATFORM_MCP_URL shape: ${mcpUrl}`);
+
+    const res = await fetch(
+      `${u.protocol}//${u.host}/api/agents/${m[1]}/invocations`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+    const text = await res.text();
+    if (!res.ok) throw new Error(`spawn -> ${res.status}: ${text}`);
+    return { id: (JSON.parse(text) as { id: string }).id };
+  };
+}

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/control-service.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/control-service.ts
@@ -7,8 +7,10 @@ import type {
   ReceivedPrompt,
   ScriptedMockService,
   SetScriptInput,
+  SpawnInvocationInput,
 } from "mock-agent-api";
 import type { MockState } from "../domain/state.js";
+import type { HarnessSpawn } from "./ports.js";
 
 export type ProxyFetch = (
   input: PerformFetchInput,
@@ -17,12 +19,13 @@ export type ProxyFetch = (
 export interface ScriptedMockDeps {
   state: MockState;
   proxyFetch: ProxyFetch;
+  harnessSpawn: HarnessSpawn;
 }
 
 export function createScriptedMockService(
   deps: ScriptedMockDeps,
 ): ScriptedMockService {
-  const { state, proxyFetch } = deps;
+  const { state, proxyFetch, harnessSpawn } = deps;
   return {
     setScript(input: SetScriptInput) {
       state.scriptEntries = input.entries;
@@ -45,6 +48,9 @@ export function createScriptedMockService(
     },
     performFetch(input: PerformFetchInput): Promise<PerformFetchResult> {
       return proxyFetch(input);
+    },
+    spawnInvocation(input: SpawnInvocationInput) {
+      return harnessSpawn(input);
     },
   };
 }

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/ports.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/ports.ts
@@ -1,3 +1,7 @@
+import type {
+  SpawnInvocationInput,
+  SpawnInvocationResult,
+} from "mock-agent-api";
 import type { JsonRpcFrame } from "../domain/frames.js";
 
 export interface AcpChannel {
@@ -14,4 +18,9 @@ export interface WorkspaceWriter {
  *  Slack. Best-effort: failures are logged, never thrown. */
 export interface SlackReplyPoster {
   (args: { text: string; threadTs?: string }): Promise<void>;
+}
+
+/** Spawns an Invocation via the harness surface, as this agent (the driver). */
+export interface HarnessSpawn {
+  (input: SpawnInvocationInput): Promise<SpawnInvocationResult>;
 }

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -4,6 +4,19 @@ const baseURL = process.env.PLATFORM_BASE_URL ?? "http://localhost:4444";
 
 const storageState = "./.auth/user.json";
 
+// Two suite tiers:
+// - smoke (src/tests/smoke/): the always-on pipeline — CI and plain
+//   `mise run e2e` / e2e:loop run exactly these.
+// - full (= smoke + src/tests/full/): on demand via
+//   `mise run e2e:loop -- --full`. src/tests/full/ holds the slow,
+//   scenario-heavy specs only the full suite runs; their projects enter the
+//   list behind this env gate. Conventions: one "<area>-full" project per
+//   area, specs self-contained (own agents, own token via getAccessToken +
+//   acceptTerms — the terms gate 412s everything else on a fresh DB — no
+//   storageState, no dependency on the smoke chain's fixtures), and each
+//   spec references its motivating ticket in the test title.
+const full = process.env.E2E_FULL === "1";
+
 export default defineConfig({
   testDir: "./src/tests",
   fullyParallel: false,
@@ -132,5 +145,16 @@ export default defineConfig({
       dependencies: ["egress-path-rules"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
+    ...(full
+      ? [
+          {
+            // Invocation lifecycles: spawn + gateway-level egress assertions,
+            // several agent boots per spec — minutes each, hence full-only.
+            name: "invocations-full",
+            testMatch: /full\/invocation-.*\.spec\.ts$/,
+            use: { ...devices["Desktop Chrome"] },
+          },
+        ]
+      : []),
   ],
 });

--- a/packages/e2e/playwright/src/lib/auth.ts
+++ b/packages/e2e/playwright/src/lib/auth.ts
@@ -4,6 +4,7 @@ import {
   keycloakUrl,
   testUser,
 } from "../config.js";
+import type { ApiClient } from "./api-client.js";
 
 interface TokenResponse {
   access_token: string;
@@ -32,4 +33,13 @@ export async function getAccessToken(
   }
   const data = (await res.json()) as TokenResponse;
   return data.access_token;
+}
+
+/** Accept the current Terms of Use for the client's user. The terms gate
+ *  412s every non-terms API call until the user accepts, and only the UI
+ *  login flow (01-auth) does it implicitly — self-contained API specs
+ *  (the full-suite tier) must call this before anything else. */
+export async function acceptTerms(api: ApiClient): Promise<void> {
+  const current = await api.terms.current.query();
+  await api.terms.accept.mutate({ version: current.version });
 }

--- a/packages/e2e/playwright/src/tests/full/invocation-egress.spec.ts
+++ b/packages/e2e/playwright/src/tests/full/invocation-egress.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+
+import { createApiClient, type ApiClient } from "../../lib/api-client.js";
+import { acceptTerms, getAccessToken } from "../../lib/auth.js";
+import { harnessName } from "../../lib/fixtures.js";
+
+// Full-suite-only spec (see playwright.config.ts): not part of the smoke
+// pipeline — run on demand with `mise run e2e:loop -- --full`.
+//
+// Egress Aliasing (#2930): an Invocation target has no egress identity of its
+// own — every request it makes is decided by the driver's live rules. Before
+// the fix a target always started on the default trusted preset, so a
+// zero-egress driver spawned a WIDER child (silent escalation) and this
+// spec's first assertion fails.
+//
+// postman-echo.com is a public echo service (same external-dependency class
+// as 11-egress-path-rules) with no connection — the driver's rules are the
+// only thing standing between the target and the internet.
+const host = "postman-echo.com";
+const url = `https://${host}/status/204`;
+const driverName = "e2e-egress-driver";
+
+/** Fetch from inside the agent pod through its gateway; 0 = blocked (the
+ *  gateway held or denied, the mock's client-side fetch gave up). */
+async function fetchStatus(
+  api: ApiClient,
+  agentId: string,
+  target: string,
+): Promise<number> {
+  try {
+    const { status } = await api.e2e.performFetch.mutate({
+      agentId,
+      url: target,
+    });
+    return status;
+  } catch {
+    return 0;
+  }
+}
+
+async function waitRunning(api: ApiClient, agentId: string): Promise<void> {
+  await expect
+    .poll(async () => (await api.agents.get.query({ id: agentId })).state, {
+      timeout: 180_000,
+      intervals: [2_000],
+      message: `agent ${agentId} did not reach running state`,
+    })
+    .toBe("running");
+}
+
+test("invocation egress follows the driver (#2930)", async () => {
+  test.setTimeout(600_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+  // Fresh DB: the terms gate 412s every non-terms call until accepted (the
+  // main chain does this via the 01-auth UI login).
+  await acceptTerms(api);
+
+  let driverId = "";
+  await test.step("create a zero-egress driver", async () => {
+    const created = await api.agents.create.mutate({
+      name: driverName,
+      templateId: harnessName,
+      egressPreset: "none",
+    });
+    driverId = created.id;
+    await waitRunning(api, driverId);
+  });
+
+  let targetId = "";
+  await test.step("spawn an invocation target from the driver", async () => {
+    // The mock agent makes the same harness POST the driver SDK does from a
+    // real pod. Long ttl so the liveness sweep can't reap the target mid-test.
+    const { id } = await api.e2e.spawnInvocation.mutate({
+      agentId: driverId,
+      templateId: harnessName,
+      prompt: "e2e invocation target; stay idle",
+      schema: { type: "object" },
+      ttlMs: 30 * 60_000,
+    });
+    targetId = id;
+    await waitRunning(api, targetId);
+  });
+
+  await test.step("the target inherits the driver's zero egress", async () => {
+    // Before Egress Aliasing the target ran on the trusted preset and this
+    // returned 204 even though the driver allows nothing.
+    expect(await fetchStatus(api, targetId, url)).not.toBe(204);
+  });
+
+  await test.step("allowing the host on the driver unlocks the running target", async () => {
+    // Host-wide rule: enforced on the SNI-only L4 path too, so no gateway
+    // roll is involved — the next request from the target must pass. The
+    // rule is written on the DRIVER; the target is never touched.
+    await api.egressRules.create.mutate({
+      agentId: driverId,
+      host,
+      method: "*",
+      pathPattern: "*",
+      verdict: "allow",
+    });
+    await expect
+      .poll(() => fetchStatus(api, targetId, url), {
+        timeout: 120_000,
+        intervals: [3_000],
+        message: "driver-side allow did not apply to the running target",
+      })
+      .toBe(204);
+  });
+
+  await test.step("the target holds no rule of its own for the host", async () => {
+    const rules = await api.egressRules.listForAgent.query({
+      agentId: targetId,
+    });
+    expect(rules.filter((r) => r.host === host)).toEqual([]);
+  });
+
+  await test.step("deleting the driver cascades to the target", async () => {
+    await api.agents.delete.mutate({ id: driverId });
+    await expect
+      .poll(
+        async () => {
+          const list = await api.agents.list.query();
+          return list.some((a) => a.id === targetId || a.id === driverId);
+        },
+        {
+          timeout: 60_000,
+          intervals: [2_000],
+          message: "driver delete did not reap the invocation target",
+        },
+      )
+      .toBe(false);
+  });
+});

--- a/packages/e2e/playwright/src/tests/smoke/01-auth.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/01-auth.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl, testUser } from "../config.js";
+import { baseUrl, testUser } from "../../config.js";
 
 const storageStatePath = "./.auth/user.json";
 

--- a/packages/e2e/playwright/src/tests/smoke/02-connection.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/02-connection.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { createCustomHeaderConnection } from "../lib/connections.js";
+import { baseUrl } from "../../config.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { createCustomHeaderConnection } from "../../lib/connections.js";
 import {
   connectionHost,
   connectionName,
@@ -11,7 +11,7 @@ import {
   headerName,
   sentinel,
   valueFormat,
-} from "../lib/fixtures.js";
+} from "../../lib/fixtures.js";
 
 test("create a custom-header connection", async ({ page }) => {
   const token = await getAccessToken();

--- a/packages/e2e/playwright/src/tests/smoke/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/03-agent.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { getConnectionId } from "../lib/connections.js";
-import { agentName, connectionName, harnessName } from "../lib/fixtures.js";
+import { baseUrl } from "../../config.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { getConnectionId } from "../../lib/connections.js";
+import { agentName, connectionName, harnessName } from "../../lib/fixtures.js";
 
 test("create a mock agent with the connection attached", async ({ page }) => {
   test.setTimeout(60_000);

--- a/packages/e2e/playwright/src/tests/smoke/04-messages.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/04-messages.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
+import { baseUrl } from "../../config.js";
 import {
   agentCardStatus,
   chatInput,
@@ -10,10 +10,10 @@ import {
   setMockAgentReply,
   setMockReplyWithMidTurnUserPrompt,
   waitForAgentRunning,
-} from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+} from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 const scriptedReply = "scripted-reply-from-e2e";
 const userPrompt = "hello-from-playwright";

--- a/packages/e2e/playwright/src/tests/smoke/05-injection.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/05-injection.spec.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
 import {
   agentName,
   echoUrl,
   envName,
   placeholder,
   sentinel,
-} from "../lib/fixtures.js";
+} from "../../lib/fixtures.js";
 
 test("connection injects the credential (env placeholder + egress after Envoy)", async () => {
   test.setTimeout(420_000);

--- a/packages/e2e/playwright/src/tests/smoke/06-api-keys.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/06-api-keys.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from "@playwright/test";
 import { TRPCClientError } from "@trpc/client";
 import type { AppRouter, Scope } from "api-server-api";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient, type ApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient, type ApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
 
 /**
  * End-to-end authorization for API keys, against the real api-server + Keycloak

--- a/packages/e2e/playwright/src/tests/smoke/07-slack.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/07-slack.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl, testUser2 } from "../config.js";
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { ensureCustomHeaderConnection } from "../lib/connections.js";
+import { baseUrl, testUser2 } from "../../config.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { ensureCustomHeaderConnection } from "../../lib/connections.js";
 import {
   agentName,
   connectionHost,
@@ -14,7 +14,7 @@ import {
   foreignSentinel,
   headerName,
   valueFormat,
-} from "../lib/fixtures.js";
+} from "../../lib/fixtures.js";
 
 const slackChannelId = "C-E2E-TRACER";
 const foreignSlackTeamId = "T-E2E";

--- a/packages/e2e/playwright/src/tests/smoke/08-session-delete.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/08-session-delete.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
+import { baseUrl } from "../../config.js";
 import {
   agentCardStatus,
   chatInput,
@@ -8,10 +8,10 @@ import {
   sendMessageToAgent,
   setMockAgentReply,
   waitForAgentRunning,
-} from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+} from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 const scriptedReply = "scripted-reply-for-delete-spec";
 const firstPrompt = "hello-before-delete";

--- a/packages/e2e/playwright/src/tests/smoke/08-slack-shared.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/08-slack-shared.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName, echoUrl, sentinel } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName, echoUrl, sentinel } from "../../lib/fixtures.js";
 
 // Mode is fixed per binding, so shared coverage gets its own
 // channel; rebinding replaces the agent's single Slack binding from 07.

--- a/packages/e2e/playwright/src/tests/smoke/09-slack-inchat-bind.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/09-slack-inchat-bind.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 // This spec exercises the in-chat bind/unbind slash commands at the command
 // level (deterministic, no OAuth round-trip). It replaces the agent's single

--- a/packages/e2e/playwright/src/tests/smoke/09-user-env.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/09-user-env.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient, type ApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName, envName, placeholder } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient, type ApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName, envName, placeholder } from "../../lib/fixtures.js";
 
 const userEnvName = "E2E_USER_ENV";
 const userEnvValue = "user-value-9d2f";

--- a/packages/e2e/playwright/src/tests/smoke/10-connection-regrant.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/10-connection-regrant.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
+import { baseUrl } from "../../config.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
 import {
   ensureCustomHeaderConnection,
   getConnectionId,
-} from "../lib/connections.js";
-import { agentName, valueFormat } from "../lib/fixtures.js";
+} from "../../lib/connections.js";
+import { agentName, valueFormat } from "../../lib/fixtures.js";
 
 const originalName = "e2e-regrant-original";
 const recreatedName = "e2e-regrant-recreated";

--- a/packages/e2e/playwright/src/tests/smoke/10-slack-ambient.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/10-slack-ambient.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 // 09 leaves the channel unbound; this spec establishes its own binding
 // (rebinding would replace the agent's single Slack binding either way).

--- a/packages/e2e/playwright/src/tests/smoke/11-egress-path-rules.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/11-egress-path-rules.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 // Path-scoped egress rules over HTTPS on a host the platform holds no
 // credential for (#2322). The rule must promote the host onto the gateway's

--- a/packages/e2e/playwright/tasks.toml
+++ b/packages/e2e/playwright/tasks.toml
@@ -13,9 +13,16 @@ fi
 '''
 
 ["e2e-playwright:run"]
+description = "Run the smoke suite (src/tests/smoke/) — the always-on pipeline tier"
 dir = "{{config_root}}/packages/e2e/playwright"
 depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
 run = "pnpm exec playwright test"
+
+["e2e-playwright:run-full"]
+description = "Run the FULL suite: smoke plus the slow on-demand specs under src/tests/full/"
+dir = "{{config_root}}/packages/e2e/playwright"
+depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
+run = "E2E_FULL=1 pnpm exec playwright test"
 
 ["e2e-playwright:run-headed"]
 description = "Run Playwright with a visible browser window"

--- a/tasks.toml
+++ b/tasks.toml
@@ -16,7 +16,7 @@ depends = ["*:scan"]
 depends = ["*:test"]
 
 ["e2e"]
-description = "Run Playwright e2e: spin up fresh test cluster, run specs, tear down. Options: --headed"
+description = "Run Playwright e2e: spin up fresh test cluster, run the smoke suite, tear down. Options: --headed --full"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -27,6 +27,7 @@ PLAYWRIGHT_TASK="e2e-playwright:run"
 for arg in "$@"; do
   case "$arg" in
     --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
+    --full) PLAYWRIGHT_TASK="e2e-playwright:run-full" ;;
   esac
 done
 
@@ -221,7 +222,7 @@ echo "e2e data reset complete."
 '''
 
 ["e2e:loop"]
-description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run specs. Options: --headed --rebuild=apiserver,ui,controller,keycloak,mock-agent"
+description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run the smoke suite. Options: --headed --full --rebuild=apiserver,ui,controller,keycloak,mock-agent"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -242,6 +243,9 @@ REBUILD_SET=false
 for arg in "$@"; do
   case "$arg" in
     --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
+    # Full suite: smoke plus the slow on-demand specs under src/tests/full/.
+    # The pipeline default is smoke only; this flag is the manual trigger.
+    --full) PLAYWRIGHT_TASK="e2e-playwright:run-full" ;;
     --rebuild=*) REBUILD="${arg#--rebuild=}"; REBUILD_SET=true ;;
   esac
 done


### PR DESCRIPTION
Closes #2930. Implements the design settled in the issue grilling (see issue comment).

## What

An invocation target has no egress identity of its own. Every request from a target is decided by the driver's live egress state:

- The ext_authz gate resolves the calling agent to its root driver (recursively for chained invocations) before rule match, HITL hold, and approval write. Rules are matched per request from the DB, so tightening or loosening the driver applies to running targets immediately.
- Approval prompts raised by target traffic surface as the driver's, fan out on the driver's channel, and stamp the originating target (`via invocation-…`) into the pending row payload, the synth frame, and the security log. Approving permanently writes the driver's rules.
- App-layer aliasing only: the target keeps its own attenuated credential set. It gains the driver's network reach, never its credentials (gateway still injects per-agent).
- Spawn seeds the target with the `none` preset — seeded target rules would be dead rows under aliasing. This also fixes the silent widening where a `none` driver spawned `trusted` targets.
- **Driver Cascade**: deleting an agent fails its running invocations (driven and own) and eagerly reaps the targets, transitively for chains, via a cleanup hook in the invocations module. The orphan sweeper saga replays a cascade missed by a crash. A target that slips through fails closed at the gate (driver unresolved).

## Docs

- ADR-078 (inherit-vs-alias decision)
- Glossary: Egress Aliasing + Driver Cascade under the Invocations context (proposed)
- security-and-credentials.md: aliasing paragraph in the HITL ext_authz section

## Notes

- Hiding invocation agents from the UI list is tracked separately (beads dam-9nk).
- Beads: dam-d24.

https://claude.ai/code/session_01BhrWyfHztr64zk1x9HwB1u