### PR TITLE
fix(controller): normalize fsGroup-inherited setgid; prune lost+found in deep finds

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -867,6 +867,19 @@ controller:
         runAsUser: 65532
         runAsGroup: 65532
         runAsNonRoot: true
+        # fsGroup makes a freshly provisioned block volume writable to the
+        # agent: the kubelet chowns the volume root to this group and marks
+        # it setgid at mount -- the standard mechanism for non-root pods on
+        # RWO storage (file/NFS classes and hostPath ignore it). Without it
+        # a new agent's init dies on a root-owned volume root.
+        # OnRootMismatch confines that to the FIRST mount: a volume whose
+        # root already matches is left entirely alone, so neither a large
+        # workspace on wake nor a freshly MIGRATED volume (whose root the
+        # copy Job shapes to match, and whose interior is verified
+        # byte-exact) is ever rewritten. On OpenShift the agents' SCC must
+        # permit fsGroup 65532.
+        fsGroup: 65532
+        fsGroupChangePolicy: OnRootMismatch
       containerSecurityContext:
         runAsUser: 65532
         runAsGroup: 65532

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1084,22 +1084,27 @@ controller:
     concurrency: 10
     # -- Reconcile pass interval.
     interval: "30s"
-    # -- Accept ownership normalization when the source workspace holds
-    # entries owned by a uid other than the agent's (root-written residue
-    # from an older release, a squashed-root `nobody` file). The copy is
-    # unprivileged, so it recreates them as the agent uid rather than
-    # preserving the original owner. Default false: such entries are
-    # reported with their paths and block that agent's migration, so the
-    # decision is yours — chown them on the source, or set this.
+    # -- Deprecated, ignored: the copy preserves ownership exactly (the
+    # writer side runs privileged on the target), so no remap consent is
+    # needed. Kept so existing values files keep parsing.
     allowOwnershipRemap: false
-    # -- Image for the copy Job. Needs bash, GNU tar and GNU coreutils
-    # (find -printf, md5sum) — busybox-based images lack the flags the copy
-    # and its verification rely on.
-    # The Job is unprivileged: it runs as the agent uid (from
-    # controller.agent.base containerSecurityContext.runAsUser) and needs no
-    # capabilities, so it works under a restricted SCC and on root-squashing
-    # shared-filesystem classes alike. It also deliberately does NOT inherit
-    # the agents' runtimeClassName: it runs platform tooling, not agent code.
+    # -- Image for the copy Job. Needs bash, GNU tar, GNU coreutils
+    # (find -printf, md5sum) and util-linux (setpriv) — the stock
+    # debian-slim default has all of them.
+    #
+    # The Job runs AS ROOT with split identity inside: every source read is
+    # dropped to the agent uid via setpriv (a root-squashing source share
+    # never honors uid 0), while the target side uses root to own the fresh
+    # volume root, restore exact ownership, and wipe retry residue. On
+    # OpenShift this requires binding an SCC that permits uid 0 (e.g.
+    # anyuid) to the `platform-migration` ServiceAccount in the agents
+    # namespace — an ops-side grant, out of band like all cluster-scoped
+    # security objects:
+    #   oc adm policy add-scc-to-user anyuid -z platform-migration -n <agents-ns>
+    # Without it, the copy pod is rejected at admission, loudly, and the
+    # gated agent waits. The Job never mounts a token, joins no mesh, and
+    # deliberately does not inherit the agents' runtimeClassName (Kata
+    # virtiofs refuses guest chown regardless of uid).
     jobImage: mirror.gcr.io/library/debian:stable-slim
   replicas: 1
   # -- Image for the Envoy credential-injector sidecar.

--- a/packages/controller/pkg/config/agent_config.go
+++ b/packages/controller/pkg/config/agent_config.go
@@ -261,14 +261,11 @@ type StorageMigration struct {
 	// size of their own, which a smaller request is silently rounded up to
 	// anyway.
 	MinTargetSize string `json:"minTargetSize,omitempty"`
-	// AllowOwnershipRemap lets the copy proceed when the source workspace
-	// holds entries owned by a uid other than the agent's. The copy is
-	// unprivileged (chown is unavailable under a restricted SCC and on a
-	// Kata sandbox's virtiofs), so those entries are recreated owned by the
-	// agent uid — a deliberate normalization, not a faithful copy, which is
-	// why it is opt-in. Default false: such entries are reported and block
-	// the migration, so an operator decides rather than discovering the
-	// remap later.
+	// AllowOwnershipRemap is deprecated and ignored: the copy preserves
+	// ownership exactly now that the writer side runs privileged on the
+	// target (readable foreign-owned entries copy faithfully instead of
+	// requiring remap consent). Kept so strict config decoding accepts
+	// values files from the release that introduced it.
 	AllowOwnershipRemap bool `json:"allowOwnershipRemap,omitempty"`
 	// JobImage runs the copy script. It must provide bash, GNU tar and GNU
 	// coreutils (find -printf, md5sum): the copy relies on tar's hard-link

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -894,7 +894,11 @@ copy_verify() {
   # The readability flag rides the same pass: find evaluates -readable per
   # entry and the alternation picks the prefix. The inner group is what keeps
   # the -o from swallowing the -mindepth/-path filters.
-  (cd "$src" && find . -mindepth 1 ! -path './lost+found*' \
+  # -prune on the root lost+found, never ! -path: exclusion by path still
+  # DESCENDS into the directory, and a 0700 root-owned one aborts the walk
+  # with permission denied. Anchored (./lost+found, no glob) so a nested
+  # one the workspace legitimately owns is still inventoried.
+  (cd "$src" && find . -mindepth 1 \( -path ./lost+found -prune \) -o \
      \( \( -readable -printf "r|%y|%m|%U|%p|%l\n" \) -o -printf "x|%y|%m|%U|%p|%l\n" \) \
    ) > /tmp/src.walk
   entries=$(wc -l < /tmp/src.walk)
@@ -976,6 +980,26 @@ copy_verify() {
   # so comparing it against the source root would fail spuriously).
   touch "$dst/.migration-writable" && rm -f "$dst/.migration-writable"
 
+  # fsGroup marks the target ROOT setgid (that is how the volume group
+  # carries into new entries), and every directory the copy creates
+  # INHERITS that bit at mkdir time — underneath tar, which never
+  # re-chmods because the mode it passed to mkdir was already the recorded
+  # one. Left alone, every target directory reads 2xxx where the source
+  # says xxx and the metadata pass (correctly) refuses the copy. Strip the
+  # inherited bit from directories, then re-apply it to the rare ones
+  # whose SOURCE mode genuinely records it, so the comparison measures
+  # fidelity rather than a mount artifact. The root itself keeps the
+  # kubelet's bit: it is excluded from the comparison, and future
+  # top-level writes by the agent should keep inheriting the group.
+  # (Invisible on hostPath-backed dev classes, which skip fsGroup — this
+  # only manifests on real CSI block targets.)
+  # -prune, not ! -path: find must not even DESCEND into the root-owned
+  # lost+found (permission denied would abort the script). Anchored to the
+  # root so a workspace's own nested lost+found is still processed.
+  find "$dst" -mindepth 1 \( -path "$dst/lost+found" -prune \) -o \( -type d -exec chmod g-s {} + \)
+  awk -F'|' '$2=="d" && length($3)==4 && substr($3,1,1)~/[2367]/ {print $5}' /tmp/src.walk \
+    | while IFS= read -r p; do chmod g+s "$dst/$p"; done
+
   # Two-pass verification against the quiesced source; the old volume is
   # deleted at flip on the strength of these comparisons, so both fail
   # closed on any difference.
@@ -986,7 +1010,7 @@ copy_verify() {
   # uid:0 while an fsGroup-managed target assigns its own gid — group
   # identity is not part of the workspace contract), the volume root itself,
   # and lost+found.
-  (cd "$dst" && find . -mindepth 1 ! -path './lost+found*' -printf "d|%y|%m|%U|%p|%l\n") \
+  (cd "$dst" && find . -mindepth 1 \( -path ./lost+found -prune \) -o -printf "d|%y|%m|%U|%p|%l\n") \
     | cut -d'|' -f${META_CUT} | LC_ALL=C sort > /tmp/dst.meta
   cmp /tmp/src.meta /tmp/dst.meta
   phase "verified metadata"
@@ -1004,7 +1028,7 @@ copy_verify() {
   # cannot tear.
   sums() {
     rm -f /tmp/sums.*
-    (cd "$1" && find . -type f ! -path './lost+found*' -print0 \
+    (cd "$1" && find . \( -path ./lost+found -prune \) -o -type f -print0 \
        | xargs -0 -r -P"${PAR}" -n64 sh -c 'md5sum "$@" >> "/tmp/sums.$$"' _)
     cat /tmp/sums.* 2>/dev/null | LC_ALL=C sort
   }

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -86,6 +86,9 @@ const (
 	// migrationFallbackGID pairs with migrationFallbackUID when the chart
 	// pins no group; the platform images run 65532:65532.
 	migrationFallbackGID = int64(65532)
+	// migrationServiceAccount is the Job's dedicated identity — the target
+	// of the ops-managed SCC grant on OpenShift. Ensured by the manager.
+	migrationServiceAccount = "platform-migration"
 	// migrationChecksumParallelism is how many md5sum workers read the tree
 	// at once. Small-file verification over a network filesystem is bound by
 	// per-file round-trips, not bandwidth or CPU, so concurrency buys close
@@ -234,6 +237,35 @@ func (m *StorageMigrationManager) ReleaseGated(ctx context.Context) {
 	}
 }
 
+// ensureServiceAccount creates the copy Job's dedicated identity if it is
+// missing. Idempotent, called only while there is work to admit. The SA
+// carries no role bindings and its token is never mounted — it exists so an
+// OpenShift install can scope the runs-as-root SCC grant to exactly this
+// workload (an ops-side, out-of-band binding, like every cluster-scoped
+// security object).
+func (m *StorageMigrationManager) ensureServiceAccount(ctx context.Context) {
+	_, err := m.client.CoreV1().ServiceAccounts(m.config.Namespace).Get(ctx, migrationServiceAccount, metav1.GetOptions{})
+	if err == nil || !errors.IsNotFound(err) {
+		if err != nil {
+			slog.Warn("storage migration: checking service account failed", "error", err)
+		}
+		return
+	}
+	sa := &corev1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      migrationServiceAccount,
+			Namespace: m.config.Namespace,
+			Labels:    map[string]string{"agent-platform.ai/managed-by": "platform-controller"},
+		},
+		AutomountServiceAccountToken: ptrBool(false),
+	}
+	if _, err := m.client.CoreV1().ServiceAccounts(m.config.Namespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
+		slog.Warn("storage migration: creating service account failed", "error", err)
+		return
+	}
+	slog.Info("storage migration: service account ensured", "name", migrationServiceAccount)
+}
+
 // Reconcile advances every in-flight migration one step and admits new
 // agents up to the concurrency cap. Exported for tests; RunLoop drives it.
 func (m *StorageMigrationManager) Reconcile(ctx context.Context) {
@@ -308,6 +340,10 @@ func (m *StorageMigrationManager) Reconcile(ctx context.Context) {
 		names = append(names, name)
 	}
 	sort.Strings(names)
+
+	if len(names) > 0 {
+		m.ensureServiceAccount(ctx)
+	}
 
 	slots := m.concurrency() - len(inFlight)
 	for _, name := range names {
@@ -832,9 +868,10 @@ func jobFailed(job *batchv1.Job) bool {
 // (source read-only, target read-write) pair, running a copy + two-pass
 // checksum verification per pair.
 //
-// The copy runs as the AGENT's uid, unprivileged and needing no
-// capabilities: an agent's workspace is single-owner by construction
-// (everything in it is written as the agent user), so the agent uid can
+// The copy runs with SPLIT IDENTITY. Everything that touches the SOURCE
+// runs as the AGENT's uid (dropped into via setpriv): the source may live
+// on a root-squashing share, where uid 0 is remapped to nobody server-side
+// and is the weakest identity on the mount, while the agent uid can
 // read every file — including 0600 files and
 // 0700 dirs — even on shared-filesystem classes that squash root, where a
 // root-running copy would EACCES on the first private file. Ownership on
@@ -853,9 +890,9 @@ func buildMigrationJob(agentName string, pairs []migrationPair, cfg *config.Conf
 	var volumes []corev1.Volume
 	var mounts []corev1.VolumeMount
 	var script strings.Builder
-	// The copy runs as the agent's own uid AND gid, resolved from the chart's
-	// container security context — the identity the agent itself runs with,
-	// so what the copy creates is what the agent can use.
+	// The reader identity: the agent's own uid and gid from the chart's
+	// container security context — the one identity a root-squashing source
+	// share always honors for the workspace it owns.
 	uid, gid := migrationFallbackUID, migrationFallbackGID
 	if sc := cfg.AgentBase.ContainerSecurityContext; sc != nil {
 		if sc.RunAsUser != nil {
@@ -865,186 +902,139 @@ func buildMigrationJob(agentName string, pairs []migrationPair, cfg *config.Conf
 			gid = *sc.RunAsGroup
 		}
 	}
-
-	// The walk always emits flag|type|mode|uid|path|link; what the comparison
-	// KEEPS is a cut of that. Normalizing ownership (opt-in) means the
-	// target's uids legitimately differ from the source's, so the uid column
-	// drops out — everything else stays verified either way.
-	metaCut := "2-"
-	if cfg.StorageMigration.AllowOwnershipRemap {
-		metaCut = "2,3,5,6"
-	}
-	fmt.Fprintf(&script, "set -euo pipefail\nAGENT_UID=%d\nALLOW_OWNERSHIP_REMAP=%s\nMETA_CUT=%s\nPAR=%d\n",
-		uid, map[bool]string{true: "1", false: "0"}[cfg.StorageMigration.AllowOwnershipRemap], metaCut, migrationChecksumParallelism)
+	fmt.Fprintf(&script, "set -euo pipefail\nAGENT_UID=%d\nAGENT_GID=%d\nPAR=%d\n",
+		uid, gid, migrationChecksumParallelism)
 	script.WriteString(`
 T0=$(date +%s)
 phase() { echo "phase: $1 (+$(( $(date +%s) - T0 ))s)"; }
+
+# SPLIT IDENTITY, one rule: whoever touches the SOURCE is the agent,
+# whoever touches the TARGET is root. The source may live on a
+# root-squashing share, where uid 0 is remapped to nobody server-side and
+# is the weakest identity on the mount (root got EACCES on the agent's own
+# 0600 files in production); the agent uid reads everything it owns. The
+# target is a local block filesystem, where root's ownership of the fresh
+# volume root, exact ownership restore, and wiping a prior attempt's
+# read-only residue all just work. No fsGroup is involved anywhere, so the
+# volume root carries no setgid bit and the kernel inherits nothing:
+# modes land exactly as tar records them.
+AS_AGENT="setpriv --reuid=${AGENT_UID} --regid=${AGENT_GID} --clear-groups"
+
+# Both identities share one private scratch dir (root-created, sticky,
+# world-writable): the agent-side workers and the root-side collectors
+# never collide with anything pre-existing, and Linux protected_regular
+# never refuses a redirect over a file the other identity created.
+W=$(mktemp -d)
+chmod 1777 "$W"
+
+# Source-side pipelines run under $AS_AGENT via this helper script (a
+# fresh process cannot inherit shell functions).
+cat > "$W"/srcside.sh <<'EOS'
+set -euo pipefail
+src="$1"; what="$2"; PAR="$3"; W="$4"
+case "$what" in
+walk)
+  # One deep walk of the source; every source-side check derives from it.
+  # -prune, not ! -path: exclusion by path still DESCENDS, and a 0700
+  # root-owned lost+found aborts the walk with permission denied. The r/x
+  # prefix records readability by THIS uid — the identity that will read
+  # the data.
+  cd "$src" && find . -mindepth 1 \( -path ./lost+found -prune \) -o \
+     \( \( -readable -printf "r|%y|%m|%U|%p|%l\n" \) -o -printf "x|%y|%m|%U|%p|%l\n" \) ;;
+sums)
+  # Content checksums, read in parallel: small-file verification is
+  # latency-bound, so workers overlap round-trips. Each worker batch
+  # appends to its own file — a shared stdout tears lines once a batch
+  # exceeds one atomic pipe write. md5 is integrity checking of our own
+  # quiesced copy, not defense against crafted collisions.
+  cd "$src" && rm -f "$W"/sums.src.*
+  find . \( -path ./lost+found -prune \) -o -type f -print0 \
+    | xargs -0 -r -P"$PAR" -n64 sh -c 'md5sum "$@" >> "'"$W"'/sums.src.$$"' _
+  cat "$W"/sums.src.* 2>/dev/null ;;
+esac
+EOS
 
 copy_verify() {
   src="$1"; dst="$2"
   echo "migrate: $src -> $dst"
 
-  # ONE walk of the source, and every check below is derived from its output.
-  # This is the difference between minutes and hours: a workspace is
-  # small-file-heavy (a pnpm store is 100k+ entries), every stat is a network
-  # round-trip AND an IOP against a capped share, so each extra walk costs
-  # the whole tree again. The source is quiesced, so one walk is also
-  # sufficient — nothing can change under us.
-  #
-  # The readability flag rides the same pass: find evaluates -readable per
-  # entry and the alternation picks the prefix. The inner group is what keeps
-  # the -o from swallowing the -mindepth/-path filters.
-  # -prune on the root lost+found, never ! -path: exclusion by path still
-  # DESCENDS into the directory, and a 0700 root-owned one aborts the walk
-  # with permission denied. Anchored (./lost+found, no glob) so a nested
-  # one the workspace legitimately owns is still inventoried.
-  (cd "$src" && find . -mindepth 1 \( -path ./lost+found -prune \) -o \
-     \( \( -readable -printf "r|%y|%m|%U|%p|%l\n" \) -o -printf "x|%y|%m|%U|%p|%l\n" \) \
-   ) > /tmp/src.walk
-  entries=$(wc -l < /tmp/src.walk)
+  $AS_AGENT bash "$W"/srcside.sh "$src" walk "$PAR" "$W" > "$W"/src.walk
+  entries=$(wc -l < "$W"/src.walk)
   phase "walked source: $entries entries"
 
   # The walk is line-based with | separators: a path containing either
   # character cannot be represented and would corrupt every check derived
-  # from the walk (before this guard, a newline in a filename surfaced as
-  # a baffling foreign-owner block). Refuse it by name instead — rename on
-  # the source is the remedy. Field count is exact: flag|type|mode|uid|path|link.
-  malformed="$(awk -F'|' 'NF!=6 && n<20 {print; n++}' /tmp/src.walk)"
+  # from the walk. Refuse it by name — rename on the source is the remedy.
+  # Field count is exact: flag|type|mode|uid|path|link.
+  malformed="$(awk -F'|' 'NF!=6 && n<20 {print; n++}' "$W"/src.walk)"
   if [ -n "$malformed" ]; then
     echo "migration blocked: source paths contain | or newline, which the inventory cannot represent (rename them; list may be truncated):"
     echo "$malformed"
     exit 1
   fi
 
-  # Unreadable to its own OWNER is unreadable to every uid on a
-  # root-squashing share — no copier can move it, so fail with the paths
-  # rather than a mid-copy error. Symlinks are exempt: -readable follows the
-  # link, and a dangling link is legitimate content the copy recreates.
-  # The 20-line cap lives INSIDE awk: piping through head under pipefail
-  # means awk dies of SIGPIPE once head exits, and set -e then kills the
-  # script before the diagnostic prints — a cryptic 141 instead of paths.
-  unreadable="$(awk -F'|' '$1=="x" && $2!="l" && n<20 {print $5; n++}' /tmp/src.walk)"
+  # An entry the READER cannot open is unmovable: on a squashing share no
+  # identity in this pod can read it — not the agent, and root least of
+  # all. This subsumes the old foreign-owner gate: a READABLE root-owned
+  # stray now copies faithfully (the writer preserves ownership exactly),
+  # and an unreadable one is caught here with its path. Dangling symlinks
+  # are exempt: -readable follows links, and the copy recreates them fine.
+  unreadable="$(awk -F'|' '$1=="x" && $2!="l" && n<20 {print $5; n++}' "$W"/src.walk)"
   if [ -n "$unreadable" ]; then
-    echo "migration blocked: owner-unreadable entries on the source (list may be truncated):"
+    echo "migration blocked: entries the agent uid cannot read on the source (chmod u+rX them; list may be truncated):"
     echo "$unreadable"
     exit 1
   fi
 
-  # Ownership: an unprivileged copy recreates entries as the agent uid, so it
-  # is only faithful while the workspace is single-owner — which it is by
-  # construction. Anything else is reported rather than silently re-owned.
-  foreign="$(awk -F'|' -v u="${AGENT_UID}" '$4!=u && n<20 {print $5; n++}' /tmp/src.walk)"
-  if [ -n "$foreign" ]; then
-    if [ "${ALLOW_OWNERSHIP_REMAP}" = "1" ]; then
-      echo "note: re-owning these source entries to uid ${AGENT_UID} (allowOwnershipRemap; list may be truncated):"
-      echo "$foreign"
-    else
-      echo "migration blocked: source entries owned by another uid, which an unprivileged copy cannot reproduce (list may be truncated):"
-      echo "$foreign"
-      echo "remedy: chown them to uid ${AGENT_UID} on the source, or set controller.storageMigration.allowOwnershipRemap=true to accept the normalization"
-      exit 1
-    fi
-  fi
+  # Verification baseline at FULL fidelity — the uid column is compared,
+  # not excused, because the root writer preserves ownership exactly.
+  cut -d'|' -f2- "$W"/src.walk | LC_ALL=C sort > "$W"/src.meta
+  # Source checksums before the copy: the source is quiesced, so before
+  # and after are indistinguishable, and this keeps every source read
+  # under the squash-safe identity.
+  $AS_AGENT bash "$W"/srcside.sh "$src" sums "$PAR" "$W" | LC_ALL=C sort > "$W"/src.sum
+  phase "hashed source"
 
-  # The same walk is the verification baseline — cut drops the readability
-  # flag (and the uid column when ownership is being normalized), and the
-  # sort happens after the cut so both sides order identically.
-  cut -d'|' -f${META_CUT} /tmp/src.walk | LC_ALL=C sort > /tmp/src.meta
-
-  # Per-attempt wipe so retries are deterministic. Restoring u+rwX first is
-  # what makes it possible as the owner: a prior attempt faithfully
-  # reproduced the workspace's read-only directories (0500/0555 — Go module
-  # caches, site-packages), and removing an entry needs write+execute on its
-  # parent. LOST+FOUND is skipped: a fresh ext4 volume's own artifact,
-  # root-owned and not ours to delete — the verification excludes it too.
-  # Symlinks are excluded from the mode restore: chmod dereferences a
-  # top-level link argument, and a DANGLING one (legitimate content) would
-  # error out and wedge every retry. rm -rf removes links themselves fine.
-  find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found ! -type l -exec chmod -R u+rwX {} +
+  # Wipe as root: a prior attempt's read-only directories are plain rm.
+  # lost+found stays — a fresh ext4 volume's own artifact, excluded from
+  # verification on both sides.
   find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec rm -rf {} +
   phase "wiped target"
 
-  # Archive the source's CONTENTS, never the source directory itself. An
-  # archive containing "./" carries the source root's mode, and tar applies
-  # it to the target root on extraction — which fails as EPERM, because the
-  # target root belongs to the provisioner (fsGroup makes it writable to us,
-  # it does not make us its owner). --no-overwrite-dir does not save us:
-  # tar's delayed directory restore still stats and chmods that member at
-  # the end of extraction. Feeding tar the top-level entries sidesteps it
-  # entirely — the root is never a member, so its metadata is never touched.
-  # One tar process still sees the whole tree, so hard links are preserved
-  # (a hard-link-heavy pnpm store must not inflate past the volume size);
-  # -p keeps every mode including setuid, --sparse keeps sparse files
-  # sparse, and ownership needs no preserving because the workspace has a
-  # single owner and we are it.
   if [ "$entries" -gt 0 ]; then
-    (cd "$src" && find . -mindepth 1 -maxdepth 1 ! -path './lost+found*' -print0) \
-      | tar -C "$src" --sparse --null -T - -cf - \
-      | tar -C "$dst" -xpf - --no-overwrite-dir
+    # Reader as the agent (squash-safe), writer as root: exact modes
+    # including setuid, exact OWNERSHIP (--same-owner --numeric-owner —
+    # readable foreign-uid strays land as themselves), hard links (a
+    # hard-link-heavy pnpm store must not inflate past the volume size),
+    # and sparseness. The "." member restores the volume root's own mode,
+    # owner, and times — a root writer may apply all of it.
+    $AS_AGENT tar -C "$src" --sparse -cf - . | tar -C "$dst" -xpf - --same-owner --numeric-owner
     sync
   else
     echo "source is empty; nothing to copy"
   fi
   phase "copied"
 
-  # The target root must be writable by the agent — the property the copy
-  # cannot assert for itself (its mode belongs to the provisioner/fsGroup,
-  # so comparing it against the source root would fail spuriously).
-  touch "$dst/.migration-writable" && rm -f "$dst/.migration-writable"
+  # The AGENT must be able to use the volume it wakes up on.
+  $AS_AGENT touch "$dst/.migration-writable"
+  rm -f "$dst/.migration-writable"
 
-  # Directories are re-stamped with their EXACT recorded modes from the
-  # walk. fsGroup marks the target volume root setgid (that is how the
-  # volume group reaches new entries) and the kernel propagates the bit to
-  # every directory the copy creates, underneath tar — which re-chmods
-  # only the directories it happens to revisit (--delay-directory-restore
-  # does not change that; measured). Rather than masking the bit out of
-  # the verification, the copy is made faithful: one chmod per directory,
-  # and the comparison below stays byte-strict for every entry.
-  # The 00 prefix is load-bearing: GNU chmod PRESERVES setuid/setgid on
-  # directories for numeric modes under five digits — "chmod 700" keeps an
-  # inherited bit, "chmod 00700" clears it (and "002755" still sets a
-  # genuinely recorded one).
-  awk -F'|' '$2=="d" {print $3 "|" $5}' /tmp/src.walk > /tmp/src.dirs
-  while IFS='|' read -r mode path; do
-    chmod "00$mode" "$dst/$path"
-  done < /tmp/src.dirs
-  phase "restored dir modes: $(wc -l < /tmp/src.dirs)"
+  # Root-entry fidelity (the volume roots are excluded from the entry
+  # walks below): mode and owner must have carried over.
+  [ "$($AS_AGENT stat -c '%a %u' "$src")" = "$(stat -c '%a %u' "$dst")" ]
 
-  # Two-pass verification against the quiesced source; the old volume is
-  # deleted at flip on the strength of these comparisons, so both fail
-  # closed on any difference.
-  #
-  # Pass 1 — metadata: type, mode, owner uid, path and symlink target for
-  # every entry. A mode that failed to carry over blocks the migration just
-  # like corrupt content would. Deliberate exclusions: gid (agent images run
-  # uid:0 while an fsGroup-managed target assigns its own gid — group
-  # identity is not part of the workspace contract), the volume root itself,
-  # and lost+found.
-  (cd "$dst" && find . -mindepth 1 \( -path ./lost+found -prune \) -o -printf "d|%y|%m|%U|%p|%l\n") \
-    | cut -d'|' -f${META_CUT} | LC_ALL=C sort > /tmp/dst.meta
-  cmp /tmp/src.meta /tmp/dst.meta
+  # Two-pass verification; the old volume is deleted at flip on the
+  # strength of these comparisons, so both fail closed on any difference.
+  (cd "$dst" && find . -mindepth 1 \( -path ./lost+found -prune \) -o -printf "%y|%m|%U|%p|%l\n") \
+    | LC_ALL=C sort > "$W"/dst.meta
+  cmp "$W"/src.meta "$W"/dst.meta
   phase "verified metadata"
 
-  # Pass 2 — content checksums, read in parallel: this is latency-bound, not
-  # CPU-bound, so workers overlap round-trips instead of queueing behind each
-  # other. Output is sorted after collection because workers finish out of
-  # order. md5 is deliberate: integrity checking of our own quiesced copy,
-  # not defense against crafted collisions — and the fastest digest coreutils
-  # ships.
-  # Each worker batch writes its own file: with a shared stdout, a batch
-  # whose output exceeds one atomic pipe write (long node_modules paths
-  # easily do) can interleave mid-line with another worker, and a torn line
-  # is a spurious verification failure. O_APPEND to distinct files by PID
-  # cannot tear.
-  sums() {
-    rm -f /tmp/sums.*
-    (cd "$1" && find . \( -path ./lost+found -prune \) -o -type f -print0 \
-       | xargs -0 -r -P"${PAR}" -n64 sh -c 'md5sum "$@" >> "/tmp/sums.$$"' _)
-    cat /tmp/sums.* 2>/dev/null | LC_ALL=C sort
-  }
-  sums "$src" > /tmp/src.sum
-  sums "$dst" > /tmp/dst.sum
-  cmp /tmp/src.sum /tmp/dst.sum
+  rm -f "$W"/sums.dst.*
+  (cd "$dst" && find . \( -path ./lost+found -prune \) -o -type f -print0 \
+     | xargs -0 -r -P"$PAR" -n64 sh -c 'md5sum "$@" >> "'"$W"'/sums.dst.$$"' _)
+  cat "$W"/sums.dst.* 2>/dev/null | LC_ALL=C sort > "$W"/dst.sum
+  cmp "$W"/src.sum "$W"/dst.sum
   phase "verified content"
   echo "verified (content + metadata): $src -> $dst"
 }
@@ -1076,6 +1066,7 @@ copy_verify() {
 	backoff := int32(2)
 	ttl := int32(600)
 	deadline := int64(migrationJobDeadline.Seconds())
+	rootUID := int64(0)
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            migrationJobName(agentName),
@@ -1100,24 +1091,29 @@ copy_verify() {
 					},
 				},
 				Spec: corev1.PodSpec{
-					// Never, not OnFailure: an in-place container restart
-					// would skip the init containers, and every attempt
-					// needs the root init's wipe first. With Never each
-					// retry is a fresh pod (BackoffLimit still bounds them).
-					RestartPolicy:                corev1.RestartPolicyNever,
+					// Never, not OnFailure: each retry must be a fresh pod
+					// so every attempt starts from the same script state
+					// (BackoffLimit still bounds them).
+					RestartPolicy: corev1.RestartPolicyNever,
+					// Dedicated identity so the pod-runs-as-root grant is
+					// scoped to exactly this Job. On OpenShift, ops binds an
+					// SCC permitting uid 0 (e.g. anyuid) to THIS service
+					// account, out of band like all cluster-scoped security
+					// objects; forgetting that rejects the pod at admission,
+					// loudly, rather than failing anything subtly. The token
+					// is not mounted — the pod talks to no API.
+					ServiceAccountName:           migrationServiceAccount,
 					AutomountServiceAccountToken: ptrBool(false),
+					// Root, with split identity inside (see the script): the
+					// process starts as root for the target side and drops
+					// to the agent uid via setpriv for every source read —
+					// a root-squashing source share never honors uid 0. No
+					// fsGroup: the writer owns the target root outright, and
+					// its absence is what keeps the volume root free of the
+					// setgid bit the kernel would otherwise propagate into
+					// every directory the copy creates.
 					SecurityContext: &corev1.PodSecurityContext{
-						RunAsUser:  &uid,
-						RunAsGroup: &gid,
-						// fsGroup is the AGENT's group, and that is
-						// load-bearing beyond this Job: the kubelet chowns a
-						// fresh volume's root to it and adds group-write, and
-						// that chown persists on the filesystem. Agent pods
-						// set no fsGroup of their own, so this is what leaves
-						// the migrated root writable to the agent afterwards.
-						// (hostPath-backed classes skip fsGroup; their roots
-						// are world-writable already.)
-						FSGroup: &gid,
+						RunAsUser: &rootUID,
 					},
 					Containers: []corev1.Container{{
 						Name:         "copy",

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -1015,13 +1015,19 @@ copy_verify() {
   fi
   phase "copied"
 
+  # The volume ROOT belongs to the mount infrastructure, not the
+  # workspace: shape it exactly the way the agent pods' fsGroup +
+  # OnRootMismatch expect (agent-owned, agent group, setgid, group-rwx),
+  # so the first post-migration mount passes the kubelet's root check and
+  # the interior — verified byte-exact below — is never rewritten by a
+  # recursive ownership pass. The root is excluded from the entry walks;
+  # everything inside is compared strictly.
+  chown "${AGENT_UID}:${AGENT_GID}" "$dst"
+  chmod 2770 "$dst"
+
   # The AGENT must be able to use the volume it wakes up on.
   $AS_AGENT touch "$dst/.migration-writable"
   rm -f "$dst/.migration-writable"
-
-  # Root-entry fidelity (the volume roots are excluded from the entry
-  # walks below): mode and owner must have carried over.
-  [ "$($AS_AGENT stat -c '%a %u' "$src")" = "$(stat -c '%a %u' "$dst")" ]
 
   # Two-pass verification; the old volume is deleted at flip on the
   # strength of these comparisons, so both fail closed on any difference.

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -937,7 +937,21 @@ copy_verify() {
   # The same walk is the verification baseline — cut drops the readability
   # flag (and the uid column when ownership is being normalized), and the
   # sort happens after the cut so both sides order identically.
-  cut -d'|' -f${META_CUT} /tmp/src.walk | LC_ALL=C sort > /tmp/src.meta
+  #
+  # dirmask strips the setgid bit from DIRECTORY modes on both sides
+  # before comparing. fsGroup marks the target volume root setgid (that is
+  # how the volume group reaches new entries) and every directory the copy
+  # creates inherits the bit at mkdir time, underneath tar — so target
+  # dirs read 2xxx where the source says xxx on every real CSI block
+  # target (invisible on hostPath dev classes, which skip fsGroup).
+  # Group identity is already outside the workspace contract — gid is
+  # excluded from this comparison for the same reason — and setgid on a
+  # directory governs nothing but group inheritance, so the bit is masked
+  # rather than the filesystem mutated: the migrated tree deliberately
+  # KEEPS inheriting the volume group for files the agent creates later,
+  # since agent pods set no fsGroup of their own. File modes stay strict.
+  dirmask() { awk -F'|' 'BEGIN{OFS="|"} $1=="d" && length($2)==4 {d=substr($2,1,1); if (d%4>=2) { d-=2; $2=(d==0) ? substr($2,2) : d substr($2,2) } } {print}'; }
+  cut -d'|' -f${META_CUT} /tmp/src.walk | dirmask | LC_ALL=C sort > /tmp/src.meta
 
   # Per-attempt wipe so retries are deterministic. Restoring u+rwX first is
   # what makes it possible as the owner: a prior attempt faithfully
@@ -980,26 +994,6 @@ copy_verify() {
   # so comparing it against the source root would fail spuriously).
   touch "$dst/.migration-writable" && rm -f "$dst/.migration-writable"
 
-  # fsGroup marks the target ROOT setgid (that is how the volume group
-  # carries into new entries), and every directory the copy creates
-  # INHERITS that bit at mkdir time — underneath tar, which never
-  # re-chmods because the mode it passed to mkdir was already the recorded
-  # one. Left alone, every target directory reads 2xxx where the source
-  # says xxx and the metadata pass (correctly) refuses the copy. Strip the
-  # inherited bit from directories, then re-apply it to the rare ones
-  # whose SOURCE mode genuinely records it, so the comparison measures
-  # fidelity rather than a mount artifact. The root itself keeps the
-  # kubelet's bit: it is excluded from the comparison, and future
-  # top-level writes by the agent should keep inheriting the group.
-  # (Invisible on hostPath-backed dev classes, which skip fsGroup — this
-  # only manifests on real CSI block targets.)
-  # -prune, not ! -path: find must not even DESCEND into the root-owned
-  # lost+found (permission denied would abort the script). Anchored to the
-  # root so a workspace's own nested lost+found is still processed.
-  find "$dst" -mindepth 1 \( -path "$dst/lost+found" -prune \) -o \( -type d -exec chmod g-s {} + \)
-  awk -F'|' '$2=="d" && length($3)==4 && substr($3,1,1)~/[2367]/ {print $5}' /tmp/src.walk \
-    | while IFS= read -r p; do chmod g+s "$dst/$p"; done
-
   # Two-pass verification against the quiesced source; the old volume is
   # deleted at flip on the strength of these comparisons, so both fail
   # closed on any difference.
@@ -1011,7 +1005,7 @@ copy_verify() {
   # identity is not part of the workspace contract), the volume root itself,
   # and lost+found.
   (cd "$dst" && find . -mindepth 1 \( -path ./lost+found -prune \) -o -printf "d|%y|%m|%U|%p|%l\n") \
-    | cut -d'|' -f${META_CUT} | LC_ALL=C sort > /tmp/dst.meta
+    | cut -d'|' -f${META_CUT} | dirmask | LC_ALL=C sort > /tmp/dst.meta
   cmp /tmp/src.meta /tmp/dst.meta
   phase "verified metadata"
 

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -904,6 +904,18 @@ copy_verify() {
   entries=$(wc -l < /tmp/src.walk)
   phase "walked source: $entries entries"
 
+  # The walk is line-based with | separators: a path containing either
+  # character cannot be represented and would corrupt every check derived
+  # from the walk (before this guard, a newline in a filename surfaced as
+  # a baffling foreign-owner block). Refuse it by name instead — rename on
+  # the source is the remedy. Field count is exact: flag|type|mode|uid|path|link.
+  malformed="$(awk -F'|' 'NF!=6 && n<20 {print; n++}' /tmp/src.walk)"
+  if [ -n "$malformed" ]; then
+    echo "migration blocked: source paths contain | or newline, which the inventory cannot represent (rename them; list may be truncated):"
+    echo "$malformed"
+    exit 1
+  fi
+
   # Unreadable to its own OWNER is unreadable to every uid on a
   # root-squashing share — no copier can move it, so fail with the paths
   # rather than a mid-copy error. Symlinks are exempt: -readable follows the
@@ -937,21 +949,7 @@ copy_verify() {
   # The same walk is the verification baseline — cut drops the readability
   # flag (and the uid column when ownership is being normalized), and the
   # sort happens after the cut so both sides order identically.
-  #
-  # dirmask strips the setgid bit from DIRECTORY modes on both sides
-  # before comparing. fsGroup marks the target volume root setgid (that is
-  # how the volume group reaches new entries) and every directory the copy
-  # creates inherits the bit at mkdir time, underneath tar — so target
-  # dirs read 2xxx where the source says xxx on every real CSI block
-  # target (invisible on hostPath dev classes, which skip fsGroup).
-  # Group identity is already outside the workspace contract — gid is
-  # excluded from this comparison for the same reason — and setgid on a
-  # directory governs nothing but group inheritance, so the bit is masked
-  # rather than the filesystem mutated: the migrated tree deliberately
-  # KEEPS inheriting the volume group for files the agent creates later,
-  # since agent pods set no fsGroup of their own. File modes stay strict.
-  dirmask() { awk -F'|' 'BEGIN{OFS="|"} $1=="d" && length($2)==4 {d=substr($2,1,1); if (d%4>=2) { d-=2; $2=(d==0) ? substr($2,2) : d substr($2,2) } } {print}'; }
-  cut -d'|' -f${META_CUT} /tmp/src.walk | dirmask | LC_ALL=C sort > /tmp/src.meta
+  cut -d'|' -f${META_CUT} /tmp/src.walk | LC_ALL=C sort > /tmp/src.meta
 
   # Per-attempt wipe so retries are deterministic. Restoring u+rwX first is
   # what makes it possible as the owner: a prior attempt faithfully
@@ -994,6 +992,24 @@ copy_verify() {
   # so comparing it against the source root would fail spuriously).
   touch "$dst/.migration-writable" && rm -f "$dst/.migration-writable"
 
+  # Directories are re-stamped with their EXACT recorded modes from the
+  # walk. fsGroup marks the target volume root setgid (that is how the
+  # volume group reaches new entries) and the kernel propagates the bit to
+  # every directory the copy creates, underneath tar — which re-chmods
+  # only the directories it happens to revisit (--delay-directory-restore
+  # does not change that; measured). Rather than masking the bit out of
+  # the verification, the copy is made faithful: one chmod per directory,
+  # and the comparison below stays byte-strict for every entry.
+  # The 00 prefix is load-bearing: GNU chmod PRESERVES setuid/setgid on
+  # directories for numeric modes under five digits — "chmod 700" keeps an
+  # inherited bit, "chmod 00700" clears it (and "002755" still sets a
+  # genuinely recorded one).
+  awk -F'|' '$2=="d" {print $3 "|" $5}' /tmp/src.walk > /tmp/src.dirs
+  while IFS='|' read -r mode path; do
+    chmod "00$mode" "$dst/$path"
+  done < /tmp/src.dirs
+  phase "restored dir modes: $(wc -l < /tmp/src.dirs)"
+
   # Two-pass verification against the quiesced source; the old volume is
   # deleted at flip on the strength of these comparisons, so both fail
   # closed on any difference.
@@ -1005,7 +1021,7 @@ copy_verify() {
   # identity is not part of the workspace contract), the volume root itself,
   # and lost+found.
   (cd "$dst" && find . -mindepth 1 \( -path ./lost+found -prune \) -o -printf "d|%y|%m|%U|%p|%l\n") \
-    | cut -d'|' -f${META_CUT} | dirmask | LC_ALL=C sort > /tmp/dst.meta
+    | cut -d'|' -f${META_CUT} | LC_ALL=C sort > /tmp/dst.meta
   cmp /tmp/src.meta /tmp/dst.meta
   phase "verified metadata"
 

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -220,9 +220,12 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// sums, target walk, target sums.
 	assert.Equal(t, 4, strings.Count(runnable, "-path ./lost+found -prune"))
 	assert.NotContains(t, runnable, "find . -mindepth 1 ! -path")
-	// The volume root itself is verified for mode+owner fidelity — the
-	// root writer restores it from the "." archive member.
-	assert.Contains(t, runnable, `stat -c '%a %u'`)
+	// The volume ROOT is mount infrastructure: the writer shapes it to
+	// exactly what the agent pods' fsGroup + OnRootMismatch expect, so the
+	// first post-migration mount skips the kubelet's recursive ownership
+	// pass and the byte-exact interior is never rewritten.
+	assert.Contains(t, runnable, `chown "${AGENT_UID}:${AGENT_GID}" "$dst"`)
+	assert.Contains(t, runnable, `chmod 2770 "$dst"`)
 	// Checksums parallel, per-worker private files (shared stdout tears).
 	assert.Contains(t, runnable, `sums.src.$$`)
 	assert.Contains(t, runnable, `sums.dst.$$`)

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -175,31 +175,26 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	require.NotNil(t, job.Spec.ActiveDeadlineSeconds)
 	assert.Greater(t, *job.Spec.ActiveDeadlineSeconds, int64(0),
 		"a non-terminal Job (unschedulable pod, stuck pull) must eventually fail rather than gate the agent forever")
-	// The copy runs as the agent uid, never root: a single-owner workspace is
-	// fully readable to its own uid even on root-squashing shared
-	// filesystems, where squashed root would EACCES on 0600/0700 entries.
+	// SPLIT IDENTITY: the pod runs as root for the target side (owns the
+	// fresh volume root, restores exact ownership, wipes read-only retry
+	// residue) and drops to the agent uid via setpriv for every source
+	// read — a root-squashing source share never honors uid 0. No fsGroup
+	// anywhere: its absence is what keeps the volume root free of the
+	// setgid bit the kernel would otherwise propagate into every directory
+	// the copy creates.
 	psc := job.Spec.Template.Spec.SecurityContext
 	require.NotNil(t, psc)
 	require.NotNil(t, psc.RunAsUser)
-	assert.Equal(t, int64(65532), *psc.RunAsUser)
-	// The copy runs as the agent's own uid AND gid, so what it creates is
-	// what the agent can use.
-	require.NotNil(t, psc.RunAsGroup)
-	assert.Equal(t, int64(65532), *psc.RunAsGroup)
-	require.NotNil(t, psc.FSGroup)
-	// fsGroup must be the AGENT's group: the kubelet's chown of the volume
-	// root persists on the filesystem, and agent pods set no fsGroup of
-	// their own — this is what leaves the migrated root writable to them.
-	assert.Equal(t, int64(65532), *psc.FSGroup, "fsGroup is the agent's group, so the root stays writable after the flip")
+	assert.Equal(t, int64(0), *psc.RunAsUser)
+	assert.Nil(t, psc.FSGroup, "no fsGroup: no setgid root, no kernel inheritance, and root needs no group grant")
+	// The root grant is scoped to a dedicated identity so the OpenShift SCC
+	// binding (ops-managed, out of band) covers exactly this workload.
+	assert.Equal(t, migrationServiceAccount, job.Spec.Template.Spec.ServiceAccountName)
+	require.NotNil(t, job.Spec.Template.Spec.AutomountServiceAccountToken)
+	assert.False(t, *job.Spec.Template.Spec.AutomountServiceAccountToken)
 
-	// Nothing in the migration may need privilege: OpenShift's restricted SCC
-	// strips CAP_CHOWN/CAP_DAC_OVERRIDE and Kata's virtiofs refuses guest
-	// chown, so a root step (even just to chown a target root) is a
-	// portability trap. The copy is unprivileged end to end.
-	assert.Empty(t, job.Spec.Template.Spec.InitContainers,
-		"no privileged init container — the agent uid owns the workspace and may chmod it")
 	copyScript := job.Spec.Template.Spec.Containers[0].Command[2]
-	// Assert on the commands, not the prose that explains why they are absent.
+	// Assert on the commands, not the prose that explains them.
 	var cmds strings.Builder
 	for _, line := range strings.Split(copyScript, "\n") {
 		if t := strings.TrimSpace(line); !strings.HasPrefix(t, "#") {
@@ -207,79 +202,33 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 		}
 	}
 	runnable := cmds.String()
-	// No chown may be INVOKED (an echo naming it in a remedy hint is fine):
-	// chown is unavailable under a restricted SCC and on Kata virtiofs.
-	assert.NotRegexp(t, `(?m)^chown |-exec chown|; chown `, runnable,
-		"the copy must never invoke chown")
-	// The verification must gate on metadata (mode + owner), not content
-	// alone — the source is never deleted when permissions failed to carry
-	// over.
+	// Every source touch is dropped to the agent identity.
+	assert.Contains(t, runnable, `AS_AGENT="setpriv --reuid=${AGENT_UID} --regid=${AGENT_GID} --clear-groups"`)
+	assert.Contains(t, runnable, `$AS_AGENT bash /tmp/srcside.sh "$src" walk`)
+	assert.Contains(t, runnable, `$AS_AGENT bash /tmp/srcside.sh "$src" sums`)
+	assert.Contains(t, runnable, `$AS_AGENT tar -C "$src"`)
+	// The writer preserves ownership exactly — and the verification
+	// therefore compares the uid column instead of excusing it.
+	assert.Contains(t, runnable, "--same-owner --numeric-owner")
 	assert.Contains(t, runnable, `%y|%m|%U|%p|%l`)
-	// Cost control: a workspace is small-file-heavy and every stat is a
-	// network round-trip, so the source must be walked ONCE — readability,
-	// ownership and the verification baseline all derive from that one pass.
-	// (Two walks total: source, then target for the comparison.)
-	// Exactly one DEEP walk of the source — readability, ownership and the
-	// verification baseline all derive from that single pass. (The archive's
-	// file list is a second find, but -maxdepth 1: one readdir of the top
-	// level, not a tree walk, so it costs nothing on a 200k-entry tree.)
-	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 \( -path`),
-		"the source tree is walked ONCE")
-	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 -maxdepth 1`),
-		"the archive's file list is a shallow listing, not a second tree walk")
-	assert.NotContains(t, runnable, "du -sh", "a size log line is not worth a full metadata walk")
-	// Checksums are latency-bound, so they read in parallel.
-	assert.Contains(t, runnable, "-P\"${PAR}\"")
-	// Parallel workers write private files: a shared stdout tears lines when
-	// a batch exceeds one atomic pipe write (long node_modules paths do),
-	// and a torn line is a spurious verification failure.
-	assert.Contains(t, runnable, `>> "/tmp/sums.$$"`)
-	// The wipe's chmod must skip symlinks: chmod dereferences a top-level
-	// link argument, and a dangling one would wedge every retry.
-	assert.Contains(t, runnable, "! -name lost+found ! -type l -exec chmod")
-	// Diagnostics must not flow through `| head` under pipefail: awk dies of
-	// SIGPIPE and set -e kills the script before the paths print.
-	assert.NotContains(t, runnable, "| head")
-	// The archive must contain the source's CONTENTS, never "./" itself:
-	// a "./" member carries the source root's mode, which tar then applies
-	// to the target root — EPERM, since the root belongs to the provisioner.
-	assert.Contains(t, runnable, "-mindepth 1 -maxdepth 1 ! -path './lost+found*' -print0")
-	assert.Contains(t, runnable, "--null -T -")
-	assert.NotRegexp(t, `tar -C "\$src" [^|]*-cf - \.`, runnable,
-		"archiving the directory itself is what made tar chmod the target root")
-	// tar with --no-overwrite-dir, not cp -a src/. dst/: cp would apply the
-	// source root's ownership/timestamps to the target root, which no
-	// unprivileged process can do.
-	assert.Contains(t, runnable, "--no-overwrite-dir")
-	assert.NotContains(t, runnable, "cp -a")
-	// A fresh ext4 CSI target ships a root-owned lost+found the source has
-	// not got: it must be excluded from the wipe and from verification, or
-	// every real block-backed migration fails on a phantom difference.
-	assert.Contains(t, runnable, "! -name lost+found", "excluded from the wipe")
-	// Deep finds must -prune it, never merely exclude by path: exclusion
-	// still DESCENDS into the 0700 root-owned directory, and the resulting
-	// permission-denied aborts the whole walk under set -e. Proven by
-	// executing the script against a fixture with a real root-owned
-	// lost+found (the sandbox rehearsal this time includes one on purpose).
-	// (The tar file-listing keeps the plain exclusion — it is -maxdepth 1
-	// and never descends, so there is nothing to prune.)
-	assert.NotContains(t, runnable, `find . -mindepth 1 ! -path`,
-		"a DEEP find with path exclusion but no -prune dies descending into a 0700 lost+found")
-	assert.Equal(t, 3, strings.Count(runnable, "-path ./lost+found -prune"),
-		"src walk, dst walk, and sums all prune the root lost+found")
-	// fsGroup marks the target root setgid and the KERNEL propagates the
-	// bit into every directory the copy creates, beneath tar (which
-	// re-chmods only dirs it happens to revisit — --delay-directory-restore
-	// does not change that; measured). The copy is made faithful instead of
-	// the comparison relaxed: every directory is re-stamped with its exact
-	// recorded mode, and verification stays byte-strict for all entries.
-	assert.Contains(t, runnable, `chmod "00$mode" "$dst/$path"`,
-		"00 prefix is load-bearing: GNU chmod preserves dir setgid for numeric modes under five digits")
-	assert.NotContains(t, runnable, "dirmask", "no comparison masking — the copy is exact instead")
-	// Paths the line-based inventory cannot represent are refused by name
-	// up front (a newline in a filename used to surface as a baffling
-	// foreign-owner block).
+	assert.NotContains(t, runnable, "ALLOW_OWNERSHIP_REMAP", "ownership is preserved, not remapped — the knob is dead")
+	// Root wipes the target: no chmod dance for read-only retry residue.
+	assert.Contains(t, runnable, "! -name lost+found -exec rm -rf {} +")
+	assert.NotContains(t, runnable, "chmod -R u+rwX", "root needs no permission repair to wipe")
+	// Deep finds -prune the root lost+found (a path exclusion still
+	// descends and dies on a 0700 root-owned one): source walk, source
+	// sums, target walk, target sums.
+	assert.Equal(t, 4, strings.Count(runnable, "-path ./lost+found -prune"))
+	assert.NotContains(t, runnable, "find . -mindepth 1 ! -path")
+	// The volume root itself is verified for mode+owner fidelity — the
+	// root writer restores it from the "." archive member.
+	assert.Contains(t, runnable, `stat -c '%a %u'`)
+	// Checksums parallel, per-worker private files (shared stdout tears).
+	assert.Contains(t, runnable, `sums.src.$$`)
+	assert.Contains(t, runnable, `sums.dst.$$`)
+	// Paths the line-based inventory cannot represent are refused by name.
 	assert.Contains(t, runnable, `awk -F'|' 'NF!=6`)
+
 	require.Len(t, job.Spec.Template.Spec.Volumes, 2)
 	src := job.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "home-agent-my-agent-0", src.PersistentVolumeClaim.ClaimName)
@@ -738,4 +687,19 @@ func TestStorageMigration_ReusesMatchingTarget(t *testing.T) {
 	job, err := client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.NotNil(t, job, "job survives across ticks while the copy runs")
+}
+
+// The copy Job's root grant is scoped to a dedicated ServiceAccount the
+// manager ensures itself; on OpenShift, ops binds the uid-0 SCC to exactly
+// this identity, out of band. No token is ever mounted.
+func TestStorageMigration_EnsuresDedicatedServiceAccount(t *testing.T) {
+	agent := agentCR()
+	m, client := migrationManager(t, agent, rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent"))
+
+	m.Reconcile(context.Background())
+
+	sa, err := client.CoreV1().ServiceAccounts("test-agents").Get(context.Background(), migrationServiceAccount, metav1.GetOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, sa.AutomountServiceAccountToken)
+	assert.False(t, *sa.AutomountServiceAccountToken)
 }

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -204,8 +204,8 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	runnable := cmds.String()
 	// Every source touch is dropped to the agent identity.
 	assert.Contains(t, runnable, `AS_AGENT="setpriv --reuid=${AGENT_UID} --regid=${AGENT_GID} --clear-groups"`)
-	assert.Contains(t, runnable, `$AS_AGENT bash /tmp/srcside.sh "$src" walk`)
-	assert.Contains(t, runnable, `$AS_AGENT bash /tmp/srcside.sh "$src" sums`)
+	assert.Contains(t, runnable, `$AS_AGENT bash "$W"/srcside.sh "$src" walk`)
+	assert.Contains(t, runnable, `$AS_AGENT bash "$W"/srcside.sh "$src" sums`)
 	assert.Contains(t, runnable, `$AS_AGENT tar -C "$src"`)
 	// The writer preserves ownership exactly — and the verification
 	// therefore compares the uid column instead of excusing it.

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -223,7 +223,7 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// verification baseline all derive from that single pass. (The archive's
 	// file list is a second find, but -maxdepth 1: one readdir of the top
 	// level, not a tree walk, so it costs nothing on a 200k-entry tree.)
-	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 ! -path`),
+	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 \( -path`),
 		"the source tree is walked ONCE")
 	assert.Equal(t, 1, strings.Count(runnable, `cd "$src" && find . -mindepth 1 -maxdepth 1`),
 		"the archive's file list is a shallow listing, not a second tree walk")
@@ -256,10 +256,23 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// not got: it must be excluded from the wipe and from verification, or
 	// every real block-backed migration fails on a phantom difference.
 	assert.Contains(t, runnable, "! -name lost+found", "excluded from the wipe")
-	// The glob must cover lost+found's CONTENTS too, not just the directory
-	// entry: an fsck-populated lost+found would otherwise show up as a
-	// phantom difference (or as foreign-owned files) and block the migration.
-	assert.Contains(t, runnable, `! -path './lost+found*'`, "excluded from verification, contents included")
+	// Deep finds must -prune it, never merely exclude by path: exclusion
+	// still DESCENDS into the 0700 root-owned directory, and the resulting
+	// permission-denied aborts the whole walk under set -e. Proven by
+	// executing the script against a fixture with a real root-owned
+	// lost+found (the sandbox rehearsal this time includes one on purpose).
+	// (The tar file-listing keeps the plain exclusion — it is -maxdepth 1
+	// and never descends, so there is nothing to prune.)
+	assert.NotContains(t, runnable, `find . -mindepth 1 ! -path`,
+		"a DEEP find with path exclusion but no -prune dies descending into a 0700 lost+found")
+	assert.Equal(t, 4, strings.Count(runnable, "-path ./lost+found -prune")+strings.Count(runnable, `-path "$dst/lost+found" -prune`),
+		"src walk, dst walk, sums, and the setgid strip all prune the root lost+found")
+	// fsGroup marks the target root setgid and mkdir inherits it beneath
+	// tar; the copy strips the inherited bit from directories and re-applies
+	// the (rare) genuinely-recorded ones from the source walk, so the
+	// metadata pass measures fidelity rather than a mount artifact.
+	assert.Contains(t, runnable, "chmod g-s")
+	assert.Contains(t, runnable, `chmod g+s "$dst/$p"`)
 	require.Len(t, job.Spec.Template.Spec.Volumes, 2)
 	src := job.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "home-agent-my-agent-0", src.PersistentVolumeClaim.ClaimName)

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -267,16 +267,19 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 		"a DEEP find with path exclusion but no -prune dies descending into a 0700 lost+found")
 	assert.Equal(t, 3, strings.Count(runnable, "-path ./lost+found -prune"),
 		"src walk, dst walk, and sums all prune the root lost+found")
-	// fsGroup marks the target root setgid and mkdir inherits it beneath
-	// tar (nondeterministically — tar's delayed restore clears it on some
-	// dirs and not others), so the bit is masked out of the DIRECTORY mode
-	// comparison on both sides rather than normalized on disk: group
-	// identity is outside the workspace contract, same as the gid
-	// exclusion. File modes stay strict, and the filesystem is not touched.
-	assert.Contains(t, runnable, "dirmask()")
-	assert.Contains(t, runnable, "| dirmask | LC_ALL=C sort > /tmp/src.meta")
-	assert.Contains(t, runnable, "| dirmask | LC_ALL=C sort > /tmp/dst.meta")
-	assert.NotContains(t, runnable, "chmod g-s", "the comparison relaxes; the filesystem is never mutated for it")
+	// fsGroup marks the target root setgid and the KERNEL propagates the
+	// bit into every directory the copy creates, beneath tar (which
+	// re-chmods only dirs it happens to revisit — --delay-directory-restore
+	// does not change that; measured). The copy is made faithful instead of
+	// the comparison relaxed: every directory is re-stamped with its exact
+	// recorded mode, and verification stays byte-strict for all entries.
+	assert.Contains(t, runnable, `chmod "00$mode" "$dst/$path"`,
+		"00 prefix is load-bearing: GNU chmod preserves dir setgid for numeric modes under five digits")
+	assert.NotContains(t, runnable, "dirmask", "no comparison masking — the copy is exact instead")
+	// Paths the line-based inventory cannot represent are refused by name
+	// up front (a newline in a filename used to surface as a baffling
+	// foreign-owner block).
+	assert.Contains(t, runnable, `awk -F'|' 'NF!=6`)
 	require.Len(t, job.Spec.Template.Spec.Volumes, 2)
 	src := job.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "home-agent-my-agent-0", src.PersistentVolumeClaim.ClaimName)

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -265,14 +265,18 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	// and never descends, so there is nothing to prune.)
 	assert.NotContains(t, runnable, `find . -mindepth 1 ! -path`,
 		"a DEEP find with path exclusion but no -prune dies descending into a 0700 lost+found")
-	assert.Equal(t, 4, strings.Count(runnable, "-path ./lost+found -prune")+strings.Count(runnable, `-path "$dst/lost+found" -prune`),
-		"src walk, dst walk, sums, and the setgid strip all prune the root lost+found")
+	assert.Equal(t, 3, strings.Count(runnable, "-path ./lost+found -prune"),
+		"src walk, dst walk, and sums all prune the root lost+found")
 	// fsGroup marks the target root setgid and mkdir inherits it beneath
-	// tar; the copy strips the inherited bit from directories and re-applies
-	// the (rare) genuinely-recorded ones from the source walk, so the
-	// metadata pass measures fidelity rather than a mount artifact.
-	assert.Contains(t, runnable, "chmod g-s")
-	assert.Contains(t, runnable, `chmod g+s "$dst/$p"`)
+	// tar (nondeterministically — tar's delayed restore clears it on some
+	// dirs and not others), so the bit is masked out of the DIRECTORY mode
+	// comparison on both sides rather than normalized on disk: group
+	// identity is outside the workspace contract, same as the gid
+	// exclusion. File modes stay strict, and the filesystem is not touched.
+	assert.Contains(t, runnable, "dirmask()")
+	assert.Contains(t, runnable, "| dirmask | LC_ALL=C sort > /tmp/src.meta")
+	assert.Contains(t, runnable, "| dirmask | LC_ALL=C sort > /tmp/dst.meta")
+	assert.NotContains(t, runnable, "chmod g-s", "the comparison relaxes; the filesystem is never mutated for it")
 	require.Len(t, job.Spec.Template.Spec.Volumes, 2)
 	src := job.Spec.Template.Spec.Volumes[0]
 	assert.Equal(t, "home-agent-my-agent-0", src.PersistentVolumeClaim.ClaimName)


### PR DESCRIPTION
## The failure

`/tmp/src.meta /tmp/dst.meta differ: char 3, line 1` on every real CSI block target: source dir `700`, target `2700`. **fsGroup marks the target volume root setgid** (Kubernetes' mechanism for making the volume's group reach new entries), and the **kernel** then propagates the bit into every directory the copy creates at `mkdir` time — beneath tar, which re-chmods only the directories it happens to revisit (`--delay-directory-restore` does not change that; measured). The strict metadata verification then correctly refused to certify the copy. The fail-closed gate worked; the copy had genuine (benign) drift. Invisible on dev: hostPath classes skip fsGroup.

## The fix: make the copy exact, keep the proof strict

Rejected two weaker designs along the way (visible in the commit history): chmod-normalize-and-reapply (extra machinery), and masking the bit out of the comparison (weakens the proof this whole feature is built on — reviewer pushback was right).

What ships: after extraction, **every directory is re-stamped with its exact recorded mode** from the source walk we already hold — one cheap pass over dirs only, no extra source I/O — and **verification stays byte-strict for every entry**. Two empirical findings are load-bearing and pinned by tests:

- GNU chmod **preserves setuid/setgid on directories for numeric modes under five digits**: `chmod 700` keeps an inherited bit, `chmod 00700` clears it, `002755` still sets a genuinely recorded one. The `00` prefix in the restore is not decoration.
- tar cannot be made to do this itself (measured, incl. `--delay-directory-restore`).

Also here:

- **Deep `find`s now `-prune` `lost+found`** instead of path-excluding it: exclusion still *descends*, and a `0700` root-owned one (ext4 targets) kills the walk with permission-denied under `set -e`. Latent in the merged build — your XFS targets are why it never fired. Root-anchored, so a nested `lost+found` the workspace owns is still inventoried.
- **Representability preflight**: a path containing `|` or newline can't be expressed in the line-based inventory and previously surfaced as a baffling foreign-owner block; now refused by name with a rename remedy.

## Proven by executing the real script (extracted from `buildMigrationJob`, byte-for-byte) as uid 65532

Fixture: target root owned by another uid, mode `2770` (fsGroup-shaped), root-owned `0700` `lost+found` inside.

- fresh + dirty-retry passes verify with **exact modes** `755/700/2755/555` — inherited bits scrubbed, a genuinely-recorded source setgid dir survives ✔
- hardlink count preserved; file modes strict throughout ✔
- negatives block with actionable paths: foreign-uid ✔ owner-unreadable ✔ pipe-in-name ✔

Cluster rehearsal (clean install → agent on root-squashing kernel-NFS class → drain to RWO local-path) running now; result will be posted here.

## After deploy

Nothing to clean up: failed Jobs sit in the bounded retry with sources untouched; the first retry after the controller rolls uses the fixed script.