### PR TITLE
feat(agents): preinstall agent-browser + Chromium, VM backend only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -472,6 +472,10 @@ jobs:
       - name: Build containerDisk and push
         env:
           AGENT_IMAGE: ${{ env.IMAGE_PREFIX }}/claude-code:${{ needs.changes.outputs.claude_code_base_tag }}
+          # Raises mise's GitHub API rate limit for the agent-browser install
+          # (build.sh passes it through as a BuildKit secret, never baked
+          # into the image).
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           docker pull "$AGENT_IMAGE"

--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -28,7 +28,8 @@ FROM quay.io/fedora/fedora-bootc:44
 RUN dnf install -y --setopt=install_weak_deps=False \
       moby-engine docker-compose docker-buildx runc \
       cloud-init qemu-guest-agent openssh-server sudo \
-      git tar gzip xz jq rsync && \
+      git tar gzip xz jq rsync \
+      chromium && \
     dnf clean all
 
 # k3s: binary in /usr (immutable bootc area), unit written by the installer;
@@ -66,6 +67,29 @@ COPY --from=agent /etc/profile.d/model-gateway.sh /etc/profile.d/model-gateway.s
 COPY --from=agent /app/ /app/
 COPY --from=agent /opt/ /opt/
 
+# agent-browser CLI, VM-only: MISE_DATA_DIR is /usr/local/share/mise, which
+# exists at build time (unlike $HOME, an unmounted virtiofs share until
+# boot), so a plain `mise install` works here without the pod image's
+# detour. AGENT_BROWSER_EXECUTABLE_PATH (set on agent-runtime.service
+# below) points it at dnf's chromium instead of downloading its own
+# Chrome-for-Testing — dnf resolves chromium's runtime libs automatically,
+# so there's no hand-picked shared-lib list to keep in sync.
+# --mount=type=secret: available only for this RUN's environment, never
+# baked into an image layer. GITHUB_TOKEN raises mise's GitHub API rate
+# limit for the release lookup + download; --build-arg couldn't do this
+# without leaking the token into the image's history.
+# MISE_DATA_DIR/MISE_CACHE_DIR explicitly: root's $HOME (/root ->
+# ../var/roothome) is, like /home, an unrealized bootc symlink at build
+# time, and mise's data/cache/download dirs default under $HOME — mkdir
+# fails with ENOENT there. agent-runtime.service sets MISE_DATA_DIR the
+# same way at runtime; mirrored here so this RUN uses the identical real
+# path, already realized via the COPY above.
+RUN --mount=type=secret,id=github_token,env=GITHUB_TOKEN \
+    MISE_DATA_DIR=/usr/local/share/mise \
+    MISE_CACHE_DIR=/usr/local/share/mise/.cache \
+    mise install "github:vercel-labs/agent-browser@0.33.1" && \
+    test -x /usr/bin/chromium-browser
+
 # The agent user matches the pod image uid so PVC content ownership carries
 # over across backends. A full VM is deliberately root-capable: docker group +
 # passwordless sudo (the machine is the sandbox; NetworkPolicy on the
@@ -83,7 +107,7 @@ RUN mkdir -p /var/home && \
     usermod -aG docker agent && \
     echo 'agent ALL=(ALL) NOPASSWD:ALL' > /etc/sudoers.d/agent && \
     chown -R agent /etc/mise /app /usr/local/share/mise && chown agent /etc/AGENTS.md && \
-    printf '\n## VM sandbox\n\nThis sandbox is a full virtual machine: systemd, `docker` (moby), a preinstalled `k3s` Kubernetes cluster (`kubectl` works out of the box), and passwordless `sudo`. OS state outside your home and workspace is discarded on hibernation.\n\nThe in-VM k3s cluster is entirely yours: nothing that manages this sandbox runs on it, so you can freely reconfigure, wipe, or reinstall it. The platform managing this sandbox lives outside the VM and is unaffected by anything you do to the inner cluster. The inner k3s deliberately uses non-default CIDRs (`/etc/rancher/k3s/config.yaml`) so it does not clash with the host network — keep those when changing its config, and prefer drop-ins under `/etc/rancher/k3s/config.yaml.d/` over editing the main file.\n' >> /etc/AGENTS.md
+    printf '\n## VM sandbox\n\nThis sandbox is a full virtual machine: systemd, `docker` (moby), a preinstalled `k3s` Kubernetes cluster (`kubectl` works out of the box), and passwordless `sudo`. OS state outside your home and workspace is discarded on hibernation.\n\nThe in-VM k3s cluster is entirely yours: nothing that manages this sandbox runs on it, so you can freely reconfigure, wipe, or reinstall it. The platform managing this sandbox lives outside the VM and is unaffected by anything you do to the inner cluster. The inner k3s deliberately uses non-default CIDRs (`/etc/rancher/k3s/config.yaml`) so it does not clash with the host network — keep those when changing its config, and prefer drop-ins under `/etc/rancher/k3s/config.yaml.d/` over editing the main file.\n\n## Browser Automation\n\nUse `agent-browser` for web automation. Run `agent-browser --help` for all commands.\n\nCore workflow:\n1. `agent-browser open <url>` - Navigate to page\n2. `agent-browser snapshot -i` - Get interactive elements with refs (@e1, @e2)\n3. `agent-browser click @e1` / `fill @e2 "text"` - Interact using refs\n4. Re-snapshot after page changes\n' >> /etc/AGENTS.md
 
 # The guest has no SSH and an ephemeral rootfs, so a boot that fails before
 # agent-runtime leaves the journal unreachable — the serial console (captured

--- a/packages/agents/claude-code-vm/build.sh
+++ b/packages/agents/claude-code-vm/build.sh
@@ -45,7 +45,17 @@ if ! docker run --rm --privileged --entrypoint sh "$SKOPEO_IMAGE" -c \
 	exit 1
 fi
 
-docker build -t "$BOOTC_TAG" -f "$PKG/Containerfile" --build-arg AGENT_IMAGE="$AGENT_IMAGE" "$PKG"
+# --secret, only when set: the Containerfile's agent-browser install mounts
+# it to authenticate mise's GitHub API calls (release lookup + download),
+# which otherwise hit the unauthenticated rate limit — shared across every
+# CI runner's IP, so this isn't hypothetical. An unset --secret env= source
+# hard-fails docker build even when the Dockerfile never mounts it, so this
+# must stay conditional for local builds without GITHUB_TOKEN exported.
+secret_args=()
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+	secret_args=(--secret id=github_token,env=GITHUB_TOKEN)
+fi
+docker build -t "$BOOTC_TAG" -f "$PKG/Containerfile" --build-arg AGENT_IMAGE="$AGENT_IMAGE" "${secret_args[@]}" "$PKG"
 
 # Key on the rootfs layers, not .Id: buildx stamps a fresh provenance
 # attestation on every run, so the image index digest (.Id) changes even when

--- a/packages/agents/claude-code-vm/system/agent-runtime.service
+++ b/packages/agents/claude-code-vm/system/agent-runtime.service
@@ -36,6 +36,9 @@ Environment=PYTHONPATH=/usr/local/lib/platform-python
 # --dangerously-skip-permissions under root unless IS_SANDBOX=1 attests the
 # environment is a sandbox — which this VM is.
 Environment=IS_SANDBOX=1
+# Point agent-browser at dnf's chromium instead of downloading its own
+# Chrome-for-Testing at runtime.
+Environment=AGENT_BROWSER_EXECUTABLE_PATH=/usr/bin/chromium-browser
 # agent-entrypoint: CA trust is root-owned here (platform-ca.service) so its
 # own attempt just warns; the ~/.cache→/tmp symlink and mise-pin heal still
 # apply, then it execs the runtime.


### PR DESCRIPTION
Pod backend keeps zero browser deps: its base image (Hummingbird OS) has no package manager at all, so agent-browser's own Chrome-for-Testing download would be the only route there anyway. The VM guest is Fedora bootc, so dnf gets it for free — chromium pulls its own runtime libs (no hand-picked shared-lib list to maintain), and agent-browser is pointed at it via AGENT_BROWSER_EXECUTABLE_PATH instead of downloading a second ~184MB browser.

Two build-time gotchas, both from the same root cause — /home and /root are unrealized bootc symlinks (-> ../var/home, ../var/roothome) until the qcow2 deploys — caught by actually building and running the image, not just reading the Containerfile:
- mise's GitHub-backend release lookup hits the (shared, unauthenticated) GitHub API rate limit — real risk on CI runners, not just local iteration. Threaded a BuildKit secret (never baked into a layer) from cd.yml's GITHUB_TOKEN through build.sh, conditional on it being set so local builds without a token still work.
- mise's cache/data/download dirs default under /Users/jp, which doesn't exist yet — same class of bug as the /usr/local symlink fix. Pointed MISE_DATA_DIR/MISE_CACHE_DIR at the already-real, already-copied /usr/local/share/mise for this one RUN, matching what agent-runtime.service already does at runtime.

Also documents agent-browser's core workflow in the guest's AGENTS.md.

Verified end-to-end in a local build: agent-browser opened a real page through the dnf-installed Chromium and read its content back.