### PR TITLE
fix(keycloak-theme): use ibm.biz/dam-docs short link on login page

### DIFF
--- a/packages/keycloak-theme/src/constants.ts
+++ b/packages/keycloak-theme/src/constants.ts
@@ -1,1 +1,1 @@
-export const LOGIN_DOCS_URL = "https://pages.github.ibm.com/dam-agents/docs/";
+export const LOGIN_DOCS_URL = "https://ibm.biz/dam-docs";


### PR DESCRIPTION
The login page linked the docs URL directly, so docs traffic originating from sign-in wasn't tracked. Point it at the short link, which redirects to the same destination.