### PR TITLE
test(e2e): cron schedule fires on the mock agent (#435)

### DIFF
--- a/packages/e2e/playwright/playwright.config.ts
+++ b/packages/e2e/playwright/playwright.config.ts
@@ -177,6 +177,13 @@ export default defineConfig({
             testMatch: /full\/gateway-.*\.spec\.ts$/,
             use: { ...devices["Desktop Chrome"] },
           },
+          {
+            // Cron firing (#435): waits up to a minute for a `* * * * *`
+            // schedule to fire on its own — hence full-only.
+            name: "schedules-full",
+            testMatch: /full\/schedule-.*\.spec\.ts$/,
+            use: { ...devices["Desktop Chrome"] },
+          },
         ]
       : []),
   ],

--- a/packages/e2e/playwright/src/tests/full/schedule-fires.spec.ts
+++ b/packages/e2e/playwright/src/tests/full/schedule-fires.spec.ts
@@ -1,0 +1,60 @@
+import { expect, test } from "@playwright/test";
+
+import { setMockAgentReply, waitForAgentRunning } from "../../lib/agents.js";
+import { createApiClient } from "../../lib/api-client.js";
+import { acceptTerms, getAccessToken } from "../../lib/auth.js";
+import { harnessName } from "../../lib/fixtures.js";
+
+const agentName = "e2e-schedule-agent";
+const task = "e2e-schedule-fires-sentinel";
+
+test("cron schedule fires and reaches the mock (#435)", async () => {
+  test.setTimeout(600_000);
+
+  const api = createApiClient(await getAccessToken());
+  await acceptTerms(api);
+
+  const { id: agentId } = await api.agents.create.mutate({
+    name: agentName,
+    templateId: harnessName,
+  });
+
+  let scheduleId = "";
+  try {
+    await waitForAgentRunning(api, agentName);
+    await setMockAgentReply(api, agentId, "scheduled reply");
+
+    const schedule = await api.schedules.createCron.mutate({
+      name: "e2e-cron",
+      agentId,
+      cron: "* * * * *",
+      task,
+      sessionMode: "fresh",
+    });
+    scheduleId = schedule.id;
+
+    await expect
+      .poll(
+        async () => {
+          const { prompts } = await api.e2e.getReceivedPrompts.query({
+            agentId,
+          });
+          return JSON.stringify(prompts).includes(task);
+        },
+        {
+          timeout: 120_000,
+          intervals: [3_000],
+          message: "scheduled task never reached the mock",
+        },
+      )
+      .toBe(true);
+
+    const { status } = await api.schedules.get.query({ id: scheduleId });
+    expect(status?.lastResult).toBe("success");
+    expect(status?.lastRun).toBeTruthy();
+    expect(status?.nextRun).toBeTruthy();
+  } finally {
+    if (scheduleId) await api.schedules.delete.mutate({ id: scheduleId });
+    await api.agents.delete.mutate({ id: agentId });
+  }
+});


### PR DESCRIPTION
Ports the schedule-firing coverage dropped with the api-server vitest suite (#404, item 8) onto the Playwright harness, on the mock agent.

A `* * * * *` cron created via `schedules.createCron` fires on its own. The spec asserts both halves independently, since the scheduler now records success at fire time rather than after the agent runs:

- the scheduled task reaches the mock harness over ACP (`e2e.getReceivedPrompts`) — proves the agent actually executed
- the scheduler records `lastResult: success` with populated `lastRun`/`nextRun`

Full-tier spec (own agent, ~1 min wait for a real tick), so it stays out of the per-PR smoke suite. `sessionMode` forced to `fresh` — the mock doesn't implement `session/resume`. Verified green against a live e2e cluster.

Closes #435
