### PR TITLE
chore(skills): vendor the updated react-ui-engineering skill

### DIFF
--- a/.agents/skills/react-ui-engineering/SKILL.md
+++ b/.agents/skills/react-ui-engineering/SKILL.md
@@ -13,7 +13,8 @@ Opinionated standards for React+TS UI code. When a rule doesn't fit, say so and 
 2. **Separation by lineage** — state is classified by where its source of truth lives (server, UI, local, URL). Each has a designated home. Mixing lineages is the single biggest driver of drift.
 3. **Small surface, small files** — a component or hook that can't be held in working memory is a bug report waiting to happen. Split along responsibilities.
 4. **Meaningful names** — identifiers carry intent: `selectedAgentId` over `sel`, `hasUnsavedChanges` over `flag`, `useFilteredAgents` over `useData`. Naming is the cheapest documentation you can write.
-5. **Types at boundaries, not assertions** — `any`, `as`, and untyped fetch responses are how large codebases rot. Prefer Zod inference and type guards.
+5. **No unnecessary comments** — names and structure say *what*; a comment says *why*, and only when the reason isn't visible in the code (a subtle invariant, an external constraint, a workaround for a specific bug). One line is usually enough. If a rename or a restructure removes the need for the comment, do that instead.
+6. **Types at boundaries, not assertions** — `any`, `as`, and untyped fetch responses are how large codebases rot. Prefer Zod inference and type guards.
 
 ## Severity tiers
 
@@ -44,9 +45,9 @@ Read only what the task needs. Don't pre-load these.
 | Deciding where a piece of state lives | `references/state-management.md` |
 | Anything that talks to the server | `references/async-data.md` |
 | Building a form | `references/forms.md` |
-| Styling decisions, inline styles, class composition | `references/styling.md` |
+| Styling, inline styles, class composition, reusing an existing component | `references/styling.md` |
 | API / fetch / tRPC setup and error handling | `references/api-layer.md` |
-| Typing a prop, a response, or an error | `references/types.md` |
+| Typing a prop, a response, an error, or defining constants / union literals | `references/types.md` |
 
 ## Legacy code migration
 

--- a/.agents/skills/react-ui-engineering/references/styling.md
+++ b/.agents/skills/react-ui-engineering/references/styling.md
@@ -1,175 +1,82 @@
 # Styling
 
-**Read when:** adding or changing styles, deciding between Tailwind/inline styles/CSS vars, composing conditional classes, reviewing existing style code.
+**Read when:** adding or changing styles, deciding between Tailwind / inline styles / CSS vars, composing conditional classes, or reviewing style code.
+
+## Principle: follow the project, don't restate it
+
+This reference teaches *how to make styling decisions* — not a project's specific tokens, primitives, or theme values. Those live in the codebase and change over time; the moment a rulebook copies them it starts to drift, and will eventually teach a token or recipe the code has already deleted.
+
+So before you style anything:
+
+- **Read the project's theme file** to learn the real tokens (colors, spacing, shadows). Never invent a token name or trust one this document happens to mention — confirm it exists in the codebase first.
+- **Find the project's shared UI/primitive library** and compose from it. Don't hand-roll a control or surface that already exists there, and don't reproduce a primitive's class recipe inline.
+- **Grep existing call sites** for the pattern you're about to write, and match what the codebase already does over any example shown here.
 
 ## The stack
 
-**Use Tailwind exclusively**, with CSS custom properties for theme-aware values in a single root stylesheet (typically `index.css`).
+**[HIGH] Use Tailwind for static styling**, with CSS custom properties for theme-aware values. No per-component CSS Modules, CSS-in-JS, or SCSS.
+
+Where the theme is defined depends on the Tailwind version the project is on — a `@theme` block in the root stylesheet (Tailwind v4) or a `tailwind.config.*` file (v3). Check which the project uses before adding tokens; don't assume, and don't add a config file to a v4 project.
 
 ## Rules
 
-### Tailwind for static styles
+### No static `style={{}}` — [CRITICAL]
 
-**[HIGH]** Everything static goes in Tailwind utility classes. No per-component CSS Modules, no CSS-in-JS, no SCSS.
+Static inline styles are forbidden: they bypass theme tokens and scatter style decisions across files. Anything static is a Tailwind class. Fix on sight when editing.
 
-```tsx
-✅ <div className="flex items-center gap-3 rounded-lg border-2 border-border-light bg-bg px-4 py-2.5" />
+### Dynamic CSS custom properties — OK — [HIGH]
 
-❌ <div style={{ display: "flex", alignItems: "center", gap: "12px" }} />
-```
-
-### No static `style={{}}`
-
-**[CRITICAL] Static inline styles are forbidden.** They duplicate Tailwind's job, bypass theme tokens, and scatter style decisions across files. Fix on sight when editing.
-
-Common offender:
-```tsx
-❌ <button style={{ boxShadow: "var(--shadow-brutal-sm)" }} className="btn">
-     Save
-   </button>
-```
-
-Fix:
-```tsx
-// index.css or a Tailwind plugin: add `shadow-brutal-sm` utility mapping to the CSS var.
-✅ <button className="btn shadow-brutal-sm">Save</button>
-```
-
-Or, for the two or three "brutal" button variants that repeat across the app, a utility component:
-```tsx
-✅ <BrutalButton variant="danger">Save</BrutalButton>
-```
-
-### Dynamic CSS custom properties — OK
-
-**[HIGH]** When a value genuinely varies at runtime (a width percentage, a user-supplied color, a computed offset), set a CSS custom property on `style` and consume it in CSS:
+When a value genuinely varies at runtime (a width percentage, a computed offset, a user-supplied color), set a CSS custom property in `style` and consume it in CSS. This is the one legitimate use of `style={{}}`.
 
 ```tsx
-✅ <div style={{ "--progress": `${percent}%` } as CSSProperties} className="progress-bar" />
+<div style={{ "--progress": `${percent}%` } as CSSProperties} className="progress-bar" />
 ```
 
-```css
-.progress-bar::before {
-  width: var(--progress);
-}
-```
+### Conditional classes: `cn()` / `clsx` — [HIGH]
 
-This is the narrow legitimate use of `style={{}}`. Never use `style` for static values that could be a class.
+Use the project's `cn()` helper (wraps `clsx` + `tailwind-merge`) for conditional classes; don't assemble class strings with template literals. `tailwind-merge` also resolves conflicting utilities (`px-4 px-6` → `px-6`). Locate the existing helper in the codebase rather than redefining it.
 
-### Conditional classes: `cn()` / `clsx`
+### Variants via `cva` when repeated — [MODERATE]
 
-**[HIGH]** Use a `cn()` helper (wrap `clsx` + `tailwind-merge`) for conditional classes. Don't build class strings with template literals.
+When a component has 3+ distinct style variants, define them with `class-variance-authority` rather than ad-hoc ternaries. For two variants with no composition, a `cn()` call is fine.
 
-```ts
-// src/lib/cn.ts
-import { clsx, type ClassValue } from "clsx";
-import { twMerge } from "tailwind-merge";
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
-```
+### Reuse an existing component before styling new markup — [HIGH]
 
-Usage:
-```tsx
-✅ <div className={cn(
-     "rounded-lg border-2 px-4 py-2",
-     isActive && "border-accent bg-accent/10",
-     disabled && "opacity-50 cursor-not-allowed",
-     className
-   )} />
+Before you hand-roll and style a new element, check whether the UI library already has a component for that **intention**. If one exists, use it. A bespoke `<div>`/`<button>` carrying its own classes to do what a primitive already does is drift by construction: it looks almost right, diverges from the primitive on states, tokens, and a11y, and multiplies the surfaces a future change has to touch. Selecting a card, toggling a disclosure, laying out a form field — these are solved in the primitive library; re-deriving their classes inline is exactly how variants of the "same" component pull apart.
 
-❌ <div className={`rounded-lg border-2 px-4 py-2 ${isActive ? "border-accent bg-accent/10" : ""} ${className ?? ""}`} />
-```
+Custom-styled markup is justified **only** when one of these holds — and if it isn't obvious which, say so:
 
-`tailwind-merge` resolves conflicts when later utilities should override earlier ones (e.g., `px-4 px-6` → `px-6`).
+- it's **layout / structure** — flex and grid containers, spacing, positioning: the connective tissue *between* components, which primitives don't own; or
+- **no existing component matches the intention**, and what you need is genuinely one-off or specific enough that it isn't worth a shared primitive.
 
-### Variants via `cva` when repeated
+When you build something new that *isn't* a one-off, flag it for promotion to the primitive library (see `references/project-structure.md`) rather than leaving a styled one-off buried in a feature file.
 
-**[MODERATE]** When a component has 3+ distinct style variants, define them with `class-variance-authority` (`cva`) rather than ad-hoc ternaries:
+### One hover treatment for clickable surfaces — [MODERATE]
 
-```ts
-import { cva } from "class-variance-authority";
-const button = cva("rounded-lg font-medium transition", {
-  variants: {
-    variant: {
-      primary: "bg-accent text-white hover:bg-accent/90",
-      ghost: "bg-transparent text-fg hover:bg-surface",
-      danger: "bg-danger text-white hover:bg-danger/90",
-    },
-    size: { sm: "px-3 py-1 text-sm", md: "px-4 py-2", lg: "px-6 py-3 text-lg" },
-  },
-  defaultVariants: { variant: "primary", size: "md" },
-});
-```
+Give clickable cards and surfaces a single, consistent hover affordance — a background-tint change, following whatever the primitive library already uses. Avoid an elevation shadow as the hover cue: in dark mode a surface sits on a near-identical background, so a shadow reads as no feedback at all. Prefer the primitive's built-in hover over inventing your own.
 
-Don't reach for `cva` when there's only 2 variants and no composition — a `cn()` call is fine.
+### Accent / brand color is config, not a literal — [HIGH]
 
-### Theme tokens
+Never hardcode the brand/accent color as a hex value. If the project sources it at runtime (e.g. fetched and applied as a CSS variable on the document root), that runtime value overrides the stylesheet's default — so "changing the accent" means changing the config/source it comes from, **not** editing a hex in a component or the stylesheet default (which silently renders nothing). Reference the accent through its theme token/utility and let the runtime layer supply the value.
 
-**[HIGH]** Define colors, shadows, and spacing unique to the design system as CSS custom properties in `index.css`, then reference them from the Tailwind config (`tailwind.config.ts`) so utilities like `bg-bg`, `text-fg`, `border-border-light` resolve correctly.
+### Arbitrary values sparingly — [MODERATE]
 
-```css
-/* index.css */
-:root {
-  --c-bg: #fff;
-  --c-fg: #111;
-  --c-border-light: #e5e5e5;
-  --shadow-brutal-sm: 3px 3px 0 #000;
-}
-.dark {
-  --c-bg: #0a0a0a;
-  --c-fg: #f5f5f5;
-  ...
-}
-```
+`bg-[#fff]` / `w-[317px]` escape hatches are OK for genuinely one-off values. If the same magic number appears 3+ times, extract a theme token instead.
 
-```ts
-// tailwind.config.ts
-theme: {
-  extend: {
-    colors: { bg: "var(--c-bg)", fg: "var(--c-fg)" },
-    boxShadow: { "brutal-sm": "var(--shadow-brutal-sm)" },
-  },
-}
-```
+### Dark mode — [MODERATE]
 
-Using `bg-bg` over `bg-[var(--c-bg)]` keeps the Tailwind IntelliSense friendly and the codebase greppable.
+Follow the project's dark-mode mechanism (typically a class on the root element plus Tailwind's `dark:` variant). If a token already differs between light and dark, consume the token — you don't need a `dark:` override layered on top of it.
 
-### Arbitrary values sparingly
+## Tooling caveat
 
-**[MODERATE]** Tailwind's `bg-[#fff]` / `w-[317px]` escape hatches are OK for genuinely one-off values. If you use the same magic number 3+ times, extract a theme token.
-
-### Class ordering
-
-**[MODERATE]** Install `prettier-plugin-tailwindcss` once ESLint lands. It reorders classes deterministically. Until then, follow the informal convention: layout → spacing → typography → color → state → responsive.
-
-### Responsive
-
-Use Tailwind's built-in breakpoints (`sm:`, `md:`, `lg:`). Don't introduce custom media queries when a breakpoint suffices.
-
-### Dark mode
-
-Class-based dark mode: toggle `.dark` on `<html>`. Use Tailwind's `dark:` variant:
-```tsx
-<div className="bg-bg text-fg dark:bg-bg dark:text-fg" />
-```
-
-If a color uses a theme token that already differs between light and dark, you don't need the `dark:` variant — the token does the work.
-
-### Global styles
-
-**[HIGH]** Global CSS stays in `src/index.css` (or a dedicated `src/styles/`):
-- Theme tokens (CSS custom properties).
-- Resets/base (already handled by Tailwind's base).
-- A handful of utility classes that repeat everywhere and are ergonomic as a class (`.btn-brutal`, `.card`).
-
-Avoid growing this file — if something is used in one component, style it in that component.
+**`git grep -E` here does not support `\b`.** A word-boundary pattern matches nothing and reads as "already clean" — which is exactly how a token sweep can look finished when it never started. Use explicit alternatives (surrounding characters, `-w`, or `rg`) when checking whether a token or class is still in use.
 
 ## Anti-patterns
 
-- **Static `style={{}}`** — move to Tailwind classes.
-- **Template-literal class strings** — use `cn()`.
-- **Re-implementing the same shadow/color combo with inline styles** — extract a utility class or component.
-- **`!important`** — nearly always a Tailwind specificity misunderstanding. `tailwind-merge` solves the common case.
-- **Mixing Tailwind with CSS Modules for the same component** — pick one per project.
-- **Arbitrary value spam** (`bg-[#a1b2c3] text-[13px] leading-[1.23]`) repeated across components — extract tokens.
+- **Static `style={{}}`** for values that could be a class.
+- **Template-literal class strings** instead of `cn()`.
+- **Hand-rolling a control or surface** the primitive library already provides.
+- **A hardcoded hex** for a color that has a theme token — especially the accent.
+- **Copying token names, primitive props, or theme values into this skill** — point at the codebase instead.
+- **Arbitrary-value spam** (`bg-[#a1b2c3] text-[13px] leading-[1.23]`) repeated across components — extract a token.
+- **`!important`** — nearly always a Tailwind specificity misunderstanding; `tailwind-merge` solves the common case.

--- a/.agents/skills/react-ui-engineering/references/types.md
+++ b/.agents/skills/react-ui-engineering/references/types.md
@@ -178,6 +178,64 @@ Then `err instanceof ApiError` narrows in `catch` blocks and toast/logging code.
 
 See `references/api-layer.md` for the end-to-end error contract.
 
+## Constants & literals
+
+**[HIGH] No magic strings/numbers.** A literal that carries meaning beyond its value, or appears more than once, becomes a named constant. The bar isn't "extract every literal" — single-use, self-explanatory values stay inline. It's "if a future reader has to read surrounding code to understand what `3000` or `"idle"` means, name it."
+
+Common offenders:
+
+```ts
+❌ if (agent.status === "running" && Date.now() - agent.startedAt > 30_000) { ... }
+❌ await fetch(`/api/v2/agents/${id}`);
+❌ setTimeout(refetch, 5000);
+```
+
+Fixed:
+
+```ts
+✅ if (agent.status === AGENT_STATUS.RUNNING && Date.now() - agent.startedAt > AGENT_STALL_MS) { ... }
+✅ await fetch(`${API_BASE}/agents/${id}`);
+✅ setTimeout(refetch, REFETCH_INTERVAL_MS);
+```
+
+### Where constants live
+
+- **Domain-scoped** (a status set, a domain-specific limit) → `modules/{domain}/constants.ts`.
+- **App-wide** (API base path, default page size, shared animation durations) → `src/utils/constants.ts` or `src/lib/constants.ts`.
+- **Single-use in one file** → module-scope `const` at the top of the same file. Don't relocate it to a constants file just to satisfy the rule.
+
+### Union literals — no TS `enum`
+
+For sets of allowed string values, the source of truth is a Zod schema or an `as const` tuple — **never a TypeScript `enum`** (emits a runtime object, doesn't tree-shake, doesn't compose with Zod, has surprising numeric-enum semantics).
+
+```ts
+// Pattern A — Zod schema is the source; type and tuple both fall out of it.
+✅ export const agentStatusSchema = z.enum(["idle", "running", "failed"]);
+   export type AgentStatus = z.infer<typeof agentStatusSchema>;
+   export const AGENT_STATUSES = agentStatusSchema.options; // readonly ["idle", "running", "failed"]
+
+// Pattern B — tuple is the source; type is derived from it.
+✅ export const AGENT_STATUSES = ["idle", "running", "failed"] as const;
+   export type AgentStatus = (typeof AGENT_STATUSES)[number];
+
+❌ enum AgentStatus { Idle = "idle", Running = "running", Failed = "failed" }
+```
+
+If you need a tuple guaranteed to cover every union member (i.e. exhaustiveness, not just no-typos), use Pattern A — Zod's `.options` gives you the full tuple by construction.
+
+### When inline is fine
+
+- Self-explanatory at the call site: `arr.slice(0, 1)`, `disabled={count === 0}`, `flex: 1`, `opacity-0`.
+- Math constants whose meaning is the literal itself: `width / 2` for centering.
+- Test fixtures and one-off mock data.
+
+Extracting these adds noise without adding meaning.
+
+### Already covered elsewhere
+
+- **Tailwind arbitrary values** repeated 3+ times → theme token. See `references/styling.md`.
+- **Query keys** → always come from the per-domain factory, never string literals. See `references/async-data.md`.
+
 ## Anti-patterns
 
 - **`any` anywhere except in a temporary migration comment with a `TODO` deadline.**
@@ -187,3 +245,5 @@ See `references/api-layer.md` for the end-to-end error contract.
 - **Redundant annotations** (`const name: string = getName()` when `getName` is typed).
 - **Missing types on exported function parameters** — always annotate the public surface.
 - **`type Props = {}`** (empty props) — omit the parameter.
+- **Magic strings / numbers** — repeated literals with semantic meaning belong in a named constant.
+- **TypeScript `enum`** — use Zod enums or `as const` tuples instead.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -15,7 +15,7 @@
       "source": "dam-agents/skills",
       "sourceType": "github",
       "skillPath": "skills/react-ui-engineering/SKILL.md",
-      "computedHash": "b84c8dd313729a13c098067539bf08e60773adcba6479b5cac77a29861478e74"
+      "computedHash": "f7ff90fe2447778593c6d27f7f190034f9101fd8d877753369d27f84cc613e38"
     },
     "typescript-engineering": {
       "source": "dam-agents/skills",


### PR DESCRIPTION
Closes #3050.

Updates the `react-ui-engineering` skill to work with the consolidated primitives and to enforce their use. Vendored from [skills#10](https://github.com/dam-agents/skills/pull/10) — the tree now matches upstream, no fork left.
