### PR TITLE
fix(channels): connect Slack socket mode on startup, not lazily

### DIFF
--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-Last verified: 2026-07-23
+Last verified: 2026-07-24
 
 ## Overview
 
@@ -113,7 +113,7 @@ Both workers implement the same internal contract — `start`, `stop`, `stopAll`
 
 ### Slack — platform channel
 
-- **Transport.** Socket Mode, one workspace-level WebSocket from the api-server to Slack. The api-server has no inbound network access requirement; events arrive over the socket the api-server itself opened. Slack caps Socket Mode at ten concurrent connections per app, which is the install-level scale ceiling for Slack.
+- **Transport.** Socket Mode, one workspace-level WebSocket from the api-server to Slack, opened unconditionally at boot so slash commands, mentions and DMs work in chats that have no binding yet (mirroring the Telegram client). The api-server has no inbound network access requirement; events arrive over the socket the api-server itself opened. Slack caps Socket Mode at ten concurrent connections per app, which is the install-level scale ceiling for Slack.
 - **Token provenance.** App-Level Token (`xapp-…`) and Bot Token come from Helm values, set at install time. Not stored per-Agent.
 - **Identity linking** (person-scoped bindings). A `/platform login` slash command starts a Keycloak OAuth flow; on callback the api-server stores `slack_user_id ↔ keycloak_sub`. All subsequent interactions require a linked identity; unlinked users get an ephemeral prompt to log in. The link table is the source of truth for "who is this Slack user in Platform terms." Shared bindings never consult it.
 - **In-chat binding** (creates a shared binding). Beyond the platform UI and CLI, a channel can be bound from inside Slack, mirroring Telegram: anyone runs `/platform bind`, authenticates through the same Keycloak OAuth flow, and picks one of _their own_ Agents on a web picker — the binding lends that Agent, under its own credentials, to the whole channel. The binding is created ambient-off; an in-chat ambient command reports and flips the binding's ambient mode afterward under the same binder-or-owner authorization as unbind. There is no admin gate (unlike Telegram's group-admin check); the ownership check on the picked Agent is the control, and the bind also links the initiator's identity so they can later release it. A bind never overrides an existing one — an already-bound channel is refused until it is unbound. `/platform unbind` releases the binding and is allowed for the binder or the Agent's owner; the owner can also disconnect from the platform UI/CLI as an escape hatch.
@@ -129,7 +129,7 @@ Both workers implement the same internal contract — `start`, `stop`, `stopAll`
 - **Identity model — there is none per user.** Telegram has no workspace to anchor a user-to-Keycloak link against, so consent attaches to the _conversation_: someone sends `/login` (in groups, only chat admins, verified via `getChatMember`; `/start` counts as login intent too, so deep links and the Start button work), the bot replies with a Keycloak OAuth link, and after authenticating the user lands on the UI's agent picker listing _their own_ Agents. The binding records conversation id, agent id, and the owner's sub as `authorized_by`, and the bot posts a confirmation in the chat. The chat's members never authenticate. `/logout` unbinds, and the owner can also disconnect a bound chat from the web UI — the bot posts a farewell note in the chat before the binding is released. Unbound groups stay silent so the bot does not spam every chat it has been added to.
 - **Lifecycle.** There is none per Agent — bindings are rows, not runtime state. Agent deletion clears the Agent's rows via the channel-cleanup saga.
 
-Slack keeps per-Agent worker registration via `SlackConnected` / `SlackDisconnected` / `AgentDeleted` events on the rxjs bus; bootstrap on api-server startup starts the Telegram client and walks the Slack channel bindings.
+Slack keeps per-Agent worker registration via `SlackConnected` / `SlackDisconnected` / `AgentDeleted` events on the rxjs bus; bootstrap on api-server startup opens the Slack socket and starts the Telegram client, then walks the Slack channel bindings to restore the per-Agent registrations.
 
 ## Inbound — channel message to ACP session
 

--- a/packages/api-server/src/__tests__/unit/channel-manager.test.ts
+++ b/packages/api-server/src/__tests__/unit/channel-manager.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from "vitest";
+import { ChannelType, type ChannelConfig } from "api-server-api";
+import { createChannelManager } from "../../modules/channels/services/channel-manager.js";
+import type { SlackWorker } from "../../modules/channels/infrastructure/slack.js";
+import type { TelegramWorker } from "../../modules/channels/infrastructure/telegram.js";
+
+function fakeSlackWorker(): SlackWorker {
+  return {
+    type: ChannelType.Slack,
+    connect: vi.fn(async () => {}),
+    start: vi.fn(async () => {}),
+    stop: vi.fn(async () => {}),
+    stopAll: vi.fn(async () => {}),
+    listConversations: vi.fn(async () => []),
+    postMessage: vi.fn(async () => ({ ok: true as const })),
+    reply: vi.fn(async () => ({ ok: true as const })),
+    react: vi.fn(async () => ({ ok: true as const })),
+  };
+}
+
+function fakeTelegramWorker(): TelegramWorker {
+  return {
+    type: ChannelType.Telegram,
+    start: vi.fn(async () => {}),
+    stopAll: vi.fn(async () => {}),
+    botUsername: vi.fn(() => null),
+    listConversations: vi.fn(async () => []),
+    postMessage: vi.fn(async () => ({ ok: true as const })),
+  };
+}
+
+describe("channel-manager bootstrap", () => {
+  it("opens the Slack socket on startup even with no bindings", async () => {
+    const slackWorker = fakeSlackWorker();
+    const telegramWorker = fakeTelegramWorker();
+    const manager = createChannelManager({ slackWorker, telegramWorker });
+
+    await manager.bootstrap(new Map());
+
+    // Regression: Slack used to connect lazily on the first bind/post, so on a
+    // fresh install with no bindings the socket never opened and inbound
+    // /login, mentions and DMs were dropped. Both bots must be up at boot.
+    expect(slackWorker.connect).toHaveBeenCalledTimes(1);
+    expect(telegramWorker.start).toHaveBeenCalledTimes(1);
+    expect(slackWorker.start).not.toHaveBeenCalled();
+
+    await manager.stopAll();
+  });
+
+  it("connects, then registers per-Agent workers for channels bound at boot", async () => {
+    const slackWorker = fakeSlackWorker();
+    const manager = createChannelManager({ slackWorker });
+
+    const channel: ChannelConfig = {
+      type: ChannelType.Slack,
+      slackChannelId: "C123",
+    };
+    await manager.bootstrap(new Map([["agent-1", [channel]]]));
+
+    expect(slackWorker.connect).toHaveBeenCalledTimes(1);
+    expect(slackWorker.start).toHaveBeenCalledWith("agent-1", channel);
+
+    await manager.stopAll();
+  });
+
+  it("boots cleanly when only Telegram is configured", async () => {
+    const telegramWorker = fakeTelegramWorker();
+    const manager = createChannelManager({ telegramWorker });
+
+    await manager.bootstrap(new Map());
+
+    expect(telegramWorker.start).toHaveBeenCalledTimes(1);
+
+    await manager.stopAll();
+  });
+});

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -281,6 +281,11 @@ export interface ChannelRegistry {
 
 export interface SlackWorker {
   type: ChannelType.Slack;
+  /** Open the workspace socket-mode connection at startup, before any binding
+   *  exists — inbound slash commands (`/<brand> login`), mentions and DMs must
+   *  reach the bot in chats that have no binding yet, mirroring the Telegram
+   *  bot. Idempotent and single-flight with the other gateway starters. */
+  connect(): Promise<void>;
   start(instanceName: string, channel: StoredChannelConfig): Promise<void>;
   stop(instanceName: string): Promise<void>;
   stopAll(): Promise<void>;
@@ -1730,6 +1735,10 @@ export function createSlackWorker(
 
   return {
     type: ChannelType.Slack,
+
+    async connect() {
+      await ensureGateway();
+    },
 
     async start(instanceName: string, _channel: StoredChannelConfig) {
       const started = await ensureGateway();

--- a/packages/api-server/src/modules/channels/services/channel-manager.ts
+++ b/packages/api-server/src/modules/channels/services/channel-manager.ts
@@ -146,10 +146,15 @@ export function createChannelManager(deps: {
     },
 
     async bootstrap(channelsByInstance: Map<string, ChannelConfig[]>) {
-      // The platform bot polls unconditionally — /login must work in chats
-      // that have no binding yet.
+      // Both platform bots connect unconditionally at startup — inbound
+      // commands (/login), mentions and DMs must reach the bot in chats that
+      // have no binding yet. Slack opens its socket-mode connection here rather
+      // than lazily on the first bind/post, so it never misses those events.
       if (telegramWorker) await telegramWorker.start();
+      if (slackWorker) await slackWorker.connect();
 
+      // The socket is already up; walking the bindings only restores the
+      // per-Agent registration the SlackConnected event installs at runtime.
       for (const [agentId, channels] of channelsByInstance) {
         for (const channel of channels) {
           if (channel.type === ChannelType.Slack && slackWorker) {


### PR DESCRIPTION
## Problem

The Slack workspace socket-mode connection was established **lazily** — it opened only on the first channel bind or the first outbound post, via `ensureGateway()`. On a fresh install (or any api-server start with no Slack bindings), the socket never opened at boot. Because socket mode is how Slack pushes inbound events, this meant slash commands (`/<brand> login`), `@mentions`, and DMs sent to the bot in **unbound** chats were silently dropped until something else happened to trigger a connect.

Telegram already connects unconditionally at boot for exactly this reason (`/login` must work in chats with no binding yet). Slack should match.

## Fix

- Add `SlackWorker.connect()` — opens the socket via the existing `ensureGateway()` (idempotent, single-flight with the other gateway starters).
- Call `slackWorker.connect()` unconditionally in `ChannelManager.bootstrap()`, alongside `telegramWorker.start()`, **before** walking the per-Agent bindings. The subsequent binding walk now only restores per-Agent registration (the socket is already up).

## Why it's safe

- `ensureGateway()` is single-flight and caches the gateway, so the boot-time connect plus any concurrent `SlackConnected` event / outbound post share one connection — no double socket.
- A failed connect latches `gatewayFailed` and returns without throwing; `bootstrap` is already fire-and-forget at the call site.
- No Slack tokens configured → `slackWorker` is `undefined` → `connect()` is skipped.
- e2e fake gateway: starting it at boot only sets its handlers earlier (idempotent, writes nothing to outbound). Every e2e flow already binds-then-fires; none depends on a pre-start throw. Verified against all four Slack smoke specs.

## Tests

New `channel-manager.test.ts` locks in the regression: `bootstrap(new Map())` (no bindings) calls `slackWorker.connect()` once and does **not** call `slackWorker.start()`; a bound channel connects first, then registers per-Agent.

- `mise run api-server:check:tsc` — clean
- `mise run api-server:check:lint` / `:format` — clean
- `mise run api-server:test` — 126 existing + 3 new pass

## Docs

Updated `docs/architecture/channels.md` (Slack transport + bootstrap contrast) and bumped `Last verified`.