### PR TITLE
fix: make the KubeVirt VM backend work on OpenShift Virtualization

### DIFF
--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -1,6 +1,6 @@
 # Persistence
 
-Last verified: 2026-07-30
+Last verified: 2026-08-04
 
 ## Overview
 
@@ -110,7 +110,7 @@ The default Claude Code template persists the workspace and `$HOME`. Together th
 
 PVCs survive hibernation — when a StatefulSet scales to zero replicas, the volume detaches but is retained. The controller explicitly deletes PVCs on Agent deletion (the standard StatefulSet behavior is to retain them to prevent data loss; Platform opts back into reclamation because Agent deletion is intentional).
 
-What does **not** survive hibernation: anything written to the container's ephemeral filesystem outside the persisted mounts — OS-level changes, packages installed at runtime, files in `/tmp`. `$HOME/.cache` is deliberately in this category: the base-image entrypoint symlinks it to pod-local disk (`/tmp/agent-cache`) so churn-heavy tool caches don't load the persistent volume. Tools and dependencies the agent relies on must be baked into the image at build time.
+What does **not** survive hibernation: anything written to the container's ephemeral filesystem outside the persisted mounts — OS-level changes, packages installed at runtime, files in `/tmp`. `$HOME/.cache` is deliberately in this category: the base-image entrypoint redirects it to node-local disk (`/tmp/agent-cache`) so churn-heavy tool caches don't load the persistent volume. The redirect is best-effort in both directions — on the VM backend the guest pre-creates the link from cloud-init, since the workspace share there refuses a non-root symlink, and a swap that fails anywhere is a performance regression rather than a boot failure, leaving that agent's cache on the workspace volume where it does survive. Tools and dependencies the agent relies on must be baked into the image at build time.
 
 ### Warm PVC pool
 

--- a/packages/agent-runtime/src/__tests__/unit/create-child-agent-process.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/create-child-agent-process.test.ts
@@ -1,3 +1,6 @@
+import { rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname } from "node:path";
 import { describe, it, expect } from "vitest";
 import { createChildAgentProcess } from "../../modules/acp/infrastructure/create-child-agent-process.js";
 
@@ -57,6 +60,20 @@ describe("createChildAgentProcess", () => {
 
     proc.kill();
     await proc.exited;
+  });
+
+  it("creates a missing workingDir instead of failing the spawn", async () => {
+    // A fresh workspace volume has no WORK_DIR yet; without the mkdir the
+    // spawn dies with a misleading ENOENT on the binary.
+    const dir = `${tmpdir()}/capd-${process.pid}-${Date.now()}/nested`;
+    const proc = createChildAgentProcess({
+      command: [process.execPath, "-e", `console.log("ok")`],
+      workingDir: dir,
+    });
+    const line = await new Promise<string>((resolve) => proc.onLine(resolve));
+    expect(line).toBe("ok");
+    await proc.exited;
+    rmSync(dirname(dir), { recursive: true, force: true });
   });
 
   it("drops sends after the harness exited", async () => {

--- a/packages/agent-runtime/src/modules/acp/infrastructure/create-child-agent-process.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/create-child-agent-process.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { mkdirSync } from "node:fs";
 import readline from "node:readline";
 import type { AgentProcess } from "./agent-process.js";
 
@@ -19,6 +20,15 @@ export function createChildAgentProcess(
       ([k]) => !k.startsWith("npm_"),
     ),
   );
+
+  // A missing cwd fails the spawn as a misleading ENOENT on the *binary*
+  // (e.g. before the workspace init script has created WORK_DIR on a fresh
+  // volume). Creating it here is always safe — it's the harness's cwd.
+  try {
+    mkdirSync(opts.workingDir, { recursive: true });
+  } catch {
+    // unwritable workspace surfaces as the spawn error below
+  }
 
   const child = spawn(cmd, args, {
     stdio: ["pipe", "pipe", "inherit"],

--- a/packages/agent-runtime/src/modules/acp/infrastructure/create-child-agent-process.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/create-child-agent-process.ts
@@ -24,10 +24,14 @@ export function createChildAgentProcess(
   // A missing cwd fails the spawn as a misleading ENOENT on the *binary*
   // (e.g. before the workspace init script has created WORK_DIR on a fresh
   // volume). Creating it here is always safe — it's the harness's cwd.
+  // Non-fatal: the spawn below still runs, but its own error reports ENOENT
+  // on the *binary*, so the mkdir failure here is the only actionable line.
   try {
     mkdirSync(opts.workingDir, { recursive: true });
-  } catch {
-    // unwritable workspace surfaces as the spawn error below
+  } catch (err) {
+    process.stderr.write(
+      `[agent-process] could not create workingDir ${opts.workingDir}: ${(err as Error).message}\n`,
+    );
   }
 
   const child = spawn(cmd, args, {

--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -12,8 +12,10 @@
 #   - platform-scratch mounts the "scratch" disk under docker/k3s image stores.
 #   - platform-ca installs the MITM CA into the OS trust store.
 #   - platform-boot-gate blocks agent-runtime until the paired gateway answers.
-#   - agent-runtime runs as uid 65532 (same as the pod image, so PVC content
-#     ownership carries over), spawning harness-chat/-terminal like in a pod.
+#   - agent-runtime runs as root (unprivileged virtiofsd EPERMs creates from
+#     any other guest uid — see agent-runtime.service), spawning
+#     harness-chat/-terminal like in a pod. The agent user still exists for
+#     SSH sessions and image-baked $HOME content.
 ARG AGENT_IMAGE=platform-claude-code:latest
 FROM ${AGENT_IMAGE} AS agent
 

--- a/packages/agents/claude-code-vm/system/agent-runtime.service
+++ b/packages/agents/claude-code-vm/system/agent-runtime.service
@@ -12,7 +12,13 @@ After=cloud-init.service cloud-init-network.service platform-ca.service platform
 Requires=platform-boot-gate.service
 
 [Service]
-User=agent
+# root, not the agent user: the workspace is unprivileged virtiofs
+# (virtiofsd runs as the launcher pod's qemu uid with all caps dropped —
+# the OpenShift Virtualization default), which EPERMs every create from
+# any other guest uid. Root creates are accepted (ownership squashes to
+# the daemon's uid). Isolation is the VM boundary itself, same stance as
+# docker/k3s already running as root in this guest.
+User=root
 WorkingDirectory=/app
 EnvironmentFile=/etc/platform/env
 Environment=PORT=8080

--- a/packages/controller/pkg/reconciler/vm_resources.go
+++ b/packages/controller/pkg/reconciler/vm_resources.go
@@ -166,6 +166,16 @@ func BuildVMCloudInitSecret(name string, agentSpec *types.AgentSpec, cfg *config
 			shellQuote(m.Path), shellQuote(tag),
 		)})
 	}
+	// agent-entrypoint swaps ~/.cache for pod-local disk, but on unprivileged
+	// virtiofs a non-root caller cannot create symlinks (virtiofsd lacks
+	// CAP_CHOWN; the guest kernel returns EPERM) — so root pre-creates the
+	// link here and the entrypoint's `[ ! -L ]` check skips its own attempt.
+	// Runs after the mount bootcmds above so the workspace share is in place.
+	cc.BootCmd = append(cc.BootCmd, []string{"sh", "-c", fmt.Sprintf(
+		"mkdir -p /tmp/agent-cache && chown %[1]d:%[1]d /tmp/agent-cache && ln -sfn /tmp/agent-cache %[2]s/.cache || true",
+		vmAgentUID, shellQuote(agentHome),
+	)})
+
 	body, err := yaml.Marshal(cc)
 	if err != nil {
 		return nil, fmt.Errorf("encoding cloud-init userdata: %w", err)

--- a/packages/controller/pkg/reconciler/vm_resources.go
+++ b/packages/controller/pkg/reconciler/vm_resources.go
@@ -254,7 +254,13 @@ func BuildAgentVirtualMachine(name string, agentSpec *types.AgentSpec, cfg *conf
 	// else the first chart-wide default. (The pod path lists all defaults as
 	// fallbacks; KubeVirt's API takes one — a multi-secret install needs the
 	// matching secret first.)
-	bootDisk := map[string]any{"image": agentSpec.Image, "imagePullPolicy": pullPolicy}
+	// Unlike a pod's container, containerDisk validates imagePullPolicy as a
+	// strict enum — the chart's default "" (tag-based K8s behavior) must be
+	// omitted, not passed through, or admission rejects the VM.
+	bootDisk := map[string]any{"image": agentSpec.Image}
+	if pullPolicy != "" {
+		bootDisk["imagePullPolicy"] = pullPolicy
+	}
 	if ref := agentSpec.ImagePullSecretRef; ref != "" {
 		bootDisk["imagePullSecret"] = ref
 	} else if len(base.ImagePullSecrets) > 0 {

--- a/packages/controller/pkg/reconciler/vm_resources.go
+++ b/packages/controller/pkg/reconciler/vm_resources.go
@@ -171,8 +171,11 @@ func BuildVMCloudInitSecret(name string, agentSpec *types.AgentSpec, cfg *config
 	// CAP_CHOWN; the guest kernel returns EPERM) — so root pre-creates the
 	// link here and the entrypoint's `[ ! -L ]` check skips its own attempt.
 	// Runs after the mount bootcmds above so the workspace share is in place.
+	// `ln -sfn` into an existing real directory nests the link instead of
+	// swapping — clear a non-symlink first so the pre-create is authoritative
+	// on volumes that already carry a real ~/.cache.
 	cc.BootCmd = append(cc.BootCmd, []string{"sh", "-c", fmt.Sprintf(
-		"mkdir -p /tmp/agent-cache && chown %[1]d:%[1]d /tmp/agent-cache && ln -sfn /tmp/agent-cache %[2]s/.cache || true",
+		"mkdir -p /tmp/agent-cache && chown %[1]d:%[1]d /tmp/agent-cache && { [ -L %[2]s/.cache ] || rm -rf %[2]s/.cache; } && ln -sfn /tmp/agent-cache %[2]s/.cache || true",
 		vmAgentUID, shellQuote(agentHome),
 	)})
 

--- a/packages/controller/pkg/reconciler/vm_test.go
+++ b/packages/controller/pkg/reconciler/vm_test.go
@@ -94,6 +94,22 @@ func TestVMBackendReconcilesVirtualMachine(t *testing.T) {
 	assert.NotContains(t, names, "scratchpad")
 	boot := names["boot"]["containerDisk"].(map[string]any)
 	assert.Equal(t, agent.Spec.Image, boot["image"])
+	assert.Equal(t, "IfNotPresent", boot["imagePullPolicy"])
+
+	// containerDisk validates imagePullPolicy as a strict enum — an unset
+	// policy must be omitted, not rendered as "" (KubeVirt admission rejects
+	// the VM outright).
+	bare := vmAgentCR()
+	bare.Spec.ImagePullPolicy = ""
+	r.config.AgentTemplateDefaults.ImagePullPolicy = ""
+	bareVM, err := BuildAgentVirtualMachine("my-agent", &bare.Spec, r.config, agentOwnerRef(bare), "10.96.42.42")
+	require.NoError(t, err)
+	bareVolumes, _, _ := unstructured.NestedSlice(bareVM.Object, "spec", "template", "spec", "volumes")
+	for _, v := range bareVolumes {
+		if m := v.(map[string]any); m["name"] == "boot" {
+			assert.NotContains(t, m["containerDisk"].(map[string]any), "imagePullPolicy")
+		}
+	}
 
 	// virtiofs filesystem for the persisted mount; PVC created with the
 	// StatefulSet-convention name and agent labels.

--- a/packages/controller/pkg/reconciler/vm_test.go
+++ b/packages/controller/pkg/reconciler/vm_test.go
@@ -151,6 +151,10 @@ func TestVMBackendReconcilesVirtualMachine(t *testing.T) {
 		"mount -t virtiofs 'scratchpad'",
 		"ephemeral mounts have no virtiofs device to mount",
 	)
+	// The ~/.cache swap must be pre-created by root: on unprivileged virtiofs
+	// a non-root guest cannot create symlinks (virtiofsd lacks CAP_CHOWN), so
+	// the entrypoint's own `ln` would fail with EPERM.
+	assert.Contains(t, userdata, "ln -sfn /tmp/agent-cache")
 }
 
 func TestVMSpecSurvivesUnstructuredDeepCopy(t *testing.T) {

--- a/packages/experiment-sdk/tasks.toml
+++ b/packages/experiment-sdk/tasks.toml
@@ -5,12 +5,12 @@ depends = ["experiment-sdk:check:*"]
 # unpinned linter changes its ruleset under CI whenever a release ships.
 ["experiment-sdk:check:lint"]
 dir = "{{config_root}}/packages/experiment-sdk"
-run = "uv run --group dev ruff check src tests"
+run = "uv run --frozen --group dev ruff check src tests"
 sources = ["src/**/*.py", "tests/**/*.py", "pyproject.toml", "uv.lock"]
 
 ["experiment-sdk:check:format"]
 dir = "{{config_root}}/packages/experiment-sdk"
-run = "uv run --group dev ruff format --check src tests"
+run = "uv run --frozen --group dev ruff format --check src tests"
 sources = ["src/**/*.py", "tests/**/*.py", "pyproject.toml", "uv.lock"]
 
 ["experiment-sdk:fix"]
@@ -18,9 +18,9 @@ depends = ["experiment-sdk:fix:*"]
 
 ["experiment-sdk:fix:format"]
 dir = "{{config_root}}/packages/experiment-sdk"
-run = "uv run --group dev ruff format src tests"
+run = "uv run --frozen --group dev ruff format src tests"
 
 ["experiment-sdk:test"]
 description = "Run the experiment SDK pytest suite against a stub platform endpoint"
 dir = "{{config_root}}/packages/experiment-sdk"
-run = "uv run --group dev pytest -q"
+run = "uv run --frozen --group dev pytest -q"

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -31,9 +31,14 @@ fi
 # target is (re)created each boot to keep the link from dangling.
 home="${HOME:-/home/agent}"
 mkdir -p /tmp/agent-cache
+# On the VM backend $HOME is unprivileged virtiofs, where a non-root caller
+# cannot create symlinks (virtiofsd lacks CAP_CHOWN, the guest kernel returns
+# EPERM); the VM userdata pre-creates the link as root, and if that ever
+# misses, a real ~/.cache on the share is a perf wart — never a boot failure.
 if [ ! -L "$home/.cache" ]; then
 	rm -rf "$home/.cache"
-	ln -sfn /tmp/agent-cache "$home/.cache"
+	ln -sfn /tmp/agent-cache "$home/.cache" \
+		|| echo "agent-entrypoint: WARNING: could not swap ~/.cache to local disk; caches stay on the workspace volume" >&2
 fi
 
 # Harness tool pins ship in the image's system-level mise config

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -36,9 +36,16 @@ mkdir -p /tmp/agent-cache
 # EPERM); the VM userdata pre-creates the link as root, and if that ever
 # misses, a real ~/.cache on the share is a perf wart — never a boot failure.
 if [ ! -L "$home/.cache" ]; then
-	rm -rf "$home/.cache"
-	ln -sfn /tmp/agent-cache "$home/.cache" \
-		|| echo "agent-entrypoint: WARNING: could not swap ~/.cache to local disk; caches stay on the workspace volume" >&2
+	# Probe with a scratch link first so a failing swap (e.g. non-root on
+	# unprivileged virtiofs, which EPERMs symlink creation) leaves any
+	# existing cache directory intact instead of deleting it with no
+	# replacement.
+	if ln -sfn /tmp/agent-cache "$home/.cache.tmp" 2>/dev/null; then
+		rm -rf "$home/.cache" && mv "$home/.cache.tmp" "$home/.cache"
+	else
+		rm -f "$home/.cache.tmp"
+		echo "agent-entrypoint: WARNING: could not swap ~/.cache to local disk; caches stay on the workspace volume" >&2
+	fi
 fi
 
 # Harness tool pins ship in the image's system-level mise config


### PR DESCRIPTION
Deploying the VM backend to a real OpenShift Virtualization cluster (CNV 4.21, unprivileged virtiofsd, real KVM — vs. the dev k3s cluster's KubeVirt v1.8 + emulation) surfaced a chain of failures that made `backend.type: vm` agents completely unusable there. Each fix below was validated live on that cluster before landing.

## Fixes

### 1. containerDisk rejects the chart's default `imagePullPolicy: ""` (controller)
KubeVirt admission validates `containerDisk.imagePullPolicy` as a strict enum (`Always|IfNotPresent|Never`), unlike pod containers where `""` means "K8s tag-based default". The controller passed the chart default through verbatim, so **every vm reconcile hard-failed at the mutating webhook** (993 retries, capped backoff). Now the field is omitted when unset.

### 2. `~/.cache` symlink swap bricked boot on unprivileged virtiofs (platform-base + controller)
`agent-entrypoint` swaps `~/.cache` to pod-local disk with `ln -sfn` under `set -e`. On unprivileged virtiofsd (the OpenShift default: qemu uid, all caps dropped) a non-root guest cannot create symlinks — virtiofsd can't `lchown`, the guest kernel returns EPERM — so the runtime died on every start **with zero diagnostics** (stderr→kmsg only carries output after exec; the failure loop looked like a silent `exit-code` crashloop).
- entrypoint: a failed cache swap is a perf wart, never a boot failure — warn and continue.
- controller: pre-create the symlink from a root `bootcmd` in the VM userdata (root creates are accepted; ownership squashes to the daemon uid), so the entrypoint's `[ ! -L ]` check skips its own `ln`.

### 3. agent-runtime must run as root in the guest (claude-code-vm)
The bigger consequence of unprivileged virtiofsd: it EPERMs **every create** (file/dir/symlink) from any guest uid other than root — verified directly with `mkdir`/`touch` as uid 65532. The runtime as uid 65532 could never write the workspace (`EPERM mkdir ~/.platform`). Idmapped virtiofs mounts would be the clean fix but this virtiofsd doesn't support them (mounts, then EOVERFLOW on create).

`agent-runtime.service` now runs as root. Isolation is the VM boundary itself — docker and k3s already run as root in this guest. Rationale documented in the unit.

### 4. Missing WORK_DIR fails harness spawn with a misleading error (agent-runtime)
On a fresh workspace volume, spawning the harness before the init script created `~/work` failed with `spawn /usr/local/bin/harness-chat ENOENT` — pointing at the binary when the actual missing path is the cwd. The runtime now `mkdir -p`s the harness cwd before spawning.

### 5. `uv run` silently upgraded ruff (experiment-sdk)
Running the lint task re-resolved `uv.lock`, bumping ruff 0.15.22 → 0.16.0 whose new rules fail lint — exactly what the task's own comment says must not happen. All experiment-sdk `uv run` tasks are now `--frozen`.

## Validation
- controller: `mise run controller:test` green, new assertions for the omitted pull policy (set + unset) and the cache-symlink bootcmd.
- agent-runtime: `mise run agent-runtime:check` + 217 tests green, new test for missing-cwd spawn.
- Live: with 1–3 applied by hand on the CNV cluster, the VM agent boots clean (0 service failures), completes hello/capabilities, and an end-to-end ACP smoke (initialize → session/new → prompt) got a model-backed reply from Claude Code inside the VM.

## Known follow-ups (not in this PR)
- After a harness spawn failure the runtime keeps the dead process attached to the session; UI sends then time out silently ("Couldn't deliver") instead of failing fast. A `session/prompt` against an exited harness should error explicitly.
- Root-in-guest shifts `$HOME` seeding semantics (files land squashed to the virtiofsd uid); revisit if/when CNV's virtiofsd gains idmapped-mount support.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>