### PR TITLE
fix(cli): reset terminal modes when a chat session disconnects

### DIFF
--- a/packages/cli/src/__tests__/terminal-bridge.test.ts
+++ b/packages/cli/src/__tests__/terminal-bridge.test.ts
@@ -1,0 +1,102 @@
+import { PassThrough } from "node:stream";
+import { encodeDataFrame, encodeExit, OP_OUTPUT } from "api-server-api";
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer } from "ws";
+
+import {
+  connectTerminalBridge,
+  TERMINAL_MODE_RESET,
+} from "../modules/chat/infrastructure/terminal-bridge.js";
+
+type FakeStdin = NodeJS.ReadStream & { setRawMode?(mode: boolean): void };
+type FakeStdout = NodeJS.WriteStream & { captured(): string };
+
+function fakeStdin(): FakeStdin {
+  return Object.assign(new PassThrough(), {
+    setRawMode: () => {},
+  }) as unknown as FakeStdin;
+}
+
+function fakeStdout(): FakeStdout {
+  const chunks: Buffer[] = [];
+  const stream = new PassThrough() as unknown as FakeStdout;
+  stream.columns = 80;
+  stream.rows = 24;
+  stream.on("data", (chunk: Buffer) => chunks.push(chunk));
+  stream.captured = () => Buffer.concat(chunks).toString("utf8");
+  return stream;
+}
+
+describe("connectTerminalBridge", () => {
+  let wss: WebSocketServer | undefined;
+
+  afterEach(() => {
+    wss?.close();
+    wss = undefined;
+  });
+
+  function listen(onConnection: (ws: import("ws").WebSocket) => void): string {
+    wss = new WebSocketServer({ port: 0 });
+    wss.on("connection", onConnection);
+    const { port } = wss.address() as { port: number };
+    return `http://127.0.0.1:${port}`;
+  }
+
+  it("resets terminal modes after an abrupt disconnect", async () => {
+    const host = listen((ws) => {
+      // Enable mouse tracking like a remote TUI would, then drop the
+      // connection without restoring anything.
+      ws.send(encodeDataFrame(OP_OUTPUT, "\x1b[?1003h\x1b[?1006h"), () =>
+        ws.terminate(),
+      );
+    });
+
+    const stdout = fakeStdout();
+    const result = await connectTerminalBridge({
+      host,
+      token: "t",
+      terminalPath: "/term",
+      stdin: fakeStdin(),
+      stdout,
+    });
+
+    expect(result.kind).toBe("disconnected");
+    expect(stdout.captured().endsWith(TERMINAL_MODE_RESET)).toBe(true);
+  });
+
+  it("resets terminal modes after a clean exit", async () => {
+    const host = listen((ws) => {
+      ws.send(encodeExit(0));
+    });
+
+    const stdout = fakeStdout();
+    const result = await connectTerminalBridge({
+      host,
+      token: "t",
+      terminalPath: "/term",
+      stdin: fakeStdin(),
+      stdout,
+    });
+
+    expect(result).toEqual({ kind: "exited", code: 0 });
+    expect(stdout.captured().endsWith(TERMINAL_MODE_RESET)).toBe(true);
+  });
+
+  it("forwards remote output to stdout before the reset", async () => {
+    const host = listen((ws) => {
+      ws.send(encodeDataFrame(OP_OUTPUT, "hello"));
+      ws.send(encodeExit(0));
+    });
+
+    const stdout = fakeStdout();
+    await connectTerminalBridge({
+      host,
+      token: "t",
+      terminalPath: "/term",
+      stdin: fakeStdin(),
+      stdout,
+    });
+
+    expect(stdout.captured()).toBe(`hello${TERMINAL_MODE_RESET}`);
+  });
+});

--- a/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
+++ b/packages/cli/src/modules/chat/infrastructure/terminal-bridge.ts
@@ -14,6 +14,20 @@ export type BridgeResult =
   | { kind: "exited"; code: number }
   | { kind: "disconnected"; reason: string };
 
+// The remote TUI flips modes on the *local* terminal emulator (mouse tracking,
+// bracketed paste, alt screen, kitty keyboard, hidden cursor) and can't restore
+// them after an abrupt disconnect — without this the shell keeps receiving
+// mouse-event garbage like `[<35;62;20M`. Terminals ignore sequences they
+// don't support, so this is safe to emit unconditionally.
+export const TERMINAL_MODE_RESET =
+  "\x1b[<u" + // pop kitty keyboard protocol flags
+  "\x1b[?1049l" + // leave alternate screen
+  "\x1b[?1000;1002;1003;1005;1006;1015;1016l" + // mouse tracking off (all variants)
+  "\x1b[?1004l" + // focus reporting off
+  "\x1b[?2004l" + // bracketed paste off
+  "\x1b[?25h" + // show cursor
+  "\x1b[0m"; // reset SGR attributes
+
 export function connectTerminalBridge({
   host,
   token,
@@ -54,6 +68,7 @@ export function connectTerminalBridge({
           stdin.setRawMode(false);
         } catch {}
       stdin.pause();
+      stdout.write(TERMINAL_MODE_RESET);
       if (
         ws.readyState === WebSocket.OPEN ||
         ws.readyState === WebSocket.CONNECTING


### PR DESCRIPTION
## Problem

When the network drops during `dam chat`, the remote TUI has enabled modes on the **local** terminal emulator (mouse tracking, bracketed paste, alt screen, kitty keyboard protocol, hidden cursor) and never gets a chance to restore them. The shell is then flooded with mouse-event sequences like `[<35;62;20M` on every mouse move/scroll until the user runs `reset`.

## Fix

The terminal bridge now emits a mode-reset sequence on every exit path (clean exit, close, error) in `finish()`:

- pop kitty keyboard protocol flags
- leave alternate screen
- disable all mouse tracking variants (1000/1002/1003/1005/1006/1015/1016)
- disable focus reporting and bracketed paste
- show cursor, reset SGR attributes

Terminals ignore sequences they don't support, so the reset is safe to emit unconditionally.

## Tests

New `terminal-bridge.test.ts` with a real `WebSocketServer`: abrupt disconnect (`ws.terminate()`, i.e. the network-outage path), clean exit, and pass-through of remote output before the reset. `mise run cli:test` (154) and `mise run cli:check` pass.