### PR TITLE
fix(ui): keep settings tab strip scrolling inside itself on mobile

### DIFF
--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -100,11 +100,18 @@ export function SettingsView() {
         size="sm"
         orientation="vertical"
         // Mobile lays the strip out as a row. It owns its horizontal overflow
-        // so a long tab set scrolls the strip instead of the whole view, the
-        // triggers keep their full label instead of shrinking into wraps, and
-        // the vertical padding leaves room for a focus ring inside the scroll
-        // box. Desktop stays the plain vertical sidebar.
-        className="flex-row overflow-x-auto py-1 [&>button]:shrink-0 md:flex-col md:overflow-x-visible md:py-0 md:w-[180px] shrink-0"
+        // so a long tab set scrolls the strip instead of the whole view, and
+        // the triggers keep their full label instead of shrinking into wraps.
+        // Specifying `overflow-x` makes the strip a scroll container on both
+        // axes, so its clipping region is its padding box — and the triggers'
+        // focus ring paints 4px outside their border box on all four sides.
+        // Hence padding on both axes: without it the first and last triggers'
+        // rings are clipped, and the first tab is the default focus target.
+        // The inline padding clears 4px rather than matching it — fractional
+        // layout leaves the scroll-end edge ~0.06px short of an exact 4px.
+        // `gap-1` already spaces the interior rings. Desktop stays the plain
+        // vertical sidebar.
+        className="flex-row overflow-x-auto px-1.5 py-1 [&>button]:shrink-0 md:flex-col md:overflow-x-visible md:px-0 md:py-0 md:w-[180px] shrink-0"
       />
 
       <div className="flex-1 min-w-0">

--- a/packages/ui/src/modules/settings/views/settings-view.tsx
+++ b/packages/ui/src/modules/settings/views/settings-view.tsx
@@ -99,7 +99,12 @@ export function SettingsView() {
         variant="pill"
         size="sm"
         orientation="vertical"
-        className="flex-row md:flex-col md:w-[180px] shrink-0"
+        // Mobile lays the strip out as a row. It owns its horizontal overflow
+        // so a long tab set scrolls the strip instead of the whole view, the
+        // triggers keep their full label instead of shrinking into wraps, and
+        // the vertical padding leaves room for a focus ring inside the scroll
+        // box. Desktop stays the plain vertical sidebar.
+        className="flex-row overflow-x-auto py-1 [&>button]:shrink-0 md:flex-col md:overflow-x-visible md:py-0 md:w-[180px] shrink-0"
       />
 
       <div className="flex-1 min-w-0">


### PR DESCRIPTION
## Summary

On a phone the Settings navigation was reachable only by side-scrolling the **whole view**, so hunting for a section made the content jump around.

Two things stacked to cause it:

1. The tab strip is a `flex-row` on mobile with `overflow: visible`. As a flex item of the column-direction wrapper its width is stretch-clamped to the content column (343px at a 375px viewport), so the triggers did not widen the strip — they spilled out of it.
2. The nearest ancestor that establishes a scroll box is `<main className="… overflow-y-auto">` in `app.tsx`. A box with `overflow-y: auto` and `overflow-x: visible` computes `overflow-x` to `auto`, so `main` became a horizontal scroller and the spilled triggers panned the entire view. `document.documentElement` never scrolled, which matches the report that the whole page shifts while the rail stays put.

The fix gives the strip its own overflow, in one class list on the one call site:

- `overflow-x-auto` — the strip owns its horizontal overflow instead of leaking it to `main`.
- `[&>button]:shrink-0` — required, not decorative. Without it the triggers shrink to min-content and render two-line wrapped labels inside the scroller. Scoped to this call site (matching the existing `[&_svg]:shrink-0` convention in `button.tsx`) rather than added to `tabTrigger`, where it would push the horizontal strips inside modals to overflow their dialogs.
- `py-1` — `ring-2` + `ring-offset-2` extends 4px outside the trigger, so without the padding a keyboard focus ring is clipped by the new scroll box. Rings are box-shadows and outlines, so this adds no phantom scroll area.
- `md:*` resets restore the desktop sidebar exactly.

Scroll was chosen over wrapping or a dropdown because it satisfies the issue's hard requirement (reaching a section never moves the rest of the page) without needing a design decision. The shared `Tabs` component is untouched, so the other three tab call sites cannot regress.

Closes #2907

## Verification

Measured in headless Chromium at 375×812 against the real compiled Tailwind CSS, in a fixture reproducing the app's container chain:

| | before | after |
|---|---|---|
| `main.scrollWidth` vs `clientWidth` | 625 > 375 — page scrolls | 375 === 375 — no page scroll |
| strip `scrollWidth` vs `clientWidth` | — | 691 > 343 — strip scrolls alone |
| trigger height | 59px (labels wrapped to two lines) | 38px (single line) |

At 1280px the strip's computed style is byte-identical before and after (`flex-direction: column`, width 180, `overflow-x: visible`, nothing scrolls), so the desktop vertical sidebar — explicitly out of scope in the issue — is provably unchanged.

- [x] `mise run ui:check` — tsc, eslint, prettier clean (the 2 remaining warnings are pre-existing `react-hooks/exhaustive-deps` in files this PR does not touch)
- [x] `mise run ui:test` — 221 tests pass

## Test plan

- [ ] **Real device pass** — the measurements above are headless Chromium only; iOS Safari and Android Chrome are unverified. Specifically worth checking that the horizontal scroll affordance is discoverable enough with overlay scrollbars, and that momentum scrolling the strip does not fight vertical page scroll.
- [ ] Confirm every section (Connections, API keys, Usage, and Channels / Experimental features when enabled) is reachable without the page moving
- [ ] Confirm the desktop vertical sidebar is unchanged past `md`
- [ ] Confirm keyboard focus rings are not clipped when tabbing along the strip

## Not addressed

- **Deep-link case.** Landing directly on e.g. `/settings/usage` on a phone leaves the active pill scrolled out of sight; the strip does not auto-scroll it into view. Not a regression — it was equally off-screen before — and fixing it means an effect in the shared `Tabs`, where a naive `scrollIntoView` would walk up to `main` and yank the page vertically. Better as its own change.
- **#830** (chat UI overflowing on mobile) does **not** share this root cause. That one is a vertical viewport problem — `h-dvh` in `chat-view.tsx` and `app.tsx` versus the visual viewport when the address bar or on-screen keyboard appears, with no `window.visualViewport` usage anywhere in the package. Different axis, different mechanism; this fix does nothing for it.
- **No automated test.** The UI package has no DOM or component tests (all unit suites are logic-only), and asserting Tailwind layout needs a real browser.