### PR TITLE
feat(ui): delete an artifact from the chat sidebar

### DIFF
--- a/docs/architecture/artifact-library.md
+++ b/docs/architecture/artifact-library.md
@@ -1,6 +1,6 @@
 # Artifact library
 
-Last verified: 2026-07-21
+Last verified: 2026-07-27
 
 ## Overview
 
@@ -129,6 +129,11 @@ flowchart LR
   (markdown prose, highlighted code, inline images).
 - Each sandbox's home view gains an **Artifacts section** listing what that
   agent published, with the same actions.
+- The chat view carries the same library twice over: an **Artifacts section**
+  in the session sidebar, scoped to the sandbox's agent and offering the same
+  per-artifact actions, and a **docked preview** beside the conversation that
+  renders the selected artifact and follows new versions as they are
+  published. Deleting the artifact a preview is showing closes that preview.
 
 ## Lifecycle and cleanup
 

--- a/packages/ui/src/modules/artifacts/components/artifact-row-menu-items.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row-menu-items.tsx
@@ -1,0 +1,44 @@
+import type { LibraryArtifact } from "api-server-api";
+import { Download, Share2, Trash2 } from "lucide-react";
+
+import {
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+import { useArtifactDeletion } from "../hooks/use-artifact-deletion.js";
+import { downloadArtifact } from "../lib/transfer.js";
+
+/** The per-artifact row menu, defined once for every surface that lists
+ *  artifacts. Sharing is the only action the surface has to own: the menu
+ *  unmounts on select, so it can't host the dialog itself. */
+export function ArtifactRowMenuItems({
+  artifact,
+  onShare,
+}: {
+  artifact: LibraryArtifact;
+  onShare: (artifact: LibraryArtifact) => void;
+}) {
+  const deleteArtifact = useArtifactDeletion();
+
+  return (
+    <>
+      <DropdownMenuItem onSelect={() => onShare(artifact)}>
+        <Share2 size={14} />
+        Sharing…
+      </DropdownMenuItem>
+      <DropdownMenuItem onSelect={() => void downloadArtifact(artifact.id)}>
+        <Download size={14} />
+        Download
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        tone="danger"
+        onSelect={() => void deleteArtifact(artifact)}
+      >
+        <Trash2 size={14} />
+        Delete
+      </DropdownMenuItem>
+    </>
+  );
+}

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -1,14 +1,5 @@
 import type { LibraryArtifact } from "api-server-api";
-import {
-  Box,
-  Clock,
-  Download,
-  Eye,
-  Link as LinkIcon,
-  MoreVertical,
-  Share2,
-  Trash2,
-} from "lucide-react";
+import { Box, Clock, Eye, Link as LinkIcon, MoreVertical } from "lucide-react";
 import { useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
@@ -16,8 +7,6 @@ import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -26,13 +15,12 @@ import { useStore } from "../../../store.js";
 import { usePrefetchArtifactPreview } from "../api/queries.js";
 import { expiryState, timeAgo } from "../lib/format.js";
 import { isRenderedKind } from "../lib/kinds.js";
-import { downloadArtifact } from "../lib/transfer.js";
 import { ArtifactKindBadge, ArtifactStatusBadge } from "./artifact-badges.js";
+import { ArtifactRowMenuItems } from "./artifact-row-menu-items.js";
 
 export interface ArtifactRowActions {
   onPreview: (artifact: LibraryArtifact) => void;
   onShare: (artifact: LibraryArtifact) => void;
-  onDelete: (artifact: LibraryArtifact) => void;
 }
 
 interface Props extends ArtifactRowActions {
@@ -46,7 +34,6 @@ export function ArtifactRow({
   showAgent = true,
   onPreview,
   onShare,
-  onDelete,
 }: Props) {
   const expiry = expiryState(artifact.expiresAt);
   const prefetchPreview = usePrefetchArtifactPreview();
@@ -118,24 +105,7 @@ export function ArtifactRow({
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end">
-              <DropdownMenuItem onSelect={() => onShare(artifact)}>
-                <Share2 size={14} />
-                Sharing…
-              </DropdownMenuItem>
-              <DropdownMenuItem
-                onSelect={() => void downloadArtifact(artifact.id)}
-              >
-                <Download size={14} />
-                Download
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem
-                tone="danger"
-                onSelect={() => onDelete(artifact)}
-              >
-                <Trash2 size={14} />
-                Delete
-              </DropdownMenuItem>
+              <ArtifactRowMenuItems artifact={artifact} onShare={onShare} />
             </DropdownMenuContent>
           </DropdownMenu>
         </div>

--- a/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
@@ -1,12 +1,21 @@
 import type { LibraryArtifact } from "api-server-api";
-import type { CSSProperties } from "react";
+import { MoreVertical } from "lucide-react";
+import { type CSSProperties, useState } from "react";
 
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 
 import { useStore } from "../../../store.js";
 import { SidebarSection } from "../../sessions/components/sidebar-section.js";
 import { useArtifacts } from "../api/queries.js";
 import { ArtifactKindBadge } from "./artifact-badges.js";
+import { ArtifactRowMenuItems } from "./artifact-row-menu-items.js";
+import { ShareDialog } from "./share-dialog.js";
 
 /** Tracks agents publishing mid-conversation without a manual refresh. */
 const LIVE_POLL_MS = 5000;
@@ -33,6 +42,7 @@ export function ChatArtifactsPanel({
   );
   const openArtifactId = useStore((s) => s.openArtifactId);
   const setOpenArtifactId = useStore((s) => s.setOpenArtifactId);
+  const [shareTarget, setShareTarget] = useState<LibraryArtifact | null>(null);
 
   return (
     <SidebarSection
@@ -58,9 +68,16 @@ export function ChatArtifactsPanel({
                   artifact.id === openArtifactId ? null : artifact.id,
                 )
               }
+              onShare={setShareTarget}
             />
           ))}
         </div>
+      )}
+      {shareTarget && (
+        <ShareDialog
+          artifact={shareTarget}
+          onClose={() => setShareTarget(null)}
+        />
       )}
     </SidebarSection>
   );
@@ -70,18 +87,24 @@ function ArtifactListRow({
   artifact,
   active,
   onClick,
+  onShare,
 }: {
   artifact: LibraryArtifact;
   active: boolean;
   onClick: () => void;
+  onShare: (artifact: LibraryArtifact) => void;
 }) {
   return (
-    <button
-      type="button"
+    <div
+      role="button"
+      tabIndex={0}
       onClick={onClick}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") onClick();
+      }}
       title={artifact.title}
       className={cn(
-        "flex h-[32px] w-full items-center gap-2 px-3 text-left text-[13px] text-text-secondary transition-colors hover:bg-muted",
+        "group flex h-[32px] w-full cursor-pointer items-center gap-2 px-3 text-left text-[13px] text-text-secondary transition-colors hover:bg-muted",
         active && "bg-muted text-foreground",
       )}
     >
@@ -101,6 +124,28 @@ function ArtifactListRow({
           title="Shared"
         />
       )}
-    </button>
+      <div
+        className="shrink-0"
+        onClick={(e) => e.stopPropagation()}
+        onKeyDown={(e) => e.stopPropagation()}
+      >
+        <DropdownMenu>
+          {/* Kept mounted at opacity-0 so hovering doesn't reflow the row. */}
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100"
+              title="More actions"
+            >
+              <MoreVertical size={13} />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            <ArtifactRowMenuItems artifact={artifact} onShare={onShare} />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </div>
+    </div>
   );
 }

--- a/packages/ui/src/modules/artifacts/components/sandbox-artifacts-section.tsx
+++ b/packages/ui/src/modules/artifacts/components/sandbox-artifacts-section.tsx
@@ -3,10 +3,8 @@ import { Info } from "lucide-react";
 import { useState } from "react";
 
 import { Card } from "@/components/ui/card";
-import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { SectionLabel } from "@/components/ui/section-label";
 
-import { useDeleteArtifact } from "../api/mutations.js";
 import { useArtifacts } from "../api/queries.js";
 import { ArtifactPreviewDialog } from "./artifact-preview-dialog.js";
 import { ArtifactRow } from "./artifact-row.js";
@@ -21,10 +19,6 @@ export function SandboxArtifactsSection({ agentId }: { agentId: string }) {
   const [previewTarget, setPreviewTarget] = useState<LibraryArtifact | null>(
     null,
   );
-  const [deleteTarget, setDeleteTarget] = useState<LibraryArtifact | null>(
-    null,
-  );
-  const deleteArtifact = useDeleteArtifact();
 
   return (
     <section className="mb-8">
@@ -69,7 +63,6 @@ export function SandboxArtifactsSection({ agentId }: { agentId: string }) {
                 showAgent={false}
                 onPreview={setPreviewTarget}
                 onShare={setShareTarget}
-                onDelete={setDeleteTarget}
               />
             ))}
           </div>
@@ -88,20 +81,6 @@ export function SandboxArtifactsSection({ agentId }: { agentId: string }) {
           onClose={() => setPreviewTarget(null)}
         />
       )}
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null);
-        }}
-        kind="destructive"
-        title={`Delete “${deleteTarget?.title}”?`}
-        description="All versions are deleted and its share link stops working. This cannot be undone."
-        confirmLabel="Delete"
-        onConfirm={() => {
-          if (deleteTarget) deleteArtifact.mutate({ id: deleteTarget.id });
-          setDeleteTarget(null);
-        }}
-      />
     </section>
   );
 }

--- a/packages/ui/src/modules/artifacts/hooks/use-artifact-deletion.ts
+++ b/packages/ui/src/modules/artifacts/hooks/use-artifact-deletion.ts
@@ -1,0 +1,32 @@
+import type { LibraryArtifact } from "api-server-api";
+import { useCallback } from "react";
+
+import { useStore } from "../../../store.js";
+import { useDeleteArtifact } from "../api/mutations.js";
+
+/** Confirm-then-delete for an artifact, shared by every surface that lists
+ *  one. A failed delete surfaces through the mutation's `errorToast`. */
+export function useArtifactDeletion() {
+  const showConfirm = useStore((s) => s.showConfirm);
+  const openArtifactId = useStore((s) => s.openArtifactId);
+  const setOpenArtifactId = useStore((s) => s.setOpenArtifactId);
+  const { mutate } = useDeleteArtifact();
+
+  return useCallback(
+    async (artifact: LibraryArtifact) => {
+      const confirmed = await showConfirm(
+        "All versions are deleted and its share link stops working. This cannot be undone.",
+        `Delete “${artifact.title}”?`,
+        { kind: "destructive", confirmLabel: "Delete" },
+      );
+      if (!confirmed) return;
+
+      // The docked preview polls `get`/`listVersions`, which start answering
+      // NOT_FOUND the moment the row is gone — leaving it open error-toasts
+      // seconds after a deliberate delete.
+      if (openArtifactId === artifact.id) setOpenArtifactId(null);
+      mutate({ id: artifact.id });
+    },
+    [showConfirm, openArtifactId, setOpenArtifactId, mutate],
+  );
+}

--- a/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
+++ b/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/ui/page-header";
 
 import { api } from "../../../api.js";
-import { useDeleteArtifact, useDeleteFolder } from "../api/mutations.js";
+import { useDeleteFolder } from "../api/mutations.js";
 import { useArtifactFolders, useArtifacts } from "../api/queries.js";
 import { ArtifactPreviewDialog } from "../components/artifact-preview-dialog.js";
 import { FolderDialog } from "../components/folder-dialog.js";
@@ -34,13 +34,9 @@ export function ArtifactsView() {
   const [previewTarget, setPreviewTarget] = useState<LibraryArtifact | null>(
     null,
   );
-  const [deleteTarget, setDeleteTarget] = useState<LibraryArtifact | null>(
-    null,
-  );
   const [deleteFolderTarget, setDeleteFolderTarget] =
     useState<ArtifactFolder | null>(null);
 
-  const deleteArtifact = useDeleteArtifact();
   const deleteFolder = useDeleteFolder();
 
   const filtered = useMemo(() => {
@@ -70,7 +66,6 @@ export function ArtifactsView() {
   const rowActions = {
     onPreview: setPreviewTarget,
     onShare: setShareTarget,
-    onDelete: setDeleteTarget,
   };
 
   const copyFolderLink = async (folder: ArtifactFolder) => {
@@ -178,20 +173,6 @@ export function ArtifactsView() {
           onClose={() => setPreviewTarget(null)}
         />
       )}
-      <ConfirmDialog
-        open={deleteTarget !== null}
-        onOpenChange={(open) => {
-          if (!open) setDeleteTarget(null);
-        }}
-        kind="destructive"
-        title={`Delete “${deleteTarget?.title}”?`}
-        description="All versions are deleted and its share link stops working. This cannot be undone."
-        confirmLabel="Delete"
-        onConfirm={() => {
-          if (deleteTarget) deleteArtifact.mutate({ id: deleteTarget.id });
-          setDeleteTarget(null);
-        }}
-      />
       <ConfirmDialog
         open={deleteFolderTarget !== null}
         onOpenChange={(open) => {


### PR DESCRIPTION
Artifacts listed in the chat's **Artifacts** section carried no actions, so the only way to remove one was to leave the conversation for the top-level Artifacts page.

Hovering an artifact row in the session sidebar now reveals a kebab menu offering **Sharing…**, **Download** and **Delete** — the same three actions the row already offers on the Artifacts page and on sandbox home, with the same confirmation before anything is deleted.

If you delete the artifact that's currently open in the preview beside the conversation, the preview closes with it rather than leaving a dead pane behind.

Closes #2922