### PR TITLE
fix(deploy,ci): keycloak rolls without downtime and only when changed

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -175,7 +175,7 @@ jobs:
 
   merge-images:
     name: merge multi-arch manifests
-    needs: [build-images, appversion, check]
+    needs: [changes, build-images, appversion, check]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -197,12 +197,17 @@ jobs:
         uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
         with:
           images: ${{ env.IMAGE_PREFIX }}/${{ matrix.component }}
+          # keycloak also gets its source-sha tag (see merge-platform-base):
+          # publish pins it into the chart so releases that don't change the
+          # keycloak image don't roll the Keycloak pod. Non-PR runs only —
+          # a PR's amd64-only manifest must never overwrite it.
           tags: |
             type=sha,prefix=,format=long
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=raw,value=${{ needs.appversion.outputs.composite }}
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=${{ fromJSON(needs.changes.outputs.source_shas)['keycloak'] }},enable=${{ matrix.component == 'keycloak' && github.event_name != 'pull_request' }}
       - name: Create manifest list and push
         env:
           IMAGE: ${{ env.IMAGE_PREFIX }}/${{ matrix.component }}
@@ -613,7 +618,7 @@ jobs:
           if-no-files-found: ignore
 
   publish:
-    needs: [merge-images, merge-agents, merge-workloads, appversion]
+    needs: [changes, merge-images, merge-agents, merge-workloads, appversion]
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -645,6 +650,19 @@ jobs:
 
       - name: Build Helm chart dependencies
         run: mise run helm:deps
+
+      # Pin the keycloak image to its content tag (source sha, pushed by
+      # merge-images) so the chart only moves the tag — and only rolls the
+      # Keycloak pod — when the image inputs actually changed. The repo
+      # default stays `""` (appVersion fallback) for charts rendered from git.
+      - name: Pin keycloak image tag
+        env:
+          KC_TAG: ${{ fromJSON(needs.changes.outputs.source_shas)['keycloak'] }}
+        run: |
+          set -euo pipefail
+          [ -n "$KC_TAG" ]
+          sed -i "s|^\\(\\s*\\)tag: \"\" # @ci-pin keycloak-image-tag$|\\1tag: \"$KC_TAG\"|" deploy/helm/platform/values.yaml
+          grep -q "tag: \"$KC_TAG\"" deploy/helm/platform/values.yaml
 
       - name: Push Helm chart (release)
         if: startsWith(github.ref, 'refs/tags/v')

--- a/deploy/helm/platform/templates/keycloak/app.yaml
+++ b/deploy/helm/platform/templates/keycloak/app.yaml
@@ -31,17 +31,30 @@ metadata:
   {{- include "platform.annotations" (dict "root" $ "component" .Values.keycloak) | nindent 2 }}
 spec:
   replicas: 1
+  # Rolling, surge-first: the old pod keeps serving logins and JWKS until the
+  # new one is ready, so a Keycloak roll is not an auth outage. In production
+  # mode (`start`, scheme https) the overlapping pods form an Infinispan
+  # cluster via jdbc-ping through the shared DB, so in-flight login flows
+  # survive the roll too; start-dev (local/e2e) uses a local cache, where an
+  # in-flight login may bounce once. A failed startup (e.g. schema migration)
+  # leaves the old pod serving instead of taking auth down.
   strategy:
-    type: Recreate
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app.kubernetes.io/component: keycloak
       app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
+      # Not `platform.labels`: it embeds the chart version (helm.sh/chart),
+      # which would change the pod template — and needlessly roll the pod —
+      # on every release. Same deliberate omission as postgres/redis.
       labels:
-        {{- include "platform.labels" . | nindent 8 }}
         app.kubernetes.io/component: keycloak
+        app.kubernetes.io/instance: {{ .Release.Name }}
       {{- include "platform.podAnnotations" (dict "root" $ "component" .Values.keycloak) | nindent 6 }}
     spec:
       {{- include "platform.imagePullSecrets" . | nindent 6 }}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -362,9 +362,13 @@ keycloak:
   # The Keycloak image is a first-party build that bakes the
   # Keycloakify theme JAR on top of upstream Keycloak. The upstream
   # version is pinned in `packages/keycloak-theme/Dockerfile`.
+  # In published charts CI replaces the empty tag with the image's content
+  # tag (the commit that last touched its inputs — see cd.yml `publish`),
+  # so a release that doesn't change the image doesn't roll the pod.
+  # Empty falls back to .Chart.AppVersion.
   image:
     repository: quay.io/dam-agents/keycloak
-    tag: "" # defaults to .Chart.AppVersion
+    tag: "" # @ci-pin keycloak-image-tag
     pullPolicy: IfNotPresent
   configCliImage: quay.io/adorsys/keycloak-config-cli:latest-26.5.4
   port: 8080

--- a/docs/guidelines/release-process.md
+++ b/docs/guidelines/release-process.md
@@ -65,6 +65,7 @@ On every `v*` tag push, the release jobs in [`cd.yml`](../../.github/workflows/c
 
 - Builds and pushes container images (platform components + agents) to `quay.io/dam-agents/*`
 - Packages and pushes the Helm chart to `oci://quay.io/dam-agents/charts`
+  - The keycloak image tag is pinned to a content tag (the commit that last touched its inputs) rather than the release version, so upgrading to a release that didn't change the image doesn't restart Keycloak
 - Publishes `@dam-agents/cli` to npm (stable tags get `latest`, RC tags get `rc`)
 
 On every push to `main` (no tag), CD builds images and pushes a dev Helm chart (`0.0.0-main.*`).

--- a/scripts/resolve-image.sh
+++ b/scripts/resolve-image.sh
@@ -45,6 +45,12 @@ own_paths() {
   case "$1" in
     platform-base) echo "$PLATFORM_BASE_PATHS" ;;
     claude-code|codex|pi-agent|bob|k-search) echo "packages/agents/$1" ;;
+    # keycloak = upstream Keycloak + the Keycloakify theme baked in. The theme
+    # build also depends on dev-config and (any) lockfile change — lockfile
+    # bumps re-tag it even when unrelated, which errs toward rebuilds. Its
+    # source-sha tag is what the published chart pins as the image tag, so a
+    # release that doesn't touch these paths doesn't roll the Keycloak pod.
+    keycloak) echo "packages/keycloak-theme packages/dev-config pnpm-lock.yaml" ;;
     mock) echo "packages/e2e/agents/mock" ;;
     *) echo "unknown component: $1" >&2; return 1 ;;
   esac
@@ -53,7 +59,7 @@ own_paths() {
 base_of() {
   if is_workload "$1"; then echo "claude-code"; return; fi
   case "$1" in
-    platform-base) echo "" ;;
+    platform-base|keycloak) echo "" ;;
     claude-code|codex|pi-agent|bob|k-search|mock) echo "platform-base" ;;
     *) echo "unknown component: $1" >&2; return 1 ;;
   esac
@@ -113,7 +119,7 @@ gha_outputs() {
   # source_shas: per-component last-touching-source sha — non-PR runs tag their
   # images with it so PR reuse hits even when that commit was never a green
   # push tip. Falls back to GITHUB_SHA (a duplicate of the sha tag, harmless).
-  src="$(for a in platform-base claude-code codex pi-agent bob k-search $WORKLOADS; do
+  src="$(for a in platform-base keycloak claude-code codex pi-agent bob k-search $WORKLOADS; do
     s="$(source_sha "$a")"; printf '%s=%s\n' "$a" "${s:-${GITHUB_SHA:-}}"
   done | jq -cRn '[inputs | split("=") | {(.[0]): .[1]}] | add')"
   if [ "$(resolve platform-base | cut -d' ' -f1)" = REUSE ]; then pb=false; else pb=true; fi
@@ -143,6 +149,8 @@ self_check() {
   chk "$(base_of skydiscover)" claude-code
   chk "$(base_of claude-code)" platform-base
   chk "$(base_of platform-base)" ""
+  chk "$(base_of keycloak)" ""
+  has "$(effective_paths keycloak)" packages/keycloak-theme
   chk "$(local_tag platform-base)" platform-base
   chk "$(local_tag bob)" "platform-bob:latest"
   has "$(effective_paths nous)" packages/platform-base


### PR DESCRIPTION
Fixes #3176

## What

- **Zero-downtime rolls:** the keycloak Deployment switches from `Recreate` to `RollingUpdate` (maxSurge 1, maxUnavailable 0). The old pod serves logins and JWKS until the new one is ready. In production mode (`start`, `scheme: https`) the overlapping pods form an Infinispan cluster via jdbc-ping through the shared DB, so even in-flight login flows survive; `start-dev` (local/e2e) may bounce an in-flight login once. A failed startup (e.g. schema migration) now leaves the old pod serving instead of taking auth down — strictly better than Recreate.
- **No restart when nothing changed:** two causes removed.
  - The pod template no longer includes `platform.labels`, whose `helm.sh/chart: platform-<version>` label rolled the pod on every release regardless of image. It now hand-writes `component` + `instance`, the same deliberate omission postgres/redis/seaweedfs already use.
  - The image tag no longer tracks the release version. `resolve-image.sh` gains keycloak as a component (`packages/keycloak-theme` + `packages/dev-config` + `pnpm-lock.yaml`); CD tags the image with its source sha (non-PR runs only, so a PR's amd64-only manifest can never overwrite it), and the chart publish step pins that tag into `values.yaml` (anchored on the `@ci-pin keycloak-image-tag` marker, asserted with a grep so drift fails loud). Charts rendered from git keep the `.Chart.AppVersion` fallback.

## Verification

Live two-upgrade proof on the dev cluster, with an in-cluster probe curling the JWKS endpoint every 0.5s throughout:

1. Upgrade to this chart — keycloak rolls once (expected: its pod template loses the version label), under RollingUpdate. **330/330 probe requests OK, zero failures.**
2. Upgrade again with only the chart version bumped — keycloak pod untouched (same UID), while ui rolled as before.

Also: `helm template` at two chart versions with the tag pinned renders a byte-identical keycloak pod template; `resolve-image.sh --self-check` extended and green; `mise run check` green.

## Notes

- The first release carrying this change rolls keycloak once (pod template change) — under the new rolling strategy, so no downtime.
- Lockfile-touching releases still re-tag (and roll) keycloak even when the theme deps didn't change — accepted: errs toward rebuilds, still kills the every-release restart.