### PR TITLE
refactor(ui): standardize the remaining page headers

### DIFF
--- a/packages/ui/src/components/ui/page-header.tsx
+++ b/packages/ui/src/components/ui/page-header.tsx
@@ -5,7 +5,10 @@ import { cn } from "@/lib/utils";
 interface PageHeaderProps {
   title: ReactNode;
   description?: ReactNode;
+  /** Text CTAs are default-size Buttons without leading icons;
+   *  icon-only utility buttons (nav, overflow menus) are fine. */
   actions?: ReactNode;
+  /** Status chip/badge rendered inline after the title. */
   adornment?: ReactNode;
   className?: string;
 }

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -59,7 +59,7 @@ export function ListView() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-[666px]">
+    <div>
       <PageHeader
         title="Sandboxes"
         actions={

--- a/packages/ui/src/modules/approvals/views/inbox-view.tsx
+++ b/packages/ui/src/modules/approvals/views/inbox-view.tsx
@@ -1,4 +1,6 @@
+import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
+import { PageHeader } from "@/components/ui/page-header";
 
 import { useApprovalsForOwner } from "../api/queries.js";
 import { ApprovalsList } from "../components/approvals-list.js";
@@ -9,20 +11,16 @@ export function InboxView() {
   const { data: rows = EMPTY, isLoading } = useApprovalsForOwner();
   const pendingCount = rows.filter((r) => r.status === "pending").length;
   return (
-    <div className="flex flex-col gap-4">
-      <div className="flex items-baseline justify-between">
-        <h1 className="text-[20px] font-extrabold tracking-[-0.02em] text-foreground">
-          Inbox
-        </h1>
-        <span className="text-[11px] text-muted-foreground">
-          {isLoading ? "loading…" : `${pendingCount} pending`}
-        </span>
-      </div>
-      <p className="text-[12px] text-muted-foreground leading-relaxed max-w-prose">
-        Decisions your agents are waiting on. Allowing permanently writes a
-        network access rule for the agent so future requests of the same shape
-        don't prompt again.
-      </p>
+    <div>
+      <PageHeader
+        title="Inbox"
+        adornment={
+          <Badge variant="muted">
+            {isLoading ? "loading…" : `${pendingCount} pending`}
+          </Badge>
+        }
+        description="Decisions your agents are waiting on. Allowing permanently writes a network access rule for the agent so future requests of the same shape don't prompt again."
+      />
       <Card className="overflow-hidden p-0">
         <ApprovalsList
           rows={rows}

--- a/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
+++ b/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
@@ -1,6 +1,6 @@
 import type { ArtifactFolder, LibraryArtifact } from "api-server-api";
 import { EXPERIMENT_FOLDER_PREFIX } from "api-server-api";
-import { Box, FolderPlus, Search, Upload } from "lucide-react";
+import { Box, Search } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -114,14 +114,11 @@ export function ArtifactsView() {
             <>
               <Button
                 variant="outline"
-                size="sm"
                 onClick={() => setFolderDialog({ folder: null })}
               >
-                <FolderPlus size={16} />
                 New folder
               </Button>
-              <Button size="sm" onClick={() => setUploadOpen(true)}>
-                <Upload size={16} />
+              <Button onClick={() => setUploadOpen(true)}>
                 Upload artifact
               </Button>
             </>


### PR DESCRIPTION
Closes #2917

## Summary

Most of #2917 already landed with the shared `PageHeader` (#2904) — Home, Sandboxes, Experiments, Knowledge Bases, Artifacts, and all Settings tabs already use it. This PR fixes what remained:

- **Inbox migrates to `PageHeader`** — it was the last bespoke header among the pages listed in the issue (20px extrabold title, 12px description). The pending count moves into a muted `Badge` adornment next to the title, same slot Sandbox Home uses for its status badge; copy is unchanged.
- **Artifacts header CTAs match the rest of the app** — it was the only page with `size="sm"` icon'd header buttons; they're now default-size and text-only like every other page's header CTA. The empty-state upload button keeps its icon (different surface).
- **The CTA convention is documented on `PageHeader.actions`** so it doesn't drift again: text CTAs are default-size without leading icons; icon-only utility buttons (nav, overflow menus) are fine.
- **Sandboxes list fills the page shell width** — it capped itself at 666px inside the shared 960px wrapper; it now matches Artifacts and the other full-width pages.

Deliberately left alone: the sandbox wizard's `StepHeader` (intentional step-eyebrow treatment), the pre-login standalone pages (Terms, Slack/Telegram bind — outside the app shell), and the chat top bar (not a page header). The Knowledge Bases list still has the 666px cap; widening it can follow if desired.

## Test plan

- `mise run ui:check` and `mise run ui:test` pass
- Visual pass over Inbox, Artifacts, and the Sandboxes list

https://claude.ai/code/session_01NeZeHv1xtCW4GXVsWbA9tC