### PR TITLE
docs: slim CLAUDE.md, drop dead skill symlinks

### DIFF
--- a/.agents/skills/cluster-ops/SKILL.md
+++ b/.agents/skills/cluster-ops/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: cluster-ops
+description: Operate the local k3s dev cluster (lima) and the Playwright e2e suite, and recover from mesh/cert failures. Use when working with the local cluster, running or debugging e2e tests, or when any of these symptoms appear - the UI suddenly can't log in, `cluster:install` hangs on the keycloak realm step or fails at a webhook admission with an expired certificate, an agent pod repeats `[runtime] hello failed`, or `e2e:loop` fails against a warm cluster. Triggers on "cluster:install", "cluster:status", "e2e:loop", "fix-certs", "lima", "k3s", "ztunnel", "waypoint", "Istio SVID", "issue #283".
+---
+
+# Cluster operations
+
+## Cluster lifecycle (k3s via lima)
+
+`mise tasks` lists every `cluster:*` task with its description. The ones you'll reach for most:
+
+- `cluster:install` — create the k3s VM, build images, install cert-manager + the Platform chart (upgrades in place if already installed)
+- `cluster:build-apiserver` / `build-ui` / `build-controller` / `build-agent` / `build-keycloak` — rebuild one image and restart just that pod
+- `cluster:status` — pods and cluster state
+- `cluster:logs` — api-server pod logs
+- `cluster:fix-certs` — recover from expired dev-cluster certs (see below)
+- `cluster:stop` / `cluster:uninstall` / `cluster:delete`
+
+The `cluster:build-*`, `cluster:fix-certs`, and `cluster:status` tasks honor a `LIMA_INSTANCE` env var (default `platform-k3s`); set it to target a different VM (e.g. the e2e cluster).
+
+Services are available at `*.localhost:4444` automatically (Traefik on port 4444, auto-forwarded by lima). `*.localtest.me:4444` also works as an alias.
+
+## E2E tests (Playwright)
+
+- `mise run e2e` — full from-scratch run: nuke the test VM, install a fresh cluster, run specs, tear down (the CI path)
+- `mise run e2e:loop` — fast rerun against a warm test cluster: bootstrap once if missing, optionally rebuild components, wipe data, run specs. Options: `--headed --rebuild=apiserver,ui,controller,keycloak,mock-agent`
+- `mise run e2e:reset` — data wipe only: drop+recreate the platform DB, delete agents (CMs/sts/pods/PVCs), clear stored Playwright auth. Leaves the cluster running
+
+`e2e:loop` runs on a dedicated persistent `platform-k3s-test` VM that it never deletes, so reruns skip VM/Istio/cert-manager/Keycloak provisioning. Running `mise run e2e` nukes that VM (shared name); the next `e2e:loop` bootstraps a fresh one. `e2e:loop` does not heal a wedged cluster — if the warm cluster is broken, it fails loud; use `mise run e2e` or `cluster:fix-certs`. Use `e2e:loop` for iteration, `e2e` after helm/realm/infra changes.
+
+**Suite tiers.** **Smoke** (`src/tests/smoke/`) is the always-on tier — CI and plain `e2e` / `e2e:loop` run exactly it. **Full** = smoke plus the slow, scenario-heavy specs under `src/tests/full/`, run on demand only: `mise run e2e:loop -- --full` (or `mise run e2e -- --full` for the fresh-cluster path). Conventions for `src/tests/full/` specs: one `<area>-full` Playwright project per area, self-contained (own agents, own token via `getAccessToken` + `acceptTerms`, no smoke-chain fixtures), each spec references its motivating ticket in the test title.
+
+## Cluster debugging (pre-approved in .claude/settings.json)
+
+Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` instead of raw `kubectl` or `export KUBECONFIG=...`. These are auto-approved.
+
+Activate cluster environment for interactive use: `export KUBECONFIG="$(mise run cluster:kubeconfig)"`.
+
+If in-mesh traffic misbehaves — the UI suddenly can't log in, `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, or a new agent never seeds its workspace (agent pod logs repeat `[runtime] hello failed`) — suspect expired Istio ambient workload SVIDs (issue #283). `mise run cluster:status` reports whether the expired-cert signature is present. The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` and the waypoint deployments within ~10 min when it sees the signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait. The same suspend/resume clock skip can expire cert-manager's webhook serving cert (`cluster:install` fails at admission with `failed calling webhook ... certificate has expired`) — `cluster:status` probes for it and `cluster:fix-certs` heals it too.

--- a/.claude/skills/adopt
+++ b/.claude/skills/adopt
@@ -1,1 +1,0 @@
-../../.agents/skills/adopt

--- a/.claude/skills/arch-review
+++ b/.claude/skills/arch-review
@@ -1,1 +1,0 @@
-../../.agents/skills/arch-review

--- a/.claude/skills/bootstrap
+++ b/.claude/skills/bootstrap
@@ -1,1 +1,0 @@
-../../.agents/skills/bootstrap

--- a/.claude/skills/build-it
+++ b/.claude/skills/build-it
@@ -1,1 +1,0 @@
-../../.agents/skills/build-it

--- a/.claude/skills/cluster-ops
+++ b/.claude/skills/cluster-ops
@@ -1,0 +1,1 @@
+../../.agents/skills/cluster-ops

--- a/.claude/skills/fix-security
+++ b/.claude/skills/fix-security
@@ -1,1 +1,0 @@
-../../.agents/skills/fix-security

--- a/.claude/skills/grill-with-adr
+++ b/.claude/skills/grill-with-adr
@@ -1,1 +1,0 @@
-../../.agents/skills/grill-with-adr

--- a/.claude/skills/ralph-it
+++ b/.claude/skills/ralph-it
@@ -1,1 +1,0 @@
-../../.agents/skills/ralph-it

--- a/.claude/skills/review
+++ b/.claude/skills/review
@@ -1,1 +1,0 @@
-../../.agents/skills/review

--- a/.claude/skills/spec
+++ b/.claude/skills/spec
@@ -1,1 +1,0 @@
-../../.agents/skills/spec

--- a/.claude/skills/upgrade
+++ b/.claude/skills/upgrade
@@ -1,1 +1,0 @@
-../../.agents/skills/upgrade

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,69 +4,13 @@ Platform — a Kubernetes platform for running AI agent harnesses (Claude Code, 
 
 ### Monorepo layout
 
-pnpm workspaces + standalone Go module. Concept depth lives in [`docs/architecture/`](docs/architecture/); this is just orientation:
-
-- `packages/controller/` — Go K8s reconciler + scheduler
-- `packages/api-server/` + `packages/api-server-api/` — TypeScript API server (tRPC, ACP relay) and its contract package
-- `packages/agent-runtime/` + `packages/agent-runtime-api/` — in-pod ACP WebSocket server and its contract package
-- `packages/agents/` — per-harness agent images (`claude-code`, `pi-agent`, `codex`, `bob`)
-- `packages/ui/` — React chat interface (Vite)
-- `packages/platform-base/` — shared base image/utilities
-- `packages/db/` — database schema and migrations
-- `deploy/helm/platform/` — Helm chart for all components + PostgreSQL
+pnpm workspaces + standalone Go module. Concept depth lives in [`docs/architecture/`](docs/architecture/).
 
 ## Workflow
 
-mise is the task runner. All tasks are defined in `tasks.toml` files. **Always use `mise run` for building, checking, testing, and cluster operations — never invoke `go`, `pnpm`, `helm`, `kubectl`, etc. directly.** mise manages tool versions and environment; running tools directly will break.
+mise is the task runner. All tasks are defined in `tasks.toml` files. **Always use `mise run` for building, checking, testing, and cluster operations — never invoke `go`, `pnpm`, `helm`, `kubectl`, etc. directly.** mise manages tool versions and environment; running tools directly will break. `mise tasks` lists everything available.
 
-```sh
-mise run check              # lint + type-check all packages (also runs as pre-commit hook)
-mise run test               # run all tests
-mise run helm:check:lint    # helm lint
-mise run helm:check:render  # helm template | kubeconform
-mise run ui:run             # start UI dev server
-```
-
-### Cluster lifecycle (k3s via lima)
-
-```sh
-mise run cluster:install         # create k3s VM, build images, install cert-manager + Platform chart (or upgrade if already installed)
-mise run cluster:build-apiserver # rebuild api-server image only, restart apiserver pod
-mise run cluster:build-ui        # rebuild UI image only, restart UI pod
-mise run cluster:build-controller# rebuild controller image only, restart controller pod
-mise run cluster:build-agent     # rebuild agent image only, restart agent pods
-mise run cluster:build-keycloak  # rebuild keycloak image only, restart keycloak pod
-mise run cluster:fix-certs       # recover from expired dev-cluster certs: roll ztunnel, waypoints, cert-manager webhook (issue #283)
-mise run cluster:status          # show pods and cluster state
-mise run cluster:logs            # show api-server pod logs
-mise run cluster:stop            # stop k3s VM (preserves data)
-mise run cluster:uninstall       # helm uninstall + cleanup PVCs
-mise run cluster:delete          # destroy k3s VM entirely
-```
-
-The `cluster:build-*`, `cluster:fix-certs`, and `cluster:status` tasks honor a `LIMA_INSTANCE` env var (default `platform-k3s`); set it to target a different VM (e.g. the e2e cluster).
-
-Services are available at `*.localhost:4444` automatically (Traefik on port 4444, auto-forwarded by lima). `*.localtest.me:4444` also works as an alias.
-
-### E2E tests (Playwright)
-
-```sh
-mise run e2e          # full from-scratch run: nuke test VM, install fresh cluster, run specs, tear down (CI path)
-mise run e2e:loop     # fast rerun against a warm test cluster: bootstrap once if missing, optionally rebuild components, wipe data, run specs. Options: --headed --rebuild=apiserver,ui,controller,keycloak,mock-agent
-mise run e2e:reset    # data wipe only: drop+recreate platform DB, delete agents (CMs/sts/pods/PVCs), clear stored Playwright auth. Leaves the cluster running
-```
-
-`e2e:loop` runs on a dedicated persistent `platform-k3s-test` VM that it never deletes, so reruns skip VM/Istio/cert-manager/Keycloak provisioning. Running `mise run e2e` nukes that VM (shared name); the next `e2e:loop` bootstraps a fresh one. `e2e:loop` does not heal a wedged cluster — if the warm cluster is broken, it fails loud; use `mise run e2e` or `cluster:fix-certs`. Use `e2e:loop` for iteration, `e2e` after helm/realm/infra changes.
-
-**Suite tiers.** **Smoke** (`src/tests/smoke/`) is the always-on tier — CI and plain `e2e` / `e2e:loop` run exactly it. **Full** = smoke plus the slow, scenario-heavy specs under `src/tests/full/`, run on demand only: `mise run e2e:loop -- --full` (or `mise run e2e -- --full` for the fresh-cluster path). Conventions for `src/tests/full/` specs: one `<area>-full` Playwright project per area, self-contained (own agents, own token via `getAccessToken` + `acceptTerms`, no smoke-chain fixtures), each spec references its motivating ticket in the test title.
-
-### Cluster debugging (pre-approved in .claude/settings.json)
-
-Use `mise run cluster:kubectl -- <args>` and `mise run cluster:shell -- <cmd>` instead of raw `kubectl` or `export KUBECONFIG=...`. These are auto-approved.
-
-Activate cluster environment for interactive use: `export KUBECONFIG="$(mise run cluster:kubeconfig)"`.
-
-If in-mesh traffic misbehaves — the UI suddenly can't log in, `cluster:install` hangs on the keycloak realm step with a misleading `Connection reset`, or a new agent never seeds its workspace (agent pod logs repeat `[runtime] hello failed`) — suspect expired Istio ambient workload SVIDs (issue #283). `mise run cluster:status` reports whether the expired-cert signature is present. The `ztunnel-cert-watchdog` CronJob in `istio-system` auto-rolls `ds/ztunnel` and the waypoint deployments within ~10 min when it sees the signature; `mise run cluster:fix-certs` is the manual escape hatch if you can't wait. The same suspend/resume clock skip can expire cert-manager's webhook serving cert (`cluster:install` fails at admission with `failed calling webhook ... certificate has expired`) — `cluster:status` probes for it and `cluster:fix-certs` heals it too.
+For the local k3s cluster (lima), e2e test runs, and mesh/cert failures, use the [`cluster-ops`](.claude/skills/cluster-ops/SKILL.md) skill.
 
 ## System Architecture (what this system is)
 
@@ -78,16 +22,6 @@ ADRs (`docs/adrs/`) are human-first decision history; the agent-facing source of
 
 Generic conventions for TS server-side code (tRPC, Zod, RxJS, layering). Invoke the `/typescript-engineering` skill whenever touching server-side TS. If you spot a contradiction between the skill and a Platform architecture doc, **stop and flag it** — the two should stay aligned, so a conflict means one of them is wrong.
 
-## Database Migrations (`packages/db`)
-
-Tables/indexes/enums are **generated** from `schema.ts`; the `usage_*` reporting views are **hand-written** raw SQL (they aren't in `schema.ts`) (#739). Full workflow in [`packages/db/README.md`](packages/db/README.md).
-
-- **Table change**: edit `src/schema.ts` → `mise run db:generate` (writes the `.sql`, `_journal.json` entry, and snapshot — never hand-edit them) → add a top comment explaining *why*.
-- **View change**: `mise run db:new -- <name>` scaffolds the `.sql` + journal entry, then hand-write the `CREATE/DROP VIEW` SQL (dependency order; `--> statement-breakpoint` between statements).
-- Never hand-write a table migration: `mise run db:check:generated` (part of `mise run check`, no database) fails if the snapshot doesn't match `schema.ts`.
-
-Migrations run automatically on api-server startup — no manual migrate step in production. The squash split the original history into `0000_squashed_baseline.sql` (tables) and `0001_usage_views.sql` (views); existing deployments skip both (do not change their journal `when`). Commit `_journal.json` alongside the `.sql` file.
-
 ## Documentation
 
 Always follow [`docs/guidelines/documentation-guidelines.md`](docs/guidelines/documentation-guidelines.md).
@@ -95,10 +29,6 @@ Always follow [`docs/guidelines/documentation-guidelines.md`](docs/guidelines/do
 ## Work process
 
 Proposed ideal flow for new features — see [`docs/guidelines/work-process.md`](docs/guidelines/work-process.md).
-
-## UI (`packages/ui`)
-
-Follow the [`react-ui-engineering`](.agents/skills/react-ui-engineering/SKILL.md) skill for all React + TypeScript work. Run `mise run lint:fix` after edits; auto-fixes import order and `import type`.
 
 ## Commit Conventions
 
@@ -109,10 +39,6 @@ Follow the [`react-ui-engineering`](.agents/skills/react-ui-engineering/SKILL.md
 - **DCO**: Always use `git commit -s` to add `Signed-off-by` trailer.
 - **Branch naming**: `type/short-description` (e.g., `feat/session-history`, `fix/stale-timer`). Same type prefixes as commits.
 
-## Separation of Concerns & DRY Principle
-
-This system is a modular component system following the DRY (Don't Repeat Yourself) principle. Each piece has a single responsibility. You should be able to swap out any component without rewriting others.
-
 ## Branding
 
 Never hardcode the brand (`Dam`, `dam`, or any replacement) in code. The codename `platform` is permanent; user-visible brand flows through Helm `brand.*` ([`deploy/helm/platform/values.yaml`](deploy/helm/platform/values.yaml)) → api-server `config.brand` → UI `getBrand()` ([`packages/ui/src/brand.ts`](packages/ui/src/brand.ts)).
@@ -120,21 +46,6 @@ Never hardcode the brand (`Dam`, `dam`, or any replacement) in code. The codenam
 ## Worktrees
 
 Use `.worktrees/` for git worktrees. Branch naming follows commit conventions (e.g., `feat/session-history`).
-
-### Setup
-
-After creating a worktree, run project setup:
-
-- **Node.js**: `pnpm install`
-
-### Verification
-
-Run tests to confirm a clean baseline before starting work. If tests fail, report failures and ask before proceeding.
-
-### Report
-
-After setup, report: worktree path, test results, and readiness.
-
 
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker

--- a/packages/db/CLAUDE.md
+++ b/packages/db/CLAUDE.md
@@ -1,0 +1,9 @@
+## Database Migrations (`packages/db`)
+
+Tables/indexes/enums are **generated** from `schema.ts`; the `usage_*` reporting views are **hand-written** raw SQL (they aren't in `schema.ts`) (#739). Full workflow in [`README.md`](README.md).
+
+- **Table change**: edit `src/schema.ts` → `mise run db:generate` (writes the `.sql`, `_journal.json` entry, and snapshot — never hand-edit them) → add a top comment explaining *why*.
+- **View change**: `mise run db:new -- <name>` scaffolds the `.sql` + journal entry, then hand-write the `CREATE/DROP VIEW` SQL (dependency order; `--> statement-breakpoint` between statements).
+- Never hand-write a table migration: `mise run db:check:generated` (part of `mise run check`, no database) fails if the snapshot doesn't match `schema.ts`.
+
+Migrations run automatically on api-server startup — no manual migrate step in production. The squash split the original history into `0000_squashed_baseline.sql` (tables) and `0001_usage_views.sql` (views); existing deployments skip both (do not change their journal `when`). Commit `_journal.json` alongside the `.sql` file.

--- a/packages/ui/CLAUDE.md
+++ b/packages/ui/CLAUDE.md
@@ -1,0 +1,3 @@
+## UI (`packages/ui`)
+
+Follow the [`react-ui-engineering`](../../.agents/skills/react-ui-engineering/SKILL.md) skill for all React + TypeScript work. Run `mise run lint:fix` after edits; auto-fixes import order and `import type`.


### PR DESCRIPTION
Fallout from a `/doctor` run on my setup. Two things.

**10 skill symlinks were dead.** `.claude/skills/{adopt,arch-review,bootstrap,build-it,fix-security,grill-with-adr,ralph-it,review,spec,upgrade}` all point at `.agents/skills/<name>` directories that don't exist. They're tracked in git, so everyone gets them, and the skills silently never load. Removed.

**Root CLAUDE.md was carrying a lot of stuff a session can just look up.** It's loaded into context on every single turn, so it should only hold things the codebase can't tell you.

Cut outright:
- the monorepo layout bullet list (`ls packages/` shows it)
- the `mise run` / `cluster:*` / `e2e` command blocks. I checked: `mise tasks` prints every one of these with near-identical descriptions
- the "Separation of Concerns & DRY Principle" section (generic advice)
- the worktree Setup/Verification/Report subsections (`pnpm install` comes from the manifest; the rest is generic)

Moved to lazy loading:
- `packages/db` migration workflow -> `packages/db/CLAUDE.md`, loads only when working in that package
- `packages/ui` guidance -> `packages/ui/CLAUDE.md`
- cluster lifecycle, e2e suite tiers, and the issue #283 mesh-cert recovery -> a new `cluster-ops` skill. Its description names the actual symptoms (UI can't log in, `cluster:install` hangs on keycloak, `[runtime] hello failed`, webhook cert expired) so it triggers when you hit them. Root file keeps a one-line pointer.

Kept everything non-derivable: the "always use `mise run`" directive, the architecture-docs-are-source-of-truth rule, ADR policy, commit conventions, branding, worktree naming.

Net: root CLAUDE.md goes 11742 -> 4948 chars, roughly 1.7k fewer tokens on every turn.

The beads block at the bottom is untouched. It's inside generated markers and `bd prime` re-injects the same content via the SessionStart hook anyway, so trimming it there is a `bd` profile question, not a file edit.

https://claude.ai/code/session_01BVoCF6q6ySoj9rYRcXk9yP