### PR TITLE
fix(agents): stop the platform NO_PROXY from clobbering docker/k3s's wider list

### DIFF
--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -150,6 +150,7 @@ COPY system/platform-scratch.service system/platform-ca.service \
      system/platform-boot-gate.service system/agent-runtime.service \
      system/platform-net-config.service \
      /usr/lib/systemd/system/
+COPY system/vm-no-proxy.env /usr/lib/platform/vm-no-proxy.env
 COPY system/proxy-dropin.conf /usr/lib/systemd/system/docker.service.d/platform.conf
 COPY system/proxy-dropin.conf /usr/lib/systemd/system/k3s.service.d/platform.conf
 COPY system/k3s-config.yaml /etc/rancher/k3s/config.yaml

--- a/packages/agents/claude-code-vm/system/proxy-dropin.conf
+++ b/packages/agents/claude-code-vm/system/proxy-dropin.conf
@@ -1,11 +1,11 @@
 # All guest egress crosses the paired gateway (HTTPS_PROXY from
-# /etc/platform/env); the MITM CA is in the OS trust store. NO_PROXY keeps
-# cluster-internal traffic (k3s pod/service CIDRs, localhost) off the proxy.
+# /etc/platform/env); the MITM CA is in the OS trust store. The second
+# EnvironmentFile= below widens NO_PROXY for docker/k3s specifically — see
+# vm-no-proxy.env for why that can't be a plain Environment= here.
 [Unit]
 After=platform-scratch.service platform-ca.service
 Requires=platform-scratch.service
 
 [Service]
 EnvironmentFile=-/etc/platform/env
-Environment=NO_PROXY=localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
-Environment=no_proxy=localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+EnvironmentFile=/usr/lib/platform/vm-no-proxy.env

--- a/packages/agents/claude-code-vm/system/vm-no-proxy.env
+++ b/packages/agents/claude-code-vm/system/vm-no-proxy.env
@@ -1,0 +1,11 @@
+# docker/k3s must keep their cluster-internal traffic (the inner k3s's own
+# pod/service CIDRs, localhost) off the egress proxy — wider than the
+# platform env's loopback-only NO_PROXY, which governs the *agent's* own
+# egress (harness API and all external hosts must cross the gateway).
+# A second EnvironmentFile=, not Environment=: systemd's EnvironmentFile=
+# always wins over Environment= regardless of directive order, so a plain
+# Environment=NO_PROXY= here would be silently shadowed by
+# /etc/platform/env — this file must be loaded via EnvironmentFile= too,
+# after it, so ITS value is what wins.
+NO_PROXY=localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local
+no_proxy=localhost,127.0.0.1,10.0.0.0/8,172.16.0.0/12,192.168.0.0/16,.svc,.cluster.local


### PR DESCRIPTION
Fixes #3179.

`systemd`'s `EnvironmentFile=` always wins over `Environment=` regardless of directive order. #3177's `NO_PROXY` in `/etc/platform/env` (loaded via `EnvironmentFile=-/etc/platform/env`) silently shadowed `proxy-dropin.conf`'s plain `Environment=NO_PROXY=` on both `docker.service` and `k3s.service`, dropping the cluster-CIDR exclusions those units deliberately need for the inner k3s's own pod/service ranges (`10.144.0.0/16` / `10.145.0.0/16`, both inside the `10.0.0.0/8` entry that stopped applying). The platform's loopback-only `NO_PROXY` is correct for the *agent's* own egress (harness API + all external hosts must cross the gateway) — it was never meant to reach these two units.

Fix: the wider list moves into its own file (`vm-no-proxy.env`), loaded via a **second** `EnvironmentFile=` after the platform one. Unlike `Environment=`, later `EnvironmentFile=` directives *do* override earlier ones for the same key — so this wins for `NO_PROXY` specifically while docker/k3s still inherit `HTTPS_PROXY` etc. from `/etc/platform/env`.

Verified against real systemd, not just unit-file inspection: booted the built image under `systemd` in a privileged container, started `docker.service`, and read `dockerd`'s actual `/proc/<pid>/environ` — wide `NO_PROXY` (cluster CIDRs intact) alongside a working `HTTPS_PROXY`.

Assisted-By: Claude (Anthropic AI) <noreply@anthropic.com>