### PR TITLE
chore(cluster): bump k3s VM to 8 cores

### DIFF
--- a/deploy/lima-k3s.yaml
+++ b/deploy/lima-k3s.yaml
@@ -7,14 +7,19 @@ images:
   - location: https://cloud-images.ubuntu.com/releases/noble/release/ubuntu-24.04-server-cloudimg-amd64.img
     arch: x86_64
 
-cpus: 4
+# ClickStack (`clickstack.enabled`) adds ~2.1 CPU of pod requests — mongodb
+# alone asks for 1 CPU. On 4 cores that left 40m free and agent pods sat
+# Pending forever with FailedScheduling: Insufficient cpu.
+cpus: 8
 # Istio ambient (istiod + istio-cni + ztunnel + waypoint Deployment) adds
 # ~1 GiB of pod requests on top of the existing platform stack. On 4 GiB the
 # k3s scheduler hit FailedScheduling: Insufficient memory for new agent pods.
 #
-# Bumping `memory:` here does not resize an existing VM. Devs upgrading
-# from a 4 GiB VM must reprovision:
-#   mise run cluster:delete && mise run cluster:install
+# Bumping `cpus:`/`memory:` here does not resize an existing VM. Devs on an
+# older VM can resize in place without losing cluster state:
+#   mise run cluster:stop
+#   limactl edit platform-k3s     # match cpus/memory to this file
+#   limactl start platform-k3s
 memory: 16GiB
 disk: 200GiB
 


### PR DESCRIPTION
## Why

With ClickStack enabled, the dev cluster ran out of CPU and new sandboxes never started. A sandbox sat in "Starting" forever because both its pods were unschedulable:

```
0/1 nodes are available: 1 Insufficient cpu.
```

The node has 4 cores and 3960m (99%) was already requested. An agent needs 500m plus 50m for its gateway, so there was no room.

ClickStack accounts for 2110m of that:

| pod | cpu req |
|---|---|
| platform-clickstack-mongodb-0 | 1000m |
| mongodb-kubernetes-operator | 500m |
| clickstack-keeper | 250m |
| clickstack-clickhouse | 250m |
| clickstack-collector | 100m |
| clickhouse-operator | 10m |

Memory was never the problem (40% used).

## What

- `cpus: 4` -> `cpus: 8` in the lima template. Host has 12 cores, so this leaves headroom for the 4-core test VM.
- Reworded the sizing comment to cover `cpus:` too, and replaced the "you must reprovision" note with the in-place resize steps.

## In-place resize

Bumping the template only affects newly created VMs. You can resize an existing one without losing cluster state:

```sh
mise run cluster:stop
limactl edit platform-k3s     # match cpus/memory to deploy/lima-k3s.yaml
limactl start platform-k3s
```

That's what I ran on `platform-k3s`. The 200GiB disk and all cluster state survived.

## Verified

- `limactl validate deploy/lima-k3s.yaml` -> OK
- VM restarted at 8 CPUs, node reports `allocatable.cpu: 8`
- Requests dropped from 99% to 56%, now including the previously-pending agent
- Both agent pods went `1/1 Running`; no unhealthy pods cluster-wide after the restart (no cert fallout from the stop/start)

https://claude.ai/code/session_01FSYFrzpAAcQ2RtPFfPV91k