### PR TITLE
fix: proxy ergonomics found by a real build workload in a VM sandbox

### DIFF
--- a/deploy/tasks.toml
+++ b/deploy/tasks.toml
@@ -224,6 +224,27 @@ else
   fi
 fi
 
+# 1c. Traefik :4444 entrypoint — on lima this rides the provision script's
+# k3s server manifest, but a pre-existing k3s (VM sandbox) never runs that,
+# so the app port silently doesn't exist. HelmChartConfig via kubectl apply
+# is idempotent and works on both.
+kubectl --kubeconfig="$KUBECONFIG" apply -f - <<'YAML'
+apiVersion: helm.cattle.io/v1
+kind: HelmChartConfig
+metadata:
+  name: traefik
+  namespace: kube-system
+spec:
+  valuesContent: |
+    ports:
+      platform:
+        port: 4444
+        expose:
+          default: true
+        exposedPort: 4444
+        protocol: TCP
+YAML
+
 # 2. Install cert-manager
 if ! kubectl --kubeconfig="$KUBECONFIG" get ns cert-manager >/dev/null 2>&1; then
   echo "Installing cert-manager..."

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -128,6 +128,12 @@ func agentPlatformEnv(name string, cfg *config.Config, agentHome, proxyAddr stri
 		{Name: "NODE_EXTRA_CA_CERTS", Value: "/etc/platform/ca/ca.crt"},
 		{Name: "NODE_USE_ENV_PROXY", Value: "1"},
 		{Name: "GIT_HTTP_PROXY_AUTHMETHOD", Value: "basic"},
+		// Loopback only — deliberately NOT .svc/cluster ranges: the harness
+		// API and every external host must cross the paired gateway. Without
+		// this, curl to a local dev server inside the sandbox is silently
+		// routed to the egress proxy and 503s.
+		{Name: "NO_PROXY", Value: "localhost,127.0.0.1,::1"},
+		{Name: "no_proxy", Value: "localhost,127.0.0.1,::1"},
 		{Name: "PLATFORM_AGENT_ID", Value: name},
 		{Name: "API_SERVER_URL", Value: cfg.APIServerURL()},
 		{Name: "HOME", Value: agentHome},

--- a/packages/controller/pkg/reconciler/vm_test.go
+++ b/packages/controller/pkg/reconciler/vm_test.go
@@ -146,6 +146,10 @@ func TestVMBackendReconcilesVirtualMachine(t *testing.T) {
 	assert.True(t, strings.HasPrefix(userdata, "#cloud-config\n"))
 	assert.Contains(t, userdata, "HTTPS_PROXY='http://10.96.42.42:10000'")
 	assert.Contains(t, userdata, "PLATFORM_AGENT_ID='my-agent'")
+	// Loopback-only NO_PROXY: local dev servers must not be routed to the
+	// egress proxy, but the harness API and external hosts still must be.
+	assert.Contains(t, userdata, "NO_PROXY='localhost,127.0.0.1,::1'")
+	assert.NotContains(t, userdata, "NO_PROXY='localhost,127.0.0.1,::1,")
 	// The JVM ignores http_proxy env and $HOME — proxy + user.home must ride
 	// JAVA_TOOL_OPTIONS or Maven/Gradle bypass the gateway and read the
 	// wrong ~/.m2 (user.home resolves via getpwuid, /root on the VM).

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -77,4 +77,21 @@ if [ -f "$user_mise_cfg" ]; then
 	done
 fi
 
+# Maven Resolver reads proxies only from settings.xml — neither http_proxy
+# env nor the JVM's -Dhttp.proxyHost reach dependency resolution — so
+# without this every `mvn` dependency fetch bypasses the egress gateway and
+# dies. Absent-only: a user-managed settings.xml wins.
+if [ -n "${HTTPS_PROXY:-}" ] && [ ! -e "$home/.m2/settings.xml" ]; then
+	_hp=${HTTPS_PROXY#http://}
+	_m2_proxy() {
+		printf '<proxy><id>platform-%s</id><active>true</active><protocol>%s</protocol><host>%s</host><port>%s</port><nonProxyHosts>localhost|127.0.0.1</nonProxyHosts></proxy>' \
+			"$1" "$1" "${_hp%:*}" "${_hp##*:}"
+	}
+	if ! { mkdir -p "$home/.m2" &&
+		printf '<settings><proxies>%s%s</proxies></settings>\n' "$(_m2_proxy http)" "$(_m2_proxy https)" \
+			> "$home/.m2/settings.xml"; } 2>/dev/null; then
+		echo "agent-entrypoint: WARNING: could not write ~/.m2/settings.xml; Maven fetches may bypass the gateway" >&2
+	fi
+fi
+
 exec "$@"


### PR DESCRIPTION
Follow-up to #3168/#3174 — the remaining workarounds an agent needed while building DAM inside a DAM VM sandbox:

### 1. `NO_PROXY` for loopback (controller, both backends)
The platform env set `HTTP(S)_PROXY` but no `NO_PROXY`, so anything dialing `localhost` — a dev server the agent just started, the in-guest k3s API at `127.0.0.1:6443` — was routed to the egress proxy and got a confusing 503. Now `NO_PROXY=localhost,127.0.0.1,::1`, **deliberately loopback-only**: the harness API and all external hosts must keep crossing the paired gateway, so no `.svc`/cluster-range exclusions (test asserts exactly this).

### 2. Maven `settings.xml` (platform-base entrypoint, both backends)
Maven Resolver reads proxies **only** from `settings.xml` — neither `http_proxy` env nor the JVM's `-Dhttp.proxyHost` (from #3168's `JAVA_TOOL_OPTIONS`) reach dependency resolution. The entrypoint now renders `~/.m2/settings.xml` from the proxy env, absent-only so a user-managed file always wins.

### 3. Traefik `:4444` entrypoint on pre-existing k3s (deploy)
`cluster:install` relied on lima's provision script to add the app port's Traefik `HelmChartConfig`; a pre-existing k3s (the VM sandbox) never runs that, so the port silently didn't exist. The installer now applies it idempotently via `kubectl apply` on both paths.

(The fourth workaround from that session — read-only `MISE_DATA_DIR` — was #3174.)

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>