### PR TITLE
fix(experiments): close the review gaps — status colors, kinded subtitles, compensated create

### DIFF
--- a/docs/architecture/knowledge-bases.md
+++ b/docs/architecture/knowledge-bases.md
@@ -27,7 +27,9 @@ Knowledge Bases is a feature-gated destination ([features](features.md)) with a 
 
 Opening a KB that has no sessions yet **greets the user**: the UI runs `/wiki-onboard` as a hidden first turn (reaches the agent, renders no user bubble, fails silently), so a fresh KB opens with the agent introducing itself rather than an empty chat. This is why every template's bootstrap installs that command. The greeting mechanism is shared with experiments.
 
-Two known gaps, both about the create being non-transactional. The greeting races the bootstrap: it fires once the agent is running, but the Install Command lands after Ready, so a very fast open can run `/wiki-onboard` before it exists. Experiments close this by waiting for their authoring skill to be reported present; a KB has nothing equivalent to probe, because its onboarding artifact is a *command* and that read covers only skills. Separately, the marker is stamped by the agent create while the install event is enqueued after it, so a failure in between leaves a marked agent whose setup never ran — indistinguishable in the lists from a healthy one, since no setup state is surfaced.
+One known gap: the greeting races the bootstrap. It fires once the agent is running, but the Install Command lands after Ready, so a very fast open can run `/wiki-onboard` before it exists. Experiments close this by waiting for their authoring skill to be reported present; a KB has nothing equivalent to probe, because its onboarding artifact is a *command* and that read covers only skills.
+
+The create itself is compensated rather than transactional: the marker is stamped by the agent create while the install event is enqueued after it, and a failed enqueue deletes the fresh agent and surfaces the failure — so a marked agent whose setup never ran can only arise if that compensating delete itself fails.
 
 Lifecycle actions (wake, restart, pause, stop, delete) are the standard agent actions.
 

--- a/packages/api-server/src/__tests__/unit/kinded-agent-create.test.ts
+++ b/packages/api-server/src/__tests__/unit/kinded-agent-create.test.ts
@@ -25,6 +25,7 @@ function makeHarness() {
     bumped: [] as { agentId: string; events: unknown[] }[],
     enqueued: [] as string[],
     woken: [] as string[],
+    deleted: [] as string[],
   };
   const runtimeMutator: RuntimeMutator = {
     async bump(agentId, events) {
@@ -41,6 +42,9 @@ function makeHarness() {
       async create(input: AgentCreateInput) {
         calls.createInputs.push(input);
         return fakeAgent("agent-x1");
+      },
+      async delete(id: string) {
+        calls.deleted.push(id);
       },
     },
     runtimeMutator,
@@ -107,6 +111,33 @@ describe("createKindedAgent", () => {
 
     expect(calls.enqueued).toEqual(["agent-x1"]);
     expect(calls.woken).toEqual(["agent-x1"]);
+  });
+
+  it("deletes the fresh agent when the install enqueue fails", async () => {
+    // Without the compensation, a throw here would leave a marked agent whose
+    // setup never ran — indistinguishable in the lists from a healthy one.
+    const { deps, calls } = makeHarness();
+    await expect(
+      createKindedAgent(
+        {
+          ...deps,
+          runtimeMutator: {
+            async bump() {
+              throw new Error("outbox unavailable");
+            },
+            async enqueueAfterCommit() {},
+          },
+        },
+        {
+          createInput: { name: "my-experiments", templateId: "claude-code" },
+          installCommand: buildExperimentInstallCommand(),
+          eventIdPrefix: "experiment-install",
+          securityEvent: "experiment_sandbox.create",
+        },
+      ),
+    ).rejects.toThrow("outbox unavailable");
+    expect(calls.deleted).toEqual(["agent-x1"]);
+    expect(calls.woken).toEqual([]);
   });
 
   it("wakes only after the install event is enqueued", async () => {

--- a/packages/api-server/src/__tests__/unit/knowledge-bases-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/knowledge-bases-service.test.ts
@@ -41,6 +41,7 @@ function makeHarness() {
         calls.createInputs.push(input);
         return fakeAgent("agent-kb1");
       },
+      async delete() {},
     },
     runtimeMutator,
     wakeAgent: async (agentId) => {

--- a/packages/api-server/src/modules/agents/services/kinded-agent-create.ts
+++ b/packages/api-server/src/modules/agents/services/kinded-agent-create.ts
@@ -8,7 +8,7 @@ const INSTALL_EVENT_TTL_MS = 30 * 24 * 60 * 60 * 1000;
 
 export interface KindedAgentCreateDeps {
   owner: string;
-  agents: Pick<AgentsService, "create">;
+  agents: Pick<AgentsService, "create" | "delete">;
   runtimeMutator: RuntimeMutator;
   wakeAgent: (agentId: string) => Promise<void>;
   now?: () => Date;
@@ -28,9 +28,13 @@ export interface KindedAgentCreateArgs {
  *  delivery (survives a pod that isn't up), once in-pod via the plugin's
  *  sentinel, retried each wake until the TTL lapses. No agent turn.
  *
- *  Not transactional — the marker is stamped by the create while the event is
- *  enqueued after, so a throw between them leaves a marked agent whose setup
- *  never ran, indistinguishable from a healthy one (#2946). */
+ *  Compensated, not transactional: the marker is stamped by the create while
+ *  the event is enqueued after, so a throw between them would leave a marked
+ *  agent whose setup never ran — the create therefore deletes the fresh agent
+ *  and rethrows when the enqueue fails, and the caller sees a clean failure.
+ *  The residual window is the compensation itself failing (best-effort). A
+ *  failed wake deliberately does NOT compensate: the event is durable and
+ *  delivers on the next wake. */
 export async function createKindedAgent(
   deps: KindedAgentCreateDeps,
   args: KindedAgentCreateArgs,
@@ -39,15 +43,20 @@ export async function createKindedAgent(
 
   const agent = await deps.agents.create(args.createInput);
 
-  await deps.runtimeMutator.bump(agent.id, [
-    {
-      id: `${args.eventIdPrefix}:${agent.id}:${now().getTime()}`,
-      kind: "workspace-command",
-      payload: { command: args.installCommand },
-      expiresAt: new Date(now().getTime() + INSTALL_EVENT_TTL_MS),
-    },
-  ]);
-  await deps.runtimeMutator.enqueueAfterCommit(agent.id);
+  try {
+    await deps.runtimeMutator.bump(agent.id, [
+      {
+        id: `${args.eventIdPrefix}:${agent.id}:${now().getTime()}`,
+        kind: "workspace-command",
+        payload: { command: args.installCommand },
+        expiresAt: new Date(now().getTime() + INSTALL_EVENT_TTL_MS),
+      },
+    ]);
+    await deps.runtimeMutator.enqueueAfterCommit(agent.id);
+  } catch (err) {
+    await deps.agents.delete(agent.id).catch(() => {});
+    throw err;
+  }
   await deps.wakeAgent(agent.id);
 
   securityLog("info", args.securityEvent, {

--- a/packages/api-server/src/modules/knowledge-bases/services/knowledge-bases-service.ts
+++ b/packages/api-server/src/modules/knowledge-bases/services/knowledge-bases-service.ts
@@ -13,7 +13,7 @@ import { buildKnowledgeBaseInstallCommand } from "../domain/install-command.js";
 
 export function createKnowledgeBasesService(deps: {
   owner: string;
-  agents: Pick<AgentsService, "create">;
+  agents: Pick<AgentsService, "create" | "delete">;
   runtimeMutator: RuntimeMutator;
   wakeAgent: (agentId: string) => Promise<void>;
   now?: () => Date;

--- a/packages/ui/src/components/ui/page-empty-state.tsx
+++ b/packages/ui/src/components/ui/page-empty-state.tsx
@@ -24,7 +24,9 @@ export function PageEmptyState({
   return (
     <Card className="flex flex-col items-center gap-3 border border-border px-6 py-12 text-center anim-in">
       <h2 className="text-[16px] font-semibold text-foreground">{title}</h2>
-      <p className="max-w-[520px] text-[14px] text-muted-foreground">{message}</p>
+      <p className="max-w-[520px] text-[14px] text-muted-foreground">
+        {message}
+      </p>
       <Button className="mt-1" onClick={onAction}>
         {actionIcon}
         {actionLabel}

--- a/packages/ui/src/modules/agents/hooks/use-agent-rows.ts
+++ b/packages/ui/src/modules/agents/hooks/use-agent-rows.ts
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { useStore } from "../../../store.js";
 import type { AgentView, TemplateView } from "../../../types.js";
 import { useAppConnections } from "../../connections/api/queries.js";
+import { useDriverSummaries } from "../../experiments/api/queries.js";
 import { useTemplates } from "../../templates/api/queries.js";
 import { useDeleteAgent } from "../api/mutations.js";
 import { useAgents } from "../api/queries.js";
@@ -31,6 +32,9 @@ export function useAgentRows() {
   const templates = templatesData ?? NO_TEMPLATES;
   const { data: agentsData } = useAgents();
   const connections = useAppConnections();
+  // Experiment-kinded rows lead their subtitle with how many named experiments
+  // they drive (#3001); one cached query, shared with the Experiments page.
+  const { data: driverSummaries } = useDriverSummaries();
   const restartingAgents = useStore((s) => s.restartingAgents);
   useSyncRestartingAgents();
   const pausingAgents = useStore((s) => s.pausingAgents);
@@ -50,6 +54,16 @@ export function useAgentRows() {
     [pausingAgents],
   );
 
+  const experimentCountByDriver = useMemo(() => {
+    if (!driverSummaries) return undefined;
+    return new Map(
+      driverSummaries.map((summary) => [
+        summary.driverAgentId,
+        new Set(summary.experiments.map((e) => e.name)).size,
+      ]),
+    );
+  }, [driverSummaries]);
+
   const subtitleLookup = useMemo<SandboxSubtitleLookup>(
     () => ({
       templateNameById: new Map(templates.map((t) => [t.id, t.name])),
@@ -63,7 +77,13 @@ export function useAgentRows() {
   const rowProps = (agent: AgentView) => ({
     agent,
     display: resolveAgentDisplay(agent, restartingIds, pausingIds),
-    subtitle: sandboxSubtitle(agent, subtitleLookup),
+    subtitle: sandboxSubtitle(agent, subtitleLookup, {
+      // 0, not undefined, once summaries have loaded: a marked sandbox with no
+      // registered experiments reads "No active experiments".
+      experimentCount: experimentCountByDriver
+        ? (experimentCountByDriver.get(agent.id) ?? 0)
+        : undefined,
+    }),
     deletePending:
       deleteAgent.isPending && deleteAgent.variables?.id === agent.id,
     onWake: () => wakeAgent.wake(agent.id),

--- a/packages/ui/src/modules/agents/hooks/use-agent-rows.ts
+++ b/packages/ui/src/modules/agents/hooks/use-agent-rows.ts
@@ -34,7 +34,7 @@ export function useAgentRows() {
   const connections = useAppConnections();
   // Experiment-kinded rows lead their subtitle with how many named experiments
   // they drive (#3001); one cached query, shared with the Experiments page.
-  const { data: driverSummaries } = useDriverSummaries();
+  const { data: driverSummaries } = useDriverSummaries({ silent: true });
   const restartingAgents = useStore((s) => s.restartingAgents);
   useSyncRestartingAgents();
   const pausingAgents = useStore((s) => s.pausingAgents);

--- a/packages/ui/src/modules/agents/utils/sandbox-subtitle.ts
+++ b/packages/ui/src/modules/agents/utils/sandbox-subtitle.ts
@@ -50,16 +50,20 @@ export function sandboxSubtitle(
   },
 ): string {
   if (agent.kind === "experiment") {
-    return joinSubtitleSegments([
+    const kinded = joinSubtitleSegments([
       experimentCountLabel(extras?.experimentCount),
       catalogConnectionsLabel(agent, lookup),
     ]);
+    // Mid-load with no connections the line would otherwise be blank.
+    return kinded || sandboxSubtitleParts(agent, lookup).harness;
   }
   if (agent.kind === "knowledge-base") {
-    return joinSubtitleSegments([
+    const kinded = joinSubtitleSegments([
       kbTemplateName(agent.kbTemplateId),
       catalogConnectionsLabel(agent, lookup),
     ]);
+    // A KB from before the template id was recorded can have no segments.
+    return kinded || sandboxSubtitleParts(agent, lookup).harness;
   }
   const { harness, provider } = sandboxSubtitleParts(agent, lookup);
   return joinSubtitleSegments([harness, provider]);

--- a/packages/ui/src/modules/agents/utils/sandbox-subtitle.ts
+++ b/packages/ui/src/modules/agents/utils/sandbox-subtitle.ts
@@ -1,6 +1,7 @@
 import { PROVIDERS, providerTypeForTemplateId } from "api-server-api";
 
 import type { AgentView } from "../../../types.js";
+import { kbTemplateName } from "../../knowledge-bases/lib/kb-templates.js";
 
 export interface SandboxSubtitleLookup {
   templateNameById: ReadonlyMap<string, string>;
@@ -22,22 +23,66 @@ export function sandboxSubtitleParts(
 }
 
 /** The one way row-subtitle segments are joined — surfaces that prepend their
- *  own segment (the KB list's template) use this too, so the separator and
- *  empty-segment omission can't drift. */
+ *  own segment use this too, so the separator and empty-segment omission
+ *  can't drift. */
 export function joinSubtitleSegments(
   segments: ReadonlyArray<string | null | undefined>,
 ): string {
   return segments.filter(Boolean).join(" · ");
 }
 
-/** "harness · provider" row subtitle; the provider segment is omitted when no
- *  granted connection resolves to a provider. */
+/** Row subtitle, shaped by the agent's Kind (#3001): a kinded sandbox leads
+ *  with what it is FOR, not the image it runs on.
+ *
+ *  - experiment:      "N experiments · M connections" ("No active experiments"
+ *                     while it has none — the state a fresh sandbox sits in)
+ *  - knowledge-base:  "Template · M connections"
+ *  - plain:           "harness · provider"
+ *
+ *  The connections segment counts catalog connections only (a provider
+ *  credential is the provider segment's business) and is omitted at zero. */
 export function sandboxSubtitle(
   agent: AgentView,
   lookup: SandboxSubtitleLookup,
+  extras?: {
+    /** Named experiments this sandbox drives; undefined while still loading. */
+    experimentCount?: number;
+  },
 ): string {
+  if (agent.kind === "experiment") {
+    return joinSubtitleSegments([
+      experimentCountLabel(extras?.experimentCount),
+      catalogConnectionsLabel(agent, lookup),
+    ]);
+  }
+  if (agent.kind === "knowledge-base") {
+    return joinSubtitleSegments([
+      kbTemplateName(agent.kbTemplateId),
+      catalogConnectionsLabel(agent, lookup),
+    ]);
+  }
   const { harness, provider } = sandboxSubtitleParts(agent, lookup);
   return joinSubtitleSegments([harness, provider]);
+}
+
+function experimentCountLabel(count: number | undefined): string | null {
+  if (count === undefined) return null;
+  if (count === 0) return "No active experiments";
+  return `${count} experiment${count === 1 ? "" : "s"}`;
+}
+
+function catalogConnectionsLabel(
+  agent: AgentView,
+  lookup: SandboxSubtitleLookup,
+): string | null {
+  let count = 0;
+  for (const connectionId of agent.grantedConnectionIds) {
+    const templateId = lookup.connectionTemplateIdById.get(connectionId);
+    if (templateId && providerTypeForTemplateId(templateId)) continue;
+    count += 1;
+  }
+  if (count === 0) return null;
+  return `${count} connection${count === 1 ? "" : "s"}`;
 }
 
 function providerLabel(

--- a/packages/ui/src/modules/experiments/api/queries.ts
+++ b/packages/ui/src/modules/experiments/api/queries.ts
@@ -36,12 +36,16 @@ export function useExperimentsAmbient() {
 
 /** The Experiments destination rows: driver agents + what they're doing.
  *  Refresh-on-open like every list. */
-export function useDriverSummaries() {
+export function useDriverSummaries(opts?: { silent?: boolean }) {
   return useQuery({
     ...trpc.experiments.driverSummaries.queryOptions(),
     refetchOnMount: "always",
     staleTime: 0,
-    meta: { errorToast: "Couldn't load experiments" },
+    // Ambient consumers (row subtitles) degrade the segment instead of
+    // toasting about a page the user isn't on.
+    ...(opts?.silent
+      ? {}
+      : { meta: { errorToast: "Couldn't load experiments" } }),
   });
 }
 

--- a/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
+++ b/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
@@ -277,10 +277,10 @@ function RunInvocations({ feed }: { feed: TraceFeed | undefined }) {
               row.waitingForRoom
                 ? "animate-pulse bg-amber-500"
                 : row.status === "running"
-                  ? "animate-pulse bg-blue-500"
+                  ? "animate-pulse bg-emerald-500"
                   : row.status === "failed"
                     ? "bg-red-500"
-                    : "bg-emerald-500",
+                    : "bg-muted-foreground/45",
             )}
           />
           <span className="min-w-0 flex-1 truncate">

--- a/packages/ui/src/modules/experiments/components/experiment-status-badge.tsx
+++ b/packages/ui/src/modules/experiments/components/experiment-status-badge.tsx
@@ -5,8 +5,8 @@ import { cn } from "@/lib/utils";
 
 const STYLES: Record<ExperimentStatus, string> = {
   draft: "bg-muted text-foreground/80",
-  running: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
-  completed: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  running: "bg-emerald-500/15 text-emerald-600 dark:text-emerald-400",
+  completed: "bg-blue-500/15 text-blue-600 dark:text-blue-400",
   failed: "bg-red-500/15 text-red-600 dark:text-red-400",
   stopped: "bg-amber-500/15 text-amber-600 dark:text-amber-400",
 };

--- a/packages/ui/src/modules/experiments/components/lineage-runs.tsx
+++ b/packages/ui/src/modules/experiments/components/lineage-runs.tsx
@@ -194,10 +194,10 @@ function InvocationDots({
               waitingForRoom(invocation)
                 ? "animate-pulse bg-amber-500"
                 : invocation.status === "running"
-                  ? "animate-pulse bg-blue-500"
+                  ? "animate-pulse bg-emerald-500"
                   : invocation.status === "failed"
                     ? "bg-red-500"
-                    : "bg-emerald-500",
+                    : "bg-muted-foreground/45",
             )}
           />
         ))}

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
@@ -8,9 +8,7 @@ import type { AgentView } from "../../../types.js";
 import { AgentRow } from "../../agents/components/agent-row.js";
 import { useAgentRows } from "../../agents/hooks/use-agent-rows.js";
 import { isKnowledgeBase } from "../../agents/utils/agent-kind.js";
-import { joinSubtitleSegments } from "../../agents/utils/sandbox-subtitle.js";
 import { confirmDeleteKnowledgeBase } from "../lib/confirm-delete.js";
-import { kbTemplateName } from "../lib/kb-templates.js";
 
 /** The Knowledge Bases surface: the owner's agents carrying the
  *  `knowledge-base` kind. Rows open the standalone knowledge-base page — the
@@ -55,18 +53,10 @@ export function KnowledgeBasesListView() {
       <div className="flex flex-col gap-3">
         {initialLoaded &&
           knowledgeBases.map((agent) => {
-            const props = rowProps(agent);
             return (
               <AgentRow
                 key={agent.id}
-                {...props}
-                // Lead the subtitle with the KB template (the installation
-                // procedure) — the segment KBs are told apart by; harness and
-                // provider follow. Omitted on KBs from before it was recorded.
-                subtitle={joinSubtitleSegments([
-                  kbTemplateName(agent.kbTemplateId),
-                  props.subtitle,
-                ])}
+                {...rowProps(agent)}
                 onSelect={() => openKnowledgeBase(agent.id)}
                 onDelete={() => void deleteKnowledgeBase(agent)}
               />


### PR DESCRIPTION
Closes the three code-closable gaps from the #2328 status audit:

**Status colors match the design (#2997).** Running = green, Completed = blue — they were inverted in `ExperimentStatusBadge`. The invocation dots now agree in both surfaces (run rows + chat dock): live pulses green, done goes quiet grey; failed red and parked amber keep their meaning.

**Kinded card subtitles (#3001).** A kinded sandbox's row leads with what it is *for*:
- experiment: `N experiments · M connections` (`No active experiments` while empty)
- knowledge base: `Template · M connections`
- plain: `harness · provider`, unchanged

The connections segment counts catalog connections only and is omitted at zero. Experiment counts ride the driver-summaries query the Experiments page already caches; the KB list drops its hand-prepended template segment now that the shared subtitle owns it.

**Kinded create is compensated (the #2946 gap).** A failed install-event enqueue now deletes the fresh agent and rethrows, so a marked sandbox whose setup never ran can only arise if the compensating delete itself fails. A failed wake deliberately does not compensate — the event is durable and delivers on the next wake. Covered by a unit test; `knowledge-bases.md` updated accordingly.

Not addressed here, by design: the #2997 click-behavior divergence (rows open the sandbox chat per Radek's direction) and #2999 (needs a design pass against the shipped wizard).

Also formats `page-empty-state.tsx` (unformatted on main, blocks every commit through the pre-commit hook — same drive-by as #3031; whichever merges first wins).

Closes #2997. Closes #3000. Closes #3001.