### PR TITLE
fix(ui): show Channels to every user, not just flag holders

### DIFF
--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,10 +1,12 @@
 # Channels
 
-Last verified: 2026-07-29
+Last verified: 2026-08-03
 
 ## Overview
 
 A **channel** is a messenger surface (Slack, Telegram) that lets users drive an Agent from outside the UI. Channels are pluggable adapters that live inside the api-server process — no separate Deployment, no sidecar in the agent pod. Each adapter (the _worker_) owns its inbound socket, its outbound API, and its thread-to-session bookkeeping; a `ChannelManager` service composes the workers and reacts to lifecycle events on the in-process event bus.
+
+Channels are a **standard Agent surface**, not a pre-release one: every Agent exposes it, with no per-user opt-in in front of it. What can be bound there is the install's own decision — a worker exists only where its token is configured — and an install with no messenger says so on the surface rather than withdrawing it. Slack as a *Connection* is a separate surface, still withheld from regular users; a channel needs nothing from it ([connections](connections.md)).
 
 Channel bindings are **1:1 with Agent**: a Slack conversation may be bound to at most one Agent globally, and an Agent has at most one Slack binding — Agent delete or Slack disconnect releases it. A Slack "conversation" is any surface the bot is party to: a public/private **channel**, a **group DM**, or a **1:1 DM**. The binding key is the conversation id in every case, so DMs and group DMs reuse the channel binding mechanics wholesale — same table, same resolution, same in-chat bind flow.
 

--- a/packages/ui/src/modules/features/components/features-tab.tsx
+++ b/packages/ui/src/modules/features/components/features-tab.tsx
@@ -18,7 +18,7 @@ const FEATURE_ROWS: FeatureRow[] = [
     id: "advanced-connections",
     label: "Advanced connections",
     description:
-      "Reveals the pre-release connection catalog (Google services, Slack, Spotify, custom client-credentials) and the sandbox Channels section.",
+      "Reveals the pre-release connection catalog (Google services, Slack, Spotify, custom client-credentials).",
   },
   {
     id: "vm-sandboxes",

--- a/packages/ui/src/modules/sandboxes/components/sandbox-channels-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-channels-section.tsx
@@ -19,7 +19,8 @@ export function SandboxChannelsSection({ agentId }: { agentId: string }) {
       </p>
       {!available.slack && !available.telegram ? (
         <p className="text-sm text-muted-foreground">
-          No channels are configured for this installation.
+          No messenger is set up on this platform, so there is nothing to
+          connect yet. Ask your operator to configure Slack or Telegram.
         </p>
       ) : (
         <Inset className="flex flex-col gap-4">

--- a/packages/ui/src/modules/sandboxes/components/sandbox-section-nav.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-section-nav.tsx
@@ -21,25 +21,15 @@ interface Props {
   onNavigate: (section: SandboxSection) => void;
   // Live one-line summary per section, keyed by section id (slice 03).
   summaries?: Partial<Record<SandboxSection, string>>;
-  /** Channels rides the advanced-connections feature flag. */
-  showChannels?: boolean;
 }
 
-export function SandboxSectionNav({
-  active,
-  onNavigate,
-  summaries,
-  showChannels = false,
-}: Props) {
-  const sections = SECTIONS.filter(
-    (entry) => entry.section !== "channels" || showChannels,
-  );
+export function SandboxSectionNav({ active, onNavigate, summaries }: Props) {
   return (
     <nav
       aria-label="Sandbox sections"
       className="flex shrink-0 flex-col gap-1 md:sticky md:top-12 md:w-[245px] md:self-start"
     >
-      {sections.map((entry) => (
+      {SECTIONS.map((entry) => (
         <SectionNavItem
           key={entry.section}
           title={entry.title}

--- a/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
@@ -6,7 +6,7 @@ import {
   useHarnessConfigCurrent,
   useHarnessConfigStatus,
 } from "../../agents/api/harness-config.js";
-import { useAgentConnections } from "../../agents/api/queries.js";
+import { useAgentConnections, useAgents } from "../../agents/api/queries.js";
 import { useSkillsState } from "../../agents/api/skills.js";
 import {
   type SandboxSubtitleLookup,
@@ -97,15 +97,20 @@ export function useSectionSummaries(agent: AgentView | null): SectionSummaries {
     return formatNameList([...standalone, ...installed]);
   }, [skillsState.data]);
 
+  const availableChannels = useAgents().data?.availableChannels;
   const channelsSummary = useMemo(() => {
-    if (!agent) return undefined;
+    if (!agent || !availableChannels) return undefined;
+    // Nothing to connect when the install wired up no messenger — say that
+    // instead of implying an empty list the user could fill.
+    if (!availableChannels.slack && !availableChannels.telegram)
+      return "No messenger configured";
     const kinds = [
       ...new Set(
         agent.channels.map((c) => (c.type === "slack" ? "Slack" : "Telegram")),
       ),
     ];
     return kinds.length > 0 ? kinds.join(", ") : "No channels connected";
-  }, [agent]);
+  }, [agent, availableChannels]);
 
   const schedulesSummary = useMemo(() => {
     if (!agent) return undefined;

--- a/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
@@ -3,7 +3,6 @@ import { Button } from "@/components/ui/button";
 import { useStore } from "../../../store.js";
 import { useResolvedAgentDisplay } from "../../agents/hooks/use-resolved-agent-display.js";
 import { SandboxArtifactsSection } from "../../artifacts/components/sandbox-artifacts-section.js";
-import { useFeatures } from "../../features/api/queries.js";
 import { routeToPath } from "../../platform/lib/routes.js";
 import { ConnectionsSection } from "../components/connections-section.js";
 import { SandboxChannelsSection } from "../components/sandbox-channels-section.js";
@@ -18,14 +17,8 @@ import { useSectionSummaries } from "../hooks/use-section-summaries.js";
 
 export function SandboxHomeView() {
   const f = useSandboxSettingsForm();
-  const rawSection = useStore((s) => s.sandboxSection);
+  const section = useStore((s) => s.sandboxSection);
   const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
-  const { data: flags } = useFeatures();
-  // Channels rides the advanced-connections feature flag: messenger channel
-  // bindings are not a regular-user surface yet.
-  const showChannels = flags?.["advanced-connections"] ?? false;
-  const section =
-    rawSection === "channels" && !showChannels ? "setup" : rawSection;
 
   const display = useResolvedAgentDisplay(f.agent);
 
@@ -73,7 +66,6 @@ export function SandboxHomeView() {
           active={section}
           onNavigate={(s) => navigateToSandboxHome(agent.id, s)}
           summaries={summaries}
-          showChannels={showChannels}
         />
       }
     >


### PR DESCRIPTION
Closes #3077

## What

The sandbox **Channels** section was gated behind the *Advanced connections* experimental feature — off by default and not something a user turns on in normal use — so a working, documented integration was unreachable. Navigating straight to a sandbox's Channels URL silently redirected to Sandbox Setup.

Channels needs nothing experimental: which messengers can be bound is decided by the install's own messenger setup, which the surface already reads. So the gate goes away.

## Changes

- **Sandbox home view** — no more feature-flag read and no more `channels → setup` redirect; the section renders for whatever the URL asks for.
- **Section nav** — Channels is an unconditional entry, like Skills or Schedules; the `showChannels` prop is gone.
- **Empty state** — where the install has no messenger configured, the section now names the reason and the next step ("No messenger is set up on this platform… Ask your operator to configure Slack or Telegram") instead of the ambiguous "No channels are configured for this installation". The nav summary agrees ("No messenger configured") rather than reading "No channels connected", which would imply a list the user could fill.
- **Experimental features tab** — the *Advanced connections* description no longer claims it reveals the Channels section.
- **Architecture doc** — `docs/architecture/channels.md` records that Channels is a standard Agent surface whose availability is the install's decision, and that Slack-as-a-Connection is a separate, still-withheld surface a channel needs nothing from.

## Explicitly not changed

Slack **as a connection** stays exactly as it is: `advanced-connections` still gates the internal-only connection catalog (Slack, Google services, Spotify, custom client-credentials, GitHub Apps). Channels becoming visible does not put Slack in the connection catalog. No backend change either — the channels endpoints were never flag-gated (flags are progressive disclosure, not authorization), and they are owner-scoped as before.

## Verification

- `mise run ui:check` (tsc, eslint, prettier) — clean; the two eslint warnings are pre-existing, in files this PR doesn't touch.
- `mise run ui:test` — 153 tests / 17 files pass.
- `docs:check` (doc-size, adr-index, adr-immutable) plus `api-server`, `api-server-api`, `db`, `e2e-playwright` checks — clean.
- `controller:check:crd-backwards-compatibility` fails, but it fails the same way on a clean `main` checkout — pre-existing, unrelated to this diff (no CRD or Go changes here).

Manual checks worth doing on a cluster, as a user **without** the flag:

1. Open a sandbox → *Channels* is in the section nav, with a live summary line.
2. Go straight to `/sandboxes/<id>/channels` → the Channels section loads instead of bouncing to Sandbox Setup.
3. Connect and disconnect a Slack channel from the section.
4. Open the connection catalog → Slack is still absent.
5. On an install with neither messenger configured, the section explains that no messenger is set up, and the nav line reads "No messenger configured".

There is no e2e coverage for the Channels UI today (the Slack specs drive the messenger side, not this surface), so the nav-visibility assertion is a reasonable follow-up if we want a regression guard.