### PR TITLE
fix(api-server,ui): stop presenting gateway-only rolls as agent restarts

### DIFF
--- a/docs/architecture/platform-topology.md
+++ b/docs/architecture/platform-topology.md
@@ -1,6 +1,6 @@
 # Platform topology
 
-Last verified: 2026-07-17
+Last verified: 2026-07-24
 
 ## Overview
 
@@ -99,7 +99,7 @@ ACP frames are JSON-RPC 2.0, one logical message per WebSocket frame.
 The controller-reconciled domain resources are CRDs under the `agent-platform.ai/v1` API group, each with a status subresource:
 
 - `spec` — user intent. Owned exclusively by the api-server; validated by the K8s API server at admission.
-- `status` — observed state. Owned exclusively by the controller, written through the status subresource. Conditions (`Ready`, `AgentPodReady`, `GatewayPodReady`, `Reconciled`) are the source of truth; the api-server routes on `Ready` alone and never inspects pods itself.
+- `status` — observed state. Owned exclusively by the controller, written through the status subresource. Conditions (`Ready`, `AgentPodReady`, `GatewayPodReady`, `Reconciled`) are the source of truth; the api-server routes on `Ready` alone and never inspects pods itself. The user-facing state projection additionally reads the pod-level conditions so a gateway-only roll (a credential or L7-chain change) is not presented as an agent restart.
 
 | Kind | Purpose |
 |---|---|

--- a/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/agent-mappers.ts
@@ -83,6 +83,8 @@ export interface InfraAgent {
   /** AgentPodReady condition reason token when False (PodNotReady, or a
    *  termination token like ImagePullFailure / OutOfMemory). */
   agentPodNotReadyReason?: string;
+  /** AgentPodReady condition is True. Undefined until published. */
+  agentPodReady?: boolean;
   /** GatewayPodReady condition is True. Undefined until published. */
   gatewayPodReady?: boolean;
 }
@@ -101,6 +103,12 @@ export function computeAgentState(
   // Parked (#1900) before the "starting" fallthrough: a parked agent is not
   // coming up — presenting it as perpetually starting would mislead pollers.
   if (infra.overBudget) return "over_budget";
+  // Gateway-only unreadiness (#2903): the agent pod is up and serving — a
+  // gateway roll (credential / L7-chain change) must not present as an agent
+  // restart. Presentation only: routing (ensureReady) still waits on the
+  // aggregate Ready.
+  if (infra.agentPodReady === true && infra.gatewayPodReady === false)
+    return preparingWorkspace ? "preparing_workspace" : "running";
   return "starting";
 }
 
@@ -189,6 +197,7 @@ export function parseInfraAgent(obj: KubeObject): InfraAgent {
     podTerminationReason: agentPodTerminationMessage(obj),
     agentPodNotReadyReason:
       agentPod?.status === "False" ? agentPod.reason : undefined,
+    agentPodReady: agentPod ? agentPod.status === "True" : undefined,
     gatewayPodReady: gatewayPod ? gatewayPod.status === "True" : undefined,
   };
 }

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -119,14 +119,14 @@ export function AgentEgressEditor({
   const stagedMode = staged !== undefined;
 
   // Path-specific and port-carrying rules need MITM, which means the
-  // controller has to re-issue the leaf cert and roll the agent pod. The
-  // L4 (host-only, 443) path is a pure DB write — no roll. Warn the user
-  // so they own the timing.
+  // controller has to re-issue the leaf cert and roll the gateway pod
+  // (the agent pod stays up, #2903). The L4 (host-only, 443) path is a
+  // pure DB write — no roll. Warn the user so they own the timing.
   const draftNeedsMitm =
     draft.method !== "*" ||
     draft.pathPattern.trim() !== "*" ||
     splitHostPort(draft.host.trim()).port != null;
-  const draftRequiresRestart =
+  const draftRequiresGatewayRestart =
     draft.host.trim().length > 0 &&
     draftNeedsMitm &&
     !serverRules.some(
@@ -157,9 +157,9 @@ export function AgentEgressEditor({
       return;
     }
     if (
-      draftRequiresRestart &&
+      draftRequiresGatewayRestart &&
       !window.confirm(
-        `Saving this rule will restart the agent (~5–15s) so Envoy can MITM "${next.host}" for path-level enforcement. Continue?`,
+        `This rule needs a gateway restart (~5–15s). The agent keeps running — outbound requests are briefly interrupted. Continue?`,
       )
     )
       return;
@@ -350,11 +350,11 @@ export function AgentEgressEditor({
           >
             <Plus size={11} /> Add rule
           </Button>
-          {draftRequiresRestart && (
+          {draftRequiresGatewayRestart && (
             <p className="basis-full text-[11px] text-warning">
-              {stagedMode
-                ? "Saving will restart the agent (~5–15s) — path-level rules need MITM on this host."
-                : "Saving will restart the agent (~5–15s) — path-level rules need MITM on this host."}
+              Saving will restart the network gateway (~5–15s) — this rule
+              requires inspecting requests to this host. The agent keeps
+              running.
             </p>
           )}
         </div>

--- a/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-save.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-save.ts
@@ -58,18 +58,24 @@ export function useSandboxSettingsSave({
 
   return handleSubmit(async (values) => {
     if (!agentId || !dirty) return;
-    // Path-specific adds force a pod roll; confirm up front so declining
-    // aborts before anything commits. This view stays mounted (unlike the
-    // old modal), so a mid-save abort would otherwise leave already-committed
-    // fields shown as unsaved.
-    const restartingHosts = net.pendingAdds
-      .filter((a) => a.method !== "*" || a.pathPattern !== "*")
+    // Adds that need L7 promotion (method, path, or non-443 port — mirrors
+    // needsL7Promotion server-side) force a gateway roll; confirm up front so
+    // declining aborts before anything commits. This view stays mounted
+    // (unlike the old modal), so a mid-save abort would otherwise leave
+    // already-committed fields shown as unsaved.
+    const gatewayRestartHosts = net.pendingAdds
+      .filter(
+        (a) =>
+          a.method !== "*" ||
+          a.pathPattern !== "*" ||
+          splitHostPort(a.host).port != null,
+      )
       .map((a) => a.host);
     if (
-      restartingHosts.length > 0 &&
+      gatewayRestartHosts.length > 0 &&
       !(await showConfirm(
-        `Saving will restart the agent (~5–15s) so Envoy can MITM ${restartingHosts.length === 1 ? `"${restartingHosts[0]}"` : `${restartingHosts.length} hosts`} for path-level enforcement.`,
-        "Restart agent?",
+        `Rule changes for ${gatewayRestartHosts.length === 1 ? `"${gatewayRestartHosts[0]}"` : `${gatewayRestartHosts.length} hosts`} need a gateway restart (~5–15s). The agent keeps running — outbound requests are briefly interrupted.`,
+        "Restart network gateway?",
         { confirmLabel: "Save & restart" },
       ))
     ) {


### PR DESCRIPTION
Permanently approving a narrowing egress rule (L7 promotion) rolls only the sandbox's network gateway — the agent itself never goes down. The UI treated any not-ready blip as an agent restart, flashing the "Starting" takeover overlay over a working chat.

Now a gateway-only roll keeps the sandbox **Running**: no overlay, no status-pill flash, sessions visibly uninterrupted. Real restarts, wakes, and cold starts still present as "Starting" exactly as before.

The egress-save flow's wording matches the new reality: the confirm dialog, inline warning, and confirm prompt say the **network gateway** restarts and the agent keeps running. Port-only rules — which promote to L7 like path/method rules — now get the same confirm dialog instead of restarting the gateway silently.

Notes:
- If the agent pod becomes ready before its gateway (rare — a wake or the tail of a manual restart), "Running" can show a few seconds before full readiness; interaction still waits on full readiness.
- A persistently broken gateway now reads "Running" with egress down (previously a perpetual "Starting" — both wrong); the gateway error still surfaces on interaction. Accepted trade-off.
- Dialog-consistency follow-ups (over-warn edges, demotion rolls) are tracked in #2969.

Closes #2903