### PR TITLE
fix(ui): show agent names instead of ids in artifact attribution

### DIFF
--- a/packages/ui/src/modules/agents/api/queries.ts
+++ b/packages/ui/src/modules/agents/api/queries.ts
@@ -61,6 +61,8 @@ export function useAgentRunState(
  * references (artifact attribution, approvals) deliberately outlive their
  * agent, so a deleted agent's id is the only attribution left.
  */
+export function useAgentDisplayName(agentId: string): string;
+export function useAgentDisplayName(agentId: string | null): string | null;
 export function useAgentDisplayName(agentId: string | null): string | null {
   const agents = useAgentsList();
   if (!agentId) return null;

--- a/packages/ui/src/modules/agents/api/queries.ts
+++ b/packages/ui/src/modules/agents/api/queries.ts
@@ -57,6 +57,17 @@ export function useAgentRunState(
 }
 
 /**
+ * Resolve an agent id to its user-facing name. Falls back to the raw id —
+ * references (artifact attribution, approvals) deliberately outlive their
+ * agent, so a deleted agent's id is the only attribution left.
+ */
+export function useAgentDisplayName(agentId: string | null): string | null {
+  const agents = useAgentsList();
+  if (!agentId) return null;
+  return agents.find((a) => a.id === agentId)?.name ?? agentId;
+}
+
+/**
  * Whether the UI can actually talk to the pod right now. Three inputs, because
  * each catches a gap the others miss:
  *   - server reports `running` (the lifecycle truth, but it lags reality),

--- a/packages/ui/src/modules/approvals/components/approvals-list.tsx
+++ b/packages/ui/src/modules/approvals/components/approvals-list.tsx
@@ -12,6 +12,7 @@ import { useMemo } from "react";
 import { Button } from "@/components/ui/button";
 
 import { useStore } from "../../../store.js";
+import { useAgentDisplayName } from "../../agents/api/queries.js";
 import {
   useApproveHost,
   useApproveOnce,
@@ -73,6 +74,7 @@ function ApprovalRow({
   const denyForever = useDenyForever();
   const dismiss = useDismissApproval();
   const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
+  const agentName = useAgentDisplayName(row.agentId);
   const { title, subtitle } = describeApprovalPayload(row.payload);
   const live = isHeldCallStillLive(row);
   const inflight =
@@ -110,8 +112,8 @@ function ApprovalRow({
             <p className="text-[11px] text-text-muted truncate">{subtitle}</p>
           )}
           {density === "full" && (
-            <p className="text-[10px] text-text-muted mt-0.5">
-              agent {row.agentId}
+            <p className="text-[10px] text-text-muted mt-0.5 truncate">
+              agent {agentName}
             </p>
           )}
         </div>

--- a/packages/ui/src/modules/approvals/components/egress-approval-toast.tsx
+++ b/packages/ui/src/modules/approvals/components/egress-approval-toast.tsx
@@ -11,7 +11,7 @@ import type { ApprovalView } from "api-server-api";
 import { Button } from "@/components/ui/button";
 
 import { useStore } from "../../../store.js";
-import { useAgents } from "../../agents/api/queries.js";
+import { useAgentDisplayName } from "../../agents/api/queries.js";
 import {
   useApproveHost,
   useApproveOnce,
@@ -29,9 +29,7 @@ export function EgressApprovalToast({
   /** Row belongs to a sandbox other than the one being viewed. */
   foreign: boolean;
 }) {
-  const { data: agentsData } = useAgents();
-  const agentName =
-    agentsData?.list.find((a) => a.id === row.agentId)?.name ?? row.agentId;
+  const agentName = useAgentDisplayName(row.agentId);
   const approveOnce = useApproveOnce();
   const approvePermanent = useApprovePermanent();
   const approveHost = useApproveHost();

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -146,11 +146,15 @@ export function ArtifactRow({
 }
 
 function CreatorChip({ agentId }: { agentId: string | null }) {
-  const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
-  const agentName = useAgentDisplayName(agentId);
   if (!agentId) {
     return <span className="rounded-full bg-muted px-2 py-px">you</span>;
   }
+  return <AgentCreatorChip agentId={agentId} />;
+}
+
+function AgentCreatorChip({ agentId }: { agentId: string }) {
+  const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
+  const agentName = useAgentDisplayName(agentId);
   return (
     <button
       type="button"

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -163,10 +163,10 @@ function AgentCreatorChip({ agentId }: { agentId: string }) {
         navigateToSandboxHome(agentId, "artifacts");
       }}
       title={`Open ${agentName}'s artifacts`}
-      className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-px transition-colors hover:bg-accent-light hover:text-accent"
+      className="inline-flex max-w-40 items-center gap-1 rounded-full bg-muted px-2 py-px transition-colors hover:bg-accent-light hover:text-accent"
     >
-      <Box size={12} />
-      {agentName}
+      <Box size={12} className="shrink-0" />
+      <span className="truncate">{agentName}</span>
     </button>
   );
 }

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -23,6 +23,7 @@ import {
 import { cn } from "@/lib/utils";
 
 import { useStore } from "../../../store.js";
+import { useAgentDisplayName } from "../../agents/api/queries.js";
 import { usePrefetchArtifactPreview } from "../api/queries.js";
 import { expiryState, timeAgo } from "../lib/format.js";
 import { isRenderedKind } from "../lib/kinds.js";
@@ -146,6 +147,7 @@ export function ArtifactRow({
 
 function CreatorChip({ agentId }: { agentId: string | null }) {
   const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
+  const agentName = useAgentDisplayName(agentId);
   if (!agentId) {
     return <span className="rounded-full bg-muted px-2 py-px">you</span>;
   }
@@ -156,11 +158,11 @@ function CreatorChip({ agentId }: { agentId: string | null }) {
         e.stopPropagation();
         navigateToSandboxHome(agentId, "artifacts");
       }}
-      title={`Open ${agentId}'s artifacts`}
+      title={`Open ${agentName}'s artifacts`}
       className="inline-flex items-center gap-1 rounded-full bg-muted px-2 py-px transition-colors hover:bg-accent-light hover:text-accent"
     >
       <Box size={12} />
-      {agentId}
+      {agentName}
     </button>
   );
 }

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -93,8 +93,7 @@ export function ChatView() {
   const agentDisplay = agentView
     ? resolveAgentDisplay(agentView, restartingIds)
     : null;
-  const selectedAgentName =
-    agents.find((a) => a.id === selectedAgent)?.name ?? selectedAgent;
+  const selectedAgentName = agentView?.name ?? selectedAgent;
   const sessionId = useStore((s) => s.sessionId);
   const sessionMode = useStore((s) => s.sessionMode);
   const setSessionMode = useStore((s) => s.setSessionMode);


### PR DESCRIPTION
Closes #2923.

## What

Artifact rows in the library showed the raw internal agent id (`agent-9df53f7718ad0cd1`) as the artifact's creator. They now show the user-defined agent name.

## How

- New `useAgentDisplayName(agentId)` hook in `modules/agents/api/queries.ts` resolves an agent id to its name from the already-polled agents list, falling back to the raw id — artifacts deliberately outlive their creating agent (see `docs/architecture/artifact-library.md`), so a deleted agent's id is the only attribution left.
- `CreatorChip` in `artifact-row.tsx` uses the hook for both the label and the tooltip; click-through navigation still keys off the id.
- DRY cleanup: the two existing inline copies of the same lookup (egress approval toast, chat view) now share the pattern — the toast uses the new hook, chat view reuses its existing `agentView` lookup.

No contract or server change: agents are k8s CRs, so resolving the name client-side keeps it live across renames and avoids coupling artifact-library to the agents module.