### PR TITLE
fix(ui): collect private-registry credentials on the Image step

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/registry-credential-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/registry-credential-section.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight } from "@carbon/icons-react";
 import { useState } from "react";
 
 import { Input } from "@/components/ui/input";
@@ -38,10 +38,11 @@ export function RegistryCredentialSection({ value, onChange, partial }: Props) {
     onChange({ ...value, [key]: next });
 
   return (
-    <section className="mb-8">
+    <div>
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
+        aria-expanded={expanded}
         className="flex items-center gap-1.5 text-[11px] font-bold uppercase tracking-[0.05em] text-muted-foreground hover:text-foreground"
       >
         <Icon size={12} />
@@ -54,20 +55,21 @@ export function RegistryCredentialSection({ value, onChange, partial }: Props) {
             the sandbox and used only by the cluster to pull the image — never
             exposed to the agent.
           </p>
-          <FormField label="Server">
+          <FormField label="Server" labelInset>
             <Input
               placeholder="ghcr.io"
               value={value.server}
               onChange={(e) => set("server", e.target.value)}
             />
           </FormField>
-          <FormField label="Username">
+          <FormField label="Username" labelInset>
             <Input
+              placeholder="octocat"
               value={value.username}
               onChange={(e) => set("username", e.target.value)}
             />
           </FormField>
-          <FormField label="Password">
+          <FormField label="Password" labelInset>
             <Input
               type="password"
               placeholder="PAT, robot account, or access token"
@@ -82,6 +84,6 @@ export function RegistryCredentialSection({ value, onChange, partial }: Props) {
           )}
         </div>
       )}
-    </section>
+    </div>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
@@ -3,16 +3,28 @@ import { Input } from "@/components/ui/input";
 import { CUSTOM_IMAGE_DOCS_URL } from "@/constants";
 import { cn } from "@/lib/utils";
 
+import type { RegistryCredential } from "../registry-credential-section.js";
+import { RegistryCredentialSection } from "../registry-credential-section.js";
+
+export interface RegistryControls {
+  value: RegistryCredential;
+  onChange: (value: RegistryCredential) => void;
+  partial: boolean;
+}
+
 export function CustomImageCard({
   value,
   selected,
   onChange,
   onSubmit,
+  registry,
 }: {
   value: string;
   selected: boolean;
   onChange: (value: string) => void;
   onSubmit: () => void;
+  /** Pull-credential controls; present once a custom image is entered. */
+  registry?: RegistryControls;
 }) {
   return (
     <div
@@ -47,6 +59,15 @@ export function CustomImageCard({
           variant="monospace"
         />
       </div>
+      {registry && (
+        <div className="mt-4 border-t border-border pt-3">
+          <RegistryCredentialSection
+            value={registry.value}
+            onChange={registry.onChange}
+            partial={registry.partial}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
@@ -12,20 +12,22 @@ export interface RegistryControls {
   partial: boolean;
 }
 
-export function CustomImageCard({
-  value,
-  selected,
-  onChange,
-  onSubmit,
-  registry,
-}: {
+interface Props {
   value: string;
   selected: boolean;
   onChange: (value: string) => void;
   onSubmit: () => void;
   /** Pull-credential controls; present once a custom image is entered. */
   registry?: RegistryControls;
-}) {
+}
+
+export function CustomImageCard({
+  value,
+  selected,
+  onChange,
+  onSubmit,
+  registry,
+}: Props) {
   return (
     <div
       className={cn(

--- a/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/setup-step.tsx
@@ -16,11 +16,6 @@ import type {
   WizardSnapshot,
 } from "../../lib/wizard-snapshot.js";
 import { CardList } from "../card-list.js";
-import {
-  type RegistryCredential,
-  RegistryCredentialSection,
-  registryFilledCount,
-} from "../registry-credential-section.js";
 import { SandboxSizeSection } from "../sandbox-size-section.js";
 import { StepHeader } from "../step-header.js";
 
@@ -50,9 +45,6 @@ interface Props {
   name: string;
   providerRef: ProviderRef | null;
   egressPreset: EgressPreset;
-  showRegistry: boolean;
-  registryCredential: RegistryCredential;
-  onRegistryChange: (value: RegistryCredential) => void;
   update: (patch: Partial<WizardSnapshot>) => void;
   setupNote?: { title: string; body: string };
   templateSize?: { cpu?: string; memory?: string };
@@ -66,9 +58,6 @@ export function SetupStep({
   name,
   providerRef,
   egressPreset,
-  showRegistry,
-  registryCredential,
-  onRegistryChange,
   update,
   setupNote,
   templateSize,
@@ -76,11 +65,6 @@ export function SetupStep({
   sizeMemoryMi,
   providers,
 }: Props) {
-  const registryPartial =
-    showRegistry &&
-    registryFilledCount(registryCredential) > 0 &&
-    registryFilledCount(registryCredential) < 3;
-
   return (
     <div>
       <StepHeader
@@ -150,14 +134,6 @@ export function SetupStep({
           ))}
         </CardList>
       </section>
-
-      {showRegistry && (
-        <RegistryCredentialSection
-          value={registryCredential}
-          onChange={onRegistryChange}
-          partial={registryPartial}
-        />
-      )}
     </div>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
@@ -12,7 +12,7 @@ import {
 } from "../../lib/wizard-snapshot.js";
 import { CardList } from "../card-list.js";
 import { StepHeader } from "../step-header.js";
-import { CustomImageCard } from "./custom-image-card.js";
+import { CustomImageCard, type RegistryControls } from "./custom-image-card.js";
 import { HarnessCard } from "./harness-card.js";
 import { KbTemplateCard } from "./kb-template-card.js";
 import { StartingPointRow } from "./starting-point-row.js";
@@ -22,6 +22,7 @@ interface Props {
   snapshot: WizardSnapshot;
   templates: TemplateView[];
   loading: boolean;
+  registry?: RegistryControls;
   onPickStartingPoint: (startingPoint: StartingPoint) => void;
   onPickTemplate: (templateId: string) => void;
   onPickKbTemplate: (kbTemplateId: WizardSnapshot["kbTemplateId"]) => void;
@@ -33,6 +34,7 @@ export function StartingPointStep({
   snapshot,
   templates,
   loading,
+  registry,
   onPickStartingPoint,
   onPickTemplate,
   onPickKbTemplate,
@@ -115,6 +117,7 @@ export function StartingPointStep({
         snapshot={snapshot}
         templates={templates}
         loading={loading}
+        registry={registry}
         onPickTemplate={onPickTemplate}
         onPickKbTemplate={onPickKbTemplate}
         onCustomImageChange={onCustomImageChange}
@@ -129,6 +132,7 @@ function StartingPointReveal({
   snapshot,
   templates,
   loading,
+  registry,
   onPickTemplate,
   onPickKbTemplate,
   onCustomImageChange,
@@ -217,6 +221,7 @@ function StartingPointReveal({
             selected={snapshot.customImage.trim().length > 0}
             onChange={onCustomImageChange}
             onSubmit={onContinue}
+            registry={registry}
           />
         </CardList>
       </section>

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -198,9 +198,20 @@ export function SandboxWizardView() {
         Continue <ArrowRight size={16} />
       </Button>
     ) : (
-      <Button onClick={finish} disabled={creating}>
-        {creating ? "Creating…" : createLabel(snapshot.startingPoint)}
-      </Button>
+      <>
+        {registryPartial && (
+          <button
+            type="button"
+            onClick={() => update({ step: 1 })}
+            className="text-[13px] text-destructive underline underline-offset-2"
+          >
+            Finish the private-registry credentials on step 1
+          </button>
+        )}
+        <Button onClick={finish} disabled={creating || registryPartial}>
+          {creating ? "Creating…" : createLabel(snapshot.startingPoint)}
+        </Button>
+      </>
     );
 
   return (

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -112,14 +112,12 @@ export function SandboxWizardView() {
 
   const goToStep = (step: WizardStep) => update({ step });
 
-  const step1CanAdvance = startingPointComplete(snapshot);
   const registryFilled = registryFilledCount(registryCredential);
   const registryPartial =
     isCustomImage && registryFilled > 0 && registryFilled < 3;
+  const step1CanAdvance = startingPointComplete(snapshot) && !registryPartial;
   const step2CanAdvance =
-    snapshot.name.trim().length > 0 &&
-    snapshot.providerRef !== null &&
-    !registryPartial;
+    snapshot.name.trim().length > 0 && snapshot.providerRef !== null;
 
   const finish = async () => {
     const image = snapshot.customImage.trim();
@@ -218,6 +216,15 @@ export function SandboxWizardView() {
           snapshot={snapshot}
           templates={templateList}
           loading={isLoading}
+          registry={
+            isCustomImage
+              ? {
+                  value: registryCredential,
+                  onChange: setRegistryCredential,
+                  partial: registryPartial,
+                }
+              : undefined
+          }
           onPickStartingPoint={(startingPoint) =>
             update(startingPointDefaults(startingPoint))
           }
@@ -239,9 +246,6 @@ export function SandboxWizardView() {
           name={snapshot.name}
           providerRef={snapshot.providerRef}
           egressPreset={snapshot.egressPreset}
-          showRegistry={isCustomImage}
-          registryCredential={registryCredential}
-          onRegistryChange={setRegistryCredential}
           update={update}
           setupNote={
             templateList.find((t) => t.id === snapshot.templateId)?.setupNote


### PR DESCRIPTION
Fixes #2748

## What

Entering a custom image URL (wizard Step 1) and the private-registry credentials needed to pull it (Step 2) were split across pages, so users with private images never found the credential fields.

- The **Private registry** collapsible now lives inside the Custom image card, directly under the URL input — it appears once a custom image is entered, collapsed by default, matching the design in the issue.
- The all-or-nothing partial-credentials gate moved with it: Step 1's **Continue** (and Enter-to-advance) blocks on partially filled credentials with the inline hint; Step 2 no longer knows about the registry.
- Credentials stay ephemeral component state — never persisted to the sessionStorage wizard snapshot (they're secrets), unchanged from before.
- Touch-up while moving: the section's chevrons switched lucide → Carbon (house icon rule), and it gained `aria-expanded`.

No backend changes — the create payload is identical.

## Testing

- `mise run ui:check`, `mise run ui:test` (108 passing)
- Manually verified against a live auth-gated registry: deployed an htpasswd-protected `registry:2` on the dev cluster, pushed the agent image into it, and created a sandbox through the wizard with image + credentials entered together on Step 1 — the pod pulled via the generated pull secret and reached Running. Partial credentials block Step 1; anonymous pull of the same image is denied.