### PR TITLE
fix(skills): make doc-drift report caller-agnostic

### DIFF
--- a/.agents/skills/adr-policy/SKILL.md
+++ b/.agents/skills/adr-policy/SKILL.md
@@ -18,8 +18,8 @@ time. The ADR model is an immutable event log with two projections (architecture
 generated index).
 
 Enforcement is split by what needs judgment. This skill owns **log integrity and
-decision judgment**. It does **not** rewrite ADRs — it surfaces findings, the user
-decides.
+decision judgment**. It does **not** rewrite ADRs — its output is a set of findings;
+acting on them is separate work outside this skill.
 
 ## Scope: the ADR log only
 
@@ -91,9 +91,9 @@ If nothing is wrong, the section is just the immutability `✅` line.
 
 ## Guidelines
 
-- **Read-only.** Never edit ADRs; propose, the user decides. Fixing a re-litigation or
-  summary problem means authoring or amending an ADR through the [`/adr`](../adr/SKILL.md)
-  flow, not editing here.
+- **Read-only.** This skill never edits ADRs — it only surfaces findings. Fixing a
+  re-litigation or summary problem is separate work outside this skill's run: authoring
+  or amending an ADR through the [`/adr`](../adr/SKILL.md) flow, not editing here.
 - **Never own immutability.** The script is authoritative. This skill only relays it.
 - **One pass with doc-drift.** On a PR touching `docs/adrs/` or `docs/architecture/`, the
   code-review agent runs this skill and [`doc-drift`](../doc-drift/SKILL.md) together and

--- a/.agents/skills/doc-drift/SKILL.md
+++ b/.agents/skills/doc-drift/SKILL.md
@@ -105,9 +105,9 @@ verdict.
 This skill may run as one sub-step of a longer process — for example, one section of a broader
 code review whose caller embeds the report and continues with its own remaining steps. The
 report is then an intermediate result, not the final deliverable, and what the caller does
-with it is not this skill's concern. Nothing in the report may read as a completion or
-termination signal, and it must carry no imperatives aimed at the caller — no "done", "no
-further action needed", "present this to the user", "stop here", or the like.
+with it is not this skill's concern. The report contains findings only: a verdict, drift
+entries, and possible-drift questions. It states no conclusion about the surrounding process
+and addresses no instruction to the caller.
 
 ## Guidelines
 

--- a/.agents/skills/doc-drift/SKILL.md
+++ b/.agents/skills/doc-drift/SKILL.md
@@ -21,8 +21,8 @@ Reviews code changes against the project's **architecture documentation** under
 > When your work changes the behavior or responsibility of a subsystem, update its page in the same PR.
 
 This skill operationalizes that rule, **and only that rule**. It reads the diff, reads the
-architecture pages, and reports mismatches. It does **not** rewrite docs — fixes are proposed,
-the user decides.
+architecture pages, and reports mismatches. It does **not** rewrite docs — its output is a set
+of findings with proposed edits; applying any of them is separate work outside this skill.
 
 ## Scope: architecture docs only
 
@@ -90,7 +90,8 @@ Each check is grounded in code changes observed in the diff and lands inside
 
 ## Report
 
-Take the subagent's output and present a focused report to the user:
+The skill's result is a focused drift report — a structured finding, not an act of delivery.
+Assemble the checks' output into this format:
 
 - **Verdict** — one line: `aligned`, `minor drift`, or `significant drift`.
 - **Drift** — every ❌, with file/line evidence and the proposed edit. Group by check number.
@@ -101,9 +102,17 @@ check-7 state-change signal) must not appear anywhere in the report — not in e
 not as a parenthetical, not as a footnote. If there is nothing to flag, the report is just the
 verdict.
 
+This skill may run as one sub-step of a longer process — for example, one section of a broader
+code review whose caller embeds the report and continues with its own remaining steps. The
+report is then an intermediate result, not the final deliverable, and what the caller does
+with it is not this skill's concern. Nothing in the report may read as a completion or
+termination signal, and it must carry no imperatives aimed at the caller — no "done", "no
+further action needed", "present this to the user", "stop here", or the like.
+
 ## Guidelines
 
-- **Read-only by default.** Do not edit docs unless the user accepts the proposed fixes.
+- **Read-only.** This skill never edits documentation — it only proposes fixes inside its
+  findings. Applying a proposed fix is separate follow-up work outside this skill's run.
 - **The documentation guidelines are the sole rulebook.** Do not invent rules. Do not flag things
   the guidelines don't forbid (e.g., short architecture pages — there is no length cap).
 - **Trivial changes are exempt.** README typos, comment-only edits, dependency bumps with no


### PR DESCRIPTION
## Problem

The `doc-drift` skill is invoked two ways: (a) directly by a user via `/doc-drift`, and (b) as one sub-step of a longer automated code-review pipeline, where the calling agent embeds its output as one section of a larger review and must continue with further steps.

The `## Report` and `## Guidelines` sections were written only for case (a) and, read as a sub-step, worked as a stop signal:

- "Take the subagent's output and present a focused report to the user"
- "fixes are proposed, the user decides"
- "Read-only by default. Do not edit docs unless the user accepts the proposed fixes"

Measured impact: 5 of 5 incomplete pipeline reviews ended exactly at the boundary where doc-drift finished its report — the review was never delivered and the run's work (~64k output tokens) was discarded.

## Change

Wording only — the substantive rules of both skills (doc-drift checks 1–7, scope, direction of drift; adr-policy checks) are untouched:

**doc-drift:**
- The report is described as the skill's **output**, not an act of delivery to the user; what the caller does with it is not the skill's concern.
- "the user decides" / "unless the user accepts" removed as termination conditions. Read-only is now stated as a property of the skill: it never edits docs, it only proposes fixes; applying them is separate work outside the skill's run.
- New explicit paragraph: the skill may run as a sub-step of a longer process and its report is then an intermediate result. Per review feedback, the rule is stated positively (the report contains findings only and addresses no instruction to the caller) rather than as a negated list that would quote the termination phrases verbatim.

**adr-policy** (review finding): carried the same "the user decides" phrasing in its intro and Guidelines, and is documented as co-invoked with doc-drift in the same one-pass code review — so the same failure mode was reachable through it. Both spots now state read-only as a property of the skill, matching doc-drift.

## Acceptance

No instruction remains in either skill that reads as "end of work" when it runs as a sub-step; direct `/doc-drift` and `/adr-policy` invocations are unaffected — the report is still the skill's visible result.