### PR TITLE
fix(ui): raise the memory size floor to 384Mi

### DIFF
--- a/packages/api-server-api/src/modules/agents/schemas.ts
+++ b/packages/api-server-api/src/modules/agents/schemas.ts
@@ -6,7 +6,8 @@ const idSchema = z.object({ id: z.string().min(1) });
 
 // CPU as cores ("2") or millicores ("500m"); memory as Mi/Gi. Deliberately
 // narrower than the full K8s quantity grammar — these are slider outputs,
-// not operator YAML. Floors keep a chosen size schedulable.
+// not operator YAML. The memory floor is what the agent needs to actually
+// run (~384Mi for Claude Code), not just be schedulable.
 const cpuQuantitySchema = z
   .string()
   .regex(/^\d+(\.\d+)?m?$/, "CPU must look like '2', '0.5' or '500m'")
@@ -16,8 +17,8 @@ const cpuQuantitySchema = z
 const memoryQuantitySchema = z
   .string()
   .regex(/^\d+(Mi|Gi)$/, "memory must look like '512Mi' or '2Gi'")
-  .refine((v) => toMemoryMi(v) >= 128, {
-    message: "memory must be at least 128Mi",
+  .refine((v) => toMemoryMi(v) >= 384, {
+    message: "memory must be at least 384Mi",
   });
 
 function toCpuMilli(v: string): number {

--- a/packages/ui/src/modules/sandboxes/components/sandbox-size-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-size-section.tsx
@@ -7,7 +7,7 @@ import { parseCpuMilli, parseMemoryMi } from "../lib/quantity.js";
 
 // Floors mirror the server-side slider validation (agentSizeSchema).
 const CPU_FLOOR_MILLI = 100;
-const MEMORY_FLOOR_MI = 128;
+const MEMORY_FLOOR_MI = 384;
 const CPU_STEP_MILLI = 100;
 const MEMORY_STEP_MI = 128;
 


### PR DESCRIPTION
Claude Code needs ~384Mi to run at all; the old 128Mi floor only made the pod schedulable. Raises the memory floor to 384Mi in both the size slider and the server-side `agentSizeSchema` validation, so an unusable size can't be chosen via UI, CLI, or API.

The controller's 128Mi `requestsFromLimits` floor is untouched — that's the derived scheduling-request minimum, a separate concern.

Fixes #3069