### PR TITLE
fix(ui): constrain empty-state copy width, hide experiments header blurb when empty

### DIFF
--- a/packages/ui/src/components/ui/page-empty-state.tsx
+++ b/packages/ui/src/components/ui/page-empty-state.tsx
@@ -24,7 +24,7 @@ export function PageEmptyState({
   return (
     <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
       <h2 className="text-[16px] font-semibold text-foreground">{title}</h2>
-      <p className="text-[14px] text-muted-foreground">{message}</p>
+      <p className="max-w-[520px] text-[14px] text-muted-foreground">{message}</p>
       <Button className="mt-1" onClick={onAction}>
         {actionIcon}
         {actionLabel}

--- a/packages/ui/src/modules/experiments/views/experiments-list-view.tsx
+++ b/packages/ui/src/modules/experiments/views/experiments-list-view.tsx
@@ -38,7 +38,11 @@ export function ExperimentsListView() {
     <div>
       <PageHeader
         title="Experiments"
-        description="Loop scripts the platform observes live, grouped by the sandbox running them. Open one to land in its chat — the experiment graph docks beside the conversation."
+        description={
+          groups.length > 0
+            ? "Loop scripts the platform observes live, grouped by the sandbox running them. Open one to land in its chat — the experiment graph docks beside the conversation."
+            : undefined
+        }
         actions={
           groups.length > 0 ? (
             <Button onClick={createExperimentSandbox}>Create experiment</Button>
@@ -53,7 +57,7 @@ export function ExperimentsListView() {
           <h2 className="text-[16px] font-semibold text-foreground">
             No experiments yet
           </h2>
-          <p className="text-[14px] text-muted-foreground">
+          <p className="max-w-[520px] text-[14px] text-muted-foreground">
             An experiment runs one goal across several variants at once and
             charts each result live, so you can compare them. Create an
             experiment sandbox and its agent will help you design the first one.


### PR DESCRIPTION
Caps empty-state copy at `max-w-[520px]` so it stops running edge-to-edge - covers Sandboxes, Artifacts, Knowledge bases (shared `PageEmptyState`) and Experiments. Also hides the Experiments header blurb when there are no experiments yet.