### PR TITLE
feat(connections): narrow a GitHub App connection to chosen repos and permissions

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-08-05
+Last verified: 2026-08-06
 
 ## Overview
 
@@ -268,6 +268,25 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
   host; only the installation token reaches the gateway's injection path. Like
   the client secret above, a rotated private key is pasted in place and proven by
   minting before it is stored.
+
+  A Connection may additionally **narrow the authority of the token it mints**,
+  below what the app installation itself holds — to a chosen set of repositories,
+  to a chosen set of permissions, or both. An installation is an
+  organization-wide grant, typically far broader than any one agent's task, and
+  narrowing is how one broadly-installed app backs many least-privilege
+  Connections without a second app per task. GitHub is the arbiter: it refuses
+  any request exceeding the installation, so the narrowing can only ever reduce
+  authority, never claim it. The chosen subset is **part of the credential's
+  stored identity, not a one-time argument** — every renewal and every key
+  rotation re-mints against the same subset, so a Connection cannot silently
+  widen back to the whole installation between renewals. Narrowing is opt-in:
+  a Connection that names no subset carries the installation's full authority,
+  which is what every Connection made before the capability existed does. Once
+  a subset stops being covered — the organization drops a repository from the
+  installation, or revokes a permission — renewal is *rejected* rather than
+  merely failing, so the Connection reads expired and waits for someone to
+  widen the installation or narrow the Connection, instead of retrying a
+  request that cannot succeed.
 
 **Multi-host connections.** A single OAuth connection can inject the
 same token on more than one host with **different auth schemes per

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -128,6 +128,12 @@ const githubAppCreateInput = z.object({
   appId: z.string().min(1),
   installationId: z.string().min(1),
   privateKey: z.string().min(1),
+  // Optional narrowing of the minted token. Space- or comma-separated; the
+  // server parses both. Single strings keep the schema-driven forms all-string,
+  // as client-credentials `scopes` does. Blank leaves the token with the
+  // installation's full authority.
+  repositories: z.string().optional(),
+  permissions: z.string().optional(),
 });
 
 const noneCreateInput = z.object({

--- a/packages/api-server-api/src/modules/connections/types.ts
+++ b/packages/api-server-api/src/modules/connections/types.ts
@@ -63,6 +63,13 @@ export const githubAppAuth = z.object({
   connectedAt: z.number().int().optional(),
   refreshFailedAt: z.number().int().optional(),
   host: z.string().min(1).optional(),
+  // Optional narrowing of the minted token, stored because every re-mint must
+  // ask for the same subset — a scope kept only on the create input would widen
+  // back to the whole installation at the first renewal. Absent means the
+  // installation's full authority, which is what every connection made before
+  // this field existed carries.
+  repositories: z.array(z.string().min(1)).nonempty().optional(),
+  permissions: z.record(z.string(), z.string()).optional(),
 });
 
 export const headerAuth = z.object({

--- a/packages/api-server/src/__tests__/unit/connections-github-app-template.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-github-app-template.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import type { Contribution, SecretRef } from "api-server-api";
 import { buildConnection } from "../../modules/connections/domain/build-connection.js";
 import { buildCatalog } from "../../modules/connections/domain/catalog.js";
+import { templateToView } from "../../modules/connections/domain/connection-template.js";
 import { connectionSecretAnnotations } from "../../modules/connections/domain/connection-sds.js";
 
 const { privateKey: PRIVATE_KEY_PEM } = crypto.generateKeyPairSync("rsa", {
@@ -26,6 +27,8 @@ function build(
     appId: string;
     installationId: string;
     privateKey: string;
+    repositories: string;
+    permissions: string;
   }> = {},
 ) {
   return buildConnection(
@@ -142,5 +145,59 @@ describe("github-app template build", () => {
     await expect(build(override)).rejects.toThrow(
       new RegExp(`missing ${field}`),
     );
+  });
+
+  // Storing the scope on the auth config is what makes it survive every
+  // re-mint; a scope that lived only on the create input would be gone by the
+  // first renewal.
+  it("stores the parsed scope on the auth config", async () => {
+    const built = await build({
+      repositories: "docs, handbook",
+      permissions: "contents:read metadata:read",
+    });
+    if (built.auth.kind !== "github-app") throw new Error("wrong kind");
+    expect(built.auth.repositories).toEqual(["docs", "handbook"]);
+    expect(built.auth.permissions).toEqual({
+      contents: "read",
+      metadata: "read",
+    });
+  });
+
+  it("leaves the scope off entirely when nothing is narrowed", async () => {
+    const built = await build();
+    if (built.auth.kind !== "github-app") throw new Error("wrong kind");
+    expect(built.auth).not.toHaveProperty("repositories");
+    expect(built.auth).not.toHaveProperty("permissions");
+  });
+
+  it("treats a blank scope as no narrowing", async () => {
+    const built = await build({ repositories: "  ", permissions: "" });
+    if (built.auth.kind !== "github-app") throw new Error("wrong kind");
+    expect(built.auth).not.toHaveProperty("repositories");
+    expect(built.auth).not.toHaveProperty("permissions");
+  });
+
+  it("fails the create on an unusable scope rather than storing it", async () => {
+    await expect(build({ repositories: "dam-agents/docs" })).rejects.toThrow(
+      /just the repository name/,
+    );
+    await expect(build({ permissions: "contents" })).rejects.toThrow(
+      /name:level/,
+    );
+  });
+
+  it("offers the scope as optional form inputs", () => {
+    const view = templateToView(
+      template(),
+      "https://cb.example/oauth/callback",
+    );
+    const byName = new Map(view.inputs.map((i) => [i.name, i]));
+    expect(byName.get("repositories")?.state).toBe("optional");
+    expect(byName.get("permissions")?.state).toBe("optional");
+    // Optional means a user who ignores both fields still gets a working
+    // connection with the installation's full authority, as before.
+    expect(
+      view.inputs.filter((i) => i.state === "required").map((i) => i.name),
+    ).toEqual(["appId", "installationId", "privateKey"]);
   });
 });

--- a/packages/api-server/src/__tests__/unit/github-app-engine.test.ts
+++ b/packages/api-server/src/__tests__/unit/github-app-engine.test.ts
@@ -17,6 +17,7 @@ interface RecordedCall {
   url: string;
   method: string | undefined;
   headers: Record<string, string>;
+  body: string | undefined;
 }
 
 function makeEngine(respond: (call: RecordedCall) => Response) {
@@ -28,6 +29,7 @@ function makeEngine(respond: (call: RecordedCall) => Response) {
         url: String(url),
         method: init?.method,
         headers: (init?.headers as Record<string, string>) ?? {},
+        body: typeof init?.body === "string" ? init.body : undefined,
       };
       calls.push(call);
       return respond(call);
@@ -164,5 +166,101 @@ describe("github app engine mintInstallationToken", () => {
       }),
     ).rejects.toThrow(/could not sign/);
     expect(calls).toHaveLength(0);
+  });
+});
+
+describe("github app engine token scoping", () => {
+  const scopedMint = (
+    engine: ReturnType<typeof makeEngine>["engine"],
+    scope: { repositories?: string[]; permissions?: Record<string, string> },
+  ) =>
+    engine.mintInstallationToken({
+      id: "connection:conn-1:github-app",
+      appId: "123456",
+      installationId: "987654",
+      privateKeyPem: PRIVATE_KEY_PEM,
+      apiBaseUrl: "https://api.github.com",
+      ...scope,
+    });
+
+  // Omitting the body is what asks for the installation's full authority, so an
+  // unscoped connection must keep sending no body at all.
+  it("sends no body and no content-type when nothing is scoped", async () => {
+    const { engine, calls } = makeEngine(() =>
+      jsonResponse({ token: "ghs_abc" }),
+    );
+    await mint(engine);
+    expect(calls[0].body).toBeUndefined();
+    expect(calls[0].headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("sends no body when the scope is present but empty", async () => {
+    const { engine, calls } = makeEngine(() =>
+      jsonResponse({ token: "ghs_abc" }),
+    );
+    await scopedMint(engine, { repositories: [], permissions: {} });
+    expect(calls[0].body).toBeUndefined();
+    expect(calls[0].headers["Content-Type"]).toBeUndefined();
+  });
+
+  it("sends repositories in the request body", async () => {
+    const { engine, calls } = makeEngine(() =>
+      jsonResponse({ token: "ghs_abc" }),
+    );
+    await scopedMint(engine, { repositories: ["docs"] });
+    expect(calls[0].headers["Content-Type"]).toBe("application/json");
+    expect(JSON.parse(calls[0].body!)).toEqual({ repositories: ["docs"] });
+  });
+
+  it("sends permissions in the request body", async () => {
+    const { engine, calls } = makeEngine(() =>
+      jsonResponse({ token: "ghs_abc" }),
+    );
+    await scopedMint(engine, { permissions: { contents: "read" } });
+    expect(JSON.parse(calls[0].body!)).toEqual({
+      permissions: { contents: "read" },
+    });
+  });
+
+  it("sends both halves together when both are scoped", async () => {
+    const { engine, calls } = makeEngine(() =>
+      jsonResponse({ token: "ghs_abc" }),
+    );
+    await scopedMint(engine, {
+      repositories: ["docs", "handbook"],
+      permissions: { contents: "read", metadata: "read" },
+    });
+    expect(JSON.parse(calls[0].body!)).toEqual({
+      repositories: ["docs", "handbook"],
+      permissions: { contents: "read", metadata: "read" },
+    });
+  });
+
+  // A 422 answers a scope the installation no longer covers. Retrying re-sends
+  // the same losing request, so it has to park rather than spin.
+  it("marks a 422 on a scoped request as permanently rejected", async () => {
+    const { engine } = makeEngine(
+      () => new Response("no access to repository", { status: 422 }),
+    );
+    await expect(
+      scopedMint(engine, { repositories: ["gone"] }),
+    ).rejects.toMatchObject({ status: 422, oauthError: "invalid_grant" });
+  });
+
+  it("leaves a 422 on an unscoped request retryable", async () => {
+    const { engine } = makeEngine(() => new Response("nope", { status: 422 }));
+    await expect(mint(engine)).rejects.toMatchObject({
+      status: 422,
+      oauthError: undefined,
+    });
+  });
+
+  it("still reports a rejected key as invalid_client when scoped", async () => {
+    const { engine } = makeEngine(
+      () => new Response("Bad credentials", { status: 401 }),
+    );
+    await expect(
+      scopedMint(engine, { repositories: ["docs"] }),
+    ).rejects.toMatchObject({ status: 401, oauthError: "invalid_client" });
   });
 });

--- a/packages/api-server/src/__tests__/unit/github-app-scope.test.ts
+++ b/packages/api-server/src/__tests__/unit/github-app-scope.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseGitHubAppScope,
+  parsePermissions,
+  parseRepositories,
+} from "../../modules/connections/domain/github-app-scope.js";
+
+describe("parseRepositories", () => {
+  // Blank must stay indistinguishable from unset: both mean the installation's
+  // full reach, which is what every pre-existing connection carries.
+  it("treats absent, empty, and whitespace-only input as no narrowing", () => {
+    expect(parseRepositories(undefined)).toBeUndefined();
+    expect(parseRepositories("")).toBeUndefined();
+    expect(parseRepositories("   ")).toBeUndefined();
+  });
+
+  it("splits on spaces, commas, and newlines alike", () => {
+    expect(parseRepositories("docs handbook")).toEqual(["docs", "handbook"]);
+    expect(parseRepositories("docs,handbook")).toEqual(["docs", "handbook"]);
+    expect(parseRepositories("docs, handbook")).toEqual(["docs", "handbook"]);
+    expect(parseRepositories("docs\nhandbook")).toEqual(["docs", "handbook"]);
+  });
+
+  it("accepts the punctuation GitHub allows in a repository name", () => {
+    expect(parseRepositories("my-repo my.repo my_repo r2")).toEqual([
+      "my-repo",
+      "my.repo",
+      "my_repo",
+      "r2",
+    ]);
+  });
+
+  it("drops duplicates while preserving order", () => {
+    expect(parseRepositories("docs handbook docs")).toEqual([
+      "docs",
+      "handbook",
+    ]);
+  });
+
+  // `owner/repo` is the likely paste; GitHub would answer 422 an hour later on
+  // a refresh, so it's worth catching at create with the fix spelled out.
+  it("rejects owner/name and names the repository to use instead", () => {
+    expect(() => parseRepositories("dam-agents/docs")).toThrow(
+      /just the repository name.*"docs"/s,
+    );
+  });
+
+  it("names the repository from a pasted repository URL too", () => {
+    expect(() =>
+      parseRepositories("https://github.com/dam-agents/docs"),
+    ).toThrow(/just the repository name.*"docs"/s);
+  });
+
+  // Suggesting a value that fails again wastes a round trip; suggesting an
+  // empty one is worse, since blank means "no narrowing" rather than an error.
+  it("suggests nothing rather than a replacement that would fail again", () => {
+    for (const bad of ["dam-agents/docs/", "docs/", "owner/docs!"]) {
+      expect(() => parseRepositories(bad)).toThrow(/without the owner\.$/);
+    }
+  });
+
+  it("rejects a name with characters GitHub does not allow", () => {
+    expect(() => parseRepositories("do cs")).not.toThrow(); // splits into two
+    expect(() => parseRepositories("docs!")).toThrow(/not a valid repository/);
+  });
+
+  it("rejects more repositories than one request may carry", () => {
+    const many = Array.from({ length: 501 }, (_, i) => `r${i}`).join(" ");
+    expect(() => parseRepositories(many)).toThrow(/at most 500/);
+  });
+
+  it("allows exactly the maximum", () => {
+    const many = Array.from({ length: 500 }, (_, i) => `r${i}`).join(" ");
+    expect(parseRepositories(many)).toHaveLength(500);
+  });
+});
+
+describe("parsePermissions", () => {
+  it("treats absent, empty, and whitespace-only input as no narrowing", () => {
+    expect(parsePermissions(undefined)).toBeUndefined();
+    expect(parsePermissions("")).toBeUndefined();
+    expect(parsePermissions("   ")).toBeUndefined();
+  });
+
+  it("parses name:level pairs", () => {
+    expect(parsePermissions("contents:read, issues:write")).toEqual({
+      contents: "read",
+      issues: "write",
+    });
+  });
+
+  it("accepts the underscored permission names GitHub uses", () => {
+    expect(parsePermissions("pull_requests:write")).toEqual({
+      pull_requests: "write",
+    });
+  });
+
+  it("normalizes the level's case", () => {
+    expect(parsePermissions("contents:READ")).toEqual({ contents: "read" });
+  });
+
+  it("lets a later duplicate correct an earlier one", () => {
+    expect(parsePermissions("contents:write contents:read")).toEqual({
+      contents: "read",
+    });
+  });
+
+  it("rejects a pair with no level", () => {
+    expect(() => parsePermissions("contents")).toThrow(/name:level/);
+  });
+
+  it("rejects a level GitHub does not accept", () => {
+    expect(() => parsePermissions("contents:readonly")).toThrow(
+      /:read, :write, or :admin/,
+    );
+  });
+
+  it("rejects an invalid permission name", () => {
+    expect(() => parsePermissions("Contents:read")).toThrow(
+      /invalid permission name/,
+    );
+  });
+});
+
+describe("parseGitHubAppScope", () => {
+  it("omits both halves when neither is given", () => {
+    expect(parseGitHubAppScope({})).toEqual({});
+  });
+
+  // Either half narrows on its own — repositories without permissions is the
+  // common "read everything, but only here" shape.
+  it("narrows on repositories alone", () => {
+    expect(parseGitHubAppScope({ repositories: "docs" })).toEqual({
+      repositories: ["docs"],
+    });
+  });
+
+  it("narrows on permissions alone", () => {
+    expect(parseGitHubAppScope({ permissions: "contents:read" })).toEqual({
+      permissions: { contents: "read" },
+    });
+  });
+
+  it("carries both halves when both are given", () => {
+    expect(
+      parseGitHubAppScope({
+        repositories: "docs",
+        permissions: "contents:read",
+      }),
+    ).toEqual({ repositories: ["docs"], permissions: { contents: "read" } });
+  });
+});

--- a/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
@@ -71,10 +71,12 @@ function makeDeps(opts: { privateKey: string | null }) {
   } as unknown as Db;
 
   const tokenCalls: string[] = [];
+  const tokenBodies: (string | undefined)[] = [];
   const githubAppEngine = createGitHubAppEngine({
     now: () => NOW_MS,
-    fetchImpl: (async (url: RequestInfo | URL) => {
+    fetchImpl: (async (url: RequestInfo | URL, init?: RequestInit) => {
       tokenCalls.push(String(url));
+      tokenBodies.push(typeof init?.body === "string" ? init.body : undefined);
       return new Response(
         JSON.stringify({
           token: "ghs_next",
@@ -85,7 +87,15 @@ function makeDeps(opts: { privateKey: string | null }) {
     }) as typeof fetch,
   });
 
-  return { githubAppEngine, secretStore, db, putCalls, dbUpdates, tokenCalls };
+  return {
+    githubAppEngine,
+    secretStore,
+    db,
+    putCalls,
+    dbUpdates,
+    tokenCalls,
+    tokenBodies,
+  };
 }
 
 describe("github-app re-mint", () => {
@@ -129,5 +139,53 @@ describe("github-app re-mint", () => {
     const parsed = connectionAuthConfigSchema.safeParse(AUTH);
     expect(parsed.success).toBe(true);
     if (parsed.success) expect(parsed.data).toEqual(AUTH);
+  });
+
+  it("sends no body for a connection with no scope stored", async () => {
+    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
+    await remintGitHubAppOne(CONN, AUTH, deps);
+    expect(deps.tokenBodies).toEqual([undefined]);
+  });
+});
+
+// The whole point of storing the scope rather than applying it once at create:
+// a token is re-minted every hour, so a scope the renewal forgot would widen
+// the connection back to the full installation without anyone noticing.
+describe("github-app re-mint with a stored scope", () => {
+  const SCOPED_AUTH: Extract<ConnectionAuthConfig, { kind: "github-app" }> = {
+    ...AUTH,
+    repositories: ["docs"],
+    permissions: { contents: "read", metadata: "read" },
+  };
+  const SCOPED_CONN: Connection = { ...CONN, auth: SCOPED_AUTH };
+
+  it("re-mints asking for the same subset", async () => {
+    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
+    await remintGitHubAppOne(SCOPED_CONN, SCOPED_AUTH, deps);
+
+    expect(deps.tokenBodies).toHaveLength(1);
+    expect(JSON.parse(deps.tokenBodies[0]!)).toEqual({
+      repositories: ["docs"],
+      permissions: { contents: "read", metadata: "read" },
+    });
+  });
+
+  it("keeps the scope on the row it writes back", async () => {
+    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
+    await remintGitHubAppOne(SCOPED_CONN, SCOPED_AUTH, deps);
+
+    const updated = deps.dbUpdates[0].auth;
+    if (updated.kind !== "github-app") throw new Error("wrong kind");
+    expect(updated.repositories).toEqual(["docs"]);
+    expect(updated.permissions).toEqual({
+      contents: "read",
+      metadata: "read",
+    });
+  });
+
+  it("scoped auth round-trips through the wire schema", () => {
+    const parsed = connectionAuthConfigSchema.safeParse(SCOPED_AUTH);
+    expect(parsed.success).toBe(true);
+    if (parsed.success) expect(parsed.data).toEqual(SCOPED_AUTH);
   });
 });

--- a/packages/api-server/src/modules/connections/domain/build-connection.ts
+++ b/packages/api-server/src/modules/connections/domain/build-connection.ts
@@ -17,6 +17,7 @@ import {
   CONNECTION_TOKEN_PLACEHOLDER,
   UPSTREAM_CA_SECRET_FIELD,
 } from "./connection-sds.js";
+import { parseGitHubAppScope } from "./github-app-scope.js";
 import {
   buildKubernetesContributions,
   decodeCaData,
@@ -479,6 +480,11 @@ function buildGitHubApp(
     contributions.push(...githubEnterpriseHostContributions(host));
   }
 
+  // Rejected here rather than at GitHub so a typo fails the create with a
+  // usable message; whether the installation actually covers the subset is
+  // GitHub's call, made by the synchronous mint that follows.
+  const scope = parseGitHubAppScope(input);
+
   return {
     auth: {
       kind: "github-app",
@@ -488,6 +494,8 @@ function buildGitHubApp(
       accessTokenRef: { ...secretPath, field: "access_token" },
       apiBaseUrl,
       ...(host ? { host } : {}),
+      ...(scope.repositories ? { repositories: scope.repositories } : {}),
+      ...(scope.permissions ? { permissions: scope.permissions } : {}),
     },
     contributions,
     secrets: new Map([[secretPath.path, { private_key: privateKeyPem }]]),

--- a/packages/api-server/src/modules/connections/domain/connection-template.ts
+++ b/packages/api-server/src/modules/connections/domain/connection-template.ts
@@ -276,6 +276,18 @@ function inputsFor(
           label: "Private key (PEM)",
           hint: "A private key generated for the app (.pem). Paste the whole file including the BEGIN/END lines, or its base64 encoding.",
         },
+        {
+          name: "repositories",
+          state: "optional",
+          label: "Limit to repositories",
+          hint: "Repository names, separated by spaces or commas — just the name, not owner/name. Leave blank for every repository the installation can reach.",
+        },
+        {
+          name: "permissions",
+          state: "optional",
+          label: "Limit to permissions",
+          hint: "Pairs like contents:read, issues:write. Leave blank for every permission the app was granted. You can only narrow what the installation already allows.",
+        },
       );
       return out;
     }

--- a/packages/api-server/src/modules/connections/domain/github-app-scope.ts
+++ b/packages/api-server/src/modules/connections/domain/github-app-scope.ts
@@ -1,0 +1,113 @@
+/** Parsing for the optional narrowing a `github-app` Connection may carry.
+ *
+ *  GitHub mints an installation token with the installation's full authority
+ *  unless the request names a narrower set, so the scope is what the user asks
+ *  for rather than what they are entitled to — GitHub rejects anything beyond
+ *  the installation. Both fields arrive as single strings to keep the
+ *  schema-driven forms all-string (same shape as client-credentials `scopes`).
+ */
+
+/** GitHub caps one installation-token request at 500 repositories. */
+const MAX_REPOSITORIES = 500;
+
+// Levels GitHub accepts for a fine-grained permission. `admin` is only valid
+// for a handful of them; GitHub is the authority on which, and answers 422.
+const PERMISSION_LEVELS = new Set(["read", "write", "admin"]);
+
+// Repository *names*, not `owner/name` — the installation implies the owner.
+const REPOSITORY_NAME = /^[A-Za-z0-9._-]+$/;
+
+// Permission keys are lower_snake_case in GitHub's schema (contents, pull_requests, …).
+const PERMISSION_NAME = /^[a-z][a-z_]*$/;
+
+export interface GitHubAppScope {
+  repositories?: string[];
+  permissions?: Record<string, string>;
+}
+
+function split(raw: string): string[] {
+  return raw
+    .split(/[\s,]+/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** Repository names the token should be limited to. Blank means every
+ *  repository the installation can reach. */
+export function parseRepositories(
+  raw: string | undefined,
+): string[] | undefined {
+  if (raw === undefined) return undefined;
+  const names = split(raw);
+  if (names.length === 0) return undefined;
+  for (const name of names) {
+    // The likely pastes are `owner/repo` and the repository's URL; say so
+    // rather than letting GitHub 422. Only name the trailing segment when it
+    // is itself usable — suggesting a value that fails again (or an empty one,
+    // which would silently mean "no narrowing") is worse than not suggesting.
+    if (name.includes("/")) {
+      const suggestion = name.slice(name.lastIndexOf("/") + 1);
+      throw new Error(
+        REPOSITORY_NAME.test(suggestion)
+          ? `Repository "${name}" must be just the repository name, without the owner — use "${suggestion}".`
+          : `Repository "${name}" must be just the repository name, without the owner.`,
+      );
+    }
+    if (!REPOSITORY_NAME.test(name)) {
+      throw new Error(`Repository "${name}" is not a valid repository name.`);
+    }
+  }
+  const unique = [...new Set(names)];
+  if (unique.length > MAX_REPOSITORIES) {
+    throw new Error(
+      `A connection can name at most ${MAX_REPOSITORIES} repositories (got ${unique.length}).`,
+    );
+  }
+  return unique;
+}
+
+/** `name:level` pairs — e.g. `contents:read, metadata:read`. Blank means every
+ *  permission the installation holds. A later duplicate wins, so re-typing a
+ *  permission corrects it rather than erroring. */
+export function parsePermissions(
+  raw: string | undefined,
+): Record<string, string> | undefined {
+  if (raw === undefined) return undefined;
+  const entries = split(raw);
+  if (entries.length === 0) return undefined;
+  const permissions: Record<string, string> = {};
+  for (const entry of entries) {
+    const sep = entry.indexOf(":");
+    if (sep === -1) {
+      throw new Error(
+        `Permission "${entry}" must be written as name:level — e.g. contents:read.`,
+      );
+    }
+    const name = entry.slice(0, sep);
+    const level = entry.slice(sep + 1).toLowerCase();
+    if (!PERMISSION_NAME.test(name)) {
+      throw new Error(`Permission "${entry}" has an invalid permission name.`);
+    }
+    if (!PERMISSION_LEVELS.has(level)) {
+      throw new Error(
+        `Permission "${entry}" must end in :read, :write, or :admin.`,
+      );
+    }
+    permissions[name] = level;
+  }
+  return permissions;
+}
+
+/** Both halves are independent — naming only repositories still narrows the
+ *  token, and so does naming only permissions. */
+export function parseGitHubAppScope(input: {
+  repositories?: string | undefined;
+  permissions?: string | undefined;
+}): GitHubAppScope {
+  const repositories = parseRepositories(input.repositories);
+  const permissions = parsePermissions(input.permissions);
+  return {
+    ...(repositories ? { repositories } : {}),
+    ...(permissions ? { permissions } : {}),
+  };
+}

--- a/packages/api-server/src/modules/connections/infrastructure/github-app-engine.ts
+++ b/packages/api-server/src/modules/connections/infrastructure/github-app-engine.ts
@@ -18,6 +18,12 @@ export interface MintInstallationTokenOpts {
   privateKeyPem: string;
   /** GitHub REST base the installation-token endpoint hangs off (no trailing slash needed). */
   apiBaseUrl: string;
+  /** Repository names the token should be limited to. Omit for every
+   *  repository the installation can reach. */
+  repositories?: string[];
+  /** Fine-grained permissions the token should carry, as name → level. Omit
+   *  for every permission the installation holds. */
+  permissions?: Record<string, string>;
 }
 
 export interface GitHubAppEngine {
@@ -95,9 +101,21 @@ export function createGitHubAppEngine(
       installationId,
       privateKeyPem,
       apiBaseUrl,
+      repositories,
+      permissions,
     }): Promise<GitHubAppTokenSet> {
       const jwt = signAppJwt(id, appId, privateKeyPem);
       const url = `${apiBaseUrl.replace(/\/+$/, "")}/app/installations/${encodeURIComponent(installationId)}/access_tokens`;
+      // Omitting the body entirely is what grants the installation's full
+      // authority, so an unscoped connection must send no body at all — an
+      // empty list or object would be a different request, not the same one.
+      const scope = {
+        ...(repositories?.length ? { repositories } : {}),
+        ...(permissions && Object.keys(permissions).length
+          ? { permissions }
+          : {}),
+      };
+      const scoped = Object.keys(scope).length > 0;
       const res = await fetchImpl(url, {
         method: "POST",
         headers: {
@@ -105,19 +123,28 @@ export function createGitHubAppEngine(
           Accept: "application/vnd.github+json",
           "X-GitHub-Api-Version": "2022-11-28",
           "User-Agent": userAgent,
+          ...(scoped ? { "Content-Type": "application/json" } : {}),
         },
+        ...(scoped ? { body: JSON.stringify(scope) } : {}),
       });
       if (!res.ok) {
         const txt = await res.text();
         // REST, not OAuth, so there is no error code to carry: translate the
-        // two dead ends (401 = key rejected, 404 = app/installation gone) into
-        // the classifier's vocabulary so the loop parks them.
-        const permanentlyRejected = res.status === 401 || res.status === 404;
+        // dead ends into the classifier's vocabulary so the loop parks them.
+        // 401 = key rejected, 404 = app/installation gone — both about the
+        // client's own credential.
+        const clientRejected = res.status === 401 || res.status === 404;
+        // 422 answers a scoped request that asks for a repository or permission
+        // the installation no longer covers. Retrying re-sends the same losing
+        // request, so park it — but only when we actually asked for a subset;
+        // an unscoped 422 is not about the scope and stays retryable.
+        const scopeRejected = scoped && res.status === 422;
         throw new OAuthTokenEndpointError(
           `GitHub App ${id}: installation-token request failed — ${res.status} ${txt.slice(0, 500)}`,
           {
             status: res.status,
-            ...(permanentlyRejected ? { oauthError: "invalid_client" } : {}),
+            ...(clientRejected ? { oauthError: "invalid_client" } : {}),
+            ...(scopeRejected ? { oauthError: "invalid_grant" } : {}),
           },
         );
       }

--- a/packages/api-server/src/modules/connections/services/github-app.ts
+++ b/packages/api-server/src/modules/connections/services/github-app.ts
@@ -6,9 +6,12 @@ export type GitHubAppAuth = Extract<
   { kind: "github-app" }
 >;
 
-/** One installation-token exchange, shared by connection create and the refresh
- *  loop. Maps the stored auth config onto the engine's mint call; `expiresAt` is
- *  always set (the engine falls back to a 1h horizon). */
+/** One installation-token exchange, shared by connection create, private-key
+ *  rotation, and the refresh loop. Maps the stored auth config onto the engine's
+ *  mint call; `expiresAt` is always set (the engine falls back to a 1h horizon).
+ *
+ *  The stored scope is read here rather than passed in, so every re-mint asks
+ *  for the same subset the connection was created with. */
 export async function mintGitHubAppToken(
   engine: GitHubAppEngine,
   opts: {
@@ -23,5 +26,7 @@ export async function mintGitHubAppToken(
     installationId: opts.auth.installationId,
     privateKeyPem: opts.privateKeyPem,
     apiBaseUrl: opts.auth.apiBaseUrl,
+    ...(opts.auth.repositories ? { repositories: opts.auth.repositories } : {}),
+    ...(opts.auth.permissions ? { permissions: opts.auth.permissions } : {}),
   });
 }

--- a/packages/cli/src/modules/connection/commands/connect.ts
+++ b/packages/cli/src/modules/connection/commands/connect.ts
@@ -40,6 +40,8 @@ interface ConnectOpts {
   appId?: string;
   installationId?: string;
   privateKey?: string;
+  repositories?: string;
+  permissions?: string;
   headerName?: string;
   valueFormat?: string;
   envName?: string;
@@ -97,6 +99,14 @@ export function buildConnectCommand(deps: {
     .option(
       "--private-key <pem>",
       'input: GitHub App private key — PEM or base64; use --private-key "$(cat app.pem)" (GitHub App installation)',
+    )
+    .option(
+      "--repositories <names>",
+      "input: limit the minted token to these repository names, space- or comma-separated (GitHub App installation)",
+    )
+    .option(
+      "--permissions <pairs>",
+      "input: limit the minted token to these name:level permissions, e.g. contents:read (GitHub App installation)",
     )
     .option("--header-name <name>", "input: header name")
     .option("--value-format <format>", "input: header value format")
@@ -323,6 +333,21 @@ async function resolveSlugTemplate(args: {
     process.exit(EXIT_INVALID_INPUT);
   }
 
+  // An older server declares no such input, and unknown keys are stripped
+  // server-side, so the flag would vanish and the token be minted with the
+  // installation's *full* authority. Every other stripped input lands in the
+  // safe direction; these two land in the unsafe one, so fail rather than
+  // report success for a connection that was never narrowed.
+  for (const flag of ["repositories", "permissions"] as const) {
+    if (opts[flag] && !template.inputs.some((i) => i.name === flag)) {
+      process.stderr.write(
+        `error: this server does not support --${camelToKebab(flag)} for '${template.id}' — ` +
+          "the token would carry the installation's full authority\n",
+      );
+      process.exit(EXIT_INVALID_INPUT);
+    }
+  }
+
   const name = (opts.name ?? slugifyTemplateName(template.name)).trim();
   validateName(name);
   const { values, presetsApplied } = await collectInputs(template, opts, json);
@@ -510,6 +535,8 @@ function buildPayload(
         appId,
         installationId,
         privateKey,
+        ...(v("repositories") ? { repositories: v("repositories")! } : {}),
+        ...(v("permissions") ? { permissions: v("permissions")! } : {}),
       };
     }
     case "header": {

--- a/packages/ui/src/__tests__/unit/build-create-payload.test.ts
+++ b/packages/ui/src/__tests__/unit/build-create-payload.test.ts
@@ -19,6 +19,15 @@ const GITHUB_APP_TEMPLATE: ConnectionTemplateView = {
   ],
 };
 
+const GITHUB_APP_SCOPED_TEMPLATE: ConnectionTemplateView = {
+  ...GITHUB_APP_TEMPLATE,
+  inputs: [
+    ...GITHUB_APP_TEMPLATE.inputs,
+    { name: "repositories", state: "optional" },
+    { name: "permissions", state: "optional" },
+  ],
+};
+
 const GITHUB_ENTERPRISE_APP_TEMPLATE: ConnectionTemplateView = {
   id: "github-enterprise-app",
   name: "GitHub Enterprise (App installation)",
@@ -59,6 +68,46 @@ describe("buildCreatePayload (github-app)", () => {
       installationId: "2",
       privateKey: "pem",
     });
+  });
+
+  it("carries the scope fields when the user fills them", () => {
+    const payload = buildCreatePayload(
+      GITHUB_APP_SCOPED_TEMPLATE,
+      values({
+        appId: "1",
+        installationId: "2",
+        privateKey: "pem",
+        repositories: "docs",
+        permissions: "contents:read",
+      }),
+    );
+    expect(payload).toEqual({
+      templateId: "github-app",
+      name: "my-connection",
+      authKind: "github-app",
+      appId: "1",
+      installationId: "2",
+      privateKey: "pem",
+      repositories: "docs",
+      permissions: "contents:read",
+    });
+  });
+
+  // Blank must not reach the server as an empty string — that would be a scope
+  // of "nothing" rather than the absence of one.
+  it("omits the scope fields when the user leaves them blank", () => {
+    const payload = buildCreatePayload(
+      GITHUB_APP_SCOPED_TEMPLATE,
+      values({
+        appId: "1",
+        installationId: "2",
+        privateKey: "pem",
+        repositories: "   ",
+        permissions: "",
+      }),
+    );
+    expect(payload).not.toHaveProperty("repositories");
+    expect(payload).not.toHaveProperty("permissions");
   });
 
   it("rejects an empty required host with an inline error, not a passthrough", () => {

--- a/packages/ui/src/modules/connections/forms/field-copy.ts
+++ b/packages/ui/src/modules/connections/forms/field-copy.ts
@@ -15,6 +15,8 @@ const FIELD_LABELS: Record<string, string> = {
   appId: "App ID",
   installationId: "Installation ID",
   privateKey: "Private key (PEM)",
+  repositories: "Limit to repositories",
+  permissions: "Limit to permissions",
   envName: "Environment variable",
   caData: "Server CA certificate",
 };
@@ -34,6 +36,8 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   appId: "123456",
   installationId: "987654",
   privateKey: "-----BEGIN RSA PRIVATE KEY-----\n…",
+  repositories: "docs handbook",
+  permissions: "contents:read metadata:read",
   envName: "MY_API_KEY",
   caData: "certificate-authority-data from your kubeconfig (base64 or PEM)",
 };

--- a/packages/ui/src/modules/connections/lib/build-create-payload.ts
+++ b/packages/ui/src/modules/connections/lib/build-create-payload.ts
@@ -79,6 +79,8 @@ export function buildCreatePayload(
         appId,
         installationId,
         privateKey,
+        repositories: submitted("repositories"),
+        permissions: submitted("permissions"),
       });
     }
     case "header": {


### PR DESCRIPTION
Closes #3201.

## Why

A GitHub App installation is an organization-wide grant. The platform minted its installation token with all of it — every permission the app holds, across every repository the org installed it on — because the token request carried no body, and an absent body is what asks GitHub for the installation's full authority.

So an agent that needed to read one repository got authority over all of them, usually including write. The only way to narrow it was to change the installation itself, which affects everyone else using that app, or to register a separate app per task.

## What changed

A GitHub App connection can now name repositories and/or permissions to mint against. GitHub is the arbiter — it refuses any request exceeding the installation — so the narrowing can only ever reduce authority, never claim it.

**The subset is stored on the connection, not applied once at create.** This is the load-bearing part. Tokens are re-minted every hour, and there are three mint sites (create, private-key rotation, the refresh loop). All three go through one shared helper that reads the subset from stored auth, so a renewal cannot silently widen a connection back to the whole installation. There's a test asserting the re-mint asks for the same subset, and another asserting the stored scope round-trips the wire schema — that one matters because the refresh loop silently drops rows its schema rejects, so a wrong schema would have parked scoped connections instead of refreshing them.

**Narrowing is opt-in and unscoped behavior is byte-identical.** An empty list is not the same request as no list, so the engine sends no body at all unless something is actually narrowed, and blank input is never stored as an empty value. Every connection created before this change is unaffected.

**A stale subset surfaces instead of spinning.** When the org drops a repository from the installation or revokes a permission, GitHub answers 422. Retrying re-sends the same losing request, so a 422 on a *scoped* request is classified permanent — the connection parks and reads expired, waiting for someone to widen the installation or narrow the connection. A 422 on an unscoped request isn't about the scope and stays retryable.

**Bad input fails at create, not an hour later.** Parsing rejects `owner/repo` and pasted repo URLs with the name to use instead, and malformed permission pairs with the expected shape — because the alternative is a refresh-time 422 long after the user has left the form.

## Notes for the reviewer

- Both fields are single strings (space- or comma-separated), matching how client-credentials `scopes` already keeps the schema-driven forms all-string. The server parses them.
- The CLI **refuses to run** if you pass `--repositories`/`--permissions` to a server too old to declare them. Normally an older server stripping an unknown input is harmless, but here the strip lands in the unsafe direction — you'd get a full-authority token and a success message. This follows the existing `--ambient` precedent in `channel slack-connect`, which fails loudly even though its strip is safe.
- Repositories are stored by **name**, not id. Names are what people recognise and type; the tradeoff is that renaming a repository turns into a refresh-time rejection rather than a create-time error. Issue #3201 flags this as an open question — worth settling here if reviewers disagree.
- Docs went to `security-and-credentials.md` rather than `connections.md`. That page owns credential authority and trust boundaries, and `connections.md` is at 39,991 of its 40,000-character cap — the guidelines say going over is a signal to re-think what a page carries, not to reword to fit, so I didn't force it in. Nothing on `connections.md` is falsified by this change; it describes the required inputs, and both new ones are optional.

## Not in scope

Reading a narrowed connection's subset back through the API, or editing it after create — the credential update path replaces the secret, and the rest of a connection's config is immutable by existing design. Changing that is a broader change than this issue.

## Verification

- `api-server` 831 tests, `cli` 154, `ui` 243 — all pass. Typecheck, lint, and format clean across all four touched packages.
- Reviewed adversarially before commit: 14 candidate findings, 12 refuted against the code, 2 confirmed and fixed (the repo-name suggestion pointed at values that fail again — including an empty one, which would have meant "no narrowing"; and the CLI version-skew fail-open above).
- `mise run check` fails on the CRD-compatibility step in a git worktree — a known tooling limitation where crdify can't resolve refs through a worktree gitdir. No CRDs are touched here; per-package checks were run directly.
