### PR TITLE
fix(e2e): restore the mock's default reply after the experiments spec

### DIFF
--- a/packages/e2e/playwright/src/tests/smoke/12-experiments.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/12-experiments.spec.ts
@@ -5,6 +5,7 @@ import {
   chatInput,
   gotoAgentDetail,
   sendMessageToAgent,
+  setMockAgentReply,
   setMockReplyWithFiles,
   waitForAgentRunning,
 } from "../../lib/agents.js";
@@ -23,6 +24,10 @@ import { agentName } from "../../lib/fixtures.js";
 
 const experimentName = "e2e-loop";
 const scriptPath = "exp.py";
+// The mock's out-of-the-box reply; 07/08/10-slack rely on it verbatim. This
+// spec overwrites it via setMockReplyWithFiles below, so it must restore it
+// before the shared agent moves on to those specs.
+const mockDefaultReply = "Hello from the mock agent.";
 
 const experimentScript = `import experiment_sdk as x
 
@@ -173,5 +178,9 @@ test("experiment: plan, execute, watch it run to completion", async ({
       a.title.startsWith(`${experimentName} —`),
     );
     expect(script).toBeTruthy();
+  });
+
+  await test.step("restore the mock's default reply for the specs that follow", async () => {
+    await setMockAgentReply(api, agentId, mockDefaultReply);
   });
 });


### PR DESCRIPTION
## Summary
- `12-experiments.spec.ts` (added in #2948) scripts the shared e2e fixture agent's mock reply to `"script written"` via `setMockReplyWithFiles`, and never restores it afterward.
- Playwright's project-dependency scheduler now runs `experiments` right after `user-env` and before the `slack`/`slack-shared` chain, so the shared agent's mock process is left permanently scripted with that leftover text.
- `08-slack-shared.spec.ts`'s first test is the first spec after `12-experiments` to drive a plain (non-forked) turn on that same agent and assert on the mock's out-of-the-box `"Hello from the mock agent."` reply — it now times out waiting for text that will never appear. The turn completes successfully and a reply does land in the thread, just with the stale script text, so there's no error/denial for the test's other assertions to catch.
- The second test in `08-slack-shared.spec.ts` (the `__FETCH__` turn) is unaffected because its expected text is computed independently of the scripted reply, which is why only the first test fails.

This reproduces deterministically on CI (e.g. run [30274973335](https://github.com/dam-agents/dam/actions/runs/30274973335)) — same failure signature (`the reply did not land back in the slack thread`, 180s timeout) every time, since the ordering is fixed.

## Fix
Restore the mock's default reply as a final step of the experiments test, mirroring the baseline-preserving cleanup `09-user-env.spec.ts` already does for env vars it mutates on the same shared agent.

## Test plan
- [x] `mise run e2e-playwright:check:tsc`
- [x] `mise run e2e-playwright:check:lint`
- [x] `mise run e2e-playwright:check:format`
- [ ] CI `mise e2e` smoke run (this fix specifically targets `08-slack-shared.spec.ts`'s first test)