### PR TITLE
feat(skills): dam-agent-creator — adopt production-proven v2.x patterns

### DIFF
--- a/.agents/skills/dam-agent-creator/SKILL.md
+++ b/.agents/skills/dam-agent-creator/SKILL.md
@@ -33,8 +33,10 @@ Every agent this skill produces shares one proven operating architecture:
 - **Definition repo checked out at the agent's `$HOME`** — instructions (`CLAUDE.md`),
   procedures (`docs/`), scripts (`scripts/`), onboarding runbook, version + changelog. An
   allowlist `.gitignore` makes a repo-at-`$HOME` safe.
-- **Runtime state in `$HOME/work/`** — config, memory, domain state files, logs. Invisible
-  to the definition repo; optionally backed by its own git repo for durable state.
+- **Runtime state in `$HOME/work/`** — config, memory, domain state files, logs. A plain
+  data directory, invisible to the definition repo and **never a git repo** (the shared
+  NFS volume corrupts a concurrently-mutated `.git`); optionally backed up to its own git
+  remote via a disposable tmpfs clone.
 - **Interactive one-time onboarding** — sentinel-guarded, idempotent runbook that sets up
   repos, walks the operator through configuration, and registers platform schedules.
 - **A hard instruction trust boundary** — only the operator in the direct session changes
@@ -44,8 +46,10 @@ Every agent this skill produces shares one proven operating architecture:
   every action the agent takes is driven by an auditable, versioned script.
 - **A weekly self-audit** — deterministic health checks plus agent judgment checks,
   reported traffic-light style. Recommended for every agent, even purely reactive ones.
-- **Versioned definition** — semver `VERSION` + `CHANGELOG.md` with idempotent upgrade
-  steps, so deployed instances can detect drift and migrate deliberately.
+- **Versioned definition** — semver `VERSION` + `CHANGELOG.md` holding idempotent upgrade
+  steps (migration instructions, not a change log), so deployed instances can detect
+  drift and migrate deliberately; an offline test suite + CI keep every definition PR
+  syntax-checked, validated, and tested.
 - **Self-modification rules** — the generated repo contains its own guardrails for future
   changes (project-agnosticism, config discipline, cost assessment, never-weaken invariants).
 
@@ -118,6 +122,10 @@ agent with no scheduled runs). Templates:
 | `templates/docs/self-modification.md.template` | `docs/self-modification.md` | Add the domain invariants to §10. |
 | `templates/docs/persistence.md.template` | `docs/persistence.md` | State backup + definition evolution + version check. |
 | `templates/preflight.sh.template` | `scripts/preflight.sh` | Only when the agent has scheduled runs (see Phase 4). |
+| `templates/work-backup.sh.template` | `scripts/work-backup.sh` | Only when git-backed state backup was chosen — tmpfs-clone persist/restore. |
+| `templates/log.sh.template` | `scripts/log.sh` | Structured JSONL events log with secret masking — extend the masks per integration. |
+| `templates/tests-run.sh.template` | `scripts/tests/run.sh` | Offline test runner (see Phase 4). |
+| `templates/ci.yml.template` | `.github/workflows/ci.yml` | CI on every definition PR (see Phase 5). |
 
 Beyond the templates, write the **domain procedure docs** — one `docs/<topic>.md` per run
 type or major procedure (e.g. `docs/triage.md` and `docs/escalation.md` for a
@@ -127,16 +135,28 @@ Also ask which **license** applies (default: the org's standard): add the `LICEN
 or — when none — drop the `!/LICENSE` re-include from `.gitignore` and the `LICENSE` path
 from the `git add` allowlist in `docs/persistence.md`.
 
-### Phase 4 — Scripts (agents with scheduled runs)
+### Phase 4 — Scripts
 
-Fill in `scripts/preflight.sh` from the template: the domain detection logic per run mode,
-per `references/preflight.md`. The contract is absolute — the script **detects, it never
-acts**: read-only toward external systems, local writes limited to bookkeeping and logs,
-single JSON object on stdout, `nothing_to_do: true` short-circuits the run.
+Copy and adapt the operational scripts the design needs:
 
-Validate: `bash -n`, then — when the target integration is reachable from this machine — a
-read-only dry run; otherwise tell the operator the dry run must happen on the pod after
-onboarding.
+- `scripts/log.sh` — whenever the agent keeps the structured events log; extend the
+  credential masks to every token shape its integrations use.
+- `scripts/work-backup.sh` — when git-backed state backup was chosen. Never generate a
+  `work/`-as-git-clone flow — `work/` stays a plain data directory
+  (`references/platform-dam.md` → State backup).
+- `scripts/preflight.sh` (agents with scheduled runs) — fill in the domain detection
+  logic per run mode, per `references/preflight.md`. The contract is absolute — the
+  script **detects, it never acts**: read-only toward external systems, local writes
+  limited to bookkeeping and logs, single JSON object on stdout, `nothing_to_do: true`
+  short-circuits the run.
+- `scripts/tests/` — `run.sh` from the template plus one offline `test_<mode>.sh` per
+  pre-flight mode: stubbed CLIs on `PATH`, sandboxed `WORK_DIR`, assertions on the
+  emitted JSON (happy path, `nothing_to_do`, dedup/skip decisions, lock takeover, error
+  fallback).
+
+Validate: `bash -n` everything, run the test suite, then — when the target integration is
+reachable from this machine — a read-only dry run of each pre-flight mode; otherwise tell
+the operator the dry run must happen on the pod after onboarding.
 
 ### Phase 5 — Validate
 
@@ -152,6 +172,13 @@ on all scripts, and dead relative links. Fix everything it reports, then re-run 
 clean. Also do a judgment pass the script cannot: no instance-specific values hard-coded
 into the definition (they belong in `work/CONFIG.md`), no concept restated in two places,
 CLAUDE.md still slim.
+
+Then make the checks permanent: copy the validator itself into the generated repo as
+`scripts/validate-definition.sh` (it is self-copy-safe) and generate
+`.github/workflows/ci.yml` from the template — every definition PR then runs the syntax
+sweep, this validator, and the offline test suite. That is the self-modification §9
+validation sweep, mechanized; the generated §9 already tells the agent to run the tests
+and to update a changed script's test case in the same PR.
 
 ### Phase 6 — Deployment handoff
 

--- a/.agents/skills/dam-agent-creator/references/architecture.md
+++ b/.agents/skills/dam-agent-creator/references/architecture.md
@@ -4,12 +4,13 @@ The structural rules every generated definition follows. Read before writing the
 proposal; cite these rules in the generated `docs/self-modification.md` rather than
 restating them there at length.
 
-## Two repos, one inside the other
+## One repo, one data directory, one backup remote
 
-| Path | Repo | Holds |
+| Path | Kind | Holds |
 | --- | --- | --- |
 | `$HOME` (`/home/agent`) | **definition repo** (`origin` = where ONBOARDING.md was fetched from, fork-aware) | `CLAUDE.md`, `ONBOARDING.md`, `README.md`, `docs/`, `scripts/`, `VERSION`, `CHANGELOG.md`, `.gitignore`, `LICENSE` |
-| `$HOME/work` | optional state repo (env var, e.g. `GITHUB_REPO_WORK`) | `CONFIG.md`, `MEMORY.md`, domain state files, logs |
+| `$HOME/work` | **plain data directory — never a git repo** (the shared volume corrupts a concurrently-mutated `.git`; `references/platform-dam.md`) | `CONFIG.md`, `MEMORY.md`, `LESSONS.md`, domain state files, logs |
+| state remote | optional git remote (env var, e.g. `GITHUB_REPO_WORK`) | durable, versioned backup of `work/`, written only via the tmpfs backup script |
 
 Why this shape works:
 
@@ -71,6 +72,11 @@ Assemble the subset the domain needs; name each chosen mechanism in CLAUDE.md's 
 - **Verified pruning** — remove an item's state only after per-item verification that it
   is really gone (never from absence in a list call — a truncated listing would mass-prune),
   and clean up everything the item owned (published artifacts, history files).
+- **Undeliverable effect → substitute channel** — when an effect becomes undeliverable
+  mid-pipeline (the item closed/vanished after the work was done), critical findings are
+  delivered through a designated fallback surface (e.g. a linked issue instead of the
+  gone item's thread) with its **own dedup marker**, instead of being discarded; minor
+  findings may be dropped. Name the fallback per effect in the design.
 - **State reconstruction** — when markers exist, a lost `work/` is rebuildable: list live
   items, find the agent's markers, rewrite tracking rows with the **external-system
   timestamps** (history, not "now"). Only learned memory is unrecoverable — which is why
@@ -101,15 +107,33 @@ cap) and a weekly consolidation in the audit run (merge duplicates, promote the 
 confirmed, drop the stale; operator-tagged entries are never dropped). Bounded memory is
 what lets the agent improve forever without the file growing forever.
 
+A third route, useful for every agent (not just learning ones): **`work/LESSONS.md`** —
+operational lessons. Verified environment facts and recurring failure modes ("GraphQL is
+not proxied here — use REST", "this API paginates at 100"), written **only when a root
+cause was actually reproduced**, read at the start of work runs. It prevents every future
+run from re-diagnosing the same environmental quirk; entries name the evidence.
+
 ## Logging
 
-- One append-only log per run type (`work/<RUNTYPE>.log`), one line per run:
-  `<ISO-UTC> <summary counters>`. Grep-friendly by design — the audit reads these.
-- Error lines share a stable prefix (`ERROR:`) so a log scan is one grep. A log whose own
+Two layers, both under `work/`:
+
+- **Per-run-type summary logs** (`work/<RUNTYPE>.log`): append-only, one line per run,
+  `<ISO-UTC> <summary counters>`. Grep-friendly — the audit reads these for cadence gaps.
+  Error lines share a stable prefix (`ERROR:`) so a log scan is one grep; a log whose own
   content would trip the scan (like the audit's) avoids the trigger substrings.
-- Optional **debug/progress log**, gated by a config key (default off): one line per
-  pipeline milestone, so a session that dies mid-item is diagnosable at the exact step.
-  Diagnostic only — never gates behavior.
+- **Structured events log** (`work/logs/events-YYYY-MM-DD.jsonl`), written through a
+  shared `scripts/log.sh` (template provided): one JSON line per event —
+  `{ts, run, job, level, event, msg}` with a per-session run id, so a dead session is
+  diagnosable at the exact step and errors are groupable across weeks. Rules baked into
+  the template: **secret masking** before anything is written (token-shaped strings never
+  reach disk), `debug` level gated by a `log_level` config key (default `info`,
+  diagnostic only — never gates behavior), every failure path swallowed (logging must
+  never break a run), and a retention sweep (e.g. 14 days) in the audit-mode pre-flight.
+- **Harness adapters** (only when the harness offers hooks): small hook scripts under
+  `scripts/harness/<harness>/` that log tool failures and pipeline progress events
+  automatically — better than asking the model to log manually (it forgets exactly in
+  the failure cases that matter). An idempotent `install.sh` registers them; the audit
+  checks each expected hook **by name** (a partially-registered instance must warn).
 - Big logs are never loaded into context — `tail`/`grep` them.
 - No secrets in any log, ever. All user-visible errors also land in the chat UI.
 
@@ -122,6 +146,8 @@ docs/self-modification.md, docs/persistence.md), write per-domain:
   sequence, output formats, error handling, and a **self-check list** the agent walks
   before declaring the run done.
 - `docs/preferences.md` — only if the agent learns (memory routes, consolidation bounds).
+- `docs/logging.md` — when the agent keeps the structured events log: event catalogue,
+  who writes what (script vs. agent vs. harness hook), triage guidance.
 - `docs/audit.md` — the audit task list (`references/audit.md`).
 - `README.md` — for humans: what it does, setup, config table, runtime requirements,
   external surfaces, token scopes.

--- a/.agents/skills/dam-agent-creator/references/audit.md
+++ b/.agents/skills/dam-agent-creator/references/audit.md
@@ -31,9 +31,19 @@ Include what applies; add domain checks from the design's effects list.
 
 - Auth/connectivity to each integration (an unauthenticated GET; plus rate-limit headroom
   where the API reports it).
-- State-repo push backlog (local commits not on the remote when git-backed state).
+- **Token scopes and CLI deps**: assert the scopes the scheduled runs actually need
+  (specified in exactly one place — README) and that required commands exist. A missing
+  scope is operator-only to fix and silently breaks posting — check it weekly, not only
+  at onboarding.
+- Backup invariants (git-backed state): no `work/.git` on the volume; `.nfs*` junk count
+  under `work/` as an early concurrency signal (`references/platform-dam.md`).
 - Run cadence: gaps in each run type's log vs. its schedule (missed runs).
-- Error scan: `ERROR:`-prefixed lines across the week's logs.
+- Error scan: `ERROR:`-prefixed lines across the week's logs; with a structured events
+  log, also group **every `level: error` event of the week into `failures[]` signatures**
+  (`event`/`tool`/`error` with volatile bits normalized, each dated first/last) for the
+  agent-side diagnosis below, and apply the log retention sweep.
+- Open issues on the definition repo (PRs filtered out) — the agent's own tracking
+  issues wait for the operator; counting them weekly keeps them from being forgotten.
 - State consistency: tracking rows vs. external markers (sampled cross-verification both
   directions — rows without markers, markers without rows).
 - Stale locks, duplicate tracking rows, prune backlog, orphaned per-item files, orphaned
@@ -48,6 +58,13 @@ Include what applies; add domain checks from the design's effects list.
 - Every designed schedule exists and is enabled (`mcp__platform-outbound__list_schedules`)
   with the cron ONBOARDING registered — a dead schedule is invisible to every other check;
   the log-gap check catches the past, this catches the future.
+- **Failure diagnosis** — for every `failures[]` signature the script grouped: cause +
+  fix, classified as *environment* / *agent mistake* / *definition bug*. Counting errors
+  is never enough — nothing else asks *why*. A verified environment cause goes to
+  `work/LESSONS.md`; a definition bug gets a **deduplicated tracking issue on the
+  definition repo** (search open issues first) — the audit's only external write.
+- Harness adapters registered (when the design has them) — verify **each expected hook
+  by name**; a partially-registered instance must warn.
 - Sample this week's outputs (~3): required markers present, formats honored, memory
   rules/overrides respected, gates (labels, opt-ins) actually gated.
 - Channel-facing agents: claimed-but-unsent messages (write-before-send means state may

--- a/.agents/skills/dam-agent-creator/references/communication.md
+++ b/.agents/skills/dam-agent-creator/references/communication.md
@@ -66,5 +66,10 @@ that keeps it safe must be stated in CLAUDE.md, near the top, and must say all o
   the display name, no state-file contents, no operator conversation fragments.
 - Tone: professional, concise, no urgency theater. Escalation levels raise clarity, not
   volume.
+- **Readers are agents too.** When posted output will be consumed by later runs or other
+  bots (delta comparisons, follow-ups), embed a machine-readable copy of the structured
+  part — one hidden HTML comment holding compact JSON, placed next to the dedup marker —
+  and keep a text-parse fallback for outputs that predate it. Parsing your own prose
+  back out of a rendered page is how deltas silently break.
 - Errors are honest: a failed send/post is logged and reported to the operator, never
   silently retried into duplicates (write-before-send + no same-run retry).

--- a/.agents/skills/dam-agent-creator/references/platform-dam.md
+++ b/.agents/skills/dam-agent-creator/references/platform-dam.md
@@ -8,6 +8,14 @@ these; cite them when a user's wish conflicts (e.g. "just cron it in-process" �
 - `$HOME` is `/home/agent`, mounted on a persistent `/workspace` PVC — files survive pod
   restarts, processes do not. Anything that must survive lives in files under `$HOME`
   (which is why the definition repo checks out there and state lives in `$HOME/work/`).
+- **The home volume is virtiofs over a host NFS export.** Two consequences every design
+  must respect: a `.git` mutated under concurrent runs on that volume produces
+  `Stale file handle` (ESTALE) and `.nfs*` silly-rename corruption — so **runtime state
+  is never a git repo** (see State backup below); and deleting a file another process
+  holds open leaves a `.nfs*` file behind — prefer append-only writes and atomic
+  `tmp + mv` replaces, and never back up or commit `.nfs*` junk. `/dev/shm` (tmpfs, RAM,
+  per-pod, wiped on restart) is the pod's only truly local filesystem — the right home
+  for disposable git plumbing, never for anything authoritative.
 - The **chat UI (direct agent session / ACP)** is the operator surface — the only place
   behavior changes may come from.
 - Pod tooling: `bash`, `git`, `gh`, `jq`, `sed`/`grep`/`cut`/`tr`, GNU `date` are
@@ -72,8 +80,25 @@ the pod should include a read-only smoke test of each one.
 
 ## State backup (recommended default)
 
-A dedicated git repo for `work/`, named by an env var (`GITHUB_REPO_WORK` pattern):
-onboarding clones it into `$HOME/work`, every state-changing run ends with
-commit + pull-rebase + push (never force-push; a failed push is logged and retried next
-run — local commits mean nothing is lost on the volume). Local-only is acceptable when
-everything important is reconstructable from external markers; the interview settles this.
+A dedicated git **remote** for `work/`, named by an env var (`GITHUB_REPO_WORK`
+pattern) — but `work/` itself stays a **plain data directory, never a git clone** (the
+virtiofs/NFS constraint above). All git plumbing lives in `scripts/work-backup.sh`
+(template provided), which runs inside a disposable tmpfs clone under `/dev/shm`:
+
+- **`persist`** (end of every state-changing run): snapshot the current `work/` files
+  into the clone via tar (a pure read of the volume — `--exclude '.git' '.nfs*'`),
+  commit, push. Mirror semantics: the remote tip always converges to the live `work/`.
+- **`restore`** (fresh volume, ONBOARDING): remote → `work/`, data only, never a `.git`.
+- **Durability model** — nothing authoritative on tmpfs: live state = `work/`
+  (persistent volume), history = the remote, clone = disposable scratch re-seeded from
+  the remote whenever missing or broken. Worst case loses one not-yet-pushed snapshot.
+- **Concurrency** — the persist step is serialized by a mkdir lock next to the clone
+  (lock-or-skip with a stale-lock TTL: a skipped persist is safe, the running one
+  snapshots the same shared files); across writers, a rejected non-fast-forward push
+  re-seeds from the new tip and takes a fresh snapshot. Never force-push; a failed push
+  is logged and retried next run.
+- The audit asserts the invariants: no `work/.git` on the volume, and a `.nfs*` junk
+  count as an early concurrency signal.
+
+Local-only is acceptable when everything important is reconstructable from external
+markers; the interview settles this.

--- a/.agents/skills/dam-agent-creator/scripts/validate-definition.sh
+++ b/.agents/skills/dam-agent-creator/scripts/validate-definition.sh
@@ -42,6 +42,9 @@ if [ -f .gitignore ]; then
   grep -qxF '!/scripts/' .gitignore || { [ -d scripts ] \
       && fail ".gitignore missing re-include: !/scripts/ (scripts/ exists)" \
       || warn "no !/scripts/ re-include (fine only if the agent has no scripts)"; }
+  grep -qxF '!/.github/' .gitignore || { [ -d .github ] \
+      && fail ".gitignore missing re-include: !/.github/ (.github/ exists)" \
+      || warn "no !/.github/ re-include (fine only if the definition has no CI)"; }
 fi
 
 # ---------------------------------------------------- version & changelog ----
@@ -59,9 +62,9 @@ if [ -f VERSION ]; then
     else
       fail "VERSION ($ver) != newest CHANGELOG heading (${latest:-<none>})"
     fi
-    grep -q '^\*\*Changed:\*\*' CHANGELOG.md && grep -q '^\*\*Upgrade:\*\*' CHANGELOG.md \
-      && pass "CHANGELOG entries carry Changed + Upgrade blocks" \
-      || fail "CHANGELOG must carry '**Changed:**' and '**Upgrade:**' blocks"
+    grep -q '^\*\*Upgrade:\*\*' CHANGELOG.md \
+      && pass "CHANGELOG entries carry Upgrade blocks" \
+      || fail "CHANGELOG must carry an '**Upgrade:**' block per version (migration instructions, not a change log)"
   fi
 fi
 
@@ -96,7 +99,7 @@ grep -rqi 'code-guardian' --include='*.md' --include='*.sh' . 2>/dev/null \
 
 # ------------------------------------------------------------- shell scripts ----
 if [ -d scripts ]; then
-  for s in scripts/*.sh; do
+  for s in scripts/*.sh scripts/tests/*.sh scripts/harness/*/*.sh; do
     [ -e "$s" ] || continue
     if bash -n "$s" 2>/dev/null; then pass "bash -n: $s"; else fail "syntax error: $s (bash -n)"; fi
     # this validator carries the literal 'awk' in its own detection pattern and message —
@@ -104,8 +107,10 @@ if [ -d scripts ]; then
     case "$(basename "$s")" in
       validate-definition.sh) pass "$s awk check skipped (validator itself)"; continue ;;
     esac
-    # comment-only lines don't count ("deliberately awk-free" headers)
-    grep -vE '^[[:space:]]*#' "$s" | grep -qE '(^|[^a-zA-Z0-9_])awk([^a-zA-Z0-9_]|$)' \
+    # comment-only lines don't count ("deliberately awk-free" headers), and an
+    # invocation always has whitespace/EOL after the word — "awk/diff" in a
+    # message string is not a call
+    grep -vE '^[[:space:]]*#' "$s" | grep -qE '(^|[^a-zA-Z0-9_])awk([[:space:]]|$)' \
       && fail "$s uses awk — not available on the pod" \
       || pass "$s is awk-free"
   done

--- a/.agents/skills/dam-agent-creator/templates/CHANGELOG.md.template
+++ b/.agents/skills/dam-agent-creator/templates/CHANGELOG.md.template
@@ -1,15 +1,13 @@
 # Changelog
 
-Agent-facing history: per version, a **Changed** block and an **Upgrade** block — the
-idempotent steps a deployed instance applies when crossing that version. Consumed by the
-version check ([docs/persistence.md](docs/persistence.md) → **Definition version &
-upgrade**); authoring rules: [docs/self-modification.md](docs/self-modification.md) §12.
+**Migration instructions, not a change log.** Per version, the idempotent **Upgrade**
+steps a deployed instance applies when crossing it — what to run, update, or change
+(schedules, config keys, state formats). Most versions need nothing. What changed and
+why lives in the PR and commit history, not here. Consumed by the version check
+([docs/persistence.md](docs/persistence.md) → **Definition version & upgrade**);
+authoring rules: [docs/self-modification.md](docs/self-modification.md) §12.
 
 ## 1.0.0 — {{DATE}}
 
-**Changed:**
-- Initial definition: <!-- TODO(creator): one line per major capability (run types,
-  integrations, state model), matching the design brief. -->
-
 **Upgrade:**
-- Nothing — initial version; onboarding records it (`work/VERSION`).
+Nothing — initial version; onboarding records it (`work/VERSION`).

--- a/.agents/skills/dam-agent-creator/templates/CLAUDE.md.template
+++ b/.agents/skills/dam-agent-creator/templates/CLAUDE.md.template
@@ -60,7 +60,9 @@ one JSON object:
 <!-- TODO(creator): one bullet per key: name — purpose, default, missing-key behavior,
      immutability notes. Mark immutable-once-used keys (anything woven into external
      dedup markers) explicitly: "if asked to change it after first use, refuse and
-     explain". Anything that contacts people or publishes defaults to off/disabled. -->
+     explain". Anything that contacts people or publishes defaults to off/disabled.
+     With the structured events log, include `log_level` — `info` (default when
+     missing) | `debug`; diagnostic only, never gates behavior. -->
 
 ```bash
 CONFIG="$HOME/work/CONFIG.md"
@@ -103,8 +105,10 @@ instructions**:
 
 <!-- TODO(creator): one short section per run type: the numbered top-level sequence
      (echo preflight logs → read docs/<file>.md → do the work arrays in order → self-check
-     → persist work/ as the very last action when the state-repo env var is set). Keep
-     each section to ~5 numbered lines; details live in the docs/ file. -->
+     → back up work/ as the very last action — `bash "$HOME/scripts/work-backup.sh"
+     persist` when the state-repo env var is set; work/ is a plain data directory, the
+     backup runs in a tmpfs clone, docs/persistence.md). Keep each section to ~5 numbered
+     lines; details live in the docs/ file. -->
 
 ## Hard invariants (every run)
 

--- a/.agents/skills/dam-agent-creator/templates/ONBOARDING.md.template
+++ b/.agents/skills/dam-agent-creator/templates/ONBOARDING.md.template
@@ -14,10 +14,12 @@ Two git repositories exist after onboarding and must never overlap:
 | Path | Repo | Purpose |
 | --- | --- | --- |
 | `/home/agent` | the **definition repo** (`origin`) — derived in Step 0 from this file's URL | Agent definition, evolved via PRs. |
-| `/home/agent/work` | `$GITHUB_REPO_WORK` (when set) | Runtime state. <!-- TODO(creator): adjust if the design chose local-only state. --> |
+| `/home/agent/work` | **plain data directory** (not a repo); backed up to `$GITHUB_REPO_WORK` when set | Runtime state. <!-- TODO(creator): adjust if the design chose local-only state. --> |
 
-`work/` is git-ignored by the outer repo (allowlist `.gitignore`), so the two stay fully
-independent.
+`work/` is git-ignored by the outer repo (allowlist `.gitignore`) and holds no `.git` of
+its own — backup runs off-volume via a tmpfs clone
+([docs/persistence.md](docs/persistence.md) → **Backup & restore**), so the two stay
+fully independent.
 
 ## Guard — skip if already onboarded
 
@@ -37,7 +39,11 @@ per volume, not per scheduled run.
    <!-- TODO(creator): one read-only probe per integration, e.g. `gh api user --jq .login`
         (also yields the bot login for the config dialog), a list_schedules call, a
         channel connection check. On failure: stop and tell the operator which
-        connection/token is broken. -->
+        connection/token is broken. Also verify the token scopes and the CLI commands
+        the design's runs actually need (both specified once, in README) — a missing
+        scope is operator-only to fix and better caught now than by the weekly audit.
+        OS packages cannot be installed on the pod, so the definition must not require
+        anything beyond the pod's toolset. -->
 2. **Definition repo** — derive `OWNER/REPO` from the URL of this runbook as given by the
    operator (for a fork that's the fork, never upstream). No URL available → ask.
    Validate, then `export DEFINITION_REPO="<owner/repo>"` (persisted in the config step).
@@ -83,25 +89,25 @@ before continuing; do not write the sentinel.
 
 ## Step 2 — Provision `work/` (runtime state)
 
-**2a — state repo env var set** → replace `work/` with a fresh clone (enables the
-end-of-run commit & push per [docs/persistence.md](docs/persistence.md)):
+**2a — state repo env var set** → restore prior state from the backup remote. `work/`
+is a **plain data directory, never a git clone** — backup runs off-volume via a tmpfs
+clone ([docs/persistence.md](docs/persistence.md)), so restore just copies the remote's
+files in:
 
 ```bash
 if [ -n "$GITHUB_REPO_WORK" ]; then
-  tmp="$(mktemp -d)"
-  if git clone "https://github.com/$GITHUB_REPO_WORK" "$tmp/work"; then
-    rm -rf /home/agent/work && mv "$tmp/work" /home/agent/work
-    git -C /home/agent/work config user.name  "{{AGENT_NAME}}"
-    git -C /home/agent/work config user.email "{{AGENT_NAME}}@agents.local"
-  else
-    echo "WARNING: clone failed; falling back to local-only (2b)."; rm -rf "$tmp"
-  fi
+  mkdir -p /home/agent/work
+  LOG_JOB=session bash "$HOME/scripts/work-backup.sh" restore
 fi
 ```
 
-**2b — unset, or the clone failed** → create the directory tree and seed files from the
-templates below, **only if missing** (never overwrite an existing memory/state file — it
-may hold unreconstructable history):
+If the remote is empty (first-ever deployment) the restore is a no-op — fall through to
+2b to seed the templates; the first end-of-run `persist` creates the initial backup.
+**Never make `work/` a git repo.**
+
+**2b — unset, or the restore was empty/failed** → create the directory tree and seed
+files from the templates below, **only if missing** (never overwrite an existing
+memory/state file — it may hold unreconstructable history):
 
 <!-- TODO(creator): mkdir the work/ tree and embed a heredoc seed for each state file
      from the design (tracking table header, MEMORY.md skeleton when the agent learns,

--- a/.agents/skills/dam-agent-creator/templates/ci.yml.template
+++ b/.agents/skills/dam-agent-creator/templates/ci.yml.template
@@ -1,0 +1,29 @@
+# CI for the {{AGENT_NAME}} definition repo — mechanizes the pre-PR validation
+# sweep (docs/self-modification.md §9) so a definition PR cannot merge broken:
+# script syntax, the structural validator (repo shape, VERSION↔CHANGELOG
+# agreement, dead links, leftover placeholders), and the offline test suite.
+# TODO(creator): drop the tests step if the design has no scripts/tests/, then
+# delete the TODO comments.
+name: ci
+on:
+  pull_request:
+  push:
+    branches: [main]
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: bash -n all scripts
+        run: |
+          set -e
+          find scripts -name '*.sh' -print0 | xargs -0 -n1 bash -n
+      - name: structural validator
+        run: bash scripts/validate-definition.sh .
+      - name: offline test suite
+        run: |
+          if [ -x scripts/tests/run.sh ] || [ -f scripts/tests/run.sh ]; then
+            bash scripts/tests/run.sh
+          else
+            echo "no scripts/tests/ — skipping"
+          fi

--- a/.agents/skills/dam-agent-creator/templates/docs/persistence.md.template
+++ b/.agents/skills/dam-agent-creator/templates/docs/persistence.md.template
@@ -1,54 +1,56 @@
 <!-- TODO(creator): adjust the state-repo env var name and the allowlisted paths to the
-     design; delete the commit & push section for local-only designs (keep the version
-     and evolution sections always); delete TODO comments. -->
+     design; delete the backup section for local-only designs (keep the version and
+     evolution sections always); delete TODO comments. -->
 
 # Persisting `work/` & evolving the definition
 
-Read this file when you need the details behind the end-of-run commit, when the operator
+Read this file when you need the details behind the end-of-run backup, when the operator
 asks to update the agent or check its version, or when the operator asks for a change to
 the agent definition itself.
 
-## Two repos, one inside the other
+## Two stores: shared live state + durable backup
 
-| Path | Remote | Tracks |
+| Path | Kind | Holds |
 | --- | --- | --- |
-| `/home/agent` (outer) | `$DEFINITION_REPO` (`origin`) | Definition: `CLAUDE.md`, `ONBOARDING.md`, `README.md`, `docs/`, `scripts/`, `VERSION`, `CHANGELOG.md`, `.gitignore`, `LICENSE`. |
-| `/home/agent/work` (inner) | `$GITHUB_REPO_WORK` | Runtime state. Exists as a repo only when the var is set. |
+| `/home/agent` (outer) | git repo, remote `$DEFINITION_REPO` (`origin`) | Definition: `CLAUDE.md`, `ONBOARDING.md`, `README.md`, `docs/`, `scripts/`, `VERSION`, `CHANGELOG.md`, `.gitignore`, `LICENSE`. |
+| `/home/agent/work` | **plain data directory** (no `.git`) | Live runtime state. Shared across concurrent runs; the source of truth. |
+| `$GITHUB_REPO_WORK` | git remote | Durable, versioned **backup** of `work/`. Written only via a disposable tmpfs clone (below). |
+
+`work/` is **never** a git repo: the home volume is virtiofs over NFS, and a `.git`
+mutated there under concurrent runs produces `Stale file handle` (ESTALE) and `.nfs*`
+silly-rename corruption. All git plumbing happens off the shared volume, in a tmpfs
+clone under `/dev/shm`; `work/` itself is only ever read.
 
 The outer `.gitignore` is an allowlist (`/*` then re-include the definition files), so
 **all** of `work/` and the HOME secrets (`.ssh`, `.claude`, `.config`) are invisible to
-the outer repo. A fresh volume seeds state files from the templates in `ONBOARDING.md`;
-this keeps a definition update (`git reset --hard origin/main`) from ever colliding with
-live runtime state. Scope commands: inner state → `git -C /home/agent/work`, definition →
-`git -C /home/agent`. **Never run `git clean` in `/home/agent`** and never `git add`
-outside the allowlist.
+the outer repo. A fresh volume seeds state files from the templates in `ONBOARDING.md`
+or restores them from the backup remote; a definition update
+(`git reset --hard origin/main`) never collides with live runtime state. **Never run
+`git clean` in `/home/agent`** and never `git add` outside the allowlist (the backup's
+`git add -A` is confined to the tmpfs clone, never the home tree).
 
-## Commit & push (end of run)
+## Backup & restore (`scripts/work-backup.sh`)
 
-Scripts never commit or push — their local bookkeeping sits uncommitted until the next
-agent-active run. At the end of every run where the agent did work, it commits & pushes
-as the very last action (this sweeps up script bookkeeping too; quiet runs stay durable
-on the volume until then):
+Pre-flight scripts never commit or push — their local bookkeeping is written straight to
+the `work/` files and stays on the volume until backed up. At the end of every run where
+the agent did work, as the very last action and only when `$GITHUB_REPO_WORK` is set:
 
 ```bash
-if [ -n "$GITHUB_REPO_WORK" ] && [ -d /home/agent/work/.git ]; then
-  cd /home/agent/work || exit 1
-  git config user.name  "{{AGENT_NAME}}" 2>/dev/null || true
-  git config user.email "{{AGENT_NAME}}@agents.local" 2>/dev/null || true
-  git add -A
-  if git diff --cached --quiet; then
-    echo "work/: nothing to persist."
-  else
-    git commit -m "chore(work): persist state $(date -u +%Y-%m-%dT%H:%M:%SZ)"
-    git pull --rebase --autostash origin "$(git rev-parse --abbrev-ref HEAD)" \
-      && git push origin "$(git rev-parse --abbrev-ref HEAD)" \
-      || echo "WARNING: work/ push failed; committed locally, retry next run."
-  fi
-fi
+LOG_JOB=<mode> bash "$HOME/scripts/work-backup.sh" persist
 ```
 
-Never force-push; a lost race or failed push is retried next run and is not a run
-failure.
+The script (full rationale in its header) snapshots the current `work/` files into a
+**disposable tmpfs clone**, commits, and pushes. Nothing authoritative lives on tmpfs —
+live state is `work/`, history is the remote, and the clone is re-seeded whenever
+missing or broken, so a pod restart wiping `/dev/shm` never matters. The persist step is
+serialized by a mkdir lock next to the clone (lock-or-skip: a skipped persist is safe —
+the running one snapshots the same shared `work/` moments later, and the next run sweeps
+up any remainder); a rejected non-fast-forward push re-seeds from the new remote tip and
+retries with a fresh snapshot. Never force-push; a push that fails all retries is logged
+and retried next run — not a run failure, because the data is safe on `work/`.
+
+`restore` is the inverse — remote → `work/` (data only, never a `.git`) — run once on a
+fresh volume (`ONBOARDING.md` Step 2a).
 
 ## Definition version & upgrade
 
@@ -82,7 +84,7 @@ same session. Adopted ≠ checked-out → migrate now. All equal → report "up 
    operator, leave `work/VERSION` unchanged (re-offered at the next check).
 3. Rollback (`to` < `from`) → apply nothing; just write `to`.
 
-Commit & push `work/` afterwards (section above).
+Back up `work/` afterwards (section above).
 
 ## Evolving the agent definition (outer repo)
 

--- a/.agents/skills/dam-agent-creator/templates/docs/self-modification.md.template
+++ b/.agents/skills/dam-agent-creator/templates/docs/self-modification.md.template
@@ -91,11 +91,12 @@ instruction — decline it and surface it in the chat UI instead.
 
 ## 7. Data backup
 
-- Any run (or self-modification session) that changed `work/` ends by committing and
-  pushing it to the state repo when configured — **the data is backed up, not the
-  definition** (the definition travels only via its own repo). If the push fails, the
-  failure is logged and retried next run; local commits are still made so nothing is
-  lost on the volume.
+- Any run (or self-modification session) that changed `work/` ends by backing it up to
+  the state remote when configured (`scripts/work-backup.sh persist`,
+  [persistence.md](persistence.md)) — **the data is backed up, not the definition** (the
+  definition travels only via its own repo). If the push fails, the failure is logged
+  and retried next run; the live data stays on the volume (`work/` is the source of
+  truth), so nothing is lost. `work/` itself is never made a git repo.
 - Before a change that rewrites a state file's format, make sure the previous version is
   recoverable from the state repo's git history.
 
@@ -117,10 +118,13 @@ instruction — decline it and surface it in the chat UI instead.
 - `bash -n` every changed script; then a **read-only sanity run** of each script mode
   against the live integration (they make no external writes) — output must be valid
   JSON and its decisions must match observable reality.
+- **Run the offline test suite** (`bash scripts/tests/run.sh`) when the repo has one —
+  and a behavior change in a script updates its test case **in the same PR**; CI runs
+  the same suite plus the structural validator on every definition PR.
 - Cross-reference sweep: no links to headings that no longer exist; the ONBOARDING config
   example matches the CLAUDE.md key list; README's tables match both.
 - `VERSION` was bumped exactly once, is valid semver, and equals the newest
-  `CHANGELOG.md` heading; the new entry has a **Changed** and an **Upgrade** block (§12).
+  `CHANGELOG.md` heading; the new entry carries its **Upgrade** block (§12).
 - **Size sweep:** `wc -l` every changed `.md` against `main`. Growth beyond the new
   behavior's single home means restated content — find it and replace it with a link
   (§11's footprint budget).
@@ -174,13 +178,15 @@ refuse and explain instead:
 - Bump: **patch** by default (no adoption steps); **minor** for a new feature, config
   key, schedule, or doc file; **major** when adoption is not purely additive (schedule
   task-text/entry-command changes, state format rewrites, marker semantics).
-- Entry template (newest first):
+- The changelog holds **migration instructions, not a change log**: per version, only
+  the **Upgrade** block — what a deployed instance runs, updates, or changes when
+  crossing it. What changed and why lives in the PR and commit history. Entry template
+  (newest first):
 
   ```markdown
   ## <version> — <YYYY-MM-DD>
-  **Changed:** what and where, 1–3 bullets.
-  **Upgrade:** the idempotent steps a deployed instance applies when crossing this
-  version, or `Nothing — docs are re-read per run.`
+  **Upgrade:**
+  Nothing — docs are re-read per run.
   ```
 
 - Upgrade steps: **idempotent** (check before create), executable by the agent alone (a

--- a/.agents/skills/dam-agent-creator/templates/gitignore.template
+++ b/.agents/skills/dam-agent-creator/templates/gitignore.template
@@ -21,9 +21,11 @@
 !/LICENSE
 !/docs/
 !/scripts/
+!/.github/
 
 # TODO(creator): if the design adds top-level definition files, re-include them above —
-# nothing else at $HOME top level may ever become trackable. Then delete this comment.
+# nothing else at $HOME top level may ever become trackable. Drop the !/.github/ line
+# when the design skipped CI. Then delete this comment.
 
 # Never track these even if a future allowlist entry would pull them in.
 .DS_Store

--- a/.agents/skills/dam-agent-creator/templates/log.sh.template
+++ b/.agents/skills/dam-agent-creator/templates/log.sh.template
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# log.sh — structured event logging for {{AGENT_NAME}}. Source this file, then:
+#
+#   logev <level> <event> <message>      # level: debug|info|warn|error
+#
+# One JSONL line per event in $WORK/logs/events-YYYY-MM-DD.jsonl:
+#   {"ts":"…","run":"…","job":"…","level":"…","event":"…","msg":"…"}
+#
+#   run — LOG_RUN_ID env, else the harness session id, else start time + pid.
+#   job — LOG_JOB env (one of the run types), default "session".
+#
+# `debug` lines are written only when work/CONFIG.md has `log_level: debug`.
+# Logging must never break a run: every failure path is swallowed. Retention
+# (delete files older than ~14 days) belongs to the audit-mode pre-flight.
+# TODO(creator): extend MASKS with any credential shapes the design's
+# integrations use, then delete the TODO comments.
+
+LOG_WORK="${WORK_DIR:-${HOME:-/home/agent}/work}"
+LOG_DIR="$LOG_WORK/logs"
+LOG_RUN="${LOG_RUN_ID:-${CLAUDE_CODE_SESSION_ID:-$(date -u +%Y%m%dT%H%M%SZ)-$$}}"
+LOG_JOB="${LOG_JOB:-session}"
+LOG_LEVEL="$(sed -n 's/^- log_level:[[:space:]]*//p' "$LOG_WORK/CONFIG.md" 2>/dev/null \
+             | head -1 | sed -e 's/[[:space:]]*#.*$//' -e 's/[[:space:]]*$//')"
+LOG_LEVEL="${LOG_LEVEL:-info}"
+
+# best-effort masking of well-known credential shapes before anything is
+# written (invariant: no secrets in any log) — GitHub/Slack tokens, bearer
+# headers. sed -E, applied to the whole message.
+_log_mask() {
+  printf '%s' "$1" | sed -E \
+    -e 's/gh[pousr]_[A-Za-z0-9]{20,}/gh*_MASKED/g' \
+    -e 's/github_pat_[A-Za-z0-9_]{20,}/github_pat_MASKED/g' \
+    -e 's/xox[baprs]-[A-Za-z0-9-]{10,}/xox*-MASKED/g' \
+    -e 's/[Bb]earer[[:space:]]+[A-Za-z0-9._~+/=-]{16,}/Bearer MASKED/g'
+}
+
+logev() {
+  { [ "$1" = "debug" ] && [ "$LOG_LEVEL" != "debug" ]; } && return 0
+  case "$1" in debug|info|warn|error) ;; *) return 0 ;; esac
+  mkdir -p "$LOG_DIR" 2>/dev/null || return 0
+  _msg="$(_log_mask "${3:-}")"
+  jq -cn --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg run "$LOG_RUN" \
+     --arg job "$LOG_JOB" --arg lvl "$1" --arg ev "${2:-event}" --arg msg "$_msg" \
+     '{ts:$ts, run:$run, job:$job, level:$lvl, event:$ev, msg:$msg}' \
+     >> "$LOG_DIR/events-$(date -u +%Y-%m-%d).jsonl" 2>/dev/null || true
+  return 0
+}

--- a/.agents/skills/dam-agent-creator/templates/preflight.sh.template
+++ b/.agents/skills/dam-agent-creator/templates/preflight.sh.template
@@ -31,9 +31,15 @@ log() { LOGS+=("$1"); }
 cfg() { sed -n "s/^- $1:[[:space:]]*//p" "$CONFIG" 2>/dev/null | head -1 \
         | sed -e 's/[[:space:]]*#.*$//' -e 's/[[:space:]]*$//'; }
 
-# GNU date first, BSD fallback (macOS dev machines); epoch 0 on unparsable input.
+# Rows of a `## <heading>` config table, bounded at the NEXT `## ` heading —
+# an unbounded range would swallow every later table in the file.
+cfg_table() { sed -n "/^## $1\$/,/^## /p" "$CONFIG" 2>/dev/null \
+              | grep '^|' | tail -n +3; }
+
+# GNU date first, BSD fallback (macOS dev machines — `-u` matters: without it the
+# trailing Z is parsed in local time and lock ages skew); epoch 0 on unparsable input.
 iso2epoch() { date -d "$1" +%s 2>/dev/null \
-              || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null || echo 0; }
+              || date -j -u -f '%Y-%m-%dT%H:%M:%SZ' "$1" +%s 2>/dev/null || echo 0; }
 
 # ---------------------------------------------------------------- config ----
 # TODO(creator): resolve every config key the detection needs, env vars first:
@@ -67,10 +73,16 @@ emit() {  # $1 = jq object body of mode-specific arrays, e.g. '{items_due:$items
 # implement here, each appending {id, status: ok|warn|fail, detail} to a checks array
 # and never fixing anything:
 #   - connectivity: one unauthenticated-failure-proof GET per integration (+ rate limit
-#     headroom where reported)
-#   - state-repo push backlog (local commits ahead of remote, when git-backed)
+#     headroom where reported); token scopes + required CLI commands (both specified
+#     once, in README)
+#   - backup invariants (git-backed state): no work/.git on the volume; count of .nfs*
+#     files under work/ (early concurrency signal)
 #   - run cadence: gaps in each run type's log vs. its registered cadence
-#   - error scan: grep "^.*ERROR:" across the week's work/*.log lines
+#   - error scan: grep "^.*ERROR:" across the week's work/*.log lines; with the events
+#     log, group the week's {level: error} events into failures[] signatures
+#     (event/tool/error, volatile bits normalized, dated first/last) for the agent's
+#     diagnosis pass, and delete events files older than the retention window
+#   - open issues on the definition repo (PRs filtered out)
 #   - stale locks / duplicate tracking rows / leftover /tmp/{{AGENT_NAME}}-* dirs
 #   - disk usage of the volume (warn threshold)
 #   - definition cleanliness (git -C "$HOME" status --porcelain empty) and version

--- a/.agents/skills/dam-agent-creator/templates/tests-run.sh.template
+++ b/.agents/skills/dam-agent-creator/templates/tests-run.sh.template
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# run.sh — offline test runner for the {{AGENT_NAME}} scripts. Discovers and
+# runs every scripts/tests/test_*.sh; a test file exits non-zero on failure.
+#
+# Test conventions (each test_*.sh):
+#   - Sandbox: create its own WORK_DIR under a temp dir — never touch a real
+#     work/ or $HOME; clean up on exit.
+#   - Offline: stub external CLIs by prepending scripts/tests/bin to PATH and
+#     placing fake executables there (e.g. a `gh` printing canned JSON per
+#     argument pattern). Tests must pass with no network and no credentials.
+#   - Determinism: pre-flight logic is pure detection, so identical stub output
+#     must yield an identical worklist — assert on the emitted JSON (jq).
+#
+# A behavior change in a script updates its test case in the same PR
+# (docs/self-modification.md §9).
+# TODO(creator): write one test_<mode>.sh per pre-flight mode covering: happy
+# path, nothing_to_do, dedup/skip decisions, lock takeover, and error fallback
+# (fail_out on unreachable integration). Then delete the TODO comments.
+set -u
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+pass=0; fail=0
+for t in "$DIR"/test_*.sh; do
+  [ -e "$t" ] || { echo "no tests found in $DIR"; exit 0; }
+  name="$(basename "$t")"
+  if bash "$t"; then
+    echo "PASS  $name"; pass=$((pass + 1))
+  else
+    echo "FAIL  $name"; fail=$((fail + 1))
+  fi
+done
+echo "tests: $pass pass, $fail fail"
+[ "$fail" -eq 0 ] || exit 1

--- a/.agents/skills/dam-agent-creator/templates/work-backup.sh.template
+++ b/.agents/skills/dam-agent-creator/templates/work-backup.sh.template
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# work-backup.sh — durable backup / restore of the shared-volume work/ state to
+# the $GITHUB_REPO_WORK remote, performed ENTIRELY inside a private tmpfs clone:
+# the home volume is virtiofs-over-NFS, and a .git mutated there under
+# concurrent runs produces ESTALE + .nfs* silly-rename corruption — so work/ is
+# a plain data directory and git only ever runs in /dev/shm. Rationale:
+# docs/persistence.md.
+#
+#   work-backup.sh persist   # end of run: snapshot work/ -> commit -> push
+#   work-backup.sh restore   # fresh volume: remote state -> work/ (data only)
+#
+# Durability: nothing authoritative lives on tmpfs — live state is work/
+# (persistent volume), history is the remote, the clone is disposable scratch
+# re-seeded whenever missing or broken. Concurrency: the persist step is
+# serialized by a mkdir lock next to the clone (lock-or-skip + stale TTL;
+# a skipped persist is safe — work/ is the source of truth and the next run
+# backs it up); a rejected non-fast-forward push re-seeds from the new tip and
+# retries with a fresh snapshot. work/ files are only ever READ here (tar).
+#
+# Never fails the run: all error paths exit 0 (a missed backup is retried next
+# run). Requires: git, tar. Sources scripts/log.sh when present.
+# TODO(creator): rename the env var / identity if the design chose different
+# names, then delete the TODO comments.
+set -u
+
+MODE="${1:-persist}"
+WORK="${WORK_DIR:-${HOME:-/home/agent}/work}"
+LOCAL="${WORK_BACKUP_LOCAL:-/dev/shm/{{AGENT_NAME}}-work-backup}"
+BRANCH="${WORK_BACKUP_BRANCH:-main}"
+RETRIES="${WORK_BACKUP_RETRIES:-3}"
+LOCK="$LOCAL.lock"                                # tmpfs too; mtime = acquire time
+LOCK_TTL_MIN="${WORK_BACKUP_LOCK_TTL_MIN:-10}"    # a persist takes seconds
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LOG_JOB="${LOG_JOB:-session}"
+if ! . "$SCRIPT_DIR/log.sh" 2>/dev/null; then logev() { :; }; fi
+
+say() { echo "work-backup: $*"; }
+
+if [ -z "${GITHUB_REPO_WORK:-}" ]; then
+  say "GITHUB_REPO_WORK unset — local-only, nothing to $MODE."; exit 0
+fi
+if ! command -v git >/dev/null 2>&1 || ! command -v tar >/dev/null 2>&1; then
+  say "git/tar unavailable — skipping $MODE."; logev warn work_backup "git/tar unavailable — $MODE skipped"; exit 0
+fi
+
+REMOTE_URL="${WORK_BACKUP_REMOTE:-https://github.com/$GITHUB_REPO_WORK}"
+
+# (Re)seed a usable clone in $LOCAL. tmpfs may be empty (fresh pod), stale, or
+# half-written (interrupted run) — validate and re-clone defensively.
+seed_clone() {
+  if ! ( cd "$LOCAL" 2>/dev/null && git rev-parse --git-dir >/dev/null 2>&1 ); then
+    rm -rf "$LOCAL" 2>/dev/null || true
+    if ! git clone -q "$REMOTE_URL" "$LOCAL" 2>/dev/null; then
+      # empty/nonexistent remote (first-ever backup): start a fresh repo
+      rm -rf "$LOCAL" 2>/dev/null || true
+      mkdir -p "$LOCAL" || return 1
+      ( cd "$LOCAL" && git init -q && git remote add origin "$REMOTE_URL" ) || return 1
+    fi
+  fi
+  ( cd "$LOCAL" || exit 1
+    git config user.name  "{{AGENT_NAME}}"              2>/dev/null || true
+    git config user.email "{{AGENT_NAME}}@agents.local" 2>/dev/null || true
+    if git fetch -q origin "$BRANCH" 2>/dev/null; then
+      git checkout -q -B "$BRANCH" FETCH_HEAD 2>/dev/null
+    else
+      git checkout -q -B "$BRANCH" 2>/dev/null || true
+    fi
+  ) || return 1
+  return 0
+}
+
+# Mirror work/ into the clone's worktree (deletions included): wipe all but
+# .git, then lay down the current state. tar keeps this a pure READ of the
+# volume; .nfs* junk is never backed up.
+sync_in() {
+  find "$LOCAL" -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} + 2>/dev/null || true
+  ( cd "$WORK" && tar -c --exclude='./.git' --exclude='.nfs*' -f - . ) \
+    | ( cd "$LOCAL" && tar -xf - ) || return 1
+  return 0
+}
+
+# Serialize the persist step (lock-or-skip): concurrent sessions share $LOCAL,
+# and two persists over one clone would race. mkdir is atomic; stale locks
+# (crashed persist) expire by TTL.
+acquire_lock() {
+  mkdir "$LOCK" 2>/dev/null && return 0
+  if [ -n "$(find "$LOCK" -maxdepth 0 -mmin "+$LOCK_TTL_MIN" 2>/dev/null)" ]; then
+    rm -rf "$LOCK" 2>/dev/null
+    if mkdir "$LOCK" 2>/dev/null; then
+      say "stole a stale persist lock (>${LOCK_TTL_MIN}m — crashed persist)."
+      logev warn work_backup "stale persist lock stolen"; return 0
+    fi
+  fi
+  return 1
+}
+release_lock() { rm -rf "$LOCK" 2>/dev/null || true; }
+
+persist() {
+  local rc
+  if ! acquire_lock; then
+    say "another persist is running — skipping; state stays on work/ and the next run backs it up."
+    logev info work_backup "persist skipped — concurrent persist holds the lock"
+    return 0
+  fi
+  do_persist; rc=$?
+  release_lock
+  return "$rc"
+}
+
+do_persist() {
+  local attempt=0 rc
+  while [ "$attempt" -lt "$RETRIES" ]; do
+    attempt=$((attempt + 1))
+    seed_clone || { logev warn work_backup "seed failed (attempt $attempt)"; continue; }
+    sync_in    || { logev warn work_backup "sync failed (attempt $attempt)"; continue; }
+    ( cd "$LOCAL" || exit 1
+      git add -A || exit 3
+      if git diff --cached --quiet; then exit 42; fi   # nothing to persist
+      git commit -q -m "chore(work): persist state $(date -u +%Y-%m-%dT%H:%M:%SZ)" || exit 3
+    ); rc=$?
+    if [ "$rc" -eq 42 ]; then say "nothing to persist."; return 0; fi
+    if [ "$rc" -ne 0 ]; then logev warn work_backup "commit failed (attempt $attempt)"; continue; fi
+    if ( cd "$LOCAL" && git push -q origin "HEAD:$BRANCH" 2>/dev/null ); then
+      say "pushed (attempt $attempt)."; logev info work_backup "pushed work/ (attempt $attempt)"; return 0
+    fi
+    say "push rejected (attempt $attempt) — re-seeding from remote tip."
+    logev warn work_backup "push rejected (attempt $attempt) — retrying"
+  done
+  say "push failed after $RETRIES attempt(s); state is safe on work/, retry next run."
+  logev error work_backup "push failed after $RETRIES attempts — retry next run"
+  return 0
+}
+
+restore() {
+  seed_clone || { say "restore: could not reach remote — leaving work/ as-is."; logev warn work_backup "restore: remote unreachable"; return 0; }
+  # copy data into work/ — never .git, and never historical .nfs* junk an older
+  # layout may have committed. Targets a fresh/empty volume; existing files
+  # with the same names are overwritten, nothing is deleted.
+  if ( cd "$LOCAL" && git rev-parse HEAD >/dev/null 2>&1 ); then
+    ( cd "$LOCAL" && tar -c --exclude='./.git' --exclude='.nfs*' -f - . ) | ( cd "$WORK" && tar -xf - ) \
+      && { say "restored work/ from remote."; logev info work_backup "restored work/ from remote"; } \
+      || { say "restore copy failed."; logev warn work_backup "restore copy failed"; }
+  else
+    say "remote is empty — nothing to restore."
+  fi
+  return 0
+}
+
+mkdir -p "$WORK" 2>/dev/null || true
+case "$MODE" in
+  persist) persist ;;
+  restore) restore ;;
+  *) say "unknown mode '$MODE' (use persist|restore)"; exit 0 ;;
+esac


### PR DESCRIPTION
## What

Back-ports the generalizable learnings from a production agent's 1.2.0 → 2.7.0 evolution into the `dam-agent-creator` scaffolding skill, so newly generated agents start with these patterns instead of rediscovering the failures behind them.

## Changes

**State backup — the important one.** The skill previously scaffolded `work/` as a git clone with end-of-run commit & push. That exact pattern corrupts on the platform's virtiofs/NFS home volume (`Stale file handle` + `.nfs*` silly-rename under concurrent runs) — production proof in the reference agent's 2.0.0. Replaced across `references/platform-dam.md`, `references/architecture.md`, and the persistence/ONBOARDING/CLAUDE templates with:
- `work/` as a **plain data directory, never a git repo**;
- new **`templates/work-backup.sh.template`**: persist/restore inside a disposable `/dev/shm` tmpfs clone — mirror semantics, lock-or-skip persist serialization (stale-lock TTL), non-fast-forward push retry with a fresh snapshot, `.nfs*` never backed up nor restored;
- backup-invariant audit checks (no `work/.git`, `.nfs*` junk count).

**Observability.** New **`templates/log.sh.template`** (structured JSONL events log with credential masking, `log_level` debug gating, swallowed failure paths, retention sweep); two-layer logging model + harness-adapter guidance in `architecture.md` (hooks log tool failures/progress; idempotent `install.sh`; audit verifies each hook **by name**); audit gains the `failures[]` signature grouping + per-signature diagnosis pass (cause + fix, environment / agent mistake / definition bug, deduplicated tracking issue).

**Tests + CI.** New **`templates/tests-run.sh.template`** (offline runner: stubbed CLIs on PATH, sandboxed `WORK_DIR`, assertions on emitted JSON) and **`templates/ci.yml.template`** (syntax sweep + structural validator + test suite on every definition PR). The generated repo now receives a self-copy of `validate-definition.sh` (already self-copy-safe from #3024's review fixes); generated self-modification §9 requires the test run and same-PR test updates; `.github/` joins the gitignore allowlist.

**Smaller adoptions.** CHANGELOG template + §12 switched to **migration instructions only** (Upgrade blocks; what/why lives in PR history) with the validator updated to match; `LESSONS.md` operational-lessons memory route; token-scopes + CLI-deps checks at onboarding and in the weekly audit; definition-repo open-issues check; *undeliverable effect → substitute channel* pattern; machine-readable output copies ("readers are agents too").

**Template bugfixes found in production:** `iso2epoch` BSD fallback parses the trailing `Z` as UTC (`date -j -u`); bounded `cfg_table` helper (an unbounded sed range swallowed every later config table). Validator: awk detection no longer false-positives on `awk` inside message strings; syntax/awk checks now also cover `scripts/tests/` and `scripts/harness/`.

**Deliberately not adopted** (offered, declined for now): Stop-hook completion enforcement + stalled-rate alerting, and the interview extensions (priority lane, re-run trigger variants, watch rules).

## Validation

- `bash -n` on the validator and all shell templates.
- Validator smoke run against the current production definition (2.7.x, with CI, tests, harness hooks, Upgrade-only changelog): **66 pass, 0 fail** — including a fixed false positive its old awk heuristic produced there.
- Internal cross-reference sweep of SKILL.md against shipped files.