### PR TITLE
fix(ui): OAuth result notification no longer disappears

### DIFF
--- a/packages/ui/src/components/ui/sonner.tsx
+++ b/packages/ui/src/components/ui/sonner.tsx
@@ -1,9 +1,15 @@
+import { useEffect } from "react";
 import { Toaster as Sonner, type ToasterProps } from "sonner";
 
+import { onToastHostMounted } from "@/lib/toast";
 import { useStore } from "@/store";
 
 const Toaster = (props: ToasterProps) => {
   const theme = useStore((s) => s.theme);
+
+  // Runs after Sonner's own subscribe effect — child effects fire before the
+  // parent's — so buffered toasts have somewhere to land by the time we flush.
+  useEffect(onToastHostMounted, []);
   const resolved =
     theme === "dark" ||
     (theme === "system" &&

--- a/packages/ui/src/lib/toast.ts
+++ b/packages/ui/src/lib/toast.ts
@@ -26,16 +26,35 @@ const EMIT: Record<
   info: sonner.info,
 };
 
-/** Surface a toast through Sonner. The single emit path for the whole app —
- *  React components and non-React modules (query helpers) both call this. */
-export function emitToast({
-  kind,
-  message,
-  action,
-  ttl,
-}: Toast): string | number {
-  return EMIT[kind](message, {
+/** Sonner fans a toast out to whoever is subscribed at publish time and keeps
+ *  no backlog, so anything emitted before `<Toaster>` mounts is lost for good.
+ *  On a cold load that silently swallows mount-time toasts — including the
+ *  OAuth result, which only ever arrives on a cold load. */
+let hostReady = false;
+const pending: Toast[] = [];
+
+/** Called by the Toaster wrapper once Sonner is subscribed. */
+export function onToastHostMounted(): () => void {
+  hostReady = true;
+  for (const toast of pending.splice(0)) send(toast);
+  return () => {
+    hostReady = false;
+  };
+}
+
+function send({ kind, message, action, ttl }: Toast): void {
+  EMIT[kind](message, {
     action,
     duration: ttl === undefined ? DEFAULT_TTL : ttl > 0 ? ttl : Infinity,
   });
+}
+
+/** Surface a toast through Sonner. The single emit path for the whole app —
+ *  React components and non-React modules (query helpers) both call this. */
+export function emitToast(toast: Toast): void {
+  if (!hostReady) {
+    pending.push(toast);
+    return;
+  }
+  send(toast);
 }


### PR DESCRIPTION
After authorizing a connection with an external provider, the app is supposed to tell you whether it worked. That notification never appeared — neither the success confirmation nor the failure message.

The cause was a timing problem: notifications sent while the app is still starting up had nowhere to go yet and were discarded. That affected the OAuth result specifically, because it always arrives just as the app reloads after returning from the provider.

Notifications sent during startup are now held briefly and shown once the app is ready. Verified for both places the OAuth result can appear: the sandbox creation wizard and the main app shell.

No other user-visible changes.