### PR TITLE
refactor(ui): centralize z-index into a named scale

### DIFF
--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -58,6 +58,43 @@
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);
   --radius-xl: calc(var(--radius) + 4px);
+
+  /* ── z-index ladder — the ordered source of truth for stacking.
+     Use the matching z-* utilities below; never raw z numbers.
+     The Sonner toaster manages its own (higher) z-index and sits above z-toast. ── */
+  --z-content: 10;
+  --z-raised: 20;
+  --z-nav: 30;
+  --z-overlay: 40;
+  --z-banner: 50;
+  --z-popover: 60;
+  --z-tooltip: 70;
+  --z-toast: 80;
+}
+
+@utility z-content {
+  z-index: var(--z-content);
+}
+@utility z-raised {
+  z-index: var(--z-raised);
+}
+@utility z-nav {
+  z-index: var(--z-nav);
+}
+@utility z-overlay {
+  z-index: var(--z-overlay);
+}
+@utility z-banner {
+  z-index: var(--z-banner);
+}
+@utility z-popover {
+  z-index: var(--z-popover);
+}
+@utility z-tooltip {
+  z-index: var(--z-tooltip);
+}
+@utility z-toast {
+  z-index: var(--z-toast);
 }
 
 /* ── Light theme (default) ── */

--- a/packages/ui/src/app.tsx
+++ b/packages/ui/src/app.tsx
@@ -127,7 +127,7 @@ function MainApp() {
       <>
         <div className="flex h-dvh bg-background overflow-hidden">
           <IconRail hideMobileBar />
-          <div className="relative z-10 flex-1 min-w-0">
+          <div className="relative z-content flex-1 min-w-0">
             <ChatView />
           </div>
         </div>
@@ -141,7 +141,7 @@ function MainApp() {
     <div className="flex flex-col h-dvh bg-background relative overflow-hidden">
       <div className="flex flex-1 min-h-0 overflow-hidden">
         <IconRail />
-        <main className="relative z-10 flex-1 overflow-y-auto">
+        <main className="relative z-content flex-1 overflow-y-auto">
           {view === "sandbox-new" ? (
             <SandboxWizardView />
           ) : view === "experiment-new" ? (

--- a/packages/ui/src/components/connection-banner.tsx
+++ b/packages/ui/src/components/connection-banner.tsx
@@ -10,7 +10,7 @@ export function ConnectionBanner() {
 
   const offline = status === "offline";
   return (
-    <div className="fixed bottom-14 left-0 right-0 z-[60] flex h-11 items-center justify-center gap-2 border-t border-warning bg-warning-light px-5 text-[13px] font-semibold text-warning md:bottom-0">
+    <div className="fixed bottom-14 left-0 right-0 z-banner flex h-11 items-center justify-center gap-2 border-t border-warning bg-warning-light px-5 text-[13px] font-semibold text-warning md:bottom-0">
       {offline ? (
         <WifiOff size={14} />
       ) : (

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -113,7 +113,7 @@ export function IconRail({
       </nav>
 
       {!hideMobileBar && (
-        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-40 flex items-stretch border-t bg-card/95 backdrop-blur-xl safe-bottom">
+        <nav className="md:hidden fixed bottom-0 left-0 right-0 z-nav flex items-stretch border-t bg-card/95 backdrop-blur-xl safe-bottom">
           {[
             sandboxes,
             ...(showExperiments ? [experiments] : []),

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -13,9 +13,9 @@ interface ModalProps {
  * users can't lose in-progress form state by accident.
  *
  * Renders into document.body via a portal so it escapes the app shell's
- * `<main>` stacking context (z-10). Without the portal, the mobile bottom
- * bar (z-40) would render above the modal because the modal's effective
- * stacking happens at z-10 from the root's perspective.
+ * `<main>` stacking context (z-content). Without the portal, the mobile
+ * bottom bar (z-nav) would render above the modal because the modal's
+ * effective stacking happens at z-content from the root's perspective.
  *
  * Compose the inside with `DialogHeader`, `DialogBody`, and `DialogFooter`
  * so layout (padding, dividers, scroll region) is consistent across every
@@ -34,7 +34,7 @@ export function Modal({ widthClass = "w-[560px]", children }: ModalProps) {
   useBodyScrollLock();
   return createPortal(
     <ModalContext.Provider value={{ labelId }}>
-      <div className="fixed inset-0 z-50 flex items-center justify-center px-4 md:px-0 bg-black/50 backdrop-blur-[4px] anim-in">
+      <div className="fixed inset-0 z-overlay flex items-center justify-center px-4 md:px-0 bg-black/50 backdrop-blur-[4px] anim-in">
         <div
           ref={panelRef}
           role="dialog"

--- a/packages/ui/src/components/resize-handle.tsx
+++ b/packages/ui/src/components/resize-handle.tsx
@@ -53,7 +53,7 @@ export function ResizeHandle({
     return (
       <div
         onMouseDown={onMouseDown}
-        className="group relative z-20 -mt-[3px] -mb-[2px] h-[5px] shrink-0 cursor-row-resize flex items-center"
+        className="group relative z-raised -mt-[3px] -mb-[2px] h-[5px] shrink-0 cursor-row-resize flex items-center"
       >
         <div className="h-[2px] w-full bg-transparent group-hover:bg-text group-active:bg-text transition-colors" />
       </div>
@@ -64,7 +64,7 @@ export function ResizeHandle({
     <div
       onMouseDown={onMouseDown}
       className={cn(
-        "group relative z-20 w-[5px] shrink-0 cursor-col-resize flex justify-center",
+        "group relative z-raised w-[5px] shrink-0 cursor-col-resize flex justify-center",
         side === "left" ? "-ml-[3px]" : "-mr-[3px]",
       )}
     >

--- a/packages/ui/src/components/ui/alert-dialog.tsx
+++ b/packages/ui/src/components/ui/alert-dialog.tsx
@@ -15,7 +15,7 @@ function AlertDialogOverlay({
   return (
     <AlertDialogPrimitive.Overlay
       className={cn(
-        "fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        "fixed inset-0 z-overlay bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
         className,
       )}
       {...props}
@@ -32,7 +32,7 @@ function AlertDialogContent({
       <AlertDialogOverlay />
       <AlertDialogPrimitive.Content
         className={cn(
-          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+          "fixed left-[50%] top-[50%] z-overlay grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
           className,
         )}
         {...props}

--- a/packages/ui/src/components/ui/menu-styles.ts
+++ b/packages/ui/src/components/ui/menu-styles.ts
@@ -6,7 +6,7 @@ import { cva } from "class-variance-authority";
  * identical-looking menu, so the surface styling lives here once.
  */
 export const menuContentClassName =
-  "z-50 min-w-[160px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95";
+  "z-popover min-w-[160px] rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95";
 
 export const menuSeparatorClassName = "my-1 h-px bg-border";
 

--- a/packages/ui/src/components/ui/searchable-select.tsx
+++ b/packages/ui/src/components/ui/searchable-select.tsx
@@ -117,7 +117,7 @@ export function SearchableSelect({
         <ChevronDown size={14} className="shrink-0 text-muted-foreground" />
       </button>
       {open && (
-        <div className="absolute z-50 mt-1 w-full overflow-hidden rounded-md border border-border bg-popover shadow-md">
+        <div className="absolute z-popover mt-1 w-full overflow-hidden rounded-md border border-border bg-popover shadow-md">
           <div className="p-1.5">
             <input
               ref={inputRef}

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -17,7 +17,7 @@ function TooltipContent({
         sideOffset={sideOffset}
         collisionPadding={8}
         className={cn(
-          "z-[60] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm font-normal normal-case tracking-normal text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          "z-tooltip overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm font-normal normal-case tracking-normal text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
           className,
         )}
         {...props}

--- a/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
+++ b/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
@@ -75,7 +75,7 @@ function OverlayFrame({
   children: ReactNode;
 }) {
   return (
-    <div className="absolute inset-0 z-40 flex flex-col bg-bg/95 backdrop-blur-sm">
+    <div className="absolute inset-0 z-overlay flex flex-col bg-bg/95 backdrop-blur-sm">
       <button
         onClick={onBack}
         className="absolute left-4 top-3 flex items-center gap-1 text-[13px] font-medium text-text-secondary hover:text-accent transition-colors"

--- a/packages/ui/src/modules/approvals/components/egress-approval-toasts.tsx
+++ b/packages/ui/src/modules/approvals/components/egress-approval-toasts.tsx
@@ -86,7 +86,7 @@ export function EgressApprovalToasts({ agentId }: { agentId: string | null }) {
       onBlur={(e) => {
         if (!e.currentTarget.contains(e.relatedTarget)) setExpanded(false);
       }}
-      className="absolute top-4 max-md:top-[78px] right-4 z-40 max-md:z-[60] w-[400px] max-w-[calc(100vw-32px)]"
+      className="absolute top-4 max-md:top-[78px] right-4 z-toast w-[400px] max-w-[calc(100vw-32px)]"
     >
       {visible.map((row, i) => {
         const rear = i > 0 && !expanded;

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -87,7 +87,7 @@ export function FileRow({
     <ContextMenu onOpenChange={setMenuOpen}>
       <ContextMenuTrigger asChild>
         <div
-          className={`group relative flex items-center h-[32px] text-[14px] cursor-pointer transition-colors ${menuOpen ? "z-20" : ""} ${highlight ? "bg-muted ring-1 ring-primary ring-inset text-text-secondary font-medium" : `text-text-secondary hover:bg-muted ${isDir ? "font-medium" : ""} ${isActive ? "bg-muted" : ""}`}`}
+          className={`group relative flex items-center h-[32px] text-[14px] cursor-pointer transition-colors ${menuOpen ? "z-raised" : ""} ${highlight ? "bg-muted ring-1 ring-primary ring-inset text-text-secondary font-medium" : `text-text-secondary hover:bg-muted ${isDir ? "font-medium" : ""} ${isActive ? "bg-muted" : ""}`}`}
           style={{ paddingLeft: `${12 + depth * 14}px`, paddingRight: 12 }}
           onClick={
             isDir ? () => panel.onToggleDir(path) : () => panel.onOpenFile(path)

--- a/packages/ui/src/modules/files/components/fullscreen-preview-dialog.tsx
+++ b/packages/ui/src/modules/files/components/fullscreen-preview-dialog.tsx
@@ -32,7 +32,7 @@ export function FullscreenPreviewDialog({ title, onClose, children }: Props) {
       role="dialog"
       aria-modal="true"
       aria-label={title}
-      className="fixed inset-0 z-50 flex flex-col bg-background"
+      className="fixed inset-0 z-overlay flex flex-col bg-background"
     >
       <div className="flex items-center gap-2 px-3 h-9 border-b border-border shrink-0">
         <span

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -170,7 +170,7 @@ export function SessionRow({
       {menuOpen && (
         <div
           ref={menuRef}
-          className="absolute right-3 top-2 z-30 rounded-lg border border-border bg-surface py-1 anim-scale-in shadow-md"
+          className="absolute right-3 top-2 z-popover rounded-lg border border-border bg-surface py-1 anim-scale-in shadow-md"
         >
           <Button
             variant="ghost"

--- a/packages/ui/src/modules/sessions/components/terminal.tsx
+++ b/packages/ui/src/modules/sessions/components/terminal.tsx
@@ -189,7 +189,7 @@ export function Terminal({
   return (
     <div className="flex flex-1 flex-col min-h-0 relative">
       {state === "connecting" && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-bg/80 backdrop-blur-sm">
+        <div className="absolute inset-0 z-content flex items-center justify-center bg-bg/80 backdrop-blur-sm">
           <div className="flex items-center gap-3 text-[14px] text-text-muted">
             <Loader2 size={18} className="animate-spin" />
             Connecting terminal...
@@ -197,7 +197,7 @@ export function Terminal({
         </div>
       )}
       {state === "disconnected" && (
-        <div className="absolute inset-0 z-10 flex items-center justify-center bg-bg/80 backdrop-blur-sm">
+        <div className="absolute inset-0 z-content flex items-center justify-center bg-bg/80 backdrop-blur-sm">
           <div className="flex flex-col items-center gap-3 text-center">
             <XCircle size={24} className="text-danger" />
             <p className="text-[14px] text-text-secondary">
@@ -210,7 +210,7 @@ export function Terminal({
         </div>
       )}
       {state === "exited" && (
-        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-10">
+        <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-content">
           <div className="flex items-center gap-2 rounded-full border border-border-light bg-surface-raised px-4 py-2 text-[12px] text-text-muted shadow-md">
             <TerminalIcon size={14} />
             Process exited with code {exitCode}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -358,7 +358,7 @@ export function ChatView() {
     <div className="flex flex-col h-dvh bg-background relative overflow-hidden">
       {/* Header spans the full width; on mobile it belongs to the chat screen only */}
       <header
-        className={`${mobileScreen === "sessions" ? "hidden md:flex" : "flex"} items-center gap-3 px-6 h-[70px] border-b border-border-light shrink-0 relative z-10`}
+        className={`${mobileScreen === "sessions" ? "hidden md:flex" : "flex"} items-center gap-3 px-6 h-[70px] border-b border-border-light shrink-0 relative z-content`}
       >
         <button
           className="md:hidden flex items-center gap-1 text-[13px] font-medium text-text-secondary hover:text-accent transition-colors"
@@ -416,7 +416,7 @@ export function ChatView() {
         {/* Left: Sessions + Files sections */}
         <div
           style={{ width: leftW }}
-          className={`shrink-0 flex flex-col border-r border-border-light overflow-hidden relative z-10 ${
+          className={`shrink-0 flex flex-col border-r border-border-light overflow-hidden relative z-content ${
             mobileScreen === "chat" ? "hidden md:flex" : "flex"
           } ${mobileScreen === "sessions" ? "max-md:!w-full" : ""}`}
         >
@@ -679,7 +679,7 @@ export function ChatView() {
                 {showJump && (
                   <button
                     onClick={scrollToBottom}
-                    className="absolute left-1/2 -translate-x-1/2 bottom-3 z-20 inline-flex items-center gap-1.5 h-[35px] rounded-full border border-border-light bg-background px-3 text-[14px] font-normal text-text shadow-[0_1px_2px_rgba(0,0,0,0.08)] hover:bg-muted transition-colors"
+                    className="absolute left-1/2 -translate-x-1/2 bottom-3 z-raised inline-flex items-center gap-1.5 h-[35px] rounded-full border border-border-light bg-background px-3 text-[14px] font-normal text-text shadow-[0_1px_2px_rgba(0,0,0,0.08)] hover:bg-muted transition-colors"
                   >
                     <ArrowDown size={16} />
                     Jump to latest
@@ -742,7 +742,7 @@ export function ChatView() {
                   : undefined
               }
               className={cn(
-                "flex flex-col overflow-hidden bg-background relative z-10 max-md:fixed max-md:inset-0 max-md:z-50",
+                "flex flex-col overflow-hidden bg-background relative z-content max-md:fixed max-md:inset-0 max-md:z-overlay",
                 rightW !== null
                   ? "md:shrink-0 md:w-[var(--file-w)]"
                   : "md:flex-1 md:basis-0 md:min-w-0",


### PR DESCRIPTION
Refs #729

## Summary

Defines the named z-index ladder in the Tailwind v4 `@theme` block (`App.css`) and migrates all 24 scattered `z-*` usages onto semantic utilities:

```
z-content(10) < z-raised(20) < z-nav(30) < z-overlay(40) < z-banner(50) < z-popover(60) < z-tooltip(70) < z-toast(80)
```

- `z-content` — app shell panels, chat header/panes, terminal overlays
- `z-raised` — in-view floating chrome (resize handles, scroll-to-bottom, row with open menu)
- `z-nav` — mobile bottom bar
- `z-overlay` — Modal, alert-dialog, fullscreen preview, agent-unavailable overlay
- `z-banner` — connection banner
- `z-popover` — dropdown menus, searchable-select, session-row menu
- `z-tooltip` — tooltip
- `z-toast` — egress approval toasts (Sonner keeps its own higher default, per the issue's out-of-scope note)

## Deliberate stacking changes

- **Popovers/menus now stack above modals** instead of tying with them at `z-50` — the #597 class of same-z tie is structurally gone.
- **Egress approval toasts** collapse from `z-40 max-md:z-[60]` to a single `z-toast`; on desktop they now show above open modals, matching toast semantics (Sonner already behaves this way).
- The `z-[9999]` popover mentioned in the issue no longer exists in the tree (removed with the #597 fix), so there was nothing to fold in.

## Test plan

- `mise run ui:check` clean (lint/format/tsc)
- Verified the compiled CSS via the Vite dev server: all eight `.z-*` utilities and the `max-md:z-overlay` variant generate correctly
- No numeric `z-*`/`z-[…]` classes remain in `packages/ui/src` (the decorative `.blob { z-index: 0 }` base layer is intentionally untouched)