### PR TITLE
feat(ui): show real skill descriptions in "Created in this sandbox"

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
@@ -103,8 +103,13 @@ export function StandaloneSkillsGroup({
                 <p className="truncate text-[15px] font-medium text-foreground">
                   {skill.name}
                 </p>
-                <p className="truncate text-[13px] text-muted-foreground">
-                  only in this sandbox
+                <p
+                  className={cn(
+                    "truncate text-[13px] text-muted-foreground",
+                    !skill.description && "italic",
+                  )}
+                >
+                  {skill.description || "No description"}
                 </p>
               </div>
 


### PR DESCRIPTION
On the sandbox Skills page, each skill created in the sandbox now shows its own description — the one the author wrote in the skill's frontmatter — instead of the same "only in this sandbox" placeholder on every row. Skills that genuinely have no description show "No description" instead.

Closes #2957