### PR TITLE
fix(ui): drop the comic-book busy words from the chat indicator

### DIFF
--- a/packages/ui/src/modules/sessions/components/busy-indicator.tsx
+++ b/packages/ui/src/modules/sessions/components/busy-indicator.tsx
@@ -1,63 +1,18 @@
-import { useEffect, useState } from "react";
-
 import { cn } from "@/lib/utils";
 
 import { WorkingDots } from "./working-dots.js";
 
-const BUSY_VERBS = [
-  "Bamboozling",
-  "Bamming",
-  "Cowabunga-ing",
-  "Gadzooksing",
-  "Gee whizzing",
-  "Gee willikering",
-  "Gollying",
-  "Great Scotting",
-  "Holy guacamoleing",
-  "Holy mackereling",
-  "Holy moleying",
-  "Hot diggitying",
-  "Jeepersing",
-  "Jiminy cricketing",
-  "Kablooeying",
-  "Kabooming",
-  "Kapowing",
-  "Kersplatting",
-  "Klonking",
-  "Leapin' lizarding",
-  "Powieing",
-  "Sakes aliving",
-  "Shazaming",
-  "Thwacking",
-  "Up-up-and-awaying",
-  "Vrooming",
-  "Whamming",
-  "Whiz-banging",
-  "Whomping",
-  "Zlonking",
-  "Zonking",
-  "Zwapping",
-];
-
+/** Streaming indicator for the chat thread. The jumping dots carry "working,
+ *  not frozen"; the activity rows above say what the agent is doing. No status
+ *  word — it would only restate what both already show (#3060).
+ *
+ *  The dots are the sole visual cue, so unlike a decorative spinner this always
+ *  announces itself. */
 export function BusyIndicator({ className }: { className?: string }) {
-  const [verb, setVerb] = useState(
-    () => BUSY_VERBS[Math.floor(Math.random() * BUSY_VERBS.length)],
-  );
-  useEffect(() => {
-    const id = setInterval(() => {
-      setVerb(BUSY_VERBS[Math.floor(Math.random() * BUSY_VERBS.length)]);
-    }, 2500);
-    return () => clearInterval(id);
-  }, []);
   return (
-    <span
-      className={cn(
-        "inline-flex items-center gap-2 text-sm font-normal text-muted-foreground",
-        className,
-      )}
-    >
+    <span role="status" className={cn("inline-flex items-center", className)}>
       <WorkingDots size="md" className="text-accent" />
-      {verb}…
+      <span className="sr-only">Working</span>
     </span>
   );
 }


### PR DESCRIPTION
The busy indicator picked a random word from a hardcoded list of 32 comic-book
exclamations and swapped it every 2.5s. It said nothing — the words are random,
so they carry no information about what the agent is doing — and it is the copy
users see most, since it shows on every turn.

Transparency is already covered twice over: the jumping dots show the agent is
active rather than frozen, and the activity rows above say what it is doing. The
word only restated both, less precisely. As an enterprise tool there is no need
to establish a lighthearted tone, and a word that changes while you wait pulls
attention off the task.

Implements the proposal in
https://github.com/dam-agents/dam/issues/3060#issuecomment-5184539690.

## Changes

`packages/ui/src/modules/sessions/components/busy-indicator.tsx` — removes
`BUSY_VERBS`, the `useState`/`useEffect`/`setInterval` rotation, and the `{verb}…`
render. `WorkingDots` is unchanged and remains the indicator.

The dots become the sole visual cue, so the indicator now announces itself to
assistive tech via `role="status"` and an `sr-only` label — without it, removing
the text would leave a screen reader with nothing to read, since the dots are
CSS animation on empty spans. This follows the existing pattern in
`packages/ui/src/components/ui/spinner.tsx`.

## Verification

I did not run the local checks for this change — CI is the first verification.
What I did confirm by search: `BusyIndicator` has exactly one caller,
`chat-message.tsx`, which passes `className="py-1"` and still works; nothing else
in the repo references `BUSY_VERBS` or any of the verbs; no test asserts on them.
The component's return shape changed, so `ui:check`'s typecheck is the one worth
watching.

Closes #3060.
