### PR TITLE
fix(agents): align the VM guest's Claude Code config with the container image

### DIFF
--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -57,6 +57,9 @@ COPY --from=agent /usr/local/share/mise/ /usr/local/share/mise/
 COPY --from=agent /usr/local/share/lazy-tools/ /usr/local/share/lazy-tools/
 COPY --from=agent /etc/mise/ /etc/mise/
 COPY --from=agent /etc/AGENTS.md /etc/AGENTS.md
+# Managed settings carry the Stop/SubagentStop background-work hooks — without
+# them a VM session's running jobs are reaped out from under it.
+COPY --from=agent /etc/claude-code/ /etc/claude-code/
 COPY --from=agent /etc/profile.d/model-gateway.sh /etc/profile.d/model-gateway.sh
 COPY --from=agent /app/ /app/
 COPY --from=agent /opt/ /opt/

--- a/packages/agents/claude-code-vm/system/agent-runtime.service
+++ b/packages/agents/claude-code-vm/system/agent-runtime.service
@@ -27,6 +27,15 @@ Environment=PATH=/app/node_modules/.bin:/usr/local/share/mise/shims:/usr/local/b
 Environment=SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 Environment=REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 Environment=KUBECONFIG=/etc/rancher/k3s/k3s.yaml
+# Parity with the container image's Dockerfile ENV (bootc copies files, not
+# image env) — see packages/agents/claude-code/Dockerfile and
+# packages/platform-base/Dockerfile.
+Environment=DISABLE_TELEMETRY=1 DISABLE_ERROR_REPORTING=1 DISABLE_FEEDBACK_COMMAND=1 DISABLE_FEEDBACK_SURVEY=1 DISABLE_AUTOUPDATER=1
+Environment=PYTHONPATH=/usr/local/lib/platform-python
+# The runtime (and thus the harness) runs as root here; Claude Code refuses
+# --dangerously-skip-permissions under root unless IS_SANDBOX=1 attests the
+# environment is a sandbox — which this VM is.
+Environment=IS_SANDBOX=1
 # agent-entrypoint: CA trust is root-owned here (platform-ca.service) so its
 # own attempt just warns; the ~/.cache→/tmp symlink and mise-pin heal still
 # apply, then it execs the runtime.

--- a/packages/controller/pkg/reconciler/vm_resources.go
+++ b/packages/controller/pkg/reconciler/vm_resources.go
@@ -179,6 +179,25 @@ func BuildVMCloudInitSecret(name string, agentSpec *types.AgentSpec, cfg *config
 		vmAgentUID, shellQuote(agentHome),
 	)})
 
+	// The init script — on the container backend an init container (see
+	// resources.go). It is what seeds $HOME from /app/working-dir on first
+	// boot (Claude Code onboarding state, settings, the work dir), so
+	// skipping it leaves the harness with a first-run wizard and no
+	// permission config. Same every-start semantics as the init container:
+	// bootcmd runs each boot and the script is idempotent by contract.
+	// Runs as root (matching agent-runtime here); HOME is set explicitly
+	// since cloud-init's env carries none.
+	initScript := agentSpec.Init
+	if initScript == "" {
+		initScript = defaults.Init
+	}
+	// Inline argv, not a write_files script: bootcmd can run before
+	// write_files within cloud-init's module order, so a file dependency
+	// would race. `env` sets HOME without shell-quoting the script.
+	if initScript != "" {
+		cc.BootCmd = append(cc.BootCmd, []string{"env", "HOME=" + agentHome, "bash", "-c", initScript})
+	}
+
 	body, err := yaml.Marshal(cc)
 	if err != nil {
 		return nil, fmt.Errorf("encoding cloud-init userdata: %w", err)
@@ -202,8 +221,9 @@ func BuildVMCloudInitSecret(name string, agentSpec *types.AgentSpec, cfg *config
 // unchanged. runStrategy is owned by applyVirtualMachine (the replicas
 // analogue); the value rendered here is a create-time default only.
 //
-// Non-persisted mounts, the user init script, and warm-pool claims are
-// container-backend concepts and deliberately don't render here.
+// Warm-pool claims are a container-backend concept and deliberately don't
+// render here. Non-persisted mount dirs and the init script ride the
+// cloud-init userdata instead (BuildVMCloudInitSecret).
 func BuildAgentVirtualMachine(name string, agentSpec *types.AgentSpec, cfg *config.Config, ownerRef metav1.OwnerReference, gatewayClusterIP string) (*unstructured.Unstructured, error) {
 	base := cfg.AgentBase
 	defaults := cfg.AgentTemplateDefaults

--- a/packages/controller/pkg/reconciler/vm_test.go
+++ b/packages/controller/pkg/reconciler/vm_test.go
@@ -25,6 +25,7 @@ func vmAgentCR() *apiv1.Agent {
 		{Path: "/home/agent", Persist: true, Size: "10Gi"},
 		{Path: "/scratchpad", Persist: false},
 	}
+	a.Spec.Init = "touch $HOME/.initialized"
 	return a
 }
 
@@ -167,6 +168,11 @@ func TestVMBackendReconcilesVirtualMachine(t *testing.T) {
 		"mount -t virtiofs 'scratchpad'",
 		"ephemeral mounts have no virtiofs device to mount",
 	)
+	// The init script must ride the userdata — it is what seeds $HOME
+	// (Claude Code onboarding state, settings, the work dir); the container
+	// backend runs it as an init container, the VM has only cloud-init.
+	assert.Contains(t, userdata, "HOME=/home/agent")
+	assert.Contains(t, userdata, ".initialized")
 	// The ~/.cache swap must be pre-created by root: on unprivileged virtiofs
 	// a non-root guest cannot create symlinks (virtiofsd lacks CAP_CHOWN), so
 	// the entrypoint's own `ln` would fail with EPERM.


### PR DESCRIPTION
Follow-up to #3156 — three ways the VM guest's Claude Code diverged from the container-based one, found smoke-testing on the CNV cluster.

### 1. Init script never ran on the VM backend (controller)
The container backend runs `spec.Init` as an init container; the VM rendered nothing. The default init seeds `$HOME` from `/app/working-dir` — Claude Code's onboarding state (`.claude.json`), `.claude/settings.json`, and the `work` dir. Without it: first-run wizard in terminal mode, per-command permission prompts in chat, and a missing `WORK_DIR` failing the first harness spawn. Now rendered as an inline `bootcmd` argv (bootcmd can precede `write_files`, so no file dependency), `HOME` set explicitly, idempotent per boot like the init container.

### 2. Dockerfile ENV doesn't carry into the bootc guest (claude-code-vm)
- **`IS_SANDBOX=1`** — the runtime (and harness) run as root since #3156, and Claude Code refuses `--dangerously-skip-permissions` under root without the sandbox attestation. The VM boundary is the sandbox, so the attestation is truthful.
- **`DISABLE_TELEMETRY` / `DISABLE_ERROR_REPORTING` / `DISABLE_FEEDBACK_COMMAND` / `DISABLE_FEEDBACK_SURVEY` / `DISABLE_AUTOUPDATER`**, **`PYTHONPATH`** — mirrored from the container Dockerfiles into the unit's `Environment=`.

### 3. Managed settings never copied into the guest image (claude-code-vm)
`/etc/claude-code/managed-settings.json` carries the Stop/SubagentStop background-work hooks; without it a VM session's running jobs can be reaped out from under it.

Validated interim on the CNV test cluster (`IS_SANDBOX` via `templateDefaults.env`; seed verified missing on a fresh VM and present on pods).

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>