### PR TITLE
fix(controller,agents): route the JVM through the egress proxy and the right home

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -196,23 +196,29 @@ kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Ready node --all --timeo
 # 1b. Ensure k3s container-log rotation is configured (issue #244 upgrade
 # path for VMs created before this flag was added). New VMs already have
 # /etc/rancher/k3s/config.yaml from the lima provision script.
+# A config.yaml.d drop-in, never config.yaml itself: k3s merges the
+# directory natively, and overwriting the main file clobbers pre-existing
+# config — inside a VM sandbox it carries the CIDR remap that keeps the
+# inner cluster off the host cluster's ranges, and losing it crash-loops
+# k3s ("cidr ... is out the range of cluster cidr").
+K3S_LOGROT_DROPIN=/etc/rancher/k3s/config.yaml.d/50-container-log-rotation.yaml
 K3S_CONFIG_YAML='kubelet-arg:
   - "container-log-max-size=10Mi"
   - "container-log-max-files=3"
 '
 if [ -n "${IS_SANDBOX:-}" ]; then
-  if ! sudo grep -q container-log-max-size /etc/rancher/k3s/config.yaml 2>/dev/null; then
+  if ! sudo grep -q container-log-max-size "$K3S_LOGROT_DROPIN" /etc/rancher/k3s/config.yaml 2>/dev/null; then
     echo "Configuring k3s container log rotation (issue #244)..."
-    sudo mkdir -p /etc/rancher/k3s
-    printf '%s' "$K3S_CONFIG_YAML" | sudo tee /etc/rancher/k3s/config.yaml >/dev/null
+    sudo mkdir -p "$(dirname "$K3S_LOGROT_DROPIN")"
+    printf '%s' "$K3S_CONFIG_YAML" | sudo tee "$K3S_LOGROT_DROPIN" >/dev/null
     sudo systemctl restart k3s
     kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Ready node --all --timeout=120s
   fi
 else
-  if ! limactl shell "$LIMA_INSTANCE" sudo grep -q container-log-max-size /etc/rancher/k3s/config.yaml 2>/dev/null; then
+  if ! limactl shell "$LIMA_INSTANCE" sudo grep -q container-log-max-size "$K3S_LOGROT_DROPIN" /etc/rancher/k3s/config.yaml 2>/dev/null; then
     echo "Configuring k3s container log rotation (issue #244)..."
-    limactl shell "$LIMA_INSTANCE" sudo mkdir -p /etc/rancher/k3s
-    printf '%s' "$K3S_CONFIG_YAML" | limactl shell "$LIMA_INSTANCE" sudo tee /etc/rancher/k3s/config.yaml >/dev/null
+    limactl shell "$LIMA_INSTANCE" sudo mkdir -p "$(dirname "$K3S_LOGROT_DROPIN")"
+    printf '%s' "$K3S_CONFIG_YAML" | limactl shell "$LIMA_INSTANCE" sudo tee "$K3S_LOGROT_DROPIN" >/dev/null
     limactl shell "$LIMA_INSTANCE" sudo systemctl restart k3s
     kubectl --kubeconfig="$KUBECONFIG" wait --for=condition=Ready node --all --timeout=120s
   fi

--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -78,7 +78,7 @@ RUN mkdir -p /var/home && \
     usermod -aG docker agent && \
     echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent && \
     chown -R agent /etc/mise /app /usr/local/share/mise && chown agent /etc/AGENTS.md && \
-    printf '\n## VM sandbox\n\nThis sandbox is a full virtual machine: systemd, `docker` (moby), a preinstalled `k3s` Kubernetes cluster (`kubectl` works out of the box), and passwordless `sudo`. OS state outside your home and workspace is discarded on hibernation.\n' >> /etc/AGENTS.md
+    printf '\n## VM sandbox\n\nThis sandbox is a full virtual machine: systemd, `docker` (moby), a preinstalled `k3s` Kubernetes cluster (`kubectl` works out of the box), and passwordless `sudo`. OS state outside your home and workspace is discarded on hibernation.\n\nThe in-VM k3s cluster is entirely yours: nothing that manages this sandbox runs on it, so you can freely reconfigure, wipe, or reinstall it. The platform managing this sandbox lives outside the VM and is unaffected by anything you do to the inner cluster. The inner k3s deliberately uses non-default CIDRs (`/etc/rancher/k3s/config.yaml`) so it does not clash with the host network — keep those when changing its config, and prefer drop-ins under `/etc/rancher/k3s/config.yaml.d/` over editing the main file.\n' >> /etc/AGENTS.md
 
 # The guest has no SSH and an ephemeral rootfs, so a boot that fails before
 # agent-runtime leaves the journal unreachable — the serial console (captured

--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -71,6 +71,10 @@ COPY --from=agent /opt/ /opt/
 # /home is a bootc symlink to /var/home, absent at build time
 RUN mkdir -p /var/home && \
     useradd -u 65532 -d /home/agent -s /bin/bash agent && \
+    # agent-runtime (and the harness) run as root here; anything resolving
+    # home via getpwuid — the JVM's user.home, ~ expansion in tools that
+    # ignore $HOME — must land on the workspace, not /root.
+    usermod -d /home/agent root && \
     usermod -aG docker agent && \
     echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent && \
     chown -R agent /etc/mise /app /usr/local/share/mise && chown agent /etc/AGENTS.md && \

--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -115,16 +115,19 @@ RUN mkdir -p /usr/lib/systemd/system.conf.d && \
       > /usr/lib/systemd/system.conf.d/platform-timeouts.conf
 
 COPY system/platform-scratch.sh /usr/libexec/platform-scratch.sh
+COPY system/platform-net-config.sh /usr/libexec/platform-net-config.sh
 COPY system/platform-boot-gate.sh /usr/libexec/platform-boot-gate.sh
 COPY system/platform-scratch.service system/platform-ca.service \
      system/platform-boot-gate.service system/agent-runtime.service \
+     system/platform-net-config.service \
      /usr/lib/systemd/system/
 COPY system/proxy-dropin.conf /usr/lib/systemd/system/docker.service.d/platform.conf
 COPY system/proxy-dropin.conf /usr/lib/systemd/system/k3s.service.d/platform.conf
 COPY system/k3s-config.yaml /etc/rancher/k3s/config.yaml
 COPY system/profile-platform.sh /etc/profile.d/platform-vm.sh
 
-RUN chmod 755 /usr/libexec/platform-scratch.sh /usr/libexec/platform-boot-gate.sh && \
+RUN chmod 755 /usr/libexec/platform-scratch.sh /usr/libexec/platform-boot-gate.sh /usr/libexec/platform-net-config.sh && \
     systemctl enable docker.service k3s.service qemu-guest-agent.service \
       platform-scratch.service platform-ca.service platform-boot-gate.service \
+      platform-net-config.service \
       agent-runtime.service

--- a/packages/agents/claude-code-vm/system/platform-net-config.service
+++ b/packages/agents/claude-code-vm/system/platform-net-config.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Platform net config (docker MTU + client proxy) — must precede docker
+# cloud-init's init stage writes /etc/platform/env; the default route must
+# exist for MTU discovery. Before=docker.service so daemon.json is in place
+# when dockerd starts (the rootfs is ephemeral, so this re-renders each boot).
+After=cloud-init.service cloud-init-network.service network-online.target
+Wants=network-online.target
+Before=docker.service agent-runtime.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/platform-net-config.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packages/agents/claude-code-vm/system/platform-net-config.sh
+++ b/packages/agents/claude-code-vm/system/platform-net-config.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Pre-docker network config the guest can't ship statically:
+#
+# 1. Docker daemon MTU. The guest NIC rides the cluster pod network (MTU
+#    1400 here, discovered at boot); docker0 would default to 1500 and
+#    large transfers inside containers/builds then hang after a successful
+#    TCP handshake. k3s (flannel) auto-derives its MTU; docker does not.
+#
+# 2. Docker client proxy config. The daemon gets proxy env via its systemd
+#    drop-in (image pulls work), but BuildKit injects proxy env into RUN
+#    steps only from the client's ~/.docker/config.json — without it every
+#    build step that fetches (npm, pip, dnf) dials the internet directly
+#    and dies against the egress lockdown.
+set -eu
+
+iface=$(ip -o route show default | awk '{print $5; exit}')
+mtu=$(cat "/sys/class/net/${iface}/mtu")
+mkdir -p /etc/docker
+printf '{\n  "mtu": %s\n}\n' "$mtu" > /etc/docker/daemon.json
+
+. /etc/platform/env 2>/dev/null || true
+[ -n "${HTTPS_PROXY:-}" ] || exit 0
+
+no_proxy_list="localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local"
+for home in /root /home/agent; do
+	cfg="$home/.docker/config.json"
+	# Never clobber an existing config — docker login writes credentials
+	# here. Ceiling: a hand-edited config keeps stale proxy settings; the
+	# gateway ClusterIP is stable for the agent's lifetime, so in practice
+	# absent-only is enough.
+	[ -e "$cfg" ] && continue
+	mkdir -p "$home/.docker"
+	cat > "$cfg" <<EOF
+{
+  "proxies": {
+    "default": {
+      "httpProxy": "$HTTPS_PROXY",
+      "httpsProxy": "$HTTPS_PROXY",
+      "noProxy": "$no_proxy_list"
+    }
+  }
+}
+EOF
+	chown -R 65532:1000 "$home/.docker" 2>/dev/null || true
+done

--- a/packages/agents/claude-code-vm/system/platform-scratch.sh
+++ b/packages/agents/claude-code-vm/system/platform-scratch.sh
@@ -17,7 +17,11 @@ blkid "$dev" >/dev/null 2>&1 || mkfs.xfs -q "$dev"
 mkdir -p /var/lib/platform-scratch
 mountpoint -q /var/lib/platform-scratch || mount "$dev" /var/lib/platform-scratch
 
-for d in docker rancher; do
+# containerd too, not just docker: moby uses the containerd image store, so
+# build layers land in /var/lib/containerd — without the bind they fill the
+# small rootfs /var while the scratch disk idles (found via ENOSPC during
+# concurrent image builds in a sandbox).
+for d in docker rancher containerd; do
 	mkdir -p "/var/lib/platform-scratch/$d" "/var/lib/$d"
 	if [ -z "$(ls -A "/var/lib/platform-scratch/$d")" ] && [ -n "$(ls -A "/var/lib/$d" 2>/dev/null)" ]; then
 		rsync -a "/var/lib/$d/" "/var/lib/platform-scratch/$d/"

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -3,6 +3,8 @@ package reconciler
 import (
 	"fmt"
 	"log/slog"
+	"net"
+	"strings"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -74,6 +76,16 @@ const (
 // resolved Secret set changes.
 const annRollRev = "agent-platform.ai/roll-rev"
 
+// hostPortOf splits an http://host:port proxy URL into host and port for
+// tools that take them separately (the JVM's proxy properties).
+func hostPortOf(proxyURL string) (string, string) {
+	hostPort := strings.TrimPrefix(proxyURL, "http://")
+	if h, p, err := net.SplitHostPort(hostPort); err == nil {
+		return h, p
+	}
+	return hostPort, "80"
+}
+
 // agentProxyAddr is the agent's HTTPS_PROXY value — IP-direct, no DNS.
 // The reconcilers requeue until the gateway ClusterIP is
 // assigned, so this never sees an empty IP at steady state.
@@ -89,7 +101,19 @@ func agentProxyAddr(cfg *config.Config, gatewayClusterIP string) string {
 // hosts AND the harness API — cross the paired gateway pod, whose SPIFFE
 // principal (per-instance SA) is the identity the waypoint enforces.
 func agentPlatformEnv(name string, cfg *config.Config, agentHome, proxyAddr string) []corev1.EnvVar {
+	// The JVM reads neither http_proxy env nor the system store's view of
+	// HOME: proxies come from -Dhttp(s).proxyHost/Port and home from
+	// user.home (getpwuid, which on the VM backend resolves root's passwd
+	// entry, not $HOME). JAVA_TOOL_OPTIONS is the JVM's official env hook
+	// for both — without it Maven/Gradle bypass the egress gateway and
+	// read ~/.m2 from the wrong home.
+	proxyHost, proxyPort := hostPortOf(proxyAddr)
+	javaToolOptions := fmt.Sprintf(
+		"-Duser.home=%s -Dhttp.proxyHost=%s -Dhttp.proxyPort=%s -Dhttps.proxyHost=%s -Dhttps.proxyPort=%s",
+		agentHome, proxyHost, proxyPort, proxyHost, proxyPort,
+	)
 	return []corev1.EnvVar{
+		{Name: "JAVA_TOOL_OPTIONS", Value: javaToolOptions},
 		{Name: "HTTPS_PROXY", Value: proxyAddr},
 		{Name: "HTTP_PROXY", Value: proxyAddr},
 		{Name: "https_proxy", Value: proxyAddr},

--- a/packages/controller/pkg/reconciler/vm_test.go
+++ b/packages/controller/pkg/reconciler/vm_test.go
@@ -146,6 +146,11 @@ func TestVMBackendReconcilesVirtualMachine(t *testing.T) {
 	assert.True(t, strings.HasPrefix(userdata, "#cloud-config\n"))
 	assert.Contains(t, userdata, "HTTPS_PROXY='http://10.96.42.42:10000'")
 	assert.Contains(t, userdata, "PLATFORM_AGENT_ID='my-agent'")
+	// The JVM ignores http_proxy env and $HOME — proxy + user.home must ride
+	// JAVA_TOOL_OPTIONS or Maven/Gradle bypass the gateway and read the
+	// wrong ~/.m2 (user.home resolves via getpwuid, /root on the VM).
+	assert.Contains(t, userdata, "JAVA_TOOL_OPTIONS='-Duser.home=/home/agent")
+	assert.Contains(t, userdata, "-Dhttp.proxyHost=10.96.42.42 -Dhttp.proxyPort=")
 	assert.Contains(t, userdata, "PLATFORM_KUBE_API_DENY='10.43.0.1:443'")
 	assert.Contains(t, userdata, "PEMDATA")
 	// The share must be mounted from bootcmd, never cloud-init's `mounts:`


### PR DESCRIPTION
Found by an agent doing a real Maven + Docker build inside a VM sandbox. Three distinct causes behind "the agent is fighting the proxy":

### 1. The JVM ignores `http_proxy` env (both backends)
Java takes proxies only from `-Dhttp(s).proxyHost/Port`, so Maven/Gradle silently bypassed the egress gateway — on pods too. `agentPlatformEnv` now composes `JAVA_TOOL_OPTIONS` (proxy host/port + `-Duser.home=$HOME`).

### 2. `user.home` resolves via `getpwuid`, not `$HOME` (VM)
The runtime/harness run as root (#3156), so Java read `/root/.m2` while the platform uses `/home/agent`. Fixed twice over: `-Duser.home` above, and root's passwd home now points at `/home/agent` in the guest image — covering every getpwuid-based tool, not just the JVM.

### 3. Docker builds couldn't fetch (VM)
- **daemon MTU**: guest NIC rides the pod network (MTU 1400) while docker0 defaulted to 1500 — TCP connects, large transfers hang. A pre-docker boot oneshot derives the MTU from the default-route interface and writes `daemon.json` each boot (ephemeral rootfs). k3s/flannel self-derives; docker doesn't.
- **client proxies**: the daemon's systemd drop-in covers image pulls only; BuildKit injects proxy env into `RUN` steps solely from `~/.docker/config.json`. Now rendered at boot for `/root` and `/home/agent` from `/etc/platform/env`, absent-only so `docker login` configs are never clobbered.

Tests: `JAVA_TOOL_OPTIONS` (user.home + proxy host/port) asserted in the VM userdata rendering; net-config script is exercised at image build/boot.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>