### PR TITLE
fix(ui): label the left-rail Inbox item "Inbox", not "Email"

### DIFF
--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -73,7 +73,7 @@ export function IconRail({
     navigate: () => setView("artifacts"),
   };
   const inbox: Destination = {
-    label: "Email",
+    label: "Inbox",
     icon: Email,
     active: view === "inbox",
     badge: pendingCount,


### PR DESCRIPTION
The left navigation rail's Inbox item was labelled **"Email"** — its hover tooltip, its mobile bottom-bar text, and its `aria-label`. It opens the approvals **Inbox**, not email, so the label was misleading.

Renamed the destination label to **"Inbox"** (the envelope icon is unchanged).

## Test plan

- `mise run ui:check` passes
- Hover the Inbox icon in the collapsed rail → tooltip reads "Inbox"