### PR TITLE
fix(ui): browser back/forward works in every view

### DIFF
--- a/packages/ui/src/__tests__/unit/routes.test.ts
+++ b/packages/ui/src/__tests__/unit/routes.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { parseRoute, routeToPath } from "../../modules/platform/lib/routes.js";
+
+// One canonical path per view. Non-canonical spellings (/settings/account,
+// /sandboxes/:id/setup) intentionally don't round-trip — routeToPath emits the
+// canonical form.
+const canonicalPaths = [
+  "/",
+  "/chat/agent-1",
+  "/settings",
+  "/settings/connections",
+  "/inbox",
+  "/terms",
+  "/telegram/bind",
+  "/slack/bind",
+  "/sandboxes/new",
+  "/sandboxes/sb-1",
+  "/sandboxes/sb-1/connections",
+  "/experiments",
+  "/knowledge-bases",
+  "/knowledge-bases/kb-1",
+  "/knowledge-bases/kb-1/settings",
+  "/artifacts",
+];
+
+describe("route round-trip", () => {
+  it.each(canonicalPaths)("routeToPath(parseRoute(%s)) is identity", (path) => {
+    expect(routeToPath(parseRoute(path))).toBe(path);
+  });
+
+  // Both traps fail silently if the literal check moves below its regex:
+  // the wizard becomes a detail page for an entity named "new".
+  it("parses /sandboxes/new as the wizard, not a sandbox id", () => {
+    expect(parseRoute("/sandboxes/new").view).toBe("sandbox-new");
+  });
+
+  it("parses the legacy /knowledge-bases/new as the wizard, not a KB id", () => {
+    expect(parseRoute("/knowledge-bases/new").view).toBe("sandbox-new");
+  });
+});

--- a/packages/ui/src/__tests__/unit/slack-bind-flow.test.ts
+++ b/packages/ui/src/__tests__/unit/slack-bind-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { pathToState, viewToPath } from "../../modules/platform/lib/routes.js";
+import { parseRoute, routeToPath } from "../../modules/platform/lib/routes.js";
 import {
   bindErrorCopy,
   callbackErrorCopy,
@@ -43,7 +43,7 @@ describe("slack bind flow helpers", () => {
 
 describe("slack bind route", () => {
   it("round-trips /slack/bind", () => {
-    expect(pathToState("/slack/bind")).toEqual({ view: "slack-bind" });
-    expect(viewToPath("slack-bind")).toBe("/slack/bind");
+    expect(parseRoute("/slack/bind")).toEqual({ view: "slack-bind" });
+    expect(routeToPath({ view: "slack-bind" })).toBe("/slack/bind");
   });
 });

--- a/packages/ui/src/__tests__/unit/telegram-bind-flow.test.ts
+++ b/packages/ui/src/__tests__/unit/telegram-bind-flow.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { pathToState, viewToPath } from "../../modules/platform/lib/routes.js";
+import { parseRoute, routeToPath } from "../../modules/platform/lib/routes.js";
 import {
   bindErrorCopy,
   callbackErrorCopy,
@@ -41,7 +41,7 @@ describe("telegram bind flow helpers", () => {
 
 describe("telegram bind route", () => {
   it("round-trips /telegram/bind", () => {
-    expect(pathToState("/telegram/bind")).toEqual({ view: "telegram-bind" });
-    expect(viewToPath("telegram-bind")).toBe("/telegram/bind");
+    expect(parseRoute("/telegram/bind")).toEqual({ view: "telegram-bind" });
+    expect(routeToPath({ view: "telegram-bind" })).toBe("/telegram/bind");
   });
 });

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -12,6 +12,7 @@ import { ExperimentsListView } from "./modules/experiments/views/experiments-lis
 import { KnowledgeBaseConfigView } from "./modules/knowledge-bases/views/knowledge-base-config-view.js";
 import { KnowledgeBasesListView } from "./modules/knowledge-bases/views/knowledge-bases-list-view.js";
 import { useBrowserHistory } from "./modules/platform/hooks/use-browser-history.js";
+import { parseRoute } from "./modules/platform/lib/routes.js";
 import { useFirstRunRedirect } from "./modules/sandboxes/hooks/use-first-run-redirect.js";
 import { SandboxHomeView } from "./modules/sandboxes/views/sandbox-home-view.js";
 import { SandboxWizardView } from "./modules/sandboxes/views/sandbox-wizard-view.js";
@@ -62,7 +63,7 @@ function MainApp() {
     // The sandbox-creation wizard owns its own OAuth-return handling so it can
     // rehydrate the in-progress sandbox before the params are stripped.
     const path = window.location.pathname;
-    if (path === "/sandboxes/new") return;
+    if (parseRoute(path).view === "sandbox-new") return;
     const params = new URLSearchParams(window.location.search);
     const oauthResult = params.get("oauth");
     if (!oauthResult) return;

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -11,6 +11,10 @@ import { ArtifactsView } from "./modules/artifacts/views/artifacts-view.js";
 import { ExperimentsListView } from "./modules/experiments/views/experiments-list-view.js";
 import { KnowledgeBaseConfigView } from "./modules/knowledge-bases/views/knowledge-base-config-view.js";
 import { KnowledgeBasesListView } from "./modules/knowledge-bases/views/knowledge-bases-list-view.js";
+import {
+  parseRoute,
+  routeToNavigationState,
+} from "./modules/platform/lib/routes.js";
 import { useFirstRunRedirect } from "./modules/sandboxes/hooks/use-first-run-redirect.js";
 import { SandboxHomeView } from "./modules/sandboxes/views/sandbox-home-view.js";
 import { SandboxWizardView } from "./modules/sandboxes/views/sandbox-wizard-view.js";
@@ -19,7 +23,7 @@ import { SettingsView } from "./modules/settings/views/settings-view.js";
 import { SlackBindView } from "./modules/slack/views/slack-bind-view.js";
 import { TelegramBindView } from "./modules/telegram/views/telegram-bind-view.js";
 import { TermsView } from "./modules/terms/views/terms-view.js";
-import { pathToState, useStore } from "./store.js";
+import { useStore } from "./store.js";
 
 export default function App() {
   const view = useStore((s) => s.view);
@@ -88,24 +92,19 @@ function MainApp() {
       useStore.setState({ selectedAgent: null, view: "list" });
     };
     const onPopState = () => {
-      const state = pathToState(window.location.pathname);
-      if (state.view === "chat") return enterChat(state.agent!);
-      if (state.view === "knowledge-base-chat") {
+      const route = parseRoute(window.location.pathname);
+      if (route.view === "chat") return enterChat(route.agent);
+      if (route.view === "knowledge-base-chat") {
         useStore.getState().resetChatContext();
         useStore.setState({
-          selectedAgent: state.agent!,
+          selectedAgent: route.agent,
           view: "knowledge-base-chat",
         });
         return;
       }
       // Unknown paths resolve to "list"; leaveChat also tears down chat context.
-      if (state.view === "list") return leaveChat();
-      useStore.setState({
-        view: state.view,
-        agentId: state.agentId ?? null,
-        settingsTab: state.settingsTab ?? "account",
-        sandboxSection: state.sandboxSection ?? "setup",
-      });
+      if (route.view === "list") return leaveChat();
+      useStore.setState(routeToNavigationState(route));
     };
     onPopState();
     window.addEventListener("popstate", onPopState);

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -11,10 +11,7 @@ import { ArtifactsView } from "./modules/artifacts/views/artifacts-view.js";
 import { ExperimentsListView } from "./modules/experiments/views/experiments-list-view.js";
 import { KnowledgeBaseConfigView } from "./modules/knowledge-bases/views/knowledge-base-config-view.js";
 import { KnowledgeBasesListView } from "./modules/knowledge-bases/views/knowledge-bases-list-view.js";
-import {
-  parseRoute,
-  routeToNavigationState,
-} from "./modules/platform/lib/routes.js";
+import { useBrowserHistory } from "./modules/platform/hooks/use-browser-history.js";
 import { useFirstRunRedirect } from "./modules/sandboxes/hooks/use-first-run-redirect.js";
 import { SandboxHomeView } from "./modules/sandboxes/views/sandbox-home-view.js";
 import { SandboxWizardView } from "./modules/sandboxes/views/sandbox-wizard-view.js";
@@ -28,6 +25,10 @@ import { useStore } from "./store.js";
 export default function App() {
   const view = useStore((s) => s.view);
   const theme = useStore((s) => s.theme);
+
+  // Must stay above the early returns: the terms/bind views render without
+  // MainApp, and back/forward has to keep working there too.
+  useBrowserHistory();
 
   // Apply theme on mount + listen for system preference changes
   useEffect(() => {
@@ -79,36 +80,6 @@ function MainApp() {
         message: "Connection authorized.",
       });
     }
-  }, []);
-
-  // Browser back/forward
-  useEffect(() => {
-    const enterChat = (agentId: string) => {
-      useStore.getState().resetChatContext();
-      useStore.setState({ selectedAgent: agentId, view: "chat" });
-    };
-    const leaveChat = () => {
-      useStore.getState().resetChatContext();
-      useStore.setState({ selectedAgent: null, view: "list" });
-    };
-    const onPopState = () => {
-      const route = parseRoute(window.location.pathname);
-      if (route.view === "chat") return enterChat(route.agent);
-      if (route.view === "knowledge-base-chat") {
-        useStore.getState().resetChatContext();
-        useStore.setState({
-          selectedAgent: route.agent,
-          view: "knowledge-base-chat",
-        });
-        return;
-      }
-      // Unknown paths resolve to "list"; leaveChat also tears down chat context.
-      if (route.view === "list") return leaveChat();
-      useStore.setState(routeToNavigationState(route));
-    };
-    onPopState();
-    window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
   }, []);
 
   // Chat owns its mobile sessions/chat nav, so the rail hides its bottom bar

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -10,6 +10,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 import { initAuth } from "./auth.js";
 import { applyBrand, loadBrand } from "./brand.js";
+import { routeToPath } from "./modules/platform/lib/routes.js";
 import { preflightTermsGate } from "./modules/terms/lib/preflight.js";
 import { queryClient } from "./query-client.js";
 import { useStore } from "./store.js";
@@ -22,7 +23,7 @@ async function main() {
   if (!user) return; // Redirecting to Keycloak, don't render
 
   if (!(await preflightTermsGate())) {
-    window.history.replaceState({}, "", "/terms");
+    window.history.replaceState({}, "", routeToPath({ view: "terms" }));
     useStore.setState({ view: "terms" });
   }
 

--- a/packages/ui/src/modules/agents/store.ts
+++ b/packages/ui/src/modules/agents/store.ts
@@ -2,7 +2,7 @@ import type { StateCreator } from "zustand";
 
 import type { PlatformStore } from "../../store.js";
 import type { AgentView } from "../../types.js";
-import { viewToPath } from "../platform/lib/routes.js";
+import { routeToPath } from "../platform/lib/routes.js";
 
 /**
  * UI-side state for the agents domain. Server state (agents list,
@@ -111,7 +111,7 @@ export const createAgentsSlice: StateCreator<
     }),
 
   selectAgent: (id) => {
-    history.pushState(null, "", viewToPath("chat", id));
+    history.pushState(null, "", routeToPath({ view: "chat", agent: id }));
     get().resetChatContext();
     set({
       selectedAgent: id,
@@ -121,7 +121,11 @@ export const createAgentsSlice: StateCreator<
   },
 
   openKnowledgeBase: (id) => {
-    history.pushState(null, "", viewToPath("knowledge-base-chat", id));
+    history.pushState(
+      null,
+      "",
+      routeToPath({ view: "knowledge-base-chat", agent: id }),
+    );
     get().resetChatContext();
     set({
       selectedAgent: id,
@@ -131,7 +135,7 @@ export const createAgentsSlice: StateCreator<
   },
 
   openAgentSession: (agentId, sessionId) => {
-    history.pushState(null, "", viewToPath("chat", agentId));
+    history.pushState(null, "", routeToPath({ view: "chat", agent: agentId }));
     get().resetChatContext();
     set({
       selectedAgent: agentId,
@@ -142,7 +146,7 @@ export const createAgentsSlice: StateCreator<
   },
 
   openAgentTerminal: (agentId) => {
-    history.pushState(null, "", viewToPath("chat", agentId));
+    history.pushState(null, "", routeToPath({ view: "chat", agent: agentId }));
     // Set the pending flag after the reset (which clears it), mirroring the
     // resume handoff; chat-view consumes it on entry to spawn a terminal.
     get().resetChatContext();
@@ -160,7 +164,7 @@ export const createAgentsSlice: StateCreator<
     history.pushState(
       null,
       "",
-      fromKnowledgeBase ? viewToPath("knowledge-bases") : "/",
+      routeToPath({ view: fromKnowledgeBase ? "knowledge-bases" : "list" }),
     );
     get().resetChatContext();
     set({

--- a/packages/ui/src/modules/connections/hooks/use-template-create-submit.ts
+++ b/packages/ui/src/modules/connections/hooks/use-template-create-submit.ts
@@ -9,6 +9,7 @@ import { emitToast } from "@/lib/toast";
 import { api } from "../../../api.js";
 import { queryClient } from "../../../query-client.js";
 import { trpc } from "../../../trpc.js";
+import { routeToPath } from "../../platform/lib/routes.js";
 import {
   useCreateConnection,
   useDiscoverMcp,
@@ -167,7 +168,7 @@ export function useTemplateCreateSubmit({
         if (!oauthReturnView)
           sessionStorage.setItem(
             "platform-return-view",
-            "/settings/connections",
+            routeToPath({ view: "settings", settingsTab: "connections" }),
           );
         window.location.href = r.authUrl;
       } catch (err) {

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-base-config-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-base-config-view.tsx
@@ -9,7 +9,7 @@ import { useStore } from "../../../store.js";
 import { useDeleteAgent } from "../../agents/api/mutations.js";
 import { useResolvedAgentDisplay } from "../../agents/hooks/use-resolved-agent-display.js";
 import { AgentEgressEditor } from "../../egress-rules/components/agent-egress-editor.js";
-import { viewToPath } from "../../platform/lib/routes.js";
+import { routeToPath } from "../../platform/lib/routes.js";
 import { ConnectionsSection } from "../../sandboxes/components/connections-section.js";
 import { READ_ONLY_FIELD } from "../../sandboxes/components/sandbox-setup-section.js";
 import { useSandboxSettingsForm } from "../../sandboxes/hooks/use-sandbox-settings-form.js";
@@ -106,7 +106,10 @@ export function KnowledgeBaseConfigView() {
         <SectionLabel spaced>Connections</SectionLabel>
         <ConnectionsSection
           agentId={agent.id}
-          oauthReturnView={viewToPath("knowledge-base-config", null, agent.id)}
+          oauthReturnView={routeToPath({
+            view: "knowledge-base-config",
+            agentId: agent.id,
+          })}
         />
       </section>
 

--- a/packages/ui/src/modules/platform/hooks/use-browser-history.ts
+++ b/packages/ui/src/modules/platform/hooks/use-browser-history.ts
@@ -1,0 +1,50 @@
+import { useEffect } from "react";
+
+import { useStore } from "../../../store.js";
+import {
+  parseRoute,
+  routeToNavigationState,
+  type View,
+} from "../lib/routes.js";
+
+/** A knowledge base's page is the same ChatView under its own route, so both
+ *  views carry their agent in `selectedAgent` and share chat's teardown. */
+const isChatView = (view: View) =>
+  view === "chat" || view === "knowledge-base-chat";
+
+/**
+ * The UI's only popstate listener. Entering either chat surface always resets
+ * chat context and sets `selectedAgent`; leaving one for any other view resets
+ * and clears it; non-chat → non-chat transitions touch no chat state.
+ */
+export function useBrowserHistory(): void {
+  useEffect(() => {
+    const applyRoute = () => {
+      const route = parseRoute(window.location.pathname);
+      const wasChat = isChatView(useStore.getState().view);
+
+      if (route.view === "chat" || route.view === "knowledge-base-chat") {
+        useStore.getState().resetChatContext();
+        useStore.setState({
+          ...routeToNavigationState(route),
+          selectedAgent: route.agent,
+        });
+        return;
+      }
+
+      if (wasChat) useStore.getState().resetChatContext();
+      useStore.setState({
+        ...routeToNavigationState(route),
+        ...(wasChat ? { selectedAgent: null } : {}),
+      });
+    };
+
+    // Not redundant next to navigation.ts's initializer: this mount-time call
+    // is the only thing that sets `selectedAgent` on a cold load at
+    // /chat/:agent (the agents slice initializes it to null), and it re-parses
+    // the URL after auth.ts restores the post-login return path.
+    applyRoute();
+    window.addEventListener("popstate", applyRoute);
+    return () => window.removeEventListener("popstate", applyRoute);
+  }, []);
+}

--- a/packages/ui/src/modules/platform/hooks/use-browser-history.ts
+++ b/packages/ui/src/modules/platform/hooks/use-browser-history.ts
@@ -3,6 +3,7 @@ import { useEffect } from "react";
 import { useStore } from "../../../store.js";
 import {
   parseRoute,
+  type Route,
   routeToNavigationState,
   type View,
 } from "../lib/routes.js";
@@ -11,6 +12,11 @@ import {
  *  views carry their agent in `selectedAgent` and share chat's teardown. */
 const isChatView = (view: View) =>
   view === "chat" || view === "knowledge-base-chat";
+
+const isChatRoute = (
+  route: Route,
+): route is Extract<Route, { view: "chat" | "knowledge-base-chat" }> =>
+  isChatView(route.view);
 
 /**
  * The UI's only popstate listener. Entering either chat surface always resets
@@ -23,7 +29,7 @@ export function useBrowserHistory(): void {
       const route = parseRoute(window.location.pathname);
       const wasChat = isChatView(useStore.getState().view);
 
-      if (route.view === "chat" || route.view === "knowledge-base-chat") {
+      if (isChatRoute(route)) {
         useStore.getState().resetChatContext();
         useStore.setState({
           ...routeToNavigationState(route),

--- a/packages/ui/src/modules/platform/lib/routes.ts
+++ b/packages/ui/src/modules/platform/lib/routes.ts
@@ -1,23 +1,5 @@
 import { z } from "zod";
 
-export const viewSchema = z.enum([
-  "list",
-  "chat",
-  "settings",
-  "inbox",
-  "terms",
-  "telegram-bind",
-  "slack-bind",
-  "sandbox-new",
-  "sandbox-home",
-  "experiments",
-  "knowledge-bases",
-  "knowledge-base-chat",
-  "knowledge-base-config",
-  "artifacts",
-]);
-export type View = z.infer<typeof viewSchema>;
-
 export const settingsTabSchema = z.enum([
   "account",
   "appearance",
@@ -39,46 +21,31 @@ export const sandboxSectionSchema = z.enum([
 ]);
 export type SandboxSection = z.infer<typeof sandboxSectionSchema>;
 
-export function viewToPath(
-  view: View,
-  agent?: string | null,
-  agentId?: string | null,
-  settingsTab?: SettingsTab | null,
-  sandboxSection?: SandboxSection | null,
-): string {
-  if (view === "chat" && agent) return `/chat/${encodeURIComponent(agent)}`;
-  if (view === "settings")
-    return settingsTab && settingsTab !== "account"
-      ? `/settings/${settingsTab}`
-      : "/settings";
-  if (view === "inbox") return "/inbox";
-  if (view === "terms") return "/terms";
-  if (view === "telegram-bind") return "/telegram/bind";
-  if (view === "slack-bind") return "/slack/bind";
-  if (view === "sandbox-new") return "/sandboxes/new";
-  if (view === "sandbox-home" && agentId) {
-    const base = `/sandboxes/${encodeURIComponent(agentId)}`;
-    return sandboxSection && sandboxSection !== "setup"
-      ? `${base}/${sandboxSection}`
-      : base;
-  }
-  if (view === "experiments") return "/experiments";
-  if (view === "knowledge-bases") return "/knowledge-bases";
-  if (view === "knowledge-base-chat" && agent)
-    return `/knowledge-bases/${encodeURIComponent(agent)}`;
-  if (view === "knowledge-base-config" && agentId)
-    return `/knowledge-bases/${encodeURIComponent(agentId)}/settings`;
-  if (view === "artifacts") return "/artifacts";
-  return "/";
-}
+export type Route =
+  | { view: "list" }
+  | { view: "chat"; agent: string }
+  | { view: "settings"; settingsTab: SettingsTab }
+  | { view: "inbox" }
+  | { view: "terms" }
+  | { view: "telegram-bind" }
+  | { view: "slack-bind" }
+  | { view: "sandbox-new" }
+  | { view: "sandbox-home"; agentId: string; sandboxSection: SandboxSection }
+  | { view: "experiments" }
+  | { view: "knowledge-bases" }
+  | { view: "knowledge-base-chat"; agent: string }
+  | { view: "knowledge-base-config"; agentId: string }
+  | { view: "artifacts" };
 
-export function pathToState(path: string): {
-  view: View;
-  agent?: string;
-  agentId?: string;
-  settingsTab?: SettingsTab;
-  sandboxSection?: SandboxSection;
-} {
+export type View = Route["view"];
+
+// Alternation derived from the schema so the regex can't drift from it.
+const sandboxSectionPattern = sandboxSectionSchema.options.join("|");
+const sandboxHomeRe = new RegExp(
+  `^/sandboxes/([^/]+)(?:/(${sandboxSectionPattern}))?$`,
+);
+
+export function parseRoute(path: string): Route {
   if (path.startsWith("/chat/"))
     return { view: "chat", agent: decodeURIComponent(path.slice(6)) };
   if (path === "/settings") return { view: "settings", settingsTab: "account" };
@@ -94,17 +61,19 @@ export function pathToState(path: string): {
   if (path === "/terms") return { view: "terms" };
   if (path === "/telegram/bind") return { view: "telegram-bind" };
   if (path === "/slack/bind") return { view: "slack-bind" };
+  // Must stay above the sandbox-home regex, which would otherwise capture
+  // "new" as an agent id.
   if (path === "/sandboxes/new") return { view: "sandbox-new" };
   if (path === "/artifacts") return { view: "artifacts" };
-  const sandboxHomeMatch = path.match(
-    /^\/sandboxes\/([^/]+)(?:\/(setup|connections|channels|skills|schedules|artifacts))?$/,
-  );
-  if (sandboxHomeMatch)
+  const sandboxHomeMatch = path.match(sandboxHomeRe);
+  if (sandboxHomeMatch) {
+    const section = sandboxSectionSchema.safeParse(sandboxHomeMatch[2]);
     return {
       view: "sandbox-home",
       agentId: decodeURIComponent(sandboxHomeMatch[1]!),
-      sandboxSection: (sandboxHomeMatch[2] as SandboxSection) ?? "setup",
+      sandboxSection: section.success ? section.data : "setup",
     };
+  }
   if (path === "/experiments") return { view: "experiments" };
   if (path === "/knowledge-bases") return { view: "knowledge-bases" };
   // Knowledge bases are created in the shared sandbox wizard now. Land old
@@ -126,4 +95,68 @@ export function pathToState(path: string): {
       agent: decodeURIComponent(knowledgeBaseChatMatch[1]!),
     };
   return { view: "list" };
+}
+
+export function routeToPath(route: Route): string {
+  switch (route.view) {
+    case "list":
+      return "/";
+    case "chat":
+      return `/chat/${encodeURIComponent(route.agent)}`;
+    case "settings":
+      return route.settingsTab === "account"
+        ? "/settings"
+        : `/settings/${route.settingsTab}`;
+    case "inbox":
+      return "/inbox";
+    case "terms":
+      return "/terms";
+    case "telegram-bind":
+      return "/telegram/bind";
+    case "slack-bind":
+      return "/slack/bind";
+    case "sandbox-new":
+      return "/sandboxes/new";
+    case "sandbox-home": {
+      const base = `/sandboxes/${encodeURIComponent(route.agentId)}`;
+      return route.sandboxSection === "setup"
+        ? base
+        : `${base}/${route.sandboxSection}`;
+    }
+    case "experiments":
+      return "/experiments";
+    case "knowledge-bases":
+      return "/knowledge-bases";
+    case "knowledge-base-chat":
+      return `/knowledge-bases/${encodeURIComponent(route.agent)}`;
+    case "knowledge-base-config":
+      return `/knowledge-bases/${encodeURIComponent(route.agentId)}/settings`;
+    case "artifacts":
+      return "/artifacts";
+    default: {
+      const unhandled: never = route;
+      return unhandled;
+    }
+  }
+}
+
+/** Map a route onto the four flat fields the navigation slice owns. */
+export function routeToNavigationState(route: Route): {
+  view: View;
+  agentId: string | null;
+  settingsTab: SettingsTab;
+  sandboxSection: SandboxSection;
+} {
+  return {
+    view: route.view,
+    // The KB settings form keys off `agentId`, the same field sandbox-home
+    // uses; both chat surfaces carry their agent as `selectedAgent` instead.
+    agentId:
+      route.view === "sandbox-home" || route.view === "knowledge-base-config"
+        ? route.agentId
+        : null,
+    settingsTab: route.view === "settings" ? route.settingsTab : "account",
+    sandboxSection:
+      route.view === "sandbox-home" ? route.sandboxSection : "setup",
+  };
 }

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -9,19 +9,30 @@ import {
   startingPointDefaults,
 } from "../../sandboxes/lib/wizard-snapshot.js";
 import {
-  pathToState,
+  parseRoute,
+  routeToNavigationState,
+  routeToPath,
   type SandboxSection,
   type SettingsTab,
   type View,
-  viewToPath,
 } from "../lib/routes.js";
+
+/** Views whose route carries no parameters — the only ones `setView` can reach. */
+type ParameterlessView =
+  | "list"
+  | "inbox"
+  | "terms"
+  | "artifacts"
+  | "experiments"
+  | "knowledge-bases"
+  | "sandbox-new";
 
 export interface NavigationSlice {
   view: View;
   agentId: string | null;
   settingsTab: SettingsTab;
   sandboxSection: SandboxSection;
-  setView: (v: View) => void;
+  setView: (v: ParameterlessView) => void;
   /** `startingPoint` pre-selects step 1, so a per-kind "New …" button lands in
    *  the shared wizard pointed at that kind. */
   navigateToCreateSandbox: (startingPoint?: StartingPoint) => void;
@@ -34,52 +45,48 @@ export interface NavigationSlice {
   setMobileScreen: (screen: "sessions" | "chat") => void;
 }
 
+/**
+ * Resolve the path to hydrate from exactly once, so the `replaceState` side
+ * effect below cannot race initializers that re-read `window.location`.
+ */
+function initialPath(): string {
+  const { pathname } = window.location;
+  // The Telegram/Slack bind pages are entered via an external redirect
+  // carrying a one-shot ?flow= param — a stale OAuth return-view must not
+  // replace them.
+  const { view } = parseRoute(pathname);
+  if (view === "telegram-bind" || view === "slack-bind") return pathname;
+
+  // Holds the path to restore after an OAuth roundtrip (e.g. /settings/connections).
+  const saved = sessionStorage.getItem("platform-return-view");
+  if (!saved) return pathname;
+  sessionStorage.removeItem("platform-return-view");
+  if (!saved.startsWith("/")) {
+    console.warn("[navigation] ignoring non-path platform-return-view:", saved);
+    return pathname;
+  }
+  if (pathname !== saved) {
+    history.replaceState(
+      null,
+      "",
+      saved + window.location.search + window.location.hash,
+    );
+  }
+  // Route on the path segment alone: a query or hash riding along in the
+  // saved value would otherwise be captured as part of an id or tab.
+  return saved.split(/[?#]/)[0]!;
+}
+
 export const createNavigationSlice: StateCreator<
   PlatformStore,
   [],
   [],
   NavigationSlice
 > = (set) => ({
-  view: (() => {
-    // The Telegram/Slack bind pages are entered via an external redirect
-    // carrying a one-shot ?flow= param — a stale OAuth return-view must not
-    // replace them.
-    if (
-      window.location.pathname === "/telegram/bind" ||
-      window.location.pathname === "/slack/bind"
-    )
-      return pathToState(window.location.pathname).view;
-    // Holds the path to restore after an OAuth roundtrip (e.g. /settings/connections).
-    const saved = sessionStorage.getItem("platform-return-view");
-    if (saved) {
-      sessionStorage.removeItem("platform-return-view");
-      if (saved.startsWith("/")) {
-        if (window.location.pathname !== saved) {
-          history.replaceState(
-            null,
-            "",
-            saved + window.location.search + window.location.hash,
-          );
-        }
-        return pathToState(saved).view;
-      }
-      console.warn(
-        "[navigation] ignoring non-path platform-return-view:",
-        saved,
-      );
-    }
-    return pathToState(window.location.pathname).view;
-  })(),
-  agentId: pathToState(window.location.pathname).agentId ?? null,
-  settingsTab: pathToState(window.location.pathname).settingsTab ?? "account",
-  sandboxSection:
-    pathToState(window.location.pathname).sandboxSection ?? "setup",
+  ...routeToNavigationState(parseRoute(initialPath())),
   setView: (v) => {
-    history.pushState(null, "", viewToPath(v));
-    // viewToPath(v) without a tab is /settings, so keep the tab in sync.
-    if (v === "settings")
-      set({ view: v, agentId: null, settingsTab: "account" });
-    else set({ view: v, agentId: null });
+    history.pushState(null, "", routeToPath({ view: v }));
+    set(routeToNavigationState({ view: v }));
   },
   navigateToCreateSandbox: (startingPoint) => {
     // Seeded into the snapshot, not the route — where every other pick lives.
@@ -92,39 +99,35 @@ export const createNavigationSlice: StateCreator<
     } else {
       clearSnapshot();
     }
-    history.pushState(null, "", viewToPath("sandbox-new"));
+    history.pushState(null, "", routeToPath({ view: "sandbox-new" }));
     set({ view: "sandbox-new", agentId: null });
   },
   navigateToSettings: (tab) => {
     const settingsTab = tab ?? "account";
-    history.pushState(
-      null,
-      "",
-      viewToPath("settings", null, null, settingsTab),
-    );
+    history.pushState(null, "", routeToPath({ view: "settings", settingsTab }));
     set({ view: "settings", settingsTab, agentId: null });
   },
   navigateToSandboxHome: (agentId, section = "setup") => {
     history.pushState(
       null,
       "",
-      viewToPath("sandbox-home", null, agentId, null, section),
+      routeToPath({ view: "sandbox-home", agentId, sandboxSection: section }),
     );
     set({ view: "sandbox-home", agentId, sandboxSection: section });
   },
   navigateToExperiments: () => {
-    history.pushState(null, "", viewToPath("experiments"));
+    history.pushState(null, "", routeToPath({ view: "experiments" }));
     set({ view: "experiments", agentId: null });
   },
   navigateToKnowledgeBases: () => {
-    history.pushState(null, "", viewToPath("knowledge-bases"));
+    history.pushState(null, "", routeToPath({ view: "knowledge-bases" }));
     set({ view: "knowledge-bases", agentId: null });
   },
   navigateToKnowledgeBaseConfig: (agentId) => {
     history.pushState(
       null,
       "",
-      viewToPath("knowledge-base-config", null, agentId),
+      routeToPath({ view: "knowledge-base-config", agentId }),
     );
     // The settings form keys off `agentId`; chat keeps `selectedAgent`. Set
     // both so returning to the KB chat keeps the same agent selected.

--- a/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/connections-step.tsx
@@ -3,6 +3,7 @@ import { useMemo, useState } from "react";
 import { useAppConnections } from "../../../connections/api/queries.js";
 import { ConnectionCatalogModal } from "../../../connections/components/connection-catalog-modal.js";
 import { useCatalogGroups } from "../../../connections/hooks/use-catalog-groups.js";
+import { routeToPath } from "../../../platform/lib/routes.js";
 import { excludeProviderConnections } from "../../lib/provider-connections.js";
 import type { WizardSnapshot } from "../../lib/wizard-snapshot.js";
 import { GrantedConnectionsPanel } from "../granted-connections-panel.js";
@@ -56,7 +57,7 @@ export function ConnectionsStep({ snapshot, update }: Props) {
         <ConnectionCatalogModal
           onClose={() => setCatalogOpen(false)}
           sandbox={{ grantedIds, onToggleGrant: toggle }}
-          oauthReturnView="/sandboxes/new"
+          oauthReturnView={routeToPath({ view: "sandbox-new" })}
         />
       )}
     </div>

--- a/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
@@ -4,6 +4,7 @@ import { useStore } from "../../../store.js";
 import { useResolvedAgentDisplay } from "../../agents/hooks/use-resolved-agent-display.js";
 import { SandboxArtifactsSection } from "../../artifacts/components/sandbox-artifacts-section.js";
 import { useFeatures } from "../../features/api/queries.js";
+import { routeToPath } from "../../platform/lib/routes.js";
 import { ConnectionsSection } from "../components/connections-section.js";
 import { SandboxChannelsSection } from "../components/sandbox-channels-section.js";
 import { SandboxHomeHeader } from "../components/sandbox-home-header.js";
@@ -94,7 +95,11 @@ export function SandboxHomeView() {
       ) : (
         <ConnectionsSection
           agentId={agent.id}
-          oauthReturnView={`/sandboxes/${agent.id}/connections`}
+          oauthReturnView={routeToPath({
+            view: "sandbox-home",
+            agentId: agent.id,
+            sandboxSection: "connections",
+          })}
           inset
         />
       )}

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -11,6 +11,7 @@ import { useCreateExperimentSandbox } from "../../experiments/api/mutations.js";
 import { useFeatures } from "../../features/api/queries.js";
 import { useCreateKnowledgeBase } from "../../knowledge-bases/api/mutations.js";
 import { DEFAULT_KB_TEMPLATE_ID } from "../../knowledge-bases/lib/kb-templates.js";
+import { routeToPath } from "../../platform/lib/routes.js";
 import { useTemplates } from "../../templates/api/queries.js";
 import {
   EMPTY_REGISTRY_CREDENTIAL,
@@ -90,7 +91,7 @@ export function SandboxWizardView() {
     const params = new URLSearchParams(window.location.search);
     const result = params.get("oauth");
     if (!result) return;
-    window.history.replaceState({}, "", "/sandboxes/new");
+    window.history.replaceState({}, "", routeToPath({ view: "sandbox-new" }));
     const connectionId = params.get("connection");
     if (result === "success" && connectionId) {
       const saved = loadSnapshot();

--- a/packages/ui/src/modules/terms/lib/on-terms-stale.ts
+++ b/packages/ui/src/modules/terms/lib/on-terms-stale.ts
@@ -1,3 +1,5 @@
+import { parseRoute, routeToPath } from "../../platform/lib/routes.js";
+
 let redirecting = false;
 let termsStale = false;
 
@@ -7,7 +9,10 @@ export function isTermsStale(): boolean {
 
 export function onTermsStale(): void {
   termsStale = true;
-  if (redirecting || window.location.pathname === "/terms") return;
+  if (redirecting || parseRoute(window.location.pathname).view === "terms")
+    return;
   redirecting = true;
-  window.location.assign("/terms");
+  // Full reload on purpose: the server signalled terms_stale, and a hard
+  // navigation guarantees a clean refetch past the 412 gate.
+  window.location.assign(routeToPath({ view: "terms" }));
 }

--- a/packages/ui/src/modules/terms/lib/preflight.ts
+++ b/packages/ui/src/modules/terms/lib/preflight.ts
@@ -1,7 +1,8 @@
 import { api } from "../../../api.js";
+import { parseRoute } from "../../platform/lib/routes.js";
 
 export async function preflightTermsGate(): Promise<boolean> {
-  if (window.location.pathname === "/terms") return true;
+  if (parseRoute(window.location.pathname).view === "terms") return true;
   try {
     const [current, latest] = await Promise.all([
       api.terms.current.query(),

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 
 import { Markdown } from "../../../components/markdown.js";
+import { useStore } from "../../../store.js";
 import { useAcceptTerms } from "../api/mutations.js";
 import { useLatestAcceptance, useTermsDocument } from "../api/queries.js";
 
@@ -46,6 +47,8 @@ export function TermsView() {
             onClick={() =>
               accept.mutate(
                 { version: doc.version },
+                // Full reload on purpose (unlike BackButton): it clears the
+                // server's 412 terms_stale gate with a clean refetch.
                 { onSuccess: () => window.location.assign("/") },
               )
             }
@@ -92,8 +95,11 @@ function AcceptButton({
 }
 
 function BackButton() {
+  const setView = useStore((s) => s.setView);
+  // setView rather than history.back(): a deep link to /terms has no in-app
+  // history behind it, and history.back() would leave the app entirely.
   return (
-    <Button type="button" onClick={() => window.location.assign("/")}>
+    <Button type="button" onClick={() => setView("list")}>
       Back
     </Button>
   );

--- a/packages/ui/src/store.ts
+++ b/packages/ui/src/store.ts
@@ -10,7 +10,6 @@ import {
   type ExperimentsSlice,
 } from "./modules/experiments/store.js";
 import { createFilesSlice, type FilesSlice } from "./modules/files/store.js";
-import { pathToState } from "./modules/platform/lib/routes.js";
 import {
   createDialogSlice,
   type DialogSlice,
@@ -61,6 +60,3 @@ export const useStore = create<PlatformStore>()((...a) => ({
   ...createArtifactsSlice(...a),
   ...createPermissionsSlice(...a),
 }));
-
-// Reuse the path parser for browser back/forward hydration
-export { pathToState };


### PR DESCRIPTION
Pressing the browser's Back button from the Terms of Use page used to strand you: the address bar went back to Settings, but the Terms page stayed on screen, and the only way out was reloading. The same gap applied to the Telegram and Slack bind pages.

Back and Forward now work everywhere in the app. The Terms page's own Back button also returns you to the app instantly instead of triggering a full page reload.

Alongside the fix, the URL-to-screen mapping is now defined in one place instead of being restated in several, which removes a class of bug where a page could quietly start pointing at the wrong address.

No other user-visible changes.

**Note for reviewers:** returning into a chat via Back now also resets the other navigation fields to their defaults. This is deliberate, not an oversight — those fields only matter while their own screen is showing.

**Rebased onto current main.** The branch was 39 commits behind, and the three PRs that landed in between (#2948, #2971, #3014) rewrote the exact routing table this refactor touches, so the resolution was not mechanical. What changed versus the previously reviewed version:

- The route union now matches main's routes: the `experiment-new` / `experiment-detail` entries are gone (#3014 folded experiment creation into the shared sandbox wizard), and the three knowledge-base routes are in, along with the legacy `/knowledge-bases/new` → wizard redirect.
- A knowledge base's page is the same chat surface under its own route, so it now shares chat's Back handling — Back into a knowledge base restores it properly, and leaving one tears its chat context down. This behavior is new since the last review and is the part worth a second look.
- `knowledge-base-config-view.tsx` picked up the same route-literal treatment as the other call sites; it was written after this branch forked.
- The round-trip test table swapped the dead experiment paths for the knowledge-base ones, and the second ordering trap now pins `/knowledge-bases/new`.

Closes #1219
