### PR TITLE
docs(guidelines): fix cd.yml link in release-process

### DIFF
--- a/docs/guidelines/release-process.md
+++ b/docs/guidelines/release-process.md
@@ -38,7 +38,7 @@ To release a different version than what's on main, run `mise run release:set-ve
 Run from the release branch. The task:
 
 1. Tags the current commit (e.g. `v0.3.0-rc1`) and pushes tag + branch atomically.
-2. The `v*` tag triggers the release jobs in [`cd.yml`](.github/workflows/cd.yml): images are built, Helm chart is pushed, CLI is published to npm with `--tag rc`.
+2. The `v*` tag triggers the release jobs in [`cd.yml`](../../.github/workflows/cd.yml): images are built, Helm chart is pushed, CLI is published to npm with `--tag rc`.
 3. Bumps the branch to the next RC (`0.3.0-rc2`).
 
 Repeat as needed — cherry-pick fixes onto the release branch and publish another RC.


### PR DESCRIPTION
## Summary

One broken link from the link-guardian report in #928.

`docs/guidelines/release-process.md` line 41 linked `.github/workflows/cd.yml`, which resolves relative to `docs/guidelines/` rather than the repo root. Line 64 of the same file already linked the identical target correctly as `../../.github/workflows/cd.yml`; line 41 now matches it. Link text is unchanged.

```diff
-2. The `v*` tag triggers the release jobs in [`cd.yml`](.github/workflows/cd.yml): …
+2. The `v*` tag triggers the release jobs in [`cd.yml`](../../.github/workflows/cd.yml): …
```

**Refs #928 — this does not close it.** Three groups from that report are deliberately left alone, each because it needs a decision or is blocked:

1. **`tseng/vocabulary.md`** in `docs/guidelines/documentation-guidelines.md:17` and `.agents/skills/doc-drift/SKILL.md:33`. There is no `vocabulary.md` and no `tseng/` directory anywhere in this repo — the target lives outside it. Fixing these is a call between de-linking and pointing at wherever the vocabulary actually lives.
2. **`docs/adrs/050-platform-reserved-paths.md`** references `044-file-import.md` when the real file is `045-file-import.md`. Obvious as the fix looks, `scripts/adr-immutable.mjs` freezes the prose body of every accepted ADR — only frontmatter is mutable — so editing it would fail that gate.
3. **The 17 links in `docs/notes/openshell-credential-threat-model.md`** pointing into `context/OpenShell/`, an external repo not present here. Another decision rather than a fix.

## Verification

The repo has no in-repo link checker (`mise tasks` exposes only `docs:check:{adr-immutable,adr-index,doc-size}`, and `scripts/` has no link script), so resolution was checked directly from the containing directory:

- old form — `ls docs/guidelines/.github/workflows/cd.yml` → no such file
- new form — `ls docs/guidelines/../../.github/workflows/cd.yml` → resolves, 43444 bytes

Swept for other links of the same shape and found none: targets beginning `.github/`, `packages/`, `deploy/`, or `scripts/` (exhaustive — those plus `docs/` are the repo's only top-level directories), `](docs/…` from inside `docs/`, root-absolute `](/…`, and reference-style `[label]: path` definitions (the one match is a `[^1]:` footnote, not a link).

- [x] All three `docs:check:*` tasks pass, including `adr-immutable` reporting no accepted ADR body was rewritten
- [x] Remaining check groups re-run explicitly — 37 tasks, exit 0

## Test plan

- [ ] Click through the two `cd.yml` links in `docs/guidelines/release-process.md` on the rendered PR page and confirm both resolve