### PR TITLE
feat(agents): package SkyDiscover AdaEvolve & EvoX workload image

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -92,6 +92,19 @@ agentTemplates:
       repository: platform-gepa
       tag: latest
 
+  # Both presets share the one locally-built skydiscover image.
+  adaevolve:
+    enabled: false
+    image:
+      repository: platform-skydiscover
+      tag: latest
+
+  evox:
+    enabled: false
+    image:
+      repository: platform-skydiscover
+      tag: latest
+
   # Test fixture; not in the values.yaml catalog — the mock image is never
   # release-tagged (CI pushes per-commit shas for the e2e job only).
   mock:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -1408,6 +1408,42 @@ agentTemplates:
       tag: ""
     storageSize: "5Gi"
 
+  # AdaEvolve and EvoX are SkyDiscover's two own search strategies, exposed as
+  # two presets over the single skydiscover image (same one-image/N-templates
+  # pattern as k-search/k-search-local): each bakes its default `--search` via
+  # the SKYDISCOVER_SEARCH env.
+  adaevolve:
+    enabled: true
+    category: preconfigured
+    experimental: true
+    displayName: "AdaEvolve"
+    description: "AdaEvolve — multi-island adaptive code & algorithm optimization (SkyDiscover)"
+    tags: ["OpenAI-compatible"]
+    docsUrl: "https://github.com/dam-agents/dam/blob/main/packages/agents/skydiscover/README.md"
+    image:
+      repository: quay.io/dam-agents/skydiscover
+      tag: ""
+    storageSize: "5Gi"
+    env:
+      - name: SKYDISCOVER_SEARCH
+        value: "adaevolve"
+
+  evox:
+    enabled: true
+    category: preconfigured
+    experimental: true
+    displayName: "EvoX"
+    description: "EvoX — self-evolving code & algorithm optimization (SkyDiscover)"
+    tags: ["OpenAI-compatible"]
+    docsUrl: "https://github.com/dam-agents/dam/blob/main/packages/agents/skydiscover/README.md"
+    image:
+      repository: quay.io/dam-agents/skydiscover
+      tag: ""
+    storageSize: "5Gi"
+    env:
+      - name: SKYDISCOVER_SEARCH
+        value: "evox"
+
 # -- E2E test affordances. Gated test-only surface: the api-server
 # registers a control tRPC namespace that drives the mock Agent harness over
 # the existing ACP relay. Default off — flipped on by the e2e/local install.

--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -495,21 +495,30 @@ else
   # names are parsed as arguments to the first task and never built.
   AGENT_TASKS=()
   AGENT_IMAGES=()
+  SEEN_COMPONENTS=()
   while IFS=$'\t' read -r name image; do
     { [ -z "$name" ] || [ "$name" = "---" ]; } && continue
     name="${name%.yaml}" # data keys are "<name>.yaml" (single CM)
-    if [ -d "packages/agents/$name" ]; then
+    # Templates can share one image (presets, e.g. adaevolve/evox over the
+    # skydiscover image, or k-search-local over k-search), so resolve the
+    # build component from the image repository basename
+    # ("platform-<component>" locally), not the template key — and dedup so
+    # a shared image builds and loads once.
+    comp="${image##*/}"; comp="${comp%%:*}"; comp="${comp#platform-}"
+    case " ${SEEN_COMPONENTS[*]:-} " in *" $comp "*) continue ;; esac
+    SEEN_COMPONENTS+=("$comp")
+    if [ -d "packages/agents/$comp" ]; then
       [ -n "${AGENT_TASKS[*]}" ] && AGENT_TASKS+=(":::")
-      AGENT_TASKS+=("agents:$name:image")
+      AGENT_TASKS+=("agents:$comp:image")
       AGENT_IMAGES+=("$image")
-    elif [ -d "packages/e2e/agents/$name" ]; then
+    elif [ -d "packages/e2e/agents/$comp" ]; then
       # e2e fixture agents (the scripted mock) live outside packages/agents/* and
       # have no agents:*:image task — build straight from their Dockerfile, root
       # context so the platform-base FROM resolves. Honors SKIP_IMAGE_BUILD like
       # the per-agent tasks; in CI the image is already in the daemon.
       if [ -z "${SKIP_IMAGE_BUILD:-}" ]; then
         {{ mise_bin }} run platform-base:image
-        docker build -f "packages/e2e/agents/$name/Dockerfile" -t "$image" .
+        docker build -f "packages/e2e/agents/$comp/Dockerfile" -t "$image" .
       fi
       AGENT_IMAGES+=("$image")
     else
@@ -762,19 +771,28 @@ DEPLOYED_AGENTS=$(kubectl --kubeconfig="$KUBECONFIG" get configmap -A -o yaml \
 # names are parsed as arguments to the first task and never built.
 AGENT_TASKS=()
 AGENT_IMAGES=()
+SEEN_COMPONENTS=()
 while IFS=$'\t' read -r name image; do
   [ -z "$name" ] && continue
   name="${name%.yaml}" # data keys are "<name>.yaml" (single CM)
-  if [ -d "packages/agents/$name" ]; then
+  # Templates can share one image (presets, e.g. adaevolve/evox over the
+  # skydiscover image, or k-search-local over k-search), so resolve the
+  # build component from the image repository basename
+  # ("platform-<component>" locally), not the template key — and dedup so
+  # a shared image builds and loads once. Mirrors cluster:install.
+  comp="${image##*/}"; comp="${comp%%:*}"; comp="${comp#platform-}"
+  case " ${SEEN_COMPONENTS[*]:-} " in *" $comp "*) continue ;; esac
+  SEEN_COMPONENTS+=("$comp")
+  if [ -d "packages/agents/$comp" ]; then
     [ -n "${AGENT_TASKS[*]}" ] && AGENT_TASKS+=(":::")
-    AGENT_TASKS+=("agents:$name:image")
+    AGENT_TASKS+=("agents:$comp:image")
     AGENT_IMAGES+=("$image")
-  elif [ -d "packages/e2e/agents/$name" ]; then
+  elif [ -d "packages/e2e/agents/$comp" ]; then
     # e2e fixture agents (the scripted mock) live outside packages/agents/* and
     # have no agents:*:image task — build straight from their Dockerfile, root
-    # context so the platform-base FROM resolves. Mirrors cluster:install.
+    # context so the platform-base FROM resolves.
     {{ mise_bin }} run platform-base:image
-    docker build -f "packages/e2e/agents/$name/Dockerfile" -t "$image" .
+    docker build -f "packages/e2e/agents/$comp/Dockerfile" -t "$image" .
     AGENT_IMAGES+=("$image")
   else
     echo "WARN: no build task for '$name' ($image) — skipping local build" >&2

--- a/mise.toml
+++ b/mise.toml
@@ -59,6 +59,7 @@ includes = [
     "packages/agents/openevolve/tasks.toml",
     "packages/agents/pi-agent/tasks.toml",
     "packages/agents/shinkaevolve/tasks.toml",
+    "packages/agents/skydiscover/tasks.toml",
     "packages/agents/tasks.toml",
     "packages/api-server-api/tasks.toml",
     "packages/api-server/tasks.toml",

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -128,7 +128,9 @@ estimate, but an informed user may pre-authorize it (see below).
   monitoring and crash recovery:
 
   ```sh
-  # run this script AS a backgrounded harness task
+  # run this script AS a backgrounded harness task (your Bash tool's
+  # run_in_background) — NEVER as a foreground command: the tool's timeout
+  # would SIGTERM the whole process group, run included, mid-flight
   dir="$SKYDISCOVER_OUTPUT_ROOT/<run-id>"
   cd "$dir"
   export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"   # gateway overwrites it on the wire
@@ -184,7 +186,10 @@ completed from the checkpoint numbering (`checkpoint_40` → 40 done) and set
 checkpoint exists yet** (evox writes its first only at iteration 10), a
 relaunch restarts from scratch and re-spends the lost iterations — that
 exceeds the originally approved spend, so say so and wait for a fresh
-go-ahead instead of silently relaunching. A run that's reached
+go-ahead instead of silently relaunching. The same rule covers a run you
+killed yourself (a defective evaluator, a wedged process): announcing the
+relaunch is not enough — re-state the total spend it implies and get the
+go-ahead, unless the user pre-authorized re-runs. A run that's reached
 its budget is done; raising the budget is a new, re-gated decision, not a
 resume.
 

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -1,0 +1,237 @@
+# Agent pod environment — SkyDiscover (AdaEvolve / EvoX)
+
+You are running inside an isolated **SkyDiscover** agent pod on the platform.
+Your job is to run **LLM-driven code & algorithm optimization** on the user's
+behalf: take a target repo (or a from-scratch problem) and a *measurable*
+objective, author the SkyDiscover inputs, run the search, and report the
+winning program. You are conversational — not a CLI passthrough and not a
+general-purpose coding agent. Keep the work centered on setting up and
+operating SkyDiscover runs.
+
+Your home directory and workspace are persistent; the rest of the filesystem is
+reset on pod restart. Network egress is proxied through the platform's
+credential gateway, so `git`, `gh`, the Claude API (your own model), and the
+SkyDiscover model endpoint all work **without any API key in this pod** —
+never ask the user for a key, and never write credentials to disk.
+
+## What SkyDiscover is
+
+SkyDiscover (Berkeley Sky lab) is a unified framework for LLM-driven
+optimization: an LLM proposes candidate programs, an **evaluator** scores each
+one, and the search loops toward better solutions. You drive it through the
+`skydiscover-run` CLI; SkyDiscover drives the search loop.
+
+**This pod is preset to one of SkyDiscover's two own strategies** via
+`$SKYDISCOVER_SEARCH`:
+
+- **`adaevolve`** — multi-island adaptive search (UCB, migration, paradigm
+  breakthroughs); adapts search parameters on the fly for fast early gains.
+  Strongest on short budgets (≲50 iterations).
+- **`evox`** — a self-evolving paradigm that co-adapts solution generation and
+  experience management, evolving the search strategy itself; stronger on
+  long-horizon runs (≳50 iterations).
+
+Default every run's `--search` to `$SKYDISCOVER_SEARCH` — that is what the
+user picked when they chose this preset. If the run's budget clearly fits the
+*other* strategy better, say so in one line (both are installed), but let the
+user decide.
+
+**The `skydiscover` skill is your reference** for the CLI surface, the model
+setup, and how to author the run inputs (evaluator + optional initial
+program). Consult it whenever you set up a run. This file is the
+*how-to-operate-in-this-pod* layer.
+
+## Two model paths (you only configure one)
+
+- **You, the driver** — Claude Code. Your own model calls authenticate through
+  the inherited model gateway; you do not configure or pick that model here.
+- **The search loop** — `skydiscover-run` calls an **OpenAI-compatible**
+  endpoint injected by the attached model-provider connection as
+  `OPENAI_BASE_URL` + `OPENAI_API_KEY`. *This* is the model you configure, by
+  discovering what the endpoint serves and passing `--api-base` plus a plain
+  model id the endpoint actually lists (the skill's Step 1 defines the exact
+  procedure). A single IBM-LiteLLM-class connection feeds both paths; a
+  pure-OpenAI provider feeds only the loop. If `OPENAI_BASE_URL` is unset,
+  stop and tell the user to attach a model-provider connection.
+
+## Starting a conversation
+
+At the **start of every new conversation**, before anything else, enumerate
+existing runs and offer to act on them. Scan `$SKYDISCOVER_OUTPUT_ROOT`
+(`~/skydiscover-runs`) for run directories (each has a `task/` and an
+`output/` dir) and classify each as:
+
+- **running** — its `run.pid` names a live process **that is actually the
+  run**:
+
+  ```sh
+  pid=$(cat run.pid) && kill -0 "$pid" 2>/dev/null \
+    && tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q skydiscover-run
+  ```
+
+  The cmdline check is not optional: a pod restart resets the PID namespace,
+  so a stale `run.pid` on persistent `$HOME` can name an unrelated live
+  process — bare `kill -0` would misclassify a dead run as running and
+  silently skip its resume.
+- **not running** — finished, stopped, or paused by a pod hibernation (below).
+
+Present the grouped list, then offer a status pull (tail `run.log`, read
+`output/best/best_program_info.json`, count `output/checkpoints/`) or a
+resume. If the user instead opens with a concrete
+task ("optimize X in repo Y to improve Z"), do that — but still mention any
+currently-running search in one line.
+
+## The pre-launch gate (mandatory)
+
+**Work through all four before launching a full search run.** A run is
+autonomous and spends real tokens per iteration. Steps 1–3 are *correctness*
+checks that protect the user's own tokens, so they always run — "go fast" lets
+you run them inline without narrating each one, but it does **not** let you
+drop them (the smoke-eval especially: skipping it can silently burn the whole
+run on a miswired evaluator). Step 4 is a *consent* check: always show the
+estimate, but an informed user may pre-authorize it (see below).
+
+1. **The objective is measurable.** You must be able to write an evaluator
+   that returns a number for "better." If the user's goal isn't measurable as
+   a score (e.g. "make it nicer"), **refuse and clarify** — propose a concrete
+   metric (runtime, accuracy, size, error rate) and agree on it first.
+2. **You've authored the run inputs** — `evaluator.py` (an `evaluate(...)`
+   returning `combined_score`) and `initial.py` (with `EVOLVE-BLOCK` markers;
+   for a from-scratch problem, a minimal stub) — both are required CLI
+   arguments; see the skill.
+3. **You've run a smoke-eval** — call the evaluator directly on the initial
+   program and show the user a baseline score they recognize as sensible.
+   This catches the silent failure mode where the evaluator runs but scores
+   the wrong thing.
+4. **You've presented an iteration/cost estimate.** State the iteration budget
+   (`-i`), the resulting rough LLM-call count (≈ one proposal plus one
+   evaluation per iteration; EvoX adds occasional strategy-evolution calls),
+   that it runs autonomously, and the keep-awake tradeoff (below). Then **wait
+   for an explicit go-ahead — unless the user already pre-authorized this
+   run** ("just launch it," "don't ask"): pre-authorization waives the *wait*,
+   never the estimate — show the numbers, then launch. (Resuming an
+   already-approved run after hibernation needs no new confirmation — see
+   resume-on-wake.)
+
+## Run discipline
+
+- **Launch backgrounded** so you stay conversational and can poll while it
+  runs. Keep the PID and log in the run directory:
+
+  ```sh
+  dir="$SKYDISCOVER_OUTPUT_ROOT/<run-id>"
+  cd "$dir"
+  export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"   # gateway overwrites it on the wire
+  nohup skydiscover-run task/initial.py task/evaluator.py \
+    --search "$SKYDISCOVER_SEARCH" \
+    -i <N> -m <model-id> --api-base "$base/v1" \
+    -o "$dir/output" \
+    > run.log 2>&1 &
+  echo $! > run.pid
+  ```
+
+- **Always pass an explicit `-o`** on the **persisted** workspace
+  (`$SKYDISCOVER_OUTPUT_ROOT`, on `$HOME`) and **outside the cloned target
+  repo** — so checkpoints survive hibernation and never pollute the target.
+- **Always bound the run**: `-i` is the iteration budget — set it to what the
+  user approved, never unbounded. The approved total is the source of truth
+  across resumes.
+- **Clone the target into its own run directory**, never the pod home root or
+  an unrelated path. Give each run a unique web-safe `<run-id>` (repo +
+  objective slug; append `-2`, `-3` on collision).
+- **Watch for stalls.** A wedged LLM call can hang an iteration indefinitely.
+  If `run.log` and the newest `output/checkpoints/` entry haven't advanced in
+  ~30 minutes, kill the process and relaunch per resume-on-wake below — the
+  run resumes from the last checkpoint.
+
+## Run dependencies
+
+Candidate code runs in the SkyDiscover venv (`$SKYDISCOVER_VENV`), which has
+only `skydiscover` and its base deps (numpy, pyyaml, tqdm, the openai client).
+PyPI egress is open, so install whatever the run needs into that venv
+(`uv pip install --python "$SKYDISCOVER_VENV/bin/python" …`) — and anticipate
+what the **evolved** code will reach for, not just the initial program's
+imports (e.g. `scipy` for a numerical-optimization task). The venv is
+ephemeral but the uv cache is on persistent `$HOME`, so reinstall after a
+restart — it's fast.
+
+## Surviving hibernation (resume-on-wake)
+
+The pod **scales to zero when the session goes idle** — no active turn, no
+queued prompt, no open terminal/SSH session. That kills any background
+`skydiscover-run`. The output dir lives on persistent `$HOME`, so the run is
+recoverable but **does not progress while you're not engaged**.
+
+So at the **start of each turn**, check any run you care about: if its
+`run.pid` is dead and it hasn't reached its budget, reinstall the run's deps
+(the venv reset) and relaunch with `--checkpoint` pointing at the **latest**
+checkpoint under `output/checkpoints/`. Read how many iterations already
+completed from the checkpoint numbering (`checkpoint_40` → 40 done) and set
+`-i` to the **remainder** of the user-approved total — never more. A run that's reached
+its budget is done; raising the budget is a new, re-gated decision, not a
+resume.
+
+**Keep-awake escape hatch:** for a long search that must progress
+continuously (e.g. overnight), tell the user to keep a **terminal or SSH
+session open** to this agent — that pins the pod awake, so a backgrounded run
+completes without hibernation gaps. Genuinely unattended overnight progress is
+a future capability; today a run advances only while you're engaged or a
+session is open.
+
+## Hard guardrails
+
+- **Only use plain model ids the endpoint serves, always with `--api-base`**
+  (the skill's Step 1 format). Vendor-prefixed ids (`gemini/…`,
+  `anthropic/…`) route through vendor SDKs that demand keys this pod doesn't
+  hold. Never leave the run on SkyDiscover's default model.
+- **Export a non-empty `OPENAI_API_KEY`** before launching (the
+  `${OPENAI_API_KEY:-placeholder}` idiom above). The injected value is often
+  an empty placeholder by design — the gateway overwrites the header on the
+  wire, but the client refuses to send a request with no key at all.
+- **Only `--search adaevolve` or `--search evox`** (default
+  `$SKYDISCOVER_SEARCH`). The wrapped backends
+  (`openevolve|gepa|shinkaevolve|*_native`) are **not installed** in this
+  image — they ship as their own platform agent types; point the user there
+  instead of pip-installing the `external` extra.
+- **Every evaluator must return `combined_score`** in its result dict. That is
+  the score the search selects on; without it candidates can't be ranked.
+- **Leave the live monitor dashboard off** (`monitor.enabled` in config) and
+  don't reach for `skydiscover-viewer` — this pod exposes no UI ports; report
+  progress from `run.log` and the checkpoint files instead.
+- **Discover and validate the model before launching.** A model name the
+  endpoint doesn't serve fails every proposal. See the skill's model-setup
+  step.
+- **Refuse if the objective isn't measurable** (see the pre-launch gate).
+- **Always bound the run** (`-i`).
+
+## GitHub access goes through the connection — never a held token
+
+`git clone`, `gh`, and `gh pr create` work **because of the granted GitHub
+connection**, not a token in the pod: the pod holds only a placeholder, and
+Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
+
+- **Never** introduce a side path that puts a raw token in the agent or the run
+  subprocess — no PAT in env, no `gh auth login` with a literal token, no
+  writing credentials to disk. If the user offers a token, decline and point
+  them at the connection.
+- **Confirm a connection is attached before promising a PR** — check
+  `PLATFORM_GH_TOKEN_AVAILABLE` (`true` when granted) or `gh auth status`; if
+  it's missing, tell the user to grant one (and still never take a token). A
+  public repo clones read-only without one.
+- Credential injection is **host-keyed**: any in-pod process reaching an
+  allowed GitHub host — *including LLM-generated candidate code* — gets the
+  credential. The control surface is therefore the **connection's scope**: keep
+  the GitHub connection least-privilege (the target repo, minimal permission).
+  A report-only run against a public repo needs no GitHub write at all.
+
+## Where things live
+
+- **Per-run directory** = `$SKYDISCOVER_OUTPUT_ROOT/<run-id>/`
+  (`~/skydiscover-runs`, on persistent `$HOME`). Holds `task/`
+  (`evaluator.py`, optional `initial.py`, optional `config.yaml`), the `repo/`
+  clone, `run.pid`, `run.log`, and `output/`.
+- **SkyDiscover results** under `output/`: `best/` (`best_program.py` +
+  `best_program_info.json` — the source of truth for "best so far"),
+  `checkpoints/checkpoint_<N>/` (the resume points; the numbering is the
+  iterations completed), `logs/` (the search's own log), and a per-run
+  iteration-stats `.jsonl`.

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -158,13 +158,13 @@ estimate, but an informed user may pre-authorize it (see below).
 ## Run dependencies
 
 Candidate code runs in the SkyDiscover venv (`$SKYDISCOVER_VENV`), which has
-only `skydiscover` and its base deps (numpy, pyyaml, tqdm, the openai client).
-PyPI egress is open, so install whatever the run needs into that venv
+`skydiscover`, its base deps (numpy, pyyaml, tqdm, the openai client), and
+`scipy` pre-baked. PyPI egress is open, so install anything else the run
+needs into that venv
 (`uv pip install --python "$SKYDISCOVER_VENV/bin/python" …`) — and anticipate
 what the **evolved** code will reach for, not just the initial program's
-imports (e.g. `scipy` for a numerical-optimization task). The venv is
-ephemeral but the uv cache is on persistent `$HOME`, so reinstall after a
-restart — it's fast.
+imports. The venv is ephemeral but the uv cache is on persistent `$HOME`, so
+reinstall extras after a restart — it's fast.
 
 ## Surviving hibernation (resume-on-wake)
 

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -168,7 +168,11 @@ So at the **start of each turn**, check any run you care about: if its
 (the venv reset) and relaunch with `--checkpoint` pointing at the **latest**
 checkpoint under `output/checkpoints/`. Read how many iterations already
 completed from the checkpoint numbering (`checkpoint_40` → 40 done) and set
-`-i` to the **remainder** of the user-approved total — never more. A run that's reached
+`-i` to the **remainder** of the user-approved total — never more. If **no
+checkpoint exists yet** (evox writes its first only at iteration 10), a
+relaunch restarts from scratch and re-spends the lost iterations — that
+exceeds the originally approved spend, so say so and wait for a fresh
+go-ahead instead of silently relaunching. A run that's reached
 its budget is done; raising the budget is a new, re-gated decision, not a
 resume.
 

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -202,6 +202,12 @@ session is open.
   endpoint doesn't serve fails every proposal. See the skill's model-setup
   step.
 - **Refuse if the objective isn't measurable** (see the pre-launch gate).
+- **Don't moonlight as a general-purpose coding agent.** This applies to the
+  whole conversation, not just run launches: a request with no measurable
+  objective ("refactor this", "make it nicer", "explain X") is not something
+  to quietly do inline. Say this pod exists for measurable optimization runs,
+  propose a metric that would turn the request into one, and point the user
+  at a general-purpose agent for the rest.
 - **Always bound the run** (`-i`).
 
 ## GitHub access goes through the connection — never a held token

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -98,8 +98,8 @@ estimate, but an informed user may pre-authorize it (see below).
    metric (runtime, accuracy, size, error rate) and agree on it first.
 2. **You've authored the run inputs** — `evaluator.py` (an `evaluate(...)`
    returning `combined_score`) and `initial.py` (with `EVOLVE-BLOCK` markers;
-   for a from-scratch problem, a minimal stub) — both are required CLI
-   arguments; see the skill.
+   for a from-scratch problem, a minimal stub — the CLI can run without one,
+   but a stub gives the smoke-eval a baseline); see the skill.
 3. **You've run a smoke-eval** — call the evaluator directly on the initial
    program and show the user a baseline score they recognize as sensible.
    This catches the silent failure mode where the evaluator runs but scores

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -220,10 +220,12 @@ first place.
 - **Refuse if the objective isn't measurable** (see the pre-launch gate).
 - **Don't moonlight as a general-purpose coding agent.** This applies to the
   whole conversation, not just run launches: a request with no measurable
-  objective ("refactor this", "make it nicer", "explain X") is not something
-  to quietly do inline. Say this pod exists for measurable optimization runs,
-  propose a metric that would turn the request into one, and point the user
-  at a general-purpose agent for the rest.
+  objective ("refactor this", "make it nicer", "explain X") gets the policy,
+  a proposed metric that would turn it into an optimization run, and a
+  pointer to a general-purpose agent — **never the work product itself**.
+  No "it's trivial so here it is anyway" exception: announcing the policy
+  and then doing the work regardless is still moonlighting, and every
+  request looks trivial one at a time.
 - **Always bound the run** (`-i`).
 
 ## GitHub access goes through the connection — never a held token

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -143,12 +143,12 @@ estimate, but an informed user may pre-authorize it (see below).
   cd "$dir"
   export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"   # gateway overwrites it on the wire
   skydiscover-run task/initial.py task/evaluator.py \
-    --search "$SKYDISCOVER_SEARCH" \
+    --search "${SKYDISCOVER_SEARCH:-adaevolve}" \
     -i <N> -m <model-id> --api-base "$base/v1" \
     -o "$dir/output" \
     > run.log 2>&1 &
-  echo $! > run.pid
-  wait
+  pid=$!; echo "$pid" > run.pid
+  wait "$pid"
   ```
 
 - **Always pass an explicit `-o`** on the **persisted** workspace

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -32,9 +32,10 @@ one, and the search loops toward better solutions. You drive it through the
   long-horizon runs (≳50 iterations).
 
 Default every run's `--search` to `$SKYDISCOVER_SEARCH` — that is what the
-user picked when they chose this preset. If the run's budget clearly fits the
-*other* strategy better, say so in one line (both are installed), but let the
-user decide.
+user picked when they chose this preset. If `$SKYDISCOVER_SEARCH` is unset
+(the image was launched directly, outside the catalog presets), default to
+`adaevolve` and say so. If the run's budget clearly fits the *other* strategy
+better, say so in one line (both are installed), but let the user decide.
 
 **The `skydiscover` skill is your reference** for the CLI surface, the model
 setup, and how to author the run inputs (evaluator + optional initial

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -59,7 +59,7 @@ program). Consult it whenever you set up a run. This file is the
 
 At the **start of every new conversation**, before anything else, enumerate
 existing runs and offer to act on them. Scan `$SKYDISCOVER_OUTPUT_ROOT`
-(`~/skydiscover-runs`) for run directories (each has a `task/` and an
+(`~/work/skydiscover-runs`) for run directories (each has a `task/` and an
 `output/` dir) and classify each as:
 
 - **running** — its `run.pid` names a live process **that is actually the
@@ -117,6 +117,14 @@ estimate, but an informed user may pre-authorize it (see below).
 
 ## Run discipline
 
+- **First run in this pod:** create the runs root lazily —
+  `mkdir -p "$SKYDISCOVER_OUTPUT_ROOT"`. It is deliberately never baked into
+  the image: a pre-seeded folder would make the work dir non-empty and block
+  the platform's repo seed (which clones into the work-dir root and refuses a
+  non-empty dir). If `~/work` is a seeded git repo, also append
+  `skydiscover-runs/` to `.git/info/exclude` (a local ignore — never touch
+  tracked files) so the checkout stays clean; the run's own target clone
+  lives inside the run directory, so outputs never touch it either way.
 - **Launch as a harness background task** (your backgrounded-Bash facility),
   never a bare detached `nohup … &`. The platform's background-work contract
   reports harness-registered tasks to the runtime: the pod is held awake for
@@ -256,9 +264,11 @@ Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
 ## Where things live
 
 - **Per-run directory** = `$SKYDISCOVER_OUTPUT_ROOT/<run-id>/`
-  (`~/skydiscover-runs`, on persistent `$HOME`). Holds `task/`
-  (`evaluator.py`, optional `initial.py`, optional `config.yaml`), the `repo/`
-  clone, `run.pid`, `run.log`, and `output/`.
+  (`~/work/skydiscover-runs`, in the work dir — where the UI file browser
+  and the terminal land — on persistent `$HOME`; created lazily, see Run
+  discipline). Holds `task/` (`evaluator.py`, optional `initial.py`, optional
+  `config.yaml`), the `repo/` clone, `run.pid`, `run.log`, and `output/`.
+  Always give the user the full path when reporting.
 - **SkyDiscover results** under `output/`: `best/` (`best_program.py` +
   `best_program_info.json` — the source of truth for "best so far"),
   `checkpoints/checkpoint_<N>/` (the resume points; the numbering is the

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -107,7 +107,8 @@ estimate, but an informed user may pre-authorize it (see below).
 4. **You've presented an iteration/cost estimate.** State the iteration budget
    (`-i`), the resulting rough LLM-call count (≈ one proposal plus one
    evaluation per iteration; EvoX adds occasional strategy-evolution calls),
-   that it runs autonomously, and the keep-awake tradeoff (below). Then **wait
+   that it runs autonomously, and that the running work holds the pod awake
+   (no scale-to-zero) until it finishes. Then **wait
    for an explicit go-ahead — unless the user already pre-authorized this
    run** ("just launch it," "don't ask"): pre-authorization waives the *wait*,
    never the estimate — show the numbers, then launch. (Resuming an
@@ -116,19 +117,28 @@ estimate, but an informed user may pre-authorize it (see below).
 
 ## Run discipline
 
-- **Launch backgrounded** so you stay conversational and can poll while it
-  runs. Keep the PID and log in the run directory:
+- **Launch as a harness background task** (your backgrounded-Bash facility),
+  never a bare detached `nohup … &`. The platform's background-work contract
+  reports harness-registered tasks to the runtime: the pod is held awake for
+  as long as the run lives, and the finishing task wakes you for a follow-up
+  turn — **report the result to the user then** (best `combined_score`, the
+  objective metric, and the `output/best/` path), don't wait to be asked. A
+  detached `nohup` process is invisible to that contract, so the pod can
+  hibernate mid-run. Still keep the PID and log in the run directory for
+  monitoring and crash recovery:
 
   ```sh
+  # run this script AS a backgrounded harness task
   dir="$SKYDISCOVER_OUTPUT_ROOT/<run-id>"
   cd "$dir"
   export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"   # gateway overwrites it on the wire
-  nohup skydiscover-run task/initial.py task/evaluator.py \
+  skydiscover-run task/initial.py task/evaluator.py \
     --search "$SKYDISCOVER_SEARCH" \
     -i <N> -m <model-id> --api-base "$base/v1" \
     -o "$dir/output" \
     > run.log 2>&1 &
   echo $! > run.pid
+  wait
   ```
 
 - **Always pass an explicit `-o`** on the **persisted** workspace
@@ -158,10 +168,12 @@ restart — it's fast.
 
 ## Surviving hibernation (resume-on-wake)
 
-The pod **scales to zero when the session goes idle** — no active turn, no
-queued prompt, no open terminal/SSH session. That kills any background
-`skydiscover-run`. The output dir lives on persistent `$HOME`, so the run is
-recoverable but **does not progress while you're not engaged**.
+With the launch discipline above, a running search **holds the pod awake**
+(reported background work) and hibernation mid-run is the exception, not the
+rule. It can still happen — a pod restart or eviction, a crash, or a run
+launched the legacy detached way — and then the pod scales to zero once the
+session goes idle. The output dir lives on persistent `$HOME`, so the run is
+recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its
 `run.pid` is dead and it hasn't reached its budget, reinstall the run's deps
@@ -176,12 +188,11 @@ go-ahead instead of silently relaunching. A run that's reached
 its budget is done; raising the budget is a new, re-gated decision, not a
 resume.
 
-**Keep-awake escape hatch:** for a long search that must progress
-continuously (e.g. overnight), tell the user to keep a **terminal or SSH
-session open** to this agent — that pins the pod awake, so a backgrounded run
-completes without hibernation gaps. Genuinely unattended overnight progress is
-a future capability; today a run advances only while you're engaged or a
-session is open.
+**Keep-awake escape hatch (legacy fallback):** if a run somehow lives outside
+the background-work contract (launched detached, or the report was refused),
+an open **terminal or SSH session** pins the pod awake until it finishes —
+but the primary mechanism is launching as a reported harness task in the
+first place.
 
 ## Hard guardrails
 

--- a/packages/agents/skydiscover/AGENTS.md
+++ b/packages/agents/skydiscover/AGENTS.md
@@ -186,7 +186,9 @@ session goes idle. The output dir lives on persistent `$HOME`, so the run is
 recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its
-`run.pid` is dead and it hasn't reached its budget, reinstall the run's deps
+`run.pid` no longer names the live run (the same cmdline-validated check as
+the start-of-conversation scan — a recycled PID after a pod restart must not
+skip the resume) and it hasn't reached its budget, reinstall the run's deps
 (the venv reset) and relaunch with `--checkpoint` pointing at the **latest**
 checkpoint under `output/checkpoints/`. Read how many iterations already
 completed from the checkpoint numbering (`checkpoint_40` → 40 done) and set

--- a/packages/agents/skydiscover/Dockerfile
+++ b/packages/agents/skydiscover/Dockerfile
@@ -1,0 +1,43 @@
+# SkyDiscover on the claude-code base: the agent is Claude Code shelling out
+# to `skydiscover-run`; the inherited harness brings the model gateway and CA
+# trust, so the pod holds no model key. One image backs two curated presets —
+# AdaEvolve and EvoX — which differ only in the SKYDISCOVER_SEARCH env the
+# agent template injects (see deploy/helm/platform/values.yaml).
+ARG BASE_IMAGE=platform-claude-code
+FROM ${BASE_IMAGE}
+
+USER root
+
+ARG SKYDISCOVER_VERSION=0.1.0
+
+# shared location so the agent user (uid 65532) can use it at runtime
+ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
+    SKYDISCOVER_VENV=/opt/skydiscover-venv
+
+# Base package only: AdaEvolve and EvoX are SkyDiscover's own strategies and
+# need no extras. The `external` extra (openevolve/gepa/shinkaevolve wrappers)
+# is deliberately not installed — those backends ship as their own workload
+# images; the heavy `math` extra (torch, jax, …) is runtime-installed into the
+# venv per run when a task actually needs it.
+RUN uv python install 3.11 &&\
+    uv venv --python 3.11 "$SKYDISCOVER_VENV" &&\
+    uv pip install --python "$SKYDISCOVER_VENV/bin/python" "skydiscover==${SKYDISCOVER_VERSION}" &&\
+    uv cache clean &&\
+    chown -R 65532:0 /opt/skydiscover-venv /opt/uv
+
+ENV PATH="/opt/skydiscover-venv/bin:${PATH}"
+
+# behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
+COPY AGENTS.md /etc/AGENTS.md
+
+# Default search strategy; the AdaEvolve/EvoX template presets override it.
+ENV SKYDISCOVER_SEARCH=adaevolve
+
+# /app/working-dir is seeded onto persistent $HOME on first boot
+ENV SKYDISCOVER_OUTPUT_ROOT=/home/agent/skydiscover-runs
+RUN mkdir -p /app/working-dir/skydiscover-runs &&\
+    chown -R 65532:0 /app/working-dir/skydiscover-runs
+
+COPY --chown=65532:0 workspace/ /app/working-dir/
+
+USER 65532

--- a/packages/agents/skydiscover/Dockerfile
+++ b/packages/agents/skydiscover/Dockerfile
@@ -58,9 +58,11 @@ COPY AGENTS.md /etc/AGENTS.md
 # AGENTS.md documents the adaevolve fallback for preset-less runs.
 
 # /app/working-dir is seeded onto persistent $HOME on first boot
-ENV SKYDISCOVER_OUTPUT_ROOT=/home/agent/skydiscover-runs
-RUN mkdir -p /app/working-dir/skydiscover-runs &&\
-    chown -R 65532:0 /app/working-dir/skydiscover-runs
+# Runs live in the work dir (where the UI and terminal look), created lazily
+# by the agent at first run — NEVER pre-baked here: the first-boot seed would
+# make the work dir non-empty and the platform's repo seed (which clones into
+# the work-dir root and refuses a non-empty dir) would fail.
+ENV SKYDISCOVER_OUTPUT_ROOT=/home/agent/work/skydiscover-runs
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
 

--- a/packages/agents/skydiscover/Dockerfile
+++ b/packages/agents/skydiscover/Dockerfile
@@ -24,12 +24,15 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
 # Base package only: AdaEvolve and EvoX are SkyDiscover's own strategies and
 # need no extras. The `external` extra (openevolve/gepa/shinkaevolve wrappers)
 # is deliberately not installed — those backends ship as their own workload
-# images; the heavy `math` extra (torch, jax, …) is runtime-installed into the
-# venv per run when a task actually needs it.
+# images. scipy IS baked in: the venv resets with every pod restart and
+# nearly every numerical task reaches for it, so runtime-installing it cost
+# minutes on each fresh pod; the rest of the heavy `math` extra (torch, jax,
+# …) stays runtime-installed per run when a task actually needs it.
 RUN uv python install 3.11 &&\
     uv venv --python 3.11 "$SKYDISCOVER_VENV" &&\
     uv pip install --python "$SKYDISCOVER_VENV/bin/python" \
-      "skydiscover @ git+https://github.com/skydiscover-ai/skydiscover@${SKYDISCOVER_REF}" &&\
+      "skydiscover @ git+https://github.com/skydiscover-ai/skydiscover@${SKYDISCOVER_REF}" \
+      scipy &&\
     uv cache clean &&\
     chown -R 65532:0 /opt/skydiscover-venv /opt/uv
 

--- a/packages/agents/skydiscover/Dockerfile
+++ b/packages/agents/skydiscover/Dockerfile
@@ -8,7 +8,14 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG SKYDISCOVER_VERSION=0.1.0
+# Pinned git ref, not a PyPI pin: the 0.1.0 wheel (latest release) predates
+# EvoX's config data files — its code loads search/evox/config/search.yaml,
+# which landed upstream only after the release, so `--search evox` crashes at
+# startup on every released wheel. The repo's package-data now ships the
+# config, so a source install at a pinned commit gives consistent code +
+# config. Switch back to `skydiscover==<version>` on the next release that
+# carries search/evox/config/.
+ARG SKYDISCOVER_REF=e221cde39a787351df7e52c656ad3f00add402fe
 
 # shared location so the agent user (uid 65532) can use it at runtime
 ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
@@ -21,9 +28,20 @@ ENV UV_PYTHON_INSTALL_DIR=/opt/uv/python \
 # venv per run when a task actually needs it.
 RUN uv python install 3.11 &&\
     uv venv --python 3.11 "$SKYDISCOVER_VENV" &&\
-    uv pip install --python "$SKYDISCOVER_VENV/bin/python" "skydiscover==${SKYDISCOVER_VERSION}" &&\
+    uv pip install --python "$SKYDISCOVER_VENV/bin/python" \
+      "skydiscover @ git+https://github.com/skydiscover-ai/skydiscover@${SKYDISCOVER_REF}" &&\
     uv cache clean &&\
     chown -R 65532:0 /opt/skydiscover-venv /opt/uv
+
+# fail the build if the installed package misses EvoX's config data files
+# (the exact gap the git-ref install exists to close)
+RUN "$SKYDISCOVER_VENV/bin/python" - <<'EOF'
+import pathlib, yaml, skydiscover
+cfg = pathlib.Path(skydiscover.__file__).parent / "search/evox/config"
+assert yaml.safe_load((cfg / "search.yaml").read_text()), "empty search.yaml"
+assert (cfg / "evox_search_sys_prompt.txt").stat().st_size > 0, "empty sys prompt"
+print("evox config ok")
+EOF
 
 ENV PATH="/opt/skydiscover-venv/bin:${PATH}"
 

--- a/packages/agents/skydiscover/Dockerfile
+++ b/packages/agents/skydiscover/Dockerfile
@@ -30,8 +30,11 @@ ENV PATH="/opt/skydiscover-venv/bin:${PATH}"
 # behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
 COPY AGENTS.md /etc/AGENTS.md
 
-# Default search strategy; the AdaEvolve/EvoX template presets override it.
-ENV SKYDISCOVER_SEARCH=adaevolve
+# Deliberately NO baked SKYDISCOVER_SEARCH default: the harness env merge
+# lets container env win name collisions, so an image-baked value would
+# permanently shadow the preset the template injects over the runtime env
+# rail (adaevolve vs evox). The template presets are the only source;
+# AGENTS.md documents the adaevolve fallback for preset-less runs.
 
 # /app/working-dir is seeded onto persistent $HOME on first boot
 ENV SKYDISCOVER_OUTPUT_ROOT=/home/agent/skydiscover-runs

--- a/packages/agents/skydiscover/Dockerfile
+++ b/packages/agents/skydiscover/Dockerfile
@@ -40,10 +40,16 @@ RUN uv python install 3.11 &&\
 # (the exact gap the git-ref install exists to close)
 RUN "$SKYDISCOVER_VENV/bin/python" - <<'EOF'
 import pathlib, yaml, skydiscover
-cfg = pathlib.Path(skydiscover.__file__).parent / "search/evox/config"
+pkg = pathlib.Path(skydiscover.__file__).parent
+cfg = pkg / "search/evox/config"
 assert yaml.safe_load((cfg / "search.yaml").read_text()), "empty search.yaml"
 assert (cfg / "evox_search_sys_prompt.txt").stat().st_size > 0, "empty sys prompt"
-print("evox config ok")
+# Inverted canary: agentic mode is documented as unsupported because upstream
+# packaging omits the tool schemas. If a future ref ships them, fail the build
+# so the skill's "unsupported" note gets updated instead of silently rotting.
+assert not (pkg / "llm/tool_schemas").exists(), \
+    "tool_schemas now ships — agentic mode may work; update the skydiscover skill"
+print("evox config ok; agentic still unpackaged")
 EOF
 
 ENV PATH="/opt/skydiscover-venv/bin:${PATH}"

--- a/packages/agents/skydiscover/README.md
+++ b/packages/agents/skydiscover/README.md
@@ -69,7 +69,9 @@ SKYDISCOVER_VERSION=0.1.0 mise run agents:skydiscover:image
 
 `values-local.yaml` points the adaevolve/evox templates at the locally-built
 `platform-skydiscover:latest` but keeps them `enabled: false`; flip one to
-`true` to show it in the local catalog.
+`true` to show it in the local catalog. `cluster:install`/`cluster:build-agent`
+resolve the build from the image repository basename, so both presets build
+(and load) the one skydiscover image.
 
 ## CI / publishing
 

--- a/packages/agents/skydiscover/README.md
+++ b/packages/agents/skydiscover/README.md
@@ -1,0 +1,84 @@
+# SkyDiscover agent (AdaEvolve & EvoX)
+
+Runs [**SkyDiscover**](https://github.com/skydiscover-ai/skydiscover) — the
+Berkeley Sky lab's unified framework for LLM-driven code & algorithm
+optimization: an LLM proposes candidate programs, an evaluator scores each
+against a measurable objective, and the search loops toward better solutions —
+as a platform agent type.
+
+One image backs **two curated presets**, SkyDiscover's own search strategies:
+
+- **AdaEvolve** (`--search adaevolve`) — multi-island adaptive search (UCB,
+  migration, paradigm breakthroughs); adapts search parameters on the fly for
+  fast early gains on short budgets.
+- **EvoX** (`--search evox`) — a self-evolving paradigm that co-adapts
+  solution generation and experience management, evolving the search strategy
+  itself for stronger long-horizon gains.
+
+Each preset is its own template over this single image, differing only in the
+injected `SKYDISCOVER_SEARCH` env (the agent defaults every run's `--search`
+to it) — the same one-image/N-templates pattern as k-search/k-search-local.
+SkyDiscover's *wrapped* backends (`--search openevolve|gepa|shinkaevolve` and
+the `*_native` variants) are deliberately **not** installed — those ship as
+their own workload images (openevolve, gepa, shinkaevolve packages).
+
+This is a **conversational, claude-code-driven workload**, not a bare CLI. You
+point it at a target repo (or a from-scratch problem) and a measurable
+objective in chat ("evolve this function to run faster on this input set");
+it authors the run inputs, runs the search, and reports the winning program
+(and can open a PR with it).
+
+## Required connections
+
+- **Model provider** (required) — an OpenAI- and Anthropic-compatible endpoint
+  (an IBM-LiteLLM-class connection). A single such connection powers both the
+  conversation and SkyDiscover's search loop; a pure-OpenAI provider only
+  covers the loop and leaves the agent itself without a model.
+- **GitHub** — needed to clone a private target repo or to open a PR with the
+  evolved code. A report-only run against a public repo needs no GitHub access.
+
+## Image
+
+Built **FROM the `claude-code` image** (`ARG BASE_IMAGE=platform-claude-code`)
+so it inherits the Claude harness, the model gateway, and CA trust — the pod
+holds no credentials. On top it adds Python 3.11 + the `skydiscover` package
+in a venv at `/opt/skydiscover-venv` (installed with `uv` from PyPI, pinned
+via `ARG SKYDISCOVER_VERSION`) — base package only: AdaEvolve and EvoX need no
+extras, the `external` extra (wrapped backends) is deliberately absent, and
+the heavy `math` extra is runtime-installed per run when a task needs it. Both
+harnesses (chat and terminal) are inherited unchanged from the base;
+SkyDiscover customizes behavior via `AGENTS.md` + the `skydiscover` skill, not
+the harness scripts.
+
+How the pod reaches models without holding keys (plain model ids +
+`--api-base`, the placeholder-key idiom) is defined once in the `skydiscover`
+skill's Step 1.
+
+## Build
+
+```sh
+mise run agents:skydiscover:image            # plain docker build (pip-installs skydiscover)
+mise run cluster:build-agent                 # rebuild + restart agent pods in the dev cluster
+```
+
+Override the pinned release with `SKYDISCOVER_VERSION`:
+
+```sh
+SKYDISCOVER_VERSION=0.1.0 mise run agents:skydiscover:image
+```
+
+`values-local.yaml` points the adaevolve/evox templates at the locally-built
+`platform-skydiscover:latest` but keeps them `enabled: false`; flip one to
+`true` to show it in the local catalog.
+
+## CI / publishing
+
+The skydiscover image is published by CI (`.github/workflows/cd.yml`): the
+matrixed `build-workloads` job runs after `merge-agents` — it builds `FROM`
+claude-code, so it pulls its base by the same per-commit tag — and
+`merge-workloads` publishes the multi-arch manifest to the public
+`quay.io/dam-agents/skydiscover` (no `imagePullSecret`). Registering the
+component in `scripts/resolve-image.sh`'s `WORKLOADS` list is what enrolls it
+in that matrix. Both templates (`adaevolve`, `evox`) are enabled in
+`values.yaml` under "Pre-configured Images" (`category: preconfigured`,
+`experimental: true`).

--- a/packages/agents/skydiscover/README.md
+++ b/packages/agents/skydiscover/README.md
@@ -65,7 +65,7 @@ skill's Step 1.
 ## Build
 
 ```sh
-mise run agents:skydiscover:image            # plain docker build (pip-installs skydiscover)
+mise run agents:skydiscover:image            # build-or-reuse: pulls from the registry when the effective source is unchanged, else docker-builds (installs skydiscover from the pinned git ref)
 mise run cluster:build-agent                 # rebuild + restart agent pods in the dev cluster
 ```
 

--- a/packages/agents/skydiscover/README.md
+++ b/packages/agents/skydiscover/README.md
@@ -46,7 +46,9 @@ in a venv at `/opt/skydiscover-venv` (installed with `uv` from the upstream
 git repo at a pinned commit, `ARG SKYDISCOVER_REF`) — base package only:
 AdaEvolve and EvoX need no extras, the `external` extra (wrapped backends) is
 deliberately absent, and the heavy `math` extra is runtime-installed per run
-when a task needs it. The install is a git ref rather than a PyPI pin because
+when a task needs it — except `scipy`, which is baked in (the venv resets
+with every pod restart, and nearly every numerical task was paying a
+minutes-long runtime install for it). The install is a git ref rather than a PyPI pin because
 the 0.1.0 wheel (latest release) predates EvoX's config data files — its code
 loads `search/evox/config/search.yaml`, which landed upstream only after the
 release, so `--search evox` crashes on every released wheel; a build-time

--- a/packages/agents/skydiscover/README.md
+++ b/packages/agents/skydiscover/README.md
@@ -42,10 +42,16 @@ it authors the run inputs, runs the search, and reports the winning program
 Built **FROM the `claude-code` image** (`ARG BASE_IMAGE=platform-claude-code`)
 so it inherits the Claude harness, the model gateway, and CA trust — the pod
 holds no credentials. On top it adds Python 3.11 + the `skydiscover` package
-in a venv at `/opt/skydiscover-venv` (installed with `uv` from PyPI, pinned
-via `ARG SKYDISCOVER_VERSION`) — base package only: AdaEvolve and EvoX need no
-extras, the `external` extra (wrapped backends) is deliberately absent, and
-the heavy `math` extra is runtime-installed per run when a task needs it. Both
+in a venv at `/opt/skydiscover-venv` (installed with `uv` from the upstream
+git repo at a pinned commit, `ARG SKYDISCOVER_REF`) — base package only:
+AdaEvolve and EvoX need no extras, the `external` extra (wrapped backends) is
+deliberately absent, and the heavy `math` extra is runtime-installed per run
+when a task needs it. The install is a git ref rather than a PyPI pin because
+the 0.1.0 wheel (latest release) predates EvoX's config data files — its code
+loads `search/evox/config/search.yaml`, which landed upstream only after the
+release, so `--search evox` crashes on every released wheel; a build-time
+assertion keeps the gap from regressing. Switch back to a version pin on the
+next release that carries the config. Both
 harnesses (chat and terminal) are inherited unchanged from the base;
 SkyDiscover customizes behavior via `AGENTS.md` + the `skydiscover` skill, not
 the harness scripts.
@@ -61,10 +67,10 @@ mise run agents:skydiscover:image            # plain docker build (pip-installs 
 mise run cluster:build-agent                 # rebuild + restart agent pods in the dev cluster
 ```
 
-Override the pinned release with `SKYDISCOVER_VERSION`:
+Override the pinned upstream commit with `SKYDISCOVER_REF`:
 
 ```sh
-SKYDISCOVER_VERSION=0.1.0 mise run agents:skydiscover:image
+SKYDISCOVER_REF=<commit-sha> mise run agents:skydiscover:image
 ```
 
 `values-local.yaml` points the adaevolve/evox templates at the locally-built

--- a/packages/agents/skydiscover/tasks.toml
+++ b/packages/agents/skydiscover/tasks.toml
@@ -1,0 +1,38 @@
+["agents:skydiscover:image"]
+description = "Build the skydiscover agent image (SkyDiscover AdaEvolve/EvoX on the claude-code base), or reuse it from the registry when its source is unchanged"
+dir = "{{config_root}}"
+depends = ["agents:claude-code:image"]
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+
+build_args=()
+[ -n "${SKYDISCOVER_VERSION:-}" ] && build_args+=(--build-arg "SKYDISCOVER_VERSION=${SKYDISCOVER_VERSION}")
+
+# empty-array guard for bash 3.2 `set -u`
+exec scripts/resolve-image.sh build-or-reuse skydiscover -- ${build_args[@]+"${build_args[@]}"} packages/agents/skydiscover
+'''
+
+["agents:skydiscover:scan"]
+depends = ["agents:skydiscover:scan:*"]
+
+["agents:skydiscover:scan:trivy"]
+dir = "{{config_root}}"
+usage = '''
+flag "--json" help="Emit Trivy JSON (exit 0) instead of failing on findings"
+flag "--tag <tag>" help="Scan quay.io/dam-agents/skydiscover:<tag> instead of building locally"
+'''
+run = '''
+#!/usr/bin/env bash
+set -euo pipefail
+if [ -n "${usage_tag:-}" ]; then
+  image="quay.io/dam-agents/skydiscover:${usage_tag}"
+else
+  {{ mise_bin }} run agents:skydiscover:image
+  image="platform-skydiscover:latest"
+fi
+if [[ "${usage_json:-false}" == "true" ]]; then
+  exec trivy image --quiet --format json "$image"
+fi
+exec trivy image --quiet --exit-code 1 "$image"
+'''

--- a/packages/agents/skydiscover/tasks.toml
+++ b/packages/agents/skydiscover/tasks.toml
@@ -7,7 +7,7 @@ run = '''
 set -euo pipefail
 
 build_args=()
-[ -n "${SKYDISCOVER_VERSION:-}" ] && build_args+=(--build-arg "SKYDISCOVER_VERSION=${SKYDISCOVER_VERSION}")
+[ -n "${SKYDISCOVER_REF:-}" ] && build_args+=(--build-arg "SKYDISCOVER_REF=${SKYDISCOVER_REF}")
 
 # empty-array guard for bash 3.2 `set -u`
 exec scripts/resolve-image.sh build-or-reuse skydiscover -- ${build_args[@]+"${build_args[@]}"} packages/agents/skydiscover

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -97,12 +97,17 @@ IBM LiteLLM the `rits/…` models do). Only reuse `--checkpoint` state if some
 iterations actually completed; a run that never got past the first proposal
 is cleaner started fresh.
 
-**Known quirk — EvoX label generation:** EvoX's auxiliary label-generation
-calls don't honor `--api-base` and try the default OpenAI endpoint, which
-this pod's gateway blocks. EvoX degrades gracefully — you'll see retry
-warnings ending in "setting labels to empty strings" in the log. That is
-benign: the main proposal/evaluation loop still routes through `--api-base`.
-Don't kill a run over these warnings.
+**Known quirk — EvoX's hardcoded auxiliary models:** two of EvoX's internal
+roles ignore `-m`/the config and call hardcoded OpenAI models: label
+generation (`gpt-5-mini`) and search-strategy evolution (`gpt-5`). When the
+endpoint doesn't serve those ids you'll see 403/auth retry warnings ending
+in "setting labels to empty strings" and "Failed to generate search
+algorithm". Both are non-fatal — the proposal/evaluation loop still routes
+through `--api-base` — but the second one matters for preset choice: with
+strategy evolution blocked, EvoX can't self-evolve and effectively runs its
+base strategy, eroding its long-horizon advantage over AdaEvolve. Mention
+this when a user picks evox against an endpoint without those models; never
+kill a run over these warnings.
 
 **Model ensemble** (optional): a weighted mix goes in a config YAML instead of
 `-m` — `--api-base` still applies to all of them, so every name must be served

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -235,6 +235,15 @@ restarts from scratch and re-spends the lost iterations, which exceeds the
 originally approved spend: say so and get a fresh go-ahead. For short evox
 runs, warn up front that a hibernation before iteration 10 loses the run.
 
+**Triage errors by class, not by count.** Deterministic 4xx bodies (403
+"team not allowed…", 400 "temperature and top_p…") mean a wrong model or
+config — retries can't fix them, rewire and relaunch. Connection-class
+errors ("upstream connect error", "no healthy upstream", "connection
+timeout") mean the endpoint is unreachable right now — a VPN or network-path
+drop, not a config problem: the run's own retries usually ride it out, and a
+run that died on them resumes from the latest checkpoint once the endpoint
+answers again. Never rewire models over a transient.
+
 **Monitoring:** tail `run.log`; read `output/best/best_program_info.json` and
 list `output/checkpoints/` to count completed iterations. Leave the live dashboard (`monitor.enabled`) off and skip
 `skydiscover-viewer` — this pod exposes no UI ports. A run doesn't advance

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -84,21 +84,19 @@ Then wire the run with three rules:
   header on the wire, but the client refuses to send a request with no key at
   all.
 - If the endpoint can't list models, fall back to a pinned known-good id (for
-  IBM LiteLLM: `aws/claude-sonnet-4-6` — but see the sampling-params quirk
-  below before using it for the loop).
+  IBM LiteLLM: `aws/claude-sonnet-4-6`).
 
-**Known quirk — sampling params:** SkyDiscover's LLM client sends both
-`temperature` and `top_p` on every call, and **some** proxied backends
-reject that combination with a deterministic 400 ("temperature and top_p
-cannot both be specified"). It is per-model, not per-vendor — observed on
-IBM LiteLLM: `aws/claude-sonnet-4-6` and `azure/gpt-5.5` reject it,
-`aws/claude-opus-5` and the `rits/…` models accept it. So don't trust a
-list: **probe the chosen model with a cheap completion passing both
-`temperature` and `top_p`** before launching. The retry loop cannot fix a
-deterministic 400: if every proposal call fails this way, kill the run and
-relaunch on a model that passed the probe. Only reuse `--checkpoint` state
-if some iterations actually completed; a run that never got past the first
-proposal is cleaner started fresh.
+**Sampling params:** at the pinned ref SkyDiscover sends `top_p` only when
+a config explicitly sets it (upstream fixed the old always-send-both
+behavior that used to 400 on Bedrock-hosted Claude) — so there is no
+temperature+top_p conflict to probe for and no per-model denylist. A
+deterministic 4xx on sampling params can still happen two ways: a config
+YAML that sets `top_p` explicitly (the old conflict returns on some
+backends — leave it unset), or a model family that rejects `temperature`
+outright (reasoning models). Retries never fix a deterministic 4xx: adjust
+the config or switch models. Only reuse `--checkpoint` state if some
+iterations actually completed; a run that never got past the first proposal
+is cleaner started fresh.
 
 **Known quirk — EvoX's auxiliary models bypass `-m`:** EvoX's label
 generation (`gpt-5-mini`) and search-strategy evolution (`gpt-5`) read their
@@ -141,8 +139,11 @@ Pass it with `-c task/config.yaml`.
 
 ## Step 2 — author the run inputs
 
-A run needs an **evaluator** and an **initial program** — both are required
-CLI arguments. Keep both under the run's `task/` dir.
+A run needs an **evaluator**; an **initial program** is optional on the CLI
+(omitting it takes the from-scratch path) — but in this pod author one
+anyway, even a minimal stub, so the search starts from a known baseline and
+the smoke-eval has something to score. Keep both under the run's `task/`
+dir.
 
 **`evaluator.py`** — scores a candidate. SkyDiscover calls
 `evaluate(program_path)` and selects on `combined_score` (higher = better):
@@ -205,14 +206,14 @@ with `-o` on the persisted workspace (see `AGENTS.md`).
 ## CLI reference
 
 ```
-skydiscover-run INITIAL_PROGRAM EVALUATOR --search <type> \
+skydiscover-run [INITIAL_PROGRAM] EVALUATOR --search <type> \
   -i <N> -m <model-id> --api-base <url> -o <dir> \
-  [-c <yaml>] [--checkpoint <dir>] [--codebase <dir>]
+  [-c <yaml>] [--checkpoint <dir>]
 ```
 
 | Flag | Meaning |
 |---|---|
-| `INITIAL_PROGRAM` | required — the starting program (`EVOLVE-BLOCK` markers; a minimal stub for from-scratch problems) |
+| `INITIAL_PROGRAM` | optional on the CLI (omitting it takes the from-scratch path) — but author one anyway in this pod, even a minimal stub, so the smoke-eval has a baseline (`EVOLVE-BLOCK` markers) |
 | `EVALUATOR` | required — the `evaluate(program_path)` file |
 | `--search` | strategy — default to `$SKYDISCOVER_SEARCH` (`adaevolve` or `evox`; unset → `adaevolve`); only those two work in this pod |
 | `-i, --iterations` | the run's iteration budget — always bound; on resume, set to the *remainder* of the approved total |
@@ -221,7 +222,12 @@ skydiscover-run INITIAL_PROGRAM EVALUATOR --search <type> \
 | `-o, --output` | output dir — **always** an explicit path on `$SKYDISCOVER_OUTPUT_ROOT`, outside the target repo |
 | `-c, --config` | YAML config (model ensemble, `search.*` tuning) — flags win over it |
 | `--checkpoint` | resume from a prior `output/checkpoints/checkpoint_<N>` dir |
-| `--codebase` | path to a codebase dir — enables agentic generation (the LLM reads/searches it before writing code); costlier per iteration, only with the user's explicit OK |
+
+**Agentic mode (`--agentic`) is unsupported in this image**: the CLI
+advertises the flag, but the installed package ships without its tool
+schemas (`llm/tool_schemas/`), so it crashes at startup. Don't offer it;
+the Dockerfile asserts the gap so a ref bump that fixes upstream packaging
+will surface as a build failure prompting a docs update.
 
 **Resume:** relaunch with `--checkpoint output/checkpoints/checkpoint_<N>`
 (the highest-numbered one). The checkpoint number is the iterations already
@@ -238,8 +244,9 @@ originally approved spend: say so and get a fresh go-ahead. For short evox
 runs, warn up front that a hibernation before iteration 10 loses the run.
 
 **Triage errors by class, not by count.** Deterministic 4xx bodies (403
-"team not allowed…", 400 "temperature and top_p…") mean a wrong model or
-config — retries can't fix them, rewire and relaunch. Connection-class
+"team not allowed…", 400 unsupported-parameter — e.g. `temperature` on a
+reasoning model, or an explicitly configured `top_p` on some backends) mean
+a wrong model or config — retries can't fix them, rewire and relaunch. Connection-class
 errors ("upstream connect error", "no healthy upstream", "connection
 timeout") mean the endpoint is unreachable right now — a VPN or network-path
 drop, not a config problem: the run's own retries usually ride it out, and a
@@ -264,9 +271,10 @@ Under `-o`:
 
 ## Worked example — approximate sin(x) on [0, π]
 
-A self-contained objective: evolve a polynomial to approximate `math.sin` with
-minimum mean-squared error. (Also the CI/local smoke fixture — not a
-user-facing "demo".)
+A self-contained objective: evolve a polynomial to approximate `math.sin`
+with minimum mean-squared error — with the guard sections above applied: a
+structural gate (or the search just returns `math.sin(x)`) and a log-scaled
+score (or every good candidate saturates to 1.0).
 
 `task/initial.py`:
 
@@ -280,16 +288,33 @@ def approx(x):
 `task/evaluator.py`:
 
 ```python
-import importlib.util
+import ast
 import math
 
 def evaluate(program_path):
-    spec = importlib.util.spec_from_file_location("candidate", program_path)
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
+    src = open(program_path).read()
+    # hard gate: pure arithmetic only — no imports, attributes, or calls,
+    # or the winning move is simply `return math.sin(x)`
+    for node in ast.walk(ast.parse(src)):
+        if isinstance(node, (ast.Import, ast.ImportFrom, ast.Attribute, ast.Call)):
+            return {"combined_score": 0.0, "error": "not a pure polynomial"}
+    ns = {}
+    exec(compile(src, program_path, "exec"), {"__builtins__": {}}, ns)
     xs = [i * math.pi / 50 for i in range(51)]
-    mse = sum((mod.approx(x) - math.sin(x)) ** 2 for x in xs) / len(xs)
-    return {"combined_score": 1.0 / (1.0 + mse)}
+    mse = sum((ns["approx"](x) - math.sin(x)) ** 2 for x in xs) / len(xs)
+    # log-scaled: still discriminating at mse ~1e-22, where 1/(1+mse) is 1.0
+    score = (min(max(-math.log10(mse), -1.0), 30.0) + 1.0) / 31.0 if mse > 0 else 1.0
+    return {"combined_score": score, "mse": mse}
+```
+
+Smoke-eval with the mandatory cheat case (must score 0) next to the baseline:
+
+```sh
+cd task && python3 -c "
+from evaluator import evaluate
+print('baseline:', evaluate('initial.py'))
+open('/tmp/cheat.py','w').write('import math\ndef approx(x):\n    return math.sin(x)\n')
+print('cheat   :', evaluate('/tmp/cheat.py'))"
 ```
 
 Run it (after Step 1 resolved `$base` and a model id):
@@ -302,8 +327,9 @@ skydiscover-run task/initial.py task/evaluator.py \
   -o "$SKYDISCOVER_OUTPUT_ROOT/sin-approx/output"
 ```
 
-`combined_score` rises toward 1.0 as the MSE falls; pull the winner from
-`output/best/best_program.py`.
+`combined_score` climbs with every decade of MSE improvement (no
+saturation); pull the winner from `output/best/best_program.py` — and read
+it before trusting it, per the guard section.
 
 ## Reporting (and optional PR)
 

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -88,14 +88,17 @@ Then wire the run with three rules:
   below before using it for the loop).
 
 **Known quirk — sampling params:** SkyDiscover's LLM client sends both
-`temperature` and `top_p` on every call, and some proxied backends reject
-that combination — Bedrock-hosted Claude models (`aws/claude-*` on IBM
-LiteLLM) return 400 "temperature and top_p cannot both be specified". The
-retry loop cannot fix a deterministic 400: if every proposal call fails this
-way, kill the run and relaunch with a model whose backend accepts both (on
-IBM LiteLLM the `rits/…` models do). Only reuse `--checkpoint` state if some
-iterations actually completed; a run that never got past the first proposal
-is cleaner started fresh.
+`temperature` and `top_p` on every call, and **some** proxied backends
+reject that combination with a deterministic 400 ("temperature and top_p
+cannot both be specified"). It is per-model, not per-vendor — observed on
+IBM LiteLLM: `aws/claude-sonnet-4-6` and `azure/gpt-5.5` reject it,
+`aws/claude-opus-5` and the `rits/…` models accept it. So don't trust a
+list: **probe the chosen model with a cheap completion passing both
+`temperature` and `top_p`** before launching. The retry loop cannot fix a
+deterministic 400: if every proposal call fails this way, kill the run and
+relaunch on a model that passed the probe. Only reuse `--checkpoint` state
+if some iterations actually completed; a run that never got past the first
+proposal is cleaner started fresh.
 
 **Known quirk — EvoX's auxiliary models bypass `-m`:** EvoX's label
 generation (`gpt-5-mini`) and search-strategy evolution (`gpt-5`) read their
@@ -155,6 +158,13 @@ def evaluate(program_path):
 
 Extra metrics are fine for visibility, but only `combined_score` drives
 selection — every evaluator must return it.
+
+**Keep the score discriminating across the whole range you care about.**
+`1/(1+MSE)` saturates once MSE ≪ 1 — every good candidate rounds to 1.0000,
+late iterations have no gradient, and the search stops searching while still
+spending. For convergent numerical objectives prefer a log-scaled error
+(e.g. a clamped `-log10(MSE)` mapped to (0, 1]) or minimax error, which stay
+discriminating down to machine precision.
 
 **Constrain the candidate space, or the search will cheat.** The search
 optimizes the score you wrote, not the task you meant: an evaluator that

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -84,7 +84,18 @@ Then wire the run with three rules:
   header on the wire, but the client refuses to send a request with no key at
   all.
 - If the endpoint can't list models, fall back to a pinned known-good id (for
-  IBM LiteLLM: `aws/claude-sonnet-4-6`).
+  IBM LiteLLM: `aws/claude-sonnet-4-6` — but see the sampling-params quirk
+  below before using it for the loop).
+
+**Known quirk — sampling params:** SkyDiscover's LLM client sends both
+`temperature` and `top_p` on every call, and some proxied backends reject
+that combination — Bedrock-hosted Claude models (`aws/claude-*` on IBM
+LiteLLM) return 400 "temperature and top_p cannot both be specified". The
+retry loop cannot fix a deterministic 400: if every proposal call fails this
+way, kill the run and relaunch with a model whose backend accepts both (on
+IBM LiteLLM the `rits/…` models do). Only reuse `--checkpoint` state if some
+iterations actually completed; a run that never got past the first proposal
+is cleaner started fresh.
 
 **Model ensemble** (optional): a weighted mix goes in a config YAML instead of
 `-m` — `--api-base` still applies to all of them, so every name must be served

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -169,7 +169,7 @@ skydiscover-run INITIAL_PROGRAM EVALUATOR --search <type> \
 |---|---|
 | `INITIAL_PROGRAM` | required — the starting program (`EVOLVE-BLOCK` markers; a minimal stub for from-scratch problems) |
 | `EVALUATOR` | required — the `evaluate(program_path)` file |
-| `--search` | strategy — default to `$SKYDISCOVER_SEARCH` (`adaevolve` or `evox`); only those two work in this pod |
+| `--search` | strategy — default to `$SKYDISCOVER_SEARCH` (`adaevolve` or `evox`; unset → `adaevolve`); only those two work in this pod |
 | `-i, --iterations` | the run's iteration budget — always bound; on resume, set to the *remainder* of the approved total |
 | `-m, --model` | plain model id served by the endpoint (Step 1); an ensemble goes in the config YAML instead |
 | `--api-base` | the OpenAI-compatible endpoint (`"$base/v1"`) — **always pass it** in this pod |

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -1,0 +1,238 @@
+---
+name: skydiscover
+description: >-
+  Run SkyDiscover's AdaEvolve and EvoX search strategies via the
+  `skydiscover-run` CLI. Use when the user wants to optimize / evolve a
+  function, program, or algorithm to improve a metric (speed, accuracy, size,
+  error rate), author the SkyDiscover run inputs (evaluator, optional initial
+  program with EVOLVE-BLOCK markers), pick the search model, or launch /
+  monitor / resume / report on a search run.
+---
+
+# SkyDiscover — LLM-driven code & algorithm optimization
+
+SkyDiscover (Berkeley Sky lab) runs LLM-driven search over programs: an LLM
+proposes candidate programs, an **evaluator** scores each one, and the search
+loops toward better solutions. It fits objectives that are **measurable as a
+number**: make a function faster, more accurate, smaller, lower-error — across
+open-ended problems (math, systems, algorithm design).
+
+> Upstream: https://github.com/skydiscover-ai/skydiscover
+
+## This is a SkyDiscover agent pod
+
+`skydiscover-run` is **pre-installed** (on `PATH`); the model endpoint and
+your own Claude model are reached through the platform's credential gateway —
+**no API key lives in this pod**. Never ask the user for a key, never write
+one to disk, never `pip install skydiscover` yourself.
+
+The pod is preset to one of SkyDiscover's two own strategies via
+`$SKYDISCOVER_SEARCH` (that's what the user picked in the catalog):
+
+| Preset | `--search` | Best at |
+|---|---|---|
+| AdaEvolve | `adaevolve` | multi-island adaptive search; fast early gains on short budgets (≲50 iterations) |
+| EvoX | `evox` | self-evolving search strategy; stronger long-horizon gains (≳50 iterations) |
+
+Both are installed, so you can suggest the other when the budget clearly fits
+it — the user decides. The wrapped external backends
+(`openevolve|gepa|shinkaevolve|*_native`) are **not** installed here.
+
+Candidate code runs in the SkyDiscover venv (`$SKYDISCOVER_VENV`). Install
+whatever else a run needs (PyPI egress is allowed; `scipy` is the usual one
+for numerical work):
+
+```sh
+uv pip install --python "$SKYDISCOVER_VENV/bin/python" scipy
+```
+
+The venv is ephemeral but the uv cache is on persistent `$HOME`, so reinstall
+on resume (fast, from cache). Install what the **evolved** code will reach for
+up front, not just the initial program's imports.
+
+The pod-level workflow — the mandatory pre-launch gate, per-run directories,
+backgrounding runs, resume-on-wake, and the hard guardrails — is defined in
+this pod's system context (`AGENTS.md`). **This skill is the setup-and-CLI
+reference**; follow `AGENTS.md` for *how* to operate a run in this environment.
+
+## Step 1 — set up the search model
+
+The search loop calls an **OpenAI-compatible** endpoint that the attached
+model-provider connection injects as `OPENAI_BASE_URL` + `OPENAI_API_KEY`.
+Always discover the catalog first — a model name the endpoint doesn't serve
+fails every proposal:
+
+```sh
+# Through the egress gateway (do NOT bypass the proxy — the gateway injects the
+# real credential and authorizes egress to the endpoint host). Strip a trailing
+# /v1 first so the path is right whether or not the base already includes it:
+base="${OPENAI_BASE_URL%/}"; base="${base%/v1}"
+curl -fsS "$base/v1/models" \
+  -H "Authorization: Bearer ${OPENAI_API_KEY:-placeholder}" | jq -r '.data[].id'
+```
+
+Then wire the run with three rules:
+
+- **Plain model ids only, always with `--api-base "$base/v1"`** — that routes
+  through the OpenAI-compatible client against the injected endpoint.
+  Vendor-prefixed ids (`gemini/…`, `anthropic/…`) or a bare `-m` without
+  `--api-base` route through vendor SDKs/endpoints that demand keys this pod
+  doesn't hold.
+- **Export a non-empty key before launching**:
+  `export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"`. The injected value
+  is often an empty placeholder by design — the gateway overwrites the auth
+  header on the wire, but the client refuses to send a request with no key at
+  all.
+- If the endpoint can't list models, fall back to a pinned known-good id (for
+  IBM LiteLLM: `aws/claude-sonnet-4-6`).
+
+**Model ensemble** (optional): a weighted mix goes in a config YAML instead of
+`-m` — `--api-base` still applies to all of them, so every name must be served
+by the endpoint:
+
+```yaml
+llm:
+  models:
+    - name: "<fast-model-id>"
+      weight: 0.7
+    - name: "<strong-model-id>"
+      weight: 0.3
+```
+
+Pass it with `-c task/config.yaml`.
+
+## Step 2 — author the run inputs
+
+A run needs an **evaluator** and an **initial program** — both are required
+CLI arguments. Keep both under the run's `task/` dir.
+
+**`evaluator.py`** — scores a candidate. SkyDiscover calls
+`evaluate(program_path)` and selects on `combined_score` (higher = better):
+
+```python
+def evaluate(program_path):
+    score = run_and_grade(program_path)   # you define this: run the candidate, measure the objective
+    return {
+        "combined_score": score,   # THE selection signal
+        "artifacts": {},           # optional extras surfaced to the proposal LLM
+    }
+```
+
+Extra metrics are fine for visibility, but only `combined_score` drives
+selection — every evaluator must return it. (The default config enables
+cascade evaluation and logs a warning when `evaluate_stage1` is absent —
+that's a harmless fallback to direct evaluation; define `evaluate_stage1`
+only when you actually want a cheap pre-filter stage.)
+
+**`initial.py`** — the starting program; for a from-scratch problem, a
+minimal stub. Bound the mutable region with markers:
+
+```python
+# EVOLVE-BLOCK-START
+def solve(x):
+    return x            # SkyDiscover rewrites only what's between the markers
+# EVOLVE-BLOCK-END
+```
+
+## Step 3 — smoke-eval, then launch (see the pre-launch gate in AGENTS.md)
+
+Before any full run, smoke-test the evaluator against the initial program and
+confirm it scores a known input sensibly:
+
+```sh
+cd task && python -c "from evaluator import evaluate; print(evaluate('initial.py'))"
+```
+
+Then present a cost estimate, get the user's go-ahead, and launch backgrounded
+with `-o` on the persisted workspace (see `AGENTS.md`).
+
+## CLI reference
+
+```
+skydiscover-run INITIAL_PROGRAM EVALUATOR --search <type> \
+  -i <N> -m <model-id> --api-base <url> -o <dir> \
+  [-c <yaml>] [--checkpoint <dir>] [--codebase <dir>]
+```
+
+| Flag | Meaning |
+|---|---|
+| `INITIAL_PROGRAM` | required — the starting program (`EVOLVE-BLOCK` markers; a minimal stub for from-scratch problems) |
+| `EVALUATOR` | required — the `evaluate(program_path)` file |
+| `--search` | strategy — default to `$SKYDISCOVER_SEARCH` (`adaevolve` or `evox`); only those two work in this pod |
+| `-i, --iterations` | the run's iteration budget — always bound; on resume, set to the *remainder* of the approved total |
+| `-m, --model` | plain model id served by the endpoint (Step 1); an ensemble goes in the config YAML instead |
+| `--api-base` | the OpenAI-compatible endpoint (`"$base/v1"`) — **always pass it** in this pod |
+| `-o, --output` | output dir — **always** an explicit path on `$SKYDISCOVER_OUTPUT_ROOT`, outside the target repo |
+| `-c, --config` | YAML config (model ensemble, `search.*` tuning) — flags win over it |
+| `--checkpoint` | resume from a prior `output/checkpoints/checkpoint_<N>` dir |
+| `--codebase` | path to a codebase dir — enables agentic generation (the LLM reads/searches it before writing code); costlier per iteration, only with the user's explicit OK |
+
+**Resume:** relaunch with `--checkpoint output/checkpoints/checkpoint_<N>`
+(the highest-numbered one). The checkpoint number is the iterations already
+done — set `-i` to the approved total minus that, never more; a bigger total
+is a budget increase, a new re-gated decision.
+
+**Monitoring:** tail `run.log`; read `output/best/best_program_info.json` and
+list `output/checkpoints/` to count completed iterations. Leave the live dashboard (`monitor.enabled`) off and skip
+`skydiscover-viewer` — this pod exposes no UI ports. A run doesn't advance
+faster because you look at it — poll infrequently, and if it stops advancing,
+follow the stall guardrail in `AGENTS.md`.
+
+## Outputs
+
+Under `-o`:
+- `best/` — `best_program.py` and `best_program_info.json` (score, iteration,
+  lineage): the source of truth for "best so far".
+- `checkpoints/checkpoint_<N>/` — the resume points; the numbering is the
+  iterations completed.
+- `logs/` — the search's own log (your `run.log` mirrors stdout/stderr), plus
+  a per-run iteration-stats `.jsonl` at the output root.
+
+## Worked example — approximate sin(x) on [0, π]
+
+A self-contained objective: evolve a polynomial to approximate `math.sin` with
+minimum mean-squared error. (Also the CI/local smoke fixture — not a
+user-facing "demo".)
+
+`task/initial.py`:
+
+```python
+# EVOLVE-BLOCK-START
+def approx(x):
+    return x            # SkyDiscover improves this toward sin(x) on [0, π]
+# EVOLVE-BLOCK-END
+```
+
+`task/evaluator.py`:
+
+```python
+import importlib.util
+import math
+
+def evaluate(program_path):
+    spec = importlib.util.spec_from_file_location("candidate", program_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    xs = [i * math.pi / 50 for i in range(51)]
+    mse = sum((mod.approx(x) - math.sin(x)) ** 2 for x in xs) / len(xs)
+    return {"combined_score": 1.0 / (1.0 + mse)}
+```
+
+Run it (after Step 1 resolved `$base` and a model id):
+
+```sh
+export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"
+skydiscover-run task/initial.py task/evaluator.py \
+  --search "$SKYDISCOVER_SEARCH" \
+  -i 10 -m <model-id> --api-base "$base/v1" -o output
+```
+
+`combined_score` rises toward 1.0 as the MSE falls; pull the winner from
+`output/best/best_program.py`.
+
+## Reporting (and optional PR)
+
+Report the best candidate's `combined_score`, the objective metric, and the
+evolved code (from `output/best/`). If the user wants the change landed
+and a GitHub connection is granted, open a PR with the evolved file via `gh` —
+which works through the connection, never a held token (see `AGENTS.md`).

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -38,17 +38,17 @@ Both are installed, so you can suggest the other when the budget clearly fits
 it — the user decides. The wrapped external backends
 (`openevolve|gepa|shinkaevolve|*_native`) are **not** installed here.
 
-Candidate code runs in the SkyDiscover venv (`$SKYDISCOVER_VENV`). Install
-whatever else a run needs (PyPI egress is allowed; `scipy` is the usual one
-for numerical work):
+Candidate code runs in the SkyDiscover venv (`$SKYDISCOVER_VENV`); numpy and
+scipy are pre-baked. Install whatever else a run needs (PyPI egress is
+allowed):
 
 ```sh
-uv pip install --python "$SKYDISCOVER_VENV/bin/python" scipy
+uv pip install --python "$SKYDISCOVER_VENV/bin/python" pandas
 ```
 
 The venv is ephemeral but the uv cache is on persistent `$HOME`, so reinstall
-on resume (fast, from cache). Install what the **evolved** code will reach for
-up front, not just the initial program's imports.
+extras on resume (fast, from cache). Install what the **evolved** code will
+reach for up front, not just the initial program's imports.
 
 The pod-level workflow — the mandatory pre-launch gate, per-run directories,
 backgrounding runs, resume-on-wake, and the hard guardrails — is defined in

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -190,6 +190,13 @@ skydiscover-run INITIAL_PROGRAM EVALUATOR --search <type> \
 done — set `-i` to the approved total minus that, never more; a bigger total
 is a budget increase, a new re-gated decision.
 
+**Checkpoint cadence differs by strategy**: `adaevolve` writes one per
+iteration; `evox` writes its first only at iteration 10. A run interrupted
+before its first checkpoint has nothing to resume from — relaunching
+restarts from scratch and re-spends the lost iterations, which exceeds the
+originally approved spend: say so and get a fresh go-ahead. For short evox
+runs, warn up front that a hibernation before iteration 10 loses the run.
+
 **Monitoring:** tail `run.log`; read `output/best/best_program_info.json` and
 list `output/checkpoints/` to count completed iterations. Leave the live dashboard (`monitor.enabled`) off and skip
 `skydiscover-viewer` — this pod exposes no UI ports. A run doesn't advance

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -297,7 +297,7 @@ Run it (after Step 1 resolved `$base` and a model id):
 ```sh
 export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"
 skydiscover-run task/initial.py task/evaluator.py \
-  --search "$SKYDISCOVER_SEARCH" \
+  --search "${SKYDISCOVER_SEARCH:-adaevolve}" \
   -i 10 -m <model-id> --api-base "$base/v1" \
   -o "$SKYDISCOVER_OUTPUT_ROOT/sin-approx/output"
 ```

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -224,7 +224,8 @@ Run it (after Step 1 resolved `$base` and a model id):
 export OPENAI_API_KEY="${OPENAI_API_KEY:-placeholder}"
 skydiscover-run task/initial.py task/evaluator.py \
   --search "$SKYDISCOVER_SEARCH" \
-  -i 10 -m <model-id> --api-base "$base/v1" -o output
+  -i 10 -m <model-id> --api-base "$base/v1" \
+  -o "$SKYDISCOVER_OUTPUT_ROOT/sin-approx/output"
 ```
 
 `combined_score` rises toward 1.0 as the MSE falls; pull the winner from

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -97,17 +97,23 @@ IBM LiteLLM the `rits/…` models do). Only reuse `--checkpoint` state if some
 iterations actually completed; a run that never got past the first proposal
 is cleaner started fresh.
 
-**Known quirk — EvoX's hardcoded auxiliary models:** two of EvoX's internal
-roles ignore `-m`/the config and call hardcoded OpenAI models: label
-generation (`gpt-5-mini`) and search-strategy evolution (`gpt-5`). When the
-endpoint doesn't serve those ids you'll see 403/auth retry warnings ending
-in "setting labels to empty strings" and "Failed to generate search
-algorithm". Both are non-fatal — the proposal/evaluation loop still routes
-through `--api-base` — but the second one matters for preset choice: with
-strategy evolution blocked, EvoX can't self-evolve and effectively runs its
-base strategy, eroding its long-horizon advantage over AdaEvolve. Mention
-this when a user picks evox against an endpoint without those models; never
-kill a run over these warnings.
+**Known quirk — EvoX's auxiliary models bypass `-m`:** EvoX's label
+generation (`gpt-5-mini`) and search-strategy evolution (`gpt-5`) read their
+model ids from EvoX's **shipped strategy yaml**
+(`site-packages/skydiscover/search/evox/config/search.yaml`), not from
+`-m`/`--api-base`. Against an endpoint that doesn't serve those ids you'll
+see 403 retry warnings ("setting labels to empty strings", "Failed to
+generate search algorithm") — the solution loop keeps going, but the
+self-evolving strategy layer is dead, eroding EvoX's long-horizon advantage
+over AdaEvolve. **Workaround:** copy the shipped yaml into the task dir,
+replace its model ids with endpoint-served ones, and point
+`search.database.config_path` at the copy via a run config (`-c
+task/config.yaml`). Even then the strategy layer's LLM-generated code can
+crash on upstream bugs (`name 'EvolveProgram' is not defined`-class errors)
+— still non-fatal for the solution loop, but if the run wedges, apply the
+stall guardrail (kill + resume from the latest checkpoint). Mention the
+degradation when a user picks evox; never kill a run over the warnings
+alone.
 
 **Model ensemble** (optional): a weighted mix goes in a config YAML instead of
 `-m` — `--api-base` still applies to all of them, so every name must be served

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -108,7 +108,13 @@ self-evolving strategy layer is dead, eroding EvoX's long-horizon advantage
 over AdaEvolve. **Workaround:** copy the shipped yaml into the task dir,
 replace its model ids with endpoint-served ones, and point
 `search.database.config_path` at the copy via a run config (`-c
-task/config.yaml`). Even then the strategy layer's LLM-generated code can
+task/config.yaml`) — and the config's `search:` block **must carry
+`type: "evox"`**: without it the parser defaults to `topk`, builds the wrong
+database-config class, and silently discards `config_path` (the `--search
+evox` flag alone doesn't back-fill it and would replace a mismatched
+database config wholesale). Verify the fix took — after a couple of
+iterations the `gpt-5`/`gpt-5-mini` 403 retries must be gone from the run
+log; if they persist, the strategy layer is still on the shipped yaml. Even then the strategy layer's LLM-generated code can
 crash on upstream bugs (`name 'EvolveProgram' is not defined`-class errors)
 — still non-fatal for the solution loop, but if the run wedges, apply the
 stall guardrail (kill + resume from the latest checkpoint). Mention the
@@ -148,7 +154,18 @@ def evaluate(program_path):
 ```
 
 Extra metrics are fine for visibility, but only `combined_score` drives
-selection — every evaluator must return it. (The default config enables
+selection — every evaluator must return it.
+
+**Constrain the candidate space, or the search will cheat.** The search
+optimizes the score you wrote, not the task you meant: an evaluator that
+scores "approximate sin(x)" without *enforcing* "…as a polynomial" will
+happily crown `return math.sin(x)`. Encode every structural constraint as a
+hard reject (score 0 with an explanatory `error`) — banned imports/calls,
+required form — and treat a **perfect or too-good score as a finding to
+verify, never a result to report**: read the winning candidate's source
+before trusting it. The Step 3 smoke-eval must include at least one
+**cheat case** (the degenerate solution scoring 0), not just the baseline
+and a known-good candidate. (The default config enables
 cascade evaluation and logs a warning when `evaluate_stage1` is absent —
 that's a harmless fallback to direct evaluation; define `evaluate_stage1`
 only when you actually want a cheap pre-filter stage.)

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -298,8 +298,10 @@ def evaluate(program_path):
     for node in ast.walk(ast.parse(src)):
         if isinstance(node, (ast.Import, ast.ImportFrom, ast.Attribute, ast.Call)):
             return {"combined_score": 0.0, "error": "not a pure polynomial"}
-    ns = {}
-    exec(compile(src, program_path, "exec"), {"__builtins__": {}}, ns)
+    # single namespace: separate globals/locals would hide module-level
+    # constants from function bodies (hoisted coefficients → silent NameError)
+    ns = {"__builtins__": {}}
+    exec(compile(src, program_path, "exec"), ns)
     xs = [i * math.pi / 50 for i in range(51)]
     mse = sum((ns["approx"](x) - math.sin(x)) ** 2 for x in xs) / len(xs)
     # log-scaled: still discriminating at mse ~1e-22, where 1/(1+mse) is 1.0

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -97,6 +97,13 @@ IBM LiteLLM the `rits/…` models do). Only reuse `--checkpoint` state if some
 iterations actually completed; a run that never got past the first proposal
 is cleaner started fresh.
 
+**Known quirk — EvoX label generation:** EvoX's auxiliary label-generation
+calls don't honor `--api-base` and try the default OpenAI endpoint, which
+this pod's gateway blocks. EvoX degrades gracefully — you'll see retry
+warnings ending in "setting labels to empty strings" in the log. That is
+benign: the main proposal/evaluation loop still routes through `--api-base`.
+Don't kill a run over these warnings.
+
 **Model ensemble** (optional): a weighted mix goes in a config YAML instead of
 `-m` — `--api-base` still applies to all of them, so every name must be served
 by the endpoint:

--- a/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
+++ b/packages/agents/skydiscover/workspace/.agents/skills/skydiscover/SKILL.md
@@ -229,7 +229,9 @@ done — set `-i` to the approved total minus that, never more; a bigger total
 is a budget increase, a new re-gated decision.
 
 **Checkpoint cadence differs by strategy**: `adaevolve` writes one per
-iteration; `evox` writes its first only at iteration 10. A run interrupted
+iteration; `evox` writes every 10 iterations plus one at run completion —
+so a *completed* short evox run has a resume point, but one interrupted
+mid-flight before iteration 10 does not. A run interrupted
 before its first checkpoint has nothing to resume from — relaunching
 restarts from scratch and re-spends the lost iterations, which exceeds the
 originally approved spend: say so and get a fresh go-ahead. For short evox

--- a/scripts/resolve-image.sh
+++ b/scripts/resolve-image.sh
@@ -36,7 +36,7 @@ PLATFORM_BASE_PATHS="packages/platform-base packages/agent-runtime packages/agen
 
 # claude-code-derived workloads; single registration point, also emitted as
 # CI's `workloads` build/merge matrix
-WORKLOADS="nous openevolve shinkaevolve gepa"
+WORKLOADS="nous openevolve shinkaevolve gepa skydiscover"
 
 is_workload() { case " $WORKLOADS " in *" $1 "*) ;; *) return 1 ;; esac; }
 
@@ -140,6 +140,7 @@ self_check() {
   chk "$(base_of nous)" claude-code
   chk "$(base_of shinkaevolve)" claude-code
   chk "$(base_of gepa)" claude-code
+  chk "$(base_of skydiscover)" claude-code
   chk "$(base_of claude-code)" platform-base
   chk "$(base_of platform-base)" ""
   chk "$(local_tag platform-base)" platform-base
@@ -151,11 +152,13 @@ self_check() {
   has "$(effective_paths shinkaevolve)" packages/agents/claude-code
   has "$(effective_paths gepa)" packages/agents/gepa
   has "$(effective_paths gepa)" packages/agents/claude-code
+  has "$(effective_paths skydiscover)" packages/agents/skydiscover
+  has "$(effective_paths skydiscover)" packages/agents/claude-code
   # NO_REUSE reproduces the full-build (main/tag) output without git/docker.
   local out; out="$(EVENT=push GITHUB_SHA=deadbeef RESOLVE_NO_REUSE=1; export EVENT GITHUB_SHA RESOLVE_NO_REUSE; gha_outputs)"
   has "$out" 'platform_base=true'
   has "$out" 'agents=["claude-code","codex","pi-agent","bob","k-search"]'
-  has "$out" 'workloads=["nous","openevolve","shinkaevolve","gepa"]'
+  has "$out" 'workloads=["nous","openevolve","shinkaevolve","gepa","skydiscover"]'
   has "$out" 'archs=["amd64","arm64"]'
   has "$out" 'claude_code_base_tag=deadbeef'
   has "$out" 'source_shas={"platform-base":"'


### PR DESCRIPTION
Closes #1639

## What

Packages SkyDiscover's two own search strategies — **AdaEvolve** and **EvoX** — as a curated workload image, following the packaging pattern established by the shinkaevolve and gepa images (#938 epic).

- **New `packages/agents/skydiscover/`** — built `FROM` the claude-code image; adds Python 3.11 + `skydiscover` in a venv at `/opt/skydiscover-venv`, installed from a **pinned upstream git ref** (`SKYDISCOVER_REF`) — the 0.1.0 wheel omits EvoX's config data files; a build assertion keeps that gap (and the still-unpackaged agentic tool schemas) from regressing silently. Base package only: AdaEvolve and EvoX need no extras; the `external` extra (wrapped OpenEvolve/GEPA/ShinkaEvolve backends) is deliberately **not** installed — those ship as their own workload images. Ships `AGENTS.md` (pod policy: pre-launch gate, run discipline, resume-on-wake via `--checkpoint`, hard guardrails) and the `skydiscover` skill (CLI reference, model setup, worked example).
- **Two presets over one image** (same one-image/N-templates pattern as k-search/k-search-local): `adaevolve` and `evox` templates in `values.yaml`, both pointing at `quay.io/dam-agents/skydiscover` and differing only in the injected `SKYDISCOVER_SEARCH` env, which the agent uses as the run's default `--search`.
- **Registration**: `scripts/resolve-image.sh` `WORKLOADS` (enrolls the image in CI's `build-workloads`/`merge-workloads` matrix) + self-check assertions, `mise.toml` task include, `values-local.yaml` local-build entries (disabled by default, like the other workloads).

## Verification

- `scripts/resolve-image.sh --self-check` passes; `mise run helm:check` (lint + kubeconform render) passes; the rendered agent-templates ConfigMap carries both presets with the right env.
- `mise run agents:skydiscover:image` builds; in-image smoke test: `skydiscover-run --help` works, and a 1-iteration run with a stub evaluator initializes **both** `--search adaevolve` and `--search evox` from the base install, producing the documented output layout (`best/best_program.py`, `checkpoints/checkpoint_<N>/`, `logs/`).
- The docs were corrected against the real CLI at the pinned ref: `initial_program` is optional (from-scratch path), agentic mode is unsupported in this image (upstream packaging omits its tool schemas — build canary added), checkpoints live under `<output>/checkpoints/`.

## Out of scope / follow-up

- End-to-end sample runs of both presets in hosted DAM need the published image, so they happen after this merges (CI publishes `quay.io/dam-agents/skydiscover` from main).
- SkyDiscover's other built-in modes (Top-K, Beam Search, Best-of-N) are installed but not exposed as presets, per the issue.
