### PR TITLE
refactor(ui): fix interaction semantics and the last hand-rolled surfaces

### DIFF
--- a/packages/ui/components.json
+++ b/packages/ui/components.json
@@ -17,5 +17,5 @@
     "lib": "@/lib",
     "hooks": "@/hooks"
   },
-  "iconLibrary": "lucide"
+  "iconLibrary": "@carbon/icons-react"
 }

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -10,6 +10,7 @@ import {
 
 import { BrandLogo } from "@/components/brand-logo";
 import { Badge } from "@/components/ui/badge";
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import { getBrand } from "../brand.js";
@@ -93,15 +94,16 @@ export function IconRail({
         data-testid="app-sidebar"
       >
         <div className="flex items-center justify-center pt-2">
-          <button
-            type="button"
-            onClick={sandboxes.navigate}
-            title={getBrand().name}
-            aria-label={getBrand().name}
-            className="rounded-lg p-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
-          >
-            <BrandLogo />
-          </button>
+          <Tooltip content={getBrand().name} side="right">
+            <button
+              type="button"
+              onClick={sandboxes.navigate}
+              aria-label={getBrand().name}
+              className="rounded-lg p-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
+            >
+              <BrandLogo />
+            </button>
+          </Tooltip>
         </div>
         <div className="flex flex-col items-center gap-1">
           <RailItem {...sandboxes} />
@@ -137,20 +139,21 @@ export function IconRail({
 
 function RailItem({ label, icon: Icon, active, badge, navigate }: Destination) {
   return (
-    <button
-      type="button"
-      onClick={navigate}
-      title={label}
-      aria-label={label}
-      className={cn(
-        "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
-        active
-          ? "text-primary bg-muted"
-          : "text-foreground/80 hover:text-foreground hover:bg-muted",
-      )}
-    >
-      <IconWithBadge icon={Icon} badge={badge} />
-    </button>
+    <Tooltip content={label} side="right">
+      <button
+        type="button"
+        onClick={navigate}
+        aria-label={label}
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
+          active
+            ? "text-primary bg-muted"
+            : "text-foreground/80 hover:text-foreground hover:bg-muted",
+        )}
+      >
+        <IconWithBadge icon={Icon} badge={badge} />
+      </button>
+    </Tooltip>
   );
 }
 

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -25,7 +25,6 @@ interface Destination {
   active: boolean;
   badge: number;
   navigate: () => void;
-  hoverLabel?: boolean;
 }
 
 export function IconRail({
@@ -55,7 +54,6 @@ export function IconRail({
     active: view === "experiments",
     badge: 0,
     navigate: navigateToExperiments,
-    hoverLabel: true,
   };
   const knowledgeBases: Destination = {
     label: "Knowledge bases",
@@ -66,7 +64,6 @@ export function IconRail({
       view === "knowledge-base-config",
     badge: 0,
     navigate: navigateToKnowledgeBases,
-    hoverLabel: true,
   };
   const artifacts: Destination = {
     label: "Artifacts",
@@ -74,7 +71,6 @@ export function IconRail({
     active: view === "artifacts",
     badge: 0,
     navigate: () => setView("artifacts"),
-    hoverLabel: true,
   };
   const inbox: Destination = {
     label: "Email",
@@ -139,35 +135,23 @@ export function IconRail({
   );
 }
 
-function RailItem({
-  label,
-  icon: Icon,
-  active,
-  badge,
-  navigate,
-  hoverLabel,
-}: Destination) {
-  const button = (
-    <button
-      type="button"
-      onClick={navigate}
-      aria-label={label}
-      className={cn(
-        "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
-        active
-          ? "text-primary bg-muted"
-          : "text-foreground/80 hover:text-foreground hover:bg-muted",
-      )}
-    >
-      <IconWithBadge icon={Icon} badge={badge} />
-    </button>
-  );
-  return hoverLabel ? (
+function RailItem({ label, icon: Icon, active, badge, navigate }: Destination) {
+  return (
     <Tooltip content={label} side="right">
-      {button}
+      <button
+        type="button"
+        onClick={navigate}
+        aria-label={label}
+        className={cn(
+          "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
+          active
+            ? "text-primary bg-muted"
+            : "text-foreground/80 hover:text-foreground hover:bg-muted",
+        )}
+      >
+        <IconWithBadge icon={Icon} badge={badge} />
+      </button>
     </Tooltip>
-  ) : (
-    button
   );
 }
 

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -25,6 +25,7 @@ interface Destination {
   active: boolean;
   badge: number;
   navigate: () => void;
+  hoverLabel?: boolean;
 }
 
 export function IconRail({
@@ -54,6 +55,7 @@ export function IconRail({
     active: view === "experiments",
     badge: 0,
     navigate: navigateToExperiments,
+    hoverLabel: true,
   };
   const knowledgeBases: Destination = {
     label: "Knowledge bases",
@@ -64,6 +66,7 @@ export function IconRail({
       view === "knowledge-base-config",
     badge: 0,
     navigate: navigateToKnowledgeBases,
+    hoverLabel: true,
   };
   const artifacts: Destination = {
     label: "Artifacts",
@@ -71,6 +74,7 @@ export function IconRail({
     active: view === "artifacts",
     badge: 0,
     navigate: () => setView("artifacts"),
+    hoverLabel: true,
   };
   const inbox: Destination = {
     label: "Email",
@@ -94,16 +98,14 @@ export function IconRail({
         data-testid="app-sidebar"
       >
         <div className="flex items-center justify-center pt-2">
-          <Tooltip content={getBrand().name} side="right">
-            <button
-              type="button"
-              onClick={sandboxes.navigate}
-              aria-label={getBrand().name}
-              className="rounded-lg p-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
-            >
-              <BrandLogo />
-            </button>
-          </Tooltip>
+          <button
+            type="button"
+            onClick={sandboxes.navigate}
+            aria-label={getBrand().name}
+            className="rounded-lg p-1 text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
+          >
+            <BrandLogo />
+          </button>
         </div>
         <div className="flex flex-col items-center gap-1">
           <RailItem {...sandboxes} />
@@ -137,23 +139,35 @@ export function IconRail({
   );
 }
 
-function RailItem({ label, icon: Icon, active, badge, navigate }: Destination) {
-  return (
+function RailItem({
+  label,
+  icon: Icon,
+  active,
+  badge,
+  navigate,
+  hoverLabel,
+}: Destination) {
+  const button = (
+    <button
+      type="button"
+      onClick={navigate}
+      aria-label={label}
+      className={cn(
+        "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
+        active
+          ? "text-primary bg-muted"
+          : "text-foreground/80 hover:text-foreground hover:bg-muted",
+      )}
+    >
+      <IconWithBadge icon={Icon} badge={badge} />
+    </button>
+  );
+  return hoverLabel ? (
     <Tooltip content={label} side="right">
-      <button
-        type="button"
-        onClick={navigate}
-        aria-label={label}
-        className={cn(
-          "flex h-10 w-10 items-center justify-center rounded-lg transition-colors",
-          active
-            ? "text-primary bg-muted"
-            : "text-foreground/80 hover:text-foreground hover:bg-muted",
-        )}
-      >
-        <IconWithBadge icon={Icon} badge={badge} />
-      </button>
+      {button}
     </Tooltip>
+  ) : (
+    button
   );
 }
 

--- a/packages/ui/src/components/key-value-editor.tsx
+++ b/packages/ui/src/components/key-value-editor.tsx
@@ -90,7 +90,6 @@ export function KeyValueEditor({
               disabled={disabled}
               className="shrink-0 text-muted-foreground"
               aria-label="Remove"
-              tooltip="Remove"
             >
               <Close size={13} />
             </Button>

--- a/packages/ui/src/components/key-value-editor.tsx
+++ b/packages/ui/src/components/key-value-editor.tsx
@@ -89,7 +89,8 @@ export function KeyValueEditor({
               onClick={() => remove(i)}
               disabled={disabled}
               className="shrink-0 text-muted-foreground"
-              title="Remove"
+              aria-label="Remove"
+              tooltip="Remove"
             >
               <Close size={13} />
             </Button>

--- a/packages/ui/src/components/markdown.tsx
+++ b/packages/ui/src/components/markdown.tsx
@@ -7,6 +7,7 @@ import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 
 import { DisclosureToggle } from "@/components/ui/disclosure";
+import { externalLinkProps } from "@/lib/external-link";
 
 import {
   ARTIFACT_LINK_PREFIX,
@@ -112,7 +113,7 @@ export function Markdown({
           );
         }
         return (
-          <a href={href} target="_blank" rel="noopener noreferrer">
+          <a href={href} {...externalLinkProps}>
             {children}
           </a>
         );

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -71,11 +71,7 @@ interface DialogHeaderProps {
    *  accessible name. */
   titleAccessory?: ReactNode;
   subtitle?: ReactNode;
-  /** Draws the ✕, at 16px like every other icon action. Omit it only where the
-   *  dialog exists to force a choice — a confirmation, or a secret shown once
-   *  that the user has to acknowledge. Every other dialog gets one: the corner
-   *  is where users look to leave, and the footer's Cancel is a second exit,
-   *  not a replacement. */
+  /** Draws the ✕. Omit only where the dialog exists to force a choice. */
   onClose?: () => void;
   /** Gate the ✕ while an in-flight action would lose something if the dialog
    *  went away — a one-time secret, or a multi-step write mid-way. */

--- a/packages/ui/src/components/modal.tsx
+++ b/packages/ui/src/components/modal.tsx
@@ -71,7 +71,11 @@ interface DialogHeaderProps {
    *  accessible name. */
   titleAccessory?: ReactNode;
   subtitle?: ReactNode;
-  /** Omit for dialogs that exit through the footer. */
+  /** Draws the ✕, at 16px like every other icon action. Omit it only where the
+   *  dialog exists to force a choice — a confirmation, or a secret shown once
+   *  that the user has to acknowledge. Every other dialog gets one: the corner
+   *  is where users look to leave, and the footer's Cancel is a second exit,
+   *  not a replacement. */
   onClose?: () => void;
   /** Gate the ✕ while an in-flight action would lose something if the dialog
    *  went away — a one-time secret, or a multi-step write mid-way. */

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -1,7 +1,9 @@
 import { Slot } from "@radix-ui/react-slot";
 import { cva, type VariantProps } from "class-variance-authority";
+import type { ReactNode } from "react";
 import * as React from "react";
 
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 const buttonVariants = cva(
@@ -66,6 +68,9 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ComponentProps<"button">, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
+  /** Hover/focus hint, in place of a native `title`. It reads as a description,
+   *  so an icon-only button still needs its own `aria-label`. */
+  tooltip?: ReactNode;
 }
 
 function Button({
@@ -74,15 +79,17 @@ function Button({
   size,
   tone,
   asChild = false,
+  tooltip,
   ...props
 }: ButtonProps) {
   const Comp = asChild ? Slot : "button";
-  return (
+  const button = (
     <Comp
       className={cn(buttonVariants({ variant, size, tone, className }))}
       {...props}
     />
   );
+  return tooltip ? <Tooltip content={tooltip}>{button}</Tooltip> : button;
 }
 
 export { Button, buttonVariants };

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -86,6 +86,12 @@ function Button({
   const button = (
     <Comp
       className={cn(buttonVariants({ variant, size, tone, className }))}
+      /* A disabled button fires neither pointer nor focus events, so the
+         tooltip can never open — `title` still reaches assistive tech, which
+         matters most for a hint that explains why the button is disabled. */
+      title={
+        props.disabled && typeof tooltip === "string" ? tooltip : undefined
+      }
       {...props}
     />
   );

--- a/packages/ui/src/components/ui/button.tsx
+++ b/packages/ui/src/components/ui/button.tsx
@@ -68,8 +68,8 @@ const buttonVariants = cva(
 export interface ButtonProps
   extends React.ComponentProps<"button">, VariantProps<typeof buttonVariants> {
   asChild?: boolean;
-  /** Hover/focus hint, in place of a native `title`. It reads as a description,
-   *  so an icon-only button still needs its own `aria-label`. */
+  /** Reads as a description, so an icon-only button still needs an
+   *  `aria-label`. */
   tooltip?: ReactNode;
 }
 

--- a/packages/ui/src/components/ui/card-button.tsx
+++ b/packages/ui/src/components/ui/card-button.tsx
@@ -1,26 +1,13 @@
-import { cva, type VariantProps } from "class-variance-authority";
+import type { VariantProps } from "class-variance-authority";
 import * as React from "react";
 
-import { CARD_HOVER, CARD_SURFACE } from "@/components/ui/card";
+import { cardSelectionVariants } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
-
-const cardButtonVariants = cva(
-  `${CARD_SURFACE} text-left ring-offset-background transition-colors focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50`,
-  {
-    variants: {
-      selected: {
-        true: "border-foreground",
-        false: `border-border ${CARD_HOVER}`,
-      },
-    },
-    defaultVariants: { selected: false },
-  },
-);
 
 interface CardButtonProps
   extends
     React.ComponentProps<"button">,
-    VariantProps<typeof cardButtonVariants> {}
+    VariantProps<typeof cardSelectionVariants> {}
 
 /** A whole card that acts as one button — a pickable option, a "connect this"
  *  affordance. Callers supply the inner layout through `className`. */
@@ -29,7 +16,11 @@ export function CardButton({ className, selected, ...props }: CardButtonProps) {
     <button
       type="button"
       aria-pressed={selected ?? undefined}
-      className={cn(cardButtonVariants({ selected }), className)}
+      className={cn(
+        cardSelectionVariants({ selected }),
+        "text-left ring-offset-background focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50",
+        className,
+      )}
       {...props}
     />
   );

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -1,3 +1,4 @@
+import { cva } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
@@ -10,6 +11,20 @@ export const CARD_SURFACE = "rounded-lg bg-card text-card-foreground border";
  *  a dark-mode card sits on a near-identical background, so an elevation shadow
  *  reads as nothing there. `transition-colors` alone is the 150ms fade. */
 export const CARD_HOVER = "transition-colors hover:bg-muted/40";
+
+/** Surface for a card that represents a choice — picked or still pickable.
+ *  The selected one drops the hover tint: its emphasized border already says
+ *  it's the current choice. Shared by `CardButton` and by the pickers that
+ *  can't be a button, so one picker never shows two selected looks. */
+export const cardSelectionVariants = cva(`${CARD_SURFACE} transition-colors`, {
+  variants: {
+    selected: {
+      true: "border-foreground",
+      false: `border-border ${CARD_HOVER}`,
+    },
+  },
+  defaultVariants: { selected: false },
+});
 
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -12,10 +12,8 @@ export const CARD_SURFACE = "rounded-lg bg-card text-card-foreground border";
  *  reads as nothing there. `transition-colors` alone is the 150ms fade. */
 export const CARD_HOVER = "transition-colors hover:bg-muted/40";
 
-/** Surface for a card that represents a choice — picked or still pickable.
- *  The selected one drops the hover tint: its emphasized border already says
- *  it's the current choice. Shared by `CardButton` and by the pickers that
- *  can't be a button, so one picker never shows two selected looks. */
+/** Surface for a card that represents a choice, picked or still pickable.
+ *  Shared with the pickers that can't be a `CardButton`. */
 export const cardSelectionVariants = cva(`${CARD_SURFACE} transition-colors`, {
   variants: {
     selected: {

--- a/packages/ui/src/components/ui/card.tsx
+++ b/packages/ui/src/components/ui/card.tsx
@@ -17,7 +17,7 @@ export const CARD_HOVER = "transition-colors hover:bg-muted/40";
 export const cardSelectionVariants = cva(`${CARD_SURFACE} transition-colors`, {
   variants: {
     selected: {
-      true: "border-foreground",
+      true: "border-foreground bg-muted/60",
       false: `border-border ${CARD_HOVER}`,
     },
   },

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -37,7 +37,8 @@ interface CheckboxItemProps extends Omit<
 }
 
 /** The multi-select counterpart of `RadioGroupItem`. `className` styles the
- *  row, not the box. */
+ *  row, not the box. `aria-label` keeps the description out of the accessible
+ *  name, which the wrapping `<label>` would otherwise run together with it. */
 function CheckboxItem({
   label,
   labelClassName,
@@ -45,6 +46,7 @@ function CheckboxItem({
   testId,
   className,
   id,
+  "aria-describedby": describedBy,
   ...props
 }: CheckboxItemProps) {
   const generatedId = React.useId();
@@ -61,7 +63,12 @@ function CheckboxItem({
       <Checkbox
         id={controlId}
         className="mt-0.5"
-        aria-describedby={description ? descriptionId : undefined}
+        aria-label={label}
+        aria-describedby={
+          [description ? descriptionId : null, describedBy]
+            .filter(Boolean)
+            .join(" ") || undefined
+        }
         data-testid={testId}
         {...props}
       />

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -25,4 +25,62 @@ function Checkbox({
   );
 }
 
-export { Checkbox };
+interface CheckboxItemProps extends Omit<
+  React.ComponentProps<typeof CheckboxPrimitive.Root>,
+  "children"
+> {
+  label: string;
+  /** Extra classes for the label text, e.g. `font-mono` for an identifier. */
+  labelClassName?: string;
+  description?: string;
+  testId?: string;
+}
+
+/** A checkbox with a label and an optional description, laid out like
+ *  `RadioGroupItem` so a multi-select list and a single-select list read the
+ *  same. The label wraps the control, so a click anywhere in the row toggles
+ *  it, and `className` styles that row rather than the box. */
+function CheckboxItem({
+  label,
+  labelClassName,
+  description,
+  testId,
+  className,
+  id,
+  ...props
+}: CheckboxItemProps) {
+  const generatedId = React.useId();
+  const controlId = id ?? generatedId;
+  const descriptionId = `${controlId}-description`;
+  return (
+    <label
+      htmlFor={controlId}
+      className={cn(
+        "flex w-full cursor-pointer items-start gap-2.5 text-left transition-colors has-[:disabled]:cursor-not-allowed has-[:disabled]:opacity-50",
+        className,
+      )}
+    >
+      <Checkbox
+        id={controlId}
+        className="mt-0.5"
+        aria-describedby={description ? descriptionId : undefined}
+        data-testid={testId}
+        {...props}
+      />
+      <span className="flex min-w-0 flex-1 flex-col gap-0.5">
+        <span
+          className={cn("text-sm font-medium text-foreground", labelClassName)}
+        >
+          {label}
+        </span>
+        {description && (
+          <span id={descriptionId} className="text-sm text-muted-foreground">
+            {description}
+          </span>
+        )}
+      </span>
+    </label>
+  );
+}
+
+export { Checkbox, CheckboxItem };

--- a/packages/ui/src/components/ui/checkbox.tsx
+++ b/packages/ui/src/components/ui/checkbox.tsx
@@ -36,10 +36,8 @@ interface CheckboxItemProps extends Omit<
   testId?: string;
 }
 
-/** A checkbox with a label and an optional description, laid out like
- *  `RadioGroupItem` so a multi-select list and a single-select list read the
- *  same. The label wraps the control, so a click anywhere in the row toggles
- *  it, and `className` styles that row rather than the box. */
+/** The multi-select counterpart of `RadioGroupItem`. `className` styles the
+ *  row, not the box. */
 function CheckboxItem({
   label,
   labelClassName,

--- a/packages/ui/src/components/ui/disclosure.tsx
+++ b/packages/ui/src/components/ui/disclosure.tsx
@@ -32,9 +32,6 @@ export function DisclosureChevron({
 export function DisclosureToggle({
   open,
   onToggle,
-  /** For a section held open by something else, so `aria-expanded` doesn't
-   *  advertise a state this button can't change. */
-  disabled,
   chevronSize,
   chevronClassName,
   testId,
@@ -43,7 +40,6 @@ export function DisclosureToggle({
 }: {
   open: boolean;
   onToggle: () => void;
-  disabled?: boolean;
   chevronSize?: number;
   chevronClassName?: string;
   testId?: string;
@@ -54,7 +50,6 @@ export function DisclosureToggle({
     <button
       type="button"
       onClick={onToggle}
-      disabled={disabled}
       aria-expanded={open}
       data-testid={testId}
       className={cn("flex items-center gap-2 text-left", className)}

--- a/packages/ui/src/components/ui/disclosure.tsx
+++ b/packages/ui/src/components/ui/disclosure.tsx
@@ -32,6 +32,9 @@ export function DisclosureChevron({
 export function DisclosureToggle({
   open,
   onToggle,
+  /** For a section held open by something else, so `aria-expanded` doesn't
+   *  advertise a state this button can't change. */
+  disabled,
   chevronSize,
   chevronClassName,
   testId,
@@ -40,6 +43,7 @@ export function DisclosureToggle({
 }: {
   open: boolean;
   onToggle: () => void;
+  disabled?: boolean;
   chevronSize?: number;
   chevronClassName?: string;
   testId?: string;
@@ -50,6 +54,7 @@ export function DisclosureToggle({
     <button
       type="button"
       onClick={onToggle}
+      disabled={disabled}
       aria-expanded={open}
       data-testid={testId}
       className={cn("flex items-center gap-2 text-left", className)}

--- a/packages/ui/src/components/ui/hover-action.ts
+++ b/packages/ui/src/components/ui/hover-action.ts
@@ -1,0 +1,10 @@
+/** A row action that only shows on hover — the "…" menu, an inline remove.
+ *
+ *  Belongs on the action itself (or its wrapper) inside a `group` row. Stays
+ *  visible below `md`, where there is no hover to reveal it at all, and from
+ *  `md` up is also revealed while focused or while its menu is open —
+ *  otherwise a keyboard user tabs onto an invisible control. Every reveal is
+ *  `md:`-scoped so it outranks `md:opacity-0`, which Tailwind emits inside the
+ *  same media query. */
+export const HOVER_ACTION =
+  "transition-opacity md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100 md:data-[state=open]:opacity-100";

--- a/packages/ui/src/components/ui/hover-action.ts
+++ b/packages/ui/src/components/ui/hover-action.ts
@@ -1,10 +1,5 @@
-/** A row action that only shows on hover — the "…" menu, an inline remove.
- *
- *  Belongs on the action itself (or its wrapper) inside a `group` row. Stays
- *  visible below `md`, where there is no hover to reveal it at all, and from
- *  `md` up is also revealed while focused or while its menu is open —
- *  otherwise a keyboard user tabs onto an invisible control. Every reveal is
- *  `md:`-scoped so it outranks `md:opacity-0`, which Tailwind emits inside the
- *  same media query. */
+/** A row action revealed on hover. Goes on the action inside a `group` row.
+ *  Every reveal is `md:`-scoped so it outranks `md:opacity-0`, which Tailwind
+ *  emits later in the same media query. */
 export const HOVER_ACTION =
   "transition-opacity md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100 md:data-[state=open]:opacity-100";

--- a/packages/ui/src/components/ui/hover-action.ts
+++ b/packages/ui/src/components/ui/hover-action.ts
@@ -1,5 +1,7 @@
-/** A row action revealed on hover. Goes on the action inside a `group` row.
- *  Every reveal is `md:`-scoped so it outranks `md:opacity-0`, which Tailwind
- *  emits later in the same media query. */
+/** A row action revealed on hover. Goes on the action, or on a wrapper around
+ *  several — hence both `focus-within` and `has()`, which a bare
+ *  `focus-visible`/`data-state` pair can't match from a wrapper. Every reveal
+ *  is `md:`-scoped so it outranks `md:opacity-0`, which Tailwind emits later in
+ *  the same media query. */
 export const HOVER_ACTION =
-  "transition-opacity md:opacity-0 md:group-hover:opacity-100 md:focus-visible:opacity-100 md:data-[state=open]:opacity-100";
+  "transition-opacity md:opacity-0 md:group-hover:opacity-100 md:focus-within:opacity-100 md:data-[state=open]:opacity-100 md:has-[[data-state=open]]:opacity-100";

--- a/packages/ui/src/components/ui/panel-card.tsx
+++ b/packages/ui/src/components/ui/panel-card.tsx
@@ -1,0 +1,48 @@
+import type { ReactNode } from "react";
+
+import { CARD_SURFACE } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface PanelCardProps {
+  /** Rendered at 16px beside the title — usually a `ConnectionIcon`. */
+  icon?: ReactNode;
+  title: string;
+  /** Sits directly after the title, e.g. a count. */
+  titleAccessory?: ReactNode;
+  /** Pushed to the header's trailing edge, e.g. a "New" button. */
+  headerRight?: ReactNode;
+  testId?: string;
+  className?: string;
+  children: ReactNode;
+}
+
+/** A card whose contents are introduced by a fixed-height header: icon, title,
+ *  and slots either side of the gap. The anatomy the channel, connection-group
+ *  and catalogue cards all draw. */
+export function PanelCard({
+  icon,
+  title,
+  titleAccessory,
+  headerRight,
+  testId,
+  className,
+  children,
+}: PanelCardProps) {
+  return (
+    <section data-testid={testId} className={cn(CARD_SURFACE, className)}>
+      <header className="flex h-[52px] items-center gap-2.5 border-b border-border px-4">
+        {icon}
+        <h3 className="min-w-0 truncate text-[15px] font-semibold text-foreground">
+          {title}
+        </h3>
+        {titleAccessory}
+        {headerRight && (
+          <div className="ml-auto flex shrink-0 items-center gap-2">
+            {headerRight}
+          </div>
+        )}
+      </header>
+      {children}
+    </section>
+  );
+}

--- a/packages/ui/src/components/ui/panel-card.tsx
+++ b/packages/ui/src/components/ui/panel-card.tsx
@@ -4,21 +4,19 @@ import { CARD_SURFACE } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 interface PanelCardProps {
-  /** Rendered at 16px beside the title — usually a `ConnectionIcon`. */
   icon?: ReactNode;
   title: string;
-  /** Sits directly after the title, e.g. a count. */
+  /** Sits directly after the title. */
   titleAccessory?: ReactNode;
-  /** Pushed to the header's trailing edge, e.g. a "New" button. */
+  /** Pushed to the header's trailing edge. */
   headerRight?: ReactNode;
   testId?: string;
   className?: string;
   children: ReactNode;
 }
 
-/** A card whose contents are introduced by a fixed-height header: icon, title,
- *  and slots either side of the gap. The anatomy the channel, connection-group
- *  and catalogue cards all draw. */
+/** A card introduced by a fixed-height header: icon, title, and a slot either
+ *  side of the gap. */
 export function PanelCard({
   icon,
   title,

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -26,7 +26,10 @@ function TooltipContent({
   );
 }
 
-interface TooltipProps {
+interface TooltipProps extends Omit<
+  React.ComponentPropsWithoutRef<"button">,
+  "content"
+> {
   children: ReactNode;
   content: ReactNode;
   side?: React.ComponentPropsWithoutRef<
@@ -36,37 +39,47 @@ interface TooltipProps {
 }
 
 /** Announced as a description, not a name — an icon-only trigger still needs
- *  its own `aria-label`. */
-function Tooltip({
-  children,
-  content,
-  side = "bottom",
-  className,
-}: TooltipProps) {
-  return (
-    <TooltipPrimitive.Root>
-      {/* Radix opens on any focus, so restoring focus to a trigger — what a
-          menu or dialog does when it closes — would leave a tooltip stuck open
-          away from the pointer. preventDefault here suppresses only Radix's
-          own handler. */}
-      <TooltipPrimitive.Trigger
-        asChild
-        onFocus={(event) => {
-          if (!event.currentTarget.matches(":focus-visible"))
-            event.preventDefault();
-        }}
-      >
-        {children}
-      </TooltipPrimitive.Trigger>
-      <TooltipContent
-        side={side}
-        className={cn("max-w-xs text-xs leading-relaxed", className)}
-      >
-        {content}
-      </TooltipContent>
-    </TooltipPrimitive.Root>
-  );
-}
+ *  its own `aria-label`.
+ *
+ *  Transparent to props and ref: when this wraps a `Button` that is itself the
+ *  child of an outer `*Trigger asChild`, the outer trigger clones *this*
+ *  element, so we forward its ref/handlers/aria onto the wrapped child (via the
+ *  Radix trigger's own `asChild` merge). Without it a slotted Button loses its
+ *  Popper anchor and its trigger a11y. */
+const Tooltip = React.forwardRef<HTMLButtonElement, TooltipProps>(
+  function Tooltip(
+    { children, content, side = "bottom", className, ...rest },
+    ref,
+  ) {
+    const { onFocus, ...triggerProps } = rest;
+    return (
+      <TooltipPrimitive.Root>
+        {/* Radix opens on any focus, so restoring focus to a trigger — what a
+            menu or dialog does when it closes — would leave a tooltip stuck
+            open away from the pointer. preventDefault here suppresses only
+            Radix's own handler. */}
+        <TooltipPrimitive.Trigger
+          asChild
+          ref={ref}
+          {...triggerProps}
+          onFocus={(event) => {
+            onFocus?.(event);
+            if (!event.currentTarget.matches(":focus-visible"))
+              event.preventDefault();
+          }}
+        >
+          {children}
+        </TooltipPrimitive.Trigger>
+        <TooltipContent
+          side={side}
+          className={cn("max-w-xs text-xs leading-relaxed", className)}
+        >
+          {content}
+        </TooltipContent>
+      </TooltipPrimitive.Root>
+    );
+  },
+);
 
 interface HintTooltipProps extends Omit<TooltipProps, "className"> {
   label: string;

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -35,12 +35,8 @@ interface TooltipProps {
   className?: string;
 }
 
-/** A hint on something that is already interactive: the child becomes the
- *  trigger, so it keeps its own focus, click and ref. Use this instead of the
- *  native `title` attribute, which neither keyboard nor touch can reach.
- *
- *  The content is announced as a description, not as a name — an icon-only
- *  trigger still needs its own `aria-label`. */
+/** Announced as a description, not a name — an icon-only trigger still needs
+ *  its own `aria-label`. */
 function Tooltip({
   children,
   content,
@@ -61,15 +57,13 @@ function Tooltip({
 }
 
 interface HintTooltipProps extends Omit<TooltipProps, "className"> {
-  /** Names the trigger, since the hint itself is only its description. */
   label: string;
   /** Classes for the focusable wrapper, not for the tooltip. */
   className?: string;
 }
 
-/** A hint hung off something inert — a status dot, a badge, a warning glyph.
- *  Wrapping it in a button is what makes the hint reachable at all: a bare
- *  span takes neither focus nor tap. */
+/** For an inert child. The button does nothing but take focus, which a bare
+ *  span can't. */
 function HintTooltip({
   children,
   label,

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -35,6 +35,12 @@ interface TooltipProps {
   className?: string;
 }
 
+/** A hint on something that is already interactive: the child becomes the
+ *  trigger, so it keeps its own focus, click and ref. Use this instead of the
+ *  native `title` attribute, which neither keyboard nor touch can reach.
+ *
+ *  The content is announced as a description, not as a name — an icon-only
+ *  trigger still needs its own `aria-label`. */
 function Tooltip({
   children,
   content,
@@ -43,9 +49,7 @@ function Tooltip({
 }: TooltipProps) {
   return (
     <TooltipPrimitive.Root>
-      <TooltipPrimitive.Trigger asChild>
-        <span className="inline-flex">{children}</span>
-      </TooltipPrimitive.Trigger>
+      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
       <TooltipContent
         side={side}
         className={cn("max-w-xs text-xs leading-relaxed", className)}
@@ -56,4 +60,33 @@ function Tooltip({
   );
 }
 
-export { Tooltip, TooltipContent, TooltipProvider };
+interface HintTooltipProps extends Omit<TooltipProps, "className"> {
+  /** Names the trigger, since the hint itself is only its description. */
+  label: string;
+  /** Classes for the focusable wrapper, not for the tooltip. */
+  className?: string;
+}
+
+/** A hint hung off something inert — a status dot, a badge, a warning glyph.
+ *  Wrapping it in a button is what makes the hint reachable at all: a bare
+ *  span takes neither focus nor tap. */
+function HintTooltip({
+  children,
+  label,
+  className,
+  ...props
+}: HintTooltipProps) {
+  return (
+    <Tooltip {...props}>
+      <button
+        type="button"
+        aria-label={label}
+        className={cn("inline-flex cursor-help items-center", className)}
+      >
+        {children}
+      </button>
+    </Tooltip>
+  );
+}
+
+export { HintTooltip, Tooltip, TooltipContent, TooltipProvider };

--- a/packages/ui/src/components/ui/tooltip.tsx
+++ b/packages/ui/src/components/ui/tooltip.tsx
@@ -45,7 +45,19 @@ function Tooltip({
 }: TooltipProps) {
   return (
     <TooltipPrimitive.Root>
-      <TooltipPrimitive.Trigger asChild>{children}</TooltipPrimitive.Trigger>
+      {/* Radix opens on any focus, so restoring focus to a trigger — what a
+          menu or dialog does when it closes — would leave a tooltip stuck open
+          away from the pointer. preventDefault here suppresses only Radix's
+          own handler. */}
+      <TooltipPrimitive.Trigger
+        asChild
+        onFocus={(event) => {
+          if (!event.currentTarget.matches(":focus-visible"))
+            event.preventDefault();
+        }}
+      >
+        {children}
+      </TooltipPrimitive.Trigger>
       <TooltipContent
         side={side}
         className={cn("max-w-xs text-xs leading-relaxed", className)}

--- a/packages/ui/src/lib/clickable.ts
+++ b/packages/ui/src/lib/clickable.ts
@@ -1,0 +1,26 @@
+import type { KeyboardEvent } from "react";
+
+/** Button semantics for a row or card that can't be a real `<button>` — one
+ *  that wraps its own action menu or link, which a button may not contain.
+ *
+ *  Activates on click, Enter and Space. Space is the half hand-rolled rows keep
+ *  missing, and it needs its default suppressed or the page scrolls instead.
+ *  Keys are ignored unless they land on the row itself, so a nested control
+ *  keeps its own Enter and Space.
+ *
+ *  Pass `undefined` to leave the element inert — a row that is only sometimes
+ *  clickable then has no stale `role` or tab stop. */
+export function clickableProps(onActivate: (() => void) | undefined) {
+  if (!onActivate) return {};
+  return {
+    role: "button",
+    tabIndex: 0,
+    onClick: onActivate,
+    onKeyDown: (event: KeyboardEvent<HTMLElement>) => {
+      if (event.target !== event.currentTarget) return;
+      if (event.key !== "Enter" && event.key !== " ") return;
+      event.preventDefault();
+      onActivate();
+    },
+  } as const;
+}

--- a/packages/ui/src/lib/clickable.ts
+++ b/packages/ui/src/lib/clickable.ts
@@ -1,15 +1,9 @@
 import type { KeyboardEvent } from "react";
 
-/** Button semantics for a row or card that can't be a real `<button>` — one
- *  that wraps its own action menu or link, which a button may not contain.
- *
- *  Activates on click, Enter and Space. Space is the half hand-rolled rows keep
- *  missing, and it needs its default suppressed or the page scrolls instead.
- *  Keys are ignored unless they land on the row itself, so a nested control
- *  keeps its own Enter and Space.
- *
- *  Pass `undefined` to leave the element inert — a row that is only sometimes
- *  clickable then has no stale `role` or tab stop. */
+/** Button semantics for a row that can't be a real `<button>` because it wraps
+ *  its own menu or link. Keys are ignored unless they land on the row itself,
+ *  so a nested control keeps its own Enter and Space. `undefined` leaves the
+ *  element inert, with no stale `role` or tab stop. */
 export function clickableProps(onActivate: (() => void) | undefined) {
   if (!onActivate) return {};
   return {

--- a/packages/ui/src/lib/external-link.ts
+++ b/packages/ui/src/lib/external-link.ts
@@ -1,0 +1,7 @@
+/** Spread onto every `<a>` that leaves the app. `noreferrer` already implies
+ *  `noopener` in current browsers, but both are named so the intent survives a
+ *  future edit that drops one of them. */
+export const externalLinkProps = {
+  target: "_blank",
+  rel: "noopener noreferrer",
+} as const;

--- a/packages/ui/src/lib/external-link.ts
+++ b/packages/ui/src/lib/external-link.ts
@@ -1,6 +1,4 @@
-/** Spread onto every `<a>` that leaves the app. `noreferrer` already implies
- *  `noopener` in current browsers, but both are named so the intent survives a
- *  future edit that drops one of them. */
+/** Spread onto every `<a>` that leaves the app. */
 export const externalLinkProps = {
   target: "_blank",
   rel: "noopener noreferrer",

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { clickableProps } from "@/lib/clickable";
 
 import { StatusBadge } from "../../../components/status-indicator.js";
 import type { AgentView } from "../../../types.js";
@@ -53,7 +54,7 @@ export function AgentRow({
   return (
     <Card
       data-testid="agent-row"
-      onClick={onSelect}
+      {...clickableProps(onSelect)}
       // The guard keeps the card flat while a nested action is hovered, so the
       // two hover states don't stack.
       className="group flex cursor-pointer items-center justify-between gap-3 border border-border p-4 anim-in transition-colors hover:not-has-[button:hover]:bg-muted/40"

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -112,12 +112,7 @@ export function AgentRow({
         <span onClick={(e) => e.stopPropagation()}>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                aria-label="Sandbox actions"
-                tooltip="Sandbox actions"
-              >
+              <Button variant="ghost" size="icon" aria-label="Sandbox actions">
                 <OverflowMenuVertical />
               </Button>
             </DropdownMenuTrigger>

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -112,7 +112,12 @@ export function AgentRow({
         <span onClick={(e) => e.stopPropagation()}>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" title="Sandbox actions">
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label="Sandbox actions"
+                tooltip="Sandbox actions"
+              >
                 <OverflowMenuVertical />
               </Button>
             </DropdownMenuTrigger>

--- a/packages/ui/src/modules/agents/components/bind-agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/bind-agent-row.tsx
@@ -1,3 +1,4 @@
+import { CardButton } from "@/components/ui/card-button";
 import { cn } from "@/lib/utils";
 
 import type { AgentView } from "../../../types.js";
@@ -21,13 +22,12 @@ export function BindAgentRow({
   onPick,
 }: Props) {
   return (
-    <button
-      type="button"
+    <CardButton
       disabled={disabled}
       onClick={onPick}
       className={cn(
-        "flex flex-col items-start gap-0.5 rounded-lg border bg-background px-4 py-3 text-left hover:border-foreground/40 disabled:opacity-60",
-        highlighted ? "border-foreground" : "border-border",
+        "flex flex-col items-start gap-0.5 px-4 py-3",
+        highlighted && "border-foreground",
       )}
     >
       <span className="text-sm font-semibold text-foreground">
@@ -43,6 +43,6 @@ export function BindAgentRow({
           {agent.templateId}
         </span>
       )}
-    </button>
+    </CardButton>
   );
 }

--- a/packages/ui/src/modules/api-keys/components/api-key-row.tsx
+++ b/packages/ui/src/modules/api-keys/components/api-key-row.tsx
@@ -48,7 +48,8 @@ export function ApiKeyRow({ apiKey, onRevoke, revoking }: Props) {
         onClick={() => onRevoke(id, name)}
         disabled={revoking}
         className="shrink-0 text-muted-foreground"
-        title="Revoke"
+        aria-label="Revoke"
+        tooltip="Revoke"
       >
         <TrashCan size={14} />
       </Button>

--- a/packages/ui/src/modules/api-keys/components/create-api-key-dialog/agent-binding-field.tsx
+++ b/packages/ui/src/modules/api-keys/components/create-api-key-dialog/agent-binding-field.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from "@/components/ui/checkbox";
+import { CheckboxItem } from "@/components/ui/checkbox";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { SectionLabel } from "@/components/ui/section-label";
 
@@ -70,18 +70,14 @@ export function AgentBindingField({
             </p>
           ) : (
             agents.map((agent) => (
-              <label
+              <CheckboxItem
                 key={agent.id}
-                htmlFor={`api-key-agent-${agent.id}`}
-                className="flex cursor-pointer items-center gap-2"
-              >
-                <Checkbox
-                  id={`api-key-agent-${agent.id}`}
-                  checked={selectedAgentIds.has(agent.id)}
-                  onCheckedChange={() => onToggleAgent(agent.id)}
-                />
-                <span className="truncate text-sm">{agent.name}</span>
-              </label>
+                id={`api-key-agent-${agent.id}`}
+                label={agent.name}
+                labelClassName="truncate"
+                checked={selectedAgentIds.has(agent.id)}
+                onCheckedChange={() => onToggleAgent(agent.id)}
+              />
             ))
           )}
         </div>

--- a/packages/ui/src/modules/api-keys/components/create-api-key-dialog/create-form.tsx
+++ b/packages/ui/src/modules/api-keys/components/create-api-key-dialog/create-form.tsx
@@ -3,7 +3,7 @@ import { useState } from "react";
 
 import { FormField } from "@/components/form-field";
 import { Callout } from "@/components/ui/callout";
-import { Checkbox } from "@/components/ui/checkbox";
+import { CheckboxItem } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
 import { SectionLabel } from "@/components/ui/section-label";
 
@@ -162,27 +162,16 @@ interface ScopeOptionProps {
 }
 
 function ScopeOption({ scope, checked, onToggle }: ScopeOptionProps) {
-  const id = `api-key-scope-${scope}`;
   return (
-    // The whole row is the label, so its padding and hover area are also the
-    // click target.
-    <label
-      htmlFor={id}
-      className="flex items-start gap-2 p-2 rounded-lg hover:bg-muted/40 cursor-pointer"
-    >
-      <Checkbox
-        id={id}
-        checked={checked}
-        onCheckedChange={onToggle}
-        className="mt-1"
-      />
-      <span className="flex-1">
-        <code className="text-sm font-semibold">{scope}</code>
-        <span className="text-xs text-muted-foreground block">
-          {scopeDescription(scope)}
-        </span>
-      </span>
-    </label>
+    <CheckboxItem
+      id={`api-key-scope-${scope}`}
+      label={scope}
+      labelClassName="font-mono font-semibold"
+      description={scopeDescription(scope)}
+      checked={checked}
+      onCheckedChange={onToggle}
+      className="rounded-lg p-2 hover:bg-muted/40"
+    />
   );
 }
 

--- a/packages/ui/src/modules/approvals/components/approvals-list.tsx
+++ b/packages/ui/src/modules/approvals/components/approvals-list.tsx
@@ -136,7 +136,7 @@ function ApprovalRow({
             tooltip={
               allowOnceDisabled
                 ? "Original request already failed; pick Allow permanently to allow future retries"
-                : "Allow this single request"
+                : undefined
             }
           >
             <Checkmark size={11} /> Allow once

--- a/packages/ui/src/modules/approvals/components/approvals-list.tsx
+++ b/packages/ui/src/modules/approvals/components/approvals-list.tsx
@@ -133,7 +133,7 @@ function ApprovalRow({
             size="xs"
             disabled={inflight || allowOnceDisabled}
             onClick={() => approveOnce.mutate({ id: row.id })}
-            title={
+            tooltip={
               allowOnceDisabled
                 ? "Original request already failed; pick Allow permanently to allow future retries"
                 : "Allow this single request"
@@ -147,7 +147,7 @@ function ApprovalRow({
             size="xs"
             disabled={inflight}
             onClick={() => approvePermanent.mutate({ id: row.id })}
-            title="Allow this exact path on this host (writes a rule)"
+            tooltip="Allow this exact path on this host (writes a rule)"
           >
             <CheckmarkFilled size={11} /> Allow permanently
           </Button>
@@ -159,7 +159,7 @@ function ApprovalRow({
               className="min-w-0 max-w-full"
               disabled={inflight}
               onClick={() => approveHost.mutate({ id: row.id })}
-              title={`Allow all requests to ${hostLabel} (writes a wildcard rule)`}
+              tooltip={`Allow all requests to ${hostLabel} (writes a wildcard rule)`}
             >
               <Globe size={11} />
               <span className="truncate">Allow {hostLabel}</span>
@@ -172,7 +172,7 @@ function ApprovalRow({
             size="xs"
             disabled={inflight || !live}
             onClick={() => dismiss.mutate({ id: row.id })}
-            title={
+            tooltip={
               !live
                 ? "Original request already failed; nothing to dismiss"
                 : "Deny this single request — re-prompts on the next attempt"
@@ -187,7 +187,7 @@ function ApprovalRow({
             size="xs"
             disabled={inflight}
             onClick={() => denyForever.mutate({ id: row.id })}
-            title="Deny this exact path on this host (writes a deny rule)"
+            tooltip="Deny this exact path on this host (writes a deny rule)"
           >
             <Misuse size={11} /> Deny forever
           </Button>
@@ -198,7 +198,7 @@ function ApprovalRow({
               size="xs"
               disabled={inflight}
               onClick={() => navigateToSandboxHome(row.agentId)}
-              title="Open this sandbox's settings (connections, network access, environment)"
+              tooltip="Open this sandbox's settings (connections, network access, environment)"
             >
               <SettingsAdjust size={11} /> Customize…
             </Button>

--- a/packages/ui/src/modules/approvals/components/egress-approval-toast.tsx
+++ b/packages/ui/src/modules/approvals/components/egress-approval-toast.tsx
@@ -75,7 +75,7 @@ export function EgressApprovalToast({
           className="h-[26px] bg-background text-sm font-medium"
           disabled={inflight || !live}
           onClick={() => approveOnce.mutate({ id: row.id })}
-          title={
+          tooltip={
             live
               ? "Allow this single request"
               : "Original request already failed; pick an Always option to allow future retries"
@@ -109,7 +109,7 @@ export function EgressApprovalToast({
           className="h-[26px] text-sm font-medium"
           disabled={inflight || !live}
           onClick={() => dismiss.mutate({ id: row.id })}
-          title={
+          tooltip={
             live
               ? "Deny this single request — re-prompts on the next attempt"
               : "Original request already failed; nothing to deny"
@@ -123,7 +123,7 @@ export function EgressApprovalToast({
           className="h-[26px] text-sm font-medium"
           disabled={inflight}
           onClick={() => denyForever.mutate({ id: row.id })}
-          title="Deny this exact path on this host (writes a deny rule)"
+          tooltip="Deny this exact path on this host (writes a deny rule)"
         >
           <Locked size={14} /> Always deny this request
         </Button>
@@ -133,7 +133,7 @@ export function EgressApprovalToast({
           className="h-[26px] text-sm font-medium"
           disabled={inflight}
           onClick={() => navigateToSandboxHome(row.agentId)}
-          title="Open this sandbox's settings"
+          tooltip="Open this sandbox's settings"
         >
           <Settings size={14} /> Customize…
         </Button>

--- a/packages/ui/src/modules/approvals/components/egress-approval-toast.tsx
+++ b/packages/ui/src/modules/approvals/components/egress-approval-toast.tsx
@@ -77,7 +77,7 @@ export function EgressApprovalToast({
           onClick={() => approveOnce.mutate({ id: row.id })}
           tooltip={
             live
-              ? "Allow this single request"
+              ? undefined
               : "Original request already failed; pick an Always option to allow future retries"
           }
         >

--- a/packages/ui/src/modules/artifacts/components/artifact-link-chip.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-link-chip.tsx
@@ -2,6 +2,8 @@ import { Box } from "@carbon/icons-react";
 import { ARTIFACT_INTERNAL_LINK_PREFIX } from "api-server-api";
 import type { ReactNode } from "react";
 
+import { Tooltip } from "@/components/ui/tooltip";
+
 import { useStore } from "../../../store.js";
 import { useArtifact } from "../api/queries.js";
 import { ArtifactKindBadge } from "./artifact-badges.js";
@@ -36,20 +38,23 @@ export function ArtifactLinkChip({
       : "artifact");
 
   return (
-    <button
-      type="button"
-      onClick={() =>
-        setOpenArtifactId(artifactId === openArtifactId ? null : artifactId)
-      }
-      title={artifact ? `Preview “${artifact.title}”` : "Preview artifact"}
-      className="not-prose inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2 py-0.5 align-middle text-sm font-medium text-foreground transition-colors hover:border-accent hover:bg-accent-light hover:text-accent"
+    <Tooltip
+      content={artifact ? `Preview “${artifact.title}”` : "Preview artifact"}
     >
-      {artifact ? (
-        <ArtifactKindBadge kind={artifact.kind} />
-      ) : (
-        <Box size={13} className="shrink-0 text-muted-foreground" />
-      )}
-      <span className="truncate">{label}</span>
-    </button>
+      <button
+        type="button"
+        onClick={() =>
+          setOpenArtifactId(artifactId === openArtifactId ? null : artifactId)
+        }
+        className="not-prose inline-flex max-w-full items-center gap-1.5 rounded-md border border-border bg-card px-2 py-0.5 align-middle text-sm font-medium text-foreground transition-colors hover:border-accent hover:bg-accent-light hover:text-accent"
+      >
+        {artifact ? (
+          <ArtifactKindBadge kind={artifact.kind} />
+        ) : (
+          <Box size={13} className="shrink-0 text-muted-foreground" />
+        )}
+        <span className="truncate">{label}</span>
+      </button>
+    </Tooltip>
   );
 }

--- a/packages/ui/src/modules/artifacts/components/artifact-preview-dialog.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-preview-dialog.tsx
@@ -87,7 +87,8 @@ export function ArtifactPreviewDialog({ artifact, onClose }: Props) {
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    title="Fullscreen"
+                    aria-label="Fullscreen"
+                    tooltip="Fullscreen"
                     onClick={() => setFullscreen(true)}
                   >
                     <Maximize size={16} />

--- a/packages/ui/src/modules/artifacts/components/artifact-preview-dialog.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-preview-dialog.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/modal";
 import { Button } from "@/components/ui/button";
 import { formatBytes } from "@/lib/format-size";
+import { externalLinkProps } from "@/lib/external-link";
 
 import { useDashboardFeedPost } from "../../experiments/hooks/use-dashboard-feed-post.js";
 import { FullscreenPreviewDialog } from "../../files/components/fullscreen-preview-dialog.js";
@@ -127,7 +128,7 @@ export function ArtifactPreviewDialog({ artifact, onClose }: Props) {
         <DialogFooter>
           {artifact.shareUrl && (
             <Button variant="outline" asChild>
-              <a href={artifact.shareUrl} target="_blank" rel="noreferrer">
+              <a href={artifact.shareUrl} {...externalLinkProps}>
                 <Launch size={16} />
                 Open share page
               </a>

--- a/packages/ui/src/modules/artifacts/components/artifact-preview-dialog.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-preview-dialog.tsx
@@ -9,8 +9,8 @@ import {
   Modal,
 } from "@/components/modal";
 import { Button } from "@/components/ui/button";
-import { formatBytes } from "@/lib/format-size";
 import { externalLinkProps } from "@/lib/external-link";
+import { formatBytes } from "@/lib/format-size";
 
 import { useDashboardFeedPost } from "../../experiments/hooks/use-dashboard-feed-post.js";
 import { FullscreenPreviewDialog } from "../../files/components/fullscreen-preview-dialog.js";

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useCopy } from "@/hooks/use-copy";
 import { timeAgo } from "@/lib/format-time";
+import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
 import { useStore } from "../../../store.js";
@@ -52,14 +53,9 @@ export function ArtifactRow({
 
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={() => onPreview(artifact)}
+      {...clickableProps(() => onPreview(artifact))}
       onMouseEnter={warmPreview}
       onFocus={warmPreview}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") onPreview(artifact);
-      }}
       className={cn(
         "group flex w-full cursor-pointer items-center gap-3 border-t border-border px-4 py-2.5 text-left transition-colors hover:bg-muted/60",
         expiry.state === "expired" && "opacity-55",
@@ -100,7 +96,6 @@ export function ArtifactRow({
         <div
           className="flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100"
           onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
         >
           <ShareLinkButton artifact={artifact} onShare={onShare} />
           <DropdownMenu>

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -17,6 +17,7 @@ import {
 import { useCopy } from "@/hooks/use-copy";
 import { timeAgo } from "@/lib/format-time";
 import { HOVER_ACTION } from "@/components/ui/hover-action";
+import { Tooltip } from "@/components/ui/tooltip";
 import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
@@ -101,7 +102,12 @@ export function ArtifactRow({
           <ShareLinkButton artifact={artifact} onShare={onShare} />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon-sm" title="More actions">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="More actions"
+                tooltip="More actions"
+              >
                 <OverflowMenuVertical size={16} />
               </Button>
             </DropdownMenuTrigger>
@@ -126,18 +132,19 @@ function AgentCreatorChip({ agentId }: { agentId: string }) {
   const navigateToSandboxHome = useStore((s) => s.navigateToSandboxHome);
   const agentName = useAgentDisplayName(agentId);
   return (
-    <button
-      type="button"
-      onClick={(e) => {
-        e.stopPropagation();
-        navigateToSandboxHome(agentId, "artifacts");
-      }}
-      title={`Open ${agentName}'s artifacts`}
-      className="inline-flex max-w-40 items-center gap-1 rounded-full bg-muted px-2 py-px transition-colors hover:bg-accent-light hover:text-accent"
-    >
-      <Box size={12} className="shrink-0" />
-      <span className="truncate">{agentName}</span>
-    </button>
+    <Tooltip content={`Open ${agentName}'s artifacts`}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          navigateToSandboxHome(agentId, "artifacts");
+        }}
+        className="inline-flex max-w-40 items-center gap-1 rounded-full bg-muted px-2 py-px transition-colors hover:bg-accent-light hover:text-accent"
+      >
+        <Box size={12} className="shrink-0" />
+        <span className="truncate">{agentName}</span>
+      </button>
+    </Tooltip>
   );
 }
 
@@ -156,7 +163,10 @@ function ShareLinkButton({
     <Button
       variant="ghost"
       size="icon-sm"
-      title={copied ? "Copied!" : url ? "Copy share link" : "Sharing settings…"}
+      aria-label={url ? "Copy share link" : "Sharing settings"}
+      tooltip={
+        copied ? "Copied!" : url ? "Copy share link" : "Sharing settings…"
+      }
       onClick={() => (url ? void copy(url) : onShare(artifact))}
     >
       <Link size={16} className={cn(copied && "text-success")} />

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -14,11 +14,11 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { useCopy } from "@/hooks/use-copy";
-import { timeAgo } from "@/lib/format-time";
 import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { Tooltip } from "@/components/ui/tooltip";
+import { useCopy } from "@/hooks/use-copy";
 import { clickableProps } from "@/lib/clickable";
+import { timeAgo } from "@/lib/format-time";
 import { cn } from "@/lib/utils";
 
 import { useStore } from "../../../store.js";

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -102,12 +102,7 @@ export function ArtifactRow({
           <ShareLinkButton artifact={artifact} onShare={onShare} />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="More actions"
-                tooltip="More actions"
-              >
+              <Button variant="ghost" size="icon-sm" aria-label="More actions">
                 <OverflowMenuVertical size={16} />
               </Button>
             </DropdownMenuTrigger>

--- a/packages/ui/src/modules/artifacts/components/artifact-row.tsx
+++ b/packages/ui/src/modules/artifacts/components/artifact-row.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useCopy } from "@/hooks/use-copy";
 import { timeAgo } from "@/lib/format-time";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
@@ -94,7 +95,7 @@ export function ArtifactRow({
       <div className="ml-auto flex shrink-0 items-center gap-2">
         <ArtifactStatusBadge artifact={artifact} />
         <div
-          className="flex gap-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+          className={cn("flex gap-0.5", HOVER_ACTION)}
           onClick={(e) => e.stopPropagation()}
         >
           <ShareLinkButton artifact={artifact} onShare={onShare} />

--- a/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
@@ -124,7 +124,8 @@ function ArtifactListRow({
               variant="ghost"
               size="icon-xs"
               className={HOVER_ACTION}
-              title="More actions"
+              aria-label="More actions"
+              tooltip="More actions"
             >
               <OverflowMenuVertical size={13} />
             </Button>

--- a/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
@@ -122,7 +123,7 @@ function ArtifactListRow({
             <Button
               variant="ghost"
               size="icon-xs"
-              className="opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100"
+              className={HOVER_ACTION}
               title="More actions"
             >
               <OverflowMenuVertical size={13} />

--- a/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
@@ -119,7 +119,7 @@ function ArtifactListRow({
       )}
       <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
         <DropdownMenu>
-          {/* Kept mounted at opacity-0 so hovering doesn't reflow the row. */}
+          {/* Kept mounted so hovering doesn't reflow the row. */}
           <DropdownMenuTrigger asChild>
             <Button
               variant="ghost"

--- a/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
@@ -8,6 +8,7 @@ import {
   DropdownMenuContent,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
 import { useStore } from "../../../store.js";
@@ -98,12 +99,7 @@ function ArtifactListRow({
 }) {
   return (
     <div
-      role="button"
-      tabIndex={0}
-      onClick={onClick}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") onClick();
-      }}
+      {...clickableProps(onClick)}
       title={artifact.title}
       className={cn(
         "group flex h-8 w-full cursor-pointer items-center gap-2 px-3 text-left text-sm text-muted-foreground transition-colors hover:bg-muted",
@@ -119,11 +115,7 @@ function ArtifactListRow({
           title="Shared"
         />
       )}
-      <div
-        className="shrink-0"
-        onClick={(e) => e.stopPropagation()}
-        onKeyDown={(e) => e.stopPropagation()}
-      >
+      <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
         <DropdownMenu>
           {/* Kept mounted at opacity-0 so hovering doesn't reflow the row. */}
           <DropdownMenuTrigger asChild>

--- a/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/chat-artifacts-panel.tsx
@@ -112,8 +112,9 @@ function ArtifactListRow({
       {artifact.version > 1 && <VersionBadge version={artifact.version} />}
       {artifact.visibility === "public" && (
         <span
+          role="img"
+          aria-label="Shared"
           className="h-1.5 w-1.5 shrink-0 rounded-full bg-success"
-          title="Shared"
         />
       )}
       <div className="shrink-0" onClick={(e) => e.stopPropagation()}>
@@ -125,7 +126,6 @@ function ArtifactListRow({
               size="icon-xs"
               className={HOVER_ACTION}
               aria-label="More actions"
-              tooltip="More actions"
             >
               <OverflowMenuVertical size={13} />
             </Button>

--- a/packages/ui/src/modules/artifacts/components/docked-artifact-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/docked-artifact-panel.tsx
@@ -115,7 +115,6 @@ export function DockedArtifactPanel() {
           variant="ghost"
           size="icon-sm"
           aria-label="Close"
-          tooltip="Close"
           onClick={() => setOpenArtifactId(null)}
         >
           <Close size={16} />

--- a/packages/ui/src/modules/artifacts/components/docked-artifact-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/docked-artifact-panel.tsx
@@ -83,7 +83,6 @@ export function DockedArtifactPanel() {
           <Button
             variant="outline"
             size="xs"
-            tooltip="Sharing settings"
             onClick={() => setShareOpen(true)}
           >
             <Share size={14} />

--- a/packages/ui/src/modules/artifacts/components/docked-artifact-panel.tsx
+++ b/packages/ui/src/modules/artifacts/components/docked-artifact-panel.tsx
@@ -83,7 +83,7 @@ export function DockedArtifactPanel() {
           <Button
             variant="outline"
             size="xs"
-            title="Sharing settings"
+            tooltip="Sharing settings"
             onClick={() => setShareOpen(true)}
           >
             <Share size={14} />
@@ -104,7 +104,8 @@ export function DockedArtifactPanel() {
           <Button
             variant="outline"
             size="icon-xs"
-            title="Download"
+            aria-label="Download"
+            tooltip="Download"
             onClick={() => void downloadArtifact(artifact.id)}
           >
             <Download size={14} />
@@ -113,7 +114,8 @@ export function DockedArtifactPanel() {
         <Button
           variant="ghost"
           size="icon-sm"
-          title="Close"
+          aria-label="Close"
+          tooltip="Close"
           onClick={() => setOpenArtifactId(null)}
         >
           <Close size={16} />

--- a/packages/ui/src/modules/artifacts/components/experiments-section.tsx
+++ b/packages/ui/src/modules/artifacts/components/experiments-section.tsx
@@ -8,7 +8,10 @@ import { EXPERIMENT_FOLDER_PREFIX } from "api-server-api";
 import { useMemo, useState } from "react";
 
 import { Card } from "@/components/ui/card";
-import { DisclosureToggle } from "@/components/ui/disclosure";
+import {
+  DisclosureChevron,
+  DisclosureToggle,
+} from "@/components/ui/disclosure";
 
 import { useExperimentsAmbient } from "../../experiments/api/queries.js";
 import type { ArtifactRowActions } from "./artifact-row.js";
@@ -119,27 +122,42 @@ export function ExperimentsSection({
   );
   if (searching && visible.length === 0) return null;
 
+  const header = (
+    <>
+      <Chemistry size={16} className="shrink-0 text-muted-foreground" />
+      <span className="text-sm font-semibold text-muted-foreground">
+        Experiments
+      </span>
+      <span className="text-xs text-muted-foreground">
+        {folders.length} experiment{folders.length === 1 ? "" : "s"} · {total}{" "}
+        artifact{total === 1 ? "" : "s"}
+      </span>
+      <span className="ml-auto hidden text-xs text-muted-foreground/70 sm:block">
+        scripts, dashboards and run results published by your agents
+      </span>
+    </>
+  );
+
   return (
     <Card className="mt-2 overflow-hidden border-dashed bg-muted/30 anim-in">
-      <DisclosureToggle
-        open={expanded}
-        onToggle={() => setOpen((o) => !o)}
-        disabled={searching}
-        chevronClassName="text-muted-foreground"
-        className="w-full cursor-pointer select-none gap-2.5 px-3.5 py-2.5 transition-colors hover:bg-muted/60"
-      >
-        <Chemistry size={16} className="shrink-0 text-muted-foreground" />
-        <span className="text-sm font-semibold text-muted-foreground">
-          Experiments
-        </span>
-        <span className="text-xs text-muted-foreground">
-          {folders.length} experiment{folders.length === 1 ? "" : "s"} · {total}{" "}
-          artifact{total === 1 ? "" : "s"}
-        </span>
-        <span className="ml-auto hidden text-xs text-muted-foreground/70 sm:block">
-          scripts, dashboards and run results published by your agents
-        </span>
-      </DisclosureToggle>
+      {searching ? (
+        // A search pins the section open, so render a static header rather than
+        // a toggle that keeps a pointer cursor and hover but does nothing — and
+        // would drop keyboard focus the moment the filter turns it inert.
+        <div className="flex items-center gap-2.5 px-3.5 py-2.5">
+          <DisclosureChevron open className="text-muted-foreground" />
+          {header}
+        </div>
+      ) : (
+        <DisclosureToggle
+          open={open}
+          onToggle={() => setOpen((o) => !o)}
+          chevronClassName="text-muted-foreground"
+          className="w-full cursor-pointer select-none gap-2.5 px-3.5 py-2.5 transition-colors hover:bg-muted/60"
+        >
+          {header}
+        </DisclosureToggle>
+      )}
       {expanded &&
         visible.map((folder) => {
           const artifacts = byFolder.get(folder.id) ?? [];

--- a/packages/ui/src/modules/artifacts/components/experiments-section.tsx
+++ b/packages/ui/src/modules/artifacts/components/experiments-section.tsx
@@ -124,6 +124,7 @@ export function ExperimentsSection({
       <DisclosureToggle
         open={expanded}
         onToggle={() => setOpen((o) => !o)}
+        disabled={searching}
         chevronClassName="text-muted-foreground"
         className="w-full cursor-pointer select-none gap-2.5 px-3.5 py-2.5 transition-colors hover:bg-muted/60"
       >

--- a/packages/ui/src/modules/artifacts/components/experiments-section.tsx
+++ b/packages/ui/src/modules/artifacts/components/experiments-section.tsx
@@ -8,7 +8,7 @@ import { EXPERIMENT_FOLDER_PREFIX } from "api-server-api";
 import { useMemo, useState } from "react";
 
 import { Card } from "@/components/ui/card";
-import { DisclosureChevron } from "@/components/ui/disclosure";
+import { DisclosureToggle } from "@/components/ui/disclosure";
 
 import { useExperimentsAmbient } from "../../experiments/api/queries.js";
 import type { ArtifactRowActions } from "./artifact-row.js";
@@ -121,16 +121,12 @@ export function ExperimentsSection({
 
   return (
     <Card className="mt-2 overflow-hidden border-dashed bg-muted/30 anim-in">
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={() => setOpen((o) => !o)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") setOpen((o) => !o);
-        }}
-        className="flex cursor-pointer select-none items-center gap-2.5 px-3.5 py-2.5 transition-colors hover:bg-muted/60"
+      <DisclosureToggle
+        open={expanded}
+        onToggle={() => setOpen((o) => !o)}
+        chevronClassName="text-muted-foreground"
+        className="w-full cursor-pointer select-none gap-2.5 px-3.5 py-2.5 transition-colors hover:bg-muted/60"
       >
-        <DisclosureChevron open={expanded} className="text-muted-foreground" />
         <Chemistry size={16} className="shrink-0 text-muted-foreground" />
         <span className="text-sm font-semibold text-muted-foreground">
           Experiments
@@ -142,7 +138,7 @@ export function ExperimentsSection({
         <span className="ml-auto hidden text-xs text-muted-foreground/70 sm:block">
           scripts, dashboards and run results published by your agents
         </span>
-      </div>
+      </DisclosureToggle>
       {expanded &&
         visible.map((folder) => {
           const artifacts = byFolder.get(folder.id) ?? [];

--- a/packages/ui/src/modules/artifacts/components/folder-group.tsx
+++ b/packages/ui/src/modules/artifacts/components/folder-group.tsx
@@ -108,7 +108,6 @@ export function FolderGroup({
                   variant="ghost"
                   size="icon-sm"
                   aria-label="Folder actions"
-                  tooltip="Folder actions"
                 >
                   <OverflowMenuVertical size={16} />
                 </Button>

--- a/packages/ui/src/modules/artifacts/components/folder-group.tsx
+++ b/packages/ui/src/modules/artifacts/components/folder-group.tsx
@@ -104,7 +104,12 @@ export function FolderGroup({
           <div className={cn("ml-auto", HOVER_ACTION)}>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="icon-sm" title="Folder actions">
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label="Folder actions"
+                  tooltip="Folder actions"
+                >
                   <OverflowMenuVertical size={16} />
                 </Button>
               </DropdownMenuTrigger>

--- a/packages/ui/src/modules/artifacts/components/folder-group.tsx
+++ b/packages/ui/src/modules/artifacts/components/folder-group.tsx
@@ -19,6 +19,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { SectionLabel } from "@/components/ui/section-label";
 import { useCopy } from "@/hooks/use-copy";
 import { cn } from "@/lib/utils";
@@ -100,7 +101,7 @@ export function FolderGroup({
           )}
         </DisclosureToggle>
         {folder && (
-          <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
+          <div className={cn("ml-auto", HOVER_ACTION)}>
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon-sm" title="Folder actions">

--- a/packages/ui/src/modules/artifacts/components/folder-group.tsx
+++ b/packages/ui/src/modules/artifacts/components/folder-group.tsx
@@ -11,7 +11,7 @@ import { useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import { DisclosureChevron } from "@/components/ui/disclosure";
+import { DisclosureToggle } from "@/components/ui/disclosure";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -74,42 +74,33 @@ export function FolderGroup({
         nested ? "border-t border-border/60" : "anim-in",
       )}
     >
-      <div
-        role="button"
-        tabIndex={0}
-        onClick={() => setCollapsed((c) => !c)}
-        onKeyDown={(e) => {
-          if (e.key === "Enter") setCollapsed((c) => !c);
-        }}
-        className="group flex cursor-pointer select-none items-center gap-2.5 px-3.5 py-2.5 transition-colors hover:bg-muted/60"
-      >
-        <DisclosureChevron
+      <div className="group flex select-none items-center pr-3.5 transition-colors hover:bg-muted/60">
+        <DisclosureToggle
           open={!collapsed}
-          className="text-muted-foreground"
-        />
-        {folder && (
-          <Folder size={16} className="shrink-0 text-muted-foreground" />
-        )}
-        <span
-          className={cn(
-            "text-sm font-semibold",
-            folder ? "text-foreground" : "text-muted-foreground",
-          )}
+          onToggle={() => setCollapsed((c) => !c)}
+          chevronClassName="text-muted-foreground"
+          className="min-w-0 flex-1 cursor-pointer gap-2.5 py-2.5 pl-3.5"
         >
-          {displayName ?? folder?.name ?? "Ungrouped"}
-        </span>
-        <span className="text-xs text-muted-foreground">
-          {artifacts.length} artifact{artifacts.length === 1 ? "" : "s"}
-        </span>
-        {folder && sharedCount > 0 && (
-          <Badge variant="success">{sharedCount} shared</Badge>
-        )}
-        {folder && (
-          <div
-            className="ml-auto opacity-0 transition-opacity group-hover:opacity-100"
-            onClick={(e) => e.stopPropagation()}
-            onKeyDown={(e) => e.stopPropagation()}
+          {folder && (
+            <Folder size={16} className="shrink-0 text-muted-foreground" />
+          )}
+          <span
+            className={cn(
+              "text-sm font-semibold",
+              folder ? "text-foreground" : "text-muted-foreground",
+            )}
           >
+            {displayName ?? folder?.name ?? "Ungrouped"}
+          </span>
+          <span className="text-xs text-muted-foreground">
+            {artifacts.length} artifact{artifacts.length === 1 ? "" : "s"}
+          </span>
+          {folder && sharedCount > 0 && (
+            <Badge variant="success">{sharedCount} shared</Badge>
+          )}
+        </DisclosureToggle>
+        {folder && (
+          <div className="ml-auto opacity-0 transition-opacity group-hover:opacity-100">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" size="icon-sm" title="Folder actions">

--- a/packages/ui/src/modules/artifacts/components/share-dialog.tsx
+++ b/packages/ui/src/modules/artifacts/components/share-dialog.tsx
@@ -88,7 +88,8 @@ export function ShareDialog({ artifact, onClose }: Props) {
               <Button
                 variant="outline"
                 size="icon-sm"
-                title="Copy link"
+                aria-label="Copy link"
+                tooltip="Copy link"
                 onClick={() => void copy(shareUrl)}
               >
                 {copied ? (

--- a/packages/ui/src/modules/artifacts/components/version-switcher.tsx
+++ b/packages/ui/src/modules/artifacts/components/version-switcher.tsx
@@ -21,7 +21,8 @@ export function VersionSwitcher({
       <Button
         variant="ghost"
         size="icon-xs"
-        title="Older version"
+        aria-label="Older version"
+        tooltip="Older version"
         disabled={current <= 1}
         onClick={() => onChange(current - 1)}
       >
@@ -33,7 +34,8 @@ export function VersionSwitcher({
       <Button
         variant="ghost"
         size="icon-xs"
-        title="Newer version"
+        aria-label="Newer version"
+        tooltip="Newer version"
         disabled={current >= total}
         onClick={() => onChange(current + 1)}
       >

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -5,6 +5,7 @@ import { type Control, Controller, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
+import { externalLinkProps } from "@/lib/external-link";
 import { emitToast } from "@/lib/toast";
 
 import { MCP_DOCS_URL } from "../../../constants.js";
@@ -197,8 +198,7 @@ export function McpCreatePane({
                 See{" "}
                 <a
                   href={MCP_DOCS_URL}
-                  target="_blank"
-                  rel="noreferrer"
+                  {...externalLinkProps}
                   className="font-medium text-foreground underline underline-offset-2 hover:text-accent"
                 >
                   documentation

--- a/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-mcp-create-pane.tsx
@@ -248,7 +248,7 @@ export function McpCreatePane({
             !awaitingPopup &&
             (pending || !template || showDetecting || !formState.isValid)
           }
-          title={
+          tooltip={
             awaitingPopup
               ? "Bring the authorization window back to the front"
               : undefined

--- a/packages/ui/src/modules/connections/components/catalog-provider-card.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-provider-card.tsx
@@ -3,7 +3,7 @@ import type { ConnectionTemplateView } from "api-server-api";
 import type { ConnectionView } from "api-server-api";
 
 import { Button } from "@/components/ui/button";
-import { CARD_SURFACE } from "@/components/ui/card";
+import { PanelCard } from "@/components/ui/panel-card";
 
 import type { CatalogProviderGroup } from "../lib/catalog-providers.js";
 import { connectionKindSubtitle } from "../lib/catalog-providers.js";
@@ -54,22 +54,19 @@ export function CatalogProviderCard({
   );
 
   return (
-    <section
-      data-testid={`catalog-provider-${provider.id}`}
-      className={CARD_SURFACE}
-    >
-      <header className="flex h-[52px] items-center gap-2.5 border-b border-border px-4">
+    <PanelCard
+      testId={`catalog-provider-${provider.id}`}
+      title={provider.title}
+      icon={
         <ConnectionIcon
           iconSlug={provider.iconSlug}
           alt=""
           size={16}
           className="shrink-0 text-foreground/80"
         />
-        <h3 className="min-w-0 flex-1 truncate text-[15px] font-semibold text-foreground">
-          {provider.title}
-        </h3>
-        {connections.length > 0 && newButton}
-      </header>
+      }
+      headerRight={connections.length > 0 && newButton}
+    >
       {connections.length > 0 ? (
         <>
           <GithubAppInstallHint connections={connections} />
@@ -103,6 +100,6 @@ export function CatalogProviderCard({
           {newButton}
         </div>
       )}
-    </section>
+    </PanelCard>
   );
 }

--- a/packages/ui/src/modules/connections/components/connection-group-card.tsx
+++ b/packages/ui/src/modules/connections/components/connection-group-card.tsx
@@ -1,6 +1,6 @@
 import type { ConnectionTemplateView, ConnectionView } from "api-server-api";
 
-import { CARD_SURFACE } from "@/components/ui/card";
+import { PanelCard } from "@/components/ui/panel-card";
 
 import type { CatalogProviderGroup } from "../lib/catalog-providers.js";
 import { connectionKindSubtitle } from "../lib/catalog-providers.js";
@@ -40,26 +40,25 @@ export function ConnectionGroupCard({
 }: Props) {
   const { provider, connections } = group;
   return (
-    <section
-      data-testid={`connection-group-${provider.id}`}
-      className={CARD_SURFACE}
-    >
-      <header className="flex h-[52px] items-center gap-2.5 border-b border-border px-4">
+    <PanelCard
+      testId={`connection-group-${provider.id}`}
+      title={provider.title}
+      icon={
         <ConnectionIcon
           iconSlug={provider.iconSlug}
           alt=""
           size={16}
           className="shrink-0 text-foreground/80"
         />
-        <h3 className="truncate text-[15px] font-semibold text-foreground">
-          {provider.title}
-        </h3>
-        {showCount && (
-          <span className="text-sm text-muted-foreground">
+      }
+      titleAccessory={
+        showCount && (
+          <span className="shrink-0 text-sm text-muted-foreground">
             {connections.length} connection{connections.length === 1 ? "" : "s"}
           </span>
-        )}
-      </header>
+        )
+      }
+    >
       <GithubAppInstallHint connections={connections} />
       <div className="divide-y divide-border">
         {connections.map((c) => (
@@ -75,6 +74,6 @@ export function ConnectionGroupCard({
           />
         ))}
       </div>
-    </section>
+    </PanelCard>
   );
 }

--- a/packages/ui/src/modules/connections/components/github-app-install-hint.tsx
+++ b/packages/ui/src/modules/connections/components/github-app-install-hint.tsx
@@ -2,6 +2,7 @@ import { Launch } from "@carbon/icons-react";
 import type { ConnectionView } from "api-server-api";
 
 import { Callout } from "@/components/ui/callout";
+import { externalLinkProps } from "@/lib/external-link";
 
 import { getBrand } from "../../../brand.js";
 import { githubAppInstallUrl } from "../lib/github-app-install-url.js";
@@ -50,8 +51,7 @@ export function GithubAppInstallLink({
   return (
     <a
       href={url}
-      target="_blank"
-      rel="noreferrer noopener"
+      {...externalLinkProps}
       className="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-accent hover:underline"
     >
       Install on GitHub <Launch size={13} aria-hidden />

--- a/packages/ui/src/modules/connections/forms/oauth-app-hint.tsx
+++ b/packages/ui/src/modules/connections/forms/oauth-app-hint.tsx
@@ -3,6 +3,7 @@ import { Checkmark, Copy, Launch } from "@carbon/icons-react";
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/ui/callout";
 import { useCopy } from "@/hooks/use-copy";
+import { externalLinkProps } from "@/lib/external-link";
 
 /** Bring-your-own-OAuth-app instructions: provider setup link plus the exact
  *  redirect URI to register. */
@@ -30,8 +31,7 @@ export function OAuthAppHint({
             {" "}
             <a
               href={setupUrl}
-              target="_blank"
-              rel="noreferrer"
+              {...externalLinkProps}
               className="inline-flex items-center gap-1 font-semibold text-primary hover:underline"
             >
               Create an app <Launch size={11} />

--- a/packages/ui/src/modules/connections/forms/oauth-app-hint.tsx
+++ b/packages/ui/src/modules/connections/forms/oauth-app-hint.tsx
@@ -54,7 +54,8 @@ export function OAuthAppHint({
               size="icon-xs"
               className="shrink-0"
               onClick={copy}
-              title="Copy redirect URI"
+              aria-label="Copy redirect URI"
+              tooltip="Copy redirect URI"
             >
               {copied ? (
                 <Checkmark size={12} className="text-success" />

--- a/packages/ui/src/modules/connections/forms/template-create-form-body.tsx
+++ b/packages/ui/src/modules/connections/forms/template-create-form-body.tsx
@@ -187,7 +187,7 @@ export function TemplateCreateFormBody({
       <Button
         onClick={awaitingPopup ? refocusPopup : onSubmit}
         disabled={pending && !awaitingPopup}
-        title={
+        tooltip={
           awaitingPopup
             ? "Bring the authorization window back to the front"
             : undefined

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -13,6 +13,7 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Select } from "@/components/ui/select";
+import { HintTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import {
@@ -490,7 +491,7 @@ function RuleRow({
         {rule.pathPattern}
       </span>
       {sourceLabel && (
-        <SourceTag label={sourceLabel} title={`source: ${rule.source}`} />
+        <SourceTag label={sourceLabel} hint={`source: ${rule.source}`} />
       )}
       <span className="ml-auto text-[10px] text-muted-foreground hidden sm:block">
         by {rule.decidedBy.slice(0, 8)}
@@ -604,16 +605,13 @@ function PreviewPresetRow({ row }: { row: PreviewRow }) {
       </span>
       <SourceTag
         label={row.sourceBadge}
-        title={`Preview — ${row.sourceBadge} (saved on commit)`}
+        hint={`Preview — ${row.sourceBadge} (saved on commit)`}
       />
-      <Badge
-        size="sm"
-        variant="accent"
-        className="uppercase tracking-wider"
-        title="This rule will be saved on commit"
-      >
-        preview
-      </Badge>
+      <HintTooltip label="preview" content="This rule will be saved on commit">
+        <Badge size="sm" variant="accent" className="uppercase tracking-wider">
+          preview
+        </Badge>
+      </HintTooltip>
       <span className="ml-auto" />
       {/* No per-row actions in preview mode: the rules don't exist yet, so
           there's nothing to revoke. The user can change the dropdown
@@ -634,10 +632,12 @@ function VerdictBadge({ verdict }: { verdict: EgressRuleView["verdict"] }) {
   );
 }
 
-function SourceTag({ label, title }: { label: string; title: string }) {
+function SourceTag({ label, hint }: { label: string; hint: string }) {
   return (
-    <Badge size="sm" variant="muted" title={title}>
-      {label}
-    </Badge>
+    <HintTooltip label={label} content={hint}>
+      <Badge size="sm" variant="muted">
+        {label}
+      </Badge>
+    </HintTooltip>
   );
 }

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -13,7 +13,6 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Select } from "@/components/ui/select";
-import { HintTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import {
@@ -607,11 +606,14 @@ function PreviewPresetRow({ row }: { row: PreviewRow }) {
         label={row.sourceBadge}
         hint={`Preview — ${row.sourceBadge} (saved on commit)`}
       />
-      <HintTooltip label="preview" content="This rule will be saved on commit">
-        <Badge size="sm" variant="accent" className="uppercase tracking-wider">
-          preview
-        </Badge>
-      </HintTooltip>
+      <Badge
+        size="sm"
+        variant="accent"
+        className="uppercase tracking-wider"
+        title="This rule will be saved on commit"
+      >
+        preview
+      </Badge>
       <span className="ml-auto" />
       {/* No per-row actions in preview mode: the rules don't exist yet, so
           there's nothing to revoke. The user can change the dropdown

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -503,7 +503,8 @@ function RuleRow({
           className="h-6 w-6 text-muted-foreground hover:text-destructive"
           onClick={onAction}
           disabled={disabled}
-          title={pendingDelete ? "Undo delete" : "Revoke rule"}
+          aria-label={pendingDelete ? "Undo delete" : "Revoke rule"}
+          tooltip={pendingDelete ? "Undo delete" : "Revoke rule"}
         >
           {pendingDelete ? (
             <RotateCounterclockwise size={11} />
@@ -543,7 +544,8 @@ function PendingAddRow({
         size="icon"
         className="h-6 w-6 text-muted-foreground hover:text-destructive"
         onClick={onCancel}
-        title="Discard pending rule"
+        aria-label="Discard pending rule"
+        tooltip="Discard pending rule"
       >
         <TrashCan size={11} />
       </Button>

--- a/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
+++ b/packages/ui/src/modules/egress-rules/components/agent-egress-editor.tsx
@@ -634,10 +634,8 @@ function VerdictBadge({ verdict }: { verdict: EgressRuleView["verdict"] }) {
 
 function SourceTag({ label, hint }: { label: string; hint: string }) {
   return (
-    <HintTooltip label={label} content={hint}>
-      <Badge size="sm" variant="muted">
-        {label}
-      </Badge>
-    </HintTooltip>
+    <Badge size="sm" variant="muted" title={hint}>
+      {label}
+    </Badge>
   );
 }

--- a/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
+++ b/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
@@ -191,7 +191,6 @@ export function ExperimentDockPanel({
             variant="ghost"
             size="icon-sm"
             aria-label="Close"
-            tooltip="Close"
             onClick={onClose}
           >
             <Close size={16} />
@@ -345,15 +344,15 @@ function RunArtifacts({
     <div className="max-h-[160px] shrink-0 overflow-y-auto border-t border-border px-4 py-2">
       <SectionLabel className="block pb-1">Run artifacts</SectionLabel>
       {runArtifacts.map((artifact) => (
-        <Tooltip key={artifact.id} content={artifact.title}>
-          <button
-            type="button"
-            onClick={() => setOpenArtifactId(artifact.id)}
-            className="block w-full truncate py-0.5 text-left text-sm text-foreground/90 hover:text-foreground hover:underline"
-          >
-            {artifact.title}
-          </button>
-        </Tooltip>
+        <button
+          key={artifact.id}
+          type="button"
+          onClick={() => setOpenArtifactId(artifact.id)}
+          className="block w-full truncate py-0.5 text-left text-sm text-foreground/90 hover:text-foreground hover:underline"
+          title={artifact.title}
+        >
+          {artifact.title}
+        </button>
       ))}
     </div>
   );

--- a/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
+++ b/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
@@ -257,60 +257,75 @@ function RunInvocations({ feed }: { feed: TraceFeed | undefined }) {
     <div className="max-h-[160px] shrink-0 overflow-y-auto border-t border-border px-4 py-2">
       <SectionLabel className="block pb-1">Invocations</SectionLabel>
       {rows.map((row) => (
-        <Tooltip
-          key={row.id}
-          content={
-            row.agentName === null
-              ? "This subagent has already been cleaned up"
-              : "Open the subagent's chat"
-          }
-        >
-          <button
-            type="button"
-            disabled={row.agentName === null}
-            onClick={() => selectAgent(row.id)}
-            className={cn(
-              "flex w-full items-center gap-2 py-0.5 text-left text-sm",
-              row.agentName === null
-                ? "cursor-default text-muted-foreground"
-                : "text-foreground/90 hover:text-foreground hover:underline",
-            )}
-          >
-            <span
-              className={cn(
-                "size-[7px] shrink-0 rounded-full",
-                // Invocation statuses: running | done | failed.
-                row.waitingForRoom
-                  ? "animate-pulse bg-amber-500"
-                  : row.status === "running"
-                    ? "animate-pulse bg-emerald-500"
-                    : row.status === "failed"
-                      ? "bg-red-500"
-                      : "bg-muted-foreground/45",
-              )}
-            />
-            <span className="min-w-0 flex-1 truncate">
-              {row.agentName ?? (
-                <>
-                  {row.id.slice(0, 8)}…{" "}
-                  <span className="italic text-muted-foreground">
-                    (deleted)
-                  </span>
-                </>
-              )}
-            </span>
-            {row.stage && (
-              <span className="shrink-0 text-[11px] text-muted-foreground">
-                {row.stage}
-              </span>
-            )}
-            <span className="shrink-0 text-[11px] text-muted-foreground">
-              {row.waitingForRoom ? "waiting for room" : row.status}
-            </span>
-          </button>
-        </Tooltip>
+        <InvocationRow key={row.id} row={row} onSelect={selectAgent} />
       ))}
     </div>
+  );
+}
+
+type InvocationRowView = TraceFeed["invocations"][number] & {
+  agentName: string | null;
+  waitingForRoom: boolean;
+  stage: string | null;
+};
+
+function InvocationRow({
+  row,
+  onSelect,
+}: {
+  row: InvocationRowView;
+  onSelect: (id: string) => void;
+}) {
+  const deleted = row.agentName === null;
+  const button = (
+    <button
+      type="button"
+      disabled={deleted}
+      onClick={() => onSelect(row.id)}
+      className={cn(
+        "flex w-full items-center gap-2 py-0.5 text-left text-sm",
+        deleted
+          ? "cursor-default text-muted-foreground"
+          : "text-foreground/90 hover:text-foreground hover:underline",
+      )}
+    >
+      <span
+        className={cn(
+          "size-[7px] shrink-0 rounded-full",
+          // Invocation statuses: running | done | failed.
+          row.waitingForRoom
+            ? "animate-pulse bg-amber-500"
+            : row.status === "running"
+              ? "animate-pulse bg-emerald-500"
+              : row.status === "failed"
+                ? "bg-red-500"
+                : "bg-muted-foreground/45",
+        )}
+      />
+      <span className="min-w-0 flex-1 truncate">
+        {row.agentName ?? (
+          <>
+            {row.id.slice(0, 8)}…{" "}
+            <span className="italic text-muted-foreground">(deleted)</span>
+          </>
+        )}
+      </span>
+      {row.stage && (
+        <span className="shrink-0 text-[11px] text-muted-foreground">
+          {row.stage}
+        </span>
+      )}
+      <span className="shrink-0 text-[11px] text-muted-foreground">
+        {row.waitingForRoom ? "waiting for room" : row.status}
+      </span>
+    </button>
+  );
+  // A disabled button fires neither pointer nor focus events, so a tooltip on
+  // one can never open; the row's own "(deleted)" text carries that instead.
+  return deleted ? (
+    button
+  ) : (
+    <Tooltip content="Open the subagent's chat">{button}</Tooltip>
   );
 }
 

--- a/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
+++ b/packages/ui/src/modules/experiments/components/experiment-dock-panel.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip } from "@/components/ui/tooltip";
 import { emitToast } from "@/lib/toast";
 import { cn } from "@/lib/utils";
 
@@ -126,24 +127,27 @@ export function ExperimentDockPanel({
       <div className="flex h-12 shrink-0 items-center gap-2 border-b border-border px-4">
         {options.length > 1 && onSelect ? (
           <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <button
-                type="button"
-                className="flex min-w-0 flex-1 items-center gap-1 truncate text-left text-sm font-medium text-foreground hover:text-foreground/80"
-                title="Switch experiment"
-              >
-                <span className="min-w-0 truncate">
-                  {experiment.name}
-                  {isDraft && (
-                    <span className="ml-1 text-muted-foreground">(draft)</span>
-                  )}
-                </span>
-                <ChevronDown
-                  size={14}
-                  className="shrink-0 text-muted-foreground"
-                />
-              </button>
-            </DropdownMenuTrigger>
+            <Tooltip content="Switch experiment">
+              <DropdownMenuTrigger asChild>
+                <button
+                  type="button"
+                  className="flex min-w-0 flex-1 items-center gap-1 truncate text-left text-sm font-medium text-foreground hover:text-foreground/80"
+                >
+                  <span className="min-w-0 truncate">
+                    {experiment.name}
+                    {isDraft && (
+                      <span className="ml-1 text-muted-foreground">
+                        (draft)
+                      </span>
+                    )}
+                  </span>
+                  <ChevronDown
+                    size={14}
+                    className="shrink-0 text-muted-foreground"
+                  />
+                </button>
+              </DropdownMenuTrigger>
+            </Tooltip>
             <DropdownMenuContent align="start">
               {options.map((option) => (
                 <DropdownMenuItem
@@ -186,7 +190,8 @@ export function ExperimentDockPanel({
           <Button
             variant="ghost"
             size="icon-sm"
-            title="Close"
+            aria-label="Close"
+            tooltip="Close"
             onClick={onClose}
           >
             <Close size={16} />
@@ -253,53 +258,58 @@ function RunInvocations({ feed }: { feed: TraceFeed | undefined }) {
     <div className="max-h-[160px] shrink-0 overflow-y-auto border-t border-border px-4 py-2">
       <SectionLabel className="block pb-1">Invocations</SectionLabel>
       {rows.map((row) => (
-        <button
+        <Tooltip
           key={row.id}
-          type="button"
-          disabled={row.agentName === null}
-          onClick={() => selectAgent(row.id)}
-          className={cn(
-            "flex w-full items-center gap-2 py-0.5 text-left text-sm",
-            row.agentName === null
-              ? "cursor-default text-muted-foreground"
-              : "text-foreground/90 hover:text-foreground hover:underline",
-          )}
-          title={
+          content={
             row.agentName === null
               ? "This subagent has already been cleaned up"
               : "Open the subagent's chat"
           }
         >
-          <span
+          <button
+            type="button"
+            disabled={row.agentName === null}
+            onClick={() => selectAgent(row.id)}
             className={cn(
-              "size-[7px] shrink-0 rounded-full",
-              // Invocation statuses: running | done | failed.
-              row.waitingForRoom
-                ? "animate-pulse bg-amber-500"
-                : row.status === "running"
-                  ? "animate-pulse bg-emerald-500"
-                  : row.status === "failed"
-                    ? "bg-red-500"
-                    : "bg-muted-foreground/45",
+              "flex w-full items-center gap-2 py-0.5 text-left text-sm",
+              row.agentName === null
+                ? "cursor-default text-muted-foreground"
+                : "text-foreground/90 hover:text-foreground hover:underline",
             )}
-          />
-          <span className="min-w-0 flex-1 truncate">
-            {row.agentName ?? (
-              <>
-                {row.id.slice(0, 8)}…{" "}
-                <span className="italic text-muted-foreground">(deleted)</span>
-              </>
-            )}
-          </span>
-          {row.stage && (
-            <span className="shrink-0 text-[11px] text-muted-foreground">
-              {row.stage}
+          >
+            <span
+              className={cn(
+                "size-[7px] shrink-0 rounded-full",
+                // Invocation statuses: running | done | failed.
+                row.waitingForRoom
+                  ? "animate-pulse bg-amber-500"
+                  : row.status === "running"
+                    ? "animate-pulse bg-emerald-500"
+                    : row.status === "failed"
+                      ? "bg-red-500"
+                      : "bg-muted-foreground/45",
+              )}
+            />
+            <span className="min-w-0 flex-1 truncate">
+              {row.agentName ?? (
+                <>
+                  {row.id.slice(0, 8)}…{" "}
+                  <span className="italic text-muted-foreground">
+                    (deleted)
+                  </span>
+                </>
+              )}
             </span>
-          )}
-          <span className="shrink-0 text-[11px] text-muted-foreground">
-            {row.waitingForRoom ? "waiting for room" : row.status}
-          </span>
-        </button>
+            {row.stage && (
+              <span className="shrink-0 text-[11px] text-muted-foreground">
+                {row.stage}
+              </span>
+            )}
+            <span className="shrink-0 text-[11px] text-muted-foreground">
+              {row.waitingForRoom ? "waiting for room" : row.status}
+            </span>
+          </button>
+        </Tooltip>
       ))}
     </div>
   );
@@ -335,15 +345,15 @@ function RunArtifacts({
     <div className="max-h-[160px] shrink-0 overflow-y-auto border-t border-border px-4 py-2">
       <SectionLabel className="block pb-1">Run artifacts</SectionLabel>
       {runArtifacts.map((artifact) => (
-        <button
-          key={artifact.id}
-          type="button"
-          onClick={() => setOpenArtifactId(artifact.id)}
-          className="block w-full truncate py-0.5 text-left text-sm text-foreground/90 hover:text-foreground hover:underline"
-          title={artifact.title}
-        >
-          {artifact.title}
-        </button>
+        <Tooltip key={artifact.id} content={artifact.title}>
+          <button
+            type="button"
+            onClick={() => setOpenArtifactId(artifact.id)}
+            className="block w-full truncate py-0.5 text-left text-sm text-foreground/90 hover:text-foreground hover:underline"
+          >
+            {artifact.title}
+          </button>
+        </Tooltip>
       ))}
     </div>
   );

--- a/packages/ui/src/modules/experiments/components/lineage-card.tsx
+++ b/packages/ui/src/modules/experiments/components/lineage-card.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Tooltip } from "@/components/ui/tooltip";
 import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
@@ -41,24 +42,26 @@ export function LineageCard({ lineage, openable, onOpen, onDelete }: Props) {
       >
         {/* Closed reads as a plain chevron; open boxes it, so an expanded row is
             obvious without reading the runs below. */}
-        <button
-          type="button"
-          title={expanded ? "Collapse runs" : "Show runs"}
-          aria-expanded={expanded}
-          onClick={(e) => {
-            e.stopPropagation();
-            setExpanded((x) => !x);
-          }}
-          className={cn(
-            "flex shrink-0 items-center justify-center rounded-md transition-all",
-            expanded ? "size-7 border border-border" : "size-5",
-          )}
-        >
-          <DisclosureChevron
-            open={expanded}
-            className={expanded ? "text-foreground" : "text-muted-foreground"}
-          />
-        </button>
+        <Tooltip content={expanded ? "Collapse runs" : "Show runs"}>
+          <button
+            type="button"
+            aria-label={expanded ? "Collapse runs" : "Show runs"}
+            aria-expanded={expanded}
+            onClick={(e) => {
+              e.stopPropagation();
+              setExpanded((x) => !x);
+            }}
+            className={cn(
+              "flex shrink-0 items-center justify-center rounded-md transition-all",
+              expanded ? "size-7 border border-border" : "size-5",
+            )}
+          >
+            <DisclosureChevron
+              open={expanded}
+              className={expanded ? "text-foreground" : "text-muted-foreground"}
+            />
+          </button>
+        </Tooltip>
 
         <div className="flex min-w-0 flex-col gap-[3px]">
           <span className="truncate text-[15px] font-semibold text-foreground">
@@ -77,7 +80,12 @@ export function LineageCard({ lineage, openable, onOpen, onDelete }: Props) {
         <div onClick={(e) => e.stopPropagation()}>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon-sm" title="More actions">
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                aria-label="More actions"
+                tooltip="More actions"
+              >
                 <OverflowMenuVertical size={16} />
               </Button>
             </DropdownMenuTrigger>

--- a/packages/ui/src/modules/experiments/components/lineage-card.tsx
+++ b/packages/ui/src/modules/experiments/components/lineage-card.tsx
@@ -10,7 +10,6 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Tooltip } from "@/components/ui/tooltip";
 import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
@@ -42,26 +41,24 @@ export function LineageCard({ lineage, openable, onOpen, onDelete }: Props) {
       >
         {/* Closed reads as a plain chevron; open boxes it, so an expanded row is
             obvious without reading the runs below. */}
-        <Tooltip content={expanded ? "Collapse runs" : "Show runs"}>
-          <button
-            type="button"
-            aria-label={expanded ? "Collapse runs" : "Show runs"}
-            aria-expanded={expanded}
-            onClick={(e) => {
-              e.stopPropagation();
-              setExpanded((x) => !x);
-            }}
-            className={cn(
-              "flex shrink-0 items-center justify-center rounded-md transition-all",
-              expanded ? "size-7 border border-border" : "size-5",
-            )}
-          >
-            <DisclosureChevron
-              open={expanded}
-              className={expanded ? "text-foreground" : "text-muted-foreground"}
-            />
-          </button>
-        </Tooltip>
+        <button
+          type="button"
+          aria-label={expanded ? "Collapse runs" : "Show runs"}
+          aria-expanded={expanded}
+          onClick={(e) => {
+            e.stopPropagation();
+            setExpanded((x) => !x);
+          }}
+          className={cn(
+            "flex shrink-0 items-center justify-center rounded-md transition-all",
+            expanded ? "size-7 border border-border" : "size-5",
+          )}
+        >
+          <DisclosureChevron
+            open={expanded}
+            className={expanded ? "text-foreground" : "text-muted-foreground"}
+          />
+        </button>
 
         <div className="flex min-w-0 flex-col gap-[3px]">
           <span className="truncate text-[15px] font-semibold text-foreground">
@@ -80,12 +77,7 @@ export function LineageCard({ lineage, openable, onOpen, onDelete }: Props) {
         <div onClick={(e) => e.stopPropagation()}>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                aria-label="More actions"
-                tooltip="More actions"
-              >
+              <Button variant="ghost" size="icon-sm" aria-label="More actions">
                 <OverflowMenuVertical size={16} />
               </Button>
             </DropdownMenuTrigger>

--- a/packages/ui/src/modules/experiments/components/lineage-card.tsx
+++ b/packages/ui/src/modules/experiments/components/lineage-card.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
 import type { LineageRow } from "../lib/sandbox-groups.js";
@@ -32,10 +33,7 @@ export function LineageCard({ lineage, openable, onOpen, onDelete }: Props) {
   return (
     <Card className="overflow-hidden">
       <div
-        role={openable ? "button" : undefined}
-        tabIndex={openable ? 0 : undefined}
-        onClick={openable ? onOpen : undefined}
-        onKeyDown={(e) => openable && e.key === "Enter" && onOpen()}
+        {...clickableProps(openable ? onOpen : undefined)}
         className={cn(
           "flex items-center gap-3 px-[18px] py-4",
           openable && "cursor-pointer transition-colors hover:bg-muted",
@@ -76,10 +74,7 @@ export function LineageCard({ lineage, openable, onOpen, onDelete }: Props) {
         <span className="ml-auto shrink-0">
           <ExperimentStatusBadge status={lineage.badge} />
         </span>
-        <div
-          onClick={(e) => e.stopPropagation()}
-          onKeyDown={(e) => e.stopPropagation()}
-        >
+        <div onClick={(e) => e.stopPropagation()}>
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
               <Button variant="ghost" size="icon-sm" title="More actions">

--- a/packages/ui/src/modules/experiments/components/lineage-runs.tsx
+++ b/packages/ui/src/modules/experiments/components/lineage-runs.tsx
@@ -3,7 +3,6 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { formatDateTime } from "@/lib/format-time";
-import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import { useAgentsList } from "../../agents/api/queries.js";
@@ -149,15 +148,15 @@ function RunRow({
       {extraArtifacts.length > 0 && (
         <div className="mt-1.5 flex flex-wrap gap-1.5">
           {extraArtifacts.map((artifact) => (
-            <Tooltip key={artifact.id} content={artifact.title}>
-              <button
-                type="button"
-                onClick={() => onOpenArtifact(artifact.id)}
-                className="max-w-[220px] truncate rounded-md border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
-              >
-                {artifact.title}
-              </button>
-            </Tooltip>
+            <button
+              key={artifact.id}
+              type="button"
+              onClick={() => onOpenArtifact(artifact.id)}
+              title={artifact.title}
+              className="max-w-[220px] truncate rounded-md border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
+            >
+              {artifact.title}
+            </button>
           ))}
         </div>
       )}

--- a/packages/ui/src/modules/experiments/components/lineage-runs.tsx
+++ b/packages/ui/src/modules/experiments/components/lineage-runs.tsx
@@ -3,6 +3,7 @@ import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { formatDateTime } from "@/lib/format-time";
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import { useAgentsList } from "../../agents/api/queries.js";
@@ -148,15 +149,15 @@ function RunRow({
       {extraArtifacts.length > 0 && (
         <div className="mt-1.5 flex flex-wrap gap-1.5">
           {extraArtifacts.map((artifact) => (
-            <button
-              key={artifact.id}
-              type="button"
-              onClick={() => onOpenArtifact(artifact.id)}
-              title={artifact.title}
-              className="max-w-[220px] truncate rounded-md border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
-            >
-              {artifact.title}
-            </button>
+            <Tooltip key={artifact.id} content={artifact.title}>
+              <button
+                type="button"
+                onClick={() => onOpenArtifact(artifact.id)}
+                className="max-w-[220px] truncate rounded-md border border-border bg-muted/40 px-2 py-0.5 text-[11px] text-foreground/80 transition-colors hover:bg-muted hover:text-foreground"
+              >
+                {artifact.title}
+              </button>
+            </Tooltip>
           ))}
         </div>
       )}

--- a/packages/ui/src/modules/experiments/components/sandbox-group-card.tsx
+++ b/packages/ui/src/modules/experiments/components/sandbox-group-card.tsx
@@ -1,3 +1,4 @@
+import { clickableProps } from "@/lib/clickable";
 import { cn } from "@/lib/utils";
 
 import type { LineageRow, SandboxGroup } from "../lib/sandbox-groups.js";
@@ -25,10 +26,7 @@ export function SandboxGroupCard({
   return (
     <section>
       <div
-        role={deleted ? undefined : "button"}
-        tabIndex={deleted ? undefined : 0}
-        onClick={deleted ? undefined : open}
-        onKeyDown={(e) => !deleted && e.key === "Enter" && open()}
+        {...clickableProps(deleted ? undefined : open)}
         // The hairline under the header is what scopes the group now that the
         // container box is gone.
         className={cn(

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -108,7 +108,8 @@ export function FileRow({
                   className={HOVER_ACTION}
                   onMouseDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
-                  title="More actions"
+                  aria-label="More actions"
+                  tooltip="More actions"
                 >
                   <OverflowMenuHorizontal size={13} />
                 </Button>

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -109,7 +109,6 @@ export function FileRow({
                   onMouseDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
                   aria-label="More actions"
-                  tooltip="More actions"
                 >
                   <OverflowMenuHorizontal size={13} />
                 </Button>

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { HOVER_ACTION } from "@/components/ui/hover-action";
+import { clickableProps } from "@/lib/clickable";
 
 import { useStore } from "../../../store.js";
 import { useFileRowDrag } from "../hooks/use-file-row-drag.js";
@@ -89,9 +90,11 @@ export function FileRow({
         <div
           className={`group relative flex items-center h-8 text-sm cursor-pointer transition-colors ${menuOpen ? "z-raised" : ""} ${highlight ? "bg-muted ring-1 ring-primary ring-inset text-muted-foreground font-medium" : `text-muted-foreground hover:bg-muted ${isDir ? "font-medium" : ""} ${isActive ? "bg-muted" : ""}`}`}
           style={{ paddingLeft: `${12 + depth * 14}px`, paddingRight: 12 }}
-          onClick={
-            isDir ? () => panel.onToggleDir(path) : () => panel.onOpenFile(path)
-          }
+          {...clickableProps(
+            isDir
+              ? () => panel.onToggleDir(path)
+              : () => panel.onOpenFile(path),
+          )}
           {...drag}
         >
           <div

--- a/packages/ui/src/modules/files/components/file-row.tsx
+++ b/packages/ui/src/modules/files/components/file-row.tsx
@@ -20,6 +20,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 
 import { useStore } from "../../../store.js";
 import { useFileRowDrag } from "../hooks/use-file-row-drag.js";
@@ -104,7 +105,7 @@ export function FileRow({
                 <Button
                   variant="ghost"
                   size="icon-xs"
-                  className="opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100"
+                  className={HOVER_ACTION}
                   onMouseDown={(e) => e.stopPropagation()}
                   onClick={(e) => e.stopPropagation()}
                   title="More actions"

--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -197,7 +197,6 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
               size="xs"
               className="text-sm"
               onClick={cancelEdit}
-              title="Cancel"
             >
               <Close size={14} /> Cancel
             </Button>
@@ -207,7 +206,7 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
               className="text-sm"
               onClick={save}
               disabled={!dirty || writeMutation.isPending}
-              title="Save (Cmd/Ctrl+S)"
+              tooltip="Save (Cmd/Ctrl+S)"
             >
               <Save size={14} /> {writeMutation.isPending ? "Saving…" : "Save"}
             </Button>
@@ -220,7 +219,6 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
                 size="xs"
                 className="text-sm"
                 onClick={() => setEditMode(true)}
-                title="Edit file"
               >
                 <Edit size={14} /> Edit
               </Button>
@@ -231,7 +229,6 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
                 size="xs"
                 className="text-sm"
                 onClick={downloadFile}
-                title="Download file"
               >
                 <Download size={14} /> Download
               </Button>
@@ -266,7 +263,8 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
                 size="icon-sm"
                 className="shrink-0"
                 onClick={() => setIsExpanded(true)}
-                title="Open fullscreen"
+                aria-label="Open fullscreen"
+                tooltip="Open fullscreen"
               >
                 <Maximize size={14} />
               </Button>
@@ -278,7 +276,8 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           size="icon-sm"
           className="shrink-0"
           onClick={onClose}
-          title="Close"
+          aria-label="Close"
+          tooltip="Close"
         >
           <Close size={16} />
         </Button>

--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -277,7 +277,6 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
           className="shrink-0"
           onClick={onClose}
           aria-label="Close"
-          tooltip="Close"
         >
           <Close size={16} />
         </Button>

--- a/packages/ui/src/modules/files/components/file-viewer.tsx
+++ b/packages/ui/src/modules/files/components/file-viewer.tsx
@@ -237,24 +237,18 @@ export function FileViewer({ file, onClose, onOpenFile }: Props) {
               <RenderToggle
                 rendered={renderSvg}
                 onToggle={() => setRenderSvg((p) => !p)}
-                rawTitle="Show raw SVG"
-                renderTitle="Render SVG"
               />
             )}
             {isMarkdown && (
               <RenderToggle
                 rendered={renderMd}
                 onToggle={() => setRenderMd((p) => !p)}
-                rawTitle="Show raw"
-                renderTitle="Render markdown"
               />
             )}
             {isHtml && (
               <RenderToggle
                 rendered={renderHtml}
                 onToggle={() => setRenderHtml((p) => !p)}
-                rawTitle="Show raw HTML"
-                renderTitle="Render HTML"
               />
             )}
             {isRenderedPreview && (

--- a/packages/ui/src/modules/files/components/files-panel.tsx
+++ b/packages/ui/src/modules/files/components/files-panel.tsx
@@ -46,7 +46,7 @@ export function FilesPanel({
           size="xs"
           className="text-sm"
           disabled={controller.isUploading}
-          title={controller.isUploading ? "Upload in progress…" : "Add"}
+          tooltip={controller.isUploading ? "Upload in progress…" : "Add"}
         >
           <Add size={12} /> Add
         </Button>

--- a/packages/ui/src/modules/files/components/files-panel.tsx
+++ b/packages/ui/src/modules/files/components/files-panel.tsx
@@ -46,7 +46,7 @@ export function FilesPanel({
           size="xs"
           className="text-sm"
           disabled={controller.isUploading}
-          tooltip={controller.isUploading ? "Upload in progress…" : "Add"}
+          tooltip={controller.isUploading ? "Upload in progress…" : undefined}
         >
           <Add size={12} /> Add
         </Button>

--- a/packages/ui/src/modules/files/components/fullscreen-preview-dialog.tsx
+++ b/packages/ui/src/modules/files/components/fullscreen-preview-dialog.tsx
@@ -46,7 +46,7 @@ export function FullscreenPreviewDialog({ title, onClose, children }: Props) {
           size="sm"
           className="h-auto px-2 py-0.5 text-[11px] font-semibold text-muted-foreground hover:text-primary"
           onClick={onClose}
-          title="Exit fullscreen (Esc)"
+          tooltip="Exit fullscreen (Esc)"
         >
           <Close size={11} /> Close
         </Button>

--- a/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
+++ b/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { HintTooltip } from "@/components/ui/tooltip";
 
 import { useIsImporting } from "../hooks/use-is-importing.js";
 
@@ -11,8 +12,8 @@ export function ImportInProgressBadge({ agentId }: Props) {
   const importing = useIsImporting(agentId);
   if (!importing) return null;
   return (
-    <Badge variant="accent" title="Importing files into the agent">
-      Importing…
-    </Badge>
+    <HintTooltip label="Importing…" content="Importing files into the agent">
+      <Badge variant="accent">Importing…</Badge>
+    </HintTooltip>
   );
 }

--- a/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
+++ b/packages/ui/src/modules/files/components/import-in-progress-badge.tsx
@@ -1,5 +1,4 @@
 import { Badge } from "@/components/ui/badge";
-import { HintTooltip } from "@/components/ui/tooltip";
 
 import { useIsImporting } from "../hooks/use-is-importing.js";
 
@@ -11,9 +10,5 @@ interface Props {
 export function ImportInProgressBadge({ agentId }: Props) {
   const importing = useIsImporting(agentId);
   if (!importing) return null;
-  return (
-    <HintTooltip label="Importing…" content="Importing files into the agent">
-      <Badge variant="accent">Importing…</Badge>
-    </HintTooltip>
-  );
+  return <Badge variant="accent">Importing…</Badge>;
 }

--- a/packages/ui/src/modules/files/components/render-toggle.tsx
+++ b/packages/ui/src/modules/files/components/render-toggle.tsx
@@ -6,28 +6,13 @@ interface Props {
   /** True when the rendered view is showing; false shows the raw source. */
   rendered: boolean;
   onToggle: () => void;
-  /** Tooltip shown while rendered (i.e. the action switches to raw). */
-  rawTitle: string;
-  /** Tooltip shown while raw (i.e. the action switches to rendered). */
-  renderTitle: string;
 }
 
 /** Toolbar button that flips a previewable file between its rendered view and
  * raw source. Shared by the SVG, markdown, and HTML file-viewer previews. */
-export function RenderToggle({
-  rendered,
-  onToggle,
-  rawTitle,
-  renderTitle,
-}: Props) {
+export function RenderToggle({ rendered, onToggle }: Props) {
   return (
-    <Button
-      variant="outline"
-      size="xs"
-      className="text-sm"
-      onClick={onToggle}
-      tooltip={rendered ? rawTitle : renderTitle}
-    >
+    <Button variant="outline" size="xs" className="text-sm" onClick={onToggle}>
       {rendered ? <Code size={14} /> : <View size={14} />}
       {rendered ? "Raw" : "Render"}
     </Button>

--- a/packages/ui/src/modules/files/components/render-toggle.tsx
+++ b/packages/ui/src/modules/files/components/render-toggle.tsx
@@ -26,7 +26,7 @@ export function RenderToggle({
       size="xs"
       className="text-sm"
       onClick={onToggle}
-      title={rendered ? rawTitle : renderTitle}
+      tooltip={rendered ? rawTitle : renderTitle}
     >
       {rendered ? <Code size={14} /> : <View size={14} />}
       {rendered ? "Raw" : "Render"}

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-base-config-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-base-config-view.tsx
@@ -121,7 +121,6 @@ export function KnowledgeBaseConfigView() {
           <span
             role="alert"
             className="inline-flex items-center gap-1.5 text-xs text-warning"
-            title="A wildcard host '*' rule is in scope. Any unmatched egress is allowed."
           >
             <span aria-hidden="true">⚠</span>
             Allow everything is on — narrow with deny rules or remove the

--- a/packages/ui/src/modules/providers/components/anthropic/form.tsx
+++ b/packages/ui/src/modules/providers/components/anthropic/form.tsx
@@ -147,7 +147,7 @@ export function AnthropicForm({
           variant="outline"
           onClick={test}
           disabled={submitDisabled}
-          title="Verify the credential with Anthropic"
+          tooltip="Verify the credential with Anthropic"
           className="shrink-0"
         >
           {testing ? "..." : "Test"}
@@ -195,7 +195,8 @@ function QuickSetupHint() {
           variant="ghost"
           size="icon-xs"
           onClick={copy}
-          title="Copy command"
+          aria-label="Copy command"
+          tooltip="Copy command"
         >
           {copied ? (
             <Checkmark size={12} className="text-success" />

--- a/packages/ui/src/modules/providers/components/bob/form.tsx
+++ b/packages/ui/src/modules/providers/components/bob/form.tsx
@@ -8,6 +8,7 @@ import { FormField } from "@/components/form-field";
 import { Button } from "@/components/ui/button";
 import { DisclosureToggle } from "@/components/ui/disclosure";
 import { Input } from "@/components/ui/input";
+import { externalLinkProps } from "@/lib/external-link";
 
 import { BOB_CHAT_MODES, type BobModelPins } from "../../../../types.js";
 import { ProviderFormShell } from "../provider-form-shell.js";
@@ -113,8 +114,7 @@ export function BobForm({
             : "IBM's AI shell assistant. Paste a Bob API key of type Inference to get started."}{" "}
           <a
             href="https://bob.ibm.com/admin/apikeys"
-            target="_blank"
-            rel="noopener noreferrer"
+            {...externalLinkProps}
             className="text-primary hover:underline inline-flex items-center gap-1"
           >
             Manage keys <Launch size={11} />

--- a/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
@@ -6,6 +6,7 @@ import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { KEY_GUIDE_URL } from "@/constants.js";
+import { externalLinkProps } from "@/lib/external-link";
 
 import { ProviderFormShell } from "../provider-form-shell.js";
 import { MODES, stripWhitespace } from "./modes.js";
@@ -63,8 +64,7 @@ export function IbmLitellmForm({
     >
       <a
         href={KEY_GUIDE_URL}
-        target="_blank"
-        rel="noopener noreferrer"
+        {...externalLinkProps}
         className="group flex items-start justify-between gap-3 rounded-lg border border-border p-3 transition-colors hover:bg-muted/40"
       >
         <div className="flex flex-col gap-0.5">

--- a/packages/ui/src/modules/providers/components/icon-button.tsx
+++ b/packages/ui/src/modules/providers/components/icon-button.tsx
@@ -11,13 +11,14 @@ import { cn } from "@/lib/utils";
  */
 export function IconButton({
   onClick,
-  title,
+  label,
   hoverTone,
   className,
   children,
 }: {
   onClick: () => void | Promise<void>;
-  title: string;
+  /** Names the button and doubles as its tooltip — there is no visible text. */
+  label: string;
   hoverTone: "accent" | "danger" | "neutral";
   className?: string;
   children: ReactNode;
@@ -34,7 +35,8 @@ export function IconButton({
       variant="ghost"
       size="icon"
       onClick={onClick}
-      title={title}
+      aria-label={label}
+      tooltip={label}
       className={cn("h-7 w-7", tone, className)}
     >
       {children}

--- a/packages/ui/src/modules/providers/components/icon-button.tsx
+++ b/packages/ui/src/modules/providers/components/icon-button.tsx
@@ -17,7 +17,6 @@ export function IconButton({
   children,
 }: {
   onClick: () => void | Promise<void>;
-  /** Names the button and doubles as its tooltip — there is no visible text. */
   label: string;
   hoverTone: "accent" | "danger" | "neutral";
   className?: string;
@@ -36,7 +35,6 @@ export function IconButton({
       size="icon"
       onClick={onClick}
       aria-label={label}
-      tooltip={label}
       className={cn("h-7 w-7", tone, className)}
     >
       {children}

--- a/packages/ui/src/modules/providers/components/provider-form-shell.tsx
+++ b/packages/ui/src/modules/providers/components/provider-form-shell.tsx
@@ -33,7 +33,7 @@ export function ProviderFormShell({
         {onCancel && (
           <IconButton
             onClick={onCancel}
-            title="Cancel"
+            label="Cancel"
             hoverTone="neutral"
             className="-mt-2 -mr-2 shrink-0"
           >

--- a/packages/ui/src/modules/sandboxes/components/channels/channel-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/channels/channel-card.tsx
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import { CARD_SURFACE } from "@/components/ui/card";
+import { PanelCard } from "@/components/ui/panel-card";
 
 import { ConnectionIcon } from "../../../connections/components/connection-icon.js";
 
@@ -16,20 +16,20 @@ export function ChannelCard({
   children: ReactNode;
 }) {
   return (
-    <section data-testid={`channel-card-${iconSlug}`} className={CARD_SURFACE}>
-      <header className="flex h-[52px] items-center gap-2.5 border-b border-border px-4">
+    <PanelCard
+      testId={`channel-card-${iconSlug}`}
+      title={title}
+      headerRight={headerRight}
+      icon={
         <ConnectionIcon
           iconSlug={iconSlug}
           alt=""
           size={16}
           className="shrink-0"
         />
-        <h3 className="min-w-0 flex-1 truncate text-[15px] font-semibold text-foreground">
-          {title}
-        </h3>
-        {headerRight}
-      </header>
+      }
+    >
       {children}
-    </section>
+    </PanelCard>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/channels/telegram-channel-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/channels/telegram-channel-card.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { externalLinkProps } from "@/lib/external-link";
 
 import { getBrand } from "../../../../brand.js";
 import { useUnbindTelegramChat } from "../../../telegram/api/mutations.js";
@@ -25,8 +26,7 @@ export function TelegramChannelCard({ agentId }: { agentId: string }) {
             <a
               className="font-medium text-accent hover:underline"
               href={`https://t.me/${handle}`}
-              target="_blank"
-              rel="noreferrer"
+              {...externalLinkProps}
             >
               @{handle}
             </a>

--- a/packages/ui/src/modules/sandboxes/components/open-in-menu.tsx
+++ b/packages/ui/src/modules/sandboxes/components/open-in-menu.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { externalLinkProps } from "@/lib/external-link";
 
 import { CLI_REFERENCE_URL } from "../../../constants.js";
 import { useStore } from "../../../store.js";
@@ -65,8 +66,7 @@ function CliQuickstartNote() {
       First time? Installing the CLI and logging in is covered in the{" "}
       <a
         href={CLI_REFERENCE_URL}
-        target="_blank"
-        rel="noreferrer"
+        {...externalLinkProps}
         className="inline-flex items-center gap-1 font-medium text-foreground hover:underline"
       >
         CLI quickstart <Launch size={13} />

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -95,7 +95,6 @@ export function SandboxHomeHeader({ agent, display }: Props) {
                 variant="outline"
                 size="icon"
                 aria-label="Sandbox actions"
-                tooltip="Sandbox actions"
               >
                 <OverflowMenuVertical />
               </Button>

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -91,7 +91,12 @@ export function SandboxHomeHeader({ agent, display }: Props) {
           <OpenInMenu agent={agent} />
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
-              <Button variant="outline" size="icon" title="Sandbox actions">
+              <Button
+                variant="outline"
+                size="icon"
+                aria-label="Sandbox actions"
+                tooltip="Sandbox actions"
+              >
                 <OverflowMenuVertical />
               </Button>
             </DropdownMenuTrigger>

--- a/packages/ui/src/modules/sandboxes/components/skills/built-in-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/built-in-skills-group.tsx
@@ -3,7 +3,6 @@ import type { LocalSkill } from "api-server-api";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { SectionLabel } from "@/components/ui/section-label";
-import { HintTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 /** Image-shipped Local Skills, split out of "Created in this sandbox"
@@ -56,13 +55,13 @@ function BuiltInSkillRow({
         </p>
       </div>
       {skill.origin === "system-modified" && (
-        <HintTooltip
-          label="Modified"
-          content="This skill's files differ from the copy shipped in the sandbox image"
+        <Badge
+          variant="warning"
           className="shrink-0"
+          title="This skill's files differ from the copy shipped in the sandbox image"
         >
-          <Badge variant="warning">Modified</Badge>
-        </HintTooltip>
+          Modified
+        </Badge>
       )}
     </div>
   );

--- a/packages/ui/src/modules/sandboxes/components/skills/built-in-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/built-in-skills-group.tsx
@@ -3,6 +3,7 @@ import type { LocalSkill } from "api-server-api";
 import { Badge } from "@/components/ui/badge";
 import { Card } from "@/components/ui/card";
 import { SectionLabel } from "@/components/ui/section-label";
+import { HintTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 /** Image-shipped Local Skills, split out of "Created in this sandbox"
@@ -55,13 +56,13 @@ function BuiltInSkillRow({
         </p>
       </div>
       {skill.origin === "system-modified" && (
-        <Badge
-          variant="warning"
+        <HintTooltip
+          label="Modified"
+          content="This skill's files differ from the copy shipped in the sandbox image"
           className="shrink-0"
-          title="This skill's files differ from the copy shipped in the sandbox image"
         >
-          Modified
-        </Badge>
+          <Badge variant="warning">Modified</Badge>
+        </HintTooltip>
       )}
     </div>
   );

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-render-modal.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-render-modal.tsx
@@ -4,6 +4,7 @@ import type { Skill, SkillSource } from "api-server-api";
 
 import { Markdown } from "@/components/markdown";
 import { DialogBody, DialogHeader, Modal } from "@/components/modal";
+import { Tooltip } from "@/components/ui/tooltip";
 import { externalLinkProps } from "@/lib/external-link";
 import { gitBlobUrl } from "@/lib/git-source";
 
@@ -48,14 +49,16 @@ export function SkillRenderModal({
         truncateTitle
         titleAccessory={
           link && (
-            <a
-              href={link}
-              {...externalLinkProps}
-              className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-              title="View SKILL.md on GitHub"
-            >
-              <Launch size={15} />
-            </a>
+            <Tooltip content="View SKILL.md on GitHub">
+              <a
+                href={link}
+                {...externalLinkProps}
+                aria-label="View SKILL.md on GitHub"
+                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <Launch size={15} />
+              </a>
+            </Tooltip>
           )
         }
         subtitle={

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-render-modal.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-render-modal.tsx
@@ -4,6 +4,7 @@ import type { Skill, SkillSource } from "api-server-api";
 
 import { Markdown } from "@/components/markdown";
 import { DialogBody, DialogHeader, Modal } from "@/components/modal";
+import { externalLinkProps } from "@/lib/external-link";
 import { gitBlobUrl } from "@/lib/git-source";
 
 import { trpc } from "../../../../trpc.js";
@@ -49,8 +50,7 @@ export function SkillRenderModal({
           link && (
             <a
               href={link}
-              target="_blank"
-              rel="noopener noreferrer"
+              {...externalLinkProps}
               className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
               title="View SKILL.md on GitHub"
             >

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-row.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-row.tsx
@@ -4,6 +4,7 @@ import type { Skill } from "api-server-api";
 import { badgeVariants } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { Tooltip } from "@/components/ui/tooltip";
 import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
@@ -60,28 +61,31 @@ export function SkillRow({
             </p>
           )}
           {hasDrift && (
-            <button
-              type="button"
-              onClick={onUpdate}
-              disabled={disabled}
-              title="Upstream changed since install — update to the latest version"
-              className={cn(
-                badgeVariants({ variant: "info", size: "sm" }),
-                "shrink-0 gap-1 px-2 text-[11px] transition-opacity hover:opacity-80 disabled:opacity-50",
-              )}
-            >
-              <Renew size={11} /> Update
-            </button>
+            <Tooltip content="Upstream changed since install — update to the latest version">
+              <button
+                type="button"
+                onClick={onUpdate}
+                disabled={disabled}
+                className={cn(
+                  badgeVariants({ variant: "info", size: "sm" }),
+                  "shrink-0 gap-1 px-2 text-[11px] transition-opacity hover:opacity-80 disabled:opacity-50",
+                )}
+              >
+                <Renew size={11} /> Update
+              </button>
+            </Tooltip>
           )}
           {hasDrift && compareUrl && (
-            <a
-              href={compareUrl}
-              {...externalLinkProps}
-              title="View changes on GitHub"
-              className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
-            >
-              <Compare size={13} />
-            </a>
+            <Tooltip content="View changes on GitHub">
+              <a
+                href={compareUrl}
+                {...externalLinkProps}
+                aria-label="View changes on GitHub"
+                className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <Compare size={13} />
+              </a>
+            </Tooltip>
           )}
         </div>
         {skill.description && (

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-row.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-row.tsx
@@ -8,6 +8,9 @@ import { Tooltip } from "@/components/ui/tooltip";
 import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
+const DRIFT_HINT =
+  "Upstream changed since install — update to the latest version";
+
 /**
  * One skill inside a source card: name (+ drift "Update" affordance) and
  * description on the left, an immediate install/uninstall toggle on the right.
@@ -61,11 +64,14 @@ export function SkillRow({
             </p>
           )}
           {hasDrift && (
-            <Tooltip content="Upstream changed since install — update to the latest version">
+            <Tooltip content={DRIFT_HINT}>
               <button
                 type="button"
                 onClick={onUpdate}
                 disabled={disabled}
+                /* A disabled button opens no tooltip, so the hint falls back to
+                   `title` exactly where "why can't I click this?" is asked. */
+                title={disabled ? DRIFT_HINT : undefined}
                 className={cn(
                   badgeVariants({ variant: "info", size: "sm" }),
                   "shrink-0 gap-1 px-2 text-[11px] transition-opacity hover:opacity-80 disabled:opacity-50",

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-row.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-row.tsx
@@ -4,6 +4,7 @@ import type { Skill } from "api-server-api";
 import { badgeVariants } from "@/components/ui/badge";
 import { Spinner } from "@/components/ui/spinner";
 import { Switch } from "@/components/ui/switch";
+import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
 /**
@@ -75,8 +76,7 @@ export function SkillRow({
           {hasDrift && compareUrl && (
             <a
               href={compareUrl}
-              target="_blank"
-              rel="noopener noreferrer"
+              {...externalLinkProps}
               title="View changes on GitHub"
               className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"
             >

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { Spinner } from "@/components/ui/spinner";
+import { externalLinkProps } from "@/lib/external-link";
 import { gitCompareUrl, repoSlug } from "@/lib/git-source";
 import { parsePlatformCta } from "@/lib/platform-cta";
 import { cn } from "@/lib/utils";
@@ -49,8 +50,7 @@ function SourceError({
       {cta ? (
         <a
           href={cta}
-          target="_blank"
-          rel="noopener noreferrer"
+          {...externalLinkProps}
           className="shrink-0 font-semibold underline hover:opacity-80"
         >
           Fix it →

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
@@ -182,7 +182,6 @@ export function SkillSourceCard({
                 variant="ghost"
                 size="icon-sm"
                 aria-label="Source actions"
-                tooltip="Source actions"
                 className="shrink-0 text-muted-foreground"
               >
                 <OverflowMenuHorizontal size={18} />

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
@@ -181,7 +181,8 @@ export function SkillSourceCard({
               <Button
                 variant="ghost"
                 size="icon-sm"
-                title="Source actions"
+                aria-label="Source actions"
+                tooltip="Source actions"
                 className="shrink-0 text-muted-foreground"
               >
                 <OverflowMenuHorizontal size={18} />

--- a/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
@@ -184,7 +184,7 @@ export function SkillSourceCard({
                 aria-label="Source actions"
                 className="shrink-0 text-muted-foreground"
               >
-                <OverflowMenuHorizontal size={18} />
+                <OverflowMenuHorizontal size={16} />
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>

--- a/packages/ui/src/modules/sandboxes/components/skills/skills-surface.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skills-surface.tsx
@@ -12,6 +12,7 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/ui/callout";
 import { SectionLabel } from "@/components/ui/section-label";
+import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
 import { useStore } from "../../../../store.js";
@@ -112,12 +113,7 @@ export function SkillsSurface({
           // newline whitespace that would otherwise separate them.
           <>
             {" The "}
-            <a
-              href={pub.prUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="underline"
-            >
+            <a href={pub.prUrl} {...externalLinkProps} className="underline">
               pull request
             </a>{" "}
             you published to {pub.sourceName} isn't withdrawn.

--- a/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SectionLabel } from "@/components/ui/section-label";
+import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
 /**
@@ -143,8 +144,7 @@ export function StandaloneSkillsGroup({
               {pub ? (
                 <a
                   href={pub.prUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  {...externalLinkProps}
                   className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-info-light px-2.5 py-1 text-xs font-medium text-info transition-opacity hover:opacity-80"
                   title={`Pull request open on ${pub.sourceName}`}
                 >

--- a/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
@@ -18,6 +18,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SectionLabel } from "@/components/ui/section-label";
+import { Tooltip } from "@/components/ui/tooltip";
 import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
@@ -142,21 +143,22 @@ export function StandaloneSkillsGroup({
               </div>
 
               {pub ? (
-                <a
-                  href={pub.prUrl}
-                  {...externalLinkProps}
-                  className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-info-light px-2.5 py-1 text-xs font-medium text-info transition-opacity hover:opacity-80"
-                  title={`Pull request open on ${pub.sourceName}`}
-                >
-                  <PullRequest size={13} /> In review · {pub.sourceName}
-                </a>
+                <Tooltip content={`Pull request open on ${pub.sourceName}`}>
+                  <a
+                    href={pub.prUrl}
+                    {...externalLinkProps}
+                    className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-info-light px-2.5 py-1 text-xs font-medium text-info transition-opacity hover:opacity-80"
+                  >
+                    <PullRequest size={13} /> In review · {pub.sourceName}
+                  </a>
+                </Tooltip>
               ) : (
                 <Button
                   variant="outline"
                   size="xs"
                   disabled={!canPublish}
                   onClick={() => onPublish(skill)}
-                  title={
+                  tooltip={
                     canPublish
                       ? "Publish this skill as a pull request"
                       : "Add a GitHub source first to publish there"
@@ -172,7 +174,8 @@ export function StandaloneSkillsGroup({
                   <Button
                     variant="ghost"
                     size="icon-sm"
-                    title="Skill actions"
+                    aria-label="Skill actions"
+                    tooltip="Skill actions"
                     className="shrink-0 text-muted-foreground"
                   >
                     <OverflowMenuHorizontal size={18} />

--- a/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
@@ -18,7 +18,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SectionLabel } from "@/components/ui/section-label";
-import { Tooltip } from "@/components/ui/tooltip";
 import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
@@ -143,15 +142,13 @@ export function StandaloneSkillsGroup({
               </div>
 
               {pub ? (
-                <Tooltip content={`Pull request open on ${pub.sourceName}`}>
-                  <a
-                    href={pub.prUrl}
-                    {...externalLinkProps}
-                    className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-info-light px-2.5 py-1 text-xs font-medium text-info transition-opacity hover:opacity-80"
-                  >
-                    <PullRequest size={13} /> In review · {pub.sourceName}
-                  </a>
-                </Tooltip>
+                <a
+                  href={pub.prUrl}
+                  {...externalLinkProps}
+                  className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-info-light px-2.5 py-1 text-xs font-medium text-info transition-opacity hover:opacity-80"
+                >
+                  <PullRequest size={13} /> In review · {pub.sourceName}
+                </a>
               ) : (
                 <Button
                   variant="outline"

--- a/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
@@ -175,7 +175,6 @@ export function StandaloneSkillsGroup({
                     variant="ghost"
                     size="icon-sm"
                     aria-label="Skill actions"
-                    tooltip="Skill actions"
                     className="shrink-0 text-muted-foreground"
                   >
                     <OverflowMenuHorizontal size={18} />

--- a/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/standalone-skills-group.tsx
@@ -177,7 +177,7 @@ export function StandaloneSkillsGroup({
                     aria-label="Skill actions"
                     className="shrink-0 text-muted-foreground"
                   >
-                    <OverflowMenuHorizontal size={18} />
+                    <OverflowMenuHorizontal size={16} />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent>

--- a/packages/ui/src/modules/sandboxes/components/skills/upload-skills-tab.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/upload-skills-tab.tsx
@@ -213,7 +213,8 @@ function StagedSkillRow({
       <Button
         variant="ghost"
         size="icon-xs"
-        title="Rename skill"
+        aria-label="Rename skill"
+        tooltip="Rename skill"
         onClick={onStartRename}
         className="shrink-0 text-muted-foreground"
       >
@@ -222,7 +223,8 @@ function StagedSkillRow({
       <Button
         variant="ghost"
         size="icon-xs"
-        title="Remove skill"
+        aria-label="Remove skill"
+        tooltip="Remove skill"
         onClick={onRemove}
         className="shrink-0 text-muted-foreground"
       >

--- a/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { CARD_SURFACE } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { CUSTOM_IMAGE_DOCS_URL } from "@/constants";
 import { externalLinkProps } from "@/lib/external-link";
@@ -34,7 +35,8 @@ export function CustomImageCard({
   return (
     <div
       className={cn(
-        "rounded-lg border px-4 py-4",
+        CARD_SURFACE,
+        "px-4 py-4 transition-colors",
         selected ? "border-foreground" : "border-border",
       )}
     >

--- a/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/custom-image-card.tsx
@@ -1,6 +1,7 @@
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
 import { CUSTOM_IMAGE_DOCS_URL } from "@/constants";
+import { externalLinkProps } from "@/lib/external-link";
 import { cn } from "@/lib/utils";
 
 import type { RegistryCredential } from "../registry-credential-section.js";
@@ -45,8 +46,7 @@ export function CustomImageCard({
         Bring your own ACP-compatible image{" "}
         <a
           href={CUSTOM_IMAGE_DOCS_URL}
-          target="_blank"
-          rel="noreferrer"
+          {...externalLinkProps}
           className="text-sm text-muted-foreground underline underline-offset-2 hover:text-primary"
         >
           Learn more

--- a/packages/ui/src/modules/sandboxes/components/steps/selectable-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/selectable-card.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
 
+import { cardSelectionVariants } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
 
 export function SelectableCard({
@@ -16,14 +17,7 @@ export function SelectableCard({
   children: ReactNode;
 }) {
   return (
-    <div
-      className={cn(
-        "relative rounded-lg border p-4 transition-colors",
-        selected
-          ? "border-foreground bg-muted/60"
-          : "border-border bg-card hover:bg-muted/40",
-      )}
-    >
+    <div className={cn(cardSelectionVariants({ selected }), "relative p-4")}>
       {/* Stretched overlay so a nested link can sit above it, which a real <button> can't wrap. */}
       <button
         type="button"

--- a/packages/ui/src/modules/sandboxes/components/steps/workload-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/steps/workload-card.tsx
@@ -1,3 +1,5 @@
+import { externalLinkProps } from "@/lib/external-link";
+
 import type { TemplateView } from "../../../../types.js";
 import { CardContent } from "./card-content.js";
 import { SelectableCard } from "./selectable-card.js";
@@ -23,8 +25,7 @@ export function WorkloadCard({
         {template.docsUrl && (
           <a
             href={template.docsUrl}
-            target="_blank"
-            rel="noreferrer"
+            {...externalLinkProps}
             className="pointer-events-auto inline-block w-fit text-sm text-muted-foreground underline underline-offset-2 hover:text-primary"
           >
             Learn more

--- a/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
+++ b/packages/ui/src/modules/sandboxes/views/sandbox-home-view.tsx
@@ -45,7 +45,6 @@ export function SandboxHomeView() {
         <span
           role="alert"
           className="mr-auto inline-flex items-center gap-1.5 text-xs text-warning"
-          title="A wildcard host '*' rule is in scope. Any unmatched egress is allowed."
         >
           <span aria-hidden="true">⚠</span>
           Allow everything is on — narrow with deny rules or remove the

--- a/packages/ui/src/modules/schedules/forms/schedule-form-modal.tsx
+++ b/packages/ui/src/modules/schedules/forms/schedule-form-modal.tsx
@@ -14,7 +14,7 @@ import { SearchableSelect } from "@/components/ui/searchable-select";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Select } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
-import { Tooltip } from "@/components/ui/tooltip";
+import { HintTooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import { FormError } from "../../../components/form-error.js";
@@ -264,9 +264,14 @@ export function ScheduleFormModal({
           <div className="flex flex-col gap-2">
             <div className="flex items-center gap-1.5">
               <SectionLabel>Session type</SectionLabel>
-              <Tooltip content={SESSION_TOOLTIP} side="top">
-                <Information size={14} className="text-muted-foreground" />
-              </Tooltip>
+              <HintTooltip
+                content={SESSION_TOOLTIP}
+                label="About session types"
+                side="top"
+                className="text-muted-foreground"
+              >
+                <Information size={14} />
+              </HintTooltip>
             </div>
             <Controller
               control={control}

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -262,6 +262,7 @@ function AttachmentChip({
         variant="destructive"
         size="icon"
         onClick={onRemove}
+        aria-label="Remove attachment"
         className={cn(
           "absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full",
           HOVER_ACTION,

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -8,7 +8,9 @@ import {
 } from "react";
 
 import { Button } from "@/components/ui/button";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
 
 import { useAutoResize } from "../../../hooks/use-auto-resize.js";
 import { isMobile } from "../../../lib/breakpoints.js";
@@ -257,7 +259,10 @@ function AttachmentChip({
         variant="destructive"
         size="icon"
         onClick={onRemove}
-        className="absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full opacity-0 group-hover:opacity-100 transition-opacity"
+        className={cn(
+          "absolute -top-1.5 -right-1.5 h-5 w-5 rounded-full",
+          HOVER_ACTION,
+        )}
       >
         <Close size={10} />
       </Button>

--- a/packages/ui/src/modules/sessions/components/chat-input.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-input.tsx
@@ -186,7 +186,8 @@ export function ChatInput({
               className="shrink-0 mb-[9px] h-10 w-10 text-muted-foreground hover:text-primary disabled:opacity-40"
               onClick={() => fileInputRef.current?.click()}
               disabled={loadingSession}
-              title="Attach file"
+              aria-label="Attach file"
+              tooltip="Attach file"
             >
               <Add size={16} />
             </Button>
@@ -208,7 +209,8 @@ export function ChatInput({
                 size="icon-sm"
                 className="shrink-0 mb-[9px] h-10 w-10"
                 onClick={onStop}
-                title="Stop"
+                aria-label="Stop"
+                tooltip="Stop"
               >
                 <Stop size={16} />
               </Button>
@@ -220,7 +222,8 @@ export function ChatInput({
                 className={`shrink-0 mb-[9px] h-10 w-10 ${hasContent ? "text-foreground" : "text-muted-foreground"} disabled:opacity-40`}
                 onClick={send}
                 disabled={sendDisabled || loadingSession}
-                title={isComputing ? "Queue" : "Send"}
+                aria-label={isComputing ? "Queue" : "Send"}
+                tooltip={isComputing ? "Queue" : "Send"}
               >
                 <SendAltFilled size={16} />
               </Button>

--- a/packages/ui/src/modules/sessions/components/permission-prompt.tsx
+++ b/packages/ui/src/modules/sessions/components/permission-prompt.tsx
@@ -209,7 +209,7 @@ export function PermissionPrompt({
                 size="sm"
                 onClick={() => pick(opt)}
                 className="bg-background h-[26px] text-sm font-medium max-w-full"
-                title={`${opt.name} — press ${i + 1}`}
+                tooltip={`${opt.name} — press ${i + 1}`}
               >
                 <span className="truncate">{opt.name}</span>
               </Button>

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -171,7 +171,6 @@ export function SessionRow({
             className={cn("shrink-0", HOVER_ACTION)}
             onClick={(e) => e.stopPropagation()}
             aria-label="More actions"
-            tooltip="More actions"
           >
             <OverflowMenuVertical size={16} />
           </Button>
@@ -262,8 +261,9 @@ function SessionIndicators({
       {needsApproval ? (
         <span
           data-testid="session-approval-dot"
+          role="img"
+          aria-label="Needs your approval"
           className="w-2 h-2 rounded-full bg-accent shrink-0"
-          title="Needs your approval"
         />
       ) : working ? (
         <WorkingDots className="text-accent" title="Working" />

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -20,8 +20,8 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { formatTimestamp } from "@/lib/format-time";
 import { HOVER_ACTION } from "@/components/ui/hover-action";
+import { formatTimestamp } from "@/lib/format-time";
 import { cn } from "@/lib/utils";
 
 import { formatTokens, formatUsdCell } from "../../metrics/lib/format.js";

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { HOVER_ACTION } from "@/components/ui/hover-action";
+import { clickableProps } from "@/lib/clickable";
 import { formatTimestamp } from "@/lib/format-time";
 import { cn } from "@/lib/utils";
 
@@ -121,7 +122,7 @@ export function SessionRow({
         "group relative flex items-center gap-1 px-4 py-3 cursor-pointer border-b border-border transition-colors select-none",
         active ? "bg-muted" : "hover:bg-muted/60",
       )}
-      onClick={handleClick}
+      {...clickableProps(handleClick)}
       onTouchStart={startPress}
       onTouchEnd={endPress}
       onTouchCancel={endPress}

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -21,6 +21,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { formatTimestamp } from "@/lib/format-time";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { cn } from "@/lib/utils";
 
 import { formatTokens, formatUsdCell } from "../../metrics/lib/format.js";
@@ -167,7 +168,7 @@ export function SessionRow({
             data-testid="session-menu-button"
             variant="ghost"
             size="icon-xs"
-            className="shrink-0 opacity-0 group-hover:opacity-100 focus:opacity-100 data-[state=open]:opacity-100"
+            className={cn("shrink-0", HOVER_ACTION)}
             onClick={(e) => e.stopPropagation()}
             title="More actions"
           >

--- a/packages/ui/src/modules/sessions/components/session-row.tsx
+++ b/packages/ui/src/modules/sessions/components/session-row.tsx
@@ -170,7 +170,8 @@ export function SessionRow({
             size="icon-xs"
             className={cn("shrink-0", HOVER_ACTION)}
             onClick={(e) => e.stopPropagation()}
-            title="More actions"
+            aria-label="More actions"
+            tooltip="More actions"
           >
             <OverflowMenuVertical size={16} />
           </Button>

--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Spinner } from "@/components/ui/spinner";
+import { Tooltip } from "@/components/ui/tooltip";
 
 import { useStore } from "../../../store.js";
 import type { SessionView } from "../../../types.js";
@@ -252,17 +253,18 @@ export function SessionsSidebar({
           </SectionLabel>
         )}
         {launchingRun && (
-          <button
-            type="button"
-            onClick={focusPendingLaunch}
-            className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/50"
-            title="Show the launch progress"
-          >
-            <Spinner />
-            <span className="min-w-0 flex-1 truncate">
-              Starting run — waking the agent…
-            </span>
-          </button>
+          <Tooltip content="Show the launch progress">
+            <button
+              type="button"
+              onClick={focusPendingLaunch}
+              className="flex w-full items-center gap-2 px-4 py-2 text-left text-sm text-muted-foreground transition-colors hover:bg-muted/50"
+            >
+              <Spinner />
+              <span className="min-w-0 flex-1 truncate">
+                Starting run — waking the agent…
+              </span>
+            </button>
+          </Tooltip>
         )}
         {runSessions.map(renderRow)}
       </div>

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -28,6 +28,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { Spinner } from "@/components/ui/spinner";
 import { formatBytes } from "@/lib/format-size";
 import { cn } from "@/lib/utils";
@@ -487,7 +488,7 @@ export function ChatView() {
                 variant="ghost"
                 size="icon-xs"
                 aria-label={surfaceCopy.actionsAria}
-                className="opacity-100 md:opacity-0 md:group-hover:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
+                className={HOVER_ACTION}
               >
                 <OverflowMenuVertical size={14} />
               </Button>

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -30,8 +30,8 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { Spinner } from "@/components/ui/spinner";
-import { formatBytes } from "@/lib/format-size";
 import { Tooltip } from "@/components/ui/tooltip";
+import { formatBytes } from "@/lib/format-size";
 import { cn } from "@/lib/utils";
 
 import { Markdown } from "../../../components/markdown.js";

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -31,6 +31,7 @@ import {
 import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { Spinner } from "@/components/ui/spinner";
 import { formatBytes } from "@/lib/format-size";
+import { Tooltip } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 
 import { Markdown } from "../../../components/markdown.js";
@@ -817,15 +818,16 @@ export function ChatView() {
                 {!hasPendingPermission && harnessCurrent?.model && (
                   <div className="px-4 md:px-8">
                     <ChatColumn>
-                      <button
-                        type="button"
-                        onClick={handleConfigureSandbox}
-                        title={surfaceCopy.modelTitle}
-                        className="flex items-center gap-1 pl-3 text-sm text-muted-foreground hover:text-foreground transition-colors"
-                      >
-                        {harnessCurrent.model}
-                        <Settings size={12} />
-                      </button>
+                      <Tooltip content={surfaceCopy.modelTitle}>
+                        <button
+                          type="button"
+                          onClick={handleConfigureSandbox}
+                          className="flex items-center gap-1 pl-3 text-sm text-muted-foreground hover:text-foreground transition-colors"
+                        >
+                          {harnessCurrent.model}
+                          <Settings size={12} />
+                        </button>
+                      </Tooltip>
                     </ChatColumn>
                   </div>
                 )}


### PR DESCRIPTION
The long tail of interaction fixes left after the primitive consolidation — individually small, mostly about how things behave rather than how they look.

**Keyboard and touch reach the whole UI now.** Clickable rows and cards answer Space as well as Enter. Hover-revealed row menus stay visible on a phone, where nothing can hover them, and appear when focused rather than leaving you tabbed onto something invisible. Hints that used to be browser tooltips — unreachable without a mouse — come from the shared tooltip, which keyboard and touch can both open.

**Tooltips only where they say something new.** An unfamiliar glyph gets named; a shortcut, a consequence ("writes a wildcard rule") or a reason a button is disabled gets explained. The overflow menu, the close ✕, a disclosure arrow and the brand mark get nothing — the icon is already its own label.

**One version of each surface.** The connection, channel and catalogue cards share a header. Cards you pick from share one selected look, so the sandbox starting-point step no longer shows two of them side by side. A checkbox with a label and description matches the radio button equivalent, which the API key scopes now use. Every link that leaves the app opens the same way.

Also: the component generator pointed at an icon library the project doesn't install, so anything scaffolded from it imported a missing package.

Closes #3054

https://claude.ai/code/session_016b96BopGRYL8bUG2wUTJSX
