### PR TITLE
chore(agents): drop the nonessential-traffic umbrella flag, keep the explicit ones

### DIFF
--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -19,11 +19,12 @@ RUN --mount=type=cache,target=/root/.npm \
 
 # Claude Code phones home (usage telemetry to Statsig, error logs to Datadog
 # intake) — traffic the gateway egress chain would surface for approval. The
-# umbrella flag plus its explicit constituents turn all of it off; the
-# auto-updater loss is intentional since the harness version is pinned above.
-# Platform OTEL export is a separate, opt-in path and is unaffected.
-ENV CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1 \
-    DISABLE_TELEMETRY=1 \
+# explicit flags below turn exactly that off; the umbrella
+# CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC is deliberately NOT set — it also
+# switches off wanted behavior beyond these constituents. The auto-updater
+# loss is intentional since the harness version is pinned above. Platform
+# OTEL export is a separate, opt-in path and is unaffected.
+ENV DISABLE_TELEMETRY=1 \
     DISABLE_ERROR_REPORTING=1 \
     DISABLE_FEEDBACK_COMMAND=1 \
     DISABLE_FEEDBACK_SURVEY=1 \

--- a/packages/ui/src/components/ui/page-empty-state.tsx
+++ b/packages/ui/src/components/ui/page-empty-state.tsx
@@ -24,7 +24,9 @@ export function PageEmptyState({
   return (
     <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
       <h2 className="text-[16px] font-semibold text-foreground">{title}</h2>
-      <p className="max-w-[520px] text-[14px] text-muted-foreground">{message}</p>
+      <p className="max-w-[520px] text-[14px] text-muted-foreground">
+        {message}
+      </p>
       <Button className="mt-1" onClick={onAction}>
         {actionIcon}
         {actionLabel}


### PR DESCRIPTION
`CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` disables more than the phone-home traffic #3028 meant to cut — it takes wanted behavior with it. This drops the umbrella and keeps the explicit constituents, which cover the original intent exactly:

- `DISABLE_TELEMETRY` — no Statsig usage telemetry
- `DISABLE_ERROR_REPORTING` — no Datadog error intake
- `DISABLE_FEEDBACK_COMMAND` / `DISABLE_FEEDBACK_SURVEY` — no feedback prompts
- `DISABLE_AUTOUPDATER` — intentional; the image pins the harness version

Platform OTEL export is a separate opt-in path and is unaffected.

Also formats `page-empty-state.tsx`, which landed on main unformatted and was failing the pre-commit format hook for every commit.

Amends #3028.