### PR TITLE
fix(agents): set root's home via passwd edit — usermod can't run in a build

### DIFF
--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -73,8 +73,11 @@ RUN mkdir -p /var/home && \
     useradd -u 65532 -d /home/agent -s /bin/bash agent && \
     # agent-runtime (and the harness) run as root here; anything resolving
     # home via getpwuid — the JVM's user.home, ~ expansion in tools that
-    # ignore $HOME — must land on the workspace, not /root.
-    usermod -d /home/agent root && \
+    # ignore $HOME — must land on the workspace, not /root. sed, not
+    # usermod: usermod refuses a user with live processes, and the build
+    # shell itself runs as root ("user root is currently used by process 1").
+    sed -i 's|^root:\(.*\):/root:|root:\1:/home/agent:|' /etc/passwd && \
+    grep -q '^root:.*:/home/agent:' /etc/passwd && \
     usermod -aG docker agent && \
     echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent && \
     chown -R agent /etc/mise /app /usr/local/share/mise && chown agent /etc/AGENTS.md && \


### PR DESCRIPTION
#3168's `usermod -d /home/agent root` fails every `claude-code-vm` build: usermod refuses to modify a user with live processes, and the docker build shell itself runs as root ("user root is currently used by process 1", exit 8). This broke main's CI at `build-claude-code-vm` (run 30993899139).

Replaced with a direct `/etc/passwd` sed (expression verified: `root:x:0:0:root:/home/agent:/bin/bash`) plus a grep assert so a silent no-op fails the build instead of shipping.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>