### PR TITLE
fix(ui): bind deep links survive login and the Terms gate

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-07-30
+Last verified: 2026-07-31
 
 ## Overview
 
@@ -134,6 +134,12 @@ The user agent flow:
 3. The api-server's `sub` claim becomes `agent-platform.ai/owner=<sub>` on every
    resource the user creates (Agent CR, K8s credential Secret,
    etc.).
+
+Two interstitials can take the browser off the page the user asked for:
+the login redirect above, and the Terms-of-Use gate. Both park that
+destination and resume it once cleared, so a deep link survives them —
+an in-chat bind link ([channels](channels.md)) is single-use, so losing
+its target would cost the user a fresh bind command rather than a retry.
 
 If the key set itself cannot be retrieved (Keycloak unreachable, fetch
 timeout, non-200 response), verification fails closed with **503** and

--- a/packages/e2e/playwright/src/tests/smoke/01-auth-deep-link.spec.ts
+++ b/packages/e2e/playwright/src/tests/smoke/01-auth-deep-link.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+import { baseUrl, testUser } from "../../config.js";
+
+// Runs before 01-auth (alphabetical, same "auth" project) and so faces the
+// Terms gate on a fresh install — the leg that made #3107 stick on the
+// dashboard. The flow id is deliberately bogus: the picker only validates it
+// when an agent is picked, so reaching the picker is the whole assertion.
+const bindFlowId = "e2e-deep-link-probe";
+const bindDeepLink = `/slack/bind?flow=${bindFlowId}`;
+
+test("a bind deep link survives the login roundtrip and the Terms gate (#3107)", async ({
+  page,
+}) => {
+  await page.goto(`${baseUrl}${bindDeepLink}`);
+
+  await page.waitForURL(/\/realms\/platform\/protocol\/openid-connect\/auth/);
+  await page.locator("#username").fill(testUser.username);
+  await page.locator("#password").fill(testUser.password);
+  await page.getByRole("button", { name: /sign in/i }).click();
+
+  const termsButton = page.getByRole("button", {
+    name: /I accept the Terms of Use/,
+  });
+  const picker = page.getByRole("heading", {
+    name: /connect this channel to an agent/i,
+  });
+
+  // Whichever comes first, both paths have to land on the picker: acceptance
+  // resumes the parked destination instead of the dashboard.
+  await expect(termsButton.or(picker)).toBeVisible();
+  if (await termsButton.isVisible()) await termsButton.click();
+
+  await expect(picker).toBeVisible();
+  await page.waitForURL(
+    (url) =>
+      url.pathname === "/slack/bind" &&
+      url.searchParams.get("flow") === bindFlowId,
+  );
+});

--- a/packages/ui/src/__tests__/unit/return-path.test.ts
+++ b/packages/ui/src/__tests__/unit/return-path.test.ts
@@ -54,6 +54,19 @@ describe("isSafeReturnPath", () => {
     expect(isSafeReturnPath("/auth/callback?code=abc&state=xyz")).toBe(false);
     expect(isSafeReturnPath("/terms")).toBe(false);
   });
+
+  // Browsers strip these while parsing, so both checks have to look past them:
+  // "/<tab>/host" resolves cross-origin and "/terms<tab>" re-enters the gate.
+  it.each(["\t", "\n", "\r"])(
+    "sees through a %j the browser would drop",
+    (control) => {
+      expect(isSafeReturnPath(`/${control}/evil.example`)).toBe(false);
+      expect(isSafeReturnPath(`/${control}\\evil.example`)).toBe(false);
+      expect(isSafeReturnPath(`/terms${control}`)).toBe(false);
+      expect(isSafeReturnPath(`/${control}terms`)).toBe(false);
+      expect(isSafeReturnPath(`/auth${control}/callback`)).toBe(false);
+    },
+  );
 });
 
 describe("toReturnPath", () => {

--- a/packages/ui/src/__tests__/unit/return-path.test.ts
+++ b/packages/ui/src/__tests__/unit/return-path.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from "vitest";
+
+import {
+  type Interstitial,
+  isSafeReturnPath,
+  rememberReturnPath,
+  type ReturnPathStore,
+  takeReturnPath,
+  toReturnPath,
+} from "../../lib/return-path.js";
+
+function fakeStore(): ReturnPathStore & { snapshot(): Record<string, string> } {
+  const entries = new Map<string, string>();
+  return {
+    getItem: (key) => entries.get(key) ?? null,
+    setItem: (key, value) => void entries.set(key, value),
+    removeItem: (key) => void entries.delete(key),
+    snapshot: () => Object.fromEntries(entries),
+  };
+}
+
+function location(pathname: string, search = "", hash = "") {
+  return { pathname, search, hash };
+}
+
+const BIND_LINK = location("/slack/bind", "?flow=abc-123");
+
+describe("isSafeReturnPath", () => {
+  it("accepts same-origin paths, with query and hash", () => {
+    expect(isSafeReturnPath("/")).toBe(true);
+    expect(isSafeReturnPath("/slack/bind?flow=abc")).toBe(true);
+    expect(isSafeReturnPath("/settings/connections#tokens")).toBe(true);
+  });
+
+  it("rejects anything that could leave the origin", () => {
+    expect(isSafeReturnPath("https://evil.example/")).toBe(false);
+    expect(isSafeReturnPath("//evil.example/")).toBe(false);
+    expect(isSafeReturnPath("/\\evil.example/")).toBe(false);
+    expect(isSafeReturnPath("javascript:alert(1)")).toBe(false);
+    expect(isSafeReturnPath("")).toBe(false);
+  });
+
+  it("rejects the interstitials themselves", () => {
+    expect(isSafeReturnPath("/auth/callback")).toBe(false);
+    expect(isSafeReturnPath("/auth/callback?code=abc&state=xyz")).toBe(false);
+    expect(isSafeReturnPath("/terms")).toBe(false);
+  });
+});
+
+describe("toReturnPath", () => {
+  it("keeps the query — the bind flow id lives there", () => {
+    expect(toReturnPath(BIND_LINK)).toBe("/slack/bind?flow=abc-123");
+    expect(toReturnPath(location("/telegram/bind", "?flow=xyz", "#top"))).toBe(
+      "/telegram/bind?flow=xyz#top",
+    );
+  });
+
+  it("is null on an interstitial location", () => {
+    expect(toReturnPath(location("/auth/callback", "?code=abc"))).toBe(null);
+    expect(toReturnPath(location("/terms"))).toBe(null);
+  });
+});
+
+describe("remember/take round-trip", () => {
+  it("hands the bind deep link back once, then falls back to the dashboard", () => {
+    const store = fakeStore();
+    rememberReturnPath("login", BIND_LINK, store);
+    expect(takeReturnPath("login", store)).toBe("/slack/bind?flow=abc-123");
+    expect(takeReturnPath("login", store)).toBe("/");
+  });
+
+  it("keeps the login and terms destinations in separate slots", () => {
+    const store = fakeStore();
+    rememberReturnPath("login", BIND_LINK, store);
+    rememberReturnPath("terms", location("/settings/usage"), store);
+    expect(takeReturnPath("login", store)).toBe("/slack/bind?flow=abc-123");
+    expect(takeReturnPath("terms", store)).toBe("/settings/usage");
+  });
+
+  it("clears a stale destination when the current location is an interstitial", () => {
+    const store = fakeStore();
+    rememberReturnPath("login", BIND_LINK, store);
+    rememberReturnPath("login", location("/terms"), store);
+    expect(takeReturnPath("login", store)).toBe("/");
+  });
+
+  it.each<Interstitial>(["login", "terms"])(
+    "drops a %s destination that isn't a same-origin path",
+    (which) => {
+      const store = fakeStore();
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      rememberReturnPath(which, BIND_LINK, store);
+      store.setItem(
+        Object.keys(store.snapshot())[0]!,
+        "https://evil.example/steal",
+      );
+      expect(takeReturnPath(which, store)).toBe("/");
+      expect(warn).toHaveBeenCalled();
+      expect(store.snapshot()).toEqual({});
+      warn.mockRestore();
+    },
+  );
+});

--- a/packages/ui/src/__tests__/unit/return-path.test.ts
+++ b/packages/ui/src/__tests__/unit/return-path.test.ts
@@ -39,6 +39,9 @@ describe("isSafeReturnPath", () => {
     expect(isSafeReturnPath("/")).toBe(true);
     expect(isSafeReturnPath("/slack/bind?flow=abc")).toBe(true);
     expect(isSafeReturnPath("/settings/connections#tokens")).toBe(true);
+    // Only the interstitials themselves are barred, not paths that share a prefix.
+    expect(isSafeReturnPath("/terms-of-service")).toBe(true);
+    expect(isSafeReturnPath("/termsx")).toBe(true);
   });
 
   it("rejects anything that could leave the origin", () => {
@@ -55,16 +58,22 @@ describe("isSafeReturnPath", () => {
     expect(isSafeReturnPath("/terms")).toBe(false);
   });
 
-  // Browsers strip these while parsing, so both checks have to look past them:
-  // "/<tab>/host" resolves cross-origin and "/terms<tab>" re-enters the gate.
-  it.each(["\t", "\n", "\r"])(
-    "sees through a %j the browser would drop",
+  // Dropped anywhere in a URL, so an interior one turns a path into a
+  // protocol-relative reference: "/<tab>/host" resolves to another origin.
+  it.each(["\t", "\n", "\r"])("sees through an interior %j", (control) => {
+    expect(isSafeReturnPath(`/${control}/evil.example`)).toBe(false);
+    expect(isSafeReturnPath(`/${control}\\evil.example`)).toBe(false);
+    expect(isSafeReturnPath(`/${control}terms`)).toBe(false);
+  });
+
+  // Trimmed at the ends — the whole C0-plus-space class, not just the three
+  // above — so a trailing one would smuggle an interstitial past the check.
+  it.each(["\t", "\n", "\r", "\f", "\v", "\0", " "])(
+    "sees through a trailing %j on an interstitial",
     (control) => {
-      expect(isSafeReturnPath(`/${control}/evil.example`)).toBe(false);
-      expect(isSafeReturnPath(`/${control}\\evil.example`)).toBe(false);
       expect(isSafeReturnPath(`/terms${control}`)).toBe(false);
-      expect(isSafeReturnPath(`/${control}terms`)).toBe(false);
-      expect(isSafeReturnPath(`/auth${control}/callback`)).toBe(false);
+      expect(isSafeReturnPath(`/auth/callback${control}`)).toBe(false);
+      expect(isSafeReturnPath(`${control}/terms`)).toBe(false);
     },
   );
 });

--- a/packages/ui/src/__tests__/unit/return-path.test.ts
+++ b/packages/ui/src/__tests__/unit/return-path.test.ts
@@ -2,12 +2,15 @@ import { describe, expect, it, vi } from "vitest";
 
 import {
   type Interstitial,
-  isSafeReturnPath,
+  type LocationLike,
   rememberReturnPath,
+  resolveReturnPath,
+  resolveReturnPathname,
   type ReturnPathStore,
   takeReturnPath,
-  toReturnPath,
 } from "../../lib/return-path.js";
+
+const ORIGIN = "https://app.example";
 
 interface FakeStore extends ReturnPathStore {
   isEmpty(): boolean;
@@ -28,67 +31,128 @@ function fakeStore(): FakeStore {
   };
 }
 
-function location(pathname: string, search = "", hash = "") {
-  return { pathname, search, hash };
+function location(pathname: string, search = "", hash = ""): LocationLike {
+  return { origin: ORIGIN, pathname, search, hash };
 }
 
 const BIND_LINK = location("/slack/bind", "?flow=abc-123");
+const resolvePath = (value: string) => resolveReturnPath(value, ORIGIN);
 
-describe("isSafeReturnPath", () => {
-  it("accepts same-origin paths, with query and hash", () => {
-    expect(isSafeReturnPath("/")).toBe(true);
-    expect(isSafeReturnPath("/slack/bind?flow=abc")).toBe(true);
-    expect(isSafeReturnPath("/settings/connections#tokens")).toBe(true);
-    // Only the interstitials themselves are barred, not paths that share a prefix.
-    expect(isSafeReturnPath("/terms-of-service")).toBe(true);
-    expect(isSafeReturnPath("/termsx")).toBe(true);
+describe("resolveReturnPath", () => {
+  it("keeps same-origin destinations whole — the bind flow id lives in the query", () => {
+    expect(resolvePath("/")).toBe("/");
+    expect(resolvePath("/slack/bind?flow=abc-123")).toBe(
+      "/slack/bind?flow=abc-123",
+    );
+    expect(resolvePath("/telegram/bind?flow=xyz#top")).toBe(
+      "/telegram/bind?flow=xyz#top",
+    );
+    expect(resolvePath("/settings/connections#tokens")).toBe(
+      "/settings/connections#tokens",
+    );
+    expect(resolvePath("/sandboxes/a%20b/channels")).toBe(
+      "/sandboxes/a%20b/channels",
+    );
   });
 
-  it("rejects anything that could leave the origin", () => {
-    expect(isSafeReturnPath("https://evil.example/")).toBe(false);
-    expect(isSafeReturnPath("//evil.example/")).toBe(false);
-    expect(isSafeReturnPath("/\\evil.example/")).toBe(false);
-    expect(isSafeReturnPath("javascript:alert(1)")).toBe(false);
-    expect(isSafeReturnPath("")).toBe(false);
+  it("bars the interstitials themselves, not paths that share their prefix", () => {
+    expect(resolvePath("/auth/callback")).toBe(null);
+    expect(resolvePath("/auth/callback?code=abc&state=xyz")).toBe(null);
+    expect(resolvePath("/terms")).toBe(null);
+    expect(resolvePath("/terms-of-service")).toBe("/terms-of-service");
+    expect(resolvePath("/termsx")).toBe("/termsx");
+    expect(resolvePath("/terms/sub")).toBe("/terms/sub");
+    expect(resolvePath("/auth/callbackx")).toBe("/auth/callbackx");
   });
 
-  it("rejects the interstitials themselves", () => {
-    expect(isSafeReturnPath("/auth/callback")).toBe(false);
-    expect(isSafeReturnPath("/auth/callback?code=abc&state=xyz")).toBe(false);
-    expect(isSafeReturnPath("/terms")).toBe(false);
+  it("rejects anything that would leave the origin", () => {
+    expect(resolvePath("https://evil.example/")).toBe(null);
+    expect(resolvePath("//evil.example/")).toBe(null);
+    expect(resolvePath("/\\evil.example/")).toBe(null);
+    expect(resolvePath("javascript:alert(1)")).toBe(null);
+    expect(resolvePath("data:text/html,<script>1</script>")).toBe(null);
+    // Same origin, but no hierarchical path to navigate to.
+    expect(resolvePath(`blob:${ORIGIN}/9c2f-uuid`)).toBe(null);
   });
 
-  // Dropped anywhere in a URL, so an interior one turns a path into a
-  // protocol-relative reference: "/<tab>/host" resolves to another origin.
-  it.each(["\t", "\n", "\r"])("sees through an interior %j", (control) => {
-    expect(isSafeReturnPath(`/${control}/evil.example`)).toBe(false);
-    expect(isSafeReturnPath(`/${control}\\evil.example`)).toBe(false);
-    expect(isSafeReturnPath(`/${control}terms`)).toBe(false);
+  it("reads an empty or blank value as the dashboard, like the parser does", () => {
+    expect(resolvePath("")).toBe("/");
+    expect(resolvePath(" ")).toBe("/");
   });
 
-  // Trimmed at the ends — the whole C0-plus-space class, not just the three
-  // above — so a trailing one would smuggle an interstitial past the check.
-  it.each(["\t", "\n", "\r", "\f", "\v", "\0", " "])(
-    "sees through a trailing %j on an interstitial",
+  // The three classes below are all the same defect — text the parser rewrites
+  // before the browser acts on it. They stay as tests because each one reached
+  // a different wrong destination before the parser became the authority.
+  it.each(["\t", "\n", "\r"])(
+    "sees through an interior %j, dropped mid-URL",
     (control) => {
-      expect(isSafeReturnPath(`/terms${control}`)).toBe(false);
-      expect(isSafeReturnPath(`/auth/callback${control}`)).toBe(false);
-      expect(isSafeReturnPath(`${control}/terms`)).toBe(false);
+      expect(resolvePath(`/${control}/evil.example`)).toBe(null);
+      expect(resolvePath(`/${control}\\evil.example`)).toBe(null);
+      expect(resolvePath(`/${control}terms`)).toBe(null);
+    },
+  );
+
+  it.each(["\t", "\n", "\r", "\f", "\v", "\0", " "])(
+    "sees through a trailing %j, trimmed at the ends",
+    (control) => {
+      expect(resolvePath(`/terms${control}`)).toBe(null);
+      expect(resolvePath(`/auth/callback${control}`)).toBe(null);
+      expect(resolvePath(`${control}/terms`)).toBe(null);
+    },
+  );
+
+  it.each([
+    "/a/../terms",
+    "/./terms",
+    "/a/b/../../terms",
+    "/terms/../terms",
+    "/%2e%2e/terms",
+    "/%2E./terms",
+    "/foo/../auth/callback",
+    "/auth/./callback",
+  ])("sees through dot segments in %j, collapsed on resolve", (value) => {
+    expect(resolvePath(value)).toBe(null);
+  });
+
+  it("hands back the parser's canonical form, so callers act on what was judged", () => {
+    expect(resolvePath("/a/../settings/usage")).toBe("/settings/usage");
+    expect(resolvePath("/settings/./usage")).toBe("/settings/usage");
+  });
+
+  // Collapsing dot segments can leave a path that begins with "//" — same origin
+  // once, another origin when the result is used as a reference again. The
+  // returned text has to mean what it was judged to mean.
+  it.each([
+    "/a/..//evil.example",
+    "/..//evil.example",
+    "/a/b/../..//evil.example",
+    "/\t..//evil.example",
+    "/a/..//evil.example?x=1",
+  ])("rejects %j, whose resolved path reads as another origin", (value) => {
+    expect(resolvePath(value)).toBe(null);
+    expect(resolveReturnPathname(value, ORIGIN)).toBe(null);
+  });
+
+  // Boot and the Terms-accept navigation both run through here, so an
+  // unparseable value has to read as "no destination", never throw.
+  it.each(["//%00evil.example", "/a/..//%00evil.example", "/%00/..//x"])(
+    "rejects %j without throwing",
+    (value) => {
+      expect(() => resolvePath(value)).not.toThrow();
+      expect(resolvePath(value)).toBe(null);
     },
   );
 });
 
-describe("toReturnPath", () => {
-  it("keeps the query — the bind flow id lives there", () => {
-    expect(toReturnPath(BIND_LINK)).toBe("/slack/bind?flow=abc-123");
-    expect(toReturnPath(location("/telegram/bind", "?flow=xyz", "#top"))).toBe(
-      "/telegram/bind?flow=xyz#top",
+describe("resolveReturnPathname", () => {
+  it("drops the query and fragment routing must not see", () => {
+    expect(resolveReturnPathname("/settings/connections?oauth=1", ORIGIN)).toBe(
+      "/settings/connections",
     );
-  });
-
-  it("is null on an interstitial location", () => {
-    expect(toReturnPath(location("/auth/callback", "?code=abc"))).toBe(null);
-    expect(toReturnPath(location("/terms"))).toBe(null);
+    expect(resolveReturnPathname("/sandboxes/abc/channels#x", ORIGIN)).toBe(
+      "/sandboxes/abc/channels",
+    );
+    expect(resolveReturnPathname("/a/../terms", ORIGIN)).toBe(null);
   });
 });
 
@@ -96,36 +160,51 @@ describe("remember/take round-trip", () => {
   it("hands the bind deep link back once, then falls back to the dashboard", () => {
     const store = fakeStore();
     rememberReturnPath("login", BIND_LINK, store);
-    expect(takeReturnPath("login", store)).toBe("/slack/bind?flow=abc-123");
-    expect(takeReturnPath("login", store)).toBe("/");
+    expect(takeReturnPath("login", store, ORIGIN)).toBe(
+      "/slack/bind?flow=abc-123",
+    );
+    expect(takeReturnPath("login", store, ORIGIN)).toBe("/");
   });
 
   it("keeps the login and terms destinations in separate slots", () => {
     const store = fakeStore();
     rememberReturnPath("login", BIND_LINK, store);
     rememberReturnPath("terms", location("/settings/usage"), store);
-    expect(takeReturnPath("login", store)).toBe("/slack/bind?flow=abc-123");
-    expect(takeReturnPath("terms", store)).toBe("/settings/usage");
+    expect(takeReturnPath("login", store, ORIGIN)).toBe(
+      "/slack/bind?flow=abc-123",
+    );
+    expect(takeReturnPath("terms", store, ORIGIN)).toBe("/settings/usage");
   });
 
   it("clears a stale destination when the current location is an interstitial", () => {
     const store = fakeStore();
     rememberReturnPath("login", BIND_LINK, store);
     rememberReturnPath("login", location("/terms"), store);
-    expect(takeReturnPath("login", store)).toBe("/");
+    expect(takeReturnPath("login", store, ORIGIN)).toBe("/");
+  });
+
+  it.each<[string, string]>([
+    ["off-origin", "https://evil.example/steal"],
+    ["protocol-relative", "//evil.example/steal"],
+    ["control-character", "/\t/evil.example"],
+    ["dot-segment", "/a/../terms"],
+  ])("drops a tampered %s destination on the way out", (_label, tampered) => {
+    const store = fakeStore();
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    rememberReturnPath("terms", BIND_LINK, store);
+    store.tamper(tampered);
+    expect(takeReturnPath("terms", store, ORIGIN)).toBe("/");
+    expect(warn).toHaveBeenCalled();
+    expect(store.isEmpty()).toBe(true);
+    warn.mockRestore();
   });
 
   it.each<Interstitial>(["login", "terms"])(
-    "drops a %s destination that isn't a same-origin path",
+    "stores the canonical form for %s, not the raw text",
     (which) => {
       const store = fakeStore();
-      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
-      rememberReturnPath(which, BIND_LINK, store);
-      store.tamper("https://evil.example/steal");
-      expect(takeReturnPath(which, store)).toBe("/");
-      expect(warn).toHaveBeenCalled();
-      expect(store.isEmpty()).toBe(true);
-      warn.mockRestore();
+      rememberReturnPath(which, location("/a/../settings/usage"), store);
+      expect(takeReturnPath(which, store, ORIGIN)).toBe("/settings/usage");
     },
   );
 });

--- a/packages/ui/src/__tests__/unit/return-path.test.ts
+++ b/packages/ui/src/__tests__/unit/return-path.test.ts
@@ -9,13 +9,22 @@ import {
   toReturnPath,
 } from "../../lib/return-path.js";
 
-function fakeStore(): ReturnPathStore & { snapshot(): Record<string, string> } {
+interface FakeStore extends ReturnPathStore {
+  isEmpty(): boolean;
+  /** Stand-in for a tampered-with sessionStorage, whose slot names the module owns. */
+  tamper(value: string): void;
+}
+
+function fakeStore(): FakeStore {
   const entries = new Map<string, string>();
   return {
     getItem: (key) => entries.get(key) ?? null,
     setItem: (key, value) => void entries.set(key, value),
     removeItem: (key) => void entries.delete(key),
-    snapshot: () => Object.fromEntries(entries),
+    isEmpty: () => entries.size === 0,
+    tamper: (value) => {
+      for (const key of entries.keys()) entries.set(key, value);
+    },
   };
 }
 
@@ -90,13 +99,10 @@ describe("remember/take round-trip", () => {
       const store = fakeStore();
       const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
       rememberReturnPath(which, BIND_LINK, store);
-      store.setItem(
-        Object.keys(store.snapshot())[0]!,
-        "https://evil.example/steal",
-      );
+      store.tamper("https://evil.example/steal");
       expect(takeReturnPath(which, store)).toBe("/");
       expect(warn).toHaveBeenCalled();
-      expect(store.snapshot()).toEqual({});
+      expect(store.isEmpty()).toBe(true);
       warn.mockRestore();
     },
   );

--- a/packages/ui/src/auth.ts
+++ b/packages/ui/src/auth.ts
@@ -1,6 +1,7 @@
 import { type AuthConfig, authConfigSchema } from "api-server-api";
 import { type User, UserManager, WebStorageStateStore } from "oidc-client-ts";
 
+import { rememberReturnPath, takeReturnPath } from "./lib/return-path.js";
 import { readStoredTheme } from "./modules/platform/store/theme.js";
 
 let userManager: UserManager;
@@ -56,9 +57,7 @@ export async function initAuth(): Promise<User | null> {
   if (window.location.pathname === "/auth/callback") {
     try {
       currentUser = await userManager.signinRedirectCallback();
-      const returnUrl = sessionStorage.getItem("platform-auth-return") || "/";
-      sessionStorage.removeItem("platform-auth-return");
-      window.history.replaceState({}, "", returnUrl);
+      window.history.replaceState({}, "", takeReturnPath("login"));
       return currentUser;
     } catch (err) {
       console.error("OIDC callback error:", err);
@@ -73,10 +72,7 @@ export async function initAuth(): Promise<User | null> {
   }
 
   // Not authenticated — save current location and redirect to Keycloak
-  sessionStorage.setItem(
-    "platform-auth-return",
-    window.location.pathname + window.location.search,
-  );
+  rememberReturnPath("login");
   await userManager.signinRedirect({ extraQueryParams: signinExtraParams() });
   return null;
 }
@@ -94,7 +90,8 @@ export async function getAccessToken(): Promise<string> {
     currentUser = renewed;
     return renewed!.access_token;
   } catch {
-    // Silent renew failed — redirect to login
+    // Silent renew failed — log in again, resuming on the current page after.
+    rememberReturnPath("login");
     await userManager.signinRedirect({ extraQueryParams: signinExtraParams() });
     throw new Error("Session expired");
   }

--- a/packages/ui/src/lib/return-path.ts
+++ b/packages/ui/src/lib/return-path.ts
@@ -33,9 +33,12 @@ export interface ReturnPathStore {
 
 /** Stored values are untrusted on the way out: only same-origin paths pass. */
 export function isSafeReturnPath(value: string): boolean {
+  // Browsers drop tab/LF/CR while parsing, so "/<tab>/host" is protocol-relative
+  // after the fact — validate what the browser will act on, not the raw text.
+  const parsed = value.replace(/[\t\n\r]/g, "");
   // "//host" and "/\host" are protocol-relative URLs, not paths.
-  if (!value.startsWith("/") || /^\/[/\\]/.test(value)) return false;
-  return !INTERSTITIAL_PATHS.includes(value.split(/[?#]/)[0]!);
+  if (!parsed.startsWith("/") || /^\/[/\\]/.test(parsed)) return false;
+  return !INTERSTITIAL_PATHS.includes(parsed.split(/[?#]/)[0]!);
 }
 
 /** The location as a return path, or null when it isn't a destination. */

--- a/packages/ui/src/lib/return-path.ts
+++ b/packages/ui/src/lib/return-path.ts
@@ -33,9 +33,12 @@ export interface ReturnPathStore {
 
 /** Stored values are untrusted on the way out: only same-origin paths pass. */
 export function isSafeReturnPath(value: string): boolean {
-  // Browsers drop tab/LF/CR while parsing, so "/<tab>/host" is protocol-relative
-  // after the fact — validate what the browser will act on, not the raw text.
-  const parsed = value.replace(/[\t\n\r]/g, "");
+  // Validate what the browser will act on, not the raw text: it drops tab/LF/CR
+  // anywhere while parsing ("/<tab>/host" ends up protocol-relative) and trims
+  // C0 controls and spaces at the ends ("/terms<FF>" ends up on the gate).
+  // Stripping the whole class judges a little more than the parser removes,
+  // which only ever rejects — the safe direction.
+  const parsed = value.replace(/[\0-\x20]/g, "");
   // "//host" and "/\host" are protocol-relative URLs, not paths.
   if (!parsed.startsWith("/") || /^\/[/\\]/.test(parsed)) return false;
   return !INTERSTITIAL_PATHS.includes(parsed.split(/[?#]/)[0]!);

--- a/packages/ui/src/lib/return-path.ts
+++ b/packages/ui/src/lib/return-path.ts
@@ -1,0 +1,69 @@
+/** Where the user was headed before an interstitial took the browser off it.
+ *
+ *  Two interstitials rewrite the URL after boot — the Keycloak login roundtrip
+ *  and the Terms-of-Use gate — and both have to hand the user back afterwards.
+ *  Deep links are why it matters: a Slack/Telegram bind link carries a one-shot
+ *  `?flow=`, so losing the target costs the user another bind command. */
+
+/** One slot per interstitial, so a login inside the Terms gate (or the reverse)
+ *  can't clobber the other's destination. */
+const SLOTS = {
+  login: "platform-auth-return",
+  terms: "platform-terms-return",
+} as const;
+
+export type Interstitial = keyof typeof SLOTS;
+
+/** Interstitials are never destinations: returning to one re-enters the gate or
+ *  replays a spent OIDC code. */
+const INTERSTITIAL_PATHS = ["/auth/callback", "/terms"];
+
+export interface LocationLike {
+  pathname: string;
+  search: string;
+  hash: string;
+}
+
+/** The sessionStorage surface used here — a narrow shape keeps it substitutable. */
+export interface ReturnPathStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/** Stored values are untrusted on the way out: only same-origin paths pass. */
+export function isSafeReturnPath(value: string): boolean {
+  // "//host" and "/\host" are protocol-relative URLs, not paths.
+  if (!value.startsWith("/") || /^\/[/\\]/.test(value)) return false;
+  return !INTERSTITIAL_PATHS.includes(value.split(/[?#]/)[0]!);
+}
+
+/** The location as a return path, or null when it isn't a destination. */
+export function toReturnPath(loc: LocationLike): string | null {
+  const path = `${loc.pathname}${loc.search}${loc.hash}`;
+  return isSafeReturnPath(path) ? path : null;
+}
+
+export function rememberReturnPath(
+  which: Interstitial,
+  loc: LocationLike = window.location,
+  store: ReturnPathStore = sessionStorage,
+): void {
+  const path = toReturnPath(loc);
+  // Clearing on a non-destination stops a stale target resurfacing later.
+  if (path) store.setItem(SLOTS[which], path);
+  else store.removeItem(SLOTS[which]);
+}
+
+/** Reads and clears the stashed destination — one-shot, dashboard as fallback. */
+export function takeReturnPath(
+  which: Interstitial,
+  store: ReturnPathStore = sessionStorage,
+): string {
+  const stashed = store.getItem(SLOTS[which]);
+  store.removeItem(SLOTS[which]);
+  if (!stashed) return "/";
+  if (isSafeReturnPath(stashed)) return stashed;
+  console.warn(`[return-path] ignoring unusable ${which} return:`, stashed);
+  return "/";
+}

--- a/packages/ui/src/lib/return-path.ts
+++ b/packages/ui/src/lib/return-path.ts
@@ -19,6 +19,7 @@ export type Interstitial = keyof typeof SLOTS;
 const INTERSTITIAL_PATHS = ["/auth/callback", "/terms"];
 
 export interface LocationLike {
+  origin: string;
   pathname: string;
   search: string;
   hash: string;
@@ -31,23 +32,61 @@ export interface ReturnPathStore {
   removeItem(key: string): void;
 }
 
-/** Stored values are untrusted on the way out: only same-origin paths pass. */
-export function isSafeReturnPath(value: string): boolean {
-  // Validate what the browser will act on, not the raw text: it drops tab/LF/CR
-  // anywhere while parsing ("/<tab>/host" ends up protocol-relative) and trims
-  // C0 controls and spaces at the ends ("/terms<FF>" ends up on the gate).
-  // Stripping the whole class judges a little more than the parser removes,
-  // which only ever rejects — the safe direction.
-  const parsed = value.replace(/[\0-\x20]/g, "");
-  // "//host" and "/\host" are protocol-relative URLs, not paths.
-  if (!parsed.startsWith("/") || /^\/[/\\]/.test(parsed)) return false;
-  return !INTERSTITIAL_PATHS.includes(parsed.split(/[?#]/)[0]!);
+/**
+ * Resolve an untrusted destination the way the browser will, or null when it
+ * must not be navigated to.
+ *
+ * The URL parser is the authority, and everything below hands back *its* output
+ * rather than the caller's text. That is the point: the parser drops control
+ * characters, trims C0 and spaces, collapses dot segments and percent-encodes,
+ * so any check against the raw string judges something the browser has already
+ * rewritten — which is how `/<tab>/host` reached another origin and
+ * `/a/../terms` reached the gate. There is no verdict-only entry point for the
+ * same reason: validating one string and navigating to another is the bug.
+ */
+function resolve(value: string, origin: string): URL | null {
+  // Every parse sits inside the guard: this runs at boot and on the way out of
+  // the Terms gate, so an unparseable value has to read as "no destination"
+  // rather than throw into either path.
+  try {
+    const base = new URL(origin);
+    const url = new URL(value, base);
+    if (url.origin !== base.origin) return null;
+    // Schemes without a hierarchical path (blob:, data:) can still report our
+    // origin, and their "pathname" is not a path.
+    if (!url.pathname.startsWith("/")) return null;
+    if (INTERSTITIAL_PATHS.includes(url.pathname)) return null;
+    // The output has to survive being used as a reference again, because that is
+    // what callers do with it. A resolved path can begin with "//" — dot segments
+    // collapse "/a/..//host" to "//host" — which reads as another origin the
+    // second time around, or fails to parse at all. Re-resolving proves the
+    // verdict instead of arguing it.
+    return new URL(pathOf(url), base).href === url.href ? url : null;
+  } catch {
+    return null;
+  }
 }
 
-/** The location as a return path, or null when it isn't a destination. */
-export function toReturnPath(loc: LocationLike): string | null {
-  const path = `${loc.pathname}${loc.search}${loc.hash}`;
-  return isSafeReturnPath(path) ? path : null;
+function pathOf(url: URL): string {
+  return `${url.pathname}${url.search}${url.hash}`;
+}
+
+/** The whole destination — path, query and fragment — canonicalized. */
+export function resolveReturnPath(
+  value: string,
+  origin: string,
+): string | null {
+  const url = resolve(value, origin);
+  return url ? pathOf(url) : null;
+}
+
+/** The path alone, for routing: a query or fragment riding along in a stored
+ *  value would otherwise be read as part of an id or tab. */
+export function resolveReturnPathname(
+  value: string,
+  origin: string,
+): string | null {
+  return resolve(value, origin)?.pathname ?? null;
 }
 
 export function rememberReturnPath(
@@ -55,21 +94,28 @@ export function rememberReturnPath(
   loc: LocationLike = window.location,
   store: ReturnPathStore = sessionStorage,
 ): void {
-  const path = toReturnPath(loc);
+  const path = resolveReturnPath(
+    `${loc.pathname}${loc.search}${loc.hash}`,
+    loc.origin,
+  );
   // Clearing on a non-destination stops a stale target resurfacing later.
   if (path) store.setItem(SLOTS[which], path);
   else store.removeItem(SLOTS[which]);
 }
 
-/** Reads and clears the stashed destination — one-shot, dashboard as fallback. */
+/** Reads and clears the stashed destination — one-shot, dashboard as fallback.
+ *  Re-resolved on the way out: the slot is attacker-writable, so what the
+ *  caller navigates to is the parser's verdict, never the stored text. */
 export function takeReturnPath(
   which: Interstitial,
   store: ReturnPathStore = sessionStorage,
+  origin: string = window.location.origin,
 ): string {
   const stashed = store.getItem(SLOTS[which]);
   store.removeItem(SLOTS[which]);
   if (!stashed) return "/";
-  if (isSafeReturnPath(stashed)) return stashed;
+  const path = resolveReturnPath(stashed, origin);
+  if (path) return path;
   console.warn(`[return-path] ignoring unusable ${which} return:`, stashed);
   return "/";
 }

--- a/packages/ui/src/main.tsx
+++ b/packages/ui/src/main.tsx
@@ -10,6 +10,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 
 import { initAuth } from "./auth.js";
 import { applyBrand, loadBrand } from "./brand.js";
+import { rememberReturnPath } from "./lib/return-path.js";
 import { routeToPath } from "./modules/platform/lib/routes.js";
 import { preflightTermsGate } from "./modules/terms/lib/preflight.js";
 import { queryClient } from "./query-client.js";
@@ -23,9 +24,16 @@ async function main() {
   if (!user) return; // Redirecting to Keycloak, don't render
 
   if (!(await preflightTermsGate())) {
+    // Park the destination so acceptance resumes it — a bind link's one-shot
+    // `?flow=` is spent by then, and dropping it costs another bind command.
+    rememberReturnPath("terms");
     window.history.replaceState({}, "", routeToPath({ view: "terms" }));
-    useStore.setState({ view: "terms" });
   }
+
+  // Both interstitials above rewrite the URL after the store derived its route,
+  // so re-derive it here: without this the first render is the pre-redirect
+  // view (the dashboard) rather than the deep link the user followed.
+  useStore.getState().hydrateRoute();
 
   const { default: App } = await import("./app.js");
   createRoot(document.getElementById("root")!).render(

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -1,5 +1,6 @@
 import type { StateCreator } from "zustand";
 
+import { isSafeReturnPath } from "../../../lib/return-path.js";
 import type { PlatformStore } from "../../../store.js";
 import {
   clearSnapshot,
@@ -32,6 +33,10 @@ export interface NavigationSlice {
   agentId: string | null;
   settingsTab: SettingsTab;
   sandboxSection: SandboxSection;
+  /** Re-derive the route from the URL. Interstitials — the login roundtrip and
+   *  the Terms gate — rewrite it after this slice was initialized, so the app
+   *  calls this once they have settled and before the first render. */
+  hydrateRoute: () => void;
   setView: (v: ParameterlessView) => void;
   /** `startingPoint` pre-selects step 1, so a per-kind "New …" button lands in
    *  the shared wizard pointed at that kind. */
@@ -61,8 +66,8 @@ function initialPath(): string {
   const saved = sessionStorage.getItem("platform-return-view");
   if (!saved) return pathname;
   sessionStorage.removeItem("platform-return-view");
-  if (!saved.startsWith("/")) {
-    console.warn("[navigation] ignoring non-path platform-return-view:", saved);
+  if (!isSafeReturnPath(saved)) {
+    console.warn("[navigation] ignoring unusable platform-return-view:", saved);
     return pathname;
   }
   if (pathname !== saved) {
@@ -84,6 +89,9 @@ export const createNavigationSlice: StateCreator<
   NavigationSlice
 > = (set) => ({
   ...routeToNavigationState(parseRoute(initialPath())),
+  // Route fields only — chat's `selectedAgent` stays owned by the popstate hook.
+  hydrateRoute: () =>
+    set(routeToNavigationState(parseRoute(window.location.pathname))),
   setView: (v) => {
     history.pushState(null, "", routeToPath({ view: v }));
     set(routeToNavigationState({ view: v }));

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -1,6 +1,6 @@
 import type { StateCreator } from "zustand";
 
-import { isSafeReturnPath } from "../../../lib/return-path.js";
+import { resolveReturnPathname } from "../../../lib/return-path.js";
 import type { PlatformStore } from "../../../store.js";
 import {
   clearSnapshot,
@@ -66,20 +66,21 @@ function initialPath(): string {
   const saved = sessionStorage.getItem("platform-return-view");
   if (!saved) return pathname;
   sessionStorage.removeItem("platform-return-view");
-  if (!isSafeReturnPath(saved)) {
+  // Resolved, never trusted as written: the slot holds a bare view path, and the
+  // live query/hash (the OAuth return params) ride along from the current URL.
+  const restored = resolveReturnPathname(saved, window.location.origin);
+  if (!restored) {
     console.warn("[navigation] ignoring unusable platform-return-view:", saved);
     return pathname;
   }
-  if (pathname !== saved) {
+  if (pathname !== restored) {
     history.replaceState(
       null,
       "",
-      saved + window.location.search + window.location.hash,
+      restored + window.location.search + window.location.hash,
     );
   }
-  // Route on the path segment alone: a query or hash riding along in the
-  // saved value would otherwise be captured as part of an id or tab.
-  return saved.split(/[?#]/)[0]!;
+  return restored;
 }
 
 export const createNavigationSlice: StateCreator<

--- a/packages/ui/src/modules/terms/lib/on-terms-stale.ts
+++ b/packages/ui/src/modules/terms/lib/on-terms-stale.ts
@@ -1,3 +1,4 @@
+import { rememberReturnPath } from "../../../lib/return-path.js";
 import { parseRoute, routeToPath } from "../../platform/lib/routes.js";
 
 let redirecting = false;
@@ -12,6 +13,7 @@ export function onTermsStale(): void {
   if (redirecting || parseRoute(window.location.pathname).view === "terms")
     return;
   redirecting = true;
+  rememberReturnPath("terms");
   // Full reload on purpose: the server signalled terms_stale, and a hard
   // navigation guarantees a clean refetch past the 412 gate.
   window.location.assign(routeToPath({ view: "terms" }));

--- a/packages/ui/src/modules/terms/views/terms-view.tsx
+++ b/packages/ui/src/modules/terms/views/terms-view.tsx
@@ -1,6 +1,7 @@
 import { Button } from "@/components/ui/button";
 
 import { Markdown } from "../../../components/markdown.js";
+import { takeReturnPath } from "../../../lib/return-path.js";
 import { useStore } from "../../../store.js";
 import { useAcceptTerms } from "../api/mutations.js";
 import { useLatestAcceptance, useTermsDocument } from "../api/queries.js";
@@ -48,8 +49,12 @@ export function TermsView() {
               accept.mutate(
                 { version: doc.version },
                 // Full reload on purpose (unlike BackButton): it clears the
-                // server's 412 terms_stale gate with a clean refetch.
-                { onSuccess: () => window.location.assign("/") },
+                // server's 412 terms_stale gate with a clean refetch. Resumes
+                // wherever the gate interrupted — a bind deep link, usually.
+                {
+                  onSuccess: () =>
+                    window.location.assign(takeReturnPath("terms")),
+                },
               )
             }
           />


### PR DESCRIPTION
Fixes #3107.

## The bug

Following a bind link from a Slack DM while logged out never reached the agent
picker. Two things dropped the destination:

1. **The post-login render used a stale route.** The navigation store derives its
   route when its module loads — which, on the way back from Keycloak, is while
   the browser is still on the OIDC callback URL. The callback then rewrites the
   URL to the parked return path, but the store has already resolved the route to
   the dashboard. A mount-time re-parse corrected it a frame later, so the bind
   picker did appear — behind a dashboard flash, and only if nothing else
   intervened first.
2. **The Terms gate replaced the URL outright.** For anyone who hadn't accepted
   the current Terms (the common case for a first visit to the web UI, which is
   exactly who follows a bind link), the gate swapped the URL for the Terms page
   and acceptance always continued to the dashboard. The deep link was gone —
   and with the link's one-shot OAuth state already spent by the login, clicking
   it again reports the link expired, so the only way forward is another
   `bind` command. That is the reported symptom.

The bind flow behind `?flow=` itself is fine: it lives well within its TTL and is
re-readable, so preserving the URL is all that is needed to finish in one pass.

## The fix

One primitive owns "where was the user headed" for both interstitials — the login
roundtrip and the Terms gate — with a slot each, so neither clobbers the other:

- The login callback and the Terms gate park the destination and resume it once
  cleared; Terms acceptance returns there instead of always to the dashboard.
- The route is re-derived once the interstitials have settled and before the first
  render, so the first paint is the deep link — no dashboard flash, and no
  dashboard shell mounting queries on the way past.
- A failed silent renew now parks the destination too; previously that re-login
  always came back to the dashboard.
- Destinations are validated on the way out: same-origin paths only (a stored
  value is attacker-reachable), and never an interstitial path — returning to the
  callback would replay a spent code, returning to the Terms page would re-enter
  the gate.

Deliberately unchanged: the OAuth state behind the link stays single-use. Deleting
it on first use is the replay control, and with the redirect fixed there is no
reason to click the link twice.

## Verification

- New unit tests cover the destination round-trip, slot separation, one-shot
  semantics, and the rejection rules.
- New smoke spec: follow a bind deep link while logged out, log in, clear the
  Terms gate, and assert the picker renders with the flow id still in the URL. It
  runs first in the `auth` project, so on a fresh install it faces the Terms leg —
  the one that made this stick.
- `mise run test` (all packages) and the UI + Playwright type/lint/format checks
  pass. `mise run check` also passes except the controller CRD-compat task, which
  cannot resolve git refs from a worktree — no CRDs are touched here.

Manual check worth doing on a cluster before merge: from a Slack DM, run the bind
command as a user who has not accepted the current Terms, follow the link in a
signed-out browser, and confirm the picker appears after acceptance.
