### PR TITLE
feat(ui): create an agent from the Slack/Telegram bind picker

### DIFF
--- a/packages/ui/src/__tests__/unit/create-agent-input.test.ts
+++ b/packages/ui/src/__tests__/unit/create-agent-input.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCreateAgentInput,
+  type CreateAgentDraft,
+  isCreateAgentDraftComplete,
+} from "../../modules/agents/lib/create-agent-input.js";
+
+const complete: CreateAgentDraft = {
+  name: "swift-otter",
+  templateId: "claude-code",
+  providerRef: { id: "conn-123" },
+  egressPreset: "trusted",
+};
+
+describe("create-agent draft completeness", () => {
+  it("is complete only with a name, a template, and a provider", () => {
+    expect(isCreateAgentDraftComplete(complete)).toBe(true);
+    expect(isCreateAgentDraftComplete({ ...complete, name: "  " })).toBe(false);
+    expect(isCreateAgentDraftComplete({ ...complete, templateId: null })).toBe(
+      false,
+    );
+    expect(isCreateAgentDraftComplete({ ...complete, providerRef: null })).toBe(
+      false,
+    );
+  });
+});
+
+describe("buildCreateAgentInput", () => {
+  it("maps the provider to the sole app-connection grant and trims the name", () => {
+    expect(
+      buildCreateAgentInput({ ...complete, name: "  swift-otter " }),
+    ).toEqual({
+      name: "swift-otter",
+      templateId: "claude-code",
+      egressPreset: "trusted",
+      appConnectionIds: ["conn-123"],
+    });
+  });
+
+  it("carries the chosen egress preset through", () => {
+    expect(
+      buildCreateAgentInput({ ...complete, egressPreset: "all" }),
+    ).toMatchObject({ egressPreset: "all" });
+  });
+
+  it("throws on an incomplete draft", () => {
+    expect(() =>
+      buildCreateAgentInput({ ...complete, providerRef: null }),
+    ).toThrow();
+  });
+});

--- a/packages/ui/src/modules/agents/components/bind-agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/bind-agent-row.tsx
@@ -1,0 +1,48 @@
+import { cn } from "@/lib/utils";
+
+import type { AgentView } from "../../../types.js";
+
+interface Props {
+  agent: AgentView;
+  /** Emphasize the row (e.g. an agent just created on this page). */
+  highlighted: boolean;
+  disabled: boolean;
+  /** This row's bind is in flight — shows a "Connecting …" label. */
+  pending: boolean;
+  onPick: () => void;
+}
+
+/** A pick-to-connect row in the Slack/Telegram bind pickers. */
+export function BindAgentRow({
+  agent,
+  highlighted,
+  disabled,
+  pending,
+  onPick,
+}: Props) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onPick}
+      className={cn(
+        "flex flex-col items-start gap-0.5 rounded-lg border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60",
+        highlighted ? "border-foreground" : "border-border",
+      )}
+    >
+      <span className="text-[14px] font-semibold text-foreground">
+        {pending ? `Connecting ${agent.name}…` : agent.name}
+      </span>
+      {agent.description && (
+        <span className="text-[12px] text-muted-foreground">
+          {agent.description}
+        </span>
+      )}
+      {agent.templateId && (
+        <span className="text-[11px] font-mono text-muted-foreground">
+          {agent.templateId}
+        </span>
+      )}
+    </button>
+  );
+}

--- a/packages/ui/src/modules/agents/components/create-agent-inline.tsx
+++ b/packages/ui/src/modules/agents/components/create-agent-inline.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react";
+
+import { FormField } from "@/components/form-field";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { SectionLabel } from "@/components/ui/section-label";
+import { Select } from "@/components/ui/select";
+
+import type { AgentView } from "../../../types.js";
+import type { ProviderRef } from "../../providers/components/provider-item.js";
+import { ProviderSection } from "../../providers/components/provider-section.js";
+import { generateSandboxName } from "../../sandboxes/lib/sandbox-name.js";
+import { useTemplates } from "../../templates/api/queries.js";
+import { useCreateAgent } from "../api/mutations.js";
+import {
+  buildCreateAgentInput,
+  type CreateAgentDraft,
+  isCreateAgentDraftComplete,
+} from "../lib/create-agent-input.js";
+
+interface Props {
+  /** Called with the freshly created agent once the create mutation resolves. */
+  onCreated: (agent: AgentView) => void;
+}
+
+/**
+ * Minimal, self-contained agent-create form for surfaces that can't leave the
+ * page (the Slack/Telegram bind pickers). It reuses the sandbox wizard's own
+ * building blocks — templates, provider selection, the create mutation — but
+ * fixes the network preset to the trusted default so the whole thing fits in
+ * one screen. Turns run under the chosen provider, so a provider is required.
+ */
+export function CreateAgentInline({ onCreated }: Props) {
+  const { data: templates = [], isLoading } = useTemplates();
+  const createAgent = useCreateAgent();
+  const [name, setName] = useState(generateSandboxName);
+  const [templateId, setTemplateId] = useState<string | null>(null);
+  const [providerRef, setProviderRef] = useState<ProviderRef | null>(null);
+
+  // Default to the first stable template (the catalogue is sorted
+  // experimental-last) until the user picks one explicitly.
+  const selectedTemplateId = templateId ?? templates[0]?.id ?? null;
+
+  const draft: CreateAgentDraft = {
+    name,
+    templateId: selectedTemplateId,
+    providerRef,
+    egressPreset: "trusted",
+  };
+  const canCreate = isCreateAgentDraftComplete(draft);
+
+  const submit = async () => {
+    if (!canCreate) return;
+    try {
+      const agent = await createAgent.mutateAsync(buildCreateAgentInput(draft));
+      onCreated(agent);
+    } catch {
+      // useCreateAgent surfaces its own error toast; stay put so the user can retry.
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-4 rounded-lg border border-border bg-card p-4">
+      <FormField label="Name" labelInset>
+        <Input
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          placeholder="my-agent"
+        />
+      </FormField>
+
+      <FormField label="Harness" labelInset>
+        <Select
+          value={selectedTemplateId ?? ""}
+          disabled={isLoading || templates.length === 0}
+          onChange={(event) => setTemplateId(event.target.value)}
+        >
+          {templates.map((template) => (
+            <option key={template.id} value={template.id}>
+              {template.name}
+              {template.experimental ? " (experimental)" : ""}
+            </option>
+          ))}
+        </Select>
+      </FormField>
+
+      <div>
+        <SectionLabel spaced>Provider</SectionLabel>
+        <ProviderSection
+          selected={providerRef}
+          onSelect={setProviderRef}
+          autoSelectFirst
+          variant="collapsible"
+          manageKeys={false}
+        />
+      </div>
+
+      <Button
+        type="button"
+        className="self-start"
+        disabled={createAgent.isPending || !canCreate}
+        onClick={submit}
+      >
+        {createAgent.isPending ? "Creating…" : "Create agent"}
+      </Button>
+    </div>
+  );
+}

--- a/packages/ui/src/modules/agents/components/create-agent-inline.tsx
+++ b/packages/ui/src/modules/agents/components/create-agent-inline.tsx
@@ -33,13 +33,20 @@ interface Props {
 export function CreateAgentInline({ onCreated }: Props) {
   const { data: templates = [], isLoading } = useTemplates();
   const createAgent = useCreateAgent();
+  // Controlled state rather than the house RHF+Zod default for a 3-field form:
+  // the provider is a bespoke imperative picker (not an RHF-registerable input),
+  // and validation + mutation-input assembly already live in the tested pure
+  // `create-agent-input` module.
   const [name, setName] = useState(generateSandboxName);
   const [templateId, setTemplateId] = useState<string | null>(null);
   const [providerRef, setProviderRef] = useState<ProviderRef | null>(null);
 
-  // Default to the first stable template (the catalogue is sorted
-  // experimental-last) until the user picks one explicitly.
-  const selectedTemplateId = templateId ?? templates[0]?.id ?? null;
+  // Default to the first non-experimental template until the user picks one,
+  // computed here rather than leaning on the catalogue's sort order.
+  const selectedTemplateId =
+    templateId ??
+    (templates.find((t) => !t.experimental) ?? templates[0])?.id ??
+    null;
 
   const draft: CreateAgentDraft = {
     name,

--- a/packages/ui/src/modules/agents/hooks/use-inline-agent-create.ts
+++ b/packages/ui/src/modules/agents/hooks/use-inline-agent-create.ts
@@ -1,0 +1,63 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import type { AgentView } from "../../../types.js";
+import { useAgents, useAgentsList } from "../api/queries.js";
+
+export interface InlineAgentCreate {
+  /** True until the agents list has loaded for the first time. */
+  isLoading: boolean;
+  /** The agents list, with a just-created agent bridged in until the
+   *  refetched server list includes it. */
+  displayedAgents: readonly AgentView[];
+  /** Id of an agent created on this page, for highlighting; null if none. */
+  justCreatedId: string | null;
+  /** Whether the inline create form is open. */
+  creating: boolean;
+  /** Open the create form (the "＋ Create a new agent" affordance). */
+  openCreateForm: () => void;
+  /** Record a freshly created agent and collapse the form. */
+  markCreated: (agent: AgentView) => void;
+}
+
+/**
+ * Orchestration shared by the Slack and Telegram bind pickers. It bridges the
+ * create→refetch gap — a just-created agent shows in the picker immediately,
+ * before the invalidated list query has refetched — and opens the create form
+ * by default when the user owns no agents, keeping it mounted across an
+ * out-of-band list change so in-progress input is never discarded.
+ */
+export function useInlineAgentCreate(): InlineAgentCreate {
+  const agents = useAgents();
+  const list = useAgentsList();
+  const [creating, setCreating] = useState(false);
+  const [justCreated, setJustCreated] = useState<AgentView | null>(null);
+
+  // The server list is authoritative once it includes the agent.
+  const displayedAgents = useMemo(() => {
+    if (!justCreated || list.some((a) => a.id === justCreated.id)) return list;
+    return [...list, justCreated];
+  }, [list, justCreated]);
+
+  // Seeded once, after the first load. A ref (not state) so an out-of-band
+  // 0→N list change can never re-open a form the user has since closed.
+  const seededCreate = useRef(false);
+  useEffect(() => {
+    if (seededCreate.current || agents.isLoading) return;
+    seededCreate.current = true;
+    if (list.length === 0) setCreating(true);
+  }, [agents.isLoading, list.length]);
+
+  const markCreated = (agent: AgentView) => {
+    setJustCreated(agent);
+    setCreating(false);
+  };
+
+  return {
+    isLoading: agents.isLoading,
+    displayedAgents,
+    justCreatedId: justCreated?.id ?? null,
+    creating,
+    openCreateForm: () => setCreating(true),
+    markCreated,
+  };
+}

--- a/packages/ui/src/modules/agents/lib/create-agent-input.ts
+++ b/packages/ui/src/modules/agents/lib/create-agent-input.ts
@@ -1,0 +1,42 @@
+/** Pure assembly of the create-agent mutation input from an inline draft —
+ *  node-testable, no DOM. Kept separate from the component so the required-field
+ *  gate and the provider→connection mapping can be unit-tested directly. */
+
+import type { EgressPreset } from "../../../types.js";
+import type { ProviderRef } from "../../providers/components/provider-item.js";
+import type { CreateAgentInput } from "../api/mutations.js";
+
+export interface CreateAgentDraft {
+  name: string;
+  templateId: string | null;
+  providerRef: ProviderRef | null;
+  egressPreset: EgressPreset;
+}
+
+/** A draft is complete once it can create a functional agent: a name, a base
+ *  template, and a model provider to run turns under. */
+export function isCreateAgentDraftComplete(draft: CreateAgentDraft): boolean {
+  return (
+    draft.name.trim().length > 0 &&
+    draft.templateId !== null &&
+    draft.providerRef !== null
+  );
+}
+
+/** Assemble the mutation input from a completed draft. The chosen provider
+ *  rides in as the sole app-connection grant, mirroring the sandbox wizard, so
+ *  credentials are present on the first snapshot. Throws on an incomplete
+ *  draft — callers gate on {@link isCreateAgentDraftComplete} first. */
+export function buildCreateAgentInput(
+  draft: CreateAgentDraft,
+): CreateAgentInput {
+  if (!isCreateAgentDraftComplete(draft)) {
+    throw new Error("cannot build create-agent input from an incomplete draft");
+  }
+  return {
+    name: draft.name.trim(),
+    templateId: draft.templateId!,
+    egressPreset: draft.egressPreset,
+    appConnectionIds: [draft.providerRef!.id],
+  };
+}

--- a/packages/ui/src/modules/providers/components/provider-row.tsx
+++ b/packages/ui/src/modules/providers/components/provider-row.tsx
@@ -19,6 +19,9 @@ interface Props {
   connected: boolean;
   selected: boolean;
   selectable?: boolean;
+  /** Show the per-row key-management menu (Edit key / Remove key). Off on
+   *  surfaces that only pick a provider and have no confirm-dialog host. */
+  manageKeys?: boolean;
   onConnect: () => void;
   onSelect: () => void;
   onEditKey: () => void;
@@ -32,6 +35,7 @@ export function ProviderRow({
   connected,
   selected,
   selectable = true,
+  manageKeys = true,
   onConnect,
   onSelect,
   onEditKey,
@@ -87,19 +91,21 @@ export function ProviderRow({
           {info}
         </div>
       )}
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button variant="ghost" size="icon-sm" title="Provider actions">
-            <MoreVertical size={16} />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent>
-          <DropdownMenuItem onSelect={onEditKey}>Edit key</DropdownMenuItem>
-          <DropdownMenuItem tone="danger" onSelect={onRemoveKey}>
-            Remove key
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      {manageKeys && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="ghost" size="icon-sm" title="Provider actions">
+              <MoreVertical size={16} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent>
+            <DropdownMenuItem onSelect={onEditKey}>Edit key</DropdownMenuItem>
+            <DropdownMenuItem tone="danger" onSelect={onRemoveKey}>
+              Remove key
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/modules/providers/components/provider-section.tsx
+++ b/packages/ui/src/modules/providers/components/provider-section.tsx
@@ -74,6 +74,9 @@ interface Props {
   autoSelectFirst?: boolean;
   variant?: "stacked" | "collapsible";
   manage?: boolean;
+  /** Show the per-row key-management menu (Edit key / Remove key). Off on
+   *  surfaces that only pick a provider and have no confirm-dialog host. */
+  manageKeys?: boolean;
   listClassName?: string;
 }
 
@@ -84,6 +87,7 @@ export function ProviderSection({
   autoSelectFirst = false,
   variant = "stacked",
   manage = false,
+  manageKeys = true,
   listClassName,
 }: Props) {
   const { data: connections = [], isPending } = useAppConnections();
@@ -129,6 +133,7 @@ export function ProviderSection({
         subtitle={item ? itemSubtitle(row.type, item) : undefined}
         connected={!!item}
         selectable={!manage}
+        manageKeys={manageKeys}
         selected={!!ref && !!selected && sameProviderRef(ref, selected)}
         onConnect={() => setDialog({ provider: row.type })}
         onSelect={() => ref && onSelect?.(ref)}

--- a/packages/ui/src/modules/slack/views/slack-bind-view.tsx
+++ b/packages/ui/src/modules/slack/views/slack-bind-view.tsx
@@ -1,11 +1,13 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 import { getBrand } from "../../../brand.js";
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import type { AgentView } from "../../../types.js";
 import { useAgents, useAgentsList } from "../../agents/api/queries.js";
+import { CreateAgentInline } from "../../agents/components/create-agent-inline.js";
 import { useBindSlackChannel } from "../api/mutations.js";
 import {
   type BindErrorCopy,
@@ -29,6 +31,32 @@ export function SlackBindView() {
     agentName: string;
     channelTitle: string | null;
   } | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [justCreated, setJustCreated] = useState<AgentView | null>(null);
+
+  // Bridge the create→refetch gap: show a freshly created agent in the picker
+  // immediately, before the invalidated list query has refetched. The server
+  // list is authoritative once it includes the agent.
+  const displayedAgents = useMemo(() => {
+    if (!justCreated || list.some((a) => a.id === justCreated.id)) return list;
+    return [...list, justCreated];
+  }, [list, justCreated]);
+
+  const handleCreated = (agent: AgentView) => {
+    setJustCreated(agent);
+    setCreating(false);
+    setError(null);
+  };
+
+  // With no agents to pick, open the create form by default — and keep it open
+  // through an out-of-band list change (another tab/CLI, the 5s poll) so
+  // in-progress input is never discarded. Seeded once, after the first load.
+  const seededCreate = useRef(false);
+  useEffect(() => {
+    if (seededCreate.current || agents.isLoading) return;
+    seededCreate.current = true;
+    if (list.length === 0) setCreating(true);
+  }, [agents.isLoading, list.length]);
 
   if (callbackError) {
     return (
@@ -65,18 +93,6 @@ export function SlackBindView() {
       </Page>
     );
   }
-  if (list.length === 0) {
-    return (
-      <Page title="Connect this channel to an agent">
-        <p className="text-sm text-muted-foreground">
-          You don&apos;t own any agents yet. Create an agent first, then run{" "}
-          <code>/{brandShort} bind</code> in the channel again.
-        </p>
-        <DashboardButton label="Go to dashboard" />
-      </Page>
-    );
-  }
-
   const pick = (agent: AgentView) => {
     setError(null);
     bind.mutate(
@@ -92,40 +108,58 @@ export function SlackBindView() {
     );
   };
 
+  const hasAgents = displayedAgents.length > 0;
+
   return (
     <Page title="Connect this channel to an agent">
       <p className="text-sm text-muted-foreground">
-        Everyone in this Slack channel will be able to use the agent you pick.
-        Turns run under the agent&apos;s own connected accounts and API tokens,
-        and your acceptance of the Terms of Use covers every turn.
+        {hasAgents
+          ? "Everyone in this Slack channel will be able to use the agent you pick. Turns run under the agent's own connected accounts and API tokens, and your acceptance of the Terms of Use covers every turn."
+          : "You don't own any agents yet. Create one to connect it — everyone in this Slack channel will then be able to use it, running under its own connected accounts and your acceptance of the Terms of Use."}
       </p>
       {error && (
         <p className="text-sm text-red-600">
           {error.title} — {error.hint}
         </p>
       )}
-      <div className="flex flex-col gap-2">
-        {list.map((agent) => (
-          <BindAgentRow
-            key={agent.id}
-            agent={agent}
-            disabled={bind.isPending}
-            pending={bind.isPending && bind.variables?.agentId === agent.id}
-            onPick={() => pick(agent)}
-          />
-        ))}
-      </div>
+      {hasAgents && (
+        <div className="flex flex-col gap-2">
+          {displayedAgents.map((agent) => (
+            <BindAgentRow
+              key={agent.id}
+              agent={agent}
+              highlighted={justCreated?.id === agent.id}
+              disabled={bind.isPending}
+              pending={bind.isPending && bind.variables?.agentId === agent.id}
+              onPick={() => pick(agent)}
+            />
+          ))}
+        </div>
+      )}
+      {creating ? (
+        <CreateAgentInline onCreated={handleCreated} />
+      ) : hasAgents ? (
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          className="self-start text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          + Create a new agent
+        </button>
+      ) : null}
     </Page>
   );
 }
 
 function BindAgentRow({
   agent,
+  highlighted,
   disabled,
   pending,
   onPick,
 }: {
   agent: AgentView;
+  highlighted: boolean;
   disabled: boolean;
   pending: boolean;
   onPick: () => void;
@@ -135,7 +169,10 @@ function BindAgentRow({
       type="button"
       disabled={disabled}
       onClick={onPick}
-      className="flex flex-col items-start gap-0.5 rounded-lg border border-border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60"
+      className={cn(
+        "flex flex-col items-start gap-0.5 rounded-lg border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60",
+        highlighted ? "border-foreground" : "border-border",
+      )}
     >
       <span className="text-[14px] font-semibold text-foreground">
         {pending ? `Connecting ${agent.name}…` : agent.name}

--- a/packages/ui/src/modules/slack/views/slack-bind-view.tsx
+++ b/packages/ui/src/modules/slack/views/slack-bind-view.tsx
@@ -1,13 +1,13 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 import { getBrand } from "../../../brand.js";
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import type { AgentView } from "../../../types.js";
-import { useAgents, useAgentsList } from "../../agents/api/queries.js";
+import { BindAgentRow } from "../../agents/components/bind-agent-row.js";
 import { CreateAgentInline } from "../../agents/components/create-agent-inline.js";
+import { useInlineAgentCreate } from "../../agents/hooks/use-inline-agent-create.js";
 import { useBindSlackChannel } from "../api/mutations.js";
 import {
   type BindErrorCopy,
@@ -23,40 +23,25 @@ const callbackError = readCallbackErrorFromSearch(window.location.search);
 
 export function SlackBindView() {
   const brandShort = getBrand().short;
-  const agents = useAgents();
-  const list = useAgentsList();
   const bind = useBindSlackChannel();
+  const {
+    isLoading,
+    displayedAgents,
+    justCreatedId,
+    creating,
+    openCreateForm,
+    markCreated,
+  } = useInlineAgentCreate();
   const [error, setError] = useState<BindErrorCopy | null>(null);
   const [bound, setBound] = useState<{
     agentName: string;
     channelTitle: string | null;
   } | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [justCreated, setJustCreated] = useState<AgentView | null>(null);
-
-  // Bridge the create→refetch gap: show a freshly created agent in the picker
-  // immediately, before the invalidated list query has refetched. The server
-  // list is authoritative once it includes the agent.
-  const displayedAgents = useMemo(() => {
-    if (!justCreated || list.some((a) => a.id === justCreated.id)) return list;
-    return [...list, justCreated];
-  }, [list, justCreated]);
 
   const handleCreated = (agent: AgentView) => {
-    setJustCreated(agent);
-    setCreating(false);
+    markCreated(agent);
     setError(null);
   };
-
-  // With no agents to pick, open the create form by default — and keep it open
-  // through an out-of-band list change (another tab/CLI, the 5s poll) so
-  // in-progress input is never discarded. Seeded once, after the first load.
-  const seededCreate = useRef(false);
-  useEffect(() => {
-    if (seededCreate.current || agents.isLoading) return;
-    seededCreate.current = true;
-    if (list.length === 0) setCreating(true);
-  }, [agents.isLoading, list.length]);
 
   if (callbackError) {
     return (
@@ -86,13 +71,14 @@ export function SlackBindView() {
   if (error?.terminal) {
     return <TerminalError copy={error} />;
   }
-  if (agents.isLoading) {
+  if (isLoading) {
     return (
       <Page title="Connect this channel to an agent">
         <ListSkeleton rows={3} />
       </Page>
     );
   }
+
   const pick = (agent: AgentView) => {
     setError(null);
     bind.mutate(
@@ -128,7 +114,7 @@ export function SlackBindView() {
             <BindAgentRow
               key={agent.id}
               agent={agent}
-              highlighted={justCreated?.id === agent.id}
+              highlighted={agent.id === justCreatedId}
               disabled={bind.isPending}
               pending={bind.isPending && bind.variables?.agentId === agent.id}
               onPick={() => pick(agent)}
@@ -141,53 +127,13 @@ export function SlackBindView() {
       ) : hasAgents ? (
         <button
           type="button"
-          onClick={() => setCreating(true)}
+          onClick={openCreateForm}
           className="self-start text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
         >
           + Create a new agent
         </button>
       ) : null}
     </Page>
-  );
-}
-
-function BindAgentRow({
-  agent,
-  highlighted,
-  disabled,
-  pending,
-  onPick,
-}: {
-  agent: AgentView;
-  highlighted: boolean;
-  disabled: boolean;
-  pending: boolean;
-  onPick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onPick}
-      className={cn(
-        "flex flex-col items-start gap-0.5 rounded-lg border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60",
-        highlighted ? "border-foreground" : "border-border",
-      )}
-    >
-      <span className="text-[14px] font-semibold text-foreground">
-        {pending ? `Connecting ${agent.name}…` : agent.name}
-      </span>
-      {agent.description && (
-        <span className="text-[12px] text-muted-foreground">
-          {agent.description}
-        </span>
-      )}
-      {agent.templateId && (
-        <span className="text-[11px] font-mono text-muted-foreground">
-          {agent.templateId}
-        </span>
-      )}
-    </button>
   );
 }
 

--- a/packages/ui/src/modules/telegram/views/telegram-bind-view.tsx
+++ b/packages/ui/src/modules/telegram/views/telegram-bind-view.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import type { AgentView } from "../../../types.js";
 import { useAgents, useAgentsList } from "../../agents/api/queries.js";
+import { CreateAgentInline } from "../../agents/components/create-agent-inline.js";
 import { useBindTelegramChat } from "../api/mutations.js";
 import { useTelegramBot } from "../api/queries.js";
 import {
@@ -28,6 +30,32 @@ export function TelegramBindView() {
     agentName: string;
     chatTitle: string | null;
   } | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [justCreated, setJustCreated] = useState<AgentView | null>(null);
+
+  // Bridge the create→refetch gap: show a freshly created agent in the picker
+  // immediately, before the invalidated list query has refetched. The server
+  // list is authoritative once it includes the agent.
+  const displayedAgents = useMemo(() => {
+    if (!justCreated || list.some((a) => a.id === justCreated.id)) return list;
+    return [...list, justCreated];
+  }, [list, justCreated]);
+
+  const handleCreated = (agent: AgentView) => {
+    setJustCreated(agent);
+    setCreating(false);
+    setError(null);
+  };
+
+  // With no agents to pick, open the create form by default — and keep it open
+  // through an out-of-band list change (another tab/CLI, the 5s poll) so
+  // in-progress input is never discarded. Seeded once, after the first load.
+  const seededCreate = useRef(false);
+  useEffect(() => {
+    if (seededCreate.current || agents.isLoading) return;
+    seededCreate.current = true;
+    if (list.length === 0) setCreating(true);
+  }, [agents.isLoading, list.length]);
 
   if (callbackError) {
     return <TerminalError copy={callbackErrorCopy(callbackError)} />;
@@ -58,18 +86,6 @@ export function TelegramBindView() {
       </Page>
     );
   }
-  if (list.length === 0) {
-    return (
-      <Page title="Connect this chat to an agent">
-        <p className="text-sm text-muted-foreground">
-          You don&apos;t own any agents yet. Create an agent first, then send
-          /login in the chat again.
-        </p>
-        <DashboardButton label="Go to dashboard" />
-      </Page>
-    );
-  }
-
   const pick = (agent: AgentView) => {
     setError(null);
     bind.mutate(
@@ -85,39 +101,58 @@ export function TelegramBindView() {
     );
   };
 
+  const hasAgents = displayedAgents.length > 0;
+
   return (
     <Page title="Connect this chat to an agent">
       <p className="text-sm text-muted-foreground">
-        Everyone in the chat will be able to talk to the agent you pick, using
-        the agent&apos;s own credentials.
+        {hasAgents
+          ? "Everyone in the chat will be able to talk to the agent you pick, using the agent's own credentials."
+          : "You don't own any agents yet. Create one to connect it — everyone in the chat will then be able to talk to it, using its own credentials."}
       </p>
       {error && (
         <p className="text-sm text-red-600">
           {error.title} — {error.hint}
         </p>
       )}
-      <div className="flex flex-col gap-2">
-        {list.map((agent) => (
-          <BindAgentRow
-            key={agent.id}
-            agent={agent}
-            disabled={bind.isPending}
-            pending={bind.isPending && bind.variables?.agentId === agent.id}
-            onPick={() => pick(agent)}
-          />
-        ))}
-      </div>
+      {hasAgents && (
+        <div className="flex flex-col gap-2">
+          {displayedAgents.map((agent) => (
+            <BindAgentRow
+              key={agent.id}
+              agent={agent}
+              highlighted={justCreated?.id === agent.id}
+              disabled={bind.isPending}
+              pending={bind.isPending && bind.variables?.agentId === agent.id}
+              onPick={() => pick(agent)}
+            />
+          ))}
+        </div>
+      )}
+      {creating ? (
+        <CreateAgentInline onCreated={handleCreated} />
+      ) : hasAgents ? (
+        <button
+          type="button"
+          onClick={() => setCreating(true)}
+          className="self-start text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
+        >
+          + Create a new agent
+        </button>
+      ) : null}
     </Page>
   );
 }
 
 function BindAgentRow({
   agent,
+  highlighted,
   disabled,
   pending,
   onPick,
 }: {
   agent: AgentView;
+  highlighted: boolean;
   disabled: boolean;
   pending: boolean;
   onPick: () => void;
@@ -127,7 +162,10 @@ function BindAgentRow({
       type="button"
       disabled={disabled}
       onClick={onPick}
-      className="flex flex-col items-start gap-0.5 rounded-lg border border-border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60"
+      className={cn(
+        "flex flex-col items-start gap-0.5 rounded-lg border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60",
+        highlighted ? "border-foreground" : "border-border",
+      )}
     >
       <span className="text-[14px] font-semibold text-foreground">
         {pending ? `Connecting ${agent.name}…` : agent.name}

--- a/packages/ui/src/modules/telegram/views/telegram-bind-view.tsx
+++ b/packages/ui/src/modules/telegram/views/telegram-bind-view.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import type { AgentView } from "../../../types.js";
-import { useAgents, useAgentsList } from "../../agents/api/queries.js";
+import { BindAgentRow } from "../../agents/components/bind-agent-row.js";
 import { CreateAgentInline } from "../../agents/components/create-agent-inline.js";
+import { useInlineAgentCreate } from "../../agents/hooks/use-inline-agent-create.js";
 import { useBindTelegramChat } from "../api/mutations.js";
 import { useTelegramBot } from "../api/queries.js";
 import {
@@ -22,40 +22,25 @@ const flowId = readFlowIdFromSearch(window.location.search);
 const callbackError = readCallbackErrorFromSearch(window.location.search);
 
 export function TelegramBindView() {
-  const agents = useAgents();
-  const list = useAgentsList();
   const bind = useBindTelegramChat();
+  const {
+    isLoading,
+    displayedAgents,
+    justCreatedId,
+    creating,
+    openCreateForm,
+    markCreated,
+  } = useInlineAgentCreate();
   const [error, setError] = useState<BindErrorCopy | null>(null);
   const [bound, setBound] = useState<{
     agentName: string;
     chatTitle: string | null;
   } | null>(null);
-  const [creating, setCreating] = useState(false);
-  const [justCreated, setJustCreated] = useState<AgentView | null>(null);
-
-  // Bridge the create→refetch gap: show a freshly created agent in the picker
-  // immediately, before the invalidated list query has refetched. The server
-  // list is authoritative once it includes the agent.
-  const displayedAgents = useMemo(() => {
-    if (!justCreated || list.some((a) => a.id === justCreated.id)) return list;
-    return [...list, justCreated];
-  }, [list, justCreated]);
 
   const handleCreated = (agent: AgentView) => {
-    setJustCreated(agent);
-    setCreating(false);
+    markCreated(agent);
     setError(null);
   };
-
-  // With no agents to pick, open the create form by default — and keep it open
-  // through an out-of-band list change (another tab/CLI, the 5s poll) so
-  // in-progress input is never discarded. Seeded once, after the first load.
-  const seededCreate = useRef(false);
-  useEffect(() => {
-    if (seededCreate.current || agents.isLoading) return;
-    seededCreate.current = true;
-    if (list.length === 0) setCreating(true);
-  }, [agents.isLoading, list.length]);
 
   if (callbackError) {
     return <TerminalError copy={callbackErrorCopy(callbackError)} />;
@@ -79,13 +64,14 @@ export function TelegramBindView() {
   if (error?.terminal) {
     return <TerminalError copy={error} />;
   }
-  if (agents.isLoading) {
+  if (isLoading) {
     return (
       <Page title="Connect this chat to an agent">
         <ListSkeleton rows={3} />
       </Page>
     );
   }
+
   const pick = (agent: AgentView) => {
     setError(null);
     bind.mutate(
@@ -121,7 +107,7 @@ export function TelegramBindView() {
             <BindAgentRow
               key={agent.id}
               agent={agent}
-              highlighted={justCreated?.id === agent.id}
+              highlighted={agent.id === justCreatedId}
               disabled={bind.isPending}
               pending={bind.isPending && bind.variables?.agentId === agent.id}
               onPick={() => pick(agent)}
@@ -134,53 +120,13 @@ export function TelegramBindView() {
       ) : hasAgents ? (
         <button
           type="button"
-          onClick={() => setCreating(true)}
+          onClick={openCreateForm}
           className="self-start text-sm text-muted-foreground underline-offset-4 hover:text-foreground hover:underline"
         >
           + Create a new agent
         </button>
       ) : null}
     </Page>
-  );
-}
-
-function BindAgentRow({
-  agent,
-  highlighted,
-  disabled,
-  pending,
-  onPick,
-}: {
-  agent: AgentView;
-  highlighted: boolean;
-  disabled: boolean;
-  pending: boolean;
-  onPick: () => void;
-}) {
-  return (
-    <button
-      type="button"
-      disabled={disabled}
-      onClick={onPick}
-      className={cn(
-        "flex flex-col items-start gap-0.5 rounded-lg border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60",
-        highlighted ? "border-foreground" : "border-border",
-      )}
-    >
-      <span className="text-[14px] font-semibold text-foreground">
-        {pending ? `Connecting ${agent.name}…` : agent.name}
-      </span>
-      {agent.description && (
-        <span className="text-[12px] text-muted-foreground">
-          {agent.description}
-        </span>
-      )}
-      {agent.templateId && (
-        <span className="text-[11px] font-mono text-muted-foreground">
-          {agent.templateId}
-        </span>
-      )}
-    </button>
   );
 }
 


### PR DESCRIPTION
## Problem

Running `/<brand> bind` in Slack (or `/login` in Telegram) sends the user to a web picker to connect one of their agents to the conversation. If the user owned **no agents**, the picker was a dead end — it only told them to create one elsewhere and re-run the command. There was no way to create an agent as part of the flow.

## Change

Users can now create an agent directly on the bind picker, without leaving the page. Staying on-page matters: the bind `?flow=` id has a 10-minute, non-consuming TTL, so a round-trip to the full sandbox wizard would risk dropping it.

- **`CreateAgentInline`** — a shared, minimal create panel (`modules/agents/`) reusing the sandbox wizard's own building blocks: harness template select, `ProviderSection` (auto-selects the first connected provider), and `useCreateAgent`. The network preset is fixed to the trusted default so it fits one screen. A provider is required, since bound turns run under it.
- **Both bind views (Slack + Telegram)** — empty state opens the form by default; a populated picker gains a "＋ Create a new agent" toggle. A freshly created agent is bridged into the picker immediately (before the invalidated list query refetches) and highlighted; the user then picks it to connect (keeping "pick = connect" as the single binding action).

## Review-driven fixes

An adversarial review pass caught two issues, both fixed here:

- **Dead "Remove key" button (medium).** `ProviderSection`'s per-row menu routes Remove through a confirm dialog whose host (`DialogOverlay`) is only mounted inside the main app shell — the bind views render outside it. Added a `manageKeys` prop (default `true`, preserving every existing caller) and set it `false` on the bind page, hiding the key-management menu on a surface that only *picks* a provider. Connecting a new provider still works (self-portaling `Modal`).
- **Form input loss (low).** The empty-state form and the toggle-gated form were separate mount points; an out-of-band list change (another tab/CLI, the 5s poll) flipping 0→N would unmount the in-progress form and discard typed input. Unified each view to a single stable `CreateAgentInline` mount and seed the open state once after first load.

## Testing

- New pure-helper unit tests for `buildCreateAgentInput` / `isCreateAgentDraftComplete` (the provider→connection mapping and required-field gate).
- `tsc`, `eslint`, `prettier`, and the full UI unit suite (96 tests) pass.
- Not yet exercised against a live cluster — the Slack/Telegram bind pages need a real OAuth callback; suggested manual check: run `/<brand> bind` as a user with zero agents, create + connect from the picker.