### PR TITLE
test(e2e): smoke/full suite tiers + invocation egress full-suite spec

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,8 @@ mise run e2e:reset    # data wipe only: drop+recreate platform DB, delete agents
 
 `e2e:loop` runs on a dedicated persistent `platform-k3s-test` VM that it never deletes, so reruns skip VM/Istio/cert-manager/Keycloak provisioning. Running `mise run e2e` nukes that VM (shared name); the next `e2e:loop` bootstraps a fresh one. `e2e:loop` does not heal a wedged cluster — if the warm cluster is broken, it fails loud; use `mise run e2e` or `cluster:fix-certs`. Use `e2e:loop` for iteration, `e2e` after helm/realm/infra changes.
 
+**Extended suites** (`src/tests/extended/`): slow, scenario-heavy specs excluded from the main pipeline (`e2e` and plain `e2e:loop` never run them). Trigger manually with `mise run e2e:loop -- --extended` (runs ONLY the extended projects). Conventions: one `<area>-extended` Playwright project per area, specs self-contained (own agents/token, no main-chain fixtures), each spec references its motivating ticket in the test title.
+
 ### Cluster debugging (pre-approved in .claude/settings.json)
 
 Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` instead of raw `kubectl` or `export KUBECONFIG=...`. These are auto-approved.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@ mise run e2e:reset    # data wipe only: drop+recreate platform DB, delete agents
 
 `e2e:loop` runs on a dedicated persistent `platform-k3s-test` VM that it never deletes, so reruns skip VM/Istio/cert-manager/Keycloak provisioning. Running `mise run e2e` nukes that VM (shared name); the next `e2e:loop` bootstraps a fresh one. `e2e:loop` does not heal a wedged cluster — if the warm cluster is broken, it fails loud; use `mise run e2e` or `cluster:fix-certs`. Use `e2e:loop` for iteration, `e2e` after helm/realm/infra changes.
 
-**Extended suites** (`src/tests/extended/`): slow, scenario-heavy specs excluded from the main pipeline (`e2e` and plain `e2e:loop` never run them). Trigger manually with `mise run e2e:loop -- --extended` (runs ONLY the extended projects). Conventions: one `<area>-extended` Playwright project per area, specs self-contained (own agents/token, no main-chain fixtures), each spec references its motivating ticket in the test title.
+**Suite tiers.** **Smoke** (`src/tests/smoke/`) is the always-on tier — CI and plain `e2e` / `e2e:loop` run exactly it. **Full** = smoke plus the slow, scenario-heavy specs under `src/tests/full/`, run on demand only: `mise run e2e:loop -- --full` (or `mise run e2e -- --full` for the fresh-cluster path). Conventions for `src/tests/full/` specs: one `<area>-full` Playwright project per area, self-contained (own agents, own token via `getAccessToken` + `acceptTerms`, no smoke-chain fixtures), each spec references its motivating ticket in the test title.
 
 ### Cluster debugging (pre-approved in .claude/settings.json)
 

--- a/packages/api-server-api/src/modules/e2e/router.ts
+++ b/packages/api-server-api/src/modules/e2e/router.ts
@@ -5,6 +5,8 @@ import {
   e2eGetEnvInputSchema,
   e2ePerformFetchInputSchema,
   e2eSetScriptInputSchema,
+  e2eSpawnInvocationInputSchema,
+  spawnInvocationResultSchema,
   getEnvResultSchema,
   getReceivedPromptsResultSchema,
   performFetchResultSchema,
@@ -51,6 +53,15 @@ export const e2eRouter = t.router({
     .query(({ ctx, input }) => {
       gate(ctx);
       return ctx.e2e.getEnv(input.agentId, input.name);
+    }),
+
+  spawnInvocation: t.procedure
+    .input(e2eSpawnInvocationInputSchema)
+    .output(spawnInvocationResultSchema)
+    .mutation(({ ctx, input }) => {
+      gate(ctx);
+      const { agentId, ...rest } = input;
+      return ctx.e2e.spawnInvocation(agentId, rest);
     }),
 
   performFetch: t.procedure

--- a/packages/api-server-api/src/modules/e2e/schemas.ts
+++ b/packages/api-server-api/src/modules/e2e/schemas.ts
@@ -75,6 +75,22 @@ export const e2ePerformFetchInputSchema = z
   })
   .strict();
 
+export const e2eSpawnInvocationInputSchema = z
+  .object({
+    agentId: z.string().min(1),
+    prompt: z.string().min(1),
+    schema: z.record(z.string(), z.unknown()),
+    templateId: z.string().min(1).optional(),
+    image: z.string().min(1).optional(),
+    connections: z.array(z.string()).optional(),
+    ttlMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const spawnInvocationResultSchema = z
+  .object({ id: z.string().min(1) })
+  .strict();
+
 export const slackFireMentionInputSchema = z
   .object({
     user: z.string().min(1),

--- a/packages/api-server-api/src/modules/e2e/types.ts
+++ b/packages/api-server-api/src/modules/e2e/types.ts
@@ -1,6 +1,7 @@
 import type { z } from "zod";
 import type {
   e2ePerformFetchInputSchema,
+  e2eSpawnInvocationInputSchema,
   getEnvResultSchema,
   getReceivedPromptsResultSchema,
   performFetchResultSchema,
@@ -11,6 +12,7 @@ import type {
   slackFireMentionInputSchema,
   slackOutboundRecordSchema,
   slackReadOutboundResultSchema,
+  spawnInvocationResultSchema,
 } from "./schemas.js";
 
 export type SetScriptInput = z.infer<typeof setScriptInputSchema>;
@@ -24,6 +26,11 @@ export type PerformFetchInput = Omit<
   z.infer<typeof e2ePerformFetchInputSchema>,
   "agentId"
 >;
+export type SpawnInvocationInput = Omit<
+  z.infer<typeof e2eSpawnInvocationInputSchema>,
+  "agentId"
+>;
+export type SpawnInvocationResult = z.infer<typeof spawnInvocationResultSchema>;
 
 export type SlackFireMentionInput = z.infer<typeof slackFireMentionInputSchema>;
 /** Same wire shape as a mention — only the trigger differs (ambient mode). */
@@ -46,6 +53,12 @@ export interface E2eService {
     agentId: string,
     input: PerformFetchInput,
   ): Promise<PerformFetchResult>;
+  /** Make the mock agent spawn an Invocation as the driver, through the same
+   *  harness POST the driver SDK uses. Returns the target agent id. */
+  spawnInvocation(
+    agentId: string,
+    input: SpawnInvocationInput,
+  ): Promise<SpawnInvocationResult>;
   slackFireMention(input: SlackFireMentionInput): Promise<ResetResult>;
   slackFireMessage(input: SlackFireMessageInput): Promise<ResetResult>;
   slackFireCommand(

--- a/packages/api-server/src/modules/e2e/services/e2e-service.ts
+++ b/packages/api-server/src/modules/e2e/services/e2e-service.ts
@@ -62,6 +62,8 @@ export function createE2eService(deps: {
       withClient(agentId, (c) => c.scriptedMock.getEnv.query({ name })),
     performFetch: (agentId, input) =>
       withClient(agentId, (c) => c.scriptedMock.performFetch.mutate(input)),
+    spawnInvocation: (agentId, input) =>
+      withClient(agentId, (c) => c.scriptedMock.spawnInvocation.mutate(input)),
     slackFireMention: async (input) => {
       await requireSlack().fireMention(input);
       return { ok: true };

--- a/packages/e2e/agents/mock-api/src/index.ts
+++ b/packages/e2e/agents/mock-api/src/index.ts
@@ -12,6 +12,8 @@ export {
   scriptEntrySchema,
   scriptFileSchema,
   setScriptInputSchema,
+  spawnInvocationInputSchema,
+  spawnInvocationResultSchema,
 } from "./modules/scripted-mock/schemas.js";
 export type {
   GetEnvInput,
@@ -25,4 +27,6 @@ export type {
   ScriptedMockService,
   ScriptFile,
   SetScriptInput,
+  SpawnInvocationInput,
+  SpawnInvocationResult,
 } from "./modules/scripted-mock/types.js";

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/router.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/router.ts
@@ -7,6 +7,8 @@ import {
   performFetchResultSchema,
   resetResultSchema,
   setScriptInputSchema,
+  spawnInvocationInputSchema,
+  spawnInvocationResultSchema,
 } from "./schemas.js";
 
 export const scriptedMockRouter = t.router({
@@ -32,4 +34,9 @@ export const scriptedMockRouter = t.router({
     .input(performFetchInputSchema)
     .output(performFetchResultSchema)
     .mutation(({ ctx, input }) => ctx.scriptedMock.performFetch(input)),
+
+  spawnInvocation: t.procedure
+    .input(spawnInvocationInputSchema)
+    .output(spawnInvocationResultSchema)
+    .mutation(({ ctx, input }) => ctx.scriptedMock.spawnInvocation(input)),
 });

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/schemas.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/schemas.ts
@@ -57,3 +57,18 @@ export const performFetchResultSchema = z
     body: z.string(),
   })
   .strict();
+
+export const spawnInvocationInputSchema = z
+  .object({
+    prompt: z.string().min(1),
+    schema: z.record(z.string(), z.unknown()),
+    templateId: z.string().min(1).optional(),
+    image: z.string().min(1).optional(),
+    connections: z.array(z.string()).optional(),
+    ttlMs: z.number().int().positive().optional(),
+  })
+  .strict();
+
+export const spawnInvocationResultSchema = z
+  .object({ id: z.string().min(1) })
+  .strict();

--- a/packages/e2e/agents/mock-api/src/modules/scripted-mock/types.ts
+++ b/packages/e2e/agents/mock-api/src/modules/scripted-mock/types.ts
@@ -10,6 +10,8 @@ import type {
   scriptEntrySchema,
   scriptFileSchema,
   setScriptInputSchema,
+  spawnInvocationInputSchema,
+  spawnInvocationResultSchema,
 } from "./schemas.js";
 
 export type ScriptEntry = z.infer<typeof scriptEntrySchema>;
@@ -24,6 +26,8 @@ export type GetEnvInput = z.infer<typeof getEnvInputSchema>;
 export type GetEnvResult = z.infer<typeof getEnvResultSchema>;
 export type PerformFetchInput = z.infer<typeof performFetchInputSchema>;
 export type PerformFetchResult = z.infer<typeof performFetchResultSchema>;
+export type SpawnInvocationInput = z.infer<typeof spawnInvocationInputSchema>;
+export type SpawnInvocationResult = z.infer<typeof spawnInvocationResultSchema>;
 
 export interface ScriptedMockService {
   setScript(input: SetScriptInput): ResetResult;
@@ -31,4 +35,7 @@ export interface ScriptedMockService {
   reset(): ResetResult;
   getEnv(input: GetEnvInput): GetEnvResult;
   performFetch(input: PerformFetchInput): Promise<PerformFetchResult>;
+  /** Spawn an Invocation as this agent (the driver) via the harness surface —
+   *  the same POST the driver SDK makes from a real agent pod. */
+  spawnInvocation(input: SpawnInvocationInput): Promise<SpawnInvocationResult>;
 }

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/compose.ts
@@ -4,6 +4,7 @@ import { createScriptedMockService } from "./services/control-service.js";
 import { startAcpService } from "./services/acp-service.js";
 import { createTrpcDispatch } from "./services/trpc-dispatch.js";
 import type { AcpChannel } from "./services/ports.js";
+import { createHarnessSpawn } from "./infrastructure/harness-spawn.js";
 import { createProxyFetch } from "./infrastructure/proxy-fetch.js";
 import { createSlackReplyPoster } from "./infrastructure/slack-reply.js";
 import { createStdioChannel } from "./infrastructure/stdio-channel.js";
@@ -19,6 +20,7 @@ export function composeScriptedMock(): ScriptedMockComposition {
   const scriptedMock = createScriptedMockService({
     state,
     proxyFetch,
+    harnessSpawn: createHarnessSpawn(),
   });
   const stdio = createStdioChannel();
 

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/infrastructure/harness-spawn.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/infrastructure/harness-spawn.ts
@@ -1,0 +1,35 @@
+import type {
+  SpawnInvocationInput,
+  SpawnInvocationResult,
+} from "mock-agent-api";
+import type { HarnessSpawn } from "../services/ports.js";
+
+const TIMEOUT_MS = 30_000;
+
+/** Spawns an Invocation through the harness surface, exactly like the driver
+ *  SDK does from a real agent pod: PLATFORM_MCP_URL encodes the harness base
+ *  and this agent's own id, and the mesh proves identity — no token. */
+export function createHarnessSpawn(): HarnessSpawn {
+  return async (
+    input: SpawnInvocationInput,
+  ): Promise<SpawnInvocationResult> => {
+    const mcpUrl = process.env.PLATFORM_MCP_URL;
+    if (!mcpUrl) throw new Error("PLATFORM_MCP_URL is not set");
+    const u = new URL(mcpUrl);
+    const m = u.pathname.match(/^\/api\/agents\/([^/]+)\/mcp$/);
+    if (!m) throw new Error(`unexpected PLATFORM_MCP_URL shape: ${mcpUrl}`);
+
+    const res = await fetch(
+      `${u.protocol}//${u.host}/api/agents/${m[1]}/invocations`,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(input),
+        signal: AbortSignal.timeout(TIMEOUT_MS),
+      },
+    );
+    const text = await res.text();
+    if (!res.ok) throw new Error(`spawn -> ${res.status}: ${text}`);
+    return { id: (JSON.parse(text) as { id: string }).id };
+  };
+}

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/control-service.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/control-service.ts
@@ -7,8 +7,10 @@ import type {
   ReceivedPrompt,
   ScriptedMockService,
   SetScriptInput,
+  SpawnInvocationInput,
 } from "mock-agent-api";
 import type { MockState } from "../domain/state.js";
+import type { HarnessSpawn } from "./ports.js";
 
 export type ProxyFetch = (
   input: PerformFetchInput,
@@ -17,12 +19,13 @@ export type ProxyFetch = (
 export interface ScriptedMockDeps {
   state: MockState;
   proxyFetch: ProxyFetch;
+  harnessSpawn: HarnessSpawn;
 }
 
 export function createScriptedMockService(
   deps: ScriptedMockDeps,
 ): ScriptedMockService {
-  const { state, proxyFetch } = deps;
+  const { state, proxyFetch, harnessSpawn } = deps;
   return {
     setScript(input: SetScriptInput) {
       state.scriptEntries = input.entries;
@@ -45,6 +48,9 @@ export function createScriptedMockService(
     },
     performFetch(input: PerformFetchInput): Promise<PerformFetchResult> {
       return proxyFetch(input);
+    },
+    spawnInvocation(input: SpawnInvocationInput) {
+      return harnessSpawn(input);
     },
   };
 }

--- a/packages/e2e/agents/mock/src/modules/scripted-mock/services/ports.ts
+++ b/packages/e2e/agents/mock/src/modules/scripted-mock/services/ports.ts
@@ -1,3 +1,7 @@
+import type {
+  SpawnInvocationInput,
+  SpawnInvocationResult,
+} from "mock-agent-api";
 import type { JsonRpcFrame } from "../domain/frames.js";
 
 export interface AcpChannel {
@@ -14,4 +18,9 @@ export interface WorkspaceWriter {
  *  Slack. Best-effort: failures are logged, never thrown. */
 export interface SlackReplyPoster {
   (args: { text: string; threadTs?: string }): Promise<void>;
+}
+
+/** Spawns an Invocation via the harness surface, as this agent (the driver). */
+export interface HarnessSpawn {
+  (input: SpawnInvocationInput): Promise<SpawnInvocationResult>;
 }

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -8,9 +8,10 @@ const storageState = "./.auth/user.json";
 // are NOT part of the main pipeline (`mise run e2e` / e2e:loop). They only
 // enter the project list behind this env gate and run via
 // `mise run e2e:loop -- --extended`. Conventions: one "<area>-extended"
-// project per area, specs are self-contained (own agents, own token, no
-// storageState, no dependency on the main chain's fixtures), and each spec
-// references its motivating ticket in the test title.
+// project per area, specs are self-contained (own agents, own token via
+// getAccessToken + acceptTerms — the terms gate 412s everything else on a
+// fresh DB — no storageState, no dependency on the main chain's fixtures),
+// and each spec references its motivating ticket in the test title.
 const extended = process.env.E2E_EXTENDED === "1";
 
 export default defineConfig({

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -4,15 +4,18 @@ const baseURL = process.env.PLATFORM_BASE_URL ?? "http://localhost:4444";
 
 const storageState = "./.auth/user.json";
 
-// Extended suites: slow, scenario-heavy specs under src/tests/extended/ that
-// are NOT part of the main pipeline (`mise run e2e` / e2e:loop). They only
-// enter the project list behind this env gate and run via
-// `mise run e2e:loop -- --extended`. Conventions: one "<area>-extended"
-// project per area, specs are self-contained (own agents, own token via
-// getAccessToken + acceptTerms — the terms gate 412s everything else on a
-// fresh DB — no storageState, no dependency on the main chain's fixtures),
-// and each spec references its motivating ticket in the test title.
-const extended = process.env.E2E_EXTENDED === "1";
+// Two suite tiers:
+// - smoke (src/tests/smoke/): the always-on pipeline — CI and plain
+//   `mise run e2e` / e2e:loop run exactly these.
+// - full (= smoke + src/tests/full/): on demand via
+//   `mise run e2e:loop -- --full`. src/tests/full/ holds the slow,
+//   scenario-heavy specs only the full suite runs; their projects enter the
+//   list behind this env gate. Conventions: one "<area>-full" project per
+//   area, specs self-contained (own agents, own token via getAccessToken +
+//   acceptTerms — the terms gate 412s everything else on a fresh DB — no
+//   storageState, no dependency on the smoke chain's fixtures), and each
+//   spec references its motivating ticket in the test title.
+const full = process.env.E2E_FULL === "1";
 
 export default defineConfig({
   testDir: "./src/tests",
@@ -142,13 +145,13 @@ export default defineConfig({
       dependencies: ["egress-path-rules"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
-    ...(extended
+    ...(full
       ? [
           {
             // Invocation lifecycles: spawn + gateway-level egress assertions,
-            // several agent boots per spec — minutes each, hence extended.
-            name: "invocations-extended",
-            testMatch: /extended\/invocation-.*\.spec\.ts$/,
+            // several agent boots per spec — minutes each, hence full-only.
+            name: "invocations-full",
+            testMatch: /full\/invocation-.*\.spec\.ts$/,
             use: { ...devices["Desktop Chrome"] },
           },
         ]

--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -4,6 +4,15 @@ const baseURL = process.env.PLATFORM_BASE_URL ?? "http://localhost:4444";
 
 const storageState = "./.auth/user.json";
 
+// Extended suites: slow, scenario-heavy specs under src/tests/extended/ that
+// are NOT part of the main pipeline (`mise run e2e` / e2e:loop). They only
+// enter the project list behind this env gate and run via
+// `mise run e2e:loop -- --extended`. Conventions: one "<area>-extended"
+// project per area, specs are self-contained (own agents, own token, no
+// storageState, no dependency on the main chain's fixtures), and each spec
+// references its motivating ticket in the test title.
+const extended = process.env.E2E_EXTENDED === "1";
+
 export default defineConfig({
   testDir: "./src/tests",
   fullyParallel: false,
@@ -132,5 +141,16 @@ export default defineConfig({
       dependencies: ["egress-path-rules"],
       use: { ...devices["Desktop Chrome"], storageState },
     },
+    ...(extended
+      ? [
+          {
+            // Invocation lifecycles: spawn + gateway-level egress assertions,
+            // several agent boots per spec — minutes each, hence extended.
+            name: "invocations-extended",
+            testMatch: /extended\/invocation-.*\.spec\.ts$/,
+            use: { ...devices["Desktop Chrome"] },
+          },
+        ]
+      : []),
   ],
 });

--- a/packages/e2e/playwright/src/lib/auth.ts
+++ b/packages/e2e/playwright/src/lib/auth.ts
@@ -38,7 +38,7 @@ export async function getAccessToken(
 /** Accept the current Terms of Use for the client's user. The terms gate
  *  412s every non-terms API call until the user accepts, and only the UI
  *  login flow (01-auth) does it implicitly — self-contained API specs
- *  (extended suites) must call this before anything else. */
+ *  (the full-suite tier) must call this before anything else. */
 export async function acceptTerms(api: ApiClient): Promise<void> {
   const current = await api.terms.current.query();
   await api.terms.accept.mutate({ version: current.version });

--- a/packages/e2e/playwright/src/lib/auth.ts
+++ b/packages/e2e/playwright/src/lib/auth.ts
@@ -4,6 +4,7 @@ import {
   keycloakUrl,
   testUser,
 } from "../config.js";
+import type { ApiClient } from "./api-client.js";
 
 interface TokenResponse {
   access_token: string;
@@ -32,4 +33,13 @@ export async function getAccessToken(
   }
   const data = (await res.json()) as TokenResponse;
   return data.access_token;
+}
+
+/** Accept the current Terms of Use for the client's user. The terms gate
+ *  412s every non-terms API call until the user accepts, and only the UI
+ *  login flow (01-auth) does it implicitly — self-contained API specs
+ *  (extended suites) must call this before anything else. */
+export async function acceptTerms(api: ApiClient): Promise<void> {
+  const current = await api.terms.current.query();
+  await api.terms.accept.mutate({ version: current.version });
 }

--- a/packages/e2e/playwright/src/tests/12-invocation-egress.spec.ts
+++ b/packages/e2e/playwright/src/tests/12-invocation-egress.spec.ts
@@ -1,0 +1,129 @@
+import { expect, test } from "@playwright/test";
+
+import { createApiClient, type ApiClient } from "../lib/api-client.js";
+import { getAccessToken } from "../lib/auth.js";
+import { harnessName } from "../lib/fixtures.js";
+
+// Egress Aliasing (#2930): an Invocation target has no egress identity of its
+// own — every request it makes is decided by the driver's live rules. Before
+// the fix a target always started on the default trusted preset, so a
+// zero-egress driver spawned a WIDER child (silent escalation) and this
+// spec's first assertion fails.
+//
+// postman-echo.com is a public echo service (same external-dependency class
+// as 11-egress-path-rules) with no connection — the driver's rules are the
+// only thing standing between the target and the internet.
+const host = "postman-echo.com";
+const url = `https://${host}/status/204`;
+const driverName = "e2e-egress-driver";
+
+/** Fetch from inside the agent pod through its gateway; 0 = blocked (the
+ *  gateway held or denied, the mock's client-side fetch gave up). */
+async function fetchStatus(
+  api: ApiClient,
+  agentId: string,
+  target: string,
+): Promise<number> {
+  try {
+    const { status } = await api.e2e.performFetch.mutate({
+      agentId,
+      url: target,
+    });
+    return status;
+  } catch {
+    return 0;
+  }
+}
+
+async function waitRunning(api: ApiClient, agentId: string): Promise<void> {
+  await expect
+    .poll(async () => (await api.agents.get.query({ id: agentId })).state, {
+      timeout: 180_000,
+      intervals: [2_000],
+      message: `agent ${agentId} did not reach running state`,
+    })
+    .toBe("running");
+}
+
+test("invocation egress follows the driver", async () => {
+  test.setTimeout(600_000);
+
+  const token = await getAccessToken();
+  const api = createApiClient(token);
+
+  let driverId = "";
+  await test.step("create a zero-egress driver", async () => {
+    const created = await api.agents.create.mutate({
+      name: driverName,
+      templateId: harnessName,
+      egressPreset: "none",
+    });
+    driverId = created.id;
+    await waitRunning(api, driverId);
+  });
+
+  let targetId = "";
+  await test.step("spawn an invocation target from the driver", async () => {
+    // The mock agent makes the same harness POST the driver SDK does from a
+    // real pod. Long ttl so the liveness sweep can't reap the target mid-test.
+    const { id } = await api.e2e.spawnInvocation.mutate({
+      agentId: driverId,
+      templateId: harnessName,
+      prompt: "e2e invocation target; stay idle",
+      schema: { type: "object" },
+      ttlMs: 30 * 60_000,
+    });
+    targetId = id;
+    await waitRunning(api, targetId);
+  });
+
+  await test.step("the target inherits the driver's zero egress", async () => {
+    // Before Egress Aliasing the target ran on the trusted preset and this
+    // returned 204 even though the driver allows nothing.
+    expect(await fetchStatus(api, targetId, url)).not.toBe(204);
+  });
+
+  await test.step("allowing the host on the driver unlocks the running target", async () => {
+    // Host-wide rule: enforced on the SNI-only L4 path too, so no gateway
+    // roll is involved — the next request from the target must pass. The
+    // rule is written on the DRIVER; the target is never touched.
+    await api.egressRules.create.mutate({
+      agentId: driverId,
+      host,
+      method: "*",
+      pathPattern: "*",
+      verdict: "allow",
+    });
+    await expect
+      .poll(() => fetchStatus(api, targetId, url), {
+        timeout: 120_000,
+        intervals: [3_000],
+        message: "driver-side allow did not apply to the running target",
+      })
+      .toBe(204);
+  });
+
+  await test.step("the target holds no rule of its own for the host", async () => {
+    const rules = await api.egressRules.listForAgent.query({
+      agentId: targetId,
+    });
+    expect(rules.filter((r) => r.host === host)).toEqual([]);
+  });
+
+  await test.step("deleting the driver cascades to the target", async () => {
+    await api.agents.delete.mutate({ id: driverId });
+    await expect
+      .poll(
+        async () => {
+          const list = await api.agents.list.query();
+          return list.some((a) => a.id === targetId || a.id === driverId);
+        },
+        {
+          timeout: 60_000,
+          intervals: [2_000],
+          message: "driver delete did not reap the invocation target",
+        },
+      )
+      .toBe(false);
+  });
+});

--- a/packages/e2e/playwright/src/tests/extended/invocation-egress.spec.ts
+++ b/packages/e2e/playwright/src/tests/extended/invocation-egress.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 import { createApiClient, type ApiClient } from "../../lib/api-client.js";
-import { getAccessToken } from "../../lib/auth.js";
+import { acceptTerms, getAccessToken } from "../../lib/auth.js";
 import { harnessName } from "../../lib/fixtures.js";
 
 // Extended suite (see playwright.config.ts): not part of the main pipeline —
@@ -53,6 +53,9 @@ test("invocation egress follows the driver (#2930)", async () => {
 
   const token = await getAccessToken();
   const api = createApiClient(token);
+  // Fresh DB: the terms gate 412s every non-terms call until accepted (the
+  // main chain does this via the 01-auth UI login).
+  await acceptTerms(api);
 
   let driverId = "";
   await test.step("create a zero-egress driver", async () => {

--- a/packages/e2e/playwright/src/tests/extended/invocation-egress.spec.ts
+++ b/packages/e2e/playwright/src/tests/extended/invocation-egress.spec.ts
@@ -1,9 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-import { createApiClient, type ApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { harnessName } from "../lib/fixtures.js";
+import { createApiClient, type ApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { harnessName } from "../../lib/fixtures.js";
 
+// Extended suite (see playwright.config.ts): not part of the main pipeline —
+// run manually with `mise run e2e:loop -- --extended`.
+//
 // Egress Aliasing (#2930): an Invocation target has no egress identity of its
 // own — every request it makes is decided by the driver's live rules. Before
 // the fix a target always started on the default trusted preset, so a
@@ -45,7 +48,7 @@ async function waitRunning(api: ApiClient, agentId: string): Promise<void> {
     .toBe("running");
 }
 
-test("invocation egress follows the driver", async () => {
+test("invocation egress follows the driver (#2930)", async () => {
   test.setTimeout(600_000);
 
   const token = await getAccessToken();

--- a/packages/e2e/playwright/src/tests/full/invocation-egress.spec.ts
+++ b/packages/e2e/playwright/src/tests/full/invocation-egress.spec.ts
@@ -4,8 +4,8 @@ import { createApiClient, type ApiClient } from "../../lib/api-client.js";
 import { acceptTerms, getAccessToken } from "../../lib/auth.js";
 import { harnessName } from "../../lib/fixtures.js";
 
-// Extended suite (see playwright.config.ts): not part of the main pipeline —
-// run manually with `mise run e2e:loop -- --extended`.
+// Full-suite-only spec (see playwright.config.ts): not part of the smoke
+// pipeline — run on demand with `mise run e2e:loop -- --full`.
 //
 // Egress Aliasing (#2930): an Invocation target has no egress identity of its
 // own — every request it makes is decided by the driver's live rules. Before

--- a/packages/e2e/playwright/src/tests/smoke/01-auth.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/01-auth.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl, testUser } from "../config.js";
+import { baseUrl, testUser } from "../../config.js";
 
 const storageStatePath = "./.auth/user.json";
 

--- a/packages/e2e/playwright/src/tests/smoke/02-connection.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/02-connection.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { createCustomHeaderConnection } from "../lib/connections.js";
+import { baseUrl } from "../../config.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { createCustomHeaderConnection } from "../../lib/connections.js";
 import {
   connectionHost,
   connectionName,
@@ -11,7 +11,7 @@ import {
   headerName,
   sentinel,
   valueFormat,
-} from "../lib/fixtures.js";
+} from "../../lib/fixtures.js";
 
 test("create a custom-header connection", async ({ page }) => {
   const token = await getAccessToken();

--- a/packages/e2e/playwright/src/tests/smoke/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/03-agent.spec.ts
@@ -1,11 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { getConnectionId } from "../lib/connections.js";
-import { agentName, connectionName, harnessName } from "../lib/fixtures.js";
+import { baseUrl } from "../../config.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { getConnectionId } from "../../lib/connections.js";
+import { agentName, connectionName, harnessName } from "../../lib/fixtures.js";
 
 test("create a mock agent with the connection attached", async ({ page }) => {
   test.setTimeout(60_000);

--- a/packages/e2e/playwright/src/tests/smoke/04-messages.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/04-messages.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
+import { baseUrl } from "../../config.js";
 import {
   agentCardStatus,
   chatInput,
@@ -10,10 +10,10 @@ import {
   setMockAgentReply,
   setMockReplyWithMidTurnUserPrompt,
   waitForAgentRunning,
-} from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+} from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 const scriptedReply = "scripted-reply-from-e2e";
 const userPrompt = "hello-from-playwright";

--- a/packages/e2e/playwright/src/tests/smoke/05-injection.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/05-injection.spec.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
 import {
   agentName,
   echoUrl,
   envName,
   placeholder,
   sentinel,
-} from "../lib/fixtures.js";
+} from "../../lib/fixtures.js";
 
 test("connection injects the credential (env placeholder + egress after Envoy)", async () => {
   test.setTimeout(420_000);

--- a/packages/e2e/playwright/src/tests/smoke/06-api-keys.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/06-api-keys.spec.ts
@@ -2,9 +2,9 @@ import { expect, test } from "@playwright/test";
 import { TRPCClientError } from "@trpc/client";
 import type { AppRouter, Scope } from "api-server-api";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient, type ApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient, type ApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
 
 /**
  * End-to-end authorization for API keys, against the real api-server + Keycloak

--- a/packages/e2e/playwright/src/tests/smoke/07-slack.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/07-slack.spec.ts
@@ -1,10 +1,10 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl, testUser2 } from "../config.js";
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { ensureCustomHeaderConnection } from "../lib/connections.js";
+import { baseUrl, testUser2 } from "../../config.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { ensureCustomHeaderConnection } from "../../lib/connections.js";
 import {
   agentName,
   connectionHost,
@@ -14,7 +14,7 @@ import {
   foreignSentinel,
   headerName,
   valueFormat,
-} from "../lib/fixtures.js";
+} from "../../lib/fixtures.js";
 
 const slackChannelId = "C-E2E-TRACER";
 const foreignSlackTeamId = "T-E2E";

--- a/packages/e2e/playwright/src/tests/smoke/08-session-delete.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/08-session-delete.spec.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
+import { baseUrl } from "../../config.js";
 import {
   agentCardStatus,
   chatInput,
@@ -8,10 +8,10 @@ import {
   sendMessageToAgent,
   setMockAgentReply,
   waitForAgentRunning,
-} from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+} from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 const scriptedReply = "scripted-reply-for-delete-spec";
 const firstPrompt = "hello-before-delete";

--- a/packages/e2e/playwright/src/tests/smoke/08-slack-shared.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/08-slack-shared.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName, echoUrl, sentinel } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName, echoUrl, sentinel } from "../../lib/fixtures.js";
 
 // Mode is fixed per binding, so shared coverage gets its own
 // channel; rebinding replaces the agent's single Slack binding from 07.

--- a/packages/e2e/playwright/src/tests/smoke/09-slack-inchat-bind.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/09-slack-inchat-bind.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 // This spec exercises the in-chat bind/unbind slash commands at the command
 // level (deterministic, no OAuth round-trip). It replaces the agent's single

--- a/packages/e2e/playwright/src/tests/smoke/09-user-env.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/09-user-env.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient, type ApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName, envName, placeholder } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient, type ApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName, envName, placeholder } from "../../lib/fixtures.js";
 
 const userEnvName = "E2E_USER_ENV";
 const userEnvValue = "user-value-9d2f";

--- a/packages/e2e/playwright/src/tests/smoke/10-connection-regrant.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/10-connection-regrant.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-import { baseUrl } from "../config.js";
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
+import { baseUrl } from "../../config.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
 import {
   ensureCustomHeaderConnection,
   getConnectionId,
-} from "../lib/connections.js";
-import { agentName, valueFormat } from "../lib/fixtures.js";
+} from "../../lib/connections.js";
+import { agentName, valueFormat } from "../../lib/fixtures.js";
 
 const originalName = "e2e-regrant-original";
 const recreatedName = "e2e-regrant-recreated";

--- a/packages/e2e/playwright/src/tests/smoke/10-slack-ambient.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/10-slack-ambient.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 // 09 leaves the channel unbound; this spec establishes its own binding
 // (rebinding would replace the agent's single Slack binding either way).

--- a/packages/e2e/playwright/src/tests/smoke/11-egress-path-rules.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/11-egress-path-rules.spec.ts
@@ -1,9 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-import { waitForAgentRunning } from "../lib/agents.js";
-import { createApiClient } from "../lib/api-client.js";
-import { getAccessToken } from "../lib/auth.js";
-import { agentName } from "../lib/fixtures.js";
+import { waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { getAccessToken } from "../../lib/auth.js";
+import { agentName } from "../../lib/fixtures.js";
 
 // Path-scoped egress rules over HTTPS on a host the platform holds no
 // credential for (#2322). The rule must promote the host onto the gateway's

--- a/packages/e2e/playwright/tasks.toml
+++ b/packages/e2e/playwright/tasks.toml
@@ -13,15 +13,16 @@ fi
 '''
 
 ["e2e-playwright:run"]
+description = "Run the smoke suite (src/tests/smoke/) — the always-on pipeline tier"
 dir = "{{config_root}}/packages/e2e/playwright"
 depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
 run = "pnpm exec playwright test"
 
-["e2e-playwright:run-extended"]
-description = "Run ONLY the extended suites (slow, manually-triggered specs under src/tests/extended/)"
+["e2e-playwright:run-full"]
+description = "Run the FULL suite: smoke plus the slow on-demand specs under src/tests/full/"
 dir = "{{config_root}}/packages/e2e/playwright"
 depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
-run = "E2E_EXTENDED=1 pnpm exec playwright test --project '*-extended'"
+run = "E2E_FULL=1 pnpm exec playwright test"
 
 ["e2e-playwright:run-headed"]
 description = "Run Playwright with a visible browser window"

--- a/packages/e2e/playwright/tasks.toml
+++ b/packages/e2e/playwright/tasks.toml
@@ -17,6 +17,12 @@ dir = "{{config_root}}/packages/e2e/playwright"
 depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
 run = "pnpm exec playwright test"
 
+["e2e-playwright:run-extended"]
+description = "Run ONLY the extended suites (slow, manually-triggered specs under src/tests/extended/)"
+dir = "{{config_root}}/packages/e2e/playwright"
+depends = ["common:setup:pnpm", "e2e-playwright:install-browsers"]
+run = "E2E_EXTENDED=1 pnpm exec playwright test --project '*-extended'"
+
 ["e2e-playwright:run-headed"]
 description = "Run Playwright with a visible browser window"
 dir = "{{config_root}}/packages/e2e/playwright"

--- a/tasks.toml
+++ b/tasks.toml
@@ -16,7 +16,7 @@ depends = ["*:scan"]
 depends = ["*:test"]
 
 ["e2e"]
-description = "Run Playwright e2e: spin up fresh test cluster, run specs, tear down. Options: --headed"
+description = "Run Playwright e2e: spin up fresh test cluster, run the smoke suite, tear down. Options: --headed --full"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -27,6 +27,7 @@ PLAYWRIGHT_TASK="e2e-playwright:run"
 for arg in "$@"; do
   case "$arg" in
     --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
+    --full) PLAYWRIGHT_TASK="e2e-playwright:run-full" ;;
   esac
 done
 
@@ -221,7 +222,7 @@ echo "e2e data reset complete."
 '''
 
 ["e2e:loop"]
-description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run specs. Options: --headed --extended --rebuild=apiserver,ui,controller,keycloak,mock-agent"
+description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run the smoke suite. Options: --headed --full --rebuild=apiserver,ui,controller,keycloak,mock-agent"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -242,9 +243,9 @@ REBUILD_SET=false
 for arg in "$@"; do
   case "$arg" in
     --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
-    # Extended suites only (src/tests/extended/) — slow specs kept out of the
-    # main pipeline; this flag is the manual trigger.
-    --extended) PLAYWRIGHT_TASK="e2e-playwright:run-extended" ;;
+    # Full suite: smoke plus the slow on-demand specs under src/tests/full/.
+    # The pipeline default is smoke only; this flag is the manual trigger.
+    --full) PLAYWRIGHT_TASK="e2e-playwright:run-full" ;;
     --rebuild=*) REBUILD="${arg#--rebuild=}"; REBUILD_SET=true ;;
   esac
 done

--- a/tasks.toml
+++ b/tasks.toml
@@ -221,7 +221,7 @@ echo "e2e data reset complete."
 '''
 
 ["e2e:loop"]
-description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run specs. Options: --headed --rebuild=apiserver,ui,controller,keycloak,mock-agent"
+description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run specs. Options: --headed --extended --rebuild=apiserver,ui,controller,keycloak,mock-agent"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -242,6 +242,9 @@ REBUILD_SET=false
 for arg in "$@"; do
   case "$arg" in
     --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
+    # Extended suites only (src/tests/extended/) — slow specs kept out of the
+    # main pipeline; this flag is the manual trigger.
+    --extended) PLAYWRIGHT_TASK="e2e-playwright:run-extended" ;;
     --rebuild=*) REBUILD="${arg#--rebuild=}"; REBUILD_SET=true ;;
   esac
 done


### PR DESCRIPTION
Stacked on #2933 (merges into `feat/invocation-egress-aliasing`). E2E coverage for #2930.

## Suite tiers

- **smoke** (`src/tests/smoke/`): the always-on tier. CI (`mise run e2e`) and plain `e2e:loop` run exactly these — behavior unchanged, the 01-11 chain just moved into the directory.
- **full** = smoke + the slow, scenario-heavy specs under `src/tests/full/`. On demand only:

  ```sh
  mise run e2e:loop -- --full [--rebuild=...]   # warm cluster
  mise run e2e -- --full                        # fresh-cluster path
  ```

  Full-only projects enter the Playwright config behind an `E2E_FULL` gate, so the default run structurally cannot pick them up. Conventions (config comment + CLAUDE.md): one `<area>-full` project per area, self-contained specs (own agents, own token via `getAccessToken` + `acceptTerms` — the terms gate 412s everything else on a fresh DB), ticket referenced in the test title.

## Spawn plumbing

`spawnInvocation` control op on the mock agent — the same harness POST the driver SDK makes from a real pod (`PLATFORM_MCP_URL` → `POST /api/agents/<id>/invocations`, mesh-authenticated) — threaded through mock-agent-api, the api-server e2e service, and the gated e2e tRPC router.

## Spec: `full/invocation-egress.spec.ts` (project `invocations-full`)

Verified green on the warm test cluster (31.8s):

1. Create a driver agent with the `none` egress preset.
2. Spawn an invocation target from it (real spawn path, mock template).
3. Target's fetch through its gateway is blocked — before Egress Aliasing the target ran on the trusted preset and this passed.
4. Host-wide allow rule written on the driver only; the same fetch from the running target turns 204 — live link, zero target-side config.
5. Target holds no egress rule of its own.
6. Deleting the driver reaps the target — Driver Cascade end to end.

https://claude.ai/code/session_01BhrWyfHztr64zk1x9HwB1u