### PR TITLE
fix(controller): migration retries survive the shaped root; source lost+found excluded

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-07-29
+Last verified: 2026-07-30
 
 ## Overview
 
@@ -522,6 +522,18 @@ The agent and the gateway are gated by different mechanisms — they live
 on opposite sides of the credential boundary, so the threat models
 differ:
 
+- **`platform-migration` ServiceAccount** in the agent namespace — the
+  identity of the one-time storage-migration copy Job, and the only
+  workload on the platform that runs as **uid 0**. The Job needs root
+  solely for the target side of the copy (owning a freshly provisioned
+  volume root, restoring exact file ownership); every read of the agent's
+  data drops to the agent's own uid, so a root-squashing source share
+  never sees uid 0. The SA carries no role bindings and its token is
+  never mounted (`automountServiceAccountToken: false` on both the SA and
+  the pod), so it cannot act against the API; its sole purpose is to
+  scope the OpenShift SCC grant that permits uid 0 to exactly this
+  workload — an ops-side, out-of-band binding. The pod joins no mesh and
+  mounts no credentials.
 - **Per-Agent ServiceAccount** in the agent namespace, name ==
   Agent ID. Both pods of the long-lived pair run as this SA, but
   only the *gateway* pod is a mesh participant — istiod stamps it with

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -243,13 +243,13 @@ func (m *StorageMigrationManager) ReleaseGated(ctx context.Context) {
 // OpenShift install can scope the runs-as-root SCC grant to exactly this
 // workload (an ops-side, out-of-band binding, like every cluster-scoped
 // security object).
-func (m *StorageMigrationManager) ensureServiceAccount(ctx context.Context) {
+func (m *StorageMigrationManager) ensureServiceAccount(ctx context.Context) error {
 	_, err := m.client.CoreV1().ServiceAccounts(m.config.Namespace).Get(ctx, migrationServiceAccount, metav1.GetOptions{})
-	if err == nil || !errors.IsNotFound(err) {
-		if err != nil {
-			slog.Warn("storage migration: checking service account failed", "error", err)
-		}
-		return
+	if err == nil {
+		return nil
+	}
+	if !errors.IsNotFound(err) {
+		return fmt.Errorf("checking migration service account: %w", err)
 	}
 	sa := &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
@@ -260,10 +260,10 @@ func (m *StorageMigrationManager) ensureServiceAccount(ctx context.Context) {
 		AutomountServiceAccountToken: ptrBool(false),
 	}
 	if _, err := m.client.CoreV1().ServiceAccounts(m.config.Namespace).Create(ctx, sa, metav1.CreateOptions{}); err != nil && !errors.IsAlreadyExists(err) {
-		slog.Warn("storage migration: creating service account failed", "error", err)
-		return
+		return fmt.Errorf("creating migration service account: %w", err)
 	}
 	slog.Info("storage migration: service account ensured", "name", migrationServiceAccount)
+	return nil
 }
 
 // Reconcile advances every in-flight migration one step and admits new
@@ -342,7 +342,14 @@ func (m *StorageMigrationManager) Reconcile(ctx context.Context) {
 	sort.Strings(names)
 
 	if len(names) > 0 {
-		m.ensureServiceAccount(ctx)
+		// Without the SA the Job would be admitted but its pods would never
+		// schedule (ServiceAccount not found) -- a quiet 4h stall behind the
+		// deadline. Fail the pass instead: nothing is gated or created this
+		// tick, and the next tick retries.
+		if err := m.ensureServiceAccount(ctx); err != nil {
+			slog.Warn("storage migration: skipping pass, service account unavailable", "error", err)
+			return
+		}
 	}
 
 	slots := m.concurrency() - len(inFlight)
@@ -925,7 +932,8 @@ AS_AGENT="setpriv --reuid=${AGENT_UID} --regid=${AGENT_GID} --clear-groups"
 # never collide with anything pre-existing, and Linux protected_regular
 # never refuses a redirect over a file the other identity created.
 W=$(mktemp -d)
-chmod 1777 "$W"
+chgrp "${AGENT_GID}" "$W"
+chmod 0770 "$W"
 
 # Source-side pipelines run under $AS_AGENT via this helper script (a
 # fresh process cannot inherit shell functions).
@@ -950,7 +958,7 @@ sums)
   cd "$src" && rm -f "$W"/sums.src.*
   find . \( -path ./lost+found -prune \) -o -type f -print0 \
     | xargs -0 -r -P"$PAR" -n64 sh -c 'md5sum "$@" >> "'"$W"'/sums.src.$$"' _
-  cat "$W"/sums.src.* 2>/dev/null ;;
+  cat "$W"/sums.src.* 2>/dev/null || true ;;
 esac
 EOS
 
@@ -999,6 +1007,17 @@ copy_verify() {
   # lost+found stays — a fresh ext4 volume's own artifact, excluded from
   # verification on both sides.
   find "$dst" -mindepth 1 -maxdepth 1 ! -name lost+found -exec rm -rf {} +
+  # Neutralize the ROOT itself on every attempt: a previous attempt's
+  # success-shaping (or the kubelet, on installs that ever ran fsGroup on
+  # the Job) may have left it setgid, and extracting under a setgid root
+  # lets the kernel stamp the bit into every 0700-style directory tar
+  # creates -- turning one transient failure into a permanently failing
+  # retry loop. chmod 00755, five digits: GNU chmod PRESERVES dir setgid
+  # for numeric modes under five digits ("755" and "0755" both keep it).
+  # Agent ownership here is also what lets the agent-identity write test
+  # below pass before the success-shaping runs.
+  chown "${AGENT_UID}:${AGENT_GID}" "$dst"
+  chmod 00755 "$dst"
   phase "wiped target"
 
   if [ "$entries" -gt 0 ]; then
@@ -1008,22 +1027,18 @@ copy_verify() {
     # hard-link-heavy pnpm store must not inflate past the volume size),
     # and sparseness. The "." member restores the volume root's own mode,
     # owner, and times — a root writer may apply all of it.
-    $AS_AGENT tar -C "$src" --sparse -cf - . | tar -C "$dst" -xpf - --same-owner --numeric-owner
+    # --exclude=./lost+found: the archive walks everything including a
+    # source ext4 root-owned 0700 lost+found, which the agent-identity
+    # reader cannot open -- and the inventory walk prunes it, so the
+    # unreadable gate never names it either. Anchored (leading ./), so a
+    # nested lost+found the workspace owns still copies, matching the
+    # walks. The "." member itself stays in the archive.
+    $AS_AGENT tar -C "$src" --sparse --exclude=./lost+found -cf - . | tar -C "$dst" -xpf - --same-owner --numeric-owner
     sync
   else
     echo "source is empty; nothing to copy"
   fi
   phase "copied"
-
-  # The volume ROOT belongs to the mount infrastructure, not the
-  # workspace: shape it exactly the way the agent pods' fsGroup +
-  # OnRootMismatch expect (agent-owned, agent group, setgid, group-rwx),
-  # so the first post-migration mount passes the kubelet's root check and
-  # the interior — verified byte-exact below — is never rewritten by a
-  # recursive ownership pass. The root is excluded from the entry walks;
-  # everything inside is compared strictly.
-  chown "${AGENT_UID}:${AGENT_GID}" "$dst"
-  chmod 2770 "$dst"
 
   # The AGENT must be able to use the volume it wakes up on.
   $AS_AGENT touch "$dst/.migration-writable"
@@ -1039,9 +1054,17 @@ copy_verify() {
   rm -f "$W"/sums.dst.*
   (cd "$dst" && find . \( -path ./lost+found -prune \) -o -type f -print0 \
      | xargs -0 -r -P"$PAR" -n64 sh -c 'md5sum "$@" >> "'"$W"'/sums.dst.$$"' _)
-  cat "$W"/sums.dst.* 2>/dev/null | LC_ALL=C sort > "$W"/dst.sum
+  { cat "$W"/sums.dst.* 2>/dev/null || true; } | LC_ALL=C sort > "$W"/dst.sum
   cmp "$W"/src.sum "$W"/dst.sum
   phase "verified content"
+
+  # Success-shaping, strictly LAST: only a fully verified copy gets the
+  # root signature the agent pods fsGroup + OnRootMismatch expect (agent
+  # group, setgid, group-rwx), so the first post-migration mount skips
+  # the kubelet recursive ownership pass. A failed attempt never reaches
+  # this line, and the wipe above re-neutralizes the root anyway --
+  # extraction always happens under a setgid-free root.
+  chmod 2770 "$dst"
   echo "verified (content + metadata): $src -> $dst"
 }
 `)

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -2,6 +2,7 @@ package reconciler
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 
 	storagev1 "k8s.io/api/storage/v1"
 
@@ -214,6 +216,22 @@ func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	assert.NotContains(t, runnable, "ALLOW_OWNERSHIP_REMAP", "ownership is preserved, not remapped — the knob is dead")
 	// Root wipes the target: no chmod dance for read-only retry residue.
 	assert.Contains(t, runnable, "! -name lost+found -exec rm -rf {} +")
+	// Every attempt neutralizes the root BEFORE extracting: a prior
+	// attempt's success-shaping left it setgid, and extracting under a
+	// setgid root stamps the bit into every 0700-style dir tar creates —
+	// one transient failure would otherwise fail every retry forever.
+	// Five digits: GNU chmod preserves dir setgid for shorter numerics.
+	assert.Contains(t, runnable, `chmod 00755 "$dst"`)
+	// ...and the 2770 success-shaping runs strictly AFTER verification.
+	assert.Greater(t, strings.Index(runnable, `chmod 2770 "$dst"`), strings.Index(runnable, `cmp "$W"/src.sum "$W"/dst.sum`),
+		"only a fully verified copy gets the kubelet root signature")
+	// The archive excludes the SOURCE's own root lost+found: the reader
+	// cannot open a root-owned 0700 one, and the inventory walk prunes it
+	// so the unreadable gate would never name it.
+	assert.Contains(t, runnable, `--exclude=./lost+found -cf - .`)
+	// Scratch dir is scoped to the two known identities, not world-writable.
+	assert.Contains(t, runnable, `chmod 0770 "$W"`)
+	assert.NotContains(t, runnable, "chmod 1777")
 	assert.NotContains(t, runnable, "chmod -R u+rwX", "root needs no permission repair to wipe")
 	// Deep finds -prune the root lost+found (a path exclusion still
 	// descends and dies on a 0700 root-owned one): source walk, source
@@ -705,4 +723,24 @@ func TestStorageMigration_EnsuresDedicatedServiceAccount(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, sa.AutomountServiceAccountToken)
 	assert.False(t, *sa.AutomountServiceAccountToken)
+}
+
+// A missing/uncreatable ServiceAccount must fail the pass BEFORE anything is
+// gated: the Job would otherwise be admitted and its pods would sit in
+// "ServiceAccount not found" until the 4h deadline — a quiet stall where the
+// operator expects a loud one.
+func TestStorageMigration_ServiceAccountFailureBlocksThePass(t *testing.T) {
+	agent := agentCR()
+	m, client := migrationManager(t, agent, rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent"))
+	client.PrependReactor("create", "serviceaccounts", func(k8stesting.Action) (bool, runtime.Object, error) {
+		return true, nil, fmt.Errorf("rbac says no")
+	})
+
+	m.Reconcile(context.Background())
+
+	ann := getAgentAnnotations(t, m, "my-agent")
+	assert.Empty(t, ann[annStorageMigration], "nothing is gated while the SA cannot exist")
+	jobs, err := client.BatchV1().Jobs("test-agents").List(context.Background(), metav1.ListOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, jobs.Items)
 }


### PR DESCRIPTION
## Both review criticals on #3094 are correct — reproduced by execution here before fixing, and both are regressions that PR introduced

**C1 — the `chmod 2770` success-shaping poisoned retries.** The shaping persists on the filesystem; any attempt that fails *after* it leaves a setgid root, and extraction under a setgid root lets the kernel stamp the bit into every `0700`-style directory tar creates (tar only re-chmods dirs it has a reason to revisit — `700` is exactly the mode it doesn't, and `700` is `.ssh`, `.gnupg`, every private-tree mkdir). Reproduced: against a shaped root, every attempt fails forever, `.private` landing `2700`. **Fix:** every attempt neutralizes the root at wipe time (`chown` agent + `chmod 00755` — five digits, GNU chmod preserves dir setgid for shorter numerics), and the `2770` shaping moves to strictly **after** verification — extraction always runs under a setgid-free root, and only a fully verified copy gets the kubelet signature.

**C2 — archiving `.` dropped the `lost+found` exclusion** the old member-list form had. On an ext4 **source** with the usual root-owned `0700` `lost+found`, the agent-identity reader gets EACCES, tar exits 2 — and the inventory walk *prunes* the directory, so the unreadable gate never names it (bare tar error instead of the actionable message). Reproduced. **Fix:** `--exclude=./lost+found` on the reader (anchored — a nested `lost+found` the workspace owns still copies; the `.` member and its root-attr restore stay).

## Also from the review

- **Missing SA now fails the pass loudly before anything is gated** — previously a swallowed Warn led to a Job whose pods sat in `ServiceAccount not found` until the 4h deadline.
- Scratch dir is `0770 root:agent` instead of `1777`-plus-`protected_regular`-reasoning.
- Empty source no longer trips `pipefail` in checksum collection.
- `security-and-credentials.md` records `platform-migration` as the platform's one uid-0 workload, in the SA inventory, with the split-identity rationale.

## Proof (fixture = real squashing kernel-NFS source, byte-for-byte script from `buildMigrationJob`)

Starting from a **deliberately poisoned `2770` root** and a source that **contains a root-owned `0700` `lost+found`**: four consecutive attempts verify end-to-end, `.private` lands exactly `700` every time, re-poisoning the root between attempts self-heals, and an empty source verifies. Unit suite `-count=1` (no cache), vet/staticcheck clean. New tests pin: the `00755` neutralize, the shaping ordered after content `cmp`, the archive exclusion, the `0770` scratch dir, and the SA-failure-blocks-the-pass behavior.

## Process note

The retry matrix in #3094's fixture ran *before* the shaping line was added in its final commit, and only the fresh pass was re-run after — that's how C1 shipped despite a 'retry-proven' claim. The fixture loop now starts from a poisoned root precisely so that ordering mistake can't hide again.