### PR TITLE
fix(controller)!: unprivileged storage migration, off by default, self-releasing when disabled

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1038,15 +1038,15 @@ controller:
   # available until the controller stops logging migrations, then decommission
   # it.
   #
-  # DISABLED by default: draining a fleet is an operator decision, and the
-  # copy's success depends on the install's storage semantics (root squash,
-  # ext4 artifacts, a Kata runtime class). Enable it deliberately — ideally
-  # with `concurrency: 1` for the first agent — and watch the controller log.
-  # Turning it back off is safe at any point: the manager releases every agent
-  # it had gated, bins the half-copied targets, and leaves each agent on the
-  # volume it started from.
+  # Enabled by default: the fleet drains itself on upgrade with no owner
+  # action, which is the point. Turning it off is safe at any point and is the
+  # escape hatch if an install's storage semantics (root squash, foreign file
+  # ownership, an unexpected class) stall the copy — a disabled manager
+  # releases every agent it had gated, bins the half-copied targets, and
+  # leaves each agent on the volume it started from. Watch the controller log
+  # through the first drain; `concurrency: 1` makes that easy to follow.
   storageMigration:
-    enabled: false
+    enabled: true
     # -- How many agents migrate at once. Each migration reads its source
     # volume in full three times (copy + two verification passes); this cap
     # is the trade between fleet drain time and read pressure on the shared

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1031,13 +1031,22 @@ controller:
   # -- One-time RWX -> RWO workspace-volume migration (#2988). For every agent
   # whose workspace PVC is still ReadWriteMany the controller forces the agent
   # down, copies the volume onto a fresh ReadWriteOnce PVC in a Job
-  # (checksum-verified), re-points the StatefulSet, deletes the old volume,
-  # and restores the agent's prior run state. Interrupt-safe and resumable; a
-  # no-op once no RWX workspace volume remains. Keep the old storage backend
-  # (e.g. nfsProvisioner, or your managed shared filesystem) available until
-  # the controller stops logging migrations, then decommission it.
+  # (content- and metadata-verified), re-points the StatefulSet, deletes the
+  # old volume, and restores the agent's prior run state. Interrupt-safe and
+  # resumable; a no-op once no RWX workspace volume remains. Keep the old
+  # storage backend (e.g. nfsProvisioner, or your managed shared filesystem)
+  # available until the controller stops logging migrations, then decommission
+  # it.
+  #
+  # DISABLED by default: draining a fleet is an operator decision, and the
+  # copy's success depends on the install's storage semantics (root squash,
+  # ext4 artifacts, a Kata runtime class). Enable it deliberately — ideally
+  # with `concurrency: 1` for the first agent — and watch the controller log.
+  # Turning it back off is safe at any point: the manager releases every agent
+  # it had gated, bins the half-copied targets, and leaves each agent on the
+  # volume it started from.
   storageMigration:
-    enabled: true
+    enabled: false
     # -- How many agents migrate at once. Each migration reads its source
     # volume in full three times (copy + two verification passes); this cap
     # is the trade between fleet drain time and read pressure on the shared
@@ -1045,13 +1054,22 @@ controller:
     concurrency: 10
     # -- Reconcile pass interval.
     interval: "30s"
-    # -- Image for the copy Job. Needs POSIX sh + GNU coreutils (cp -a that
-    # preserves hard links, find, md5sum) — busybox-based images inflate
-    # hard-link-heavy workspaces (pnpm stores) past the volume size.
-    # The Job runs as the agent uid (from controller.agent.base
-    # containerSecurityContext.runAsUser), never root, so it works on
-    # root-squashing shared-filesystem classes: a workspace is single-owner
-    # by construction, and its own uid can read everything in it.
+    # -- Accept ownership normalization when the source workspace holds
+    # entries owned by a uid other than the agent's (root-written residue
+    # from an older release, a squashed-root `nobody` file). The copy is
+    # unprivileged, so it recreates them as the agent uid rather than
+    # preserving the original owner. Default false: such entries are
+    # reported with their paths and block that agent's migration, so the
+    # decision is yours — chown them on the source, or set this.
+    allowOwnershipRemap: false
+    # -- Image for the copy Job. Needs bash, GNU tar and GNU coreutils
+    # (find -printf, md5sum) — busybox-based images lack the flags the copy
+    # and its verification rely on.
+    # The Job is unprivileged: it runs as the agent uid (from
+    # controller.agent.base containerSecurityContext.runAsUser) and needs no
+    # capabilities, so it works under a restricted SCC and on root-squashing
+    # shared-filesystem classes alike. It also deliberately does NOT inherit
+    # the agents' runtimeClassName: it runs platform tooling, not agent code.
     jobImage: mirror.gcr.io/library/debian:stable-slim
   replicas: 1
   # -- Image for the Envoy credential-injector sidecar.

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -247,9 +247,9 @@ type StorageMigration struct {
 	// the migration, so an operator decides rather than discovering the
 	// remap later.
 	AllowOwnershipRemap bool `json:"allowOwnershipRemap,omitempty"`
-	// JobImage runs the copy script. It must provide a POSIX sh with GNU
-	// coreutils (cp -a preserving hard links, find, md5sum) — busybox images
-	// break hard-link-heavy workspaces (pnpm stores) by inflating them past
-	// the volume size.
+	// JobImage runs the copy script. It must provide bash, GNU tar and GNU
+	// coreutils (find -printf, md5sum): the copy relies on tar's hard-link
+	// and sparse handling — a hard-link-heavy store (pnpm) would otherwise
+	// inflate past the volume size — and the verification on find -printf.
 	JobImage string `json:"jobImage,omitempty"`
 }

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -238,6 +238,15 @@ type StorageMigration struct {
 	// Interval between reconcile passes. Zero falls back to a built-in
 	// default.
 	Interval Duration `json:"interval,omitempty"`
+	// AllowOwnershipRemap lets the copy proceed when the source workspace
+	// holds entries owned by a uid other than the agent's. The copy is
+	// unprivileged (chown is unavailable under a restricted SCC and on a
+	// Kata sandbox's virtiofs), so those entries are recreated owned by the
+	// agent uid — a deliberate normalization, not a faithful copy, which is
+	// why it is opt-in. Default false: such entries are reported and block
+	// the migration, so an operator decides rather than discovering the
+	// remap later.
+	AllowOwnershipRemap bool `json:"allowOwnershipRemap,omitempty"`
 	// JobImage runs the copy script. It must provide a POSIX sh with GNU
 	// coreutils (cp -a preserving hard links, find, md5sum) — busybox images
 	// break hard-link-heavy workspaces (pnpm stores) by inflating them past

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -633,10 +633,10 @@ func jobFailed(job *batchv1.Job) bool {
 // (source read-only, target read-write) pair, running a copy + two-pass
 // checksum verification per pair.
 //
-// The copy runs as the AGENT's uid, unprivileged, and needs no capabilities:
-// an agent's workspace is
-// single-owner by construction (everything in it is written as the agent
-// user), so the agent uid can read every file — including 0600 files and
+// The copy runs as the AGENT's uid, unprivileged and needing no
+// capabilities: an agent's workspace is single-owner by construction
+// (everything in it is written as the agent user), so the agent uid can
+// read every file — including 0600 files and
 // 0700 dirs — even on shared-filesystem classes that squash root, where a
 // root-running copy would EACCES on the first private file. Ownership on
 // the target is preserved by construction (the creator is the same uid).
@@ -705,7 +705,7 @@ copy_verify() {
   # controller.storageMigration.allowOwnershipRemap to accept the
   # normalization. Privilege is not an option here: a restricted SCC strips
   # CAP_CHOWN and Kata virtiofs refuses guest chown outright.
-  foreign="$(cd "$src" && find . ! -uid ${AGENT_UID} ! -path ./lost+found | head -20)"
+  foreign="$(cd "$src" && find . ! -uid ${AGENT_UID} ! -path './lost+found*' | head -20)"
   if [ -n "$foreign" ]; then
     if [ "${ALLOW_OWNERSHIP_REMAP}" = "1" ]; then
       echo "note: re-owning these source entries to uid ${AGENT_UID} (allowOwnershipRemap; list may be truncated):"
@@ -753,14 +753,14 @@ copy_verify() {
   # uid:0, while an fsGroup-managed target assigns its own gid — group
   # identity is not part of the workspace contract), the volume root itself,
   # and lost+found.
-  meta() { (cd "$1" && find . -mindepth 1 ! -path ./lost+found -printf "${META_FMT}\n" | LC_ALL=C sort); }
+  meta() { (cd "$1" && find . -mindepth 1 ! -path './lost+found*' -printf "${META_FMT}\n" | LC_ALL=C sort); }
   meta "$src" > /tmp/src.meta
   meta "$dst" > /tmp/dst.meta
   cmp /tmp/src.meta /tmp/dst.meta
   # Pass 2 — content checksums. md5 is deliberate: this is integrity
   # checking of our own quiesced copy, not defense against an adversary
   # crafting collisions — and it is the fastest digest coreutils ships.
-  sums() { (cd "$1" && find . -type f ! -path ./lost+found/\* -print0 | LC_ALL=C sort -z | xargs -0 -r md5sum); }
+  sums() { (cd "$1" && find . -type f ! -path './lost+found*' -print0 | LC_ALL=C sort -z | xargs -0 -r md5sum); }
   sums "$src" > /tmp/src.sum
   sums "$dst" > /tmp/dst.sum
   cmp /tmp/src.sum /tmp/dst.sum

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -121,9 +121,16 @@ func (m *StorageMigrationManager) concurrency() int {
 	return defaultMigrationConcurrency
 }
 
-// RunLoop reconciles until ctx is done. A no-op ticker when disabled.
+// RunLoop reconciles until ctx is done. When disabled it first releases
+// anything a previous run left gated, then stops for good.
 func (m *StorageMigrationManager) RunLoop(ctx context.Context) {
 	if !m.config.StorageMigration.Enabled {
+		// Turning the migration off must never strand an agent: the gate is
+		// a hard-stop-strength negative override that only this manager
+		// clears, so a disabled manager that ignored existing gates would
+		// leave those agents scaled to zero with nothing left to lift them.
+		// Unwind instead — the off switch is an off switch.
+		m.ReleaseGated(ctx)
 		return
 	}
 	slog.Info("storage migration: manager started",
@@ -136,6 +143,72 @@ func (m *StorageMigrationManager) RunLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-t.C:
+		}
+	}
+}
+
+// ReleaseGated unwinds every in-flight migration and lifts its gate, so a
+// disabled (or newly-disabled) migration leaves no agent parked. Two shapes,
+// decided per agent by whether its source volume is still there:
+//
+//   - source still ReadWriteMany -> the copy never completed: bin the copy
+//     Job and the unclaimed target, then lift the gate. The agent comes back
+//     on the volume it never left, byte for byte — nothing was deleted.
+//   - source gone -> the flip already ran: finish its tail (sweep the
+//     superseded source, lift the gate, restore the prior run state).
+//
+// Idempotent, and safe to run at boot: an agent with no gate is skipped.
+func (m *StorageMigrationManager) ReleaseGated(ctx context.Context) {
+	agents, err := m.dynamic.Resource(AgentsGVR).Namespace(m.config.Namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		slog.Warn("storage migration: listing agents to release gates failed", "error", err)
+		return
+	}
+	rwx := map[string]bool{}
+	if pvcs, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: LabelAgent,
+	}); err == nil {
+		for _, p := range pvcs.Items {
+			if isRWX(p.Spec.AccessModes) {
+				rwx[p.Labels[LabelAgent]] = true
+			}
+		}
+	} else {
+		slog.Warn("storage migration: listing PVCs to release gates failed", "error", err)
+		return
+	}
+
+	for i := range agents.Items {
+		agent, err := FromCacheObject[apiv1.Agent](&agents.Items[i])
+		if err != nil || agent.Annotations[annStorageMigration] == "" {
+			continue
+		}
+		if rwx[agent.Name] {
+			// Abandon: the source is intact, so the target is half-copied
+			// garbage. The selector only matches UNCLAIMED targets (a
+			// flipped one carries the agent label instead), so a completed
+			// migration's volume can never be caught here.
+			prop := metav1.DeletePropagationBackground
+			if err := m.client.BatchV1().Jobs(m.config.Namespace).Delete(ctx, migrationJobName(agent.Name),
+				metav1.DeleteOptions{PropagationPolicy: &prop}); err != nil && !errors.IsNotFound(err) {
+				slog.Warn("storage migration: deleting abandoned copy job failed", "agent", agent.Name, "error", err)
+			}
+			targets, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).List(ctx,
+				metav1.ListOptions{LabelSelector: LabelMigrationFor + "=" + agent.Name})
+			if err != nil {
+				slog.Warn("storage migration: listing abandoned targets failed", "agent", agent.Name, "error", err)
+			} else {
+				for _, t := range targets.Items {
+					if err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).
+						Delete(ctx, t.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+						slog.Warn("storage migration: deleting abandoned target failed", "agent", agent.Name, "pvc", t.Name, "error", err)
+					}
+				}
+			}
+			slog.Info("storage migration: released gated agent, migration abandoned", "agent", agent.Name)
+		}
+		if err := m.finishFlip(ctx, agent); err != nil {
+			slog.Warn("storage migration: releasing gate failed", "agent", agent.Name, "error", err)
 		}
 	}
 }
@@ -560,7 +633,8 @@ func jobFailed(job *batchv1.Job) bool {
 // (source read-only, target read-write) pair, running a copy + two-pass
 // checksum verification per pair.
 //
-// The copy runs as the AGENT's uid, not root: an agent's workspace is
+// The copy runs as the AGENT's uid, unprivileged, and needs no capabilities:
+// an agent's workspace is
 // single-owner by construction (everything in it is written as the agent
 // user), so the agent uid can read every file — including 0600 files and
 // 0700 dirs — even on shared-filesystem classes that squash root, where a
@@ -580,15 +654,41 @@ func buildMigrationJob(agentName string, pairs []migrationPair, cfg *config.Conf
 	var volumes []corev1.Volume
 	var mounts []corev1.VolumeMount
 	var script strings.Builder
-	script.WriteString(`set -eu
+	// The copy runs as the agent uid — resolved from the chart's container
+	// security context, which is the identity the agent itself runs with.
+	uid := migrationFallbackUID
+	if sc := cfg.AgentBase.ContainerSecurityContext; sc != nil && sc.RunAsUser != nil {
+		uid = *sc.RunAsUser
+	}
+	gid := int64(0)
+
+	// The ownership preflight and the uid column of the metadata comparison
+	// move together: normalizing ownership (opt-in) means the target's uids
+	// legitimately differ from the source's, so comparing them would fail by
+	// design. Everything else — type, mode, path, symlink target, content —
+	// is verified either way.
+	metaFmt := "%y|%m|%U|%p|%l"
+	if cfg.StorageMigration.AllowOwnershipRemap {
+		metaFmt = "%y|%m|%p|%l"
+	}
+	fmt.Fprintf(&script, "set -euo pipefail\nAGENT_UID=%d\nALLOW_OWNERSHIP_REMAP=%s\nMETA_FMT=%q\n",
+		uid, map[bool]string{true: "1", false: "0"}[cfg.StorageMigration.AllowOwnershipRemap], metaFmt)
+	script.WriteString(`
 copy_verify() {
   src="$1"; dst="$2"
   echo "migrate: $src -> $dst"
-  # Preflight: an entry its OWNER cannot read is unreadable to every uid on
-  # a root-squashing share — no copier can move it. Fail fast with the exact
+  # Everything here runs as the AGENT's uid — no root, no capabilities.
+  # Privilege is not available to rely on: OpenShift's restricted SCC strips
+  # CAP_CHOWN/CAP_DAC_OVERRIDE (so even uid 0 cannot chown or bypass a mode),
+  # and a Kata sandbox's virtiofs refuses guest-side chown outright. What the
+  # agent uid always has is OWNERSHIP of the whole workspace, and an owner may
+  # chmod its own entries — which is all this needs.
+
+  # Preflight: an entry its OWNER cannot read is unreadable to every uid on a
+  # root-squashing share — no copier can move it. Fail fast with the exact
   # list (the fix is chmod u+rX on the source) instead of a mid-copy error.
   # Dangling symlinks are excluded: -readable follows links, and a dangling
-  # link is legitimate workspace content that cp -a recreates fine.
+  # link is legitimate workspace content that the copy recreates fine.
   unreadable="$(cd "$src" && find . ! -type l ! -readable | head -20)"
   if [ -n "$unreadable" ]; then
     echo "migration blocked: owner-unreadable entries on the source (list may be truncated):"
@@ -596,36 +696,73 @@ copy_verify() {
     exit 1
   fi
   echo "source size: $(du -sh "$src" | cut -f1)"
-  # The target arrives EMPTY: the root init container wipes it before every
-  # attempt (restartPolicy Never makes each attempt a fresh pod, so the init
-  # re-runs). The cleanup cannot live here — the agent uid can neither
-  # descend into a root-owned lost+found (ext4 block volumes) nor delete
-  # inside the read-only dirs (0500/0555: Go module caches, site-packages)
-  # that a prior attempt's cp -a faithfully reproduced.
-  # GNU cp -a: permissions, ownership, times, symlinks, AND hard links —
-  # hard-link-heavy stores (pnpm) must not inflate past the volume size.
-  cp -a "$src/." "$dst/"
+
+  # Ownership: an unprivileged copy recreates entries as the agent uid, so it
+  # is only faithful while the workspace is single-owner — which it is by
+  # construction (the agent writes its own workspace). Anything owned by
+  # another uid is reported and blocks the copy rather than being silently
+  # re-owned. Remedy: chown it to the agent uid on the source, or set
+  # controller.storageMigration.allowOwnershipRemap to accept the
+  # normalization. Privilege is not an option here: a restricted SCC strips
+  # CAP_CHOWN and Kata virtiofs refuses guest chown outright.
+  foreign="$(cd "$src" && find . ! -uid ${AGENT_UID} ! -path ./lost+found | head -20)"
+  if [ -n "$foreign" ]; then
+    if [ "${ALLOW_OWNERSHIP_REMAP}" = "1" ]; then
+      echo "note: re-owning these source entries to uid ${AGENT_UID} (allowOwnershipRemap; list may be truncated):"
+      echo "$foreign"
+    else
+      echo "migration blocked: source entries owned by another uid, which an unprivileged copy cannot reproduce (list may be truncated):"
+      echo "$foreign"
+      echo "remedy: chown them to uid ${AGENT_UID} on the source, or set controller.storageMigration.allowOwnershipRemap=true to accept the normalization"
+      exit 1
+    fi
+  fi
+
+  # Per-attempt wipe so retries are deterministic. Restoring u+rwX first is
+  # what makes it possible as the owner: a prior attempt faithfully
+  # reproduced the workspace's read-only directories (0500/0555 — Go module
+  # caches, site-packages), and removing an entry needs write+execute on its
+  # parent. LOST+FOUND is skipped: it is a fresh ext4 volume's own artifact,
+  # root-owned and not ours to delete — the verification excludes it too.
+  find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec chmod -R u+rwX {} +
+  find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec rm -rf {} +
+
+  # tar, not "cp -a src/. dst/": cp applies the SOURCE ROOT's ownership and
+  # timestamps to the TARGET ROOT, which no unprivileged process can do (the
+  # root belongs to the provisioner; fsGroup, not us, makes it writable).
+  # --no-overwrite-dir leaves the target root's own metadata alone; -p keeps
+  # every mode including setuid; tar preserves hard links natively (a
+  # hard-link-heavy pnpm store must not inflate past the volume size) and
+  # --sparse keeps sparse files sparse. Ownership needs no preserving: the
+  # workspace has a single owner and we are it.
+  tar -C "$src" --sparse -cf - . | tar -C "$dst" -xpf - --no-overwrite-dir
   sync
+
+  # The target root must be writable by the agent — the property the copy
+  # cannot assert for itself (its mode belongs to the provisioner/fsGroup,
+  # so comparing it against the source root would fail spuriously).
+  touch "$dst/.migration-writable" && rm -f "$dst/.migration-writable"
+
   # Two-pass verification against the quiesced source; the old volume is
   # deleted at flip on the strength of these comparisons, so both fail
   # closed on any difference.
   #
   # Pass 1 — metadata: type, mode, owner uid, path, and symlink target for
-  # every entry. A mode or owner that failed to carry over blocks the
-  # migration just like corrupt content would. Two deliberate exclusions:
-  # gid (agent images run uid:0; group identity is not part of the
-  # workspace contract) and the volume ROOT's ownership (the target root
-  # is chowned to the agent uid by design; old roots predate the
-  # single-owner model) — the root's MODE is still compared below.
-  (cd "$src" && find . -mindepth 1 -printf "%y|%m|%U|%p|%l\n" | LC_ALL=C sort) > /tmp/src.meta
-  (cd "$dst" && find . -mindepth 1 -printf "%y|%m|%U|%p|%l\n" | LC_ALL=C sort) > /tmp/dst.meta
+  # every entry. A mode that failed to carry over blocks the migration just
+  # like corrupt content would. Deliberate exclusions: gid (agent images run
+  # uid:0, while an fsGroup-managed target assigns its own gid — group
+  # identity is not part of the workspace contract), the volume root itself,
+  # and lost+found.
+  meta() { (cd "$1" && find . -mindepth 1 ! -path ./lost+found -printf "${META_FMT}\n" | LC_ALL=C sort); }
+  meta "$src" > /tmp/src.meta
+  meta "$dst" > /tmp/dst.meta
   cmp /tmp/src.meta /tmp/dst.meta
-  [ "$(stat -c %a "$src")" = "$(stat -c %a "$dst")" ]
   # Pass 2 — content checksums. md5 is deliberate: this is integrity
   # checking of our own quiesced copy, not defense against an adversary
   # crafting collisions — and it is the fastest digest coreutils ships.
-  (cd "$src" && find . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r md5sum) > /tmp/src.sum
-  (cd "$dst" && find . -type f -print0 | LC_ALL=C sort -z | xargs -0 -r md5sum) > /tmp/dst.sum
+  sums() { (cd "$1" && find . -type f ! -path ./lost+found/\* -print0 | LC_ALL=C sort -z | xargs -0 -r md5sum); }
+  sums "$src" > /tmp/src.sum
+  sums "$dst" > /tmp/dst.sum
   cmp /tmp/src.sum /tmp/dst.sum
   echo "verified (content + metadata): $src -> $dst"
 }
@@ -657,27 +794,6 @@ copy_verify() {
 	backoff := int32(2)
 	ttl := int32(600)
 	deadline := int64(migrationJobDeadline.Seconds())
-	uid := migrationFallbackUID
-	if sc := cfg.AgentBase.ContainerSecurityContext; sc != nil && sc.RunAsUser != nil {
-		uid = *sc.RunAsUser
-	}
-	root := int64(0)
-	var dstMounts []corev1.VolumeMount
-	var prep strings.Builder
-	prep.WriteString("set -eu\n")
-	for _, mnt := range mounts {
-		if mnt.ReadOnly {
-			continue
-		}
-		dstMounts = append(dstMounts, mnt)
-		// Root does the wipe: a retry's target holds the prior attempt's
-		// tree — including faithfully-copied read-only directories — and
-		// ext4 block volumes ship a root-owned lost+found; both are
-		// undeletable as the agent uid. Then hand the empty root to the
-		// agent uid so the copy can preserve its attributes.
-		fmt.Fprintf(&prep, "find %s -mindepth 1 -delete\n", mnt.MountPath)
-		fmt.Fprintf(&prep, "chown %d:%d %s\n", uid, uid, mnt.MountPath)
-	}
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            migrationJobName(agentName),
@@ -711,31 +827,18 @@ copy_verify() {
 					SecurityContext: &corev1.PodSecurityContext{
 						RunAsUser: &uid,
 						// Group 0, matching the agent images' own uid:0
-						// convention: with the process gid equal to the
-						// files' gid, cp -a preserves ownership completely —
-						// and GNU cp strips setuid/setgid bits from any file
-						// whose ownership it FAILS to preserve, which the
-						// metadata verification would then reject.
-						RunAsGroup: &root,
+						// convention, so anything the copy creates carries
+						// the identity the agent itself runs with.
+						RunAsGroup: &gid,
 						// fsGroup covers CSI block backends; hostPath-backed
 						// classes (local-path) skip it, which is what the
 						// chown init container below is for.
 						FSGroup: &uid,
 					},
-					InitContainers: []corev1.Container{{
-						// Root touches ONLY the empty targets (see the file
-						// comment): the source — possibly a root-squashing
-						// share — is not even mounted here.
-						Name:            "prep-target",
-						Image:           cfg.StorageMigration.JobImage,
-						Command:         []string{"sh", "-c", prep.String()},
-						VolumeMounts:    dstMounts,
-						SecurityContext: &corev1.SecurityContext{RunAsUser: &root, RunAsGroup: &root},
-					}},
 					Containers: []corev1.Container{{
 						Name:         "copy",
 						Image:        cfg.StorageMigration.JobImage,
-						Command:      []string{"sh", "-c", script.String()},
+						Command:      []string{"bash", "-c", script.String()},
 						VolumeMounts: mounts,
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{
@@ -753,6 +856,14 @@ copy_verify() {
 			},
 		},
 	}
+	// Scheduling (nodeSelector/tolerations/affinity) is inherited so the
+	// target volume binds where agents actually run — but the runtime class
+	// is deliberately dropped. The agents' class is Kata on some installs,
+	// whose virtiofs-backed mounts refuse guest-side chown and give no
+	// guarantee about hard-link or sparse fidelity; this pod runs only
+	// platform tooling over the agent's data, never agent code, so the VM
+	// isolation buys nothing and costs correctness plus a VM boot per copy.
 	applyAgentBaseScheduling(&job.Spec.Template.Spec, cfg.AgentBase)
+	job.Spec.Template.Spec.RuntimeClassName = nil
 	return job
 }

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,7 +35,8 @@ func migrationConfig() *config.Config {
 			StorageSize: "10Gi",
 		},
 		StorageMigration: config.StorageMigration{
-			Enabled:  true,
+			Enabled: true, // the chart default is off; tests drive it on
+
 			JobImage: "mirror.gcr.io/library/debian:stable-slim",
 		},
 	}
@@ -157,36 +159,45 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	require.NotNil(t, psc)
 	require.NotNil(t, psc.RunAsUser)
 	assert.Equal(t, int64(65532), *psc.RunAsUser)
-	// Group 0 matches the agent images' uid:0 convention so cp preserves
-	// ownership completely (a failed ownership preserve strips suid bits,
-	// which the metadata verification would reject).
+	// Group 0 matches the agent images' uid:0 convention, so what the copy
+	// creates carries the identity the agent itself runs with.
 	require.NotNil(t, psc.RunAsGroup)
 	assert.Equal(t, int64(0), *psc.RunAsGroup)
-	// The verification must gate on metadata (mode + owner), not content
-	// alone — the source is never deleted when permissions failed to
-	// carry over.
-	assert.Contains(t, job.Spec.Template.Spec.Containers[0].Command[2], `%y|%m|%U|%p|%l`)
 	require.NotNil(t, psc.FSGroup)
 	assert.Equal(t, int64(65532), *psc.FSGroup, "fsGroup makes the fresh target volume writable to the agent uid")
-	// A root init container chowns the EMPTY target root to the agent uid
-	// (cp -a must preserve the root dir's attributes, and fsGroup is skipped
-	// on hostPath-backed classes). It must never mount the source — a
-	// squashing share must never see uid 0.
-	require.Len(t, job.Spec.Template.Spec.InitContainers, 1)
-	prep := job.Spec.Template.Spec.InitContainers[0]
-	require.NotNil(t, prep.SecurityContext.RunAsUser)
-	assert.Equal(t, int64(0), *prep.SecurityContext.RunAsUser)
-	require.Len(t, prep.VolumeMounts, 1, "prep mounts targets only, never the source")
-	assert.Equal(t, "dst-0", prep.VolumeMounts[0].Name)
-	// Root owns the per-attempt wipe: the agent uid cannot delete inside
-	// read-only dirs (0500 caches) or a root-owned lost+found on ext4.
-	require.Len(t, prep.Command, 3)
-	assert.Contains(t, prep.Command[2], "find /mnt/dst-0 -mindepth 1 -delete")
-	assert.NotContains(t, job.Spec.Template.Spec.Containers[0].Command[2], "-delete",
-		"the copy container must not clean up — it lacks the permissions on retries")
-	// Never, not OnFailure: in-place container restarts skip init containers,
-	// and every attempt needs the wipe to run first.
-	assert.Equal(t, corev1.RestartPolicyNever, job.Spec.Template.Spec.RestartPolicy)
+	// Nothing in the migration may need privilege: OpenShift's restricted SCC
+	// strips CAP_CHOWN/CAP_DAC_OVERRIDE and Kata's virtiofs refuses guest
+	// chown, so a root step (even just to chown a target root) is a
+	// portability trap. The copy is unprivileged end to end.
+	assert.Empty(t, job.Spec.Template.Spec.InitContainers,
+		"no privileged init container — the agent uid owns the workspace and may chmod it")
+	copyScript := job.Spec.Template.Spec.Containers[0].Command[2]
+	// Assert on the commands, not the prose that explains why they are absent.
+	var cmds strings.Builder
+	for _, line := range strings.Split(copyScript, "\n") {
+		if t := strings.TrimSpace(line); !strings.HasPrefix(t, "#") {
+			cmds.WriteString(t + "\n")
+		}
+	}
+	runnable := cmds.String()
+	// No chown may be INVOKED (an echo naming it in a remedy hint is fine):
+	// chown is unavailable under a restricted SCC and on Kata virtiofs.
+	assert.NotRegexp(t, `(?m)^chown |-exec chown|; chown `, runnable,
+		"the copy must never invoke chown")
+	// The verification must gate on metadata (mode + owner), not content
+	// alone — the source is never deleted when permissions failed to carry
+	// over.
+	assert.Contains(t, runnable, `%y|%m|%U|%p|%l`)
+	// tar with --no-overwrite-dir, not cp -a src/. dst/: cp would apply the
+	// source root's ownership/timestamps to the target root, which no
+	// unprivileged process can do.
+	assert.Contains(t, runnable, "--no-overwrite-dir")
+	assert.NotContains(t, runnable, "cp -a")
+	// A fresh ext4 CSI target ships a root-owned lost+found the source has
+	// not got: it must be excluded from the wipe and from verification, or
+	// every real block-backed migration fails on a phantom difference.
+	assert.Contains(t, runnable, "! -name lost+found")
+	assert.Contains(t, runnable, "! -path ./lost+found")
 	require.Len(t, job.Spec.Template.Spec.Volumes, 2)
 	src := job.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "home-agent-my-agent-0", src.PersistentVolumeClaim.ClaimName)
@@ -408,3 +419,44 @@ func renderedAgentSTS(name string) *appsv1.StatefulSet {
 }
 
 func ptrInt64(v int64) *int64 { return &v }
+
+// Turning the migration off must not strand the agents it had already gated:
+// the gate is a negative override only this manager clears, so a disabled
+// manager releases them, bins the half-copied targets, and leaves each agent
+// on the volume it never left.
+func TestStorageMigration_DisabledReleasesGatedAgents(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{
+		annStorageMigration:           "migrating",
+		annStorageMigrationWasRunning: "true",
+	}
+	target := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-home-agent-my-agent-0", Namespace: "test-agents",
+			Labels: map[string]string{
+				LabelPool: migrationPoolValue, LabelMount: "home-agent",
+				LabelMigrationFor: "my-agent",
+			},
+		},
+	}
+	job := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{
+		Name: "mig-my-agent", Namespace: "test-agents",
+		Labels: map[string]string{LabelMigrationFor: "my-agent"},
+	}}
+	source := rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent")
+	m, client := migrationManager(t, agent, source, target, job)
+	m.config.StorageMigration.Enabled = false
+
+	m.RunLoop(context.Background())
+
+	ann := getAgentAnnotations(t, m, "my-agent")
+	assert.Empty(t, ann[annStorageMigration], "the gate must be lifted so the agent can run again")
+	assert.NotEmpty(t, ann[annLastActivity], "an agent that was running is woken back up")
+
+	_, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err, "the source volume is untouched — nothing was copied, nothing is deleted")
+	_, err = client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	assert.Error(t, err, "the half-copied target is binned")
+	_, err = client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
+	assert.Error(t, err, "the abandoned copy job is binned")
+}

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -196,8 +196,11 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// A fresh ext4 CSI target ships a root-owned lost+found the source has
 	// not got: it must be excluded from the wipe and from verification, or
 	// every real block-backed migration fails on a phantom difference.
-	assert.Contains(t, runnable, "! -name lost+found")
-	assert.Contains(t, runnable, "! -path ./lost+found")
+	assert.Contains(t, runnable, "! -name lost+found", "excluded from the wipe")
+	// The glob must cover lost+found's CONTENTS too, not just the directory
+	// entry: an fsck-populated lost+found would otherwise show up as a
+	// phantom difference (or as foreign-owned files) and block the migration.
+	assert.Contains(t, runnable, `! -path './lost+found*'`, "excluded from verification, contents included")
 	require.Len(t, job.Spec.Template.Spec.Volumes, 2)
 	src := job.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "home-agent-my-agent-0", src.PersistentVolumeClaim.ClaimName)


### PR DESCRIPTION
## Why (urgent)

The storage migration merged in #3046 **cannot run on a real OpenShift install**. Its copy Job chowned the target volume root; a restricted SCC strips `CAP_CHOWN` and a Kata runtime class's virtiofs refuses guest-side chown, so every Job failed with `chown: changing ownership of '/mnt/dst-0': Operation not permitted` — and because the migration gate is a hard-stop-strength override only the manager clears, the **10 agents it had admitted stayed scaled to zero** on dev.

Neither cause could surface in the pre-merge rehearsals: the sandbox's `local-path` is hostPath-backed and runs under runc. **No data was ever at risk** — a source volume is deleted only after a verified copy, so every source survived intact (confirmed on dev: sources still Bound and RWX, no `superseded` label anywhere, 10 half-copied targets and nothing else).

## Recovery, and what deploying this does

`storageMigration.enabled` **stays `true` by default** (product decision: the fleet drains itself on upgrade with no owner action). So deploying this resumes the migration with the fixed, unprivileged copy — the currently-gated agents get their stale half-copied targets wiped and re-copied properly, then flip and come back.

The off switch is now a genuine escape hatch, which is the part that was missing: **a disabled manager releases every agent it had gated** — bins the abandoned copy Job and the half-copied target, lifts the gate, restores the prior run state (a previously-running agent is woken). Sources are untouched, so each agent returns to the volume it never left. Set `enabled: false` for one deploy if you would rather release the fleet first and re-enable deliberately (`concurrency: 1` makes the first agent easy to follow in the controller log).

## The fix: unprivileged end to end

- **No init container, no root anywhere.** The per-attempt wipe runs as the agent uid — `chmod` needs *ownership*, not write permission, and the agent owns its whole workspace, so restoring `u+rwX` first makes even a prior attempt's `0500` cache dirs removable.
- **`tar --no-overwrite-dir` replaces `cp -a src/. dst/`.** The chown existed *only* because `cp` applies the source root's ownership/timestamps to the target root, which no unprivileged process can do. tar leaves the target root's own metadata alone while preserving modes (incl. setuid), hard links, sparseness and times. `fsGroup` — unprivileged — makes a CSI target root writable; a write test replaces the root-mode comparison.
- **Ownership**: preserved by construction while the workspace is single-owner (it is, by design — verified on a live agent: `find . ! -uid 65532` returns only the volume root). Anything owned by another uid is **reported with its paths and blocks that agent's migration** rather than being silently re-owned; `allowOwnershipRemap` (default false) accepts the normalization deliberately, and then the uid column drops out of the metadata comparison. Privilege would not help here anyway — that is exactly what the SCC and virtiofs deny.
- **`lost+found` excluded** from the wipe and both verification passes: a fresh ext4 CSI target ships one and the source hasn't got it, so every block-backed migration would otherwise fail on a phantom difference. (Another gap hostPath rehearsals could not show.)
- **Copy Job no longer inherits the agents' `runtimeClassName`.** It runs platform tooling over agent data, never agent code, so Kata's VM isolation buys nothing while its virtiofs costs correctness (the chown refusal; no guarantee on hard-link or sparse fidelity) plus a VM boot per copy. Scheduling (nodeSelector/tolerations/affinity) is still inherited so the target binds where agents run.

## Verification

- Controller: all 7 Go packages green, `go vet` + staticcheck clean, helm lint clean. New test asserts the copy invokes no `chown`, has no init container, uses `--no-overwrite-dir`, excludes `lost+found`, and that a **disabled manager releases a gated agent** while leaving its source intact.
- Not yet exercised live: the sandbox cannot reproduce a restricted SCC or Kata, which is the whole point of this PR. Recommend the dev canary above as the acceptance step — one agent, `concurrency: 1`.

## Follow-ups (not here)

- The RWX-era `0500`-directory and `lost+found` findings suggest an e2e that runs the copy against an ext4 CSI volume; the sandbox can't, CI could.
- Warm PVC pool now provisions RWO spares; whether it still earns its keep post-RWO is an open question worth its own issue.