### PR TITLE
fix(agents): describe opus as Opus 5 in the claude-code model list

### DIFF
--- a/packages/agents/claude-code/runtime-manifest.yaml
+++ b/packages/agents/claude-code/runtime-manifest.yaml
@@ -24,7 +24,7 @@ drivers:
               description: "Fable 5 · Most capable for the hardest, longest-running tasks"
             - value: opus
               name: "Opus (recommended)"
-              description: "Opus 4.8 · Best for everyday, complex tasks"
+              description: "Opus 5 · Best for everyday, complex tasks"
             - value: sonnet
               name: "Sonnet"
               description: "Sonnet 4.6 · Efficient for routine tasks"


### PR DESCRIPTION
## Summary

The Claude Code `opus` alias now resolves to Opus 5, but the model picker's Opus choice in `packages/agents/claude-code/runtime-manifest.yaml` still described it as "Opus 4.8". This updates the description to "Opus 5" so the picker matches the model the agent actually gets.

Fixes #3048