### PR TITLE
feat(ui): simplify the Artifacts empty state

### DIFF
--- a/packages/ui/src/components/ui/page-empty-state.tsx
+++ b/packages/ui/src/components/ui/page-empty-state.tsx
@@ -1,0 +1,31 @@
+import type { ReactNode } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+interface Props {
+  title: string;
+  message: ReactNode;
+  actionLabel: string;
+  onAction: () => void;
+}
+
+/** The empty state for a whole page: a centered card with a heading, one line
+ *  of copy, and a single primary action. Distinct from `EmptyStateCard`, which
+ *  is the inline add-affordance used inside a populated sandbox section. */
+export function PageEmptyState({
+  title,
+  message,
+  actionLabel,
+  onAction,
+}: Props) {
+  return (
+    <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
+      <h2 className="text-[16px] font-semibold text-foreground">{title}</h2>
+      <p className="text-[14px] text-muted-foreground">{message}</p>
+      <Button className="mt-1" onClick={onAction}>
+        {actionLabel}
+      </Button>
+    </Card>
+  );
+}

--- a/packages/ui/src/components/ui/page-empty-state.tsx
+++ b/packages/ui/src/components/ui/page-empty-state.tsx
@@ -7,6 +7,7 @@ interface Props {
   title: string;
   message: ReactNode;
   actionLabel: string;
+  actionIcon?: ReactNode;
   onAction: () => void;
 }
 
@@ -17,6 +18,7 @@ export function PageEmptyState({
   title,
   message,
   actionLabel,
+  actionIcon,
   onAction,
 }: Props) {
   return (
@@ -24,6 +26,7 @@ export function PageEmptyState({
       <h2 className="text-[16px] font-semibold text-foreground">{title}</h2>
       <p className="text-[14px] text-muted-foreground">{message}</p>
       <Button className="mt-1" onClick={onAction}>
+        {actionIcon}
         {actionLabel}
       </Button>
     </Card>

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { PageEmptyState } from "@/components/ui/page-empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
@@ -74,17 +74,12 @@ export function ListView() {
       {!initialLoaded && <ListSkeleton rows={2} rowHeight={70} />}
 
       {initialLoaded && agents.length === 0 && (
-        <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
-          <h2 className="text-[16px] font-semibold text-foreground">
-            No sandboxes yet
-          </h2>
-          <p className="text-[14px] text-muted-foreground">
-            Create your first sandbox to get started.
-          </p>
-          <Button className="mt-1" onClick={navigateToCreateSandbox}>
-            Create sandbox
-          </Button>
-        </Card>
+        <PageEmptyState
+          title="No sandboxes yet"
+          message="Create your first sandbox to get started."
+          actionLabel="Create sandbox"
+          onAction={navigateToCreateSandbox}
+        />
       )}
 
       <div className="flex flex-col gap-3">

--- a/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
+++ b/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
@@ -1,15 +1,17 @@
 import type { ArtifactFolder, LibraryArtifact } from "api-server-api";
 import { EXPERIMENT_FOLDER_PREFIX } from "api-server-api";
-import { FolderPlus, Search, Upload } from "lucide-react";
+import { Box, FolderPlus, Search, Upload } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import { Input } from "@/components/ui/input";
+import { PageEmptyState } from "@/components/ui/page-empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 
 import { api } from "../../../api.js";
+import { ListSkeleton } from "../../../components/list-skeleton.js";
+import { useStore } from "../../../store.js";
 import { useDeleteFolder } from "../api/mutations.js";
 import { useArtifactFolders, useArtifacts } from "../api/queries.js";
 import { ArtifactPreviewDialog } from "../components/artifact-preview-dialog.js";
@@ -24,8 +26,12 @@ const EMPTY_ARTIFACTS: LibraryArtifact[] = [];
 const EMPTY_FOLDERS: ArtifactFolder[] = [];
 
 export function ArtifactsView() {
-  const { data: artifacts = EMPTY_ARTIFACTS, isLoading } = useArtifacts();
-  const { data: folders = EMPTY_FOLDERS } = useArtifactFolders();
+  const { data: artifacts = EMPTY_ARTIFACTS, isLoading: artifactsLoading } =
+    useArtifacts();
+  const { data: folders = EMPTY_FOLDERS, isLoading: foldersLoading } =
+    useArtifactFolders();
+
+  const setView = useStore((s) => s.setView);
 
   const [search, setSearch] = useState("");
   const [uploadOpen, setUploadOpen] = useState(false);
@@ -88,81 +94,99 @@ export function ArtifactsView() {
   );
 
   const ungrouped = byFolder.get(null) ?? [];
-  const isEmpty = !isLoading && artifacts.length === 0 && folders.length === 0;
+  const loading = artifactsLoading || foldersLoading;
+  const hasContent = artifacts.length > 0 || folders.length > 0;
+  // Folders load on their own query — a folders-only library must not flash the
+  // empty state (which also strips the search box) before its groups land.
+  const isEmpty = !loading && !hasContent;
 
   return (
     <div className="anim-in">
       <PageHeader
         title="Artifacts"
-        description="Pages and files created by you and your agents. Share with a link, set an expiry."
+        description={
+          hasContent
+            ? "Pages and files created by you and your agents. Share with a link, set an expiry."
+            : undefined
+        }
         actions={
-          <>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => setFolderDialog({ folder: null })}
-            >
-              <FolderPlus size={16} />
-              New folder
-            </Button>
-            <Button size="sm" onClick={() => setUploadOpen(true)}>
-              <Upload size={16} />
-              Upload artifact
-            </Button>
-          </>
+          hasContent ? (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setFolderDialog({ folder: null })}
+              >
+                <FolderPlus size={16} />
+                New folder
+              </Button>
+              <Button size="sm" onClick={() => setUploadOpen(true)}>
+                <Upload size={16} />
+                Upload artifact
+              </Button>
+            </>
+          ) : undefined
         }
       />
 
-      <div className="relative mt-7">
-        <Search
-          size={16}
-          className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
-        />
-        <Input
-          className="pl-9"
-          placeholder="Search artifacts…"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-        />
-      </div>
+      {hasContent && (
+        <div className="relative mt-7">
+          <Search
+            size={16}
+            className="pointer-events-none absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground"
+          />
+          <Input
+            className="pl-9"
+            placeholder="Search artifacts…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+        </div>
+      )}
 
-      <div className="mt-5 flex flex-col gap-3">
-        {isEmpty ? (
-          <EmptyState onUpload={() => setUploadOpen(true)} />
-        ) : (
-          <>
-            {userFolders.map((folder) => (
-              <FolderGroup
-                key={folder.id}
-                folder={folder}
-                artifacts={byFolder.get(folder.id) ?? []}
-                onEditFolder={(f) => setFolderDialog({ folder: f })}
-                onDeleteFolder={setDeleteFolderTarget}
-                onCopyFolderLink={copyFolderLink}
-                {...rowActions}
-              />
-            ))}
-            {ungrouped.length > 0 && (
-              <FolderGroup
-                folder={null}
-                artifacts={ungrouped}
-                {...rowActions}
-              />
-            )}
-            {experimentFolders.length > 0 && (
-              <ExperimentsSection
-                folders={experimentFolders}
-                byFolder={byFolder}
-                searching={search.trim().length > 0}
-                onEditFolder={(f) => setFolderDialog({ folder: f })}
-                onDeleteFolder={setDeleteFolderTarget}
-                onCopyFolderLink={copyFolderLink}
-                {...rowActions}
-              />
-            )}
-          </>
-        )}
-      </div>
+      {/* Artifacts can be warm from another view while folders is still cold —
+          skeleton only when there is nothing to show, never above content. */}
+      {loading && !hasContent && <ListSkeleton rows={2} rowHeight={70} />}
+
+      {isEmpty && (
+        <PageEmptyState
+          title="No artifacts yet"
+          message="Artifacts from every sandbox collect here."
+          actionLabel="Go to sandboxes"
+          actionIcon={<Box size={16} />}
+          onAction={() => setView("list")}
+        />
+      )}
+
+      {hasContent && (
+        <div className="mt-5 flex flex-col gap-3">
+          {userFolders.map((folder) => (
+            <FolderGroup
+              key={folder.id}
+              folder={folder}
+              artifacts={byFolder.get(folder.id) ?? []}
+              onEditFolder={(f) => setFolderDialog({ folder: f })}
+              onDeleteFolder={setDeleteFolderTarget}
+              onCopyFolderLink={copyFolderLink}
+              {...rowActions}
+            />
+          ))}
+          {ungrouped.length > 0 && (
+            <FolderGroup folder={null} artifacts={ungrouped} {...rowActions} />
+          )}
+          {experimentFolders.length > 0 && (
+            <ExperimentsSection
+              folders={experimentFolders}
+              byFolder={byFolder}
+              searching={search.trim().length > 0}
+              onEditFolder={(f) => setFolderDialog({ folder: f })}
+              onDeleteFolder={setDeleteFolderTarget}
+              onCopyFolderLink={copyFolderLink}
+              {...rowActions}
+            />
+          )}
+        </div>
+      )}
 
       {artifacts.length > 0 && (
         <p className="mt-5 text-[13px] text-muted-foreground">
@@ -211,23 +235,5 @@ export function ArtifactsView() {
         }}
       />
     </div>
-  );
-}
-
-function EmptyState({ onUpload }: { onUpload: () => void }) {
-  return (
-    <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
-      <h2 className="text-[16px] font-semibold text-foreground">
-        No artifacts yet
-      </h2>
-      <p className="max-w-[400px] text-[14px] text-muted-foreground">
-        Agents publish artifacts with their built-in tools, or upload one
-        yourself — then share it with a link.
-      </p>
-      <Button size="sm" onClick={onUpload}>
-        <Upload size={16} />
-        Upload artifact
-      </Button>
-    </Card>
   );
 }

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
@@ -1,5 +1,5 @@
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
+import { PageEmptyState } from "@/components/ui/page-empty-state";
 import { PageHeader } from "@/components/ui/page-header";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
@@ -46,18 +46,12 @@ export function KnowledgeBasesListView() {
       {!initialLoaded && <ListSkeleton rows={2} rowHeight={70} />}
 
       {initialLoaded && knowledgeBases.length === 0 && (
-        <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
-          <h2 className="text-[16px] font-semibold text-foreground">
-            No knowledge bases yet
-          </h2>
-          <p className="text-[14px] text-muted-foreground">
-            A knowledge base is an agent that builds and maintains a body of
-            knowledge for you. Create one and it sets itself up.
-          </p>
-          <Button className="mt-1" onClick={navigateToCreateKnowledgeBase}>
-            New knowledge base
-          </Button>
-        </Card>
+        <PageEmptyState
+          title="No knowledge bases yet"
+          message="A knowledge base is an agent that builds and maintains a body of knowledge for you. Create one and it sets itself up."
+          actionLabel="New knowledge base"
+          onAction={navigateToCreateKnowledgeBase}
+        />
       )}
 
       <div className="flex flex-col gap-3">


### PR DESCRIPTION
An empty Artifacts page used to sell manual upload: three lines of explanation and an **Upload artifact** button, under a header carrying a description, two actions, and a search box over nothing.

But uploading is not how artifacts normally appear — agents running in a sandbox publish them. So an empty library now says just that, and points at Sandboxes:

> **No artifacts yet**
> Artifacts from every sandbox collect here.
> `[ Go to sandboxes ]`

The description, both header actions, and the search box stay hidden until there is something to describe, act on, or search, and a cold load fills with the same skeleton the Sandboxes and Knowledge bases lists use. Everything returns unchanged the moment the library holds an artifact or a folder.

Note that this deliberately makes user upload unreachable from an *empty* library — de-emphasising it is the point of the issue.

Closes #2913