### PR TITLE
fix(ui): keep an interrupted response visible (#933)

### DIFF
--- a/docs/architecture/knowledge-bases.md
+++ b/docs/architecture/knowledge-bases.md
@@ -1,6 +1,6 @@
 # Knowledge Bases
 
-Last verified: 2026-07-29
+Last verified: 2026-08-05
 
 ## Overview
 
@@ -25,7 +25,7 @@ The module has no persistence of its own: a Knowledge Base is exactly the owner'
 
 Knowledge Bases is a feature-gated destination ([features](features.md)) with a list and a **standalone per-KB page** — the chat surface under the knowledge base's own route, so the rail keeps the Knowledge Bases context and leaving returns to the KB list, never to Sandboxes. Creation is **not** its own form: it is the `knowledge-base` starting point on the shared [sandbox wizard](agent-lifecycle.md)'s first step, which pins the Claude Code harness, hides it, and reveals the KB Template picker; the wizard's finish dispatches to this module's create. The KB list's own create button enters that wizard with the starting point pre-picked.
 
-Opening a KB that has no sessions yet **greets the user**: the UI runs `/wiki-onboard` as a hidden first turn (reaches the agent, renders no user bubble, fails silently), so a fresh KB opens with the agent introducing itself rather than an empty chat. This is why every template's bootstrap installs that command. The greeting mechanism is shared with experiments.
+Opening a KB that has no sessions yet **greets the user**: the UI runs `/wiki-onboard` as a hidden first turn (reaches the agent, renders no user bubble, surfaces no error — a greeting that breaks before it says anything leaves no trace, while one interrupted mid-stream keeps what it already said), so a fresh KB opens with the agent introducing itself rather than an empty chat. This is why every template's bootstrap installs that command. The greeting mechanism is shared with experiments.
 
 One known gap: the greeting races the bootstrap. It fires once the agent is running, but the Install Command lands after Ready, so a very fast open can run `/wiki-onboard` before it exists. Experiments close this by waiting for their authoring skill to be reported present; a KB has nothing equivalent to probe, because its onboarding artifact is a *command* and that read covers only skills.
 

--- a/packages/ui/src/modules/acp/session-projection.ts
+++ b/packages/ui/src/modules/acp/session-projection.ts
@@ -165,6 +165,13 @@ export function hasStreamingAssistant(messages: Message[]): boolean {
   return messages.some((m) => m.role === "assistant" && m.streaming);
 }
 
+/** True if the agent actually produced something. Verdict parts are minted by
+ *  the client when the user answers a permission prompt — they can land on a
+ *  bubble the agent never wrote to, so they don't count as agent output. */
+export function hasAgentContent(m: Message): boolean {
+  return m.parts.some((p) => p.kind !== "verdict");
+}
+
 function handleUserChunk(messages: Message[], u: ContentChunk): Message[] {
   const queued = u._meta?.queued === true;
   const mid = u.messageId ?? null;

--- a/packages/ui/src/modules/sessions/components/chat-message-part.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-message-part.tsx
@@ -1,0 +1,69 @@
+import { Document } from "@carbon/icons-react";
+
+import { formatBytes } from "@/lib/format-size";
+
+import { Markdown } from "../../../components/markdown.js";
+import type { MessagePart, Role } from "../../../types.js";
+import { PermissionVerdictLine } from "./permission-prompt.js";
+import { ThoughtBlock } from "./thought-block.js";
+import { ToolChip } from "./tool-chip.js";
+
+interface Props {
+  part: MessagePart;
+  role: Role;
+  /** The owning message is still streaming — drives the thought block's
+   *  in-progress state and the typing caret. */
+  streaming: boolean;
+  /** Last part of the message: only that one carries the caret. */
+  isLast: boolean;
+  onFileClick: (path: string) => void;
+}
+
+/** One part of a message, rendered by kind. */
+export function ChatMessagePart({
+  part,
+  role,
+  streaming,
+  isLast,
+  onFileClick,
+}: Props) {
+  switch (part.kind) {
+    case "text":
+      if (role === "assistant")
+        return <Markdown onFileClick={onFileClick}>{part.text}</Markdown>;
+      return (
+        <span className="whitespace-pre-wrap break-words">
+          {part.text}
+          {streaming && isLast && (
+            <span className="inline-block w-[7px] h-4 bg-accent ml-0.5 align-text-bottom anim-blink rounded-sm" />
+          )}
+        </span>
+      );
+    case "thought":
+      return <ThoughtBlock text={part.text} streaming={streaming} />;
+    case "image":
+      return (
+        <img
+          src={`data:${part.mimeType};base64,${part.data}`}
+          alt="image"
+          className="max-w-[400px] max-h-[400px] rounded-lg border border-border object-contain"
+        />
+      );
+    case "verdict":
+      return <PermissionVerdictLine verdict={part} />;
+    case "file":
+      return (
+        <div className="inline-flex items-center gap-2 rounded-md border border-border bg-muted px-3 py-2">
+          <Document size={14} className="text-muted-foreground shrink-0" />
+          <span className="text-xs text-muted-foreground">{part.name}</span>
+          {part.size !== undefined && (
+            <span className="text-[10px] text-muted-foreground">
+              {formatBytes(part.size)}
+            </span>
+          )}
+        </div>
+      );
+    default:
+      return <ToolChip chip={part} />;
+  }
+}

--- a/packages/ui/src/modules/sessions/components/chat-message.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-message.tsx
@@ -1,0 +1,102 @@
+import { cn } from "@/lib/utils";
+
+import type { Attachment, Message } from "../../../types.js";
+import { hasAgentContent } from "../../acp/session-projection.js";
+import { BusyIndicator } from "./busy-indicator.js";
+import { ChatMessagePart } from "./chat-message-part.js";
+import { PermissionStatusLine } from "./permission-prompt.js";
+import { SendErrorCard } from "./send-error-card.js";
+
+interface Props {
+  message: Message;
+  /** Last entry in the transcript — only that one anchors the pending-approval
+   *  status line. */
+  isLast: boolean;
+  hasPendingPermission: boolean;
+  onRetry: (text: string, attachments?: Attachment[]) => void;
+  onFileClick: (path: string) => void;
+}
+
+/** One transcript entry. A failed turn keeps whatever it already streamed and
+ *  takes the error card *underneath* that content; the card stands in for the
+ *  bubble only when there is nothing to show, so an interruption never reads
+ *  as a lost turn. The card's own label keys off `hasAgentContent`, which is
+ *  stricter than "has parts" — a verdict-only bubble renders its verdict line
+ *  and still reads as a send that never landed, because the agent never
+ *  produced anything. */
+export function ChatMessage({
+  message,
+  isLast,
+  hasPendingPermission,
+  onRetry,
+  onFileClick,
+}: Props) {
+  if (message.notice) {
+    return (
+      <div className="flex justify-center anim-in">
+        <span className="text-[11px] italic text-muted-foreground px-3 py-1 border-t border-b border-border/60">
+          {message.parts.find((p) => p.kind === "text")?.text ?? "…"}
+        </span>
+      </div>
+    );
+  }
+
+  const { role, parts, streaming, queued, error } = message;
+  const isAssistant = role === "assistant";
+  const retryWith = error?.retryWith;
+
+  return (
+    <div
+      data-testid="chat-message"
+      data-role={role}
+      className={cn(
+        "flex flex-col gap-1 anim-in",
+        isAssistant ? "items-start" : "items-end",
+      )}
+    >
+      <span className="text-[11px] font-medium text-muted-foreground mb-0.5">
+        {isAssistant ? "Agent" : "You"}
+      </span>
+      {(!error || parts.length > 0) && (
+        <div
+          className={
+            isAssistant
+              ? "flex flex-col gap-4 w-full max-w-full"
+              : "flex flex-col gap-2 rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground"
+          }
+        >
+          {parts.map((p, i) => (
+            <ChatMessagePart
+              key={i}
+              part={p}
+              role={role}
+              streaming={streaming}
+              isLast={i === parts.length - 1}
+              onFileClick={onFileClick}
+            />
+          ))}
+          {streaming && queued && parts.length === 0 && (
+            <span className="text-xs text-muted-foreground italic">
+              Waiting for previous prompt…
+            </span>
+          )}
+          {isAssistant && isLast && <PermissionStatusLine />}
+          {isAssistant && streaming && !queued && !hasPendingPermission && (
+            <BusyIndicator className="py-1" />
+          )}
+        </div>
+      )}
+      {error && (
+        <SendErrorCard
+          rawError={error.message}
+          interrupted={hasAgentContent(message)}
+          onRetry={
+            retryWith
+              ? () => onRetry(retryWith.text, retryWith.attachments)
+              : undefined
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/modules/sessions/components/send-error-card.tsx
+++ b/packages/ui/src/modules/sessions/components/send-error-card.tsx
@@ -1,0 +1,54 @@
+import { Renew, Warning } from "@carbon/icons-react";
+
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+import { cn } from "@/lib/utils";
+
+import { describeSendError } from "../../acp/errors.js";
+
+interface Props {
+  rawError: string;
+  /** The turn had already streamed content before it broke — the card then
+   *  sits under that content and says so, instead of reading as a send that
+   *  never landed. */
+  interrupted?: boolean;
+  onRetry?: () => void;
+}
+
+/** Why a turn didn't complete, rendered inside the assistant bubble. */
+export function SendErrorCard({ rawError, interrupted, onRetry }: Props) {
+  const { message, hint } = describeSendError(rawError);
+  return (
+    <Callout
+      tone="danger"
+      className={cn(
+        "flex max-w-[620px] items-start gap-2.5 anim-in",
+        interrupted && "mt-2",
+      )}
+      role="alert"
+    >
+      <Warning size={16} className="text-danger shrink-0 mt-0.5" />
+      <div className="flex-1 min-w-0 flex flex-col gap-2">
+        <div className="text-sm text-foreground break-words">
+          <span className="font-bold text-danger">
+            {interrupted ? "Response interrupted:" : "Send failed:"}
+          </span>{" "}
+          {message}
+        </div>
+        {hint && (
+          <p className="text-xs text-muted-foreground break-words">{hint}</p>
+        )}
+        {onRetry && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onRetry}
+            className="self-start"
+          >
+            <Renew size={11} /> Retry
+          </Button>
+        )}
+      </div>
+    </Callout>
+  );
+}

--- a/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
@@ -7,6 +7,7 @@ import type { Attachment, Message } from "../../../types.js";
 import { extractErrorMessage } from "../../acp/errors.js";
 import {
   finalizeAllStreaming,
+  hasAgentContent,
   hasStreamingAssistant,
 } from "../../acp/session-projection.js";
 import { buildPromptBlocks } from "../../acp/utils.js";
@@ -16,8 +17,9 @@ const DELIVERY_TIMEOUT_MS = 60_000;
 
 export interface SendPromptOptions {
   /** Send the prompt to the agent without rendering a user bubble, and drop
-   *  the turn silently if it fails — so an auto-sent prompt reads as the agent
-   *  speaking first rather than the user having typed a command. */
+   *  the turn silently if it fails before producing anything — so an auto-sent
+   *  prompt reads as the agent speaking first rather than the user having
+   *  typed a command. */
   hidden?: boolean;
 }
 
@@ -73,8 +75,8 @@ export function useAcpPrompt(
 
       // Hidden sends (e.g. a KB's auto-run onboarding) still reach the agent
       // but render no user bubble, so the turn reads as the agent speaking
-      // first. A hidden send that fails is dropped silently rather than
-      // leaving an error the user never asked for.
+      // first. A hidden send that fails with nothing to show is dropped
+      // silently rather than leaving an error the user never asked for.
       const hidden = opts?.hidden ?? false;
 
       const userParts: Message["parts"] = [];
@@ -132,7 +134,6 @@ export function useAcpPrompt(
                       ...m,
                       streaming: false,
                       queued: false,
-                      parts: [],
                       error: {
                         message: "Couldn't deliver — the agent didn't respond.",
                         retryWith: { text, attachments },
@@ -168,23 +169,24 @@ export function useAcpPrompt(
           ),
         );
       } catch (err: unknown) {
-        if (hidden) {
+        const bubble = useStore.getState().messages.find((m) => m.id === aId);
+        const streamed = !!bubble && hasAgentContent(bubble);
+        if (hidden && !streamed) {
           dropBubble();
         } else {
-          const errMsg = extractErrorMessage(err);
+          // Whatever already streamed stays put — an interruption is not a
+          // lost turn, and the error card renders below it. A hidden turn
+          // keeps its content but still surfaces no error.
+          const error = hidden
+            ? undefined
+            : {
+                message: extractErrorMessage(err),
+                retryWith: { text, attachments },
+              };
           setMessages((p) =>
             p.map((m) =>
               m.id === aId
-                ? {
-                    ...m,
-                    streaming: false,
-                    queued: false,
-                    parts: [],
-                    error: {
-                      message: errMsg,
-                      retryWith: { text, attachments },
-                    },
-                  }
+                ? { ...m, streaming: false, queued: false, error }
                 : m,
             ),
           );

--- a/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-prompt.ts
@@ -123,7 +123,8 @@ export function useAcpPrompt(
       watchdogRef.current = setTimeout(() => {
         const msgs = useStore.getState().messages;
         const bubble = msgs.find((m) => m.id === aId);
-        if (bubble?.streaming && bubble.parts.length === 0) {
+        // Not a part count: a verdict can land on a bubble the agent never wrote.
+        if (bubble?.streaming && !hasAgentContent(bubble)) {
           if (hidden) {
             dropBubble();
           } else {

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -42,6 +42,7 @@ import type { SessionError } from "../../../store.js";
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
 import { describeSendError } from "../../acp/errors.js";
+import { hasAgentContent } from "../../acp/session-projection.js";
 import { useHarnessConfigCurrent } from "../../agents/api/harness-config.js";
 import { useDeleteAgent } from "../../agents/api/mutations.js";
 import { useAgents, useIsAgentOperable } from "../../agents/api/queries.js";
@@ -691,20 +692,7 @@ export function ChatView() {
                           <span className="text-[11px] font-medium text-muted-foreground mb-0.5">
                             {m.role === "user" ? "You" : "Agent"}
                           </span>
-                          {m.error ? (
-                            <SendErrorCard
-                              rawError={m.error.message}
-                              onRetry={
-                                m.error.retryWith
-                                  ? () =>
-                                      sendPrompt(
-                                        m.error!.retryWith!.text,
-                                        m.error!.retryWith!.attachments,
-                                      )
-                                  : undefined
-                              }
-                            />
-                          ) : (
+                          {(!m.error || m.parts.length > 0) && (
                             <div
                               className={
                                 m.role === "user"
@@ -788,6 +776,21 @@ export function ChatView() {
                                   <BusyIndicator className="py-1" />
                                 )}
                             </div>
+                          )}
+                          {m.error && (
+                            <SendErrorCard
+                              rawError={m.error.message}
+                              interrupted={hasAgentContent(m)}
+                              onRetry={
+                                m.error.retryWith
+                                  ? () =>
+                                      sendPrompt(
+                                        m.error!.retryWith!.text,
+                                        m.error!.retryWith!.attachments,
+                                      )
+                                  : undefined
+                              }
+                            />
                           )}
                         </div>
                       ),
@@ -978,24 +981,35 @@ function SessionErrorCard({
   );
 }
 
+/** `interrupted` means the turn had already streamed content before it broke —
+ *  the card then sits under that content and says so, instead of reading as a
+ *  send that never landed. */
 function SendErrorCard({
   rawError,
+  interrupted,
   onRetry,
 }: {
   rawError: string;
+  interrupted?: boolean;
   onRetry?: () => void;
 }) {
   const { message, hint } = describeSendError(rawError);
   return (
     <Callout
       tone="danger"
-      className="flex max-w-[620px] items-start gap-2.5"
+      className={cn(
+        "flex max-w-[620px] items-start gap-2.5 anim-in",
+        interrupted && "mt-2",
+      )}
       role="alert"
     >
       <Warning size={16} className="text-danger shrink-0 mt-0.5" />
       <div className="flex-1 min-w-0 flex flex-col gap-2">
         <div className="text-sm text-foreground break-words">
-          <span className="font-bold text-danger">Send failed:</span> {message}
+          <span className="font-bold text-danger">
+            {interrupted ? "Response interrupted:" : "Send failed:"}
+          </span>{" "}
+          {message}
         </div>
         {hint && (
           <p className="text-xs text-muted-foreground break-words">{hint}</p>

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -1,9 +1,7 @@
 import {
   ArrowDown,
   ArrowLeft,
-  Document,
   OverflowMenuVertical,
-  Renew,
   Settings,
   TrashCan,
   Warning,
@@ -31,18 +29,14 @@ import {
 import { HOVER_ACTION } from "@/components/ui/hover-action";
 import { Spinner } from "@/components/ui/spinner";
 import { Tooltip } from "@/components/ui/tooltip";
-import { formatBytes } from "@/lib/format-size";
 import { cn } from "@/lib/utils";
 
-import { Markdown } from "../../../components/markdown.js";
 import { ResizeHandle } from "../../../components/resize-handle.js";
 import { isMobile } from "../../../lib/breakpoints.js";
 import { queryClient } from "../../../query-client.js";
 import type { SessionError } from "../../../store.js";
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
-import { describeSendError } from "../../acp/errors.js";
-import { hasAgentContent } from "../../acp/session-projection.js";
 import { useHarnessConfigCurrent } from "../../agents/api/harness-config.js";
 import { useDeleteAgent } from "../../agents/api/mutations.js";
 import { useAgents, useIsAgentOperable } from "../../agents/api/queries.js";
@@ -73,17 +67,12 @@ import {
   optimisticInsertSession,
   setSessionRunning,
 } from "../api/queries.js";
-import { BusyIndicator } from "../components/busy-indicator.js";
 import { ChatColumn } from "../components/chat-column.js";
 import { ChatInputArea } from "../components/chat-input-area.js";
-import {
-  PermissionStatusLine,
-  PermissionVerdictLine,
-} from "../components/permission-prompt.js";
+import { ChatMessage } from "../components/chat-message.js";
+import { PermissionStatusLine } from "../components/permission-prompt.js";
 import { SessionsSidebar } from "../components/sessions-sidebar.js";
 import { Terminal } from "../components/terminal.js";
-import { ThoughtBlock } from "../components/thought-block.js";
-import { ToolChip } from "../components/tool-chip.js";
 import type { ConnectionState } from "../hooks/use-acp-connection.js";
 import { useAcpSession } from "../hooks/use-acp-session.js";
 import { useHasPendingPermission } from "../hooks/use-pending-permissions.js";
@@ -668,133 +657,16 @@ export function ChatView() {
                           </p>
                         </div>
                       ))}
-                    {messages.map((m, mi) =>
-                      m.notice ? (
-                        <div key={m.id} className="flex justify-center anim-in">
-                          <span className="text-[11px] italic text-muted-foreground px-3 py-1 border-t border-b border-border/60">
-                            {m.parts.find((p) => p.kind === "text")?.kind ===
-                            "text"
-                              ? (
-                                  m.parts.find((p) => p.kind === "text") as {
-                                    text: string;
-                                  }
-                                ).text
-                              : "…"}
-                          </span>
-                        </div>
-                      ) : (
-                        <div
-                          key={m.id}
-                          data-testid="chat-message"
-                          data-role={m.role}
-                          className={`flex flex-col gap-1 anim-in ${m.role === "user" ? "items-end" : "items-start"}`}
-                        >
-                          <span className="text-[11px] font-medium text-muted-foreground mb-0.5">
-                            {m.role === "user" ? "You" : "Agent"}
-                          </span>
-                          {(!m.error || m.parts.length > 0) && (
-                            <div
-                              className={
-                                m.role === "user"
-                                  ? "flex flex-col gap-2 rounded-xl border border-border bg-card px-4 py-3 text-sm text-foreground"
-                                  : "flex flex-col gap-4 w-full max-w-full"
-                              }
-                            >
-                              {m.parts.map((p, i) =>
-                                p.kind === "text" ? (
-                                  m.role === "assistant" ? (
-                                    <Markdown
-                                      key={i}
-                                      onFileClick={openFileHandler}
-                                    >
-                                      {p.text}
-                                    </Markdown>
-                                  ) : (
-                                    <span
-                                      key={i}
-                                      className="whitespace-pre-wrap break-words"
-                                    >
-                                      {p.text}
-                                      {m.streaming &&
-                                        i === m.parts.length - 1 && (
-                                          <span className="inline-block w-[7px] h-4 bg-accent ml-0.5 align-text-bottom anim-blink rounded-sm" />
-                                        )}
-                                    </span>
-                                  )
-                                ) : p.kind === "thought" ? (
-                                  <ThoughtBlock
-                                    key={i}
-                                    text={p.text}
-                                    streaming={m.streaming}
-                                  />
-                                ) : p.kind === "image" ? (
-                                  <img
-                                    key={i}
-                                    src={`data:${p.mimeType};base64,${p.data}`}
-                                    alt="image"
-                                    className="max-w-[400px] max-h-[400px] rounded-lg border border-border object-contain"
-                                  />
-                                ) : p.kind === "verdict" ? (
-                                  <PermissionVerdictLine key={i} verdict={p} />
-                                ) : p.kind === "file" ? (
-                                  <div
-                                    key={i}
-                                    className="inline-flex items-center gap-2 rounded-md border border-border bg-muted px-3 py-2"
-                                  >
-                                    <Document
-                                      size={14}
-                                      className="text-muted-foreground shrink-0"
-                                    />
-                                    <span className="text-xs text-muted-foreground">
-                                      {p.name}
-                                    </span>
-                                    {p.size !== undefined && (
-                                      <span className="text-[10px] text-muted-foreground">
-                                        {formatBytes(p.size)}
-                                      </span>
-                                    )}
-                                  </div>
-                                ) : (
-                                  <ToolChip key={i} chip={p} />
-                                ),
-                              )}
-                              {m.streaming &&
-                                m.queued &&
-                                m.parts.length === 0 && (
-                                  <span className="text-xs text-muted-foreground italic">
-                                    Waiting for previous prompt…
-                                  </span>
-                                )}
-                              {m.role === "assistant" &&
-                                mi === messages.length - 1 && (
-                                  <PermissionStatusLine />
-                                )}
-                              {m.role === "assistant" &&
-                                m.streaming &&
-                                !m.queued &&
-                                !hasPendingPermission && (
-                                  <BusyIndicator className="py-1" />
-                                )}
-                            </div>
-                          )}
-                          {m.error && (
-                            <SendErrorCard
-                              rawError={m.error.message}
-                              interrupted={hasAgentContent(m)}
-                              onRetry={
-                                m.error.retryWith
-                                  ? () =>
-                                      sendPrompt(
-                                        m.error!.retryWith!.text,
-                                        m.error!.retryWith!.attachments,
-                                      )
-                                  : undefined
-                              }
-                            />
-                          )}
-                        </div>
-                      ),
-                    )}
+                    {messages.map((m, mi) => (
+                      <ChatMessage
+                        key={m.id}
+                        message={m}
+                        isLast={mi === messages.length - 1}
+                        hasPendingPermission={hasPendingPermission}
+                        onRetry={sendPrompt}
+                        onFileClick={openFileHandler}
+                      />
+                    ))}
                     {!statusLineInThread && <PermissionStatusLine />}
                   </ChatColumn>
                 </div>
@@ -974,54 +846,6 @@ function SessionErrorCard({
         {error.kind === "not-found" && (
           <Button variant="destructive" size="sm" onClick={onDelete}>
             <TrashCan size={12} /> Delete orphaned session
-          </Button>
-        )}
-      </div>
-    </Callout>
-  );
-}
-
-/** `interrupted` means the turn had already streamed content before it broke —
- *  the card then sits under that content and says so, instead of reading as a
- *  send that never landed. */
-function SendErrorCard({
-  rawError,
-  interrupted,
-  onRetry,
-}: {
-  rawError: string;
-  interrupted?: boolean;
-  onRetry?: () => void;
-}) {
-  const { message, hint } = describeSendError(rawError);
-  return (
-    <Callout
-      tone="danger"
-      className={cn(
-        "flex max-w-[620px] items-start gap-2.5 anim-in",
-        interrupted && "mt-2",
-      )}
-      role="alert"
-    >
-      <Warning size={16} className="text-danger shrink-0 mt-0.5" />
-      <div className="flex-1 min-w-0 flex flex-col gap-2">
-        <div className="text-sm text-foreground break-words">
-          <span className="font-bold text-danger">
-            {interrupted ? "Response interrupted:" : "Send failed:"}
-          </span>{" "}
-          {message}
-        </div>
-        {hint && (
-          <p className="text-xs text-muted-foreground break-words">{hint}</p>
-        )}
-        {onRetry && (
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={onRetry}
-            className="self-start"
-          >
-            <Renew size={11} /> Retry
           </Button>
         )}
       </div>

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -79,6 +79,8 @@ export interface Message {
    *  catch-up when the session log has been truncated. Invisible to the
    *  projection's routing (findActiveAssistant skips these). */
   notice?: boolean;
+  /** A failed or interrupted turn. Coexists with `parts`: an interruption
+   *  keeps whatever streamed and renders the notice underneath it. */
   error?: {
     message: string;
     /** Cleared once any subsequent send starts, so the Retry button only lives


### PR DESCRIPTION
Closes #933.

## The problem

When a turn broke mid-stream, the error card and its **Retry** button replaced the entire assistant message. Everything the agent had already produced disappeared from view.

Nothing was ever lost — the runtime appends every chunk to the session log as it arrives, so a reload brought the partial response back. But the live view said otherwise: a long turn looked like an hour of work had vanished, which pushed people into retries that re-ran work that was fine.

## The fix

Two places conspired to hide it:

- `use-acp-prompt.ts` — the `sendPrompt` catch set `parts: []` on the assistant bubble, discarding everything already streamed into it.
- `chat-view.tsx` — the render was a ternary, so even with parts preserved the error card would still have replaced them.

Now the content block renders whenever there are parts, and the notice renders below it — matching what a reload shows, so an interruption reads as an interruption.

The card also switches its label to **"Response interrupted:"** once content is present. "Send failed" is factually wrong sitting under a half-written response, and misleading copy is the substance of the issue.

Hidden turns (the agent auto-greeting) previously dropped their bubble on any failure. They now drop it only when the agent produced nothing — discarding content the server has already persisted would recreate the exact live-view/reload mismatch this is about.

### Out of scope, per the issue

A send that never reached the agent still replaces its empty bubble. There is no partial content to preserve, and that path is unchanged.

## Verification

No automated coverage — this lives in a React view and a hook, and the suite here covers pure helpers only. Verified by hand against a local cluster with a temporary fault injector that rejected the in-flight `session/prompt` with the issue's error while leaving the WebSocket open, which is what a harness losing its own upstream connection looks like. Confirmed in both directions: with the fix reverted the bubble went blank, with it in place the content survived and the notice appeared below. The injector was removed before this branch was squashed and appears nowhere in history.

Also exercised: retry after an interruption, the empty-send path, and reload parity.

## Known limitation

This covers a harness dying with our WebSocket still open — the case in the issue. If *our* ACP socket is what drops, the reconnect fires at ~1s and `loadHistory` replaces the transcript, taking the new notice and its Retry with it. The content is still correct; only the explanation is short-lived. Covering that means merging client-side error state across a history reload, which is a design change rather than a tweak.

## Note on `hasAgentContent`

Reviewers caught that `parts.length > 0` was the wrong proxy for "the agent streamed something": `appendVerdict` anchors a **client-minted** permission verdict on the last assistant bubble when no message owns the tool call, so a bubble the agent never wrote to could look like it had content. That mislabelled an empty failure as an interruption and, worse, kept a hidden turn's orphan bubble alive. The shared predicate in `session-projection.ts` excludes verdicts rather than allow-listing agent kinds, so a future agent-produced part kind counts as content by default instead of silently reintroducing this.