### PR TITLE
refactor(ui): extract a shared `Callout` (bordered box) component

### DIFF
--- a/packages/ui/src/components/ui/callout.tsx
+++ b/packages/ui/src/components/ui/callout.tsx
@@ -1,0 +1,61 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import * as React from "react";
+
+import { FIELD_INSET } from "@/components/ui/inset";
+import { cn } from "@/lib/utils";
+
+const calloutVariants = cva("rounded-lg border", {
+  variants: {
+    tone: {
+      default: "border-border",
+      muted: "border-border bg-muted/40",
+      info: "border-callout-border bg-callout",
+      warning: "border-warning bg-warning-light",
+      danger: "border-danger bg-danger-light",
+    },
+    variant: {
+      solid: "",
+      dashed: "border-dashed",
+    },
+    size: {
+      sm: "p-3",
+      md: "p-4",
+    },
+  },
+  defaultVariants: { tone: "default", variant: "solid", size: "md" },
+});
+
+export interface CalloutProps
+  extends React.ComponentProps<"div">, VariantProps<typeof calloutVariants> {
+  inset?: boolean;
+}
+
+/** The one bordered box: hints, notices, alerts, and form groups all render
+ *  through it so radius, border weight, padding, and background stop drifting
+ *  per call site. A dumb container — children own their own anatomy.
+ *
+ *  `inset` is off by default (unlike `FormField`'s): most call sites live in
+ *  gutter-less containers where the outdent would push the box onto the
+ *  container's border. */
+function Callout({
+  className,
+  tone,
+  variant,
+  size,
+  inset,
+  ...props
+}: CalloutProps) {
+  return (
+    <div
+      data-slot="callout"
+      className={cn(
+        calloutVariants({ tone, variant, size }),
+        inset && FIELD_INSET,
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
+export { Callout, calloutVariants };

--- a/packages/ui/src/components/ui/empty-state-card.tsx
+++ b/packages/ui/src/components/ui/empty-state-card.tsx
@@ -1,7 +1,7 @@
 import { Add } from "@carbon/icons-react";
 
 import { Button } from "@/components/ui/button";
-import { Inset } from "@/components/ui/inset";
+import { Callout } from "@/components/ui/callout";
 
 interface Props {
   message: string;
@@ -20,8 +20,8 @@ export function EmptyStateCard({
   actionTestId,
 }: Props) {
   return (
-    <Inset className="rounded-lg border border-border bg-card">
-      <div className="flex flex-col items-center gap-4 py-10">
+    <Callout inset className="bg-card">
+      <div className="flex flex-col items-center gap-4 py-6">
         <p className="text-[14px] text-foreground/80">{message}</p>
         <Button
           variant="outline"
@@ -33,6 +33,6 @@ export function EmptyStateCard({
           {actionLabel}
         </Button>
       </div>
-    </Inset>
+    </Callout>
   );
 }

--- a/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
+++ b/packages/ui/src/modules/agents/components/configure-agent/env-tab.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, KeyRound, Lock } from "lucide-react";
 
+import { Callout } from "@/components/ui/callout";
 import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
@@ -72,14 +73,18 @@ export function EnvTab({
       <div className="flex flex-col gap-2">
         <SectionLabel>Custom</SectionLabel>
         {warnings.length > 0 && (
-          <div className="flex flex-col gap-1 rounded-md border-2 border-warning bg-warning-light px-3 py-2 text-[12px]">
+          <Callout
+            tone="warning"
+            size="sm"
+            className="flex flex-col gap-1 text-[12px]"
+          >
             <div className="flex items-center gap-2 text-warning">
               <AlertTriangle size={12} />
               <span className="font-bold uppercase tracking-[0.05em] text-[10px]">
                 Shadowing inherited values
               </span>
             </div>
-            <ul className="list-disc pl-5 text-text-muted">
+            <ul className="list-disc pl-5 text-muted-foreground">
               {warnings.map((w) => (
                 <li key={w.envName}>
                   <span className="font-mono">{w.envName}</span> shadows{" "}
@@ -87,7 +92,7 @@ export function EnvTab({
                 </li>
               ))}
             </ul>
-          </div>
+          </Callout>
         )}
         <EnvVarsEditor
           value={envVars}

--- a/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
@@ -3,6 +3,7 @@ import { KeyRound } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
 import { PageHeader } from "@/components/ui/page-header";
 
 import { useRevokeApiKey } from "../api/mutations.js";
@@ -42,7 +43,7 @@ export function ApiKeysList() {
       )}
 
       {isError && (
-        <div className="p-4 rounded-xl border-2 border-danger-light bg-danger-light">
+        <Callout tone="danger">
           <p className="text-[13px] text-danger font-semibold mb-1">
             Couldn't load API keys
           </p>
@@ -50,7 +51,7 @@ export function ApiKeysList() {
             The server returned an error. Try again or check your network
             connection.
           </p>
-        </div>
+        </Callout>
       )}
 
       {!isLoading && !isError && keys && keys.length === 0 && (

--- a/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-keys-list.tsx
@@ -55,13 +55,15 @@ export function ApiKeysList() {
       )}
 
       {!isLoading && !isError && keys && keys.length === 0 && (
-        <div className="flex flex-col items-center gap-3 p-8 rounded-xl border border-dashed border-border bg-card">
-          <KeyRound size={32} className="text-muted-foreground" />
-          <p className="text-[13px] text-muted-foreground">
-            No API keys yet. Create one to authenticate the CLI without a
-            browser.
-          </p>
-        </div>
+        <Callout variant="dashed" className="bg-card">
+          <div className="flex flex-col items-center gap-3 py-4">
+            <KeyRound size={32} className="text-muted-foreground" />
+            <p className="text-[13px] text-muted-foreground">
+              No API keys yet. Create one to authenticate the CLI without a
+              browser.
+            </p>
+          </div>
+        </Callout>
       )}
 
       {!isLoading && !isError && keys && keys.length > 0 && (

--- a/packages/ui/src/modules/api-keys/components/create-api-key-dialog/create-form.tsx
+++ b/packages/ui/src/modules/api-keys/components/create-api-key-dialog/create-form.tsx
@@ -3,8 +3,8 @@ import { useState } from "react";
 
 import { FormField } from "@/components/form-field";
 import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
-import { Inset } from "@/components/ui/inset.js";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import {
@@ -107,7 +107,7 @@ export function CreateApiKeyForm({ onCreated, onCancel }: Props) {
             exfiltrated key with only <code>agents:read</code> cannot change
             anything or run an agent.
           </p>
-          <Inset className="space-y-4 rounded-lg border border-border p-4">
+          <Callout inset className="space-y-4">
             {SCOPE_GROUPS.map((group) => (
               <div key={group.label}>
                 <SectionLabel className="mb-1.5 block">
@@ -125,7 +125,7 @@ export function CreateApiKeyForm({ onCreated, onCancel }: Props) {
                 </div>
               </div>
             ))}
-          </Inset>
+          </Callout>
         </div>
 
         {showBinding && (

--- a/packages/ui/src/modules/artifacts/components/sandbox-artifacts-section.tsx
+++ b/packages/ui/src/modules/artifacts/components/sandbox-artifacts-section.tsx
@@ -2,6 +2,7 @@ import type { LibraryArtifact } from "api-server-api";
 import { Info } from "lucide-react";
 import { useState } from "react";
 
+import { Callout } from "@/components/ui/callout";
 import { Card } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { SectionLabel } from "@/components/ui/section-label";
@@ -33,7 +34,11 @@ export function SandboxArtifactsSection({ agentId }: { agentId: string }) {
         Pages and files this agent has published to your artifact library.
       </p>
 
-      <div className="mb-4 flex items-start gap-2.5 rounded-lg border border-callout-border bg-callout p-3 text-[13px] text-text-secondary">
+      <Callout
+        tone="info"
+        size="sm"
+        className="mb-4 flex items-start gap-2.5 text-[13px] text-muted-foreground"
+      >
         <Info size={16} className="mt-0.5 shrink-0 text-accent" />
         <span>
           Agents publish through the built-in platform MCP tools —{" "}
@@ -47,7 +52,7 @@ export function SandboxArtifactsSection({ agentId }: { agentId: string }) {
           for direct-to-storage uploads. No extra credentials needed in the
           sandbox.
         </span>
-      </div>
+      </Callout>
 
       {isLoading ? (
         <p className="text-[13px] text-muted-foreground">Loading…</p>

--- a/packages/ui/src/modules/budgets/components/budget-meter.tsx
+++ b/packages/ui/src/modules/budgets/components/budget-meter.tsx
@@ -1,5 +1,7 @@
 import type { CSSProperties } from "react";
 
+import { Callout } from "@/components/ui/callout";
+
 import { useBudgetReserved } from "../api/queries.js";
 import { formatCores, formatGi } from "../lib/format.js";
 
@@ -40,8 +42,8 @@ export function BudgetMeter() {
   if (!data) return null;
   const { cpu, memory } = data;
   return (
-    <div
-      className="mb-6 flex items-center gap-6 rounded-lg border border-border px-4 py-3"
+    <Callout
+      className="mb-6 flex items-center gap-6"
       title="Compute your running sandboxes can use, against your budget. Pause or stop a sandbox to free room."
     >
       <Dimension
@@ -58,6 +60,6 @@ export function BudgetMeter() {
         unit="Gi"
         fill={fillPercent(memory.reservedBytes, memory.ceilingBytes)}
       />
-    </div>
+    </Callout>
   );
 }

--- a/packages/ui/src/modules/connections/components/github-app-install-hint.tsx
+++ b/packages/ui/src/modules/connections/components/github-app-install-hint.tsx
@@ -1,6 +1,8 @@
 import { Launch } from "@carbon/icons-react";
 import type { ConnectionView } from "api-server-api";
 
+import { Callout } from "@/components/ui/callout";
+
 import { getBrand } from "../../../brand.js";
 import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
 
@@ -23,13 +25,17 @@ export function GithubAppInstallHint({
 }) {
   if (!connections.some((c) => activeInstallUrl(c) !== null)) return null;
   return (
-    <p className="mx-4 mt-3 rounded-md border border-border bg-muted/40 px-3.5 py-2.5 text-[13px] leading-relaxed text-muted-foreground">
+    <Callout
+      tone="muted"
+      size="sm"
+      className="mx-4 mt-3 text-[13px] leading-relaxed text-muted-foreground"
+    >
       <strong className="text-foreground/80">
         GitHub App connections need one more step.
       </strong>{" "}
       To let {getBrand().name} work with your private repos, install the app on
       the organization that owns them.
-    </p>
+    </Callout>
   );
 }
 

--- a/packages/ui/src/modules/connections/forms/disclosure-box.tsx
+++ b/packages/ui/src/modules/connections/forms/disclosure-box.tsx
@@ -1,6 +1,7 @@
 import { ChevronDown, ChevronRight } from "@carbon/icons-react";
 import { type ReactNode, useState } from "react";
 
+import { Callout } from "@/components/ui/callout";
 import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
@@ -31,7 +32,7 @@ export function DisclosureBox({
 
   if (variant === "section") {
     return (
-      <div className="rounded-lg border border-border p-4">
+      <Callout>
         <button
           type="button"
           onClick={() => setOpen((v) => !v)}
@@ -48,7 +49,7 @@ export function DisclosureBox({
           </div>
         )}
         {open && <div className={cn("mt-4", bodyClassName)}>{children}</div>}
-      </div>
+      </Callout>
     );
   }
 

--- a/packages/ui/src/modules/connections/forms/oauth-app-hint.tsx
+++ b/packages/ui/src/modules/connections/forms/oauth-app-hint.tsx
@@ -2,6 +2,7 @@ import { Check, Copy, ExternalLink } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
 
 /** Bring-your-own-OAuth-app instructions: provider setup link plus the exact
  *  redirect URI to register. */
@@ -23,7 +24,7 @@ export function OAuthAppHint({
   };
 
   return (
-    <div className="rounded-lg border border-border bg-muted/40 p-4 flex flex-col gap-2">
+    <Callout tone="muted" className="flex flex-col gap-2">
       <p className="text-[12px] text-foreground/80">
         Register an OAuth app at the provider, then paste its client credentials
         below.
@@ -67,6 +68,6 @@ export function OAuthAppHint({
           </div>
         </div>
       )}
-    </div>
+    </Callout>
   );
 }

--- a/packages/ui/src/modules/connections/hooks/use-disconnect-connection.tsx
+++ b/packages/ui/src/modules/connections/hooks/use-disconnect-connection.tsx
@@ -1,3 +1,5 @@
+import { Callout } from "@/components/ui/callout";
+
 import { api } from "../../../api.js";
 import { useStore } from "../../../store.js";
 import { useDeleteConnection } from "../api/mutations.js";
@@ -47,7 +49,7 @@ export function useDisconnectConnection() {
           function as expected.
         </p>
         {affected.length > 0 && (
-          <div className="mt-4 rounded-lg border border-border bg-muted/40 p-4">
+          <Callout tone="muted" className="mt-4">
             <p className="text-[11px] font-semibold uppercase tracking-[0.6px] text-muted-foreground">
               Affected sandboxes
             </p>
@@ -56,7 +58,7 @@ export function useDisconnectConnection() {
                 <li key={n}>{n}</li>
               ))}
             </ul>
-          </div>
+          </Callout>
         )}
       </>,
       `Delete ${name}?`,

--- a/packages/ui/src/modules/sandboxes/components/sandbox-model-settings.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-model-settings.tsx
@@ -1,4 +1,4 @@
-import { Inset } from "@/components/ui/inset";
+import { Callout } from "@/components/ui/callout";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import { useHarnessConfigStatus } from "../../agents/api/harness-config.js";
@@ -26,11 +26,11 @@ export function SandboxModelSettings({ agentId }: { agentId: string }) {
           <SectionLabel>Model settings</SectionLabel>
           <WakeToEditButton agentId={agentId} comingUp={comingUp} />
         </div>
-        <Inset className="rounded-lg border border-border p-4">
+        <Callout inset>
           <p className="text-[13px] text-muted-foreground">
             Start the agent to load and edit its model settings.
           </p>
-        </Inset>
+        </Callout>
       </section>
     );
   }

--- a/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
@@ -1,8 +1,9 @@
 import { Controller } from "react-hook-form";
 
 import { FormField } from "@/components/form-field";
+import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
-import { FIELD_INSET, Inset } from "@/components/ui/inset";
+import { FIELD_INSET } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import { EnvTab } from "../../agents/components/configure-agent/env-tab.js";
@@ -89,18 +90,18 @@ export function SandboxSetupSection({ f }: Props) {
 
       <section className="mb-8">
         <SectionLabel spaced>Network access</SectionLabel>
-        <Inset className="rounded-lg border border-border p-4">
+        <Callout inset>
           <AgentEgressEditor
             agentId={agent.id}
             currentPreset={f.currentPreset}
             staged={f.egressStaged}
           />
-        </Inset>
+        </Callout>
       </section>
 
       <section className="mb-8">
         <SectionLabel spaced>Lifecycle</SectionLabel>
-        <Inset className="rounded-lg border border-border p-4">
+        <Callout inset>
           <HibernationTimeoutField
             register={f.register("hibernationTimeoutMin", {
               valueAsNumber: true,
@@ -109,12 +110,12 @@ export function SandboxSetupSection({ f }: Props) {
             error={f.errors.hibernationTimeoutMin?.message}
             disabled={f.saving}
           />
-        </Inset>
+        </Callout>
       </section>
 
       <section className="mb-8">
         <SectionLabel spaced>Environment</SectionLabel>
-        <Inset className="rounded-lg border border-border p-4">
+        <Callout inset>
           <Controller
             control={f.control}
             name="envVars"
@@ -127,7 +128,7 @@ export function SandboxSetupSection({ f }: Props) {
               />
             )}
           />
-        </Inset>
+        </Callout>
       </section>
     </>
   );

--- a/packages/ui/src/modules/sandboxes/components/skills/skills-surface.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skills-surface.tsx
@@ -4,6 +4,7 @@ import type { DragEvent } from "react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
 import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
@@ -148,14 +149,16 @@ export function SkillsSurface({
       {isEmpty ? (
         <section>
           <SectionLabel spaced>Skills</SectionLabel>
-          <div className="flex flex-col items-center gap-4 rounded-lg border border-dashed border-border px-6 py-14 text-center">
-            <Upload size={22} className="text-muted-foreground" />
-            <p className="text-[14px] text-muted-foreground">
-              Drop a .md file here to create a skill, or add a GitHub repo as a
-              source.
-            </p>
-            {addSourceButton}
-          </div>
+          <Callout variant="dashed">
+            <div className="flex flex-col items-center gap-4 py-10 text-center">
+              <Upload size={22} className="text-muted-foreground" />
+              <p className="text-[14px] text-muted-foreground">
+                Drop a .md file here to create a skill, or add a GitHub repo as
+                a source.
+              </p>
+              {addSourceButton}
+            </div>
+          </Callout>
         </section>
       ) : (
         <>

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -1,4 +1,5 @@
 import { FormField } from "@/components/form-field";
+import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
 import { FIELD_INSET } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
@@ -101,14 +102,14 @@ export function SetupStep({
 
       {setupNote && (
         <section className="mb-8">
-          <div className="rounded-lg border border-callout-border bg-callout p-4 md:-ml-4">
+          <Callout tone="info" inset>
             <p className="text-[14px] font-semibold text-foreground">
               {setupNote.title}
             </p>
             <p className="mt-1 text-[14px] text-muted-foreground">
               {setupNote.body}
             </p>
-          </div>
+          </Callout>
         </section>
       )}
 

--- a/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
+++ b/packages/ui/src/modules/sandboxes/components/template-update-notice.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Inset } from "@/components/ui/inset";
+import { Callout } from "@/components/ui/callout";
 
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
@@ -40,27 +40,30 @@ export function TemplateUpdateNotice({ agent }: Props) {
   };
 
   return (
-    <Inset className="mt-3">
-      <div className="flex flex-wrap items-center gap-x-10 gap-y-1.5 rounded-md border border-border bg-muted/40 px-3.5 py-2.5">
-        <p className="min-w-0 flex-1 basis-[280px] text-[13px] leading-relaxed text-muted-foreground">
-          <strong className="font-medium text-foreground/80">
-            Update available.
-          </strong>{" "}
-          The template now ships{" "}
-          <span className="break-all font-mono text-[12px] text-foreground">
-            {update.toImage}
-          </span>
-        </p>
-        <Button
-          variant="ghost"
-          size="sm"
-          className="shrink-0 font-medium text-accent hover:bg-accent-light hover:text-accent-hover"
-          disabled={upgrade.isPending}
-          onClick={() => void onUpgrade()}
-        >
-          {upgrade.isPending ? "Upgrading…" : "Upgrade"}
-        </Button>
-      </div>
-    </Inset>
+    <Callout
+      tone="muted"
+      size="sm"
+      inset
+      className="mt-3 flex flex-wrap items-center gap-x-10 gap-y-1.5"
+    >
+      <p className="min-w-0 flex-1 basis-[280px] text-[13px] leading-relaxed text-muted-foreground">
+        <strong className="font-medium text-foreground/80">
+          Update available.
+        </strong>{" "}
+        The template now ships{" "}
+        <span className="break-all font-mono text-[12px] text-foreground">
+          {update.toImage}
+        </span>
+      </p>
+      <Button
+        variant="ghost"
+        size="sm"
+        className="shrink-0 font-medium text-accent hover:bg-accent-light hover:text-accent-hover"
+        disabled={upgrade.isPending}
+        onClick={() => void onUpgrade()}
+      >
+        {upgrade.isPending ? "Upgrading…" : "Upgrade"}
+      </Button>
+    </Callout>
   );
 }

--- a/packages/ui/src/modules/schedules/components/schedule-details.tsx
+++ b/packages/ui/src/modules/schedules/components/schedule-details.tsx
@@ -1,5 +1,7 @@
 import { Time } from "@carbon/icons-react";
 
+import { Callout } from "@/components/ui/callout";
+
 import type { Schedule } from "../../../types.js";
 import {
   formatRunTime,
@@ -15,12 +17,12 @@ function DetailCard({
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-lg border border-border p-3">
+    <Callout size="sm">
       <p className="text-[12px] text-muted-foreground">{label}</p>
       <div className="mt-1 text-[13px] font-medium text-foreground">
         {children}
       </div>
-    </div>
+    </Callout>
   );
 }
 

--- a/packages/ui/src/modules/sessions/components/model-settings-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/model-settings-panel.tsx
@@ -1,13 +1,13 @@
 import { Check, ChevronDown, Loader2 } from "lucide-react";
 import { type ReactNode, useEffect, useState } from "react";
 
+import { Callout } from "@/components/ui/callout";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Inset } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
@@ -187,10 +187,10 @@ export function ModelSettingsPanel({
           <SectionLabel>Model settings</SectionLabel>
           {headerAction ?? (saving ? <SavingHint /> : null)}
         </div>
-        <Inset className="rounded-lg border border-border p-4">
+        <Callout inset>
           {groups}
           {note}
-        </Inset>
+        </Callout>
       </section>
     );
   }

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -19,6 +19,7 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -894,7 +895,7 @@ function SessionErrorCard({
         ? "Can't reach the agent"
         : "Failed to load session";
   return (
-    <div className="my-4 rounded-xl border-2 border-danger bg-danger-light p-5 flex flex-col gap-3 anim-in">
+    <Callout tone="danger" className="my-4 flex flex-col gap-3 anim-in">
       <div className="flex items-start gap-3">
         <AlertCircle size={20} className="text-danger shrink-0 mt-0.5" />
         <div className="flex-1 min-w-0">
@@ -914,7 +915,7 @@ function SessionErrorCard({
           </Button>
         )}
       </div>
-    </div>
+    </Callout>
   );
 }
 
@@ -926,8 +927,9 @@ function SendErrorCard({
   onRetry?: () => void;
 }) {
   return (
-    <div
-      className="rounded-xl border-2 border-danger bg-danger-light px-4 py-3 flex items-start gap-2.5 max-w-[620px]"
+    <Callout
+      tone="danger"
+      className="flex max-w-[620px] items-start gap-2.5"
       role="alert"
     >
       <AlertCircle size={16} className="text-danger shrink-0 mt-0.5" />
@@ -946,6 +948,6 @@ function SendErrorCard({
           </Button>
         )}
       </div>
-    </div>
+    </Callout>
   );
 }


### PR DESCRIPTION
Forms and panels across the app each hand-rolled their own bordered box — for hints, notices, error banners, and grouped form fields. An audit found ~47 of them, drifting across three corner radii, six paddings, four "subtle" backgrounds, and three different error-border treatments. Every new box meant re-deriving the same class string and re-matching the field inset by hand.

This adds one shared box primitive and moves ~25 of those boxes onto it, normalizing the geometry as it goes. A bordered box is now one import with a tone, not a class string to reinvent.

**What changes visually.** Migrated boxes now share a single radius, a 1px border, one of two padding steps, and one background per tone. The most noticeable ones:

- The chat error cards get quieter — a 1px border instead of a heavy 2px one, on the app's most-seen surface.
- The API-keys error box gains a visible red border. It had been setting its border to the same colour as its own background, so the border never rendered at all. That's a bug fix that reads as a visual change.
- A few hints and notices shift by 1–2px as their padding lands on the shared step.

Field groups keep their gutter alignment: the box carries the field outdent itself, so groups still line up with the form controls above and below them on wide windows and go flush on narrow ones.

Bordered surfaces that belong to other families — selectable cards, list rows, chips, the app-shell banner, chat composer surfaces — are deliberately left alone. The remaining empty states are blocked on a separate redesign of the shared empty-state card and are not touched here.

Closes #2197