### PR TITLE
feat(ui): provider selection as a single-select

### DIFF
--- a/packages/e2e/playwright/src/tests/smoke/03-agent.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/03-agent.spec.ts
@@ -58,7 +58,8 @@ test("create a mock agent with the connection attached", async ({ page }) => {
     await page.getByPlaceholder("my-sandbox").fill(agentName);
 
     const dialog = page.getByRole("dialog");
-    await page.getByRole("button", { name: /openai/i }).click();
+    await page.getByTestId("provider-select").click();
+    await page.getByTestId("provider-option-openai").click();
     await dialog.locator('input[type="password"]').fill("sk-e2e-dummy-key");
     await dialog.getByRole("button", { name: "Save" }).click();
     await expect(dialog).toBeHidden();

--- a/packages/ui/src/__tests__/unit/provider-policy.test.ts
+++ b/packages/ui/src/__tests__/unit/provider-policy.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "vitest";
 
 import {
+  offeredProviderRows,
+  PROVIDER_ROWS,
+} from "../../modules/providers/lib/provider-rows.js";
+import {
   providerPolicy,
   startingPointDefaults,
 } from "../../modules/sandboxes/lib/wizard-snapshot.js";
@@ -27,5 +31,24 @@ describe("providerPolicy", () => {
     // and ride the create call.
     expect(startingPointDefaults("experiment").providerRef).toBeNull();
     expect(startingPointDefaults("knowledge-base").providerRef).toBeNull();
+  });
+});
+
+describe("offeredProviderRows", () => {
+  test("offers every provider in catalog order without a policy", () => {
+    expect(offeredProviderRows().map((row) => row.type)).toEqual(
+      PROVIDER_ROWS.map((row) => row.type),
+    );
+  });
+
+  test("applies a kinded policy: only the allowed rows, recommended first", () => {
+    const { allow, recommended } = providerPolicy("experiment");
+    expect(offeredProviderRows(allow, recommended).map((row) => row.type)) //
+      .toEqual(["ibm-litellm", "anthropic"]);
+  });
+
+  test("keeps the recommended row first whatever the catalog order", () => {
+    const rows = offeredProviderRows(["openai", "anthropic"], "openai");
+    expect(rows.map((row) => row.type)).toEqual(["openai", "anthropic"]);
   });
 });

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -123,16 +123,15 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement | null>) {
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
     // A spawning menu's focus trap stays alive through its exit animation and
-    // refocuses its trigger at the end — a single focus() loses. Re-assert
-    // briefly (same workaround as inline-name-row.tsx).
+    // refocuses its trigger at the end, so re-assert until it gives up.
     let grabRaf = 0;
-    let grabTicks = 0;
+    const reassertUntil = performance.now() + 500;
     const grab = () => {
       if (!container.contains(document.activeElement)) {
-        const first = container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-        first?.focus();
+        container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR)?.focus();
       }
-      if (++grabTicks < 30) grabRaf = requestAnimationFrame(grab);
+      if (performance.now() < reassertUntil)
+        grabRaf = requestAnimationFrame(grab);
     };
     grab();
 

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -122,10 +122,19 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement | null>) {
     if (!container) return;
     const previouslyFocused = document.activeElement as HTMLElement | null;
 
-    if (!container.contains(document.activeElement)) {
-      const first = container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-      first?.focus();
-    }
+    // A spawning menu's focus trap stays alive through its exit animation and
+    // refocuses its trigger at the end — a single focus() loses. Re-assert
+    // briefly (same workaround as inline-name-row.tsx).
+    let grabRaf = 0;
+    let grabTicks = 0;
+    const grab = () => {
+      if (!container.contains(document.activeElement)) {
+        const first = container.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
+        first?.focus();
+      }
+      if (++grabTicks < 30) grabRaf = requestAnimationFrame(grab);
+    };
+    grab();
 
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== "Tab") return;
@@ -152,6 +161,7 @@ export function useFocusTrap(containerRef: RefObject<HTMLElement | null>) {
 
     container.addEventListener("keydown", onKey);
     return () => {
+      cancelAnimationFrame(grabRaf);
       container.removeEventListener("keydown", onKey);
       previouslyFocused?.focus?.();
     };

--- a/packages/ui/src/components/ui/rich-select.tsx
+++ b/packages/ui/src/components/ui/rich-select.tsx
@@ -1,0 +1,130 @@
+import { Checkmark, ChevronDown } from "@carbon/icons-react";
+import type { ReactNode } from "react";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+export interface RichSelectOption<T extends string = string> {
+  value: T;
+  title: string;
+  description?: string;
+  /** Icon on the menu row (compact). */
+  icon?: ReactNode;
+  /** Icon in the closed control while selected; falls back to `icon`. */
+  triggerIcon?: ReactNode;
+  /** Rendered after the title in the closed control while selected
+   *  (e.g. a status badge). */
+  triggerBadge?: ReactNode;
+  /** Right-aligned affordance on the menu row (e.g. "Connect"). Hidden on
+   *  the selected row, which shows a check instead. */
+  trailing?: ReactNode;
+  testId?: string;
+}
+
+interface Props<T extends string> {
+  options: readonly RichSelectOption<T>[];
+  value: T | null;
+  /** Fires for any option, selected or not — the caller decides whether the
+   *  pick selects, needs a confirmation, or opens a side flow first. */
+  onSelect: (value: T) => void;
+  placeholder: string;
+  disabled?: boolean;
+  testId?: string;
+}
+
+/** Single-select over options too rich for a native `<select>` — each option
+ *  carries an icon, title, description, and an optional trailing affordance.
+ *  The closed control is a card showing the selected option in full. */
+export function RichSelect<T extends string>({
+  options,
+  value,
+  onSelect,
+  placeholder,
+  disabled = false,
+  testId,
+}: Props<T>) {
+  const selected = options.find((o) => o.value === value);
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          data-testid={testId}
+          className="group flex w-full items-center gap-3.5 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-foreground"
+        >
+          {selected ? (
+            <>
+              {selected.triggerIcon ?? selected.icon}
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2.5">
+                  <p className="truncate text-[16px] font-medium text-foreground">
+                    {selected.title}
+                  </p>
+                  {selected.triggerBadge}
+                </div>
+                {selected.description && (
+                  <p className="truncate text-[14px] text-muted-foreground">
+                    {selected.description}
+                  </p>
+                )}
+              </div>
+            </>
+          ) : (
+            <p className="flex-1 text-[15px] text-muted-foreground">
+              {placeholder}
+            </p>
+          )}
+          <ChevronDown
+            size={18}
+            className="shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180"
+          />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        align="start"
+        sideOffset={8}
+        className="w-[var(--radix-dropdown-menu-trigger-width)] p-1.5"
+      >
+        {options.map((option) => (
+          <DropdownMenuItem
+            key={option.value}
+            // Radix emits role="menuitem"; radio semantics announce the
+            // selection state a plain menu item lacks.
+            role="menuitemradio"
+            aria-checked={option.value === value}
+            textValue={option.title}
+            data-testid={option.testId}
+            onSelect={() => onSelect(option.value)}
+            className={cn(
+              "h-auto items-center gap-3 rounded-lg px-3 py-2.5",
+              option.value === value && "bg-muted/50",
+            )}
+          >
+            {option.icon}
+            <div className="min-w-0 flex-1">
+              <p className="truncate text-[14px] font-medium text-foreground">
+                {option.title}
+              </p>
+              {option.description && (
+                <p className="truncate text-[13px] text-muted-foreground">
+                  {option.description}
+                </p>
+              )}
+            </div>
+            {option.value === value ? (
+              <Checkmark size={16} className="shrink-0 text-foreground" />
+            ) : (
+              option.trailing
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/ui/src/components/ui/rich-select.tsx
+++ b/packages/ui/src/components/ui/rich-select.tsx
@@ -17,6 +17,8 @@ export interface RichSelectOption<T extends string = string> {
   icon?: ReactNode;
   /** Icon in the closed control while selected; falls back to `icon`. */
   triggerIcon?: ReactNode;
+  /** Rendered after the title on the menu row (e.g. "Recommended"). */
+  badge?: ReactNode;
   /** Rendered after the title in the closed control while selected
    *  (e.g. a status badge). */
   triggerBadge?: ReactNode;
@@ -108,9 +110,12 @@ export function RichSelect<T extends string>({
           >
             {option.icon}
             <div className="min-w-0 flex-1">
-              <p className="truncate text-[14px] font-medium text-foreground">
-                {option.title}
-              </p>
+              <div className="flex items-center gap-2">
+                <p className="truncate text-[14px] font-medium text-foreground">
+                  {option.title}
+                </p>
+                {option.badge}
+              </div>
               {option.description && (
                 <p className="truncate text-[13px] text-muted-foreground">
                   {option.description}

--- a/packages/ui/src/components/ui/rich-select.tsx
+++ b/packages/ui/src/components/ui/rich-select.tsx
@@ -28,6 +28,8 @@ interface Props<T extends string> {
    *  whether a pick selects, confirms, or opens a side flow. */
   onSelect: (value: T) => void;
   placeholder: string;
+  /** Names what the control picks, read out ahead of the current value. */
+  ariaLabel?: string;
   disabled?: boolean;
   testId?: string;
 }
@@ -37,6 +39,7 @@ export function RichSelect<T extends string>({
   value,
   onSelect,
   placeholder,
+  ariaLabel,
   disabled = false,
   testId,
 }: Props<T>) {
@@ -50,6 +53,7 @@ export function RichSelect<T extends string>({
           data-testid={testId}
           className="group flex min-h-[76px] w-full items-center gap-3.5 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-foreground"
         >
+          {ariaLabel && <span className="sr-only">{ariaLabel}</span>}
           {selected ? (
             <>
               {selected.triggerIcon ?? selected.icon}

--- a/packages/ui/src/components/ui/rich-select.tsx
+++ b/packages/ui/src/components/ui/rich-select.tsx
@@ -13,17 +13,10 @@ export interface RichSelectOption<T extends string = string> {
   value: T;
   title: string;
   description?: string;
-  /** Icon on the menu row (compact). */
   icon?: ReactNode;
-  /** Icon in the closed control while selected; falls back to `icon`. */
   triggerIcon?: ReactNode;
-  /** Rendered after the title on the menu row (e.g. "Recommended"). */
   badge?: ReactNode;
-  /** Rendered after the title in the closed control while selected
-   *  (e.g. a status badge). */
   triggerBadge?: ReactNode;
-  /** Right-aligned affordance on the menu row (e.g. "Connect"). Hidden on
-   *  the selected row, which shows a check instead. */
   trailing?: ReactNode;
   testId?: string;
 }
@@ -31,17 +24,14 @@ export interface RichSelectOption<T extends string = string> {
 interface Props<T extends string> {
   options: readonly RichSelectOption<T>[];
   value: T | null;
-  /** Fires for any option, selected or not — the caller decides whether the
-   *  pick selects, needs a confirmation, or opens a side flow first. */
+  /** Fires for any option, even the selected one — the caller decides
+   *  whether a pick selects, confirms, or opens a side flow. */
   onSelect: (value: T) => void;
   placeholder: string;
   disabled?: boolean;
   testId?: string;
 }
 
-/** Single-select over options too rich for a native `<select>` — each option
- *  carries an icon, title, description, and an optional trailing affordance.
- *  The closed control is a card showing the selected option in full. */
 export function RichSelect<T extends string>({
   options,
   value,
@@ -58,7 +48,7 @@ export function RichSelect<T extends string>({
           type="button"
           disabled={disabled}
           data-testid={testId}
-          className="group flex w-full items-center gap-3.5 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-foreground"
+          className="group flex min-h-[76px] w-full items-center gap-3.5 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:border-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-foreground"
         >
           {selected ? (
             <>
@@ -96,8 +86,7 @@ export function RichSelect<T extends string>({
         {options.map((option) => (
           <DropdownMenuItem
             key={option.value}
-            // Radix emits role="menuitem"; radio semantics announce the
-            // selection state a plain menu item lacks.
+            // Radix's default menuitem role hides which option is selected
             role="menuitemradio"
             aria-checked={option.value === value}
             textValue={option.title}

--- a/packages/ui/src/modules/agents/components/create-agent-inline.tsx
+++ b/packages/ui/src/modules/agents/components/create-agent-inline.tsx
@@ -8,7 +8,7 @@ import { Select } from "@/components/ui/select";
 
 import type { AgentView } from "../../../types.js";
 import type { ProviderRef } from "../../providers/components/provider-item.js";
-import { ProviderSection } from "../../providers/components/provider-section.js";
+import { ProviderSelect } from "../../providers/components/provider-select.js";
 import { generateSandboxName } from "../../sandboxes/lib/sandbox-name.js";
 import { useTemplates } from "../../templates/api/queries.js";
 import { useCreateAgent } from "../api/mutations.js";
@@ -93,12 +93,10 @@ export function CreateAgentInline({ onCreated }: Props) {
 
       <div>
         <SectionLabel spaced>Provider</SectionLabel>
-        <ProviderSection
+        <ProviderSelect
           selected={providerRef}
           onSelect={setProviderRef}
           autoSelectFirst
-          variant="collapsible"
-          manageKeys={false}
         />
       </div>
 

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -2,6 +2,7 @@ import type { StateCreator } from "zustand";
 
 import type { PlatformStore } from "../../../store.js";
 import {
+  clearSnapshot,
   EMPTY_SNAPSHOT,
   saveSnapshot,
   type StartingPoint,
@@ -82,11 +83,15 @@ export const createNavigationSlice: StateCreator<
   },
   navigateToCreateSandbox: (startingPoint) => {
     // Seeded into the snapshot, not the route — where every other pick lives.
+    // Without a starting point the wizard opens fresh; only URL-based re-entry
+    // (refresh, OAuth return) resumes a persisted draft.
     if (startingPoint) {
       saveSnapshot({
         ...EMPTY_SNAPSHOT,
         ...startingPointDefaults(startingPoint),
       });
+    } else {
+      clearSnapshot();
     }
     history.pushState(null, "", viewToPath("sandbox-new"));
     set({ view: "sandbox-new", agentId: null });

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -83,8 +83,7 @@ export const createNavigationSlice: StateCreator<
   },
   navigateToCreateSandbox: (startingPoint) => {
     // Seeded into the snapshot, not the route — where every other pick lives.
-    // Without a starting point the wizard opens fresh; only URL-based re-entry
-    // (refresh, OAuth return) resumes a persisted draft.
+    // Only URL-based re-entry (refresh, OAuth return) resumes a persisted draft.
     if (startingPoint) {
       saveSnapshot({
         ...EMPTY_SNAPSHOT,

--- a/packages/ui/src/modules/providers/components/connected-badge.tsx
+++ b/packages/ui/src/modules/providers/components/connected-badge.tsx
@@ -1,0 +1,7 @@
+export function ConnectedBadge() {
+  return (
+    <span className="shrink-0 rounded-full bg-success-light px-2.5 py-0.5 text-[12px] font-normal text-success">
+      Connected
+    </span>
+  );
+}

--- a/packages/ui/src/modules/providers/components/connected-badge.tsx
+++ b/packages/ui/src/modules/providers/components/connected-badge.tsx
@@ -1,7 +1,0 @@
-export function ConnectedBadge() {
-  return (
-    <span className="shrink-0 rounded-full bg-success-light px-2.5 py-0.5 text-[12px] font-normal text-success">
-      Connected
-    </span>
-  );
-}

--- a/packages/ui/src/modules/providers/components/provider-item.ts
+++ b/packages/ui/src/modules/providers/components/provider-item.ts
@@ -16,10 +16,6 @@ export function providerRef(item: ProviderItem): ProviderRef {
   return { id: item.id };
 }
 
-export function sameProviderRef(a: ProviderRef, b: ProviderRef): boolean {
-  return a.id === b.id;
-}
-
 // Bob's config inputs ride as `env` contributions whose placeholder holds the
 // (non-secret) value, keyed by the same env names the legacy pins use.
 export function bobPinsFromConnection(conn: ConnectionView): BobModelPins {

--- a/packages/ui/src/modules/providers/components/provider-row.tsx
+++ b/packages/ui/src/modules/providers/components/provider-row.tsx
@@ -76,7 +76,7 @@ export function ProviderRow({
 
 ProviderRow.Skeleton = function ProviderRowSkeleton() {
   return (
-    <div className="h-[72px] rounded-lg border border-border bg-card anim-pulse" />
+    <div className="h-[76px] rounded-lg border border-border bg-card anim-pulse" />
   );
 };
 

--- a/packages/ui/src/modules/providers/components/provider-row.tsx
+++ b/packages/ui/src/modules/providers/components/provider-row.tsx
@@ -1,4 +1,4 @@
-import { MoreVertical } from "lucide-react";
+import { OverflowMenuVertical } from "@carbon/icons-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -8,7 +8,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { cn } from "@/lib/utils";
 
 import { type ProviderPresetType, PROVIDERS } from "../../../types.js";
 import { CardIcon } from "./card-icon.js";
@@ -16,32 +15,19 @@ import { CardIcon } from "./card-icon.js";
 interface Props {
   type: ProviderPresetType;
   description: string;
-  subtitle?: string;
   connected: boolean;
-  selected: boolean;
-  selectable?: boolean;
-  /** The provider this surface steers toward, marked on the row. */
-  recommended?: boolean;
-  /** Show the per-row key-management menu (Edit key / Remove key). Off on
-   *  surfaces that only pick a provider and have no confirm-dialog host. */
-  manageKeys?: boolean;
   onConnect: () => void;
-  onSelect: () => void;
   onEditKey: () => void;
   onRemoveKey: () => void;
 }
 
+/** Settings → Providers row: the global credential per provider. Connected
+ *  rows manage the key via the ⋮ menu; the rest offer Connect. */
 export function ProviderRow({
   type,
   description,
-  subtitle,
   connected,
-  selected,
-  selectable = true,
-  recommended = false,
-  manageKeys = true,
   onConnect,
-  onSelect,
   onEditKey,
   onRemoveKey,
 }: Props) {
@@ -55,11 +41,7 @@ export function ProviderRow({
         className="flex w-full items-start gap-3 rounded-lg border border-border bg-card p-4 text-left transition-colors hover:bg-muted/40"
       >
         <CardIcon provider={type} />
-        <ProviderText
-          name={name}
-          description={description}
-          recommended={recommended}
-        />
+        <ProviderText name={name} description={description} />
         <span className="shrink-0 text-[14px] font-normal text-muted-foreground">
           Connect
         </span>
@@ -67,54 +49,29 @@ export function ProviderRow({
     );
   }
 
-  const info = (
-    <>
-      <CardIcon provider={type} />
-      <ProviderText
-        name={name}
-        description={subtitle ?? description}
-        connected
-        recommended={recommended}
-      />
-    </>
-  );
-
   return (
-    <div
-      className={cn(
-        "flex items-center gap-1 rounded-lg border bg-card pr-2 transition-colors",
-        selectable && selected ? "border-foreground" : "border-border",
-      )}
-    >
-      {selectable ? (
-        <button
-          type="button"
-          onClick={onSelect}
-          aria-pressed={selected}
-          className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-4 py-4 text-left transition-colors hover:bg-muted/30"
-        >
-          {info}
-        </button>
-      ) : (
-        <div className="flex min-w-0 flex-1 items-center gap-3 px-4 py-4">
-          {info}
-        </div>
-      )}
-      {manageKeys && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <Button variant="ghost" size="icon-sm" title="Provider actions">
-              <MoreVertical size={16} />
-            </Button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent>
-            <DropdownMenuItem onSelect={onEditKey}>Edit key</DropdownMenuItem>
-            <DropdownMenuItem tone="danger" onSelect={onRemoveKey}>
-              Remove key
-            </DropdownMenuItem>
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+    <div className="flex items-center gap-1 rounded-lg border border-border bg-card pr-2 transition-colors">
+      <div className="flex min-w-0 flex-1 items-center gap-3 px-4 py-4">
+        <CardIcon provider={type} />
+        <ProviderText name={name} description={description} connected />
+      </div>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            aria-label={`Actions for ${name}`}
+          >
+            <OverflowMenuVertical size={16} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem onSelect={onEditKey}>Edit key</DropdownMenuItem>
+          <DropdownMenuItem tone="danger" onSelect={onRemoveKey}>
+            Remove key
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     </div>
   );
 }
@@ -129,19 +86,16 @@ function ProviderText({
   name,
   description,
   connected = false,
-  recommended = false,
 }: {
   name: string;
   description: string;
   connected?: boolean;
-  recommended?: boolean;
 }) {
   return (
     <div className="min-w-0 flex-1">
       <div className="flex items-center gap-2">
         <p className="text-[16px] font-medium text-foreground">{name}</p>
-        {connected && <Badge variant="success">Connected</Badge>}
-        {recommended && <Badge variant="muted">Recommended</Badge>}
+{connected && <Badge variant="success">Connected</Badge>}
       </div>
       <p className="text-[14px] text-muted-foreground">{description}</p>
     </div>

--- a/packages/ui/src/modules/providers/components/provider-row.tsx
+++ b/packages/ui/src/modules/providers/components/provider-row.tsx
@@ -93,7 +93,7 @@ function ProviderText({
     <div className="min-w-0 flex-1">
       <div className="flex items-center gap-2">
         <p className="text-[16px] font-medium text-foreground">{name}</p>
-{connected && <Badge variant="success">Connected</Badge>}
+        {connected && <Badge variant="success">Connected</Badge>}
       </div>
       <p className="text-[14px] text-muted-foreground">{description}</p>
     </div>

--- a/packages/ui/src/modules/providers/components/provider-row.tsx
+++ b/packages/ui/src/modules/providers/components/provider-row.tsx
@@ -21,8 +21,6 @@ interface Props {
   onRemoveKey: () => void;
 }
 
-/** Settings → Providers row: the global credential per provider. Connected
- *  rows manage the key via the ⋮ menu; the rest offer Connect. */
 export function ProviderRow({
   type,
   description,

--- a/packages/ui/src/modules/providers/components/provider-section.tsx
+++ b/packages/ui/src/modules/providers/components/provider-section.tsx
@@ -1,211 +1,53 @@
-import { type ConnectionView, providerTypeForTemplateId } from "api-server-api";
-import { ChevronDown, ChevronUp } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
-
-import { cn } from "@/lib/utils";
+import { useState } from "react";
 
 import type { ProviderPresetType } from "../../../types.js";
-import { useAppConnections } from "../../connections/api/queries.js";
-import { MODES } from "./anthropic/modes.js";
+import { useProviderItems } from "../hooks/use-provider-items.js";
+import { PROVIDER_ROWS } from "../lib/provider-rows.js";
 import { ProviderConnectDialog } from "./provider-connect-dialog.js";
-import {
-  bobPinsFromConnection,
-  type ProviderItem,
-  type ProviderRef,
-  providerRef,
-  sameProviderRef,
-} from "./provider-item.js";
+import { type ProviderItem, providerRef } from "./provider-item.js";
 import { ProviderRow } from "./provider-row.js";
 import { useProviderActions } from "./use-provider-actions.js";
 
-export const PROVIDER_ROWS: {
-  type: ProviderPresetType;
-  description: string;
-}[] = [
-  {
-    type: "ibm-litellm",
-    description: "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS.",
-  },
-  {
-    type: "bob",
-    description:
-      "IBM Bob Shell endpoint with twin-secret credential injection.",
-  },
-  {
-    type: "anthropic",
-    description:
-      "Claude Code, Claude SDK, and any Anthropic-compatible client.",
-  },
-  {
-    type: "openai",
-    description: "GPT-family models for Codex and OpenAI-compatible agents.",
-  },
-];
-
-function connectionSubtitle(
-  type: ProviderPresetType,
-  conn: ConnectionView,
-): string | undefined {
-  if (type === "anthropic") {
-    const label =
-      conn.templateId === "anthropic-oauth"
-        ? MODES.oauth.label
-        : MODES["api-key"].label;
-    return `Set up with ${label}`;
-  }
-  if (type === "bob") {
-    const model = bobPinsFromConnection(conn).model;
-    return model ? `Model: ${model}` : "Default model";
-  }
-  return undefined;
-}
-
-function itemSubtitle(
-  type: ProviderPresetType,
-  item: ProviderItem,
-): string | undefined {
-  return connectionSubtitle(type, item.conn);
-}
-
-interface Props {
-  selected?: ProviderRef | null;
-  onSelect?: (ref: ProviderRef) => void;
-  onProviderRemoved?: (ref: ProviderRef) => void;
-  autoSelectFirst?: boolean;
-  variant?: "stacked" | "collapsible";
-  manage?: boolean;
-  /** Show the per-row key-management menu (Edit key / Remove key). Off on
-   *  surfaces that only pick a provider and have no confirm-dialog host. */
-  manageKeys?: boolean;
-  /** Restrict the offered providers. Omit to offer all of them. */
-  allow?: readonly ProviderPresetType[];
-  /** Ordered first and badged; `autoSelectFirst` therefore prefers it. */
-  recommended?: ProviderPresetType;
-  listClassName?: string;
-}
-
-export function ProviderSection({
-  selected = null,
-  onSelect,
-  onProviderRemoved,
-  autoSelectFirst = false,
-  variant = "stacked",
-  manage = false,
-  manageKeys = true,
-  allow,
-  recommended,
-  listClassName,
-}: Props) {
-  const { data: connections = [], isPending } = useAppConnections();
+/** Settings → Providers: the global credential store. Sandboxes pick one of
+ *  these via {@link ProviderSelect}; this page only manages the keys. */
+export function ProviderSection() {
+  const { itemByType, isPending } = useProviderItems();
   const providerActions = useProviderActions();
   const [dialog, setDialog] = useState<{
     provider: ProviderPresetType;
     item?: ProviderItem;
   } | null>(null);
-  const [expanded, setExpanded] = useState(false);
-
-  const rows = useMemo(() => {
-    const offered = allow
-      ? PROVIDER_ROWS.filter((row) => allow.includes(row.type))
-      : PROVIDER_ROWS;
-    if (!recommended) return offered;
-    return [...offered].sort(
-      (a, b) => Number(b.type === recommended) - Number(a.type === recommended),
-    );
-  }, [allow, recommended]);
-
-  const itemByType = useMemo(() => {
-    const connByType = new Map<ProviderPresetType, ConnectionView>();
-    for (const c of connections) {
-      const preset = providerTypeForTemplateId(c.templateId);
-      if (preset && !connByType.has(preset)) connByType.set(preset, c);
-    }
-    const m = new Map<ProviderPresetType, ProviderItem>();
-    for (const row of rows) {
-      const conn = connByType.get(row.type);
-      if (conn) m.set(row.type, { id: conn.id, conn });
-    }
-    return m;
-  }, [connections, rows]);
-
-  // Only acts while empty so a just-connected provider isn't nulled out during
-  // the list refetch.
-  useEffect(() => {
-    if (!autoSelectFirst || selected) return;
-    const first = rows.map((r) => itemByType.get(r.type)).find(Boolean);
-    if (first) onSelect?.(providerRef(first));
-  }, [autoSelectFirst, selected, itemByType, rows, onSelect]);
-
-  const renderRow = (row: (typeof PROVIDER_ROWS)[number]) => {
-    const item = itemByType.get(row.type);
-    const ref = item ? providerRef(item) : null;
-    return (
-      <ProviderRow
-        key={row.type}
-        type={row.type}
-        description={row.description}
-        subtitle={item ? itemSubtitle(row.type, item) : undefined}
-        connected={!!item}
-        selectable={!manage}
-        recommended={row.type === recommended}
-        manageKeys={manageKeys}
-        selected={!!ref && !!selected && sameProviderRef(ref, selected)}
-        onConnect={() => setDialog({ provider: row.type })}
-        onSelect={() => ref && onSelect?.(ref)}
-        onEditKey={() => item && setDialog({ provider: row.type, item })}
-        onRemoveKey={() =>
-          item &&
-          void providerActions.remove(providerRef(item), () =>
-            onProviderRemoved?.(providerRef(item)),
-          )
-        }
-      />
-    );
-  };
-
-  const connectedRows = rows.filter((r) => itemByType.has(r.type));
-  const disconnectedRows = rows.filter((r) => !itemByType.has(r.type));
-  // Connected providers stay visible; the rest hide behind "Show all". With
-  // nothing connected there's nothing to collapse, so reveal everything.
-  const collapsible =
-    variant === "collapsible" &&
-    connectedRows.length > 0 &&
-    disconnectedRows.length > 0;
-  const visibleRows =
-    variant === "collapsible"
-      ? [
-          ...connectedRows,
-          ...(collapsible && !expanded ? [] : disconnectedRows),
-        ]
-      : rows;
 
   return (
     <>
-      <div className={cn("flex flex-col gap-3", listClassName)}>
+      <div className="flex flex-col gap-3">
         {isPending
-          ? rows.map((row) => <ProviderRow.Skeleton key={row.type} />)
-          : visibleRows.map(renderRow)}
+          ? PROVIDER_ROWS.map((row) => <ProviderRow.Skeleton key={row.type} />)
+          : PROVIDER_ROWS.map((row) => {
+              const item = itemByType.get(row.type);
+              return (
+                <ProviderRow
+                  key={row.type}
+                  type={row.type}
+                  description={row.description}
+                  connected={!!item}
+                  onConnect={() => setDialog({ provider: row.type })}
+                  onEditKey={() =>
+                    item && setDialog({ provider: row.type, item })
+                  }
+                  onRemoveKey={() =>
+                    item && void providerActions.remove(providerRef(item))
+                  }
+                />
+              );
+            })}
       </div>
-
-      {!isPending && collapsible && (
-        <button
-          type="button"
-          onClick={() => setExpanded((v) => !v)}
-          className="mt-3 inline-flex items-center gap-1 text-[13px] text-muted-foreground hover:text-foreground"
-        >
-          {expanded ? "Show less" : "Show all"}
-          {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
-        </button>
-      )}
 
       {dialog && (
         <ProviderConnectDialog
           provider={dialog.provider}
           item={dialog.item}
-          onConnected={(ref) => {
-            onSelect?.(ref);
-            setDialog(null);
-          }}
+          onConnected={() => setDialog(null)}
           onClose={() => setDialog(null)}
         />
       )}

--- a/packages/ui/src/modules/providers/components/provider-section.tsx
+++ b/packages/ui/src/modules/providers/components/provider-section.tsx
@@ -8,8 +8,6 @@ import { type ProviderItem, providerRef } from "./provider-item.js";
 import { ProviderRow } from "./provider-row.js";
 import { useProviderActions } from "./use-provider-actions.js";
 
-/** Settings → Providers: the global credential store. Sandboxes pick one of
- *  these via {@link ProviderSelect}; this page only manages the keys. */
 export function ProviderSection() {
   const { itemByType, isPending } = useProviderItems();
   const providerActions = useProviderActions();

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useMemo, useState } from "react";
+
+import { RichSelect, type RichSelectOption } from "@/components/ui/rich-select";
+
+import { type ProviderPresetType, PROVIDERS } from "../../../types.js";
+import { useProviderItems } from "../hooks/use-provider-items.js";
+import { PROVIDER_ROWS } from "../lib/provider-rows.js";
+import { CardIcon } from "./card-icon.js";
+import { ConnectedBadge } from "./connected-badge.js";
+import { ProviderConnectDialog } from "./provider-connect-dialog.js";
+import { type ProviderRef, providerRef } from "./provider-item.js";
+
+interface Props {
+  selected: ProviderRef | null;
+  onSelect: (ref: ProviderRef) => void;
+  /** Gate for switching away from an already-selected provider (Configure's
+   *  warning). Resolve false to keep the current one. Not consulted on first
+   *  selection or when the pick goes through the connect dialog. */
+  confirmSwitch?: () => Promise<boolean>;
+  autoSelectFirst?: boolean;
+  disabled?: boolean;
+}
+
+/** Single-select for the sandbox's provider — a sandbox uses exactly one, so
+ *  picking another replaces it. Providers without a key show "Connect" and
+ *  open the key dialog; a saved key selects that provider directly. */
+export function ProviderSelect({
+  selected,
+  onSelect,
+  confirmSwitch,
+  autoSelectFirst = false,
+  disabled = false,
+}: Props) {
+  const { itemByType, isPending } = useProviderItems();
+  const [connecting, setConnecting] = useState<ProviderPresetType | null>(null);
+
+  const selectedType = useMemo(() => {
+    if (!selected) return null;
+    for (const [type, item] of itemByType)
+      if (item.id === selected.id) return type;
+    return null;
+  }, [itemByType, selected]);
+
+  // Only acts while empty so a just-connected provider isn't nulled out during
+  // the list refetch.
+  useEffect(() => {
+    if (!autoSelectFirst || selected) return;
+    const first = PROVIDER_ROWS.map((r) => itemByType.get(r.type)).find(
+      Boolean,
+    );
+    if (first) onSelect(providerRef(first));
+  }, [autoSelectFirst, selected, itemByType, onSelect]);
+
+  const pick = async (type: ProviderPresetType) => {
+    const item = itemByType.get(type);
+    if (!item) {
+      setConnecting(type);
+      return;
+    }
+    if (type === selectedType) return;
+    if (selected && confirmSwitch && !(await confirmSwitch())) return;
+    onSelect(providerRef(item));
+  };
+
+  if (isPending)
+    return (
+      <div className="h-[76px] rounded-lg border border-border bg-card anim-pulse" />
+    );
+
+  const options: RichSelectOption<ProviderPresetType>[] = PROVIDER_ROWS.map(
+    (row) => ({
+      value: row.type,
+      title: PROVIDERS[row.type].displayName,
+      description: row.description,
+      icon: <CardIcon provider={row.type} size="sm" />,
+      triggerIcon: <CardIcon provider={row.type} />,
+      triggerBadge: itemByType.has(row.type) ? <ConnectedBadge /> : undefined,
+      trailing: itemByType.has(row.type) ? undefined : (
+        <span className="shrink-0 text-[13px] text-muted-foreground">
+          Connect
+        </span>
+      ),
+      testId: `provider-option-${row.type}`,
+    }),
+  );
+
+  return (
+    <>
+      <RichSelect
+        options={options}
+        value={selectedType}
+        onSelect={(type) => void pick(type)}
+        placeholder="Select a provider"
+        disabled={disabled}
+        testId="provider-select"
+      />
+      {connecting && (
+        <ProviderConnectDialog
+          provider={connecting}
+          onConnected={(ref) => {
+            onSelect(ref);
+            setConnecting(null);
+          }}
+          onClose={() => setConnecting(null)}
+        />
+      )}
+    </>
+  );
+}

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -14,9 +14,6 @@ import { type ProviderRef, providerRef } from "./provider-item.js";
 interface Props {
   selected: ProviderRef | null;
   onSelect: (ref: ProviderRef) => void;
-  /** Gate for switching away from an already-selected provider (Configure's
-   *  warning). Resolve false to keep the current one. Not consulted on first
-   *  selection or when the pick goes through the connect dialog. */
   confirmSwitch?: () => Promise<boolean>;
   autoSelectFirst?: boolean;
   disabled?: boolean;
@@ -26,9 +23,6 @@ interface Props {
   recommended?: ProviderPresetType;
 }
 
-/** Single-select for the sandbox's provider — a sandbox uses exactly one, so
- *  picking another replaces it. Providers without a key show "Connect" and
- *  open the key dialog; a saved key selects that provider directly. */
 export function ProviderSelect({
   selected,
   onSelect,
@@ -38,19 +32,16 @@ export function ProviderSelect({
   allow,
   recommended,
 }: Props) {
-  const { itemByType, isPending } = useProviderItems();
+  const { itemByType, typeByConnectionId, isPending } = useProviderItems();
   const [connecting, setConnecting] = useState<ProviderPresetType | null>(null);
   const rows = useMemo(
     () => offeredProviderRows(allow, recommended),
     [allow, recommended],
   );
 
-  const selectedType = useMemo(() => {
-    if (!selected) return null;
-    for (const [type, item] of itemByType)
-      if (item.id === selected.id) return type;
-    return null;
-  }, [itemByType, selected]);
+  const selectedType = selected
+    ? (typeByConnectionId.get(selected.id) ?? null)
+    : null;
 
   // Only acts while empty so a just-connected provider isn't nulled out during
   // the list refetch.

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -33,13 +33,20 @@ export function ProviderSelect({
 }: Props) {
   const { itemByType, typeByConnectionId, isPending } = useProviderItems();
   const [connecting, setConnecting] = useState<ProviderPresetType | null>(null);
+  const [connected, setConnected] = useState<{
+    id: string;
+    type: ProviderPresetType;
+  } | null>(null);
   const rows = useMemo(
     () => offeredProviderRows(allow, recommended),
     [allow, recommended],
   );
 
+  // A key saved through the dialog isn't in the connections list until it
+  // refetches; until then resolve the selection from the dialog's own result.
   const selectedType = selected
-    ? (typeByConnectionId.get(selected.id) ?? null)
+    ? (typeByConnectionId.get(selected.id) ??
+      (connected?.id === selected.id ? connected.type : null))
     : null;
 
   // Only acts while empty so a just-connected provider isn't nulled out during
@@ -96,6 +103,7 @@ export function ProviderSelect({
         value={selectedType}
         onSelect={(type) => void pick(type)}
         placeholder="Select a provider"
+        ariaLabel="Provider"
         disabled={disabled}
         testId="provider-select"
       />
@@ -103,6 +111,7 @@ export function ProviderSelect({
         <ProviderConnectDialog
           provider={connecting}
           onConnected={(ref) => {
+            setConnected({ id: ref.id, type: connecting });
             onSelect(ref);
             setConnecting(null);
           }}

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -51,13 +51,15 @@ export function ProviderSelect({
   }, [autoSelectFirst, selected, itemByType, rows, onSelect]);
 
   const pick = async (type: ProviderPresetType) => {
+    if (type === selectedType) return;
+    // Ask before the key dialog, so nobody enters a credential only to be
+    // asked whether they meant to switch.
+    if (selectedType && confirmSwitch && !(await confirmSwitch())) return;
     const item = itemByType.get(type);
     if (!item) {
       setConnecting(type);
       return;
     }
-    if (type === selectedType) return;
-    if (selected && confirmSwitch && !(await confirmSwitch())) return;
     onSelect(providerRef(item));
   };
 

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -7,7 +7,6 @@ import { type ProviderPresetType, PROVIDERS } from "../../../types.js";
 import { useProviderItems } from "../hooks/use-provider-items.js";
 import { offeredProviderRows } from "../lib/provider-rows.js";
 import { CardIcon } from "./card-icon.js";
-import { ConnectedBadge } from "./connected-badge.js";
 import { ProviderConnectDialog } from "./provider-connect-dialog.js";
 import { type ProviderRef, providerRef } from "./provider-item.js";
 
@@ -77,7 +76,9 @@ export function ProviderSelect({
       row.type === recommended ? (
         <Badge variant="muted">Recommended</Badge>
       ) : undefined,
-    triggerBadge: itemByType.has(row.type) ? <ConnectedBadge /> : undefined,
+    triggerBadge: itemByType.has(row.type) ? (
+      <Badge variant="success">Connected</Badge>
+    ) : undefined,
     trailing: itemByType.has(row.type) ? undefined : (
       <span className="shrink-0 text-[13px] text-muted-foreground">
         Connect

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -1,10 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
 
+import { Badge } from "@/components/ui/badge";
 import { RichSelect, type RichSelectOption } from "@/components/ui/rich-select";
 
 import { type ProviderPresetType, PROVIDERS } from "../../../types.js";
 import { useProviderItems } from "../hooks/use-provider-items.js";
-import { PROVIDER_ROWS } from "../lib/provider-rows.js";
+import { offeredProviderRows } from "../lib/provider-rows.js";
 import { CardIcon } from "./card-icon.js";
 import { ConnectedBadge } from "./connected-badge.js";
 import { ProviderConnectDialog } from "./provider-connect-dialog.js";
@@ -19,6 +20,10 @@ interface Props {
   confirmSwitch?: () => Promise<boolean>;
   autoSelectFirst?: boolean;
   disabled?: boolean;
+  /** Restrict the offered providers. Omit to offer all of them. */
+  allow?: readonly ProviderPresetType[];
+  /** Offered first and badged; `autoSelectFirst` therefore prefers it. */
+  recommended?: ProviderPresetType;
 }
 
 /** Single-select for the sandbox's provider — a sandbox uses exactly one, so
@@ -30,9 +35,15 @@ export function ProviderSelect({
   confirmSwitch,
   autoSelectFirst = false,
   disabled = false,
+  allow,
+  recommended,
 }: Props) {
   const { itemByType, isPending } = useProviderItems();
   const [connecting, setConnecting] = useState<ProviderPresetType | null>(null);
+  const rows = useMemo(
+    () => offeredProviderRows(allow, recommended),
+    [allow, recommended],
+  );
 
   const selectedType = useMemo(() => {
     if (!selected) return null;
@@ -45,11 +56,9 @@ export function ProviderSelect({
   // the list refetch.
   useEffect(() => {
     if (!autoSelectFirst || selected) return;
-    const first = PROVIDER_ROWS.map((r) => itemByType.get(r.type)).find(
-      Boolean,
-    );
+    const first = rows.map((r) => itemByType.get(r.type)).find(Boolean);
     if (first) onSelect(providerRef(first));
-  }, [autoSelectFirst, selected, itemByType, onSelect]);
+  }, [autoSelectFirst, selected, itemByType, rows, onSelect]);
 
   const pick = async (type: ProviderPresetType) => {
     const item = itemByType.get(type);
@@ -67,22 +76,24 @@ export function ProviderSelect({
       <div className="h-[76px] rounded-lg border border-border bg-card anim-pulse" />
     );
 
-  const options: RichSelectOption<ProviderPresetType>[] = PROVIDER_ROWS.map(
-    (row) => ({
-      value: row.type,
-      title: PROVIDERS[row.type].displayName,
-      description: row.description,
-      icon: <CardIcon provider={row.type} size="sm" />,
-      triggerIcon: <CardIcon provider={row.type} />,
-      triggerBadge: itemByType.has(row.type) ? <ConnectedBadge /> : undefined,
-      trailing: itemByType.has(row.type) ? undefined : (
-        <span className="shrink-0 text-[13px] text-muted-foreground">
-          Connect
-        </span>
-      ),
-      testId: `provider-option-${row.type}`,
-    }),
-  );
+  const options: RichSelectOption<ProviderPresetType>[] = rows.map((row) => ({
+    value: row.type,
+    title: PROVIDERS[row.type].displayName,
+    description: row.description,
+    icon: <CardIcon provider={row.type} size="sm" />,
+    triggerIcon: <CardIcon provider={row.type} />,
+    badge:
+      row.type === recommended ? (
+        <Badge variant="muted">Recommended</Badge>
+      ) : undefined,
+    triggerBadge: itemByType.has(row.type) ? <ConnectedBadge /> : undefined,
+    trailing: itemByType.has(row.type) ? undefined : (
+      <span className="shrink-0 text-[13px] text-muted-foreground">
+        Connect
+      </span>
+    ),
+    testId: `provider-option-${row.type}`,
+  }));
 
   return (
     <>

--- a/packages/ui/src/modules/providers/components/use-provider-actions.ts
+++ b/packages/ui/src/modules/providers/components/use-provider-actions.ts
@@ -9,15 +9,14 @@ export function useProviderActions() {
   return {
     /** Confirm with the user, then delete the provider connection.
      *  Destructive variant: removing a provider breaks any agent using it. */
-    async remove(ref: ProviderRef, onRemoved?: () => void) {
+    async remove(ref: ProviderRef) {
       const ok = await showConfirm(
         "Are you sure you want to remove this provider? Any agent currently using this provider will no longer work as expected.",
         "Remove Provider?",
         { kind: "destructive", confirmLabel: "Remove provider" },
       );
       if (!ok) return;
-      const opts = onRemoved ? { onSuccess: () => onRemoved() } : undefined;
-      deleteConnection.mutate({ id: ref.id }, opts);
+      deleteConnection.mutate({ id: ref.id });
     },
   };
 }

--- a/packages/ui/src/modules/providers/hooks/use-provider-items.ts
+++ b/packages/ui/src/modules/providers/hooks/use-provider-items.ts
@@ -6,8 +6,6 @@ import { useAppConnections } from "../../connections/api/queries.js";
 import type { ProviderItem } from "../components/provider-item.js";
 import { PROVIDER_ROWS } from "../lib/provider-rows.js";
 
-/** The user's provider credentials, keyed by preset type — one connection per
- *  provider (the first one wins if several exist). */
 export function useProviderItems() {
   const { data: connections = [], isPending } = useAppConnections();
 
@@ -25,5 +23,16 @@ export function useProviderItems() {
     return m;
   }, [connections]);
 
-  return { itemByType, isPending };
+  // itemByType keeps one connection per preset, but a sandbox may hold a
+  // different connection of the same preset — resolve those by id.
+  const typeByConnectionId = useMemo(() => {
+    const m = new Map<string, ProviderPresetType>();
+    for (const c of connections) {
+      const preset = providerTypeForTemplateId(c.templateId);
+      if (preset) m.set(c.id, preset);
+    }
+    return m;
+  }, [connections]);
+
+  return { itemByType, typeByConnectionId, isPending };
 }

--- a/packages/ui/src/modules/providers/hooks/use-provider-items.ts
+++ b/packages/ui/src/modules/providers/hooks/use-provider-items.ts
@@ -1,0 +1,29 @@
+import { type ConnectionView, providerTypeForTemplateId } from "api-server-api";
+import { useMemo } from "react";
+
+import type { ProviderPresetType } from "../../../types.js";
+import { useAppConnections } from "../../connections/api/queries.js";
+import type { ProviderItem } from "../components/provider-item.js";
+import { PROVIDER_ROWS } from "../lib/provider-rows.js";
+
+/** The user's provider credentials, keyed by preset type — one connection per
+ *  provider (the first one wins if several exist). */
+export function useProviderItems() {
+  const { data: connections = [], isPending } = useAppConnections();
+
+  const itemByType = useMemo(() => {
+    const connByType = new Map<ProviderPresetType, ConnectionView>();
+    for (const c of connections) {
+      const preset = providerTypeForTemplateId(c.templateId);
+      if (preset && !connByType.has(preset)) connByType.set(preset, c);
+    }
+    const m = new Map<ProviderPresetType, ProviderItem>();
+    for (const row of PROVIDER_ROWS) {
+      const conn = connByType.get(row.type);
+      if (conn) m.set(row.type, { id: conn.id, conn });
+    }
+    return m;
+  }, [connections]);
+
+  return { itemByType, isPending };
+}

--- a/packages/ui/src/modules/providers/hooks/use-provider-items.ts
+++ b/packages/ui/src/modules/providers/hooks/use-provider-items.ts
@@ -1,37 +1,26 @@
-import { type ConnectionView, providerTypeForTemplateId } from "api-server-api";
+import { providerTypeForTemplateId } from "api-server-api";
 import { useMemo } from "react";
 
 import type { ProviderPresetType } from "../../../types.js";
 import { useAppConnections } from "../../connections/api/queries.js";
 import type { ProviderItem } from "../components/provider-item.js";
-import { PROVIDER_ROWS } from "../lib/provider-rows.js";
 
 export function useProviderItems() {
   const { data: connections = [], isPending } = useAppConnections();
 
-  const itemByType = useMemo(() => {
-    const connByType = new Map<ProviderPresetType, ConnectionView>();
-    for (const c of connections) {
-      const preset = providerTypeForTemplateId(c.templateId);
-      if (preset && !connByType.has(preset)) connByType.set(preset, c);
-    }
-    const m = new Map<ProviderPresetType, ProviderItem>();
-    for (const row of PROVIDER_ROWS) {
-      const conn = connByType.get(row.type);
-      if (conn) m.set(row.type, { id: conn.id, conn });
-    }
-    return m;
-  }, [connections]);
-
   // itemByType keeps one connection per preset, but a sandbox may hold a
-  // different connection of the same preset — resolve those by id.
-  const typeByConnectionId = useMemo(() => {
-    const m = new Map<string, ProviderPresetType>();
-    for (const c of connections) {
-      const preset = providerTypeForTemplateId(c.templateId);
-      if (preset) m.set(c.id, preset);
+  // different connection of the same preset — hence the lookup by id too.
+  const { itemByType, typeByConnectionId } = useMemo(() => {
+    const itemByType = new Map<ProviderPresetType, ProviderItem>();
+    const typeByConnectionId = new Map<string, ProviderPresetType>();
+    for (const conn of connections) {
+      const preset = providerTypeForTemplateId(conn.templateId);
+      if (!preset) continue;
+      typeByConnectionId.set(conn.id, preset);
+      if (!itemByType.has(preset))
+        itemByType.set(preset, { id: conn.id, conn });
     }
-    return m;
+    return { itemByType, typeByConnectionId };
   }, [connections]);
 
   return { itemByType, typeByConnectionId, isPending };

--- a/packages/ui/src/modules/providers/lib/provider-rows.ts
+++ b/packages/ui/src/modules/providers/lib/provider-rows.ts
@@ -1,10 +1,12 @@
 import type { ProviderPresetType } from "../../../types.js";
 
 /** The offered providers, in display order, with their static descriptions. */
-export const PROVIDER_ROWS: {
+export interface ProviderRowDef {
   type: ProviderPresetType;
   description: string;
-}[] = [
+}
+
+export const PROVIDER_ROWS: ProviderRowDef[] = [
   {
     type: "ibm-litellm",
     description: "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS.",
@@ -24,3 +26,17 @@ export const PROVIDER_ROWS: {
     description: "GPT-family models for Codex and OpenAI-compatible agents.",
   },
 ];
+
+/** The rows a surface offers: `allow` restricts them, `recommended` goes first. */
+export function offeredProviderRows(
+  allow?: readonly ProviderPresetType[],
+  recommended?: ProviderPresetType,
+): ProviderRowDef[] {
+  const offered = allow
+    ? PROVIDER_ROWS.filter((row) => allow.includes(row.type))
+    : PROVIDER_ROWS;
+  if (!recommended) return offered;
+  return [...offered].sort(
+    (a, b) => Number(b.type === recommended) - Number(a.type === recommended),
+  );
+}

--- a/packages/ui/src/modules/providers/lib/provider-rows.ts
+++ b/packages/ui/src/modules/providers/lib/provider-rows.ts
@@ -1,0 +1,26 @@
+import type { ProviderPresetType } from "../../../types.js";
+
+/** The offered providers, in display order, with their static descriptions. */
+export const PROVIDER_ROWS: {
+  type: ProviderPresetType;
+  description: string;
+}[] = [
+  {
+    type: "ibm-litellm",
+    description: "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS.",
+  },
+  {
+    type: "bob",
+    description:
+      "IBM Bob Shell endpoint with twin-secret credential injection.",
+  },
+  {
+    type: "anthropic",
+    description:
+      "Claude Code, Claude SDK, and any Anthropic-compatible client.",
+  },
+  {
+    type: "openai",
+    description: "GPT-family models for Codex and OpenAI-compatible agents.",
+  },
+];

--- a/packages/ui/src/modules/providers/lib/provider-rows.ts
+++ b/packages/ui/src/modules/providers/lib/provider-rows.ts
@@ -5,7 +5,7 @@ export interface ProviderRowDef {
   description: string;
 }
 
-export const PROVIDER_ROWS: ProviderRowDef[] = [
+export const PROVIDER_ROWS: readonly ProviderRowDef[] = [
   {
     type: "ibm-litellm",
     description: "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS.",
@@ -30,7 +30,7 @@ export const PROVIDER_ROWS: ProviderRowDef[] = [
 export function offeredProviderRows(
   allow?: readonly ProviderPresetType[],
   recommended?: ProviderPresetType,
-): ProviderRowDef[] {
+): readonly ProviderRowDef[] {
   const offered = allow
     ? PROVIDER_ROWS.filter((row) => allow.includes(row.type))
     : PROVIDER_ROWS;

--- a/packages/ui/src/modules/providers/lib/provider-rows.ts
+++ b/packages/ui/src/modules/providers/lib/provider-rows.ts
@@ -1,6 +1,5 @@
 import type { ProviderPresetType } from "../../../types.js";
 
-/** The offered providers, in display order, with their static descriptions. */
 export interface ProviderRowDef {
   type: ProviderPresetType;
   description: string;

--- a/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
@@ -3,12 +3,13 @@ import { Controller } from "react-hook-form";
 import { FormField } from "@/components/form-field";
 import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
-import { FIELD_INSET } from "@/components/ui/inset";
+import { Inset } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
 
+import { useStore } from "../../../store.js";
 import { EnvTab } from "../../agents/components/configure-agent/env-tab.js";
 import { AgentEgressEditor } from "../../egress-rules/components/agent-egress-editor.js";
-import { ProviderSection } from "../../providers/components/provider-section.js";
+import { ProviderSelect } from "../../providers/components/provider-select.js";
 import type { useSandboxSettingsForm } from "../hooks/use-sandbox-settings-form.js";
 import { HibernationTimeoutField } from "./hibernation-timeout-field.js";
 import { SandboxModelSettings } from "./sandbox-model-settings.js";
@@ -27,8 +28,22 @@ interface Props {
 }
 
 export function SandboxSetupSection({ f }: Props) {
+  const showConfirm = useStore((s) => s.showConfirm);
   const { agent } = f;
   if (!agent) return null;
+
+  const confirmSwitch = () =>
+    showConfirm(
+      <p>
+        This will change the model provider used by{" "}
+        <strong>{agent.name}</strong>. Switching between different model
+        families (for example, Claude → OpenAI) may cause the agent to stop
+        working and can interrupt tasks in progress. The switch applies when you
+        save.
+      </p>,
+      "Switch this sandbox's provider?",
+      { confirmLabel: "Switch provider" },
+    );
 
   return (
     <>
@@ -74,13 +89,14 @@ export function SandboxSetupSection({ f }: Props) {
 
       <section className="mb-8">
         <SectionLabel spaced>Provider</SectionLabel>
-        <ProviderSection
-          variant="collapsible"
-          listClassName={FIELD_INSET}
-          selected={f.selectedProvider}
-          onSelect={f.selectProvider}
-          onProviderRemoved={f.dropProviderGrant}
-        />
+        <Inset>
+          <ProviderSelect
+            selected={f.selectedProvider}
+            onSelect={f.selectProvider}
+            confirmSwitch={confirmSwitch}
+            disabled={f.saving}
+          />
+        </Inset>
         <p className="mt-3 text-[12px] text-muted-foreground">
           Changing the provider swaps this sandbox's model credential. A
           cross-family switch (e.g. Anthropic → OpenAI on a Claude image) can

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -1,15 +1,12 @@
 import { FormField } from "@/components/form-field";
 import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
-import { FIELD_INSET } from "@/components/ui/inset";
+import { Inset } from "@/components/ui/inset";
 import { SectionLabel } from "@/components/ui/section-label";
 import { cn } from "@/lib/utils";
 
-import {
-  type ProviderRef,
-  sameProviderRef,
-} from "../../../providers/components/provider-item.js";
-import { ProviderSection } from "../../../providers/components/provider-section.js";
+import type { ProviderRef } from "../../../providers/components/provider-item.js";
+import { ProviderSelect } from "../../../providers/components/provider-select.js";
 import type {
   EgressPreset,
   providerPolicy,
@@ -122,18 +119,15 @@ export function SetupStep({
 
       <section className="mb-8">
         <SectionLabel spaced>Provider</SectionLabel>
-        <ProviderSection
-          selected={providerRef}
-          onSelect={(ref) => update({ providerRef: ref })}
-          onProviderRemoved={(ref) => {
-            if (providerRef && sameProviderRef(providerRef, ref))
-              update({ providerRef: null });
-          }}
-          autoSelectFirst
-          allow={providers.allow}
-          recommended={providers.recommended}
-          listClassName={FIELD_INSET}
-        />
+        <Inset>
+          <ProviderSelect
+            selected={providerRef}
+            onSelect={(ref) => update({ providerRef: ref })}
+            autoSelectFirst
+            allow={providers.allow}
+            recommended={providers.recommended}
+          />
+        </Inset>
       </section>
 
       <section className="mb-8">

--- a/packages/ui/src/modules/sandboxes/hooks/use-provider-staging.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-provider-staging.ts
@@ -6,8 +6,8 @@ import type { ProviderRef } from "../../providers/components/provider-item.js";
 interface Args {
   apps: readonly ConnectionView[];
   assignedAppIds: string[];
-  /** Read at call time, not render time — a confirm dialog can hold
-   *  `selectProvider` open across background grant refetches. */
+  /** Read at call time — a confirm dialog can hold `selectProvider` open
+   *  across background grant refetches. */
   getAssignedAppIds: () => string[];
   setAssignedAppIds: (ids: string[]) => void;
 }

--- a/packages/ui/src/modules/sandboxes/hooks/use-provider-staging.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-provider-staging.ts
@@ -6,6 +6,9 @@ import type { ProviderRef } from "../../providers/components/provider-item.js";
 interface Args {
   apps: readonly ConnectionView[];
   assignedAppIds: string[];
+  /** Read at call time, not render time — a confirm dialog can hold
+   *  `selectProvider` open across background grant refetches. */
+  getAssignedAppIds: () => string[];
   setAssignedAppIds: (ids: string[]) => void;
 }
 
@@ -13,6 +16,7 @@ interface Args {
 export function useProviderStaging({
   apps,
   assignedAppIds,
+  getAssignedAppIds,
   setAssignedAppIds,
 }: Args) {
   const providerAppIds = useMemo(
@@ -36,18 +40,15 @@ export function useProviderStaging({
     setAssignedAppIds(
       [
         ...new Set([
-          ...assignedAppIds.filter((id) => !providerAppIds.has(id)),
+          ...getAssignedAppIds().filter((id) => !providerAppIds.has(id)),
           ref.id,
         ]),
       ].sort(),
     );
-  const dropProviderGrant = (ref: ProviderRef) =>
-    setAssignedAppIds(assignedAppIds.filter((id) => id !== ref.id).sort());
 
   return {
     providerAppIds,
     selectedProvider,
     selectProvider,
-    dropProviderGrant,
   };
 }

--- a/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
@@ -55,6 +55,7 @@ export function useSandboxSettingsForm() {
     handleSubmit,
     watch,
     setValue,
+    getValues,
     reset,
     resetField,
     formState,
@@ -135,17 +136,14 @@ export function useSandboxSettingsForm() {
     resetField,
   ]);
 
-  const {
-    providerAppIds,
-    selectedProvider,
-    selectProvider,
-    dropProviderGrant,
-  } = useProviderStaging({
-    apps,
-    assignedAppIds,
-    setAssignedAppIds: (ids) =>
-      setValue("assignedAppIds", ids, { shouldDirty: true }),
-  });
+  const { providerAppIds, selectedProvider, selectProvider } =
+    useProviderStaging({
+      apps,
+      assignedAppIds,
+      getAssignedAppIds: () => getValues("assignedAppIds"),
+      setAssignedAppIds: (ids) =>
+        setValue("assignedAppIds", ids, { shouldDirty: true }),
+    });
 
   const inheritedEnvs = useInheritedEnvs({
     agentEnv: agent?.env ?? [],
@@ -204,7 +202,6 @@ export function useSandboxSettingsForm() {
     saving,
     selectedProvider,
     selectProvider,
-    dropProviderGrant,
     currentPreset,
     egressStaged,
     inheritedEnvs,

--- a/packages/ui/src/modules/settings/views/providers-view.tsx
+++ b/packages/ui/src/modules/settings/views/providers-view.tsx
@@ -11,7 +11,7 @@ export function ProvidersView() {
       />
 
       <section className="mb-8">
-        <ProviderSection manage />
+        <ProviderSection />
       </section>
     </div>
   );


### PR DESCRIPTION
Refs #2854

## What

A sandbox uses exactly one model provider, but the provider picker rendered a card list that read as multi-select — every keyed provider showed a "Connected" pill, selection was a subtle border, and picking another silently replaced the current one. This PR makes the single-select nature explicit, per the prototype agreed in the issue.

- **New `RichSelect` primitive** (`components/ui/rich-select.tsx`): single-select over options too rich for a native `<select>` — icon, title, description, trailing affordance per option. Built on the existing Radix dropdown-menu wrapper; menu width pinned to the trigger; `menuitemradio` + `aria-checked` semantics.
- **New `ProviderSelect`** composing it: keyed providers select directly; unkeyed ones show "Connect" and open the existing key dialog, auto-selecting once the key saves. The connection→preset mapping moved to a shared `useProviderItems` hook.
- **Wired on all three selection surfaces**: sandbox Configure (switching gates behind a "Switch this sandbox's provider?" confirmation; change still applies on Save), wizard Setup step, and the inline create form on the Slack/Telegram bind pages (no confirmation — the agent doesn't exist yet).
- **`ProviderSection`/`ProviderRow` slimmed to Settings → Providers only**: selection + collapsible machinery removed; connected rows keep the static provider description instead of swapping it for credential details (requested by Jenna in the issue); Carbon overflow icon; per-row aria labels.
- **Focus fix in `Modal`'s `useFocusTrap`**: dialogs spawned from menus re-assert focus for a few frames (a closing menu's focus scope outlives its exit animation and refocuses its trigger). Same workaround as `inline-name-row.tsx`; the underlying problem is tracked in #3013.
- **Ride-along fix**: "Create sandbox" now clears the persisted wizard draft so the wizard always starts fresh; URL re-entry (refresh, OAuth return) still resumes.

## Notes

- Per-sandbox single-provider was already enforced by the staging logic; this is a UI-truthfulness change, no backend changes.
- `selectProvider` now reads the grant list at call time so a confirm dialog held open across a background refetch can't write back a stale list.
- Reviewed by code-reviewer agent; all findings addressed except the durable focus-trap redesign (#3013).
- e2e smoke `03-agent.spec.ts` updated to drive the select via testids.

## Testing

- `mise run ui:check`, `mise run ui:test` (108 passing)
- Manually verified on the dev cluster: Configure shows the granted provider, switch confirmation, connect-from-select flow with focus landing in the dialog, wizard + inline form selection, Settings page unchanged behavior.