### PR TITLE
fix(ui): show private registry section whenever Custom is selected

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
@@ -17,7 +17,7 @@ interface Props {
   selected: boolean;
   onChange: (value: string) => void;
   onSubmit: () => void;
-  /** Pull-credential controls; present once a custom image is entered. */
+  /** Pull-credential controls; present whenever Custom is the starting point. */
   registry?: RegistryControls;
 }
 

--- a/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-wizard-view.tsx
@@ -63,8 +63,7 @@ export function SandboxWizardView() {
   const [registryCredential, setRegistryCredential] = useState(
     EMPTY_REGISTRY_CREDENTIAL,
   );
-  const isCustomImage =
-    !snapshot.templateId && snapshot.customImage.trim().length > 0;
+  const isCustomImage = snapshot.startingPoint === "custom";
 
   const imageLabel = useMemo(() => {
     // The image is pinned and hidden on these paths — name the kind instead.


### PR DESCRIPTION
## Problem

On the Custom image step, the collapsed "Private registry" trigger only rendered once the image address field had at least one character. Typing a single letter made it appear; clearing the field made it vanish.

The gate was `isCustomImage`, which required a non-empty image:

```ts
const isCustomImage = !snapshot.templateId && snapshot.customImage.trim().length > 0;
```

Two problems with that:

- The section is collapsed anyway, so hiding it buys no simplicity while making the layout shift as you type.
- It hides the information at the moment it is most useful. If you are about to paste a private image address, knowing credentials are supported is part of deciding what to paste.

## Change

Gate on Custom being the starting point instead:

```ts
const isCustomImage = snapshot.startingPoint === "custom";
```

The section stays collapsed by default, so this only affects whether the one-line trigger is present. `startingPointDefaults` nulls `templateId` on the custom path, so the dropped `!snapshot.templateId` check was redundant.

Also fixes an edge case by construction: credentials live in ephemeral state rather than the persisted snapshot, and `registryPartial` blocks advancing when 1 or 2 of 3 fields are filled. Previously the section could unmount while that state survived, so partially filled credentials could block Continue with no visible fields to correct. Always rendering the section makes that unreachable.

## Notes

`finish()` still guards submission on `!!image` independently, so widening this does not let credentials be sent without an image address.

Not typechecked locally, leaving that to CI.