### PR TITLE
feat(ui): update the starting-point step description copy

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
@@ -53,7 +53,7 @@ export function StartingPointStep({
       <StepHeader
         step={1}
         title="Choose your starting point"
-        subtitle="Every sandbox boots from an image. Start with one already set up for a particular job, or take a general-purpose image and configure it yourself."
+        subtitle="Every sandbox starts from an image. Choose one configured for a specific job, or start with a general-purpose image and customize it yourself."
       />
 
       {!kindedHarnessInstalled && (


### PR DESCRIPTION
Closes #2999

## Summary

The behavioural scope of #2999 — the 5 starting-point cards and their reveals, the LiteLLM-recommended provider guard, and custom-image registry credentials — already shipped across #3014, #3017, and #3026. The one remaining delta from the issue was the header description copy on the "Choose your starting point" step:

> Every sandbox starts from an image. Choose one configured for a specific job, or start with a general-purpose image and customize it yourself.

Card names/descriptions were out of scope per the issue, so this is the sole change.

## Test plan

- Prettier-clean; no logic touched