### PR TITLE
feat(keycloak-theme): render social provider label verbatim

### DIFF
--- a/packages/keycloak-theme/src/login/components/social-provider-button.tsx
+++ b/packages/keycloak-theme/src/login/components/social-provider-button.tsx
@@ -33,12 +33,9 @@ export function SocialProviderButton({ provider }: Props) {
           className="h-5 w-auto shrink-0"
         />
       )}
-      <span>
-        Continue with{" "}
-        <span
-          dangerouslySetInnerHTML={{ __html: kcSanitize(provider.displayName) }}
-        />
-      </span>
+      <span
+        dangerouslySetInnerHTML={{ __html: kcSanitize(provider.displayName) }}
+      />
     </a>
   );
 }


### PR DESCRIPTION
Removes the hardcoded "Continue with" prefix from the social provider login button. The button now renders the identity provider display name verbatim, so the full label is controlled from Keycloak — a "Continue with …" wording can simply be set as the provider display name there.

Verified with `mise run keycloak-theme:check` (format, tsc, eslint).