### PR TITLE
feat(issues): rework issue types and templates to be problem-first

### DIFF
--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: draft-issue
 description: >
-  Template and writing guidelines for a GitHub issue. Every issue is one of epic, story, task, or bug — the user decides the type, and each type has its own template. Stories, tasks, and bugs can suggest a parent epic from the project board.
+  Template and writing guidelines for a GitHub issue. Every issue is one of epic, feature, task, bug, or research task — the user decides the type, and each type has its own template. Non-epic types can suggest a parent epic from the project board.
 ---
 
 # Draft an Issue
@@ -12,13 +12,13 @@ Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guid
 
 1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
 
-2. **Let the user decide the type.** Every issue is an **epic**, **story**, **task**, or **bug** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template. Skip the question only when the type is unmistakable (e.g. the user said "bug" or described a clear defect).
+2. **Let the user decide the type.** Every issue is an **epic**, **feature**, **task**, **bug**, or **research task** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template. Skip the question only when the type is unmistakable (e.g. the user said "bug" or described a clear defect).
 
 3. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
 
    **But keep the research out of the issue itself.** Do not pull file paths, function names, line numbers, data structures, or architectural detail into the draft. The research informs your writing; it does not appear in it. If a sentence only makes sense to someone who's read the code, rewrite it.
 
-4. **For a story, task, or bug: consider an epic.** Fetch the epics from the project board and check whether one clearly fits:
+4. **For any non-epic type: consider an epic.** Fetch the epics from the project board and check whether one clearly fits:
 
    ```sh
    gh project item-list 1 --owner dam-agents --limit 3000 --format json \

--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -12,6 +12,8 @@ Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guid
 
 1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
 
+   Because **Context leads every template** — why this matters, what led here — make sure you actually have it. If the user's ask doesn't convey that context, ask them for it before drafting. A ticket without real context is the main thing this step exists to prevent.
+
 2. **Let the user decide the type.** Every issue is an **epic**, **feature**, **task**, **bug**, or **research task** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template. Skip the question only when the type is unmistakable (e.g. the user said "bug" or described a clear defect).
 
 3. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -8,13 +8,13 @@ argument-hint: "[what the issue is about]"
 
 # File an Issue
 
-Draft a GitHub issue and file it after the user approves. For the content shape — the issue types (epic, story, task, bug), style, and the per-type templates — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → decide type → research → dedupe → draft → approve → file) on top of those guidelines.
+Draft a GitHub issue and file it after the user approves. For the content shape — the issue types (epic, feature, task, bug, research task), style, and the per-type templates — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → decide type → research → dedupe → draft → approve → file) on top of those guidelines.
 
 ## Workflow
 
 1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
 
-   Then let the user decide the type: every issue is an **epic**, **story**, **task**, or **bug** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template and how the issue is filed. Skip the question only when the type is unmistakable.
+   Then let the user decide the type: every issue is an **epic**, **feature**, **task**, **bug**, or **research task** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template and how the issue is filed. Skip the question only when the type is unmistakable.
 
 2. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.
 
@@ -28,7 +28,7 @@ Draft a GitHub issue and file it after the user approves. For the content shape 
 
    Use multiple keyword variations drawn from the user's request. If you find a plausible duplicate or closely-related issue, surface it to the user with a one-line summary and ask how to proceed — options include: add a comment to the existing issue, file a new one anyway with a cross-link, or close the request as already-tracked. Do not silently file a duplicate.
 
-4. **For a story, task, or bug: consider an epic.** Fetch the epics from the project board and check whether one clearly fits:
+4. **For any non-epic type: consider an epic.** Fetch the epics from the project board and check whether one clearly fits:
 
    ```sh
    gh project item-list 1 --owner dam-agents --limit 3000 --format json \

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -14,6 +14,8 @@ Draft a GitHub issue and file it after the user approves. For the content shape 
 
 1. **Understand the request thoroughly.** Read the user's prompt carefully — multiple times if it's long or ambiguous. Identify what problem they're describing, who it affects, and what outcome they want. Restate it back in one or two sentences to confirm shared understanding. Ask follow-ups for anything that would change the shape of the issue (scope, who it affects, dependencies on other work). Do not start drafting until you genuinely understand the ask.
 
+   Because **Context leads every template** — why this matters, what led here — make sure you actually have it. If the user's ask doesn't convey that context, ask them for it before drafting. A ticket without real context is the main thing this step exists to prevent.
+
    Then let the user decide the type: every issue is an **epic**, **feature**, **task**, **bug**, or **research task** (see the guidelines doc). State which type you read the ask as and why, and let the user confirm or override — the type picks the template and how the issue is filed. Skip the question only when the type is unmistakable.
 
 2. **Research the codebase thoroughly.** Do real investigation of the current state — read relevant files, trace how the feature works today, understand the user-visible behavior end-to-end. The goal is to describe the status quo *accurately*, not superficially. A shallow understanding produces a vague ticket.

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -60,7 +60,7 @@ An epic defines the value, not a single fix, and gives enough shape that issues 
 
 ### Feature
 
-The **Problem** describes what's wrong or missing today from the user's point of view — a concrete scenario if it sharpens it, and why it matters. The **Goal** is what success looks like as user-visible outcome. Keep it problem-first: if you have a solution in mind, put it under **Proposed solution** and explain the reasoning — otherwise leave it open.
+The **Problem** describes what's wrong or missing today from the user's point of view — a concrete scenario if it sharpens it, and why it matters. The **Goal** is what success looks like as user-visible outcome. The **User Stories** break the goal into the concrete things different users want to do and why. Keep it problem-first: if you have a solution in mind, put it under **Proposed solution** and explain the reasoning — otherwise leave it open.
 
 ```markdown
 **Title:** <short, declarative>
@@ -78,6 +78,12 @@ The **Problem** describes what's wrong or missing today from the user's point of
 
 <What success looks like — the user-visible outcome, not the mechanism.>
 
+## User Stories
+
+<The value from each user's perspective, in the form "As a <role>, I want <capability> so that <benefit>." One per distinct need. For example: "As an operator, I want to see a schedule's last run status so that I can tell at a glance whether it's healthy.">
+
+- As a <role>, I want <capability> so that <benefit>.
+
 ## Scope
 
 <optional — what's included and what's not>
@@ -86,13 +92,13 @@ The **Problem** describes what's wrong or missing today from the user's point of
 
 <optional — the shape of a solution, if you have one. State it only if you show why, so others can reach the same conclusion; otherwise leave it open and let discussion get there.>
 
-## Notes
-
-<optional — constraints, research, designs, technical considerations, dependencies, out of scope>
-
 ## Open Questions
 
 <optional — decisions the team needs to make>
+
+## Additional resources
+
+<optional — links to designs, research, related issues, docs, or other supporting material>
 ```
 
 ### Task
@@ -151,7 +157,7 @@ Lead with observed vs. expected behavior. Reproduction steps should be minimal a
 
 ### Research Task
 
-A research task defines what we need to learn and why, before committing to build. The value is the knowledge it produces.
+A research task defines what we need to learn and why, before committing to build. The value is the knowledge it produces, so it's done when it produces an answer someone can act on — not when "research happened."
 
 ```markdown
 **Title:** <short, declarative — the question, not the answer>
@@ -163,21 +169,29 @@ A research task defines what we need to learn and why, before committing to buil
 
 ## Research Goal
 
-<What we want to learn.>
+<What we want to learn, in one or two sentences.>
 
 ## Research Questions
 
-- <what this research should answer>
-
-## Sources of Insight
-
-- <how we'll gather evidence: interviews, analytics, competitive research, support data, existing research>
+- <the specific questions this research must answer>
 
 ## Users / Audience
 
 <Who or what we're learning about.>
 
-## Considerations
+## Sources of Insight
 
-<optional — constraints, assumptions, existing insights, related work>
+- <how we'll gather evidence: interviews, analytics, competitive research, support data, existing research>
+
+## Decision it informs
+
+<What choice or work this research unblocks — why we need the answer now, and what we'll do differently depending on what we find.>
+
+## Done when
+
+<The observable end state — the answer, recommendation, or artifact produced, and where it lands.>
+
+## Additional resources
+
+<optional — links to existing research, related issues, docs, or other supporting material>
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -2,18 +2,23 @@
 
 Shared content guidelines for writing GitHub issues.
 
-A GitHub issue should read like a product ticket, not an engineering plan. The reader should understand **what problem exists** and **what the user-visible outcome of fixing it looks like** — nothing more.
+A GitHub issue should read like a product ticket, not an engineering plan. The reader should understand **what problem exists** and **what success looks like** — enough context to see *why it matters*, without being told *how to build it*.
 
-## Issue types
+On solutions: usually it's best to state the problem and invite discussion. But if you're confident in an outcome, you may state it — as long as you show the reasoning, so someone else can follow it to the same conclusion. The problem to avoid isn't proposing a solution; it's an *unexplained* one that shuts down discussion before it starts.
 
-Decide the type first — it picks the template. Every issue is one of:
+Keep it concise and easy to digest.
 
-- **Epic** — a meaningful chunk of value we want to deliver. Epics are owned by the Product Owner.
-- **Story** — a user-facing improvement: new behavior, or a change the user can see.
-- **Task** — work that needs to happen but isn't user-facing: chores, tooling, upgrades, refactors.
-- **Bug** — something that should work but doesn't.
+## Which type?
 
-Stories, tasks, and bugs can be attached to an epic. If the issue clearly serves an existing epic, suggest it. If nothing fits, leave it out.
+Decide the type first — it picks the template and acts as a signal for what kind of work this is. Every issue is one of:
+
+- **Epic** — coordinate a chunk of value across multiple issues. Owned by the Product Owner.
+- **Feature** — build something a user can see.
+- **Task** — do necessary work a user won't see: chores, tooling, upgrades, refactors.
+- **Bug** — fix something that should work but doesn't.
+- **Research Task** — learn something we don't yet know, before committing to build.
+
+Features, tasks, bugs, and research tasks can attach to an epic. If the issue clearly serves an existing epic, suggest it; if nothing fits, leave it out. Epics have no parent.
 
 ## Style
 
@@ -25,14 +30,18 @@ Stories, tasks, and bugs can be attached to an epic. If the issue clearly serves
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Stories, tasks, and bugs may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed.
+Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed.
 
 ### Epic
 
-An epic body defines the value, not a single fix, and gives enough shape that issues can be attached to it with confidence. It should make sense to anyone on the team. The **Problem** is the most important part — spend the effort there.
+An epic defines the value, not a single fix, and gives enough shape that issues can be attached to it with confidence. It should make sense to anyone on the team. The **Problem** is the most important part — spend the effort there.
 
 ```markdown
-**Title:** <the value delivered, short and declarative>
+**Title:** Epic - <the value delivered, short and declarative>
+
+## Context
+
+<Why we're investing here. What user or business problem led to this.>
 
 ## Problem
 
@@ -40,33 +49,52 @@ An epic body defines the value, not a single fix, and gives enough shape that is
 
 ## Goal
 
-<The chunk of value this epic delivers. Who benefits and how.>
+<The outcome we want. Who benefits and how.>
+
+## Scope
+
+<What's included and what's not.>
+
+## Open Questions
+
+<Key decisions or unknowns.>
 ```
 
-### Story
+### Feature
 
-The **Problem** describes what's wrong or missing today, from the user's point of view — include a concrete scenario if it sharpens it, and explain *why it matters*. The **Proposed solution** is the high-level shape of the fix as user-visible behavior ("the agent can do X", "the UI shows Y"), not the mechanism.
+The **Problem** describes what's wrong or missing today from the user's point of view — a concrete scenario if it sharpens it, and why it matters. The **Goal** is what success looks like as user-visible outcome. Keep it problem-first: if you have a solution in mind, put it under **Proposed solution** and explain the reasoning — otherwise leave it open.
 
 ```markdown
 **Title:** <short, declarative>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
+## Context
+
+<Why we're doing this. What led here.>
+
 ## Problem
 
 <What's wrong or missing today, from the user's perspective. A concrete scenario if it helps. Why it matters.>
 
+## Goal
+
+<What success looks like — the user-visible outcome, not the mechanism.>
+
+## Scope
+
+<optional — what's included and what's not>
+
 ## Proposed solution
 
-<The user-visible shape of the fix. High-level, no mechanism.>
+<optional — the shape of a solution, if you have one. State it only if you show why, so others can reach the same conclusion; otherwise leave it open and let discussion get there.>
 
-### Scope
-<optional — boundaries: what it does and does not cover>
+## Notes
 
-### Dependencies
-<optional — Blocked on #NNN, blocks #NNN>
+<optional — constraints, research, designs, technical considerations, dependencies, out of scope>
 
-### Out of scope
-<optional — deferred things, with a one-line reason each>
+## Open Questions
+
+<optional — decisions the team needs to make>
 ```
 
 ### Task
@@ -77,13 +105,17 @@ A task states the work and what it unblocks. It's the one type where naming engi
 **Title:** <short, declarative>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
-## What
+## Context
 
-<The work to be done, in plain language.>
+<Why this needs doing now.>
 
-## Why
+## Problem
 
-<What it unblocks or improves. Why it's worth doing now.>
+<The work to be done, in plain language, and what it unblocks or improves.>
+
+## Goal
+
+<The outcome we want.>
 
 ## Done when
 
@@ -92,21 +124,62 @@ A task states the work and what it unblocks. It's the one type where naming engi
 
 ### Bug
 
-Lead with observed vs expected behavior. Reproduction steps should be minimal and numbered.
+Lead with observed vs. expected behavior. Reproduction steps should be minimal and numbered.
 
 ```markdown
 **Title:** <short, declarative — the misbehavior, not the suspected cause>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
-## What happens
+## Context
 
-<The observed behavior. A concrete scenario.>
+<Environment, frequency, screenshots, logs, related issues.>
 
-## What should happen
+## Problem
 
-<The expected behavior.>
+<What's broken, and the user impact.>
 
-## Steps to reproduce
+## Expected Behavior
+
+<What should happen.>
+
+## Actual Behavior
+
+<What happens instead.>
+
+## Steps to Reproduce
 
 1. <minimal, numbered steps>
+```
+
+### Research Task
+
+A research task defines what we need to learn and why, before committing to build. The value is the knowledge it produces.
+
+```markdown
+**Title:** <short, declarative — the question, not the answer>
+**Epic:** <#NNN — epic title, if one clearly fits>
+
+## Context
+
+<Why we're researching this. What decision or problem led here.>
+
+## Research Goal
+
+<What we want to learn.>
+
+## Research Questions
+
+- <what this research should answer>
+
+## Sources of Insight
+
+- <how we'll gather evidence: interviews, analytics, competitive research, support data, existing research>
+
+## Users / Audience
+
+<Who or what we're learning about.>
+
+## Considerations
+
+<optional — constraints, assumptions, existing insights, related work>
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -4,8 +4,6 @@ Shared content guidelines for writing GitHub issues.
 
 A GitHub issue should read like a product ticket, not an engineering plan. The reader should understand **what problem exists** and **what success looks like** — enough context to see *why it matters*, without being told *how to build it*.
 
-On solutions: usually it's best to state the problem and invite discussion. But if you're confident in an outcome, you may state it — as long as you show the reasoning, so someone else can follow it to the same conclusion. The problem to avoid isn't proposing a solution; it's an *unexplained* one that shuts down discussion before it starts.
-
 Keep it concise and easy to digest.
 
 ## Which type?


### PR DESCRIPTION
## What

Reworks `issue-guidelines.md` and the two issue skills.

**Types** (four → five):
- **Story → Feature**, reframed problem-first. "Proposed solution" is now optional and gated on explaining why.
- **+ Research Task** for learning work (Research Goal / Questions / Sources of Insight).
- Epic, Task, Bug kept.

**Templates** — every template leads with **Context**; section names made consistent (Task: What/Why → Problem/Goal; Bug: added Expected/Actual).

**Guidance** — new "Which type?" signal guide; intro states the philosophy (context over prescription; solutions allowed only with reasoning).

**Skills** — `draft-issue` / `file-issue` updated to the five types.