### PR TITLE
feat(agents): port skydiscover run conventions to shinkaevolve, gepa, openevolve

### DIFF
--- a/packages/agents/gepa/AGENTS.md
+++ b/packages/agents/gepa/AGENTS.md
@@ -183,7 +183,9 @@ the session goes idle. The run directory lives on persistent `$HOME`, so the
 run is recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its
-`run.pid` is dead and it hasn't exhausted its budget, reinstall any extra deps
+`run.pid` no longer names the live run (the same cmdline-validated check as the
+start-of-conversation scan — a recycled PID after a pod restart must not
+skip the resume) and it hasn't exhausted its budget, reinstall any extra deps
 (the venv reset) and relaunch the **identical** driver — same `run_dir`, same
 `max_metric_calls`. GEPA detects the existing state in `run_dir`, restores it,
 and continues only up to the original budget — the budget is a **total**, not

--- a/packages/agents/gepa/AGENTS.md
+++ b/packages/agents/gepa/AGENTS.md
@@ -57,7 +57,8 @@ run. This file is the *how-to-operate-in-this-pod* layer.
 ## Starting a conversation
 
 At the **start of every new conversation**, before anything else, enumerate
-existing runs and offer to act on them. Scan `$GEPA_OUTPUT_ROOT` (`~/gepa-runs`)
+existing runs and offer to act on them. Scan `$GEPA_OUTPUT_ROOT`
+(`~/work/gepa-runs`)
 for run directories (each has a `driver.py` and a `run_dir/`) and classify each
 as:
 
@@ -106,7 +107,8 @@ estimate, but an informed user may pre-authorize it (see below).
 4. **You've presented a budget/cost estimate.** State the `max_metric_calls`
    you'll set, the resulting rough LLM-call count (metric calls for the task
    model, plus roughly one reflection call per iteration for the strong
-   model), that it runs autonomously, and the keep-awake tradeoff (below).
+   model), that it runs autonomously, and that the running work holds the
+   pod awake (no scale-to-zero) until it finishes.
    Then **wait for an explicit go-ahead — unless the user already
    pre-authorized this run** ("just launch it," "don't ask"):
    pre-authorization waives the *wait*, never the estimate — show the numbers,
@@ -115,14 +117,32 @@ estimate, but an informed user may pre-authorize it (see below).
 
 ## Run discipline
 
-- **Launch backgrounded** so you stay conversational and can poll while it
-  runs. Keep the PID and log in the run directory:
+- **First run in this pod:** create the runs root lazily —
+  `mkdir -p "$GEPA_OUTPUT_ROOT"`. It is deliberately never baked into the
+  image: a pre-seeded folder would make the work dir non-empty and block the
+  platform's repo seed (which clones into the work-dir root and refuses a
+  non-empty dir). If `~/work` is a seeded git repo, also append
+  `gepa-runs/` to `.git/info/exclude` (a local ignore — never touch tracked
+  files) so the checkout stays clean; any target repo the run needs is
+  cloned inside the run directory, so outputs never touch it either way.
+- **Launch as a harness background task** (your backgrounded-Bash facility),
+  never a bare detached `nohup … &`. The platform's background-work contract
+  reports harness-registered tasks to the runtime: the pod is held awake for
+  as long as the run lives, and the finishing task wakes you for a follow-up
+  turn — **report the result to the user then** (the best candidate and the
+  `run_dir/` path), don't wait to be asked. A detached `nohup` process is
+  invisible to that contract, so the pod can hibernate mid-run. Still keep
+  the PID and log in the run directory for monitoring and crash recovery:
 
   ```sh
+  # run this script AS a backgrounded harness task (your Bash tool's
+  # run_in_background) — NEVER as a foreground command: the tool's timeout
+  # would SIGTERM the whole process group, run included, mid-flight
   dir="$GEPA_OUTPUT_ROOT/<run-id>"
   cd "$dir"
-  nohup python driver.py > run.log 2>&1 &
+  python driver.py > run.log 2>&1 &
   echo $! > run.pid
+  wait
   ```
 
 - **Always pass `run_dir`** in the driver, pointing inside the run's directory
@@ -155,10 +175,12 @@ but the uv cache is on persistent `$HOME`, so reinstall extras after a restart
 
 ## Surviving hibernation (resume-on-wake)
 
-The pod **scales to zero when the session goes idle** — no active turn, no
-queued prompt, no open terminal/SSH session. That kills any background driver.
-The run directory lives on persistent `$HOME`, so the run is recoverable but
-**does not progress while you're not engaged**.
+With the launch discipline above, a running optimization **holds the pod
+awake** (reported background work) and hibernation mid-run is the exception,
+not the rule. It can still happen — a pod restart or eviction, a crash, or a
+run launched the legacy detached way — and then the pod scales to zero once
+the session goes idle. The run directory lives on persistent `$HOME`, so the
+run is recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its
 `run.pid` is dead and it hasn't exhausted its budget, reinstall any extra deps
@@ -170,12 +192,11 @@ a per-invocation count, so never inflate it on resume (and remove a leftover
 reached its budget is done; raising the budget is a new, re-gated decision,
 not a resume.
 
-**Keep-awake escape hatch:** for a long optimization that must progress
-continuously (e.g. overnight), tell the user to keep a **terminal or SSH
-session open** to this agent — that pins the pod awake, so a backgrounded run
-completes without hibernation gaps. Genuinely unattended overnight progress is
-a future capability; today a run advances only while you're engaged or a
-session is open.
+**Keep-awake escape hatch (legacy fallback):** if a run somehow lives outside
+the background-work contract (launched detached, or the report was refused),
+an open **terminal or SSH session** pins the pod awake until it finishes —
+but the primary mechanism is launching as a reported harness task in the
+first place.
 
 ## Hard guardrails
 
@@ -222,9 +243,12 @@ Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
 
 ## Where things live
 
-- **Per-run directory** = `$GEPA_OUTPUT_ROOT/<run-id>/` (`~/gepa-runs`, on
-  persistent `$HOME`). Holds `driver.py`, the dataset, any `repo/` clone,
-  `run.pid`, `run.log` (driver stdout), and `run_dir/` (GEPA's own state).
+- **Per-run directory** = `$GEPA_OUTPUT_ROOT/<run-id>/` (`~/work/gepa-runs`,
+  in the work dir — where the UI file browser and the terminal land — on
+  persistent `$HOME`; created lazily, see Run discipline). Holds `driver.py`,
+  the dataset, any `repo/` clone, `run.pid`, `run.log` (driver stdout), and
+  `run_dir/` (GEPA's own state). Always give the user the full path when
+  reporting.
 - **GEPA state** under `run_dir/`: `gepa_state.bin` (the checkpoint that makes
   reruns resume), `run_log.txt` (iteration log), `candidates.json` (every
   candidate proposed so far), and `generated_best_outputs_valset/` (best

--- a/packages/agents/gepa/AGENTS.md
+++ b/packages/agents/gepa/AGENTS.md
@@ -141,8 +141,8 @@ estimate, but an informed user may pre-authorize it (see below).
   dir="$GEPA_OUTPUT_ROOT/<run-id>"
   cd "$dir"
   python driver.py > run.log 2>&1 &
-  echo $! > run.pid
-  wait
+  pid=$!; echo "$pid" > run.pid
+  wait "$pid"
   ```
 
 - **Always pass `run_dir`** in the driver, pointing inside the run's directory

--- a/packages/agents/gepa/Dockerfile
+++ b/packages/agents/gepa/Dockerfile
@@ -34,10 +34,11 @@ ENV PATH="/opt/gepa-venv/bin:${PATH}"
 # behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
 COPY AGENTS.md /etc/AGENTS.md
 
-# /app/working-dir is seeded onto persistent $HOME on first boot
-ENV GEPA_OUTPUT_ROOT=/home/agent/gepa-runs
-RUN mkdir -p /app/working-dir/gepa-runs &&\
-    chown -R 65532:0 /app/working-dir/gepa-runs
+# Runs live in the work dir (where the UI and terminal look), created lazily
+# by the agent at first run — NEVER pre-baked here: the first-boot seed would
+# make the work dir non-empty and the platform's repo seed (which clones into
+# the work-dir root and refuses a non-empty dir) would fail.
+ENV GEPA_OUTPUT_ROOT=/home/agent/work/gepa-runs
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
 

--- a/packages/agents/openevolve/AGENTS.md
+++ b/packages/agents/openevolve/AGENTS.md
@@ -45,7 +45,18 @@ existing runs and offer to act on them. Scan `$OPENEVOLVE_OUTPUT_ROOT`
 (`~/work/openevolve-runs`) for run directories (each has a `config.yaml` and an
 output dir) and classify each as:
 
-- **running** — its `run.pid` names a live process (`kill -0 "$(cat run.pid)"`).
+- **running** — its `run.pid` names a live process **that is actually the
+  run**:
+
+  ```sh
+  pid=$(cat run.pid) && kill -0 "$pid" 2>/dev/null \
+    && tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q openevolve-run
+  ```
+
+  The cmdline check is not optional: a pod restart resets the PID namespace,
+  so a stale `run.pid` on persistent `$HOME` can name an unrelated live
+  process — bare `kill -0` would misclassify a dead run as running and
+  silently skip its resume.
 - **not running** — finished, stopped, or paused by a pod hibernation (below).
 
 Present the grouped list, then offer a status pull (tail the log, read
@@ -112,8 +123,8 @@ an informed user may pre-authorize it (see below).
   openevolve-run program.py evaluator.py -c config.yaml \
     -o "$dir/output" -i <N> -l INFO \
     > run.log 2>&1 &
-  echo $! > run.pid
-  wait
+  pid=$!; echo "$pid" > run.pid
+  wait "$pid"
   ```
 
 - **Always pass an explicit `--output`** on the **persisted** workspace

--- a/packages/agents/openevolve/AGENTS.md
+++ b/packages/agents/openevolve/AGENTS.md
@@ -158,7 +158,9 @@ session goes idle. The output dir lives on persistent `$HOME`, so the run is
 recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its `run.pid`
-is dead and it hasn't reached its budget, reinstall the run's deps (the venv
+no longer names the live run (the same cmdline-validated check as the
+start-of-conversation scan — a recycled PID after a pod restart must not
+skip the resume) and it hasn't reached its budget, reinstall the run's deps (the venv
 reset) and resume from the latest checkpoint with `--checkpoint`. One non-obvious
 catch — `-i` counts the iterations *this invocation* runs, not an absolute cap, so
 on a resume it runs that many **more**: pass the **remaining** budget

--- a/packages/agents/openevolve/AGENTS.md
+++ b/packages/agents/openevolve/AGENTS.md
@@ -42,7 +42,7 @@ pod* layer.
 
 At the **start of every new conversation**, before anything else, enumerate
 existing runs and offer to act on them. Scan `$OPENEVOLVE_OUTPUT_ROOT`
-(`~/openevolve-runs`) for run directories (each has a `config.yaml` and an
+(`~/work/openevolve-runs`) for run directories (each has a `config.yaml` and an
 output dir) and classify each as:
 
 - **running** — its `run.pid` names a live process (`kill -0 "$(cat run.pid)"`).
@@ -75,8 +75,9 @@ an informed user may pre-authorize it (see below).
    catches the silent failure mode where the evaluator runs but scores the wrong
    thing.
 4. **You've presented an iteration/cost estimate.** State the rough call count
-   (≈ iterations × models-per-iteration), that it runs autonomously, and the
-   keep-awake tradeoff (below). Then **wait for an explicit go-ahead — unless the
+   (≈ iterations × models-per-iteration), that it runs autonomously, and that
+   the running work holds the pod awake (no scale-to-zero) until it
+   finishes. Then **wait for an explicit go-ahead — unless the
    user already pre-authorized this run** ("just launch it," "don't ask"):
    pre-authorization waives the *wait*, never the estimate — show the numbers,
    then launch. (Resuming an already-approved run after hibernation needs no new
@@ -84,16 +85,35 @@ an informed user may pre-authorize it (see below).
 
 ## Run discipline
 
-- **Launch backgrounded** so you stay conversational and can poll while it runs.
-  Keep the PID and log in the run directory:
+- **First run in this pod:** create the runs root lazily —
+  `mkdir -p "$OPENEVOLVE_OUTPUT_ROOT"`. It is deliberately never baked into
+  the image: a pre-seeded folder would make the work dir non-empty and block
+  the platform's repo seed (which clones into the work-dir root and refuses a
+  non-empty dir). If `~/work` is a seeded git repo, also append
+  `openevolve-runs/` to `.git/info/exclude` (a local ignore — never touch
+  tracked files) so the checkout stays clean; the run's own target clone
+  lives inside the run directory, so outputs never touch it either way.
+- **Launch as a harness background task** (your backgrounded-Bash facility),
+  never a bare detached `nohup … &`. The platform's background-work contract
+  reports harness-registered tasks to the runtime: the pod is held awake for
+  as long as the run lives, and the finishing task wakes you for a follow-up
+  turn — **report the result to the user then** (best `combined_score` and
+  the `output/best/` path), don't wait to be asked. A detached `nohup`
+  process is invisible to that contract, so the pod can hibernate mid-run.
+  Still keep the PID and log in the run directory for monitoring and crash
+  recovery:
 
   ```sh
+  # run this script AS a backgrounded harness task (your Bash tool's
+  # run_in_background) — NEVER as a foreground command: the tool's timeout
+  # would SIGTERM the whole process group, run included, mid-flight
   dir="$OPENEVOLVE_OUTPUT_ROOT/<run-id>"
   cd "$dir"
-  nohup openevolve-run program.py evaluator.py -c config.yaml \
+  openevolve-run program.py evaluator.py -c config.yaml \
     -o "$dir/output" -i <N> -l INFO \
     > run.log 2>&1 &
   echo $! > run.pid
+  wait
   ```
 
 - **Always pass an explicit `--output`** on the **persisted** workspace
@@ -119,10 +139,12 @@ install up front rather than chasing failures.
 
 ## Surviving hibernation (resume-on-wake)
 
-The pod **scales to zero when the session goes idle** — no active turn, no
-queued prompt, no open terminal/SSH session. That kills any background
-`openevolve-run`. The output dir lives on persistent `$HOME`, so the run is
-recoverable but **does not progress while you're not engaged**.
+With the launch discipline above, a running evolution **holds the pod awake**
+(reported background work) and hibernation mid-run is the exception, not the
+rule. It can still happen — a pod restart or eviction, a crash, or a run
+launched the legacy detached way — and then the pod scales to zero once the
+session goes idle. The output dir lives on persistent `$HOME`, so the run is
+recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its `run.pid`
 is dead and it hasn't reached its budget, reinstall the run's deps (the venv
@@ -134,11 +156,11 @@ that checkpoint), not the original `-i`, or it overshoots. A run that's reached
 its budget is done; going further is a new, re-gated decision, not a resume.
 (Lower `checkpoint_interval` if a short run needs to leave a resumable checkpoint.)
 
-**Keep-awake escape hatch:** for a long evolution that must progress
-continuously (e.g. overnight), tell the user to keep a **terminal or SSH session
-open** to this agent — that pins the pod awake, so a backgrounded run completes
-without hibernation gaps. Genuinely unattended overnight progress is a future
-capability; today a run advances only while you're engaged or a session is open.
+**Keep-awake escape hatch (legacy fallback):** if a run somehow lives outside
+the background-work contract (launched detached, or the report was refused),
+an open **terminal or SSH session** pins the pod awake until it finishes —
+but the primary mechanism is launching as a reported harness task in the
+first place.
 
 ## Hard guardrails
 
@@ -176,9 +198,12 @@ Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
 
 ## Where things live
 
-- **Per-run directory** = `$OPENEVOLVE_OUTPUT_ROOT/<run-id>/` (`~/openevolve-runs`,
-  on persistent `$HOME`). Holds `program.py`, `evaluator.py`, `config.yaml`, the
-  `repo/` clone, `run.pid`, `run.log`, and OpenEvolve's `output/`.
+- **Per-run directory** = `$OPENEVOLVE_OUTPUT_ROOT/<run-id>/`
+  (`~/work/openevolve-runs`, in the work dir — where the UI file browser and
+  the terminal land — on persistent `$HOME`; created lazily, see Run
+  discipline). Holds `program.py`, `evaluator.py`, `config.yaml`, the
+  `repo/` clone, `run.pid`, `run.log`, and OpenEvolve's `output/`. Always
+  give the user the full path when reporting.
 - **OpenEvolve output** under `output/`: `best/best_program.*` +
   `best/best_program_info.json` (the winner + its metrics), `checkpoints/checkpoint_<N>/`
   (resumable state), `logs/`.

--- a/packages/agents/openevolve/Dockerfile
+++ b/packages/agents/openevolve/Dockerfile
@@ -32,12 +32,11 @@ ENV PATH="/opt/openevolve-venv/bin:${PATH}"
 # behavioral policy (pre-launch gate, resume-on-wake, guardrails) lives here.
 COPY AGENTS.md /etc/AGENTS.md
 
-# Run outputs (target clones + checkpoints) persist on $HOME. /app/working-dir is
-# ephemeral image content the agent init seeds into $HOME on first boot, so create
-# the dir under the seed and point the env at the persisted path.
-ENV OPENEVOLVE_OUTPUT_ROOT=/home/agent/openevolve-runs
-RUN mkdir -p /app/working-dir/openevolve-runs &&\
-    chown -R 65532:0 /app/working-dir/openevolve-runs
+# Runs live in the work dir (where the UI and terminal look), created lazily
+# by the agent at first run — NEVER pre-baked here: the first-boot seed would
+# make the work dir non-empty and the platform's repo seed (which clones into
+# the work-dir root and refuses a non-empty dir) would fail.
+ENV OPENEVOLVE_OUTPUT_ROOT=/home/agent/work/openevolve-runs
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
 

--- a/packages/agents/shinkaevolve/AGENTS.md
+++ b/packages/agents/shinkaevolve/AGENTS.md
@@ -46,7 +46,18 @@ existing runs and offer to act on them. Scan `$SHINKA_OUTPUT_ROOT`
 (`~/work/shinka-runs`) for run directories (each has a `task/` and a `results/`
 dir) and classify each as:
 
-- **running** — its `run.pid` names a live process (`kill -0 "$(cat run.pid)"`).
+- **running** — its `run.pid` names a live process **that is actually the
+  run**:
+
+  ```sh
+  pid=$(cat run.pid) && kill -0 "$pid" 2>/dev/null \
+    && tr '\0' ' ' < "/proc/$pid/cmdline" | grep -q shinka_run
+  ```
+
+  The cmdline check is not optional: a pod restart resets the PID namespace,
+  so a stale `run.pid` on persistent `$HOME` can name an unrelated live
+  process — bare `kill -0` would misclassify a dead run as running and
+  silently skip its resume.
 - **not running** — finished, stopped, or paused by a pod hibernation (below).
 
 Present the grouped list, then offer a status pull (tail `run.log`, count
@@ -115,8 +126,8 @@ estimate, but an informed user may pre-authorize it (see below).
     --set evo.llm_models='["local/<model>@<url>?api_key_env=OPENAI_API_KEY"]' \
     --set evo.embedding_model=null \
     > run.log 2>&1 &
-  echo $! > run.pid
-  wait
+  pid=$!; echo "$pid" > run.pid
+  wait "$pid"
   ```
 
 - **Always pass an explicit `--results_dir`** on the **persisted** workspace

--- a/packages/agents/shinkaevolve/AGENTS.md
+++ b/packages/agents/shinkaevolve/AGENTS.md
@@ -165,7 +165,9 @@ session goes idle. The results dir lives on persistent `$HOME`, so the run is
 recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its
-`run.pid` is dead and it hasn't reached its budget, reinstall the run's deps
+`run.pid` no longer names the live run (the same cmdline-validated check as the
+start-of-conversation scan — a recycled PID after a pod restart must not
+skip the resume) and it hasn't reached its budget, reinstall the run's deps
 (the venv reset) and relaunch the **identical** `shinka_run` command — same
 `--task-dir`, same `--results_dir`, same `--num_generations`. ShinkaEvolve
 detects the existing `results/programs.sqlite`, restores the population, and

--- a/packages/agents/shinkaevolve/AGENTS.md
+++ b/packages/agents/shinkaevolve/AGENTS.md
@@ -43,7 +43,7 @@ Consult it whenever you set up a run. This file is the
 
 At the **start of every new conversation**, before anything else, enumerate
 existing runs and offer to act on them. Scan `$SHINKA_OUTPUT_ROOT`
-(`~/shinka-runs`) for run directories (each has a `task/` and a `results/`
+(`~/work/shinka-runs`) for run directories (each has a `task/` and a `results/`
 dir) and classify each as:
 
 - **running** — its `run.pid` names a live process (`kill -0 "$(cat run.pid)"`).
@@ -77,7 +77,8 @@ estimate, but an informed user may pre-authorize it (see below).
    wrong thing.
 4. **You've presented a generation/cost estimate.** State the rough call count
    (≈ generations × models-per-generation, plus evaluations), that it runs
-   autonomously, and the keep-awake tradeoff (below). Then **wait for an
+   autonomously, and that the running work holds the pod awake (no
+   scale-to-zero) until it finishes. Then **wait for an
    explicit go-ahead — unless the user already pre-authorized this run** ("just
    launch it," "don't ask"): pre-authorization waives the *wait*, never the
    estimate — show the numbers, then launch. (Resuming an already-approved run
@@ -85,18 +86,37 @@ estimate, but an informed user may pre-authorize it (see below).
 
 ## Run discipline
 
-- **Launch backgrounded** so you stay conversational and can poll while it
-  runs. Keep the PID and log in the run directory:
+- **First run in this pod:** create the runs root lazily —
+  `mkdir -p "$SHINKA_OUTPUT_ROOT"`. It is deliberately never baked into the
+  image: a pre-seeded folder would make the work dir non-empty and block the
+  platform's repo seed (which clones into the work-dir root and refuses a
+  non-empty dir). If `~/work` is a seeded git repo, also append
+  `shinka-runs/` to `.git/info/exclude` (a local ignore — never touch
+  tracked files) so the checkout stays clean; the run's own target clone
+  lives inside the run directory, so outputs never touch it either way.
+- **Launch as a harness background task** (your backgrounded-Bash facility),
+  never a bare detached `nohup … &`. The platform's background-work contract
+  reports harness-registered tasks to the runtime: the pod is held awake for
+  as long as the run lives, and the finishing task wakes you for a follow-up
+  turn — **report the result to the user then** (best `combined_score`, the
+  objective metric, and where the winner lives in `results/`), don't wait to
+  be asked. A detached `nohup` process is invisible to that contract, so the
+  pod can hibernate mid-run. Still keep the PID and log in the run directory
+  for monitoring and crash recovery:
 
   ```sh
+  # run this script AS a backgrounded harness task (your Bash tool's
+  # run_in_background) — NEVER as a foreground command: the tool's timeout
+  # would SIGTERM the whole process group, run included, mid-flight
   dir="$SHINKA_OUTPUT_ROOT/<run-id>"
   cd "$dir"
-  nohup shinka_run --task-dir "$dir/task" --results_dir "$dir/results" \
+  shinka_run --task-dir "$dir/task" --results_dir "$dir/results" \
     --num_generations <N> \
     --set evo.llm_models='["local/<model>@<url>?api_key_env=OPENAI_API_KEY"]' \
     --set evo.embedding_model=null \
     > run.log 2>&1 &
   echo $! > run.pid
+  wait
   ```
 
 - **Always pass an explicit `--results_dir`** on the **persisted** workspace
@@ -126,10 +146,12 @@ uv cache is on persistent `$HOME`, so reinstall after a restart — it's fast.
 
 ## Surviving hibernation (resume-on-wake)
 
-The pod **scales to zero when the session goes idle** — no active turn, no
-queued prompt, no open terminal/SSH session. That kills any background
-`shinka_run`. The results dir lives on persistent `$HOME`, so the run is
-recoverable but **does not progress while you're not engaged**.
+With the launch discipline above, a running evolution **holds the pod awake**
+(reported background work) and hibernation mid-run is the exception, not the
+rule. It can still happen — a pod restart or eviction, a crash, or a run
+launched the legacy detached way — and then the pod scales to zero once the
+session goes idle. The results dir lives on persistent `$HOME`, so the run is
+recoverable but **does not progress while the pod is down**.
 
 So at the **start of each turn**, check any run you care about: if its
 `run.pid` is dead and it hasn't reached its budget, reinstall the run's deps
@@ -141,12 +163,11 @@ is a **total**, not a per-invocation count, so never inflate it on resume. A
 run that's reached its budget is done; raising the budget is a new, re-gated
 decision, not a resume.
 
-**Keep-awake escape hatch:** for a long evolution that must progress
-continuously (e.g. overnight), tell the user to keep a **terminal or SSH
-session open** to this agent — that pins the pod awake, so a backgrounded run
-completes without hibernation gaps. Genuinely unattended overnight progress is
-a future capability; today a run advances only while you're engaged or a
-session is open.
+**Keep-awake escape hatch (legacy fallback):** if a run somehow lives outside
+the background-work contract (launched detached, or the report was refused),
+an open **terminal or SSH session** pins the pod awake until it finishes —
+but the primary mechanism is launching as a reported harness task in the
+first place.
 
 ## Hard guardrails
 
@@ -188,9 +209,12 @@ Envoy injects the real credential on the wire to the allowed GitHub hosts. So:
 
 ## Where things live
 
-- **Per-run directory** = `$SHINKA_OUTPUT_ROOT/<run-id>/` (`~/shinka-runs`, on
-  persistent `$HOME`). Holds `task/` (`initial.<ext>`, `evaluate.py`), the
-  `repo/` clone, `run.pid`, `run.log`, and `results/`.
+- **Per-run directory** = `$SHINKA_OUTPUT_ROOT/<run-id>/`
+  (`~/work/shinka-runs`, in the work dir — where the UI file browser and the
+  terminal land — on persistent `$HOME`; created lazily, see Run discipline).
+  Holds `task/` (`initial.<ext>`, `evaluate.py`), the `repo/` clone,
+  `run.pid`, `run.log`, and `results/`. Always give the user the full path
+  when reporting.
 - **ShinkaEvolve results** under `results/`: `programs.sqlite` (the population —
   candidates, scores, lineage; the source of truth for "best so far") and
   per-generation folders, each holding the candidate `main.<ext>` and its

--- a/packages/agents/shinkaevolve/Dockerfile
+++ b/packages/agents/shinkaevolve/Dockerfile
@@ -45,10 +45,11 @@ ENV PATH="/opt/shinka-venv/bin:${PATH}"
 # behavioral policy; claude-code symlinks /etc/claude-code/CLAUDE.md here
 COPY AGENTS.md /etc/AGENTS.md
 
-# /app/working-dir is seeded onto persistent $HOME on first boot
-ENV SHINKA_OUTPUT_ROOT=/home/agent/shinka-runs
-RUN mkdir -p /app/working-dir/shinka-runs &&\
-    chown -R 65532:0 /app/working-dir/shinka-runs
+# Runs live in the work dir (where the UI and terminal look), created lazily
+# by the agent at first run — NEVER pre-baked here: the first-boot seed would
+# make the work dir non-empty and the platform's repo seed (which clones into
+# the work-dir root and refuses a non-empty dir) would fail.
+ENV SHINKA_OUTPUT_ROOT=/home/agent/work/shinka-runs
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
 


### PR DESCRIPTION
Ports the two run conventions proven on the skydiscover workload (#3109, live-tested end to end) to the three older workload images, uniformly.

## Runs move into the work dir

`*_OUTPUT_ROOT` becomes `~/work/<name>-runs` — the work dir is where the UI file browser and the terminal land, so run artifacts stop being invisible-by-default. Two guards keep the platform's repo seed working:

- The runs folder is **created lazily at first run**, never image-baked — the first-boot seed would make the work dir non-empty, and the workspace seed (which clones into the work-dir root and refuses a non-empty dir) would fail.
- When the work dir **is** a seeded repo, the agent appends `<name>-runs/` to `.git/info/exclude` (local ignore) so the checkout stays clean. The run's own target clone lives inside the run directory, so outputs never touch it either way.

## Searches ride the background-work contract

Launch discipline changes from detached `nohup … &` to a **harness background task** (Bash `run_in_background`, with an explicit never-foreground warning — a foreground tool call's timeout SIGTERMs the whole process group). The background-work contract (#2965/#3044) then holds the pod awake for the run's lifetime and wakes the agent on completion to report the result proactively — no more silent completions discovered on the next prompt, and no more hibernation killing a run mid-flight. Resume-on-wake and the keep-awake terminal remain documented as fallbacks for pod restarts and legacy-launched runs.

## Verification

- All three images build (`agents:{shinkaevolve,gepa,openevolve}:image`).
- Both conventions were validated live on the skydiscover workload in a dev cluster: pod held awake by a reported task through a full search with the session closed, proactive completion report delivered, lazy work-dir creation confirmed, and the empty-vs-seeded work-dir branch exercised.

## Out of scope

- `nous` (never-hibernate campaign model, its own lifecycle).
- A UI indicator for reported background work (the runtime already publishes it on `/api/status`; the UI doesn't read it yet) — candidate follow-up.