### PR TITLE
fix(ui): close artifact share dialog and toast on save

### DIFF
--- a/packages/ui/src/modules/artifacts/components/share-dialog.tsx
+++ b/packages/ui/src/modules/artifacts/components/share-dialog.tsx
@@ -35,7 +35,15 @@ interface Props {
  *  which closes the dialog and confirms through a toast — a save that only
  *  flipped the button back to "Save" read as a no-op. A failure keeps the
  *  dialog open and surfaces through the mutation's `errorToast`, so the user
- *  can retry without re-entering anything. */
+ *  can retry without re-entering anything.
+ *
+ *  Both exits are gated while the save is in flight. The confirmation lives in
+ *  a `mutate`-scoped `onSuccess`, which React Query skips once the observer has
+ *  no listeners — leaving on a closed dialog would land the write with nothing
+ *  to show for it, the very no-op this dialog was fixed to stop reading as.
+ *  Gating is the narrow fix: a hook-level `onSuccess` would fire after unmount,
+ *  but `defaultMutationOptions` shallow-merges, so it would silently replace
+ *  the client-wide `onSuccess` that applies `meta.invalidates`. */
 export function ShareDialog({ artifact, onClose }: Props) {
   const [isPublic, setIsPublic] = useState(artifact.visibility === "public");
   const [expiry, setExpiry] = useState<string>(
@@ -65,7 +73,28 @@ export function ShareDialog({ artifact, onClose }: Props) {
                   message: "Sharing updated — the public link is live.",
                   action: {
                     label: "Copy link",
-                    onClick: () => void copy(savedUrl),
+                    // Runs after this dialog has unmounted, so `useCopy`'s
+                    // state-based failure channel would have no renderer left
+                    // and a rejected write (insecure context, denied
+                    // permission) would look like a success. Report the
+                    // outcome as its own toast instead.
+                    onClick: () => {
+                      void navigator.clipboard
+                        .writeText(savedUrl)
+                        .then(() =>
+                          emitToast({
+                            kind: "success",
+                            message: "Link copied.",
+                          }),
+                        )
+                        .catch(() =>
+                          emitToast({
+                            kind: "error",
+                            message:
+                              "Couldn't copy the link — use “Copy share link” on the artifact row.",
+                          }),
+                        );
+                    },
                   },
                 }
               : {
@@ -81,7 +110,11 @@ export function ShareDialog({ artifact, onClose }: Props) {
 
   return (
     <Modal>
-      <DialogHeader title={`Share “${artifact.title}”`} onClose={onClose} />
+      <DialogHeader
+        title={`Share “${artifact.title}”`}
+        onClose={onClose}
+        closeDisabled={sharing.isPending}
+      />
       <DialogBody>
         <div className="flex flex-col gap-5">
           <label className="flex items-center justify-between gap-3">
@@ -152,6 +185,7 @@ export function ShareDialog({ artifact, onClose }: Props) {
         label="Save"
         pendingLabel="Saving…"
         pending={sharing.isPending}
+        cancelDisabled={sharing.isPending}
         onSubmit={save}
       />
     </Modal>

--- a/packages/ui/src/modules/artifacts/components/share-dialog.tsx
+++ b/packages/ui/src/modules/artifacts/components/share-dialog.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { useCopy } from "@/hooks/use-copy";
+import { emitToast } from "@/lib/toast";
 
 import { useSetArtifactSharing } from "../api/mutations.js";
 
@@ -30,14 +31,17 @@ interface Props {
   onClose: () => void;
 }
 
-/** Sharing controls: public link on/off and expiry. Saved in one mutation;
- *  the fresh share URL comes back on the mutation result. */
+/** Sharing controls: public link on/off and expiry. Saved in one mutation,
+ *  which closes the dialog and confirms through a toast — a save that only
+ *  flipped the button back to "Save" read as a no-op. A failure keeps the
+ *  dialog open and surfaces through the mutation's `errorToast`, so the user
+ *  can retry without re-entering anything. */
 export function ShareDialog({ artifact, onClose }: Props) {
   const [isPublic, setIsPublic] = useState(artifact.visibility === "public");
   const [expiry, setExpiry] = useState<string>(
     artifact.expiresAt === null ? "never" : "keep",
   );
-  const [shareUrl, setShareUrl] = useState(artifact.shareUrl);
+  const shareUrl = artifact.shareUrl;
   const { copy, copied } = useCopy();
   const sharing = useSetArtifactSharing();
 
@@ -51,9 +55,25 @@ export function ShareDialog({ artifact, onClose }: Props) {
           : { expiresInHours: expiry === "never" ? null : Number(expiry) }),
       },
       {
-        onSuccess: (updated) => {
-          setShareUrl(updated.shareUrl);
-          if (!updated.shareUrl) onClose();
+        onSuccess: ({ shareUrl: savedUrl }) => {
+          // Closing takes the link field away with it, so the toast carries the
+          // copy affordance for the one flow that just produced a fresh URL.
+          emitToast(
+            savedUrl
+              ? {
+                  kind: "success",
+                  message: "Sharing updated — the public link is live.",
+                  action: {
+                    label: "Copy link",
+                    onClick: () => void copy(savedUrl),
+                  },
+                }
+              : {
+                  kind: "success",
+                  message: "Sharing updated — the artifact is now private.",
+                },
+          );
+          onClose();
         },
       },
     );


### PR DESCRIPTION
## Summary

Saving sharing settings only flipped the button back from "Saving…", which read as a no-op. The old `onSuccess` closed the dialog only when the save *removed* the share URL (`if (!updated.shareUrl) onClose()`), so enabling a public link — or merely changing the expiry on an already-public artifact — left the modal open with nothing on screen changed at all.

- Close the dialog on a successful save and confirm with a success toast, worded for the outcome ("the public link is live" vs. "the artifact is now private").
- Carry a **Copy link** action on the toast when the save produced a public URL, since closing the dialog takes the URL field away exactly when the user has just created the link. The link also stays reachable from the row's existing "Copy share link".
- Read the share URL from the `artifact` prop instead of mirroring it in local state — the mirror existed only to display the post-save URL while the dialog stayed open, and the dialog no longer outlives the save.

Reuses `emitToast` from `@/lib/toast`, the app-wide emit path; closest precedent is the same success-toast-then-`onClose()` shape in `connection-catalog-modal.tsx`.

The failure path needed no code. `useSetArtifactSharing` already carries `meta: { errorToast: "Failed to update sharing" }` and the QueryClient's central `mutations.onError` renders it with the server detail appended. Since closing happens only in `onSuccess`, a failed save already keeps the dialog open with its state intact so the user can retry without re-entering anything.

Closes #3089

## Test plan

- [x] `mise run ui:check` — tsc, prettier, eslint clean (the 2 remaining warnings are pre-existing, in files this PR does not touch)
- [x] `mise run ui:test` — 221 tests pass
- [ ] Manual: enable a public link and save — dialog closes, toast confirms, "Copy link" copies the URL
- [ ] Manual: change only the expiry on an already-public artifact — dialog closes and the toast confirms (previously the most confusing case)
- [ ] Manual: make sharing private and save — dialog closes, toast says the artifact is now private
- [ ] Manual: force a failing save — dialog stays open, error toast names the reason

No automated test: `ShareDialog` has no existing unit or e2e coverage, and UI vitest currently runs `environment: "node"` with pure-logic suites only, so a dialog-level test means introducing a render harness first.