### PR TITLE
fix(ui): stop a terminal inheriting a chat's working dot on switch

### DIFF
--- a/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
+++ b/packages/ui/src/modules/sessions/components/sessions-sidebar.tsx
@@ -133,7 +133,7 @@ export function SessionsSidebar({
       s.mode === SessionMode.Terminal
         ? !!s.running
         : isOpen
-          ? busy
+          ? busy || !!s.running
           : !!s.running;
     // Polled approvals cover all sessions; the live store surfaces the open one instantly.
     const needsApproval =

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -1,5 +1,5 @@
 import { SessionMode } from "api-server-api";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { queryClient } from "../../../query-client.js";
 import { useStore } from "../../../store.js";
@@ -46,7 +46,10 @@ export function useAcpSession(
   }, [busy, setBusy]);
   // Mirror busy into the list cache's `running` so the row keeps its blue dot
   // when it stops being the open session (the poll-fed `running` lags a switch).
+  const prevBusyRef = useRef(busy);
   useEffect(() => {
+    if (prevBusyRef.current === busy) return;
+    prevBusyRef.current = busy;
     if (selectedAgent && sessionId) {
       setSessionRunning(selectedAgent, sessionId, busy);
     }

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -1,3 +1,4 @@
+import { SessionMode } from "api-server-api";
 import { useCallback, useEffect, useState } from "react";
 
 import { queryClient } from "../../../query-client.js";
@@ -38,7 +39,8 @@ export function useAcpSession(
   // Derive busy from the projection instead of explicit setBusy calls in
   // sendPrompt / resume / disconnect paths. The projection owns streaming
   // state on every message, so "any streaming assistant" is authoritative.
-  const busy = hasStreamingAssistant(messages);
+  const busy =
+    sessionMode !== SessionMode.Terminal && hasStreamingAssistant(messages);
   useEffect(() => {
     setBusy(busy);
   }, [busy, setBusy]);


### PR DESCRIPTION
Closes #2778

## Problem

Switching from a busy chat session to an idle **terminal** session briefly lit the terminal's "working" dot for a few seconds before it settled to idle on its own.

## Cause

The chat→terminal switch (`mobileResumeSession`) only swaps `sessionId`/`sessionMode`; unlike the chat resume path it never clears `messages`. So on the transition render the projected `busy = hasStreamingAssistant(messages)` is still `true` from the chat you left, while `sessionId` is already the terminal. The busy→`running` mirror effect in `use-acp-session.ts` then stamps the terminal's `running: true` in the list cache. A terminal has no `_meta.platform`, so the server always reports `running: false` for it — the next `session/list` poll (5s) reconciles the flag back, producing the transient flicker.

## Fix

Skip the busy→`running` mirror when the open session is a terminal, so a terminal's status dot reflects only its own state (server `running`, always false) with no carry-over from the previously-viewed chat. Guarding at the mirror covers every terminal-entry path, not just the reported one.

## Testing

- Manually verified: chat working → switch to idle terminal no longer flickers.
- `ui:check:tsc`, `ui:fix:lint`, and `ui:test` (221 passing) all green.
