### PR TITLE
fix(controller): re-land the lost tar fix; never reuse a wrong-destination target

### DIFF
--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -82,6 +82,9 @@ const (
 	// migrationFallbackUID runs the copy when the chart doesn't pin the
 	// agent container's uid. Matches the platform images' agent user.
 	migrationFallbackUID = int64(65532)
+	// migrationFallbackGID pairs with migrationFallbackUID when the chart
+	// pins no group; the platform images run 65532:65532.
+	migrationFallbackGID = int64(65532)
 	// migrationChecksumParallelism is how many md5sum workers read the tree
 	// at once. Small-file verification over a network filesystem is bound by
 	// per-file round-trips, not bandwidth or CPU, so concurrency buys close
@@ -763,13 +766,18 @@ func buildMigrationJob(agentName string, pairs []migrationPair, cfg *config.Conf
 	var volumes []corev1.Volume
 	var mounts []corev1.VolumeMount
 	var script strings.Builder
-	// The copy runs as the agent uid — resolved from the chart's container
-	// security context, which is the identity the agent itself runs with.
-	uid := migrationFallbackUID
-	if sc := cfg.AgentBase.ContainerSecurityContext; sc != nil && sc.RunAsUser != nil {
-		uid = *sc.RunAsUser
+	// The copy runs as the agent's own uid AND gid, resolved from the chart's
+	// container security context — the identity the agent itself runs with,
+	// so what the copy creates is what the agent can use.
+	uid, gid := migrationFallbackUID, migrationFallbackGID
+	if sc := cfg.AgentBase.ContainerSecurityContext; sc != nil {
+		if sc.RunAsUser != nil {
+			uid = *sc.RunAsUser
+		}
+		if sc.RunAsGroup != nil {
+			gid = *sc.RunAsGroup
+		}
 	}
-	gid := int64(0)
 
 	// The walk always emits flag|type|mode|uid|path|link; what the comparison
 	// KEEPS is a cut of that. Normalizing ownership (opt-in) means the
@@ -847,16 +855,27 @@ copy_verify() {
   find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec rm -rf {} +
   phase "wiped target"
 
-  # tar, not "cp -a src/. dst/": cp applies the SOURCE ROOT's ownership and
-  # timestamps to the TARGET ROOT, which no unprivileged process can do (the
-  # root belongs to the provisioner; fsGroup, not us, makes it writable).
-  # --no-overwrite-dir leaves the target root's own metadata alone; -p keeps
-  # every mode including setuid; tar preserves hard links natively (a
-  # hard-link-heavy pnpm store must not inflate past the volume size) and
-  # --sparse keeps sparse files sparse. Ownership needs no preserving: the
-  # workspace has a single owner and we are it.
-  tar -C "$src" --sparse -cf - . | tar -C "$dst" -xpf - --no-overwrite-dir
-  sync
+  # Archive the source's CONTENTS, never the source directory itself. An
+  # archive containing "./" carries the source root's mode, and tar applies
+  # it to the target root on extraction — which fails as EPERM, because the
+  # target root belongs to the provisioner (fsGroup makes it writable to us,
+  # it does not make us its owner). --no-overwrite-dir does not save us:
+  # tar's delayed directory restore still stats and chmods that member at
+  # the end of extraction. Feeding tar the top-level entries sidesteps it
+  # entirely — the root is never a member, so its metadata is never touched.
+  # One tar process still sees the whole tree, so hard links are preserved
+  # (a hard-link-heavy pnpm store must not inflate past the volume size);
+  # -p keeps every mode including setuid, --sparse keeps sparse files
+  # sparse, and ownership needs no preserving because the workspace has a
+  # single owner and we are it.
+  if [ "$entries" -gt 0 ]; then
+    (cd "$src" && find . -mindepth 1 -maxdepth 1 ! -path './lost+found*' -print0) \
+      | tar -C "$src" --sparse --null -T - -cf - \
+      | tar -C "$dst" -xpf - --no-overwrite-dir
+    sync
+  else
+    echo "source is empty; nothing to copy"
+  fi
   phase "copied"
 
   # The target root must be writable by the agent — the property the copy
@@ -952,15 +971,17 @@ copy_verify() {
 					RestartPolicy:                corev1.RestartPolicyNever,
 					AutomountServiceAccountToken: ptrBool(false),
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser: &uid,
-						// Group 0, matching the agent images' own uid:0
-						// convention, so anything the copy creates carries
-						// the identity the agent itself runs with.
+						RunAsUser:  &uid,
 						RunAsGroup: &gid,
-						// fsGroup covers CSI block backends; hostPath-backed
-						// classes (local-path) skip it, which is what the
-						// chown init container below is for.
-						FSGroup: &uid,
+						// fsGroup is the AGENT's group, and that is
+						// load-bearing beyond this Job: the kubelet chowns a
+						// fresh volume's root to it and adds group-write, and
+						// that chown persists on the filesystem. Agent pods
+						// set no fsGroup of their own, so this is what leaves
+						// the migrated root writable to the agent afterwards.
+						// (hostPath-backed classes skip fsGroup; their roots
+						// are world-writable already.)
+						FSGroup: &gid,
 					},
 					Containers: []corev1.Container{{
 						Name:         "copy",

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -10,6 +10,7 @@ import (
 
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,6 +107,7 @@ type StorageMigrationManager struct {
 	skippedVM       map[string]bool
 	warnedSameClass map[string]bool
 	loggedReason    map[string]bool
+	warnedResolve   bool
 }
 
 func NewStorageMigrationManager(client kubernetes.Interface, dyn dynamic.Interface, cfg *config.Config) *StorageMigrationManager {
@@ -331,7 +333,7 @@ func (m *StorageMigrationManager) Reconcile(ctx context.Context) {
 			}
 			slots--
 		}
-		if err := m.migrateAgent(ctx, agent, rwxByAgent[name]); err != nil {
+		if err := m.migrateAgent(ctx, agent, rwxByAgent[name], targetClass); err != nil {
 			slog.Warn("storage migration: agent migration step failed", "agent", name, "error", err)
 		}
 	}
@@ -354,16 +356,42 @@ func (m *StorageMigrationManager) resolveTargetClass(ctx context.Context) (name 
 	if err != nil {
 		// Without the default class's name the class comparison can't run;
 		// the RWX rule still does, so the drain degrades rather than stops.
-		slog.Warn("storage migration: cannot resolve the cluster default storage class; migrating on access mode only", "error", err)
+		m.warnResolveOnce("storage migration: cannot resolve the cluster default storage class; migrating on access mode only", err)
 		return "", false
 	}
-	for _, sc := range classes.Items {
-		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] == "true" {
-			return sc.Name, false
+	// Same tie-break as the DefaultStorageClass admission plugin: with
+	// several classes annotated default, the NEWEST wins. Diverging from
+	// admission here would discard-and-recreate targets forever — admission
+	// stamps one class, this comparison expects another.
+	var picked *storagev1.StorageClass
+	for i := range classes.Items {
+		sc := &classes.Items[i]
+		if sc.Annotations["storageclass.kubernetes.io/is-default-class"] != "true" {
+			continue
+		}
+		if picked == nil || sc.CreationTimestamp.After(picked.CreationTimestamp.Time) {
+			picked = sc
 		}
 	}
-	slog.Warn("storage migration: no default storage class found; migrating on access mode only")
+	if picked != nil {
+		return picked.Name, false
+	}
+	m.warnResolveOnce("storage migration: no default storage class found; migrating on access mode only", nil)
 	return "", false
+}
+
+// warnResolveOnce keeps the per-tick resolution warnings from repeating every
+// 30s for the lifetime of a misconfigured install.
+func (m *StorageMigrationManager) warnResolveOnce(msg string, err error) {
+	if m.warnedResolve {
+		return
+	}
+	m.warnedResolve = true
+	if err != nil {
+		slog.Warn(msg, "error", err)
+		return
+	}
+	slog.Warn(msg)
 }
 
 // migrationReason says why a workspace needs migrating, or "" if it does not.
@@ -392,6 +420,32 @@ func migrationReason(pvc *corev1.PersistentVolumeClaim, targetClass string, allo
 		return "storage class " + srcClass + " is not the migration target " + targetClass, true
 	}
 	return "", false
+}
+
+// targetReusable says whether an existing, unclaimed migration target may
+// receive this configuration's copy. Class must match the resolved
+// destination (unknown destination — lookup failed — accepts anything rather
+// than churn), and the size must meet the configured floor so a floor added
+// after a failed attempt takes effect on the retry.
+func (m *StorageMigrationManager) targetReusable(existing *corev1.PersistentVolumeClaim, targetClass string) bool {
+	if targetClass != "" && ptrClassString(existing.Spec.StorageClassName) != targetClass {
+		return false
+	}
+	if floor := m.config.StorageMigration.MinTargetSize; floor != "" {
+		if q, err := resource.ParseQuantity(floor); err == nil {
+			if size := existing.Spec.Resources.Requests[corev1.ResourceStorage]; size.Cmp(q) < 0 {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func ptrClassString(sc *string) string {
+	if sc == nil {
+		return ""
+	}
+	return *sc
 }
 
 func isRWX(modes []corev1.PersistentVolumeAccessMode) bool {
@@ -423,7 +477,7 @@ func migrationJobName(agentName string) string {
 
 // migrateAgent advances one agent's migration by one step. Every step is
 // idempotent; the caller re-invokes each tick until nothing is left to do.
-func (m *StorageMigrationManager) migrateAgent(ctx context.Context, agent *apiv1.Agent, rwxPVCs []corev1.PersistentVolumeClaim) error {
+func (m *StorageMigrationManager) migrateAgent(ctx context.Context, agent *apiv1.Agent, rwxPVCs []corev1.PersistentVolumeClaim, targetClass string) error {
 	name := agent.Name
 
 	// Step 1 — gate the agent down. The annotation is a shouldRun negative
@@ -463,7 +517,7 @@ func (m *StorageMigrationManager) migrateAgent(ctx context.Context, agent *apiv1
 				// PVC-name prefix by the `<mount>-<agent>-0` convention.
 				mount = strings.TrimSuffix(old.Name, "-"+name+"-0")
 			}
-			target, err := m.ensureTargetPVC(ctx, name, mount, &old, ownerRef)
+			target, err := m.ensureTargetPVC(ctx, name, mount, &old, ownerRef, targetClass)
 			if err != nil {
 				return err
 			}
@@ -520,11 +574,44 @@ type migrationPair struct {
 // Size follows the source's request; class is the agents' configured class
 // (empty = cluster default, WaitForFirstConsumer binding lands it on the
 // copy Job's node).
-func (m *StorageMigrationManager) ensureTargetPVC(ctx context.Context, agentName, mount string, old *corev1.PersistentVolumeClaim, ownerRef metav1.OwnerReference) (string, error) {
+func (m *StorageMigrationManager) ensureTargetPVC(ctx context.Context, agentName, mount string, old *corev1.PersistentVolumeClaim, ownerRef metav1.OwnerReference, targetClass string) (string, error) {
 	targetName := migrationTargetName(old.Name)
-	_, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).Get(ctx, targetName, metav1.GetOptions{})
+	existing, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).Get(ctx, targetName, metav1.GetOptions{})
 	if err == nil {
-		return targetName, nil
+		// A pre-existing target is only reusable if it is where THIS
+		// configuration wants the data to land. The wrong-class incident
+		// left exactly the counterexample behind: targets provisioned on
+		// the shared-filesystem class by the old inherit-the-agents'-class
+		// bug — reusing one would copy every byte straight back onto the
+		// backend being drained, silently defeating a corrected config.
+		if existing.DeletionTimestamp != nil {
+			return "", fmt.Errorf("stale migration target %s is still terminating; retrying next tick", targetName)
+		}
+		if m.targetReusable(existing, targetClass) {
+			return targetName, nil
+		}
+		// Refuse to touch anything claimed: LabelAgent appears on the
+		// target only at flip, when it becomes the agent's LIVE volume.
+		// An unclaimed target is garbage by construction — but if this
+		// ever disagrees, erring on "migration stalls" beats "volume
+		// deleted".
+		if existing.Labels[LabelAgent] != "" {
+			return "", fmt.Errorf("target %s does not match the configured destination but is already claimed; refusing to replace it", targetName)
+		}
+		slog.Warn("storage migration: discarding stale target provisioned for a different destination",
+			"agent", agentName, "pvc", targetName,
+			"have", ptrClassString(existing.Spec.StorageClassName), "want", targetClass)
+		// The copy Job (if any) mounts the stale target by name; it must go
+		// first or pvc-protection pins the PVC until the pod exits anyway.
+		prop := metav1.DeletePropagationBackground
+		if err := m.client.BatchV1().Jobs(m.config.Namespace).Delete(ctx, migrationJobName(agentName),
+			metav1.DeleteOptions{PropagationPolicy: &prop}); err != nil && !errors.IsNotFound(err) {
+			return "", err
+		}
+		if err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).Delete(ctx, targetName, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return "", err
+		}
+		return "", fmt.Errorf("discarded stale migration target %s; recreating next tick", targetName)
 	}
 	if !errors.IsNotFound(err) {
 		return "", err
@@ -817,7 +904,10 @@ copy_verify() {
   # root-squashing share — no copier can move it, so fail with the paths
   # rather than a mid-copy error. Symlinks are exempt: -readable follows the
   # link, and a dangling link is legitimate content the copy recreates.
-  unreadable="$(awk -F'|' '$1=="x" && $2!="l" {print $5}' /tmp/src.walk | head -20)"
+  # The 20-line cap lives INSIDE awk: piping through head under pipefail
+  # means awk dies of SIGPIPE once head exits, and set -e then kills the
+  # script before the diagnostic prints — a cryptic 141 instead of paths.
+  unreadable="$(awk -F'|' '$1=="x" && $2!="l" && n<20 {print $5; n++}' /tmp/src.walk)"
   if [ -n "$unreadable" ]; then
     echo "migration blocked: owner-unreadable entries on the source (list may be truncated):"
     echo "$unreadable"
@@ -827,7 +917,7 @@ copy_verify() {
   # Ownership: an unprivileged copy recreates entries as the agent uid, so it
   # is only faithful while the workspace is single-owner — which it is by
   # construction. Anything else is reported rather than silently re-owned.
-  foreign="$(awk -F'|' -v u="${AGENT_UID}" '$4!=u {print $5}' /tmp/src.walk | head -20)"
+  foreign="$(awk -F'|' -v u="${AGENT_UID}" '$4!=u && n<20 {print $5; n++}' /tmp/src.walk)"
   if [ -n "$foreign" ]; then
     if [ "${ALLOW_OWNERSHIP_REMAP}" = "1" ]; then
       echo "note: re-owning these source entries to uid ${AGENT_UID} (allowOwnershipRemap; list may be truncated):"
@@ -851,7 +941,10 @@ copy_verify() {
   # caches, site-packages), and removing an entry needs write+execute on its
   # parent. LOST+FOUND is skipped: a fresh ext4 volume's own artifact,
   # root-owned and not ours to delete — the verification excludes it too.
-  find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec chmod -R u+rwX {} +
+  # Symlinks are excluded from the mode restore: chmod dereferences a
+  # top-level link argument, and a DANGLING one (legitimate content) would
+  # error out and wedge every retry. rm -rf removes links themselves fine.
+  find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found ! -type l -exec chmod -R u+rwX {} +
   find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec rm -rf {} +
   phase "wiped target"
 
@@ -904,8 +997,17 @@ copy_verify() {
   # order. md5 is deliberate: integrity checking of our own quiesced copy,
   # not defense against crafted collisions — and the fastest digest coreutils
   # ships.
-  sums() { (cd "$1" && find . -type f ! -path './lost+found*' -print0 \
-              | xargs -0 -r -P"${PAR}" -n64 md5sum) | LC_ALL=C sort; }
+  # Each worker batch writes its own file: with a shared stdout, a batch
+  # whose output exceeds one atomic pipe write (long node_modules paths
+  # easily do) can interleave mid-line with another worker, and a torn line
+  # is a spurious verification failure. O_APPEND to distinct files by PID
+  # cannot tear.
+  sums() {
+    rm -f /tmp/sums.*
+    (cd "$1" && find . -type f ! -path './lost+found*' -print0 \
+       | xargs -0 -r -P"${PAR}" -n64 sh -c 'md5sum "$@" >> "/tmp/sums.$$"' _)
+    cat /tmp/sums.* 2>/dev/null | LC_ALL=C sort
+  }
   sums "$src" > /tmp/src.sum
   sums "$dst" > /tmp/dst.sum
   cmp /tmp/src.sum /tmp/dst.sum

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -182,12 +182,16 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	require.NotNil(t, psc)
 	require.NotNil(t, psc.RunAsUser)
 	assert.Equal(t, int64(65532), *psc.RunAsUser)
-	// Group 0 matches the agent images' uid:0 convention, so what the copy
-	// creates carries the identity the agent itself runs with.
+	// The copy runs as the agent's own uid AND gid, so what it creates is
+	// what the agent can use.
 	require.NotNil(t, psc.RunAsGroup)
-	assert.Equal(t, int64(0), *psc.RunAsGroup)
+	assert.Equal(t, int64(65532), *psc.RunAsGroup)
 	require.NotNil(t, psc.FSGroup)
-	assert.Equal(t, int64(65532), *psc.FSGroup, "fsGroup makes the fresh target volume writable to the agent uid")
+	// fsGroup must be the AGENT's group: the kubelet's chown of the volume
+	// root persists on the filesystem, and agent pods set no fsGroup of
+	// their own — this is what leaves the migrated root writable to them.
+	assert.Equal(t, int64(65532), *psc.FSGroup, "fsGroup is the agent's group, so the root stays writable after the flip")
+
 	// Nothing in the migration may need privilege: OpenShift's restricted SCC
 	// strips CAP_CHOWN/CAP_DAC_OVERRIDE and Kata's virtiofs refuses guest
 	// chown, so a root step (even just to chown a target root) is a
@@ -215,13 +219,24 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// network round-trip, so the source must be walked ONCE — readability,
 	// ownership and the verification baseline all derive from that one pass.
 	// (Two walks total: source, then target for the comparison.)
-	// (The one source walk carries two -printf actions — the readability
-	// alternation — so count walks, not actions.)
-	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find`),
-		"the source is walked ONCE: readability, ownership and the verification baseline all derive from that pass")
+	// Exactly one DEEP walk of the source — readability, ownership and the
+	// verification baseline all derive from that single pass. (The archive's
+	// file list is a second find, but -maxdepth 1: one readdir of the top
+	// level, not a tree walk, so it costs nothing on a 200k-entry tree.)
+	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 ! -path`),
+		"the source tree is walked ONCE")
+	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 -maxdepth 1`),
+		"the archive's file list is a shallow listing, not a second tree walk")
 	assert.NotContains(t, runnable, "du -sh", "a size log line is not worth a full metadata walk")
 	// Checksums are latency-bound, so they read in parallel.
 	assert.Contains(t, runnable, "-P\"${PAR}\"")
+	// The archive must contain the source's CONTENTS, never "./" itself:
+	// a "./" member carries the source root's mode, which tar then applies
+	// to the target root — EPERM, since the root belongs to the provisioner.
+	assert.Contains(t, runnable, "-mindepth 1 -maxdepth 1 ! -path './lost+found*' -print0")
+	assert.Contains(t, runnable, "--null -T -")
+	assert.NotRegexp(t, `tar -C "\$src" [^|]*-cf - \.`, runnable,
+		"archiving the directory itself is what made tar chmod the target root")
 	// tar with --no-overwrite-dir, not cp -a src/. dst/: cp would apply the
 	// source root's ownership/timestamps to the target root, which no
 	// unprivileged process can do.

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -230,6 +230,16 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	assert.NotContains(t, runnable, "du -sh", "a size log line is not worth a full metadata walk")
 	// Checksums are latency-bound, so they read in parallel.
 	assert.Contains(t, runnable, "-P\"${PAR}\"")
+	// Parallel workers write private files: a shared stdout tears lines when
+	// a batch exceeds one atomic pipe write (long node_modules paths do),
+	// and a torn line is a spurious verification failure.
+	assert.Contains(t, runnable, `>> "/tmp/sums.$$"`)
+	// The wipe's chmod must skip symlinks: chmod dereferences a top-level
+	// link argument, and a dangling one would wedge every retry.
+	assert.Contains(t, runnable, "! -name lost+found ! -type l -exec chmod")
+	// Diagnostics must not flow through `| head` under pipefail: awk dies of
+	// SIGPIPE and set -e kills the script before the paths print.
+	assert.NotContains(t, runnable, "| head")
 	// The archive must contain the source's CONTENTS, never "./" itself:
 	// a "./" member carries the source root's mode, which tar then applies
 	// to the target root — EPERM, since the root belongs to the provisioner.
@@ -619,4 +629,93 @@ func TestStorageMigration_TargetSizeFloorNeverShrinks(t *testing.T) {
 	require.NoError(t, err)
 	got := target.Spec.Resources.Requests[corev1.ResourceStorage]
 	assert.Equal(t, "7Gi", got.String(), "a floor below the source's request changes nothing")
+}
+
+// The wrong-class incident left targets on the shared-filesystem class
+// behind. Reusing one would copy every byte straight back onto the backend
+// being drained — a corrected targetStorageClass must discard and re-provision
+// them, and must take the copy Job (which mounts the stale target) with it.
+func TestStorageMigration_DiscardsStaleTargetOnWrongClass(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{annStorageMigration: "migrating"}
+	stale := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-home-agent-my-agent-0", Namespace: "test-agents",
+			Labels: map[string]string{
+				LabelPool: migrationPoolValue, LabelMount: "home-agent",
+				LabelMigrationFor: "my-agent",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: ptrString("ibmc-vpc-file-500-iops-agent"),
+		},
+	}
+	staleJob := &batchv1.Job{ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"}}
+	m, client := migrationManager(t, agent,
+		classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "ibmc-vpc-file-500-iops-agent", corev1.ReadWriteMany),
+		stale, staleJob, fileClass())
+	m.config.StorageMigration.TargetStorageClass = "block-target"
+
+	m.Reconcile(context.Background()) // discards the stale pair
+	_, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.Error(t, err, "the wrong-class target is binned")
+	_, err = client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
+	require.Error(t, err, "the Job mounting it goes first, or pvc-protection pins the PVC")
+
+	m.Reconcile(context.Background()) // recreates on the configured destination
+	target, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, target.Spec.StorageClassName)
+	assert.Equal(t, "block-target", *target.Spec.StorageClassName)
+}
+
+// The inverse guard: a target that already carries LabelAgent is the agent's
+// LIVE volume (flip has run). Class mismatch or not, it must never be deleted
+// — a stalled migration beats a deleted volume, every time.
+func TestStorageMigration_NeverDeletesClaimedTarget(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{annStorageMigration: "migrating"}
+	claimed := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-home-agent-my-agent-0", Namespace: "test-agents",
+			Labels: map[string]string{
+				LabelAgent: "my-agent", LabelPool: migrationPoolValue, LabelMount: "home-agent",
+			},
+		},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			StorageClassName: ptrString("ibmc-vpc-file-500-iops-agent"),
+		},
+	}
+	m, client := migrationManager(t, agent,
+		classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "ibmc-vpc-file-500-iops-agent", corev1.ReadWriteMany),
+		claimed, fileClass())
+	m.config.StorageMigration.TargetStorageClass = "block-target"
+
+	m.Reconcile(context.Background())
+
+	_, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	assert.NoError(t, err, "a claimed volume survives no matter what the config says")
+}
+
+// A matching target is reused, not churned — the discard guard must not turn
+// every tick into delete-and-recreate.
+func TestStorageMigration_ReusesMatchingTarget(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{annStorageMigration: "migrating"}
+	m, client := migrationManager(t, agent,
+		classedPVC("home-agent-my-agent-0", "my-agent", "home-agent", "ibmc-vpc-file-500-iops-agent", corev1.ReadWriteMany),
+		fileClass())
+	m.config.StorageMigration.TargetStorageClass = "block-target"
+
+	m.Reconcile(context.Background())
+	m.Reconcile(context.Background())
+
+	target, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "block-target", *target.Spec.StorageClassName)
+	job, err := client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.NotNil(t, job, "job survives across ticks while the copy runs")
 }


### PR DESCRIPTION
## Urgent: the tar fix never reached main

The fix for the production failure (`tar: .: Cannot change mode to rwx------: Operation not permitted`) was pushed **after** #3083 had already been squash-merged — the push output said `[new branch]` because the merge had deleted the remote branch, and I missed what that meant. The commit landed on a re-created branch attached to no PR. **The merged build on main still fails every copy.** This PR re-lands it, cherry-picked unchanged:

- Archive the source **contents**, never `.` itself — a `./` member carries the source root's `0700` mode and tar applies it to the target root we don't own (EPERM; `--no-overwrite-dir` does not prevent the delayed directory restore). One tar still sees the whole tree, so hard links/sparse/modes are preserved; the listing is `-maxdepth 1`, one readdir, not a second walk.
- The Job runs as the agent's **uid and gid** (chart pins `65532:65532`, not the `uid:0` previously assumed) with `fsGroup` = the agent **group** — agent pods set no fsGroup of their own, so the kubelet's persistent chown of the fresh root is what keeps the migrated volume writable to them.

## Plus four defects found reviewing that code adversarially

1. **`ensureTargetPVC` reused any existing target by name — class unexamined.** The wrong-class incident left `mig-*` targets **on the file class** behind; reusing one copies everything straight back onto the backend being drained, silently defeating the corrected config. Unclaimed targets that don't match the resolved destination (class, or size below `minTargetSize`) are now **discarded and re-provisioned** — copy Job deleted first, or pvc-protection pins the PVC. A target carrying `LabelAgent` is the agent's **live** volume and is never touched: that mismatch stalls loudly instead. *A stalled migration beats a deleted volume, every time.*
2. **Default-class tie-break mismatch.** The resolver took the *first* default-annotated class; admission takes the *newest*. With two defaults the discard guard above would churn forever. Now mirrors admission. (Resolution warnings also de-duplicated instead of every-30s spam.)
3. **Retry wipe wedged by a dangling symlink**: `chmod -R` dereferences a top-level link argument, so a dangling one (legitimate content) errored every attempt. Symlinks are excluded from the mode restore; `rm -rf` removes them fine.
4. **Diagnostics and checksums could fail confusingly**: `awk | head` under `pipefail` dies of SIGPIPE with >20 offending paths (cryptic 141 instead of the file list — cap now inside awk), and parallel md5 workers shared one stdout, where a batch exceeding one atomic pipe write (long `node_modules` paths) can tear a line mid-write and fail verification spuriously — workers now write private per-PID files.

## Tests

New: stale wrong-class target discarded **and** its Job with it, then recreated on the configured class (this is exactly the cluster's current state); a `LabelAgent`-carrying target is never deleted regardless of config; a matching target is reused without churn; script assertions pin the symlink exclusion, no-`|head`, and private sum files. Controller 7/7, vet/staticcheck/helm-lint clean.

## Deploy notes

Set `storageMigration.targetStorageClass` explicitly (`ibmc-vpc-block-10iops-tier`) — on same-namespace installs the controller's Role can't list cluster-scoped StorageClasses, so empty-means-cluster-default degrades to access-mode-only and skips the RWO-on-file recovery. `minTargetSize: 10Gi` recommended for the per-GB IOPS tier. Stale file-class `mig-*` PVCs from the incident are cleaned up automatically by finding 1's guard.