### PR TITLE
feat(ui): complete the knowledge bases page copy

### DIFF
--- a/docs/architecture/knowledge-bases.md
+++ b/docs/architecture/knowledge-bases.md
@@ -1,6 +1,6 @@
 # Knowledge Bases
 
-Last verified: 2026-07-28
+Last verified: 2026-07-29
 
 ## Overview
 
@@ -23,7 +23,7 @@ The module has no persistence of its own: a Knowledge Base is exactly the owner'
 
 ## UI
 
-Knowledge Bases is a feature-gated destination ([features](features.md)) with a list and a **standalone per-KB page** — the chat surface under the knowledge base's own route, so the rail keeps the Knowledge Bases context and leaving returns to the KB list, never to Sandboxes. Creation is **not** its own form: it is the `knowledge-base` starting point on the shared [sandbox wizard](agent-lifecycle.md)'s first step, which pins the Claude Code harness, hides it, and reveals the KB Template picker; the wizard's finish dispatches to this module's create. The KB list's own "New knowledge base" button enters that wizard with the starting point pre-picked.
+Knowledge Bases is a feature-gated destination ([features](features.md)) with a list and a **standalone per-KB page** — the chat surface under the knowledge base's own route, so the rail keeps the Knowledge Bases context and leaving returns to the KB list, never to Sandboxes. Creation is **not** its own form: it is the `knowledge-base` starting point on the shared [sandbox wizard](agent-lifecycle.md)'s first step, which pins the Claude Code harness, hides it, and reveals the KB Template picker; the wizard's finish dispatches to this module's create. The KB list's own create button enters that wizard with the starting point pre-picked.
 
 Opening a KB that has no sessions yet **greets the user**: the UI runs `/wiki-onboard` as a hidden first turn (reaches the agent, renders no user bubble, fails silently), so a fresh KB opens with the agent introducing itself rather than an empty chat. This is why every template's bootstrap installs that command. The greeting mechanism is shared with experiments.
 

--- a/packages/ui/src/components/ui/page-header.tsx
+++ b/packages/ui/src/components/ui/page-header.tsx
@@ -38,7 +38,7 @@ export function PageHeader({
           </div>
         )}
         {description && (
-          <p className="order-2 mt-1 text-[14px] text-muted-foreground @lg:order-3 @lg:w-full">
+          <p className="order-2 mt-1 text-[14px] text-balance text-muted-foreground @lg:order-3 @lg:w-full">
             {description}
           </p>
         )}

--- a/packages/ui/src/modules/knowledge-bases/lib/kb-templates.ts
+++ b/packages/ui/src/modules/knowledge-bases/lib/kb-templates.ts
@@ -14,13 +14,13 @@ export const KB_TEMPLATES: readonly KbTemplate[] = [
     id: "llm-wiki",
     name: "LLM Wiki",
     description:
-      "Installs the LLM Wiki toolkit and keeps an interlinked, self-maintaining knowledge wiki as you feed it sources.",
+      "Structured wiki with a knowledge graph, from the llm-wiki toolkit.",
   },
   {
     id: "plain-wiki",
     name: "Plain Wiki",
     description:
-      "No toolkit — the agent reads your files as knowledge and keeps what it learns as plain markdown notes. Works offline.",
+      "Lightweight — the agent asks for files and organizes them for you. Works offline.",
   },
 ];
 

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
@@ -32,9 +32,14 @@ export function KnowledgeBasesListView() {
     <div>
       <PageHeader
         title="Knowledge bases"
+        description={
+          knowledgeBases.length > 0
+            ? "A knowledge base is a sandbox that builds and maintains a wiki in its workspace. Open one to work with it in chat — ask questions and add to it."
+            : undefined
+        }
         actions={
           knowledgeBases.length > 0 ? (
-            <Button onClick={createKnowledgeBase}>New knowledge base</Button>
+            <Button onClick={createKnowledgeBase}>Create knowledge base</Button>
           ) : undefined
         }
       />
@@ -44,8 +49,8 @@ export function KnowledgeBasesListView() {
       {initialLoaded && knowledgeBases.length === 0 && (
         <PageEmptyState
           title="No knowledge bases yet"
-          message="A knowledge base is an agent that builds and maintains a body of knowledge for you. Create one and it sets itself up."
-          actionLabel="New knowledge base"
+          message="A knowledge base is a sandbox that builds and maintains a wiki you can chat with. Point it at a repo or docs, or add knowledge as you go. Create a sandbox with the knowledge base preset to get started."
+          actionLabel="Create knowledge base"
           onAction={createKnowledgeBase}
         />
       )}

--- a/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/starting-point-step.tsx
@@ -74,7 +74,7 @@ export function StartingPointStep({
             startingPoint="experiment"
             icon={FlaskConical}
             name="Experiment sandbox"
-            description="A Claude Code sandbox with the experiment authoring skill installed. It runs one goal across several variants at once and charts each result live, so you can compare them."
+            description="A Claude Code sandbox with the experiment skill preloaded. It runs one goal across several variants at once, charting each result live so you can compare them."
             selected={startingPoint === "experiment"}
             onSelect={() => onPickStartingPoint("experiment")}
           />
@@ -84,7 +84,7 @@ export function StartingPointStep({
             startingPoint="knowledge-base"
             icon={Library}
             name="Knowledge base sandbox"
-            description="A Claude Code sandbox that builds and maintains a body of knowledge you can chat with. Feed it a repo or your docs, or add to it as you go."
+            description="A Claude Code sandbox that builds and maintains a wiki. Ask questions in chat, add knowledge as you go, or point it at a repo or docs."
             selected={startingPoint === "knowledge-base"}
             onSelect={() => onPickStartingPoint("knowledge-base")}
           />
@@ -93,7 +93,7 @@ export function StartingPointStep({
           startingPoint="specialized"
           icon={Puzzle}
           name="Specialized sandbox"
-          description="An image already built for one particular task — optimizers, research harnesses, and more."
+          description="A sandbox already built for one particular task — optimizers, research harnesses, and more."
           selected={startingPoint === "specialized"}
           onSelect={() => onPickStartingPoint("specialized")}
         />
@@ -101,7 +101,7 @@ export function StartingPointStep({
           startingPoint="general-purpose"
           icon={Boxes}
           name="General-purpose sandbox"
-          description="A capable coding agent with no preset — code, research, ops, or anything else. Pick the harness to start from."
+          description="A capable agent with no preset — code, research, ops, or anything else. Pick a harness to start."
           selected={startingPoint === "general-purpose"}
           onSelect={() => onPickStartingPoint("general-purpose")}
         />
@@ -147,7 +147,7 @@ function StartingPointReveal({
   if (snapshot.startingPoint === "knowledge-base") {
     return (
       <section className="anim-in">
-        <SectionLabel spaced>Template</SectionLabel>
+        <SectionLabel spaced>Choose a template</SectionLabel>
         <CardList>
           {KB_TEMPLATES.map((template) => (
             <KbTemplateCard


### PR DESCRIPTION
Closes #2998

The Knowledge bases page now explains itself. A populated list carries a description under the header, and both create buttons read "Create knowledge base" — what the creation flow already calls itself once you're in it.

The empty state says what a knowledge base actually is: a sandbox that builds and maintains a wiki you can chat with, which you point at a repo or docs, or add to as you go. Previously it described a vaguer "body of knowledge" and called it an agent rather than a sandbox.

Step 1 of sandbox creation picks up the card copy from its own design (#2999) — that issue's closing PR deliberately left card descriptions for later, so a knowledge base was described one way there and another way on its own page. Both now match, and the template picker labels itself like the other choices in that step.

Two small departures from the mockups, both to keep the copy true: the empty state says you *point* a knowledge base at a repo rather than *sync* it to one, since there is no sync mechanism, and the LLM Wiki template is described as a toolkit rather than a skill, which is what it is.

Page-header descriptions are also balanced now, so one that wraps splits into even lines instead of filling the width and stranding a short tail.