### PR TITLE
fix(ui): hold usage figures across month changes and latch disabled metrics

### DIFF
--- a/packages/ui/src/modules/metrics/api/queries.ts
+++ b/packages/ui/src/modules/metrics/api/queries.ts
@@ -1,17 +1,52 @@
-import { skipToken, useQuery } from "@tanstack/react-query";
+import { keepPreviousData, skipToken, useQuery } from "@tanstack/react-query";
+import { TRPCClientError } from "@trpc/client";
+import { useEffect, useState } from "react";
 
 import { trpc } from "../../../trpc.js";
+
+/** A deployment without a telemetry store answers every metrics read with
+ *  PRECONDITION_FAILED. That is a verdict about the deployment, not about the
+ *  range that happened to be asked for. */
+function isMetricsDisabled(error: unknown): boolean {
+  return (
+    error instanceof TRPCClientError &&
+    error.data?.code === "PRECONDITION_FAILED"
+  );
+}
 
 /** The whole Usage tab in one read: per-model, per-agent, and per-day spend
  *  across all of the user's agents over [from, to). Per-day rows are bucketed
  *  into the browser's local calendar days and are sparse — the caller zero-fills
- *  the month. One query so the page has a single loading/error state. */
+ *  the month. One query so the page has a single loading/error state.
+ *
+ *  `isUnavailable` latches the deployment-level "metrics are off here" verdict:
+ *  once seen, no further range fires a request we already know will fail. */
 export function useSpendBreakdown(from: string, to: string, timeZone: string) {
-  return useQuery({
+  const [metricsDisabled, setMetricsDisabled] = useState(false);
+  const query = useQuery({
     ...trpc.metrics.spendBreakdown.queryOptions({ from, to, timeZone }),
+    enabled: !metricsDisabled,
     staleTime: 60_000,
     retry: false,
+    // Each range is its own query key, so a fresh key starts with no cached
+    // data — without this, switching range tears the page down to its skeleton
+    // every time. Keep the last figures on screen until the new ones land.
+    placeholderData: keepPreviousData,
   });
+  const isUnavailable = metricsDisabled || isMetricsDisabled(query.error);
+  useEffect(() => {
+    if (isUnavailable) setMetricsDisabled(true);
+  }, [isUnavailable]);
+  // Named fields rather than a spread: spreading the result would read every
+  // property and so opt the page out of React Query's render tracking.
+  return {
+    data: query.data,
+    isPending: query.isPending,
+    isError: query.isError,
+    // True while the figures on screen belong to the previously viewed range.
+    isPlaceholderData: query.isPlaceholderData,
+    isUnavailable,
+  };
 }
 
 /** Per-session cost lookup for the sessions sidebar, keyed by ACP session id. */

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -8,7 +8,6 @@ import { Card } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";
 import { formatDate } from "@/lib/format-time";
-import { cn } from "@/lib/utils";
 
 import { useSpendBreakdown } from "../api/queries.js";
 import { AgentSpendBars } from "../components/agent-spend-bars.js";
@@ -98,6 +97,14 @@ export function UsageView() {
 
   const total = data?.byModel.reduce((sum, row) => sum + row.costUsd, 0) ?? 0;
   const dataMonth = monthOfRows(data?.byDay, month);
+  // Copy inside the figures block describes the month the rows came from, not
+  // the one the user just picked — while a switch is in flight those differ,
+  // and naming the selection would assert something about a month whose data
+  // has not arrived. The period control keeps showing `month`, the selection.
+  const dataMonthLabel = formatDate(dataMonth, {
+    month: "long",
+    year: "numeric",
+  });
   const dailyDays = fillMonthDays(
     dataMonth,
     dataMonth >= currentMonth,
@@ -110,46 +117,58 @@ export function UsageView() {
         title="Usage"
         description={PAGE_DESCRIPTION}
         actions={
-          <div className="flex items-center gap-1">
-            <Button
-              variant="outline"
-              size="icon-sm"
-              aria-label="Previous month"
-              onClick={() => setMonth(monthStart(month, -1))}
-            >
-              <ChevronLeft size={16} className="text-muted-foreground" />
-            </Button>
-            <span className="min-w-[120px] text-center text-sm font-medium">
-              {monthLabel}
-            </span>
-            <Button
-              variant="outline"
-              size="icon-sm"
-              aria-label="Next month"
-              disabled={isCurrentMonth}
-              onClick={() => setMonth(monthStart(month, 1))}
-            >
-              <ChevronRight size={16} className="text-muted-foreground" />
-            </Button>
+          <div className="flex items-center gap-3">
+            {/* Names the staleness instead of only dimming it: the figures
+                below still belong to the previously viewed month. Dimming the
+                whole block was the earlier cue, but at 60% its
+                `text-muted-foreground` body copy fell under the AA contrast
+                minimum. */}
+            {isPlaceholderData && (
+              <span className="text-xs text-muted-foreground">Updating…</span>
+            )}
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="icon-sm"
+                aria-label="Previous month"
+                onClick={() => setMonth(monthStart(month, -1))}
+              >
+                <ChevronLeft size={16} className="text-muted-foreground" />
+              </Button>
+              <span className="min-w-[120px] text-center text-sm font-medium">
+                {monthLabel}
+              </span>
+              <Button
+                variant="outline"
+                size="icon-sm"
+                aria-label="Next month"
+                disabled={isCurrentMonth}
+                onClick={() => setMonth(monthStart(month, 1))}
+              >
+                <ChevronRight size={16} className="text-muted-foreground" />
+              </Button>
+            </div>
           </div>
         }
       />
 
+      {/* A failed month replaces the figures rather than holding them: React
+          Query applies `placeholderData` only while a query is pending, so the
+          rejected key has no data to keep, and `retry: false` means that is the
+          first failure. Showing the previous month's numbers under an error
+          would need a last-good cache of our own — deliberately out of scope,
+          since the figures are money and a stale total beside a failure notice
+          is worse than an honest gap. */}
       {isError && (
         <NoticeCard>Couldn't load usage for {monthLabel}.</NoticeCard>
       )}
-      {isPending && !isError && <UsageSkeleton />}
+      {isPending && <UsageSkeleton />}
       {data && (
         // `isPlaceholderData` means these are the previously viewed month's
-        // figures, held on screen while the selected month loads; dim them so
-        // the numbers don't read as final.
-        <div
-          aria-busy={isPlaceholderData}
-          className={cn(
-            "space-y-10 transition-opacity",
-            isPlaceholderData && "opacity-60",
-          )}
-        >
+        // figures, held on screen while the selected month loads. `aria-busy`
+        // carries that to assistive tech; the visible cue is the "Updating…"
+        // label by the period control.
+        <div aria-busy={isPlaceholderData} className="space-y-10">
           <section>
             <SectionLabel spaced>Total spend</SectionLabel>
             <div className="font-mono text-5xl font-bold leading-none tracking-[-0.02em] tabular-nums text-foreground">
@@ -159,7 +178,7 @@ export function UsageView() {
           {data.byModel.length === 0 ? (
             <section>
               <SectionLabel spaced>Spend by day</SectionLabel>
-              <NoticeCard>No LLM calls in {monthLabel}.</NoticeCard>
+              <NoticeCard>No LLM calls in {dataMonthLabel}.</NoticeCard>
             </section>
           ) : (
             <>

--- a/packages/ui/src/modules/metrics/views/usage-view.tsx
+++ b/packages/ui/src/modules/metrics/views/usage-view.tsx
@@ -1,5 +1,6 @@
 import { ChevronLeft, ChevronRight } from "@carbon/icons-react";
 import type { SpendByDay } from "api-server-api";
+import type { ReactNode } from "react";
 import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
@@ -7,6 +8,7 @@ import { Card } from "@/components/ui/card";
 import { PageHeader } from "@/components/ui/page-header";
 import { SectionLabel } from "@/components/ui/section-label";
 import { formatDate } from "@/lib/format-time";
+import { cn } from "@/lib/utils";
 
 import { useSpendBreakdown } from "../api/queries.js";
 import { AgentSpendBars } from "../components/agent-spend-bars.js";
@@ -21,6 +23,13 @@ import { formatUsdCents } from "../lib/format.js";
 // resulting instants, so "calendar month" means the user's wall-clock month.
 const monthStart = (base: Date, offset: number) =>
   new Date(base.getFullYear(), base.getMonth() + offset, 1);
+
+const PAGE_DESCRIPTION = (
+  <span className="block max-w-[460px]">
+    LLM API spend across all supported agents (currently only Claude Code and
+    derivatives).
+  </span>
+);
 
 // The browser owns calendar semantics: from the sparse per-day rows the server
 // returns, build the full day list for the selected month, zero-filling days
@@ -45,11 +54,21 @@ function fillMonthDays(
   return days;
 }
 
+// Which month the rows on screen actually describe. While a month switch is in
+// flight the previous month's figures are still displayed, so the chart has to
+// be zero-filled against *their* calendar — remapping them onto the newly
+// selected month would draw a flat, empty chart the data never claimed.
+function monthOfRows(rows: SpendByDay[] | undefined, fallback: Date): Date {
+  const [year, month] = rows?.[0]?.day.split("-").map(Number) ?? [];
+  return year && month ? new Date(year, month - 1, 1) : fallback;
+}
+
 /** Settings tab: the user's LLM API spend for one calendar month, totalled
  *  and broken down per model across all their agents. */
 export function UsageView() {
   const [month, setMonth] = useState(() => monthStart(new Date(), 0));
-  const isCurrentMonth = month >= monthStart(new Date(), 0);
+  const currentMonth = monthStart(new Date(), 0);
+  const isCurrentMonth = month >= currentMonth;
   const monthLabel = formatDate(month, {
     month: "long",
     year: "numeric",
@@ -60,20 +79,36 @@ export function UsageView() {
   // One query backs the whole tab, so per-model / per-agent / per-day spend
   // land together under a single loading/error state — the chart never renders
   // an all-zero month while its data is still in flight.
-  const { data, isPending, isError } = useSpendBreakdown(from, to, timeZone);
+  const { data, isPending, isError, isPlaceholderData, isUnavailable } =
+    useSpendBreakdown(from, to, timeZone);
+
+  // A deployment without a telemetry store has no usage to show for any month,
+  // so the verdict is rendered once in place of the period control rather than
+  // re-derived per month behind a skeleton.
+  if (isUnavailable) {
+    return (
+      <div>
+        <PageHeader title="Usage" description={PAGE_DESCRIPTION} />
+        <NoticeCard>
+          Usage metrics are unavailable on this deployment.
+        </NoticeCard>
+      </div>
+    );
+  }
+
   const total = data?.byModel.reduce((sum, row) => sum + row.costUsd, 0) ?? 0;
-  const dailyDays = fillMonthDays(month, isCurrentMonth, data?.byDay);
+  const dataMonth = monthOfRows(data?.byDay, month);
+  const dailyDays = fillMonthDays(
+    dataMonth,
+    dataMonth >= currentMonth,
+    data?.byDay,
+  );
 
   return (
     <div>
       <PageHeader
         title="Usage"
-        description={
-          <span className="block max-w-[460px]">
-            LLM API spend across all supported agents (currently only Claude
-            Code and derivatives).
-          </span>
-        }
+        description={PAGE_DESCRIPTION}
         actions={
           <div className="flex items-center gap-1">
             <Button
@@ -101,17 +136,20 @@ export function UsageView() {
       />
 
       {isError && (
-        <Card
-          className={`flex ${CHART_HEIGHT_CLASS} items-center justify-center p-5`}
-        >
-          <p className="text-sm text-muted-foreground">
-            Usage metrics are unavailable on this deployment.
-          </p>
-        </Card>
+        <NoticeCard>Couldn't load usage for {monthLabel}.</NoticeCard>
       )}
       {isPending && !isError && <UsageSkeleton />}
       {data && (
-        <div className="space-y-10">
+        // `isPlaceholderData` means these are the previously viewed month's
+        // figures, held on screen while the selected month loads; dim them so
+        // the numbers don't read as final.
+        <div
+          aria-busy={isPlaceholderData}
+          className={cn(
+            "space-y-10 transition-opacity",
+            isPlaceholderData && "opacity-60",
+          )}
+        >
           <section>
             <SectionLabel spaced>Total spend</SectionLabel>
             <div className="font-mono text-5xl font-bold leading-none tracking-[-0.02em] tabular-nums text-foreground">
@@ -121,13 +159,7 @@ export function UsageView() {
           {data.byModel.length === 0 ? (
             <section>
               <SectionLabel spaced>Spend by day</SectionLabel>
-              <Card
-                className={`flex ${CHART_HEIGHT_CLASS} items-center justify-center p-5`}
-              >
-                <p className="text-sm text-muted-foreground">
-                  No LLM calls in {monthLabel}.
-                </p>
-              </Card>
+              <NoticeCard>No LLM calls in {monthLabel}.</NoticeCard>
             </section>
           ) : (
             <>
@@ -156,6 +188,18 @@ export function UsageView() {
         </div>
       )}
     </div>
+  );
+}
+
+/** One-line message at the day chart's height, so standing in for a chart —
+ *  or for the whole page — doesn't collapse the layout. */
+function NoticeCard({ children }: { children: ReactNode }) {
+  return (
+    <Card
+      className={`flex ${CHART_HEIGHT_CLASS} items-center justify-center p-5`}
+    >
+      <p className="text-sm text-muted-foreground">{children}</p>
+    </Card>
   );
 }
 


### PR DESCRIPTION
## Summary

Changing the month on Settings › Usage re-flashed the full four-section skeleton before showing anything, because each range is its own query key and a fresh key starts with no cached data. On a deployment without a telemetry store it was worse: every month change fired a request guaranteed to fail, so the page flickered skeleton → "Usage metrics are unavailable on this deployment." each time.

`useSpendBreakdown` (`modules/metrics/api/queries.ts`):

- `placeholderData: keepPreviousData` — the previous month's figures stay on screen until the new ones land, instead of tearing the page down to its skeleton.
- A deployment-level latch. `isMetricsDisabled` matches `TRPCClientError` with `data.code === "PRECONDITION_FAILED"`, which is what `createDisabledMetricsService` throws. Once seen it latches, and `enabled: !metricsDisabled` stops every subsequent month from firing a request we already know will fail.
- Returns named fields rather than spreading the query result — spreading reads every tracked property and opts the page out of React Query's render tracking.

`UsageView` (`modules/metrics/views/usage-view.tsx`):

- `isUnavailable` is an early return: header plus the notice, and **no period control at all**, since there is no month that could show anything. The verdict renders once instead of being re-derived per month behind a skeleton.
- `monthOfRows()` derives the chart's month from the rows' own `YYYY-MM-DD` keys. This is required by `keepPreviousData`, not optional polish: without it `fillMonthDays` would remap the held-over rows onto the newly selected month and briefly draw a fabricated all-zero chart — worse than showing stale data.
- Held-over figures are dimmed (`opacity-60 transition-opacity`) and marked `aria-busy`, so stale numbers do not read as final.
- Non-precondition failures get their own copy, `Couldn't load usage for <month>.`, instead of the old blanket "unavailable on this deployment" for any error.
- Extracted the repeated centered `Card` into `NoticeCard` (unavailable, error, and "No LLM calls" states) and the header description into a constant, which the early return also needs.

Closes #3148

## Test plan

- [x] `mise run ui:check` — tsc, prettier, eslint clean (the 2 remaining warnings are pre-existing, in files this PR does not touch)
- [x] `mise run ui:test` — 221 tests pass
- [ ] Manual: page through several months — figures hold and dim while loading, no skeleton after the first load
- [ ] Manual: confirm the day chart never flashes an all-zero month mid-switch
- [ ] Manual: on a deployment without a telemetry store, confirm the unavailable notice renders once with no period control, and that changing month fires no further requests
- [ ] Manual: force a non-precondition error and confirm the per-month copy appears, not the deployment-level notice

No automated test: `packages/ui/src/__tests__/unit` has no `renderHook` or testing-library harness (all suites are pure-logic), so covering the latch and the placeholder path means introducing a React render setup first. `monthOfRows` and the latch are verified by review and manual testing only.