### PR TITLE
fix(helm): storage migration off by default pending #3103

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1062,7 +1062,7 @@ controller:
   # leaves each agent on the volume it started from. Watch the controller log
   # through the first drain; `concurrency: 1` makes that easy to follow.
   storageMigration:
-    enabled: true
+    enabled: false
     # -- Storage class migrated workspaces land on: the DESTINATION of the
     # migration. Empty (default) = the cluster's default class, i.e. ordinary
     # storage, which is the point of the exercise.


### PR DESCRIPTION
One-liner: `storageMigration.enabled: true → false` pending the critical fixes in #3103.

Safe by construction: a disabled manager **releases** anything it had gated (bins abandoned Jobs and half-copied targets, restores prior run state) — every agent returns to the volume it started from. Installs that want to keep draining can set it back explicitly. Re-flip to on-by-default can ride #3103 or follow it.