### PR TITLE
feat(connections): add GitHub App auth for GitHub Enterprise (bots/agents)

### DIFF
--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -117,10 +117,13 @@ const clientCredentialsCreateInput = z.object({
 
 // GitHub App installation credential: the app's numeric identity plus a private
 // key. The key is accepted as raw PEM or its base64 encoding (see the build
-// step); the platform mints installation tokens from it server-side.
+// step); the platform mints installation tokens from it server-side. `host`
+// is only meaningful for a template whose REST base is host-parameterized
+// (a GitHub Enterprise installation) — ignored otherwise.
 const githubAppCreateInput = z.object({
   ...commonFields,
   authKind: z.literal("github-app"),
+  host: z.string().min(1).optional(),
   appId: z.string().min(1),
   installationId: z.string().min(1),
   privateKey: z.string().min(1),

--- a/packages/api-server/src/__tests__/unit/connections-github-enterprise-app-template.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-github-enterprise-app-template.test.ts
@@ -1,0 +1,170 @@
+import crypto from "node:crypto";
+import { describe, it, expect } from "vitest";
+import type { Contribution, SecretRef } from "api-server-api";
+import { buildConnection } from "../../modules/connections/domain/build-connection.js";
+import {
+  buildCatalog,
+  type OperatorCredentials,
+} from "../../modules/connections/domain/catalog.js";
+import { templateToView } from "../../modules/connections/domain/connection-template.js";
+import { connectionSecretAnnotations } from "../../modules/connections/domain/connection-sds.js";
+
+const { privateKey: PRIVATE_KEY_PEM } = crypto.generateKeyPairSync("rsa", {
+  modulusLength: 2048,
+  publicKeyEncoding: { type: "spki", format: "pem" },
+  privateKeyEncoding: { type: "pkcs1", format: "pem" },
+});
+
+function mintRef(purpose: string): SecretRef {
+  return { storeId: "k8s", path: `secret-${purpose}`, field: "" };
+}
+
+function template(creds?: OperatorCredentials) {
+  const t = buildCatalog(creds).find((t) => t.id === "github-enterprise-app");
+  if (!t) throw new Error("github-enterprise-app missing from catalog");
+  return t;
+}
+
+function build(
+  input: Partial<{
+    host: string;
+    appId: string;
+    installationId: string;
+    privateKey: string;
+  }> = {},
+  creds?: OperatorCredentials,
+) {
+  return buildConnection(
+    template(creds),
+    {
+      templateId: "github-enterprise-app",
+      name: "my-ghe-app",
+      authKind: "github-app",
+      host: "ghe.acme.com",
+      appId: "123456",
+      installationId: "987654",
+      privateKey: PRIVATE_KEY_PEM,
+      ...input,
+    },
+    mintRef,
+    "https://cb.example/oauth/callback",
+    "Test",
+  );
+}
+
+function hostsOf(contributions: Contribution[]): string[] {
+  return contributions
+    .filter((c) => c.kind === "egress-inject")
+    .map((c) => (c.kind === "egress-inject" ? c.host : ""));
+}
+
+describe("github-enterprise-app template build", () => {
+  it("substitutes the enterprise host into apiBaseUrl and auth.host", async () => {
+    const built = await build();
+    expect(built.auth).toEqual({
+      kind: "github-app",
+      appId: "123456",
+      installationId: "987654",
+      privateKeyRef: {
+        storeId: "k8s",
+        path: "secret-connection:github-enterprise-app",
+        field: "private_key",
+      },
+      accessTokenRef: {
+        storeId: "k8s",
+        path: "secret-connection:github-enterprise-app",
+        field: "access_token",
+      },
+      apiBaseUrl: "https://api.ghe.acme.com",
+      host: "ghe.acme.com",
+    });
+  });
+
+  it("contributes GH_TOKEN, GH_HOST, and the enterprise host injections", async () => {
+    const built = await build();
+    const envNames = built.contributions
+      .filter((c) => c.kind === "env")
+      .map((c) => (c.kind === "env" ? c.name : ""));
+    expect(envNames).toEqual(["GH_TOKEN", "GH_HOST"]);
+    expect(hostsOf(built.contributions)).toEqual([
+      "api.ghe.acme.com",
+      "ghe.acme.com",
+    ]);
+    // The apex host uses Basic x-access-token so git-over-HTTPS works, same
+    // as the interactive OAuth GHE connection.
+    const git = built.contributions.find(
+      (c) => c.kind === "egress-inject" && c.host === "ghe.acme.com",
+    );
+    expect(git).toMatchObject({
+      valueFormat: "Basic {value}",
+      encoding: "basic-x-access-token",
+    });
+  });
+
+  it("rejects a missing host", async () => {
+    await expect(build({ host: "" })).rejects.toThrow(/missing host/);
+  });
+
+  it("falls back to the operator-preset host when the user supplies none", async () => {
+    const built = await build(
+      { host: undefined },
+      { githubEnterprise: { host: "ghe.operator.example" } },
+    );
+    expect(built.auth).toMatchObject({
+      apiBaseUrl: "https://api.ghe.operator.example",
+      host: "ghe.operator.example",
+    });
+  });
+
+  it("carries the injection hosts to the controller annotation", async () => {
+    const built = await build();
+    const raw = connectionSecretAnnotations(built.contributions)[
+      "agent-platform.ai/injection-hosts"
+    ];
+    const entries = JSON.parse(raw) as Record<string, unknown>[];
+    expect(entries.map((e) => e.host)).toEqual([
+      "api.ghe.acme.com",
+      "ghe.acme.com",
+    ]);
+  });
+
+  it.each([
+    ["appId", { appId: "" }],
+    ["installationId", { installationId: "" }],
+    ["privateKey", { privateKey: "" }],
+  ])("rejects a missing %s", async (field, override) => {
+    await expect(build(override)).rejects.toThrow(
+      new RegExp(`missing ${field}`),
+    );
+  });
+});
+
+describe("github-enterprise-app template view", () => {
+  it("requires a host input when the operator has not preset one", () => {
+    const view = templateToView(
+      template(),
+      "https://cb.example/oauth/callback",
+    );
+    const host = view.inputs.find((i) => i.name === "host");
+    expect(host).toMatchObject({ state: "required" });
+  });
+
+  it("surfaces the operator-preset host as overridable", () => {
+    const view = templateToView(
+      template({ githubEnterprise: { host: "ghe.operator.example" } }),
+      "https://cb.example/oauth/callback",
+    );
+    const host = view.inputs.find((i) => i.name === "host");
+    expect(host).toMatchObject({
+      state: "overridable",
+      presetValue: "ghe.operator.example",
+    });
+  });
+
+  it("does not ask the fixed github.com template for a host", () => {
+    const t = buildCatalog().find((t) => t.id === "github-app");
+    if (!t) throw new Error("github-app missing from catalog");
+    const view = templateToView(t, "https://cb.example/oauth/callback");
+    expect(view.inputs.find((i) => i.name === "host")).toBeUndefined();
+  });
+});

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -142,20 +142,7 @@ async function buildOAuthStatic(
 
   if (template.id === "github-enterprise") {
     if (!host) throw new Error(`template github-enterprise: missing host`);
-    contributions.push({ kind: "env", name: "GH_HOST", placeholder: host });
-    contributions.push({
-      kind: "egress-inject",
-      host: `api.${host}`,
-      headerName: "Authorization",
-      valueFormat: "Bearer {value}",
-    });
-    contributions.push({
-      kind: "egress-inject",
-      host,
-      headerName: "Authorization",
-      valueFormat: "Basic {value}",
-      encoding: "basic-x-access-token",
-    });
+    contributions.push(...githubEnterpriseHostContributions(host));
   }
 
   const appSlug =
@@ -212,6 +199,29 @@ function substituteHostInContribution(
     case "skill-ref":
       return c;
   }
+}
+
+// Shared by every GitHub Enterprise auth mode (OAuth today, GitHub App
+// below): GH_HOST for the `gh` CLI, plus the two host-scoped injections a
+// subdomain-isolated GHES instance serves — `api.{host}` (Bearer, REST) and
+// the apex `{host}` (Basic x-access-token, git-over-HTTPS).
+function githubEnterpriseHostContributions(host: string): Contribution[] {
+  return [
+    { kind: "env", name: "GH_HOST", placeholder: host },
+    {
+      kind: "egress-inject",
+      host: `api.${host}`,
+      headerName: "Authorization",
+      valueFormat: "Bearer {value}",
+    },
+    {
+      kind: "egress-inject",
+      host,
+      headerName: "Authorization",
+      valueFormat: "Basic {value}",
+      encoding: "basic-x-access-token",
+    },
+  ];
 }
 
 async function buildOAuthDcr(
@@ -448,8 +458,26 @@ function buildGitHubApp(
   }
   const privateKeyPem = normalizePrivateKeyPem(input.privateKey);
 
+  // A host-parameterized template (its apiBaseUrl carries `{host}`, e.g. the
+  // GitHub Enterprise sibling) takes the host from user input and substitutes
+  // it through, same as the OAuth GHE path; the fixed github.com template has
+  // nothing to substitute and keeps its static host + contributions.
+  const apiBaseUrlTemplate = template.apiBaseUrl ?? "https://api.github.com";
+  const needsHost = apiBaseUrlTemplate.includes("{host}");
+  const host = needsHost ? (input.host ?? template.host) : template.host;
+  if (needsHost && !host)
+    throw new Error(`template ${template.id}: missing host`);
+  const apiBaseUrl = host
+    ? apiBaseUrlTemplate.replace(/\{host\}/g, host)
+    : apiBaseUrlTemplate;
+
   const secretPath = mintSecretRef(`connection:${template.id}`);
-  const contributions: Contribution[] = [...template.contributions];
+  const contributions: Contribution[] = template.contributions.map((c) =>
+    needsHost && host ? substituteHostInContribution(c, host) : c,
+  );
+  if (needsHost && host) {
+    contributions.push(...githubEnterpriseHostContributions(host));
+  }
 
   return {
     auth: {
@@ -458,8 +486,8 @@ function buildGitHubApp(
       installationId: input.installationId,
       privateKeyRef: { ...secretPath, field: "private_key" },
       accessTokenRef: { ...secretPath, field: "access_token" },
-      apiBaseUrl: template.apiBaseUrl ?? "https://api.github.com",
-      ...(template.host ? { host: template.host } : {}),
+      apiBaseUrl,
+      ...(host ? { host } : {}),
     },
     contributions,
     secrets: new Map([[secretPath.path, { private_key: privateKeyPem }]]),

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -758,6 +758,33 @@ const GITHUB_APP: GitHubAppConnectionTemplate = {
   ],
 };
 
+// GitHub App installation on a GitHub Enterprise host — the bot/agent
+// counterpart to the interactive `github-enterprise` OAuth connection. The
+// user supplies the enterprise host at connect time; `apiBaseUrl`'s `{host}`
+// placeholder is substituted the same way OAuth endpoint placeholders are
+// (see `buildGitHubApp`), and the host-scoped injections mirror the OAuth
+// template's (subdomain-isolated `api.{host}` for REST, apex `{host}` for
+// git-over-HTTPS).
+function githubEnterpriseApp(
+  creds?: GitHubEnterpriseCredentials,
+): GitHubAppConnectionTemplate {
+  return {
+    id: "github-enterprise-app",
+    name: "GitHub Enterprise (App installation)",
+    category: "app",
+    isCustom: false,
+    description:
+      "Act as a GitHub App installation on a GitHub Enterprise host. The platform mints short-lived installation tokens (ghs_…) from the app's private key — usable by bots and scheduled agents, not just interactive sign-in.",
+    iconSlug: "github-enterprise",
+    authKind: "github-app",
+    ...(creds?.host ? { host: creds.host } : {}),
+    apiBaseUrl: "https://api.{host}",
+    contributions: [
+      { kind: "env", name: "GH_TOKEN", placeholder: "dummy-placeholder" },
+    ],
+  };
+}
+
 const CUSTOM_HEADER: HeaderConnectionTemplate = {
   id: "custom-header",
   name: "Custom header credential",
@@ -824,6 +851,7 @@ export function buildCatalog(
     GITHUB_PAT,
     GITHUB_APP,
     githubEnterprise(creds.githubEnterprise),
+    githubEnterpriseApp(creds.githubEnterprise),
     KUBERNETES,
     spotify(creds.spotify),
     slack(creds.slack),

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -247,8 +247,15 @@ function inputsFor(
         required("valueFormat", { presetValue: t.valueFormat }),
         optional("envName"),
       ];
-    case "github-app":
-      return [
+    case "github-app": {
+      const out: ConnectionTemplateInput[] = [];
+      // Only a host-parameterized template (its apiBaseUrl carries a
+      // `{host}` placeholder, e.g. the GitHub Enterprise sibling) asks for a
+      // host — the fixed github.com template has nothing to substitute.
+      if (t.apiBaseUrl?.includes("{host}")) {
+        out.push(t.host ? overridable("host", t.host) : required("host"));
+      }
+      out.push(
         {
           name: "appId",
           state: "required",
@@ -269,7 +276,9 @@ function inputsFor(
           label: "Private key (PEM)",
           hint: "A private key generated for the app (.pem). Paste the whole file including the BEGIN/END lines, or its base64 encoding.",
         },
-      ];
+      );
+      return out;
+    }
     case "header": {
       const out: ConnectionTemplateInput[] = [];
       if (t.isCustom) {

--- a/packages/cli/src/modules/connection/commands/connect.ts
+++ b/packages/cli/src/modules/connection/commands/connect.ts
@@ -140,6 +140,8 @@ export function buildConnectCommand(deps: {
         "      --issuer-url https://auth.example.com/realms/main --client-id … --client-secret …\n" +
         "  dam connection connect github-app --app-id 123456 --installation-id 987654 \\\n" +
         '      --private-key "$(cat app.pem)"\n' +
+        "  dam connection connect github-enterprise-app --host ghe.acme.com \\\n" +
+        '      --app-id 123456 --installation-id 987654 --private-key "$(cat app.pem)"\n' +
         "  dam connection connect bob --value sk-… --config model=premium-shell --config chatMode=code\n" +
         "  dam connection connect https://mcp.example.com\n" +
         "  dam connection connect https://mcp.example.com --auth none\n",
@@ -504,6 +506,7 @@ function buildPayload(
       return {
         ...common,
         authKind: "github-app",
+        ...(v("host") ? { host: v("host")! } : {}),
         appId,
         installationId,
         privateKey,

--- a/packages/ui/src/__tests__/unit/build-create-payload.test.ts
+++ b/packages/ui/src/__tests__/unit/build-create-payload.test.ts
@@ -1,0 +1,97 @@
+import type { ConnectionTemplateView } from "api-server-api";
+import { describe, expect, it } from "vitest";
+
+import {
+  buildCreatePayload,
+  type CreateFormValues,
+} from "../../modules/connections/lib/build-create-payload.js";
+
+const GITHUB_APP_TEMPLATE: ConnectionTemplateView = {
+  id: "github-app",
+  name: "GitHub App (installation)",
+  category: "app",
+  isCustom: false,
+  authKind: "github-app",
+  inputs: [
+    { name: "appId", state: "required" },
+    { name: "installationId", state: "required" },
+    { name: "privateKey", state: "required", secret: true },
+  ],
+};
+
+const GITHUB_ENTERPRISE_APP_TEMPLATE: ConnectionTemplateView = {
+  id: "github-enterprise-app",
+  name: "GitHub Enterprise (App installation)",
+  category: "app",
+  isCustom: false,
+  authKind: "github-app",
+  inputs: [
+    { name: "host", state: "required" },
+    { name: "appId", state: "required" },
+    { name: "installationId", state: "required" },
+    { name: "privateKey", state: "required", secret: true },
+  ],
+};
+
+const GITHUB_ENTERPRISE_APP_PRESET_TEMPLATE: ConnectionTemplateView = {
+  ...GITHUB_ENTERPRISE_APP_TEMPLATE,
+  inputs: [
+    { name: "host", state: "overridable", presetValue: "ghe.operator.example" },
+    ...GITHUB_ENTERPRISE_APP_TEMPLATE.inputs.slice(1),
+  ],
+};
+
+function values(fields: Record<string, string>): CreateFormValues {
+  return { name: "my-connection", fields, overrideDefaults: false };
+}
+
+describe("buildCreatePayload (github-app)", () => {
+  it("builds without a host field when the template has none", () => {
+    const payload = buildCreatePayload(
+      GITHUB_APP_TEMPLATE,
+      values({ appId: "1", installationId: "2", privateKey: "pem" }),
+    );
+    expect(payload).toEqual({
+      templateId: "github-app",
+      name: "my-connection",
+      authKind: "github-app",
+      appId: "1",
+      installationId: "2",
+      privateKey: "pem",
+    });
+  });
+
+  it("rejects an empty required host with an inline error, not a passthrough", () => {
+    const payload = buildCreatePayload(
+      GITHUB_ENTERPRISE_APP_TEMPLATE,
+      values({
+        host: "",
+        appId: "1",
+        installationId: "2",
+        privateKey: "pem",
+      }),
+    );
+    expect(payload).toEqual({ error: "Host is required" });
+  });
+
+  it("includes the host once supplied", () => {
+    const payload = buildCreatePayload(
+      GITHUB_ENTERPRISE_APP_TEMPLATE,
+      values({
+        host: "ghe.acme.com",
+        appId: "1",
+        installationId: "2",
+        privateKey: "pem",
+      }),
+    );
+    expect(payload).toMatchObject({ host: "ghe.acme.com" });
+  });
+
+  it("does not require an empty host when it's only overridable (operator preset)", () => {
+    const payload = buildCreatePayload(
+      GITHUB_ENTERPRISE_APP_PRESET_TEMPLATE,
+      values({ host: "", appId: "1", installationId: "2", privateKey: "pem" }),
+    );
+    expect(payload).not.toHaveProperty("error");
+  });
+});

--- a/packages/ui/src/modules/connections/internal-only.ts
+++ b/packages/ui/src/modules/connections/internal-only.ts
@@ -7,6 +7,7 @@ export const INTERNAL_ONLY_TEMPLATE_IDS: ReadonlySet<string> = new Set([
   "youtube",
   "custom-client-credentials",
   "github-app",
+  "github-enterprise-app",
 ]);
 
 // All Google services (catalog ids "google-*") are internal-only as a group.

--- a/packages/ui/src/modules/connections/lib/build-create-payload.ts
+++ b/packages/ui/src/modules/connections/lib/build-create-payload.ts
@@ -62,16 +62,20 @@ export function buildCreatePayload(
         envName: submitted("envName"),
       });
     case "github-app": {
+      const host = submitted("host");
       const appId = submitted("appId");
       const installationId = submitted("installationId");
       const privateKey = submitted("privateKey");
+      if (inputsByName.get("host")?.state === "required" && !host) {
+        return { error: "Host is required" };
+      }
       if (!appId) return { error: "App ID is required" };
       if (!installationId) return { error: "Installation ID is required" };
       if (!privateKey) return { error: "Private key is required" };
       return compact({
         ...common,
         authKind: "github-app" as const,
-        host: submitted("host"),
+        host,
         appId,
         installationId,
         privateKey,

--- a/packages/ui/src/modules/connections/lib/build-create-payload.ts
+++ b/packages/ui/src/modules/connections/lib/build-create-payload.ts
@@ -71,6 +71,7 @@ export function buildCreatePayload(
       return compact({
         ...common,
         authKind: "github-app" as const,
+        host: submitted("host"),
         appId,
         installationId,
         privateKey,

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,6 +1,15 @@
+import path from "node:path";
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  // Mirrors vite.config.ts / tsconfig.json's `@` alias so a unit test can
+  // import a module that itself imports via `@/...` (e.g. `@/lib/compact`).
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
   test: {
     include: ["src/__tests__/unit/**/*.test.ts"],
     environment: "node",


### PR DESCRIPTION
## Summary

- Closes #2978. The GitHub Enterprise connector only supported interactive OAuth, so bot/scheduled-agent identities (e.g. automated PR/issue creation) couldn't authenticate against a GHE instance — only against github.com.
- Adds a `github-enterprise-app` connection template: the same GitHub App installation auth (app id + installation id + private key, no user consent step) already offered for github.com via `github-app`, now with the enterprise host taken as user input. The platform mints installation tokens (`ghs_…`) from the app's private key exactly as it already does for github.com.
- The host is substituted through `apiBaseUrl` and the two GHE host injections (`api.{host}` Bearer for REST, apex `{host}` Basic x-access-token for git-over-HTTPS), mirroring the existing interactive `github-enterprise` OAuth path's host handling — factored into a shared `githubEnterpriseHostContributions` helper so both auth modes stay in sync.
- Wires the new `host` input through the connection-template input list, the API create-input schema, the UI create form, and the CLI (`dam connection connect github-enterprise-app --host ghe.acme.com ...`).
- The operator-preset GHE host (`oauthAppDefaults.githubEnterprise.host`, already wired for the OAuth template) is reused as a preset for this template too, so operators don't configure the enterprise host twice.
- Gated behind the advanced-connections experimental flag, same as the existing `github-app` (github.com) template — this is a UI-catalog-offering gate only, not a backend restriction.

## Test plan

- [x] `packages/api-server`: new unit test file (`connections-github-enterprise-app-template.test.ts`) covering host substitution into `apiBaseUrl`/`auth.host`, the GH_TOKEN/GH_HOST + host-injection contributions, missing-host rejection, operator-preset host fallback, and the template-view input states (required vs. overridable). Full suite: 629 passed (2 pre-existing, unrelated `cluster-ca-probe` failures reproduce on `main`).
- [x] `packages/api-server-api`, `packages/ui`, `packages/cli`: `tsc --noEmit`, `eslint`, `prettier --check` all clean on touched files.
- [x] `packages/ui` (104 tests) and `packages/cli` (154 tests) full suites pass with no regressions.
- [ ] Manual: create a `github-enterprise-app` connection against a real GHE instance and confirm an agent can read/open a PR on it (not done — no live GHE instance available in this environment).