### PR TITLE
fix(controller)!: migration destination is its own class, defaulting to the cluster default

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1028,8 +1028,11 @@ controller:
     #  - size: "5Gi"
     #    target: 2
 
-  # -- One-time RWX -> RWO workspace-volume migration (#2988). For every agent
-  # whose workspace PVC is still ReadWriteMany the controller forces the agent
+  # -- One-time workspace-volume migration onto ordinary single-writer storage
+  # (#2988). A workspace is migrated when it is still ReadWriteMany, OR when it
+  # sits on a storage class other than `targetStorageClass` below — the second
+  # trigger is what moves a volume that was flipped to ReadWriteOnce but left
+  # on the shared filesystem. The controller forces the agent
   # down, copies the volume onto a fresh ReadWriteOnce PVC in a Job
   # (content- and metadata-verified), re-points the StatefulSet, deletes the
   # old volume, and restores the agent's prior run state. Interrupt-safe and
@@ -1047,6 +1050,23 @@ controller:
   # through the first drain; `concurrency: 1` makes that easy to follow.
   storageMigration:
     enabled: true
+    # -- Storage class migrated workspaces land on: the DESTINATION of the
+    # migration. Empty (default) = the cluster's default class, i.e. ordinary
+    # storage, which is the point of the exercise.
+    #
+    # Deliberately NOT `controller.agent.base.storageClass`: on an install
+    # that has not migrated yet, that field still names the shared filesystem
+    # being drained, so inheriting it would force-restart every agent and copy
+    # every byte only to arrive back on NFS with a different access mode. Set
+    # this to the block class agents should end on, or leave it empty for the
+    # cluster default — and fix `agent.base.storageClass` (and
+    # `warmPool.storageClass`) too, or newly-created agents keep landing on
+    # the old backend.
+    targetStorageClass: ""
+    # -- Permit a migration whose target class is the class the workspace is
+    # already on. Refused by default: it changes the access mode and nothing
+    # else, at the cost of a forced restart and a full copy per agent.
+    allowSameStorageClass: false
     # -- How many agents migrate at once. Each migration reads its source
     # volume in full three times (copy + two verification passes); this cap
     # is the trade between fleet drain time and read pressure on the shared

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1067,10 +1067,20 @@ controller:
     # already on. Refused by default: it changes the access mode and nothing
     # else, at the cost of a forced restart and a full copy per agent.
     allowSameStorageClass: false
-    # -- How many agents migrate at once. Each migration reads its source
-    # volume in full three times (copy + two verification passes); this cap
-    # is the trade between fleet drain time and read pressure on the shared
-    # filesystem being drained — lower it if the filer struggles.
+    # -- Floor for a migrated volume's size; empty keeps the source's request.
+    # Set this when the target class prices IOPS PER GIGABYTE (IBM's block
+    # tiers do): a faithfully-sized 1Gi volume then inherits a 1Gi share of
+    # IOPS, and a copy that is bound by per-file operations crawls. Such
+    # classes usually have a minimum volume size anyway, which a smaller
+    # request is silently rounded up to. "10Gi" suits IBM VPC block.
+    minTargetSize: ""
+    # -- How many agents migrate at once. Each migration walks its source
+    # once and reads it twice (copy + checksum), so this cap is the trade
+    # between fleet drain time and pressure on the shared filesystem being
+    # drained — lower it if the filer struggles. Duration is driven by FILE
+    # COUNT, not bytes: every entry is a round-trip and, on an IOPS-capped
+    # class, an IOP. The copy Job logs `phase:` lines with elapsed seconds so
+    # a slow drain can be attributed rather than guessed at.
     concurrency: 10
     # -- Reconcile pass interval.
     interval: "30s"

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -253,6 +253,14 @@ type StorageMigration struct {
 	// copies every byte to arrive at the same backend — so it is refused with
 	// a loud log naming the remedy.
 	AllowSameStorageClass bool `json:"allowSameStorageClass,omitempty"`
+	// MinTargetSize floors the size of a migrated workspace volume. Empty
+	// (the default) keeps the source's request verbatim. Set it where the
+	// target class prices IOPS PER GIGABYTE — IBM's block tiers do — because
+	// there a faithfully-sized 1Gi volume also inherits a 1Gi share of IOPS
+	// and the copy crawls; such classes also tend to have a minimum volume
+	// size of their own, which a smaller request is silently rounded up to
+	// anyway.
+	MinTargetSize string `json:"minTargetSize,omitempty"`
 	// AllowOwnershipRemap lets the copy proceed when the source workspace
 	// holds entries owned by a uid other than the agent's. The copy is
 	// unprivileged (chown is unavailable under a restricted SCC and on a

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -238,6 +238,21 @@ type StorageMigration struct {
 	// Interval between reconcile passes. Zero falls back to a built-in
 	// default.
 	Interval Duration `json:"interval,omitempty"`
+	// TargetStorageClass is the class migrated workspaces land on. Empty
+	// (the default) means the CLUSTER DEFAULT class — deliberately NOT
+	// AgentBase.StorageClass, which on a pre-migration install still names
+	// the shared filesystem being drained: inheriting it would move a
+	// workspace from RWX to RWO on the same NFS backend, changing the access
+	// mode and nothing else. The migration exists to leave that backend, so
+	// its destination is configured independently and defaults to ordinary
+	// cluster-default storage.
+	TargetStorageClass string `json:"targetStorageClass,omitempty"`
+	// AllowSameStorageClass permits a migration whose target class is the
+	// class the workspace already sits on. Default false: that combination is
+	// almost always a misconfiguration — it force-restarts every agent and
+	// copies every byte to arrive at the same backend — so it is refused with
+	// a loud log naming the remedy.
+	AllowSameStorageClass bool `json:"allowSameStorageClass,omitempty"`
 	// AllowOwnershipRemap lets the copy proceed when the source workspace
 	// holds entries owned by a uid other than the agent's. The copy is
 	// unprivileged (chown is unavailable under a restricted SCC and on a

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -82,6 +82,11 @@ const (
 	// migrationFallbackUID runs the copy when the chart doesn't pin the
 	// agent container's uid. Matches the platform images' agent user.
 	migrationFallbackUID = int64(65532)
+	// migrationChecksumParallelism is how many md5sum workers read the tree
+	// at once. Small-file verification over a network filesystem is bound by
+	// per-file round-trips, not bandwidth or CPU, so concurrency buys close
+	// to linear speedup; 8 keeps well inside an IOPS-capped share's budget.
+	migrationChecksumParallelism = 8
 )
 
 // StorageMigrationManager runs the migration loop. Leader-only, like the
@@ -526,6 +531,18 @@ func (m *StorageMigrationManager) ensureTargetPVC(ctx context.Context, agentName
 	if size.IsZero() {
 		size = resource.MustParse(m.config.AgentTemplateDefaults.StorageSize)
 	}
+	// Floor the request where the target class ties IOPS to capacity: a
+	// faithfully-sized small volume would inherit a proportionally tiny IOPS
+	// budget and make the copy — which is per-file bound — crawl.
+	if floor := m.config.StorageMigration.MinTargetSize; floor != "" {
+		if q, err := resource.ParseQuantity(floor); err != nil {
+			slog.Warn("storage migration: minTargetSize is not a valid quantity; ignoring", "value", floor, "error", err)
+		} else if size.Cmp(q) < 0 {
+			slog.Info("storage migration: raising target size to the configured floor",
+				"agent", agentName, "requested", size.String(), "floor", q.String())
+			size = q
+		}
+	}
 	spec := corev1.PersistentVolumeClaimSpec{
 		AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		Resources: corev1.VolumeResourceRequirements{
@@ -754,50 +771,55 @@ func buildMigrationJob(agentName string, pairs []migrationPair, cfg *config.Conf
 	}
 	gid := int64(0)
 
-	// The ownership preflight and the uid column of the metadata comparison
-	// move together: normalizing ownership (opt-in) means the target's uids
-	// legitimately differ from the source's, so comparing them would fail by
-	// design. Everything else — type, mode, path, symlink target, content —
-	// is verified either way.
-	metaFmt := "%y|%m|%U|%p|%l"
+	// The walk always emits flag|type|mode|uid|path|link; what the comparison
+	// KEEPS is a cut of that. Normalizing ownership (opt-in) means the
+	// target's uids legitimately differ from the source's, so the uid column
+	// drops out — everything else stays verified either way.
+	metaCut := "2-"
 	if cfg.StorageMigration.AllowOwnershipRemap {
-		metaFmt = "%y|%m|%p|%l"
+		metaCut = "2,3,5,6"
 	}
-	fmt.Fprintf(&script, "set -euo pipefail\nAGENT_UID=%d\nALLOW_OWNERSHIP_REMAP=%s\nMETA_FMT=%q\n",
-		uid, map[bool]string{true: "1", false: "0"}[cfg.StorageMigration.AllowOwnershipRemap], metaFmt)
+	fmt.Fprintf(&script, "set -euo pipefail\nAGENT_UID=%d\nALLOW_OWNERSHIP_REMAP=%s\nMETA_CUT=%s\nPAR=%d\n",
+		uid, map[bool]string{true: "1", false: "0"}[cfg.StorageMigration.AllowOwnershipRemap], metaCut, migrationChecksumParallelism)
 	script.WriteString(`
+T0=$(date +%s)
+phase() { echo "phase: $1 (+$(( $(date +%s) - T0 ))s)"; }
+
 copy_verify() {
   src="$1"; dst="$2"
   echo "migrate: $src -> $dst"
-  # Everything here runs as the AGENT's uid — no root, no capabilities.
-  # Privilege is not available to rely on: OpenShift's restricted SCC strips
-  # CAP_CHOWN/CAP_DAC_OVERRIDE (so even uid 0 cannot chown or bypass a mode),
-  # and a Kata sandbox's virtiofs refuses guest-side chown outright. What the
-  # agent uid always has is OWNERSHIP of the whole workspace, and an owner may
-  # chmod its own entries — which is all this needs.
 
-  # Preflight: an entry its OWNER cannot read is unreadable to every uid on a
-  # root-squashing share — no copier can move it. Fail fast with the exact
-  # list (the fix is chmod u+rX on the source) instead of a mid-copy error.
-  # Dangling symlinks are excluded: -readable follows links, and a dangling
-  # link is legitimate workspace content that the copy recreates fine.
-  unreadable="$(cd "$src" && find . ! -type l ! -readable | head -20)"
+  # ONE walk of the source, and every check below is derived from its output.
+  # This is the difference between minutes and hours: a workspace is
+  # small-file-heavy (a pnpm store is 100k+ entries), every stat is a network
+  # round-trip AND an IOP against a capped share, so each extra walk costs
+  # the whole tree again. The source is quiesced, so one walk is also
+  # sufficient — nothing can change under us.
+  #
+  # The readability flag rides the same pass: find evaluates -readable per
+  # entry and the alternation picks the prefix. The inner group is what keeps
+  # the -o from swallowing the -mindepth/-path filters.
+  (cd "$src" && find . -mindepth 1 ! -path './lost+found*' \
+     \( \( -readable -printf "r|%y|%m|%U|%p|%l\n" \) -o -printf "x|%y|%m|%U|%p|%l\n" \) \
+   ) > /tmp/src.walk
+  entries=$(wc -l < /tmp/src.walk)
+  phase "walked source: $entries entries"
+
+  # Unreadable to its own OWNER is unreadable to every uid on a
+  # root-squashing share — no copier can move it, so fail with the paths
+  # rather than a mid-copy error. Symlinks are exempt: -readable follows the
+  # link, and a dangling link is legitimate content the copy recreates.
+  unreadable="$(awk -F'|' '$1=="x" && $2!="l" {print $5}' /tmp/src.walk | head -20)"
   if [ -n "$unreadable" ]; then
     echo "migration blocked: owner-unreadable entries on the source (list may be truncated):"
     echo "$unreadable"
     exit 1
   fi
-  echo "source size: $(du -sh "$src" | cut -f1)"
 
   # Ownership: an unprivileged copy recreates entries as the agent uid, so it
   # is only faithful while the workspace is single-owner — which it is by
-  # construction (the agent writes its own workspace). Anything owned by
-  # another uid is reported and blocks the copy rather than being silently
-  # re-owned. Remedy: chown it to the agent uid on the source, or set
-  # controller.storageMigration.allowOwnershipRemap to accept the
-  # normalization. Privilege is not an option here: a restricted SCC strips
-  # CAP_CHOWN and Kata virtiofs refuses guest chown outright.
-  foreign="$(cd "$src" && find . ! -uid ${AGENT_UID} ! -path './lost+found*' | head -20)"
+  # construction. Anything else is reported rather than silently re-owned.
+  foreign="$(awk -F'|' -v u="${AGENT_UID}" '$4!=u {print $5}' /tmp/src.walk | head -20)"
   if [ -n "$foreign" ]; then
     if [ "${ALLOW_OWNERSHIP_REMAP}" = "1" ]; then
       echo "note: re-owning these source entries to uid ${AGENT_UID} (allowOwnershipRemap; list may be truncated):"
@@ -810,14 +832,20 @@ copy_verify() {
     fi
   fi
 
+  # The same walk is the verification baseline — cut drops the readability
+  # flag (and the uid column when ownership is being normalized), and the
+  # sort happens after the cut so both sides order identically.
+  cut -d'|' -f${META_CUT} /tmp/src.walk | LC_ALL=C sort > /tmp/src.meta
+
   # Per-attempt wipe so retries are deterministic. Restoring u+rwX first is
   # what makes it possible as the owner: a prior attempt faithfully
   # reproduced the workspace's read-only directories (0500/0555 — Go module
   # caches, site-packages), and removing an entry needs write+execute on its
-  # parent. LOST+FOUND is skipped: it is a fresh ext4 volume's own artifact,
+  # parent. LOST+FOUND is skipped: a fresh ext4 volume's own artifact,
   # root-owned and not ours to delete — the verification excludes it too.
   find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec chmod -R u+rwX {} +
   find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec rm -rf {} +
+  phase "wiped target"
 
   # tar, not "cp -a src/. dst/": cp applies the SOURCE ROOT's ownership and
   # timestamps to the TARGET ROOT, which no unprivileged process can do (the
@@ -829,6 +857,7 @@ copy_verify() {
   # workspace has a single owner and we are it.
   tar -C "$src" --sparse -cf - . | tar -C "$dst" -xpf - --no-overwrite-dir
   sync
+  phase "copied"
 
   # The target root must be writable by the agent — the property the copy
   # cannot assert for itself (its mode belongs to the provisioner/fsGroup,
@@ -839,23 +868,29 @@ copy_verify() {
   # deleted at flip on the strength of these comparisons, so both fail
   # closed on any difference.
   #
-  # Pass 1 — metadata: type, mode, owner uid, path, and symlink target for
+  # Pass 1 — metadata: type, mode, owner uid, path and symlink target for
   # every entry. A mode that failed to carry over blocks the migration just
   # like corrupt content would. Deliberate exclusions: gid (agent images run
-  # uid:0, while an fsGroup-managed target assigns its own gid — group
+  # uid:0 while an fsGroup-managed target assigns its own gid — group
   # identity is not part of the workspace contract), the volume root itself,
   # and lost+found.
-  meta() { (cd "$1" && find . -mindepth 1 ! -path './lost+found*' -printf "${META_FMT}\n" | LC_ALL=C sort); }
-  meta "$src" > /tmp/src.meta
-  meta "$dst" > /tmp/dst.meta
+  (cd "$dst" && find . -mindepth 1 ! -path './lost+found*' -printf "d|%y|%m|%U|%p|%l\n") \
+    | cut -d'|' -f${META_CUT} | LC_ALL=C sort > /tmp/dst.meta
   cmp /tmp/src.meta /tmp/dst.meta
-  # Pass 2 — content checksums. md5 is deliberate: this is integrity
-  # checking of our own quiesced copy, not defense against an adversary
-  # crafting collisions — and it is the fastest digest coreutils ships.
-  sums() { (cd "$1" && find . -type f ! -path './lost+found*' -print0 | LC_ALL=C sort -z | xargs -0 -r md5sum); }
+  phase "verified metadata"
+
+  # Pass 2 — content checksums, read in parallel: this is latency-bound, not
+  # CPU-bound, so workers overlap round-trips instead of queueing behind each
+  # other. Output is sorted after collection because workers finish out of
+  # order. md5 is deliberate: integrity checking of our own quiesced copy,
+  # not defense against crafted collisions — and the fastest digest coreutils
+  # ships.
+  sums() { (cd "$1" && find . -type f ! -path './lost+found*' -print0 \
+              | xargs -0 -r -P"${PAR}" -n64 md5sum) | LC_ALL=C sort; }
   sums "$src" > /tmp/src.sum
   sums "$dst" > /tmp/dst.sum
   cmp /tmp/src.sum /tmp/dst.sum
+  phase "verified content"
   echo "verified (content + metadata): $src -> $dst"
 }
 `)

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -93,17 +93,22 @@ type StorageMigrationManager struct {
 	config  *config.Config
 	now     func() time.Time
 	// skippedVM de-dupes the vm-backend warning so it logs once per agent
-	// per process, not once per tick.
-	skippedVM map[string]bool
+	// per process, not once per tick. warnedSameClass and loggedReason do the
+	// same for the misconfigured-target refusal and the per-agent reason.
+	skippedVM       map[string]bool
+	warnedSameClass map[string]bool
+	loggedReason    map[string]bool
 }
 
 func NewStorageMigrationManager(client kubernetes.Interface, dyn dynamic.Interface, cfg *config.Config) *StorageMigrationManager {
 	return &StorageMigrationManager{
-		client:    client,
-		dynamic:   dyn,
-		config:    cfg,
-		now:       time.Now,
-		skippedVM: map[string]bool{},
+		client:          client,
+		dynamic:         dyn,
+		config:          cfg,
+		now:             time.Now,
+		skippedVM:       map[string]bool{},
+		warnedSameClass: map[string]bool{},
+		loggedReason:    map[string]bool{},
 	}
 }
 
@@ -164,12 +169,18 @@ func (m *StorageMigrationManager) ReleaseGated(ctx context.Context) {
 		slog.Warn("storage migration: listing agents to release gates failed", "error", err)
 		return
 	}
+	// "Source still present" — by the same rule Reconcile admits work with,
+	// so a workspace pending only a storage-class move is recognised as an
+	// un-flipped source rather than mistaken for a completed migration.
+	targetClass, _ := m.resolveTargetClass(ctx)
+	allowSame := m.config.StorageMigration.AllowSameStorageClass
 	rwx := map[string]bool{}
 	if pvcs, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: LabelAgent,
 	}); err == nil {
-		for _, p := range pvcs.Items {
-			if isRWX(p.Spec.AccessModes) {
+		for i := range pvcs.Items {
+			p := pvcs.Items[i]
+			if _, needed := migrationReason(&p, targetClass, allowSame); needed {
 				rwx[p.Labels[LabelAgent]] = true
 			}
 		}
@@ -224,15 +235,35 @@ func (m *StorageMigrationManager) Reconcile(ctx context.Context) {
 		return
 	}
 
-	// Agents that still own an RWX workspace volume, plus agents already
-	// gated (annotation set) whose source volume may already be stripped —
-	// the union is the resumable work list.
+	targetClass, explicitClass := m.resolveTargetClass(ctx)
+	allowSame := m.config.StorageMigration.AllowSameStorageClass
+
+	// Agents whose workspace volume is on the wrong access mode or the wrong
+	// storage class, plus agents already gated (annotation set) whose source
+	// may already be stripped — the union is the resumable work list.
 	rwxByAgent := map[string][]corev1.PersistentVolumeClaim{}
-	for _, p := range pvcs.Items {
-		if !isRWX(p.Spec.AccessModes) {
+	for i := range pvcs.Items {
+		p := pvcs.Items[i]
+		reason, needed := migrationReason(&p, targetClass, allowSame)
+		agent := p.Labels[LabelAgent]
+		if !needed {
+			// Distinguish "nothing to do" from "refused": a shared-writable
+			// volume already sitting on the target class means the target is
+			// the shared filesystem itself, which the migration exists to
+			// leave. Say so, once per agent per process.
+			if isRWX(p.Spec.AccessModes) && !m.warnedSameClass[agent] {
+				m.warnedSameClass[agent] = true
+				slog.Warn("storage migration: refusing to migrate onto the volume's own storage class — the access mode would change but the backend would not",
+					"agent", agent, "pvc", p.Name, "class", targetClass,
+					"remedy", "set controller.storageMigration.targetStorageClass to the class agents should end on (empty = cluster default), or allowSameStorageClass=true if this is intended")
+			}
 			continue
 		}
-		agent := p.Labels[LabelAgent]
+		if !m.loggedReason[agent] {
+			m.loggedReason[agent] = true
+			slog.Info("storage migration: workspace needs migrating", "agent", agent, "pvc", p.Name,
+				"reason", reason, "target", map[bool]string{true: targetClass, false: targetClass + " (cluster default)"}[explicitClass])
+		}
 		rwxByAgent[agent] = append(rwxByAgent[agent], p)
 	}
 
@@ -296,6 +327,63 @@ func (m *StorageMigrationManager) Reconcile(ctx context.Context) {
 			slog.Warn("storage migration: agent migration step failed", "agent", name, "error", err)
 		}
 	}
+}
+
+// resolveTargetClass returns the storage class migrated workspaces land on,
+// and whether the chart named it explicitly. Empty-and-inexplicit means the
+// cluster default: the target PVC then omits storageClassName so ordinary
+// default storage applies, while the resolved NAME is still needed to tell a
+// workspace that has already arrived from one that has not.
+//
+// Deliberately independent of AgentBase.StorageClass: on an install that has
+// not migrated yet, that value still names the shared filesystem being
+// drained, so inheriting it would copy every byte to reach the same backend.
+func (m *StorageMigrationManager) resolveTargetClass(ctx context.Context) (name string, explicit bool) {
+	if c := m.config.StorageMigration.TargetStorageClass; c != "" {
+		return c, true
+	}
+	classes, err := m.client.StorageV1().StorageClasses().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		// Without the default class's name the class comparison can't run;
+		// the RWX rule still does, so the drain degrades rather than stops.
+		slog.Warn("storage migration: cannot resolve the cluster default storage class; migrating on access mode only", "error", err)
+		return "", false
+	}
+	for _, sc := range classes.Items {
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
+			return sc.Name, false
+		}
+	}
+	slog.Warn("storage migration: no default storage class found; migrating on access mode only")
+	return "", false
+}
+
+// migrationReason says why a workspace needs migrating, or "" if it does not.
+// Two triggers: a shared-writable access mode, and sitting on the wrong
+// storage class — the second is what moves a workspace that was already
+// flipped to ReadWriteOnce but left on the shared filesystem.
+func migrationReason(pvc *corev1.PersistentVolumeClaim, targetClass string, allowSame bool) (string, bool) {
+	srcClass := ""
+	if pvc.Spec.StorageClassName != nil {
+		srcClass = *pvc.Spec.StorageClassName
+	}
+	sameClass := targetClass != "" && srcClass == targetClass
+	if isRWX(pvc.Spec.AccessModes) {
+		if sameClass && !allowSame {
+			// Refuse rather than drain a fleet to no purpose: the operator
+			// has pointed the migration at the very filesystem it exists to
+			// leave. Changing the access mode alone buys nothing.
+			return "", false
+		}
+		return "shared-writable access mode", true
+	}
+	// Already single-writer: only the destination is left to fix. A volume
+	// with no class at all is left alone — it is statically provisioned, and
+	// "converge it onto the default class" is not a call this should make.
+	if targetClass != "" && srcClass != "" && srcClass != targetClass {
+		return "storage class " + srcClass + " is not the migration target " + targetClass, true
+	}
+	return "", false
 }
 
 func isRWX(modes []corev1.PersistentVolumeAccessMode) bool {
@@ -444,7 +532,11 @@ func (m *StorageMigrationManager) ensureTargetPVC(ctx context.Context, agentName
 			Requests: corev1.ResourceList{corev1.ResourceStorage: size},
 		},
 	}
-	if sc := m.config.AgentBase.StorageClass; sc != "" {
+	// The migration's own destination — NOT AgentBase.StorageClass, which on
+	// an unmigrated install still names the shared filesystem being drained.
+	// Left unset when the chart names no class, so the cluster default
+	// applies exactly as it would for any ordinary PVC.
+	if sc := m.config.StorageMigration.TargetStorageClass; sc != "" {
 		spec.StorageClassName = &sc
 	}
 	pvc := &corev1.PersistentVolumeClaim{

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -211,6 +211,17 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// alone — the source is never deleted when permissions failed to carry
 	// over.
 	assert.Contains(t, runnable, `%y|%m|%U|%p|%l`)
+	// Cost control: a workspace is small-file-heavy and every stat is a
+	// network round-trip, so the source must be walked ONCE — readability,
+	// ownership and the verification baseline all derive from that one pass.
+	// (Two walks total: source, then target for the comparison.)
+	// (The one source walk carries two -printf actions — the readability
+	// alternation — so count walks, not actions.)
+	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find`),
+		"the source is walked ONCE: readability, ownership and the verification baseline all derive from that pass")
+	assert.NotContains(t, runnable, "du -sh", "a size log line is not worth a full metadata walk")
+	// Checksums are latency-bound, so they read in parallel.
+	assert.Contains(t, runnable, "-P\"${PAR}\"")
 	// tar with --no-overwrite-dir, not cp -a src/. dst/: cp would apply the
 	// source root's ownership/timestamps to the target root, which no
 	// unprivileged process can do.
@@ -560,4 +571,37 @@ func TestStorageMigration_RefusesTargetEqualToSourceClass(t *testing.T) {
 	m.Reconcile(context.Background())
 	ann = getAgentAnnotations(t, m, "my-agent")
 	assert.Equal(t, "migrating", ann[annStorageMigration])
+}
+
+// A target class that prices IOPS per gigabyte throttles a small volume to
+// nothing, which is how a 1 GiB workspace took an hour to copy. The floor is
+// opt-in — without it the source's request is honoured verbatim.
+func TestStorageMigration_TargetSizeFloor(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{annStorageMigration: "migrating"}
+	small := rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent")
+	small.Spec.Resources.Requests[corev1.ResourceStorage] = resource.MustParse("1Gi")
+	m, client := migrationManager(t, agent, small)
+	m.config.StorageMigration.MinTargetSize = "10Gi"
+
+	m.Reconcile(context.Background())
+
+	target, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	got := target.Spec.Resources.Requests[corev1.ResourceStorage]
+	assert.Equal(t, "10Gi", got.String(), "raised to the floor")
+}
+
+func TestStorageMigration_TargetSizeFloorNeverShrinks(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{annStorageMigration: "migrating"}
+	m, client := migrationManager(t, agent, rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent")) // 7Gi
+	m.config.StorageMigration.MinTargetSize = "5Gi"
+
+	m.Reconcile(context.Background())
+
+	target, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	got := target.Spec.Resources.Requests[corev1.ResourceStorage]
+	assert.Equal(t, "7Gi", got.String(), "a floor below the source's request changes nothing")
 }

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -16,6 +16,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 
+	storagev1 "k8s.io/api/storage/v1"
+
 	apiv1 "github.com/kagenti/platform/packages/controller/api/v1"
 	"github.com/kagenti/platform/packages/controller/pkg/config"
 )
@@ -56,6 +58,27 @@ func rwxPVC(name, agent, mount string) *corev1.PersistentVolumeClaim {
 			},
 		},
 	}
+}
+
+// defaultBlockClass stands in for the ordinary cluster-default class a
+// migration should land on (an IBM install's block class, k3s's local-path).
+func defaultBlockClass() *storagev1.StorageClass {
+	return &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{
+		Name:        "block-default",
+		Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+	}}
+}
+
+// fileClass is the shared filesystem an install is migrating OFF.
+func fileClass() *storagev1.StorageClass {
+	return &storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "ibmc-vpc-file-500-iops-agent"}}
+}
+
+func classedPVC(name, agent, mount, class string, mode corev1.PersistentVolumeAccessMode) *corev1.PersistentVolumeClaim {
+	p := rwxPVC(name, agent, mount)
+	p.Spec.AccessModes = []corev1.PersistentVolumeAccessMode{mode}
+	p.Spec.StorageClassName = &class
+	return p
 }
 
 func migrationManager(t *testing.T, agent *apiv1.Agent, objects ...runtime.Object) (*StorageMigrationManager, *fake.Clientset) {
@@ -462,4 +485,79 @@ func TestStorageMigration_DisabledReleasesGatedAgents(t *testing.T) {
 	assert.Error(t, err, "the half-copied target is binned")
 	_, err = client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
 	assert.Error(t, err, "the abandoned copy job is binned")
+}
+
+// The destination is the migration's own knob, never AgentBase.StorageClass:
+// on an unmigrated install that still names the shared filesystem, so
+// inheriting it would copy every byte to reach the same NFS backend. Unset
+// means the cluster default, so the target PVC carries no class at all.
+func TestStorageMigration_TargetLandsOnClusterDefaultNotAgentClass(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{annStorageMigration: "migrating"}
+	m, client := migrationManager(t, agent,
+		classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "ibmc-vpc-file-500-iops-agent", corev1.ReadWriteMany),
+		defaultBlockClass(), fileClass())
+	m.config.AgentBase.StorageClass = "ibmc-vpc-file-500-iops-agent" // what new agents get today
+
+	m.Reconcile(context.Background())
+
+	target, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Nil(t, target.Spec.StorageClassName,
+		"no class means the cluster default — the agents' own class is the filesystem being drained")
+}
+
+// A workspace already flipped to ReadWriteOnce but left on the shared
+// filesystem is exactly what the first broken drain produced. The access mode
+// no longer flags it, so the storage class must.
+func TestStorageMigration_MigratesWrongClassEvenWhenAlreadyRWO(t *testing.T) {
+	agent := agentCR()
+	src := classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "ibmc-vpc-file-500-iops-agent", corev1.ReadWriteOnce)
+	m, _ := migrationManager(t, agent, src, defaultBlockClass(), fileClass())
+
+	m.Reconcile(context.Background())
+
+	ann := getAgentAnnotations(t, m, "my-agent")
+	assert.Equal(t, "migrating", ann[annStorageMigration],
+		"an RWO volume stranded on the shared filesystem must still be drained")
+}
+
+// ...and once it has arrived on the target class it is left alone, so the
+// drain converges instead of looping.
+func TestStorageMigration_LeavesWorkspacesOnTheTargetClassAlone(t *testing.T) {
+	agent := agentCR()
+	src := classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "block-default", corev1.ReadWriteOnce)
+	m, client := migrationManager(t, agent, src, defaultBlockClass())
+
+	m.Reconcile(context.Background())
+
+	ann := getAgentAnnotations(t, m, "my-agent")
+	assert.Empty(t, ann[annStorageMigration], "already migrated — nothing to do")
+	jobs, err := client.BatchV1().Jobs("test-agents").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, jobs.Items)
+}
+
+// Pointing the migration at the volume's own class is refused, not obeyed: it
+// would force-restart every agent and copy every byte to reach the same
+// backend. This is the failure the first production drain actually hit.
+func TestStorageMigration_RefusesTargetEqualToSourceClass(t *testing.T) {
+	agent := agentCR()
+	src := classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "ibmc-vpc-file-500-iops-agent", corev1.ReadWriteMany)
+	m, client := migrationManager(t, agent, src, fileClass())
+	m.config.StorageMigration.TargetStorageClass = "ibmc-vpc-file-500-iops-agent"
+
+	m.Reconcile(context.Background())
+
+	ann := getAgentAnnotations(t, m, "my-agent")
+	assert.Empty(t, ann[annStorageMigration], "the agent must not be gated for a pointless migration")
+	jobs, err := client.BatchV1().Jobs("test-agents").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, jobs.Items, "and no bytes copied")
+
+	// Deliberate override still works, for an install that means it.
+	m.config.StorageMigration.AllowSameStorageClass = true
+	m.Reconcile(context.Background())
+	ann = getAgentAnnotations(t, m, "my-agent")
+	assert.Equal(t, "migrating", ann[annStorageMigration])
 }


### PR DESCRIPTION
## The bug

The migration took its target storage class from `controller.agent.base.storageClass`. On an install that hasn't migrated yet **that field still names the shared filesystem being drained** — so the first production drain moved workspaces from `ReadWriteMany` to `ReadWriteOnce` **on the same `ibmc-vpc-file-*` NFS class**: every agent force-restarted, every byte copied, and the backend this whole epic exists to leave still load-bearing. The access mode changed; nothing else did.

And it did not self-correct. The trigger was the access mode alone, so once a workspace was RWO-on-file it became **invisible to the migration forever** — fixing the values would have fixed only newly-created agents while every already-migrated workspace stayed on NFS.

## The fix

- **`storageMigration.targetStorageClass`** is the destination now, independent of the agents' own class. Empty (the default) means the **cluster default class** — the target PVC carries no `storageClassName` at all and gets ordinary storage, which is the point of the exercise.
- **Two triggers:** a workspace migrates when it is `ReadWriteMany` **or** when it sits on a class other than the target. The second is what recovers everything the broken drain stranded on the filer. A volume with *no* class is left alone (statically provisioned — converging it isn't this component's call), and one already on the target class is skipped, so the drain converges instead of looping.
- **Targeting the class a workspace already sits on is refused**, with a log naming the remedy, unless `allowSameStorageClass: true` says it's deliberate. That is exactly the misconfiguration above; it can no longer happen silently.
- Values docs say plainly that `targetStorageClass` is the destination, and that **`agent.base.storageClass` and `warmPool.storageClass` must be fixed too** — otherwise newly-created agents keep landing on the old backend regardless.

## Operator steps (independent of this PR)

1. `storageMigration.enabled: false` → deploy. Releases every gated agent, bins half-copied targets, stops further copies onto the filer.
2. Point **`agent.base.storageClass`** and **`warmPool.storageClass`** at the block class (or empty for cluster default), or new agents keep being born on NFS.
3. Deploy this PR, then re-enable — ideally `concurrency: 1` for the first agent — and watch the log. Workspaces already flipped to RWO-on-file are picked up by the new class trigger and moved for real.

## Also here: the copy is ~5x cheaper in round-trips

A 1 GiB workspace was taking **an hour** on the IOPS-capped file class. The bytes were never the issue — a workspace is small-file-heavy (a pnpm store is 100k+ entries) and every entry is a network round-trip *and* an IOP against a capped share. The script walked the source **five times** before counting data passes: readability preflight, `du -sh` for a log line, ownership preflight, metadata baseline, checksum find.

- **One source walk.** `find`'s `-readable` alternation puts a readability flag in the same pass, so the unreadable check, the ownership check and the verification baseline all derive from that single output. The source is quiesced, so re-walking could never have learned anything new.
- **`du -sh` deleted** — a full metadata walk for a log line. The walk yields an entry count, which predicts duration far better than a byte total.
- **Parallel checksums** (8 workers): latency-bound, not CPU- or bandwidth-bound, so overlapping round-trips is close to a linear win. Output is sorted after collection since workers finish out of order.
- **`phase:` log lines with elapsed seconds** (walk / wipe / copy / metadata / content) so the next slow drain is attributable instead of guesswork.
- **`minTargetSize`** floors the target volume: a class that prices IOPS per gigabyte gives a faithfully-sized 1Gi volume a 1Gi share of IOPS, throttling exactly the per-file work the copy does. Empty by default; **`10Gi` is the right value for IBM VPC block**, which has that minimum anyway.

## Tests

Four new cases, each pinning a property that failed in production: the target lands on the **cluster default even when `agent.base.storageClass` names the file class**; an **already-RWO volume on the wrong class is still drained**; a volume **already on the target class is left alone** (convergence); and **target == source class is refused** with no gate and no bytes copied, while the explicit override still works.

Controller: 7/7 packages green, `go vet` + staticcheck clean, helm lint clean.

## What I got wrong

I flagged this exact risk in prose when asked whether the migration works with IBM's classes — "flip `base.storageClass` or targets land RWO on the file class and you're still on NFS" — and then shipped code that silently accepted precisely that, and never checked the deployed values before the drain. A guard belongs in the code, which is what this adds.