### PR TITLE
feat(e2e): e2e:loop --test= spec filter

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -221,7 +221,7 @@ echo "e2e data reset complete."
 '''
 
 ["e2e:loop"]
-description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run the smoke suite. Options: --headed --full --rebuild=apiserver,ui,controller,keycloak,mock-agent --test=<playwright file/title filter, e.g. prompt-delivery>"
+description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run the smoke suite. Options: --headed --full --rebuild=apiserver,ui,controller,keycloak,mock-agent --test=<playwright file/title filter, e.g. prompt-delivery; smoke specs still run their dependency chain>"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -247,10 +247,14 @@ for arg in "$@"; do
     # The pipeline default is smoke only; this flag is the manual trigger.
     --full) PLAYWRIGHT_TASK="e2e-playwright:run-full" ;;
     --rebuild=*) REBUILD="${arg#--rebuild=}"; REBUILD_SET=true ;;
-    # Narrow the run to matching specs (Playwright's positional file/title
-    # filter, substring or regex — e.g. --test=prompt-delivery runs the four
-    # prompt-delivery specs). Full-only specs also need --full, or their
-    # project doesn't exist and the filter matches nothing.
+    # Positional Playwright filter (file/title substring or regex). It fully
+    # narrows the run only for full-only projects, which have no dependencies
+    # — e.g. --full --test=prompt-delivery runs just the four prompt-delivery
+    # specs. A smoke spec still pulls in its whole dependency chain: Playwright
+    # always runs a selected project's dependencies, and here they're needed
+    # anyway because e2e:reset (step 3) wipes the state the chain builds up.
+    # Full-only specs also need --full, or their project doesn't exist and
+    # the filter matches nothing.
     --test=*) TEST_FILTER="${arg#--test=}" ;;
   esac
 done

--- a/tasks.toml
+++ b/tasks.toml
@@ -221,7 +221,7 @@ echo "e2e data reset complete."
 '''
 
 ["e2e:loop"]
-description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run the smoke suite. Options: --headed --full --rebuild=apiserver,ui,controller,keycloak,mock-agent"
+description = "Fast e2e rerun against the warm test cluster (no VM recreate): optionally rebuild components, wipe data, run the smoke suite. Options: --headed --full --rebuild=apiserver,ui,controller,keycloak,mock-agent --test=<playwright file/title filter, e.g. prompt-delivery>"
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -239,6 +239,7 @@ fi
 PLAYWRIGHT_TASK="e2e-playwright:run"
 REBUILD=""
 REBUILD_SET=false
+TEST_FILTER=""
 for arg in "$@"; do
   case "$arg" in
     --headed) PLAYWRIGHT_TASK="e2e-playwright:run-headed" ;;
@@ -246,6 +247,11 @@ for arg in "$@"; do
     # The pipeline default is smoke only; this flag is the manual trigger.
     --full) PLAYWRIGHT_TASK="e2e-playwright:run-full" ;;
     --rebuild=*) REBUILD="${arg#--rebuild=}"; REBUILD_SET=true ;;
+    # Narrow the run to matching specs (Playwright's positional file/title
+    # filter, substring or regex — e.g. --test=prompt-delivery runs the four
+    # prompt-delivery specs). Full-only specs also need --full, or their
+    # project doesn't exist and the filter matches nothing.
+    --test=*) TEST_FILTER="${arg#--test=}" ;;
   esac
 done
 
@@ -314,10 +320,11 @@ if [ "$READY" != true ]; then
 fi
 
 # 4. Run the specs against the warm cluster. No teardown — the cluster stays up
-# for the next loop.
+# for the next loop. The filter rides after `--` so mise appends it to the
+# playwright command instead of parsing it as its own flag.
 PLATFORM_BASE_URL="http://localhost:5555" \
 PLATFORM_KEYCLOAK_URL="http://keycloak.localhost:5555" \
-  mise run "$PLAYWRIGHT_TASK"
+  mise run "$PLAYWRIGHT_TASK" ${TEST_FILTER:+-- "$TEST_FILTER"}
 '''
 
 # -- Git hooks --


### PR DESCRIPTION
Adds a `--test=<filter>` option to `e2e:loop` that narrows the spec run against the warm cluster:

```bash
mise run e2e:loop --full --rebuild=apiserver --test=prompt-delivery
```

The value is Playwright's positional file/title filter, forwarded to the spec run after `--` so mise appends it to the playwright command.

Two limits, both noted in the task's option docs:
- The filter fully narrows the run only for full-only projects, which have no dependencies. A smoke spec still runs its whole dependency chain: Playwright always runs a selected project's dependencies, and here they are needed anyway because `e2e:reset` wipes the state the chain builds up.
- Full-only specs still need `--full`, otherwise their project doesn't exist and the filter matches nothing.

Verified: `mise run e2e-playwright:run-full -- invocation --list` resolves to `pnpm exec playwright test invocation --list` and matches the full-suite spec.

https://claude.ai/code/session_01XngAMdE1psd6swN2TZLFLm