### PR TITLE
feat(connections): make GitHub Enterprise connector usable by bots/agents

### DIFF
--- a/docs/architecture/connections.md
+++ b/docs/architecture/connections.md
@@ -1,6 +1,6 @@
 # Connections, Contributions, and the Runtime Channel
 
-Last verified: 2026-07-23
+Last verified: 2026-07-27
 
 ## Overview
 
@@ -89,7 +89,7 @@ A header connection's stored credential can be **updated in place** — the valu
 
 A **client-credentials** connection resolves the token endpoint from the authorization server's published OAuth metadata at create time and mints its first access token synchronously — an undiscoverable issuer or invalid credentials fail the create before anything is persisted. The issuer URL is optional: when omitted, the authorization server is discovered from the API host itself (its protected-resource metadata naming the issuer, or the host serving issuer metadata directly). The same background loop that refreshes OAuth tokens re-mints it before expiry using the stored client secret. One per-Connection Secret holds the client secret, the current access token, and the SDS files baked from it; only the minted access token is ever injected on the wire. A connection whose re-mint keeps failing surfaces as **expired** once its token horizon passes.
 
-A **GitHub App** connection applies the same mint-and-refresh shape to a GitHub App installation, signing the exchange with a private key rather than trading a client secret. The user supplies the app id, installation id, and a PEM private key; the platform signs a short-lived JWT and mints an installation token (`ghs_…`) synchronously at create and again before each expiry. The per-Connection Secret holds the private key (which never leaves the api-server), the current token, and its SDS; the token injects on the same GitHub hosts as a personal access token, and past-expiry surfaces as **expired**.
+A **GitHub App** connection applies the same mint-and-refresh shape to a GitHub App installation, signing the exchange with a private key rather than trading a client secret. The user supplies the app id, installation id, and a PEM private key; the platform signs a short-lived JWT and mints an installation token (`ghs_…`) synchronously at create and again before each expiry. The per-Connection Secret holds the private key (which never leaves the api-server), the current token, and its SDS; the token injects on the same GitHub hosts as a personal access token, and past-expiry surfaces as **expired**. A `github-enterprise-app` sibling targets a configurable host instead.
 
 ### Contribution
 

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-07-23
+Last verified: 2026-07-27
 
 ## Overview
 
@@ -254,7 +254,13 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
   installation-token endpoint (once at connect, then before each expiry via
   the same refresh loop), and re-bakes the same three GitHub host injections
   as the PAT template. The private key stays at rest and is never sent to any
-  host; only the installation token reaches the gateway's injection path.
+  host; only the installation token reaches the gateway's injection path. A
+  `github-enterprise-app` Connection is the same grant against a GitHub
+  Enterprise host: the user also supplies that host (and, optionally, the
+  REST API base the installation-token endpoint lives at, when it isn't the
+  default `https://api.<host>`), and the re-baked injections target that
+  host's own `api.<host>`/`<host>` pair instead of the github.com trio — the
+  same two-host shape the `github-enterprise` OAuth template already uses.
 
 **Multi-host connections.** A single OAuth connection can inject the
 same token on more than one host with **different auth schemes per

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -117,13 +117,17 @@ const clientCredentialsCreateInput = z.object({
 
 // GitHub App installation credential: the app's numeric identity plus a private
 // key. The key is accepted as raw PEM or its base64 encoding (see the build
-// step); the platform mints installation tokens from it server-side.
+// step); the platform mints installation tokens from it server-side. `host`
+// and `apiBaseUrl` only apply to the `github-enterprise-app` template — the
+// plain `github-app` template ignores them and always targets github.com.
 const githubAppCreateInput = z.object({
   ...commonFields,
   authKind: z.literal("github-app"),
   appId: z.string().min(1),
   installationId: z.string().min(1),
   privateKey: z.string().min(1),
+  host: z.string().min(1).optional(),
+  apiBaseUrl: z.string().url().optional(),
 });
 
 const noneCreateInput = z.object({

--- a/packages/api-server/src/__tests__/unit/connections-github-app-inputs.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-github-app-inputs.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { buildCatalog } from "../../modules/connections/domain/catalog.js";
+import { templateToView } from "../../modules/connections/domain/connection-template.js";
+
+const CALLBACK_URL = "https://cb.example/oauth/callback";
+
+describe("github-app template inputs", () => {
+  it("plain github-app exposes no host/apiBaseUrl inputs", () => {
+    const t = buildCatalog().find((t) => t.id === "github-app")!;
+    const view = templateToView(t, CALLBACK_URL);
+    expect(view.inputs.map((i) => i.name)).toEqual([
+      "appId",
+      "installationId",
+      "privateKey",
+    ]);
+  });
+
+  it("github-enterprise-app requires a host and offers an optional apiBaseUrl override", () => {
+    const t = buildCatalog().find((t) => t.id === "github-enterprise-app")!;
+    const view = templateToView(t, CALLBACK_URL);
+    expect(view.inputs.map((i) => i.name)).toEqual([
+      "host",
+      "apiBaseUrl",
+      "appId",
+      "installationId",
+      "privateKey",
+    ]);
+    const host = view.inputs.find((i) => i.name === "host")!;
+    expect(host.state).toBe("required");
+    const apiBaseUrl = view.inputs.find((i) => i.name === "apiBaseUrl")!;
+    expect(apiBaseUrl.state).toBe("optional");
+  });
+
+  it("github-enterprise-app's host is overridable when operator-preset", () => {
+    const t = buildCatalog({
+      githubEnterprise: { host: "ghe.acme.com" },
+    }).find((t) => t.id === "github-enterprise-app")!;
+    const view = templateToView(t, CALLBACK_URL);
+    const host = view.inputs.find((i) => i.name === "host")!;
+    expect(host.state).toBe("overridable");
+    expect(host.presetValue).toBe("ghe.acme.com");
+  });
+});

--- a/packages/api-server/src/__tests__/unit/connections-github-enterprise-app-template.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-github-enterprise-app-template.test.ts
@@ -1,0 +1,184 @@
+import crypto from "node:crypto";
+import { describe, it, expect } from "vitest";
+import type { Contribution, SecretRef } from "api-server-api";
+import { buildConnection } from "../../modules/connections/domain/build-connection.js";
+import { buildCatalog } from "../../modules/connections/domain/catalog.js";
+import { connectionSecretAnnotations } from "../../modules/connections/domain/connection-sds.js";
+
+const { privateKey: PRIVATE_KEY_PEM } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs1", format: "pem" },
+});
+
+function mintRef(purpose: string): SecretRef {
+  return { storeId: "k8s", path: `secret-${purpose}`, field: "" };
+}
+
+function template() {
+  const t = buildCatalog().find((t) => t.id === "github-enterprise-app");
+  if (!t) throw new Error("github-enterprise-app missing from catalog");
+  return t;
+}
+
+function build(
+  input: Partial<{
+    appId: string;
+    installationId: string;
+    privateKey: string;
+    host: string;
+    apiBaseUrl: string;
+  }> = {},
+) {
+  return buildConnection(
+    template(),
+    {
+      templateId: "github-enterprise-app",
+      name: "my-ghe-app",
+      authKind: "github-app",
+      appId: "123456",
+      installationId: "987654",
+      privateKey: PRIVATE_KEY_PEM,
+      host: "ghe.acme.com",
+      ...input,
+    },
+    mintRef,
+    "https://cb.example/oauth/callback",
+    "Test",
+  );
+}
+
+function hostsOf(contributions: Contribution[]): string[] {
+  return contributions
+    .filter((c) => c.kind === "egress-inject")
+    .map((c) => (c.kind === "egress-inject" ? c.host : ""));
+}
+
+describe("github-enterprise-app template build", () => {
+  it("projects inputs into github-app auth with the enterprise host", async () => {
+    const built = await build();
+    expect(built.auth).toEqual({
+      kind: "github-app",
+      appId: "123456",
+      installationId: "987654",
+      privateKeyRef: {
+        storeId: "k8s",
+        path: "secret-connection:github-enterprise-app",
+        field: "private_key",
+      },
+      accessTokenRef: {
+        storeId: "k8s",
+        path: "secret-connection:github-enterprise-app",
+        field: "access_token",
+      },
+      apiBaseUrl: "https://api.ghe.acme.com",
+      host: "ghe.acme.com",
+    });
+  });
+
+  it("honors an explicit apiBaseUrl override", async () => {
+    const built = await build({
+      apiBaseUrl: "https://ghe.acme.com/api/v3",
+    });
+    expect(built.auth).toMatchObject({
+      apiBaseUrl: "https://ghe.acme.com/api/v3",
+      host: "ghe.acme.com",
+    });
+  });
+
+  it("contributes GH_TOKEN, GH_HOST, and the host-derived Bearer/Basic injections", async () => {
+    const built = await build();
+    const env = built.contributions.filter((c) => c.kind === "env");
+    expect(env).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: "GH_TOKEN" }),
+        expect.objectContaining({
+          name: "GH_HOST",
+          placeholder: "ghe.acme.com",
+        }),
+      ]),
+    );
+    expect(hostsOf(built.contributions)).toEqual([
+      "api.ghe.acme.com",
+      "ghe.acme.com",
+    ]);
+    // ghe.acme.com uses Basic x-access-token so git-over-HTTPS works.
+    const git = built.contributions.find(
+      (c) => c.kind === "egress-inject" && c.host === "ghe.acme.com",
+    );
+    expect(git).toMatchObject({
+      valueFormat: "Basic {value}",
+      encoding: "basic-x-access-token",
+    });
+    const api = built.contributions.find(
+      (c) => c.kind === "egress-inject" && c.host === "api.ghe.acme.com",
+    );
+    expect(api).toMatchObject({ valueFormat: "Bearer {value}" });
+  });
+
+  it("stores only the normalized private key — no token material at build time", async () => {
+    const built = await build();
+    expect(
+      built.secrets.get("secret-connection:github-enterprise-app"),
+    ).toEqual({
+      private_key: PRIVATE_KEY_PEM.trim(),
+    });
+  });
+
+  it("carries the injection hosts to the controller annotation", async () => {
+    const built = await build();
+    const raw = connectionSecretAnnotations(built.contributions)[
+      "agent-platform.ai/injection-hosts"
+    ];
+    const entries = JSON.parse(raw) as Record<string, unknown>[];
+    expect(entries.map((e) => e.host)).toEqual([
+      "api.ghe.acme.com",
+      "ghe.acme.com",
+    ]);
+  });
+
+  it("rejects a missing host", async () => {
+    await expect(build({ host: "" })).rejects.toThrow(/missing host/);
+  });
+
+  it.each([
+    ["appId", { appId: "" }],
+    ["installationId", { installationId: "" }],
+    ["privateKey", { privateKey: "" }],
+  ])("rejects a missing %s", async (field, override) => {
+    await expect(build(override)).rejects.toThrow(
+      new RegExp(`missing ${field}`),
+    );
+  });
+
+  it("leaves the plain github-app template's github.com behavior untouched", async () => {
+    const t = buildCatalog().find((t) => t.id === "github-app");
+    if (!t) throw new Error("github-app missing from catalog");
+    const built = await buildConnection(
+      t,
+      {
+        templateId: "github-app",
+        name: "my-app",
+        authKind: "github-app",
+        appId: "123456",
+        installationId: "987654",
+        privateKey: PRIVATE_KEY_PEM,
+        // A host/apiBaseUrl override has no effect outside github-enterprise-app.
+        host: "ghe.acme.com",
+        apiBaseUrl: "https://ghe.acme.com/api/v3",
+      },
+      mintRef,
+      "https://cb.example/oauth/callback",
+      "Test",
+    );
+    expect(built.auth).toMatchObject({
+      apiBaseUrl: "https://api.github.com",
+      host: "github.com",
+    });
+    expect(hostsOf(built.contributions)).toEqual([
+      "api.github.com",
+      "github.com",
+      "raw.githubusercontent.com",
+    ]);
+  });
+});

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -434,6 +434,12 @@ function normalizePrivateKeyPem(raw: string): string {
 // only the signing material (the private key); the installation token and its
 // SDS files are minted by the service before the secret write. The token reaches
 // only the gateway — the private key never leaves the api-server.
+//
+// `github-enterprise-app` is the only variant whose host is per-connection: its
+// contributions are synthesized here (GH_HOST env, plus the same api.{host} /
+// {host} Bearer/Basic split `github-enterprise`'s OAuth build path uses) rather
+// than shipped statically on the template, the way the plain `github-app`
+// template's three github.com contributions are.
 function buildGitHubApp(
   template: Extract<ConnectionTemplate, { authKind: "github-app" }>,
   input: Extract<ConnectionCreateInput, { authKind: "github-app" }>,
@@ -448,8 +454,36 @@ function buildGitHubApp(
   }
   const privateKeyPem = normalizePrivateKeyPem(input.privateKey);
 
+  const isEnterprise = template.id === "github-enterprise-app";
+  const host = isEnterprise ? (input.host ?? template.host) : template.host;
+  if (isEnterprise && !host) {
+    throw new Error(`template ${template.id}: missing host`);
+  }
+  const apiBaseUrl = isEnterprise
+    ? (input.apiBaseUrl ?? template.apiBaseUrl ?? `https://api.${host}`)
+    : (template.apiBaseUrl ?? "https://api.github.com");
+
   const secretPath = mintSecretRef(`connection:${template.id}`);
   const contributions: Contribution[] = [...template.contributions];
+
+  if (isEnterprise) {
+    contributions.push(
+      { kind: "env", name: "GH_HOST", placeholder: host! },
+      {
+        kind: "egress-inject",
+        host: `api.${host}`,
+        headerName: "Authorization",
+        valueFormat: "Bearer {value}",
+      },
+      {
+        kind: "egress-inject",
+        host: host!,
+        headerName: "Authorization",
+        valueFormat: "Basic {value}",
+        encoding: "basic-x-access-token",
+      },
+    );
+  }
 
   return {
     auth: {
@@ -458,8 +492,8 @@ function buildGitHubApp(
       installationId: input.installationId,
       privateKeyRef: { ...secretPath, field: "private_key" },
       accessTokenRef: { ...secretPath, field: "access_token" },
-      apiBaseUrl: template.apiBaseUrl ?? "https://api.github.com",
-      ...(template.host ? { host: template.host } : {}),
+      apiBaseUrl,
+      ...(host ? { host } : {}),
     },
     contributions,
     secrets: new Map([[secretPath.path, { private_key: privateKeyPem }]]),

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -758,6 +758,31 @@ const GITHUB_APP: GitHubAppConnectionTemplate = {
   ],
 };
 
+// GitHub App installation grant against a GitHub Enterprise host — the bot/agent
+// counterpart to the interactive `github-enterprise` OAuth template above. The
+// host has no fixed default (unless operator-preset): contributions are
+// synthesized per-host at build time (see buildGitHubApp's `github-enterprise-app`
+// branch), mirroring the `api.{host}` / `{host}` split `github-enterprise`'s OAuth
+// build path already uses for its own host-specific contributions.
+function githubEnterpriseApp(
+  creds?: GitHubEnterpriseCredentials,
+): GitHubAppConnectionTemplate {
+  return {
+    id: "github-enterprise-app",
+    name: "GitHub Enterprise App (installation)",
+    category: "app",
+    isCustom: false,
+    description:
+      "Act as a GitHub App installation on a GitHub Enterprise host. The platform mints short-lived installation tokens (ghs_…) from the app's private key.",
+    iconSlug: "github-enterprise",
+    authKind: "github-app",
+    ...(creds?.host ? { host: creds.host } : {}),
+    contributions: [
+      { kind: "env", name: "GH_TOKEN", placeholder: "dummy-placeholder" },
+    ],
+  };
+}
+
 const CUSTOM_HEADER: HeaderConnectionTemplate = {
   id: "custom-header",
   name: "Custom header credential",
@@ -824,6 +849,7 @@ export function buildCatalog(
     GITHUB_PAT,
     GITHUB_APP,
     githubEnterprise(creds.githubEnterprise),
+    githubEnterpriseApp(creds.githubEnterprise),
     KUBERNETES,
     spotify(creds.spotify),
     slack(creds.slack),

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -247,8 +247,24 @@ function inputsFor(
         required("valueFormat", { presetValue: t.valueFormat }),
         optional("envName"),
       ];
-    case "github-app":
-      return [
+    case "github-app": {
+      const out: ConnectionTemplateInput[] = [];
+      if (t.id === "github-enterprise-app") {
+        out.push({
+          name: "host",
+          state: t.host ? "overridable" : "required",
+          ...(t.host ? { presetValue: t.host } : {}),
+          label: "Host",
+          hint: "The GitHub Enterprise host to reach, e.g. ghe.acme.com.",
+        });
+        out.push({
+          name: "apiBaseUrl",
+          state: "optional",
+          label: "API base URL",
+          hint: "Where the platform mints installation tokens from. Leave blank to default to https://api.<host>; override for a deployment whose REST API lives elsewhere (e.g. https://<host>/api/v3 for GitHub Enterprise Server).",
+        });
+      }
+      out.push(
         {
           name: "appId",
           state: "required",
@@ -269,7 +285,9 @@ function inputsFor(
           label: "Private key (PEM)",
           hint: "A private key generated for the app (.pem). Paste the whole file including the BEGIN/END lines, or its base64 encoding.",
         },
-      ];
+      );
+      return out;
+    }
     case "header": {
       const out: ConnectionTemplateInput[] = [];
       if (t.isCustom) {

--- a/packages/ui/src/modules/connections/forms/field-copy.ts
+++ b/packages/ui/src/modules/connections/forms/field-copy.ts
@@ -13,6 +13,7 @@ const FIELD_LABELS: Record<string, string> = {
   appId: "App ID",
   installationId: "Installation ID",
   privateKey: "Private key (PEM)",
+  apiBaseUrl: "API base URL",
   envName: "Environment variable",
   caData: "Server CA certificate",
 };
@@ -32,6 +33,7 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   appId: "123456",
   installationId: "987654",
   privateKey: "-----BEGIN RSA PRIVATE KEY-----\n…",
+  apiBaseUrl: "https://api.ghe.acme.com",
   envName: "MY_API_KEY",
   caData: "certificate-authority-data from your kubeconfig (base64 or PEM)",
 };

--- a/packages/ui/src/modules/connections/internal-only.ts
+++ b/packages/ui/src/modules/connections/internal-only.ts
@@ -7,6 +7,7 @@ export const INTERNAL_ONLY_TEMPLATE_IDS: ReadonlySet<string> = new Set([
   "youtube",
   "custom-client-credentials",
   "github-app",
+  "github-enterprise-app",
 ]);
 
 // All Google services (catalog ids "google-*") are internal-only as a group.

--- a/packages/ui/src/modules/connections/lib/build-create-payload.ts
+++ b/packages/ui/src/modules/connections/lib/build-create-payload.ts
@@ -74,6 +74,8 @@ export function buildCreatePayload(
         appId,
         installationId,
         privateKey,
+        host: submitted("host"),
+        apiBaseUrl: submitted("apiBaseUrl"),
       });
     }
     case "header": {


### PR DESCRIPTION
## Summary

- Adds a `github-enterprise-app` Connection template — a `github-app`-authKind sibling of the existing `github-app` template — so a GitHub App installation (a bot/agent identity, no human consent step) can target a GitHub Enterprise host instead of only github.com.
- The connection's host is per-connection input (operator-presettable via the same `githubEnterprise` credentials already used by the interactive `github-enterprise` OAuth template), with an optional API base URL override for deployments whose REST API isn't at the default `https://api.<host>` (e.g. self-hosted GitHub Enterprise Server's `/api/v3`).
- Contributions (GH_HOST env, Bearer/Basic egress-injects) are synthesized per-host at build time, reusing the exact `api.<host>` / `<host>` two-host split the existing `github-enterprise` OAuth template's build path already uses — no new runtime/gateway mechanics introduced.
- The plain `github-app` template (github.com) is untouched — its contributions, `apiBaseUrl`, and `host` stay hardcoded exactly as before.
- New template is internal-only (gated behind the `advanced-connections` flag), same as the existing `github-app` template.

## Why

Closes #2978. The `dam-application[bot]` GitHub App identity (and any other bot/agent installation) could only ever authenticate against github.com — there was no way to mint installation tokens for, or inject credentials on, a GitHub Enterprise host from a non-interactive (bot) connection. The interactive `github-enterprise` OAuth template already supports a configurable host, but requires a human consent step, which doesn't work for automation.

## Test plan

- [x] `mise run check` per-package (tsc/eslint/prettier) on `api-server`, `api-server-api`, `ui` — clean (full repo-wide `mise run check` isn't runnable from this worktree — the Go CRD-backwards-compat check can't resolve refs through a worktree gitdir; unrelated to this change, which touches no Go/CRD files)
- [x] `docs:check:doc-size` — both edited architecture pages stay under the character cap
- [x] New unit tests: `connections-github-enterprise-app-template.test.ts` (host required, apiBaseUrl default/override, contributions, secrets, controller annotation, plain `github-app` behavior unchanged) and `connections-github-app-inputs.test.ts` (template `inputs[]` shape for both templates)
- [x] Full `api-server`/`ui` vitest suites pass (627 + 104 tests)
- [ ] Manual: create a `github-enterprise-app` connection against a real GHE instance and confirm an agent can read/open a PR on it