### PR TITLE
chore(agents): disable Claude Code nonessential network traffic in the harness image

### DIFF
--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -17,6 +17,18 @@ RUN --mount=type=cache,target=/root/.npm \
       "$(dirname "$(mise where npm:@agentclientprotocol/claude-agent-acp)")" &&\
     find /etc/mise -name '*.lock' -exec chmod 644 {} +
 
+# Claude Code phones home (usage telemetry to Statsig, error logs to Datadog
+# intake) — traffic the gateway egress chain would surface for approval. The
+# umbrella flag plus its explicit constituents turn all of it off; the
+# auto-updater loss is intentional since the harness version is pinned above.
+# Platform OTEL export is a separate, opt-in path and is unaffected.
+ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
+    DISABLE_TELEMETRY=1 \
+    DISABLE_ERROR_REPORTING=1 \
+    DISABLE_FEEDBACK_COMMAND=1 \
+    DISABLE_FEEDBACK_SURVEY=1 \
+    DISABLE_AUTOUPDATER=1
+
 COPY model-gateway.mjs /usr/local/lib/model-gateway.mjs
 COPY model-gateway.sh /usr/local/lib/model-gateway.sh
 COPY sync-otel-settings.mjs /usr/local/lib/sync-otel-settings.mjs


### PR DESCRIPTION
## Why

The Claude Code harness phones home from agent pods — usage telemetry to Statsig and error logs to `http-intake.logs.us5.datadoghq.com` — traffic the gateway egress chain surfaces as annoying network approval prompts.

## What

Bakes the opt-out env into the `claude-code` agent image (`packages/agents/claude-code/Dockerfile`):

- `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` — umbrella flag for all nonessential traffic
- Explicit `DISABLE_TELEMETRY`, `DISABLE_ERROR_REPORTING`, `DISABLE_FEEDBACK_COMMAND`, `DISABLE_FEEDBACK_SURVEY`, `DISABLE_AUTOUPDATER` — self-documenting and robust across CLI versions

## Notes

- Auto-updater loss is intentional: the image pins the harness version (`harness-tools.toml`).
- Platform OTEL export ([observability](../blob/main/docs/architecture/observability.md)) is a separate, operator-opt-in path (`CLAUDE_CODE_ENABLE_TELEMETRY` + `OTEL_*` via the harness env rail) and is unaffected by these flags.
- Follows the existing harness-image convention of behavior flags as Dockerfile `ENV` (cf. pi-agent's `PI_SKIP_VERSION_CHECK=1`).