### PR TITLE
fix(ui): drop cube icon from artifacts empty-state CTA

### DIFF
--- a/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
+++ b/packages/ui/src/modules/artifacts/views/artifacts-view.tsx
@@ -1,6 +1,6 @@
 import type { ArtifactFolder, LibraryArtifact } from "api-server-api";
 import { EXPERIMENT_FOLDER_PREFIX } from "api-server-api";
-import { Box, FolderPlus, Search, Upload } from "lucide-react";
+import { FolderPlus, Search, Upload } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -153,7 +153,6 @@ export function ArtifactsView() {
           title="No artifacts yet"
           message="Artifacts from every sandbox collect here."
           actionLabel="Go to sandboxes"
-          actionIcon={<Box size={16} />}
           onAction={() => setView("list")}
         />
       )}


### PR DESCRIPTION
drop the icon on the empty state CTA for artifacts

## current state

<img width="1031" height="411" alt="image" src="https://github.com/user-attachments/assets/663fee1a-de9e-4c3b-b254-1382a5204aa5" />

## desired state

<img width="792" height="419" alt="image" src="https://github.com/user-attachments/assets/88fc9553-b688-4d1b-a016-b21cab8ed934" />
