### PR TITLE
feat(ui): rename Home page header and align list/wizard widths

### DIFF
--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -41,7 +41,7 @@ export function IconRail({
   const pendingCount = approvals.filter((r) => r.status === "pending").length;
 
   const sandboxes: Destination = {
-    label: "Sandboxes",
+    label: "Home",
     icon: Home,
     active: view === "list",
     badge: 0,

--- a/packages/ui/src/modules/agents/views/list-view.tsx
+++ b/packages/ui/src/modules/agents/views/list-view.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { PageEmptyState } from "@/components/ui/page-empty-state";
 import { PageHeader } from "@/components/ui/page-header";
+import { SectionLabel } from "@/components/ui/section-label";
 
 import { ListSkeleton } from "../../../components/list-skeleton.js";
 import { useStore } from "../../../store.js";
@@ -63,7 +64,7 @@ export function ListView() {
   return (
     <div>
       <PageHeader
-        title="Sandboxes"
+        title="Home"
         actions={
           agents.length > 0 ? (
             <Button onClick={() => navigateToCreateSandbox()}>
@@ -73,7 +74,12 @@ export function ListView() {
         }
       />
 
-      {initialLoaded && agents.length > 0 && <BudgetMeter />}
+      {initialLoaded && agents.length > 0 && (
+        <>
+          <BudgetMeter />
+          <SectionLabel spaced>Sandboxes</SectionLabel>
+        </>
+      )}
 
       {!initialLoaded && <ListSkeleton rows={2} rowHeight={70} />}
 

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
@@ -31,7 +31,7 @@ export function KnowledgeBasesListView() {
   };
 
   return (
-    <div className="mx-auto w-full max-w-[666px]">
+    <div>
       <PageHeader
         title="Knowledge bases"
         actions={

--- a/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
@@ -63,7 +63,7 @@ export function StartingPointStep({
         </p>
       )}
 
-      <div className="mb-8 flex flex-col gap-3">
+      <CardList className="mb-8">
         {kindedHarnessInstalled && (
           <StartingPointRow
             startingPoint="experiment"
@@ -109,7 +109,7 @@ export function StartingPointStep({
           selected={startingPoint === "custom"}
           onSelect={() => onPickStartingPoint("custom")}
         />
-      </div>
+      </CardList>
 
       <StartingPointReveal
         snapshot={snapshot}
@@ -138,7 +138,7 @@ function StartingPointReveal({
     return (
       <section className="anim-in">
         <SectionLabel spaced>Template</SectionLabel>
-        <div className="flex flex-col gap-3">
+        <CardList>
           {KB_TEMPLATES.map((template) => (
             <KbTemplateCard
               key={template.id}
@@ -147,7 +147,7 @@ function StartingPointReveal({
               onSelect={() => onPickKbTemplate(template.id)}
             />
           ))}
-        </div>
+        </CardList>
       </section>
     );
   }


### PR DESCRIPTION
Closes #2996

## Summary

A combined pass of small home/layout fixes:

- **Home page header (#2996)** — the sandboxes list page now titles as **"Home"**, with a smaller uppercase **"SANDBOXES"** section label above the list (populated state only). The icon-rail's home destination is relabeled "Home" to match. Empty state is just the "Home" header + the empty-state card, per the mock.
- **Knowledge bases list width** — dropped its `max-w-[666px]` cap so it fills the shared page shell, matching the sandboxes list (#3021) and the experiments list (#3025).
- **Starting-point wizard cards** — the "Choose your starting point" cards now route through the shared `CardList` (`Inset`) wrapper, so they outdent in line with the step header and with the image/template cards that reveal once a starting point is picked. Also switched the knowledge-base **Template** reveal from a bare `<div>` to `CardList` so every card group in that step insets identically.

## Test plan

- `mise run ui:check` and `mise run ui:test` pass
- Visual pass over Home (empty + populated), Knowledge bases list, and the create-sandbox wizard's first step

https://claude.ai/code/session_01NeZeHv1xtCW4GXVsWbA9tC