### PR TITLE
fix(ui): close the chat dock when switching sandboxes

### DIFF
--- a/packages/ui/src/modules/sessions/store/sessions.ts
+++ b/packages/ui/src/modules/sessions/store/sessions.ts
@@ -52,9 +52,10 @@ export interface SessionsSlice {
 
   /**
    * Wipe all per-chat-session state (active session, messages, file tree,
-   * session config, queued prompt). Callers like `selectInstance`,
-   * `goBack`, and the popstate handler invoke this so every entry point
-   * leaves chat state in the same clean shape.
+   * docked file/artifact panel, session config, queued prompt). Callers like
+   * `selectInstance`, `goBack`, and the popstate handler invoke this so every
+   * entry point leaves chat state in the same clean shape — nothing from a
+   * previously-viewed sandbox survives into the next one.
    */
   resetChatContext: () => void;
 }
@@ -102,7 +103,17 @@ export const createSessionsSlice: StateCreator<
       messages: [],
       sessionError: null,
       terminalPaused: false,
+      // The right dock is scoped to the sandbox that opened it — both of its
+      // occupants clear here so entering any sandbox starts with the dock
+      // closed instead of showing the previous sandbox's file or artifact.
+      // (The third occupant, the experiment panel, is derived per agent and
+      // needs no reset.) The viewer's edit/dirty flags ride along, mirroring
+      // `setOpenFilePath(null)`: leaving a dirty file behind would otherwise
+      // prompt "Discard unsaved changes?" on the next sandbox's first click.
       openFilePath: null,
+      openArtifactId: null,
+      openFileDirty: false,
+      openFileEdit: false,
       pendingPermissions: [],
       queuedMessage: null,
       pendingResumeSessionId: null,


### PR DESCRIPTION
## Summary

`resetChatContext` already cleared `openFilePath` but not `openArtifactId`, so an artifact opened in one sandbox stayed docked after navigating to another — including a brand-new sandbox with no artifacts of its own. That made it look like an artifact was leaking across sandbox boundaries; it was the panel state persisting.

The fix goes in the single chokepoint every sandbox entry/exit path already funnels through (`selectAgent`, `openKnowledgeBase`, `openAgentSession`, `openAgentTerminal`, `goBack`, and the popstate handler), so no new effect and no per-consumer guards.

- Clear `openArtifactId` in `resetChatContext`.
- Clear the `openFileDirty` / `openFileEdit` residue alongside it, matching what `setOpenFilePath(null)` does. `resetChatContext` set `openFilePath` directly and bypassed that, so a dirty file left open in one sandbox would prompt "Discard unsaved changes?" on the next sandbox's first file click, with no file open.

Two things deliberately left alone:

- **The docked experiment panel** is derived per-agent via `useDockedExperiment(selectedAgent)`, not store state, and its manual override is scoped by `{agentId, sessionId}` — it cannot leak, so a reset there would be dead code.
- **`artifactsSectionOpen`** is the left sidebar section's collapse state, not the dock. It is the same lineage as `filesSectionOpen`, which the reset preserves on purpose as a user preference; resetting it would collapse the sidebar on every navigation.

Closes #3141

## Test plan

- [x] `mise run ui:check` — tsc, prettier, eslint clean (the 2 remaining warnings are pre-existing, in files this PR does not touch)
- [x] `mise run ui:test` — 221 tests pass
- [ ] Manual: open an artifact in chat in sandbox A, switch to sandbox B, confirm the dock starts closed
- [ ] Manual: leave an unsaved file open in sandbox A, switch to sandbox B, confirm the first file click does not prompt to discard changes

No automated regression test: UI vitest runs `environment: "node"` and the store's navigation slice touches `window.location` / `sessionStorage` / `history` at module init, so covering this needs a jsdom harness added to the UI test setup first.