### PR TITLE
feat(brand): drive the browser tab title from brand.title

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -390,8 +390,8 @@ spec:
               value: {{ .Values.brand.name | quote }}
             - name: BRAND_SHORT
               value: {{ .Values.brand.short | quote }}
-            - name: BRAND_TAGLINE
-              value: {{ .Values.brand.tagline | quote }}
+            - name: BRAND_TITLE
+              value: {{ .Values.brand.title | quote }}
             - name: BRAND_THEME_LIGHT_ACCENT
               value: {{ .Values.brand.theme.light.accent | quote }}
             - name: BRAND_THEME_LIGHT_ACCENT_HOVER

--- a/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
+++ b/deploy/helm/platform/templates/keycloak/realm-configmap.yaml
@@ -14,6 +14,7 @@ data:
     {
       "realm": {{ .Values.keycloak.realm | quote }},
       "displayName": {{ .Values.brand.name | quote }},
+      "displayNameHtml": {{ .Values.brand.title | default .Values.brand.name | quote }},
       "enabled": true,
       "loginTheme": "platform",
       "sslRequired": {{ if eq .Values.scheme "https" }}"external"{{ else }}"none"{{ end }},

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -7,14 +7,15 @@
 brand:
   # Display name shown in the PWA manifest, OAuth dynamic client_name,
   # skill-publish git author, and the Keycloak realm display name (sign-in
-  # heading + tab title).
+  # heading).
   name: DAM
   # Lowercase identifier (DNS/URL-safe). Used for the Slack slash command
   # (`/<short> login`), GitHub publish branch prefix, and git-author email
   # local-part.
   short: dam
-  # Browser tab title of the web app. Set a per-environment variant here
-  # (e.g. "IBM Research DAM - Staging"). Empty string falls back to `name`.
+  # Browser tab title of the web app and the Keycloak sign-in pages. Set a
+  # per-environment variant here (e.g. "IBM Research DAM - Staging"). Empty
+  # string falls back to `name`.
   title: "IBM Research DAM"
   # UI theme — applied at runtime as CSS custom properties so a brand
   # change requires no UI rebuild.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -13,9 +13,9 @@ brand:
   # (`/<short> login`), GitHub publish branch prefix, and git-author email
   # local-part.
   short: dam
-  # Marketing tagline shown as the browser tab title in the web app (the
-  # `name` expansion). Empty string falls back to `name`.
-  tagline: "Deploy Agents Massively"
+  # Browser tab title of the web app. Set a per-environment variant here
+  # (e.g. "IBM Research DAM - Staging"). Empty string falls back to `name`.
+  title: "IBM Research DAM"
   # UI theme — applied at runtime as CSS custom properties so a brand
   # change requires no UI rebuild.
   theme:

--- a/packages/api-server-api/src/modules/brand/types.ts
+++ b/packages/api-server-api/src/modules/brand/types.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 export const brandSchema = z.object({
   name: z.string(),
   short: z.string(),
-  tagline: z.string(),
+  title: z.string(),
   theme: z.object({
     light: z.object({
       accent: z.string(),

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -374,7 +374,7 @@ export function loadConfig(): Config {
     brand: {
       name: process.env.BRAND_NAME ?? "Platform",
       short: process.env.BRAND_SHORT ?? "platform",
-      tagline: process.env.BRAND_TAGLINE ?? "",
+      title: process.env.BRAND_TITLE ?? "",
       theme: {
         light: {
           accent: process.env.BRAND_THEME_LIGHT_ACCENT ?? "#1D6BE1",

--- a/packages/keycloak-theme/src/login/Template.tsx
+++ b/packages/keycloak-theme/src/login/Template.tsx
@@ -9,9 +9,11 @@ import { useApplyThemeScript } from "./hooks/use-apply-theme-script.js";
 import type { I18n } from "./i18n.js";
 import type { KcContext } from "./KcContext.js";
 
-// Brand shown on the auth screens comes from the realm `displayName` at
-// runtime (Helm `brand.name`). This is only the fallback for when it's
-// absent — e.g. the local mocked-kcContext dev preview.
+// Brand on the auth screens comes from the realm at runtime: `displayName`
+// (Helm `brand.name`) names the sign-in heading, `displayNameHtml` (Helm
+// `brand.title`, plain text) titles the browser tab like the web app. This
+// is only the fallback for when they're absent — e.g. the local
+// mocked-kcContext dev preview.
 const BRAND_FALLBACK = "Platform";
 
 export default function Template(props: TemplateProps<KcContext, I18n>) {
@@ -33,8 +35,9 @@ export default function Template(props: TemplateProps<KcContext, I18n>) {
   useEffect(() => {
     document.title =
       documentTitle ??
-      msgStr("loginTitle", realm.displayName || BRAND_FALLBACK);
-  }, [documentTitle, msgStr, realm.displayName]);
+      (realm.displayNameHtml ||
+        msgStr("loginTitle", realm.displayName || BRAND_FALLBACK));
+  }, [documentTitle, msgStr, realm.displayNameHtml, realm.displayName]);
 
   useSetClassName({ qualifiedName: "html", className: "" });
   useSetClassName({ qualifiedName: "body", className: "" });

--- a/packages/ui/src/brand.ts
+++ b/packages/ui/src/brand.ts
@@ -16,7 +16,7 @@ import { type Brand, brandSchema } from "api-server-api";
 const FALLBACK: Brand = {
   name: "Platform",
   short: "platform",
-  tagline: "",
+  title: "",
   theme: {
     light: {
       accent: "#1D6BE1",
@@ -73,7 +73,7 @@ function setSafe(el: HTMLElement, prop: string, value: string): void {
 }
 
 export function applyBrand(brand: Brand): void {
-  document.title = brand.tagline || brand.name;
+  document.title = brand.title || brand.name;
 
   const themeMeta = document.querySelector<HTMLMetaElement>(
     'meta[name="theme-color"]',


### PR DESCRIPTION
Closes #2874

## What

Sets the browser tab title to **IBM Research DAM** — in the web app and on the Keycloak sign-in pages — configurable per environment through Helm values (e.g. `brand.title: "IBM Research DAM - Staging"`), as discussed in the issue comments.

## Deployment note

Any environment values override that sets `brand.tagline` must switch to `brand.title` when this ships — the old key is silently ignored.

## Testing

- `mise run check` (lint + type-check + helm lint/render) ✅
- `mise run ui:test` 92/92, `mise run api-server:test` 604/604 ✅