### PR TITLE
feat(ui): distinguish the ambient Slack session from its thread sessions

### DIFF
--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -273,6 +273,9 @@ export {
   SessionType,
   SessionMode,
   sessionModeSchema,
+  AMBIENT_THREAD_KEY_PREFIX,
+  ambientThreadKey,
+  isAmbientThreadKey,
 } from "./modules/sessions/types.js";
 export type { SessionView } from "./modules/sessions/types.js";
 

--- a/packages/api-server-api/src/modules/sessions/types.ts
+++ b/packages/api-server-api/src/modules/sessions/types.ts
@@ -18,6 +18,28 @@ export enum SessionMode {
 export const sessionModeSchema = z.enum(SessionMode);
 
 /**
+ * Reserved prefix for a channel's rolling "ambient" session key. Top-level
+ * channel chatter the agent reads along with shares one session per channel
+ * (`ambient:<channelId>`), while thread replies keep their per-thread keys.
+ * Slack `thread_ts` values are numeric, so this prefix can't collide with a
+ * real thread key. Defined here so the channel worker (writer) and the UI
+ * (reader) agree on the format in one place.
+ */
+export const AMBIENT_THREAD_KEY_PREFIX = "ambient:";
+
+/** Build the rolling ambient session key for a channel. */
+export function ambientThreadKey(channelId: string): string {
+  return `${AMBIENT_THREAD_KEY_PREFIX}${channelId}`;
+}
+
+/** True when a session's thread key is a channel's rolling ambient reader. */
+export function isAmbientThreadKey(
+  threadKey: string | null | undefined,
+): boolean {
+  return !!threadKey && threadKey.startsWith(AMBIENT_THREAD_KEY_PREFIX);
+}
+
+/**
  * Sessions are agent-owned: the UI and channel workers read, create,
  * and mutate them directly over ACP, decoding this view from `_meta.platform`.
  * The server has no session service — the one schedule-scoped mutation (reset)
@@ -33,6 +55,14 @@ export interface SessionView {
   experimentId?: string | null;
   title?: string | null;
   updatedAt?: string | null;
+  /**
+   * Channel session's thread key from `_meta.platform.threadTs`: the rolling
+   * ambient key (`ambient:<channelId>`) for a channel's reads-along session, or
+   * the Slack `thread_ts` / Telegram conversation id for a thread session.
+   * Absent on non-channel sessions. Lets the UI tell an ambient reader from the
+   * threads it spins off — see {@link isAmbientThreadKey}.
+   */
+  threadTs?: string | null;
   /** Live turn state from `session/list` enrichment — true while a turn is in flight. */
   running?: boolean;
   /** When a viewer last saw the session; unread = updatedAt newer than this. */

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -1,6 +1,11 @@
 import { filter, merge, take, timeout } from "rxjs";
 import { match, P } from "ts-pattern";
-import { ChannelType, SessionType, type AgentsService } from "api-server-api";
+import {
+  ambientThreadKey,
+  ChannelType,
+  SessionType,
+  type AgentsService,
+} from "api-server-api";
 import type { StoredChannelConfig } from "../stored-channel.js";
 import type {
   ChannelReaction,
@@ -143,14 +148,6 @@ function framePrompt(opts: {
   const text = parts.join("\n\n");
   if (opts.images.length === 0) return text;
   return [{ type: "text", text }, ...opts.images.map((i) => i.block)];
-}
-
-/** Session key for a channel's rolling ambient session: top-level channel
- *  messages share one session (the agent "reads along"), while thread replies
- *  keep their per-thread sessions. Slack thread_ts values are numeric, so the
- *  prefix cannot collide with a real thread key. */
-function ambientThreadKey(channelId: string): string {
-  return `ambient:${channelId}`;
 }
 
 /** A 1:1 DM conversation (Slack `im`) always has an id starting with "D". Used

--- a/packages/ui/src/__tests__/unit/session-category.test.ts
+++ b/packages/ui/src/__tests__/unit/session-category.test.ts
@@ -1,0 +1,92 @@
+import { SessionMode, SessionType, type SessionView } from "api-server-api";
+import { describe, expect, test } from "vitest";
+
+import {
+  sessionCategory,
+  slackSessionKind,
+} from "../../modules/sessions/lib/session-category.js";
+
+const session = (over: Partial<SessionView>): SessionView => ({
+  sessionId: "s1",
+  agentId: "a1",
+  type: SessionType.Regular,
+  mode: SessionMode.Chat,
+  createdAt: "2026-07-24T00:00:00.000Z",
+  ...over,
+});
+
+describe("sessionCategory", () => {
+  test("terminal mode wins over type", () => {
+    expect(sessionCategory(session({ mode: SessionMode.Terminal }))).toBe(
+      "terminal",
+    );
+  });
+
+  test("both channel types land in channels", () => {
+    expect(sessionCategory(session({ type: SessionType.ChannelSlack }))).toBe(
+      "channels",
+    );
+    expect(
+      sessionCategory(session({ type: SessionType.ChannelTelegram })),
+    ).toBe("channels");
+  });
+
+  test("cron is scheduled, regular is chats", () => {
+    expect(sessionCategory(session({ type: SessionType.ScheduleCron }))).toBe(
+      "scheduled",
+    );
+    expect(sessionCategory(session({ type: SessionType.Regular }))).toBe(
+      "chats",
+    );
+  });
+});
+
+describe("slackSessionKind", () => {
+  test("an ambient-keyed Slack session is the ambient reader", () => {
+    expect(
+      slackSessionKind(
+        session({
+          type: SessionType.ChannelSlack,
+          threadTs: "ambient:C123",
+        }),
+      ),
+    ).toBe("ambient");
+  });
+
+  test("a numeric thread_ts Slack session is a thread", () => {
+    expect(
+      slackSessionKind(
+        session({
+          type: SessionType.ChannelSlack,
+          threadTs: "1700000005.000100",
+        }),
+      ),
+    ).toBe("thread");
+  });
+
+  test("a Slack session with no thread key is a thread, not ambient", () => {
+    expect(slackSessionKind(session({ type: SessionType.ChannelSlack }))).toBe(
+      "thread",
+    );
+  });
+
+  test("ambient is Slack-only: Telegram never reads as ambient", () => {
+    // Even if a Telegram conversation id somehow carried the prefix, it is not
+    // a Slack channel session, so the ambient split does not apply.
+    expect(
+      slackSessionKind(
+        session({
+          type: SessionType.ChannelTelegram,
+          threadTs: "ambient:C123",
+        }),
+      ),
+    ).toBe(null);
+  });
+
+  test("non-channel sessions have no Slack kind", () => {
+    expect(slackSessionKind(session({ type: SessionType.Regular }))).toBe(null);
+    expect(slackSessionKind(session({ type: SessionType.ScheduleCron }))).toBe(
+      null,
+    );
+  });
+});

--- a/packages/ui/src/modules/sessions/api/acp-session-ops.ts
+++ b/packages/ui/src/modules/sessions/api/acp-session-ops.ts
@@ -40,6 +40,7 @@ function toSessionView(agentId: string, s: ListedSession): SessionView {
     createdAt: p?.createdAt ?? s.updatedAt ?? new Date(0).toISOString(),
     scheduleId: p?.scheduleId ?? null,
     experimentId: p?.experimentId ?? null,
+    threadTs: p?.threadTs ?? null,
     title: s.title ?? null,
     updatedAt: s.updatedAt ?? null,
     running: p?.running ?? false,

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -18,6 +18,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { formatSessionTimestamp } from "../lib/format-session-timestamp.js";
+import { slackSessionKind } from "../lib/session-category.js";
 import { WorkingDots } from "./working-dots.js";
 
 const LONG_PRESS_MS = 400;
@@ -98,6 +99,9 @@ export function SessionRow({
   const channel =
     s.type === SessionType.ChannelSlack ||
     s.type === SessionType.ChannelTelegram;
+  // Slack channel sessions split into the channel's rolling ambient reader and
+  // the threads it spins off; the ambient one wears an extra "A" marker.
+  const slackKind = slackSessionKind(s);
 
   return (
     <div
@@ -126,11 +130,15 @@ export function SessionRow({
             scheduled={scheduled}
             terminal={terminal}
             channel={channel}
+            ambient={slackKind === "ambient"}
             needsApproval={needsApproval}
             working={working}
           />
         </div>
         <span className="text-[11px] text-muted-foreground">
+          {slackKind
+            ? `${slackKind === "ambient" ? "Ambient" : "Thread"} · `
+            : ""}
           {formatSessionTimestamp(s.updatedAt ?? s.createdAt)}
         </span>
       </div>
@@ -187,12 +195,14 @@ function SessionIndicators({
   scheduled,
   terminal,
   channel,
+  ambient,
   needsApproval,
   working,
 }: {
   scheduled: boolean;
   terminal: boolean;
   channel: boolean;
+  ambient: boolean;
   needsApproval: boolean;
   working: boolean;
 }) {
@@ -203,9 +213,29 @@ function SessionIndicators({
       {terminal && (
         <Code size={16} className="text-text" aria-label="Terminal" />
       )}
-      {channel && (
-        <Hashtag size={16} className="text-text" aria-label="Channel session" />
-      )}
+      {channel &&
+        (ambient ? (
+          // Rolling channel reader: keep the # channel glyph, brand it with a
+          // superscript "A" so it stands apart from the threads it spins off.
+          <span
+            className="inline-flex items-start text-text"
+            aria-label="Ambient channel session"
+          >
+            <Hashtag size={16} />
+            <span
+              className="text-[9px] font-semibold leading-none text-accent"
+              aria-hidden
+            >
+              A
+            </span>
+          </span>
+        ) : (
+          <Hashtag
+            size={16}
+            className="text-text"
+            aria-label="Channel session"
+          />
+        ))}
       {scheduled && (
         <Time size={16} className="text-text" aria-label="Scheduled" />
       )}

--- a/packages/ui/src/modules/sessions/lib/session-category.ts
+++ b/packages/ui/src/modules/sessions/lib/session-category.ts
@@ -1,4 +1,9 @@
-import { SessionMode, SessionType, type SessionView } from "api-server-api";
+import {
+  isAmbientThreadKey,
+  SessionMode,
+  SessionType,
+  type SessionView,
+} from "api-server-api";
 
 export const SESSION_CATEGORIES = [
   "chats",
@@ -24,4 +29,20 @@ export function sessionCategory(session: SessionView): SessionCategory {
     return "channels";
   if (session.type === SessionType.ScheduleCron) return "scheduled";
   return "chats";
+}
+
+/**
+ * A Slack channel session is either the channel's rolling **ambient** reader
+ * (keyed `ambient:<channel>`, where top-level reads-along chatter accrues) or a
+ * **thread** the agent got pulled into (its own `thread_ts` session). Returns
+ * null for any other session — ambient is a Slack-only mode, so Telegram and
+ * non-channel sessions have no such split.
+ */
+export type SlackSessionKind = "ambient" | "thread";
+
+export function slackSessionKind(
+  session: SessionView,
+): SlackSessionKind | null {
+  if (session.type !== SessionType.ChannelSlack) return null;
+  return isAmbientThreadKey(session.threadTs) ? "ambient" : "thread";
 }


### PR DESCRIPTION
## What

In the session sidebar, the channel's rolling **ambient** (reads-along) session and the **thread** sessions it spins off were both rendered as identical `#` channel rows — there was no way to tell which row was the ambient reader vs. a thread the agent got pulled into.

This marks the ambient reader with a superscript **`A`** on the channel glyph (`#ᴬ`) and adds an **`Ambient`** / **`Thread`** kind label to the row's subtitle line.

Before → after (Slack channel rows):

```
  does anyone know deploy…      #        does anyone know deploy…      #ᴬ
  Jul 24, 3:12 PM          →    Ambient · Jul 24, 3:12 PM
  Re: deploy runbook            #        Re: deploy runbook            #
  Jul 24, 3:14 PM               Thread · Jul 24, 3:14 PM
```

## Why

The ambient session is keyed with a synthetic `ambient:<channelId>` while thread sessions use the real Slack `thread_ts`, but the UI dropped `threadTs` when decoding sessions, so both surfaced as `type: ChannelSlack` with the same icon. You couldn't find the ambient reader to see what it's reading, or tell it apart from the threads.

## How

- **api-server-api** — add `threadTs` to `SessionView`; add a shared `AMBIENT_THREAD_KEY_PREFIX` / `ambientThreadKey()` / `isAmbientThreadKey()` so the Slack worker (writer) and the UI (reader) agree on the key format in one place (it previously lived only inside the worker).
- **api-server** — the Slack worker now imports the shared `ambientThreadKey` instead of its local copy (behaviour-preserving).
- **ui** — decode `threadTs` in `toSessionView`; add `slackSessionKind()` (`"ambient" | "thread" | null`, Slack-only); render the `#ᴬ` marker + subtitle label in `SessionRow`.

Telegram channel sessions are intentionally untouched (ambient is Slack-only), and non-channel rows are unchanged.

## Scope

Per the design discussion, this is presentation only: distinguish ambient vs. thread. There is **no** parent→child link recorded between an ambient session and the threads it spawns (that would need new session metadata + worker wiring) — deliberately left out.

## Tests

- New `session-category.test.ts` covering `sessionCategory` and `slackSessionKind` (ambient / thread / DM-no-key / Telegram-not-ambient / non-channel).
- `tsc`, `eslint`, `prettier` clean on all touched packages.
- Existing api-server Slack suites (126 tests incl. `slack-ambient`) pass with the rerouted helper.

## Manual verification (not yet done)

Visual confirmation in a running UI — bind a channel shared+ambient, send a top-level message and a threaded follow-up, and confirm the ambient row shows `#ᴬ` / `Ambient` and the thread row shows `#` / `Thread`.