### PR TITLE
feat(ui): experiments page matches the design faithfully

### DIFF
--- a/packages/cli/src/__tests__/agent-get.integration.test.ts
+++ b/packages/cli/src/__tests__/agent-get.integration.test.ts
@@ -40,7 +40,16 @@ async function runDam(
   env: Record<string, string>,
 ): Promise<RunResult> {
   try {
-    const { stdout, stderr } = await exec("node", [BIN_PATH, ...args], { env });
+    // process.execPath, not "node" from PATH: under mise, PATH's node is a
+    // shim that needs mise's own env, which this deliberately stripped env
+    // doesn't carry — the shim then dies silently with exit 1.
+    const { stdout, stderr } = await exec(
+      process.execPath,
+      [BIN_PATH, ...args],
+      {
+        env,
+      },
+    );
     return { exitCode: 0, stdout, stderr };
   } catch (e) {
     const err = e as { code?: number; stdout?: string; stderr?: string };

--- a/packages/cli/src/__tests__/agent-list.integration.test.ts
+++ b/packages/cli/src/__tests__/agent-list.integration.test.ts
@@ -40,7 +40,16 @@ async function runDam(
   env: Record<string, string>,
 ): Promise<RunResult> {
   try {
-    const { stdout, stderr } = await exec("node", [BIN_PATH, ...args], { env });
+    // process.execPath, not "node" from PATH: under mise, PATH's node is a
+    // shim that needs mise's own env, which this deliberately stripped env
+    // doesn't carry — the shim then dies silently with exit 1.
+    const { stdout, stderr } = await exec(
+      process.execPath,
+      [BIN_PATH, ...args],
+      {
+        env,
+      },
+    );
     return { exitCode: 0, stdout, stderr };
   } catch (e) {
     const err = e as { code?: number; stdout?: string; stderr?: string };

--- a/packages/ui/src/__tests__/unit/experiment-sandbox-groups.test.ts
+++ b/packages/ui/src/__tests__/unit/experiment-sandbox-groups.test.ts
@@ -81,14 +81,22 @@ describe("toSandboxGroups", () => {
     expect(groups[0]?.lineages).toHaveLength(1);
   });
 
-  test("keeps a deleted sandbox's experiments reachable, marked as deleted", () => {
+  test("collects every deleted sandbox's experiments into one trailing group", () => {
     const groups = toSandboxGroups(
-      [summary("gone", [experiment("e1", "evolver", "completed")])],
+      [
+        summary("gone-1", [experiment("e1", "evolver", "completed")]),
+        summary("gone-2", [experiment("e2", "tuner", "completed")]),
+      ],
       [],
       isExperimentSandbox,
     );
-    expect(groups[0]?.agent).toBeNull();
-    expect(groups[0]?.lineages).toHaveLength(1);
+    expect(groups).toHaveLength(1);
+    expect(groups[0]).toMatchObject({
+      agentId: "__deleted__",
+      agent: null,
+      name: "Deleted sandboxes",
+    });
+    expect(groups[0]?.lineages).toHaveLength(2);
   });
 
   test("excludes plain sandboxes that never registered a plan", () => {
@@ -177,7 +185,7 @@ describe("toSandboxGroups", () => {
       "live",
       "busy",
       "empty",
-      "gone",
+      "__deleted__",
     ]);
   });
 });

--- a/packages/ui/src/modules/experiments/components/sandbox-group-card.tsx
+++ b/packages/ui/src/modules/experiments/components/sandbox-group-card.tsx
@@ -10,8 +10,9 @@ interface Props {
   onDeleteLineage: (lineage: LineageRow) => void;
 }
 
-/** A sandbox and the experiments it holds, including none yet. The sandbox is a
- *  visible container that bundles them, so ownership reads off the page. */
+/** A sandbox and the experiments it holds, including none yet. No container
+ *  box, per the design: the header sits bare on the page and only the
+ *  experiment cards are bordered — the grouping reads from proximity. */
 export function SandboxGroupCard({
   group,
   onOpenSandbox,
@@ -19,33 +20,19 @@ export function SandboxGroupCard({
 }: Props) {
   const deleted = group.agent === null;
   const count = group.lineages.length;
-  const live = group.lineages.some((lineage) => lineage.liveCount > 0);
   const open = () => onOpenSandbox(group.agentId);
 
   return (
-    <div
-      className={cn(
-        "overflow-hidden rounded-xl border bg-surface",
-        // A live run tints the whole container, so a busy sandbox is findable
-        // without reading any row.
-        live ? "border-success" : "border-border",
-        deleted && "border-dashed",
-      )}
-    >
-      {deleted && (
-        <p className="px-4 pt-2.5 text-[12px] text-text-muted">
-          This sandbox was deleted; its runs and results still live in the
-          artifact library.
-        </p>
-      )}
-
+    <section>
       <div
         role={deleted ? undefined : "button"}
         tabIndex={deleted ? undefined : 0}
         onClick={deleted ? undefined : open}
         onKeyDown={(e) => !deleted && e.key === "Enter" && open()}
+        // The hairline under the header is what scopes the group now that the
+        // container box is gone.
         className={cn(
-          "group/head flex w-full items-center gap-2.5 border-b border-border-light px-4 py-3.5 text-left",
+          "group/head mb-3 flex w-full items-center gap-2.5 border-b border-border-light px-1.5 pb-3 pt-1.5 text-left",
           !deleted && "cursor-pointer transition-colors hover:bg-info-light",
         )}
       >
@@ -82,13 +69,20 @@ export function SandboxGroupCard({
         )}
       </div>
 
+      {deleted && (
+        <p className="mb-3 px-1.5 text-[12px] text-text-muted">
+          These sandboxes were deleted; their runs and results still live in the
+          artifact library.
+        </p>
+      )}
+
       {count === 0 ? (
-        <p className="px-4 py-[18px] text-[13px] text-muted-foreground">
+        <p className="px-1.5 text-[13px] text-muted-foreground">
           No experiments yet — open the sandbox chat and ask the agent to set
           one up.
         </p>
       ) : (
-        <div className="flex flex-col gap-2.5 p-3">
+        <div className="flex flex-col gap-3">
           {group.lineages.map((lineage) => (
             <LineageCard
               key={lineage.key}
@@ -100,6 +94,6 @@ export function SandboxGroupCard({
           ))}
         </div>
       )}
-    </div>
+    </section>
   );
 }

--- a/packages/ui/src/modules/experiments/lib/sandbox-groups.ts
+++ b/packages/ui/src/modules/experiments/lib/sandbox-groups.ts
@@ -85,15 +85,33 @@ export function toSandboxGroups(
   const agentById = new Map(agents.map((agent) => [agent.id, agent]));
   const groups = new Map<string, SandboxGroup>();
 
+  // Every deleted sandbox's lineages collect into ONE trailing group, as the
+  // vision draws it — the sandboxes are gone, so per-sandbox containers would
+  // just multiply tombstones.
+  const deletedLineages: LineageRow[] = [];
   for (const summary of summaries) {
     const agent = agentById.get(summary.driverAgentId) ?? null;
     const lineages = toLineages(summary);
+    if (agent === null) {
+      deletedLineages.push(...lineages);
+      continue;
+    }
     groups.set(summary.driverAgentId, {
       agentId: summary.driverAgentId,
       agent,
-      name: agent?.name ?? "Deleted sandbox",
+      name: agent.name,
       lineages,
       rollup: rollupStatus(lineages),
+    });
+  }
+  if (deletedLineages.length > 0) {
+    deletedLineages.sort((a, b) => b.newestAt.localeCompare(a.newestAt));
+    groups.set("__deleted__", {
+      agentId: "__deleted__",
+      agent: null,
+      name: "Deleted sandboxes",
+      lineages: deletedLineages,
+      rollup: null,
     });
   }
 

--- a/packages/ui/src/modules/experiments/views/experiments-list-view.tsx
+++ b/packages/ui/src/modules/experiments/views/experiments-list-view.tsx
@@ -21,6 +21,7 @@ export function ExperimentsListView() {
   const { data: agentsData } = useAgents();
   const selectAgent = useStore((s) => s.selectAgent);
   const navigateToCreateSandbox = useStore((s) => s.navigateToCreateSandbox);
+  const setView = useStore((s) => s.setView);
   const deleteExperiment = useDeleteExperiment();
   const [deleteTarget, setDeleteTarget] = useState<LineageRow | null>(null);
 
@@ -38,7 +39,7 @@ export function ExperimentsListView() {
     <div>
       <PageHeader
         title="Experiments"
-        description="Loop scripts the platform observes live, grouped by the sandbox running them. Open one to land in its chat — the experiment graph docks beside the conversation."
+        description="Experiments are grouped by the sandbox running them. Open a sandbox to work with it in chat, where the experiment graph docks beside the conversation."
         actions={
           groups.length > 0 ? (
             <Button onClick={createExperimentSandbox}>Create experiment</Button>
@@ -64,7 +65,7 @@ export function ExperimentsListView() {
         </Card>
       )}
 
-      <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-9">
         {initialLoaded &&
           groups.map((group) => (
             <SandboxGroupCard
@@ -75,6 +76,21 @@ export function ExperimentsListView() {
             />
           ))}
       </div>
+
+      {initialLoaded && groups.length > 0 && (
+        <p className="mt-6 text-[13px] text-muted-foreground">
+          Deleting a sandbox doesn&apos;t delete its experiments — the runs and
+          their published results stay in the{" "}
+          <button
+            type="button"
+            onClick={() => setView("artifacts")}
+            className="text-accent hover:underline"
+          >
+            artifact library
+          </button>
+          .
+        </p>
+      )}
 
       <ConfirmDialog
         open={deleteTarget !== null}


### PR DESCRIPTION
Follow-up to #3014, which merged mid-polish. Fidelity fixes against the endorsed design screenshot for the Experiments destination:

- **No container box around a sandbox group** — the header sits bare on the page and only the experiment cards are bordered; grouping reads from proximity, with wider spacing between groups. The live green container border goes with it (the rolled-up Running badge carries the signal).
- **One "Deleted sandboxes" group** — every deleted sandbox's experiments collect into a single trailing group instead of a tombstone container per sandbox.
- **Footer note restored** — deleting a sandbox doesn't delete its experiments; results stay in the artifact library (linked). Subtitle copy matches the design verbatim.

Also carries a `fix(cli)`: the agent-get/agent-list integration tests exec `process.execPath` instead of `"node"` from PATH. Under mise, PATH's node is a shim that needs mise's own environment — which the tests' deliberately stripped env doesn't carry — so the shim dies silently with exit 1 whenever shim state drifts. This is what made the agent-get suite start failing with no repo change.

`mise run check` clean; all suites green (15 UI / 90 api-server / 26 CLI / 23 agent-runtime).