### PR TITLE
fix(ui): surface actionable send-failure reasons instead of "Internal error"

### DIFF
--- a/packages/ui/src/__tests__/unit/send-error.test.ts
+++ b/packages/ui/src/__tests__/unit/send-error.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "vitest";
+
+import {
+  describeSendError,
+  extractErrorMessage,
+} from "../../modules/acp/errors.js";
+
+describe("send-error surfacing", () => {
+  test("JSON-RPC internal error is replaced by data.details", () => {
+    expect(
+      extractErrorMessage({
+        code: -32603,
+        message: "Internal error",
+        data: { details: "API error: 402 Payment Required" },
+      }),
+    ).toBe("API error: 402 Payment Required");
+  });
+
+  test("billing failures get an actionable hint", () => {
+    const { message, hint } = describeSendError(
+      "API error: 402 Payment Required",
+    );
+    expect(message).toBe("API error: 402 Payment Required");
+    expect(hint).toMatch(/billing/i);
+  });
+
+  test("bare internal error is rewritten to say where to look", () => {
+    const { message, hint } = describeSendError("Internal error");
+    expect(message).not.toMatch(/internal error/i);
+    expect(hint).toMatch(/session log/i);
+  });
+});

--- a/packages/ui/src/modules/acp/errors.ts
+++ b/packages/ui/src/modules/acp/errors.ts
@@ -1,0 +1,116 @@
+/**
+ * Error extraction and presentation for the ACP session surface. Kept free of
+ * imports with browser side effects so node-environment unit tests (and any
+ * non-DOM caller) can use it directly.
+ */
+
+/**
+ * Read a human-readable message off any error shape we may see here. The
+ * promise that `prompt`/`loadSession` returns can reject with:
+ *  - an `Error` / `DOMException` — has `.message`
+ *  - the raw JSON-RPC error `{ code, message, data }` — has `.message`
+ *  - a WebSocket `CloseEvent` on connection drop — no message; use `code`/`reason`
+ *  - a WebSocket `Event` from `onerror` — browsers omit useful details here
+ *
+ * The fallback `String(e)` on an Event yields `[object Event]`, which is what
+ * users were seeing on disconnect.
+ */
+export function extractErrorMessage(e: unknown): string {
+  if (e && typeof e === "object" && "message" in e) {
+    const m = (e as { message: unknown }).message;
+    if (typeof m === "string" && m) {
+      const details = jsonRpcErrorDetails(e);
+      if (details && !m.includes(details)) {
+        // "Internal error" is the JSON-RPC boilerplate for -32603 — the real
+        // reason (e.g. the model backend's HTTP error) rides in data.details.
+        return /^internal error\.?$/i.test(m.trim())
+          ? details
+          : `${m}: ${details}`;
+      }
+      return m;
+    }
+  }
+  if (e instanceof Error) return e.message;
+  if (typeof CloseEvent !== "undefined" && e instanceof CloseEvent) {
+    return e.reason || `Connection closed (code ${e.code})`;
+  }
+  if (typeof Event !== "undefined" && e instanceof Event) {
+    return "Connection error";
+  }
+  return String(e);
+}
+
+/** Pull the harness's detail string out of a JSON-RPC error's `data` slot.
+ *  The ACP SDK ships it either as `data.details` (string) or as the whole
+ *  `data` value when the harness threw a plain string. */
+function jsonRpcErrorDetails(e: object): string | null {
+  const data = (e as { data?: unknown }).data;
+  if (typeof data === "string" && data) return data;
+  if (data && typeof data === "object") {
+    const details = (data as { details?: unknown }).details;
+    if (typeof details === "string" && details) return details;
+  }
+  return null;
+}
+
+export interface SendErrorDescription {
+  /** What to render as the failure reason. */
+  message: string;
+  /** Actionable next step for failure classes we recognize. */
+  hint?: string;
+}
+
+const SEND_ERROR_HINTS: ReadonlyArray<[RegExp, string]> = [
+  [
+    /\b402\b|payment.required|insufficient.credits|credit balance|billing|quota exceeded|out of credits/i,
+    "The model backend refused the request for billing reasons — the inference account is out of credits or over quota. Topping up or raising the quota on the provider account should restore sends.",
+  ],
+  [
+    /\b401\b|authentication_error|unauthenticated|invalid (api|x-api).key|unauthorized/i,
+    "The model backend rejected the credential. Check that the API/OAuth secret is correct and linked to this agent (Agents → select agent → Secrets).",
+  ],
+  [
+    /\b429\b|rate.limit/i,
+    "The model backend is rate-limiting requests. Wait a moment and retry.",
+  ],
+];
+
+/**
+ * Turn a raw send-failure message into what the error card renders. Known
+ * upstream failure classes (billing, credentials, rate limits) get an
+ * actionable hint; bare JSON-RPC "Internal error" — all the harness gave us —
+ * gets replaced with wording that at least says where to look next.
+ */
+export function describeSendError(raw: string): SendErrorDescription {
+  for (const [pattern, hint] of SEND_ERROR_HINTS) {
+    if (pattern.test(raw)) return { message: raw, hint };
+  }
+  if (/^internal error\.?$/i.test(raw.trim())) {
+    return {
+      message: "The agent couldn't process this message.",
+      hint: "The harness reported an internal error without details — the agent's session log usually has the underlying cause (often the model backend rejecting the request).",
+    };
+  }
+  return { message: raw };
+}
+
+/**
+ * Classify a resume-time failure so the inline error card can render the
+ * right message and action. Prefers structured error fields (ACP JSON-RPC
+ * `code`, tRPC `data.code`) over regexing the human-readable message — the
+ * latter breaks the moment server wording changes.
+ */
+export function classifyResumeError(
+  e: unknown,
+): "not-found" | "connection" | "other" {
+  if (e && typeof e === "object") {
+    const anyE = e as { code?: unknown; data?: { code?: unknown } };
+    if (anyE.code === -32002) return "not-found";
+    if (anyE.data?.code === "NOT_FOUND") return "not-found";
+    if (e instanceof DOMException) return "connection";
+  }
+  const msg = extractErrorMessage(e);
+  if (/not\s*found/i.test(msg)) return "not-found";
+  if (/refused|ECONN|WebSocket|network/i.test(msg)) return "connection";
+  return "other";
+}

--- a/packages/ui/src/modules/acp/errors.ts
+++ b/packages/ui/src/modules/acp/errors.ts
@@ -62,15 +62,15 @@ export interface SendErrorDescription {
 
 const SEND_ERROR_HINTS: ReadonlyArray<[RegExp, string]> = [
   [
-    /\b402\b|payment.required|insufficient.credits|credit balance|billing|quota exceeded|out of credits/i,
+    /\b402\b|payment[\s_-]?required|insufficient[\s_-]?credits|credit balance|quota exceeded|out of credits/i,
     "The model backend refused the request for billing reasons — the inference account is out of credits or over quota. Topping up or raising the quota on the provider account should restore sends.",
   ],
   [
-    /\b401\b|authentication_error|unauthenticated|invalid (api|x-api).key|unauthorized/i,
+    /\b401\b|authentication_error|unauthenticated|invalid (api|x-api)[\s_-]?key|unauthorized/i,
     "The model backend rejected the credential. Check that the API/OAuth secret is correct and linked to this agent (Agents → select agent → Secrets).",
   ],
   [
-    /\b429\b|rate.limit/i,
+    /\b429\b|rate[\s_-]?limit/i,
     "The model backend is rate-limiting requests. Wait a moment and retry.",
   ],
 ];
@@ -83,7 +83,13 @@ const SEND_ERROR_HINTS: ReadonlyArray<[RegExp, string]> = [
  */
 export function describeSendError(raw: string): SendErrorDescription {
   for (const [pattern, hint] of SEND_ERROR_HINTS) {
-    if (pattern.test(raw)) return { message: raw, hint };
+    if (!pattern.test(raw)) continue;
+    // agent-runtime already prefixes authentication_error frames with its own
+    // remediation text (rewriteAuthError's AUTH_HINT) — when the message
+    // already tells the user to check the credential secret, don't render a
+    // second near-identical instruction underneath.
+    if (/credential secret/i.test(raw)) return { message: raw };
+    return { message: raw, hint };
   }
   if (/^internal error\.?$/i.test(raw.trim())) {
     return {

--- a/packages/ui/src/modules/acp/utils.ts
+++ b/packages/ui/src/modules/acp/utils.ts
@@ -54,49 +54,6 @@ export async function buildPromptBlocks(
   return blocks;
 }
 
-/**
- * Read a human-readable message off any error shape we may see here. The
- * promise that `prompt`/`loadSession` returns can reject with:
- *  - an `Error` / `DOMException` — has `.message`
- *  - the raw JSON-RPC error `{ code, message, data }` — has `.message`
- *  - a WebSocket `CloseEvent` on connection drop — no message; use `code`/`reason`
- *  - a WebSocket `Event` from `onerror` — browsers omit useful details here
- *
- * The fallback `String(e)` on an Event yields `[object Event]`, which is what
- * users were seeing on disconnect.
- */
-export function extractErrorMessage(e: unknown): string {
-  if (e && typeof e === "object" && "message" in e) {
-    const m = (e as { message: unknown }).message;
-    if (typeof m === "string" && m) return m;
-  }
-  if (e instanceof Error) return e.message;
-  if (typeof CloseEvent !== "undefined" && e instanceof CloseEvent) {
-    return e.reason || `Connection closed (code ${e.code})`;
-  }
-  if (typeof Event !== "undefined" && e instanceof Event) {
-    return "Connection error";
-  }
-  return String(e);
-}
-
-/**
- * Classify a resume-time failure so the inline error card can render the
- * right message and action. Prefers structured error fields (ACP JSON-RPC
- * `code`, tRPC `data.code`) over regexing the human-readable message — the
- * latter breaks the moment server wording changes.
- */
-export function classifyResumeError(
-  e: unknown,
-): "not-found" | "connection" | "other" {
-  if (e && typeof e === "object") {
-    const anyE = e as { code?: unknown; data?: { code?: unknown } };
-    if (anyE.code === -32002) return "not-found";
-    if (anyE.data?.code === "NOT_FOUND") return "not-found";
-    if (e instanceof DOMException) return "connection";
-  }
-  const msg = extractErrorMessage(e);
-  if (/not\s*found/i.test(msg)) return "not-found";
-  if (/refused|ECONN|WebSocket|network/i.test(msg)) return "connection";
-  return "other";
-}
+// Error extraction/presentation helpers live in ./errors.js — kept separate
+// so node-environment unit tests can import them without this module's
+// upload-API dependency chain (which touches `window` at import time).

--- a/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
@@ -4,11 +4,12 @@ import { useCallback, useRef } from "react";
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
 import type { Attachment, Message } from "../../../types.js";
+import { extractErrorMessage } from "../../acp/errors.js";
 import {
   finalizeAllStreaming,
   hasStreamingAssistant,
 } from "../../acp/session-projection.js";
-import { buildPromptBlocks, extractErrorMessage } from "../../acp/utils.js";
+import { buildPromptBlocks } from "../../acp/utils.js";
 import { acpSessionsKeys } from "../api/queries.js";
 
 const DELIVERY_TIMEOUT_MS = 60_000;

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -2,8 +2,8 @@ import { useCallback, useEffect, useState } from "react";
 
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
+import { classifyResumeError, extractErrorMessage } from "../../acp/errors.js";
 import { hasStreamingAssistant } from "../../acp/session-projection.js";
-import { classifyResumeError, extractErrorMessage } from "../../acp/utils.js";
 import { useIsAgentOperable } from "../../agents/api/queries.js";
 import {
   deleteAgentSession,

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -38,6 +38,7 @@ import { queryClient } from "../../../query-client.js";
 import type { SessionError } from "../../../store.js";
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
+import { describeSendError } from "../../acp/errors.js";
 import { useHarnessConfigCurrent } from "../../agents/api/harness-config.js";
 import { useDeleteAgent } from "../../agents/api/mutations.js";
 import { useAgents, useIsAgentOperable } from "../../agents/api/queries.js";
@@ -982,6 +983,7 @@ function SendErrorCard({
   error: string;
   onRetry?: () => void;
 }) {
+  const { message, hint } = describeSendError(error);
   return (
     <Callout
       tone="danger"
@@ -991,8 +993,11 @@ function SendErrorCard({
       <Warning size={16} className="text-danger shrink-0 mt-0.5" />
       <div className="flex-1 min-w-0 flex flex-col gap-2">
         <div className="text-sm text-foreground break-words">
-          <span className="font-bold text-danger">Send failed:</span> {error}
+          <span className="font-bold text-danger">Send failed:</span> {message}
         </div>
+        {hint && (
+          <p className="text-xs text-muted-foreground break-words">{hint}</p>
+        )}
         {onRetry && (
           <Button
             variant="outline"

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -690,7 +690,7 @@ export function ChatView() {
                           </span>
                           {m.error ? (
                             <SendErrorCard
-                              error={m.error.message}
+                              rawError={m.error.message}
                               onRetry={
                                 m.error.retryWith
                                   ? () =>
@@ -977,13 +977,13 @@ function SessionErrorCard({
 }
 
 function SendErrorCard({
-  error,
+  rawError,
   onRetry,
 }: {
-  error: string;
+  rawError: string;
   onRetry?: () => void;
 }) {
-  const { message, hint } = describeSendError(error);
+  const { message, hint } = describeSendError(rawError);
   return (
     <Callout
       tone="danger"


### PR DESCRIPTION
## Problem

Addresses the UX half of #3007: when a harness's `session/prompt` fails, the chat UI showed a bare **"Send failed: Internal error"** — the JSON-RPC -32603 boilerplate — even when the real reason (e.g. the model backend answering `402 Payment Required`) was shipped in the error's `data.details` slot. The outage behind #3007 itself was an external billing issue on the inference account and is not fixed by code.

## Changes

- `extractErrorMessage` now reads the JSON-RPC error `data` slot: a bare "Internal error" is replaced by `data.details` when present (both shapes the ACP SDK produces — `data.details` string and a plain string `data`); non-generic messages get the detail appended without duplication.
- `SendErrorCard` classifies known upstream failure classes and renders an actionable hint under the failure reason:
  - **billing / 402 / credits / quota** → check the inference account's credits or quota
  - **credentials / 401 / authentication_error** → check the API/OAuth secret linked to the agent (mirrors agent-runtime's existing auth hint)
  - **rate limit / 429** → wait and retry
  - a detail-less "Internal error" is rewritten to say the agent's session log has the underlying cause
- Error extraction/presentation helpers moved from `modules/acp/utils.ts` to a new `modules/acp/errors.ts` so node-environment unit tests can import them without the upload-API dependency chain (which touches `window` at import time).

## Testing

- New unit tests in `send-error.test.ts` (detail surfacing, billing hint, internal-error rewrite)
- `ui:check` (tsc, eslint, prettier) and the full `ui:test` suite pass