### PR TITLE
fix(security): add baseline HTTP security headers

### DIFF
--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -326,6 +326,21 @@ export function startApiServerApp(deps: ApiServerAppDeps) {
   });
   app.use("*", createShareHostGate(config.shareBaseUrl, shareViewerApp));
 
+  // Baseline security headers for every app response (JSON API + the brand
+  // asset routes below). The static UI sets its own equivalents in
+  // packages/ui/default.conf; nothing here overlaps with the share viewer,
+  // which the gate above already returned from for its own host.
+  app.use("*", async (c, next) => {
+    await next();
+    c.header("X-Content-Type-Options", "nosniff");
+    c.header("X-Frame-Options", "DENY");
+    c.header("Referrer-Policy", "no-referrer");
+    c.header(
+      "Strict-Transport-Security",
+      "max-age=31536000; includeSubDomains",
+    );
+  });
+
   app.get("/api/health", (c) => c.json({ status: "ok" }));
   // Readiness (not liveness): 503 until the Keycloak JWKS has been fetched
   // once, so a rolling update keeps the old pod serving while this pod's

--- a/packages/ui/default.conf
+++ b/packages/ui/default.conf
@@ -15,8 +15,19 @@ log_format json_access escape=json
 server {
     listen       8080;
     server_name  localhost;
+    server_tokens off;
 
     access_log /dev/stdout json_access;
+
+    # Static UI has no cookies/auth of its own (the api-server owns that), so
+    # these are safe platform-wide defaults. style-src needs 'unsafe-inline'
+    # for inline style attributes set by UI component libraries; font-src/
+    # style-src allow Google Fonts, the one external asset this app loads.
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-Frame-Options "DENY" always;
+    add_header Referrer-Policy "no-referrer" always;
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
 
     location / {
         root  /usr/share/nginx/html;


### PR DESCRIPTION
## Summary
- Fixes the corporate ZAP scan findings: missing CSP, X-Frame-Options, X-Content-Type-Options, HSTS headers, and the nginx `Server` version-leak header.
- `packages/ui/default.conf`: `server_tokens off;` + `add_header` for CSP/X-Frame-Options/X-Content-Type-Options/Referrer-Policy/HSTS on the static UI. CSP explicitly allowlists `fonts.googleapis.com`/`fonts.gstatic.com` so Google Fonts keeps loading (the ZAP "Cross-Domain Misconfiguration" finding on that request is a scanner false-positive for a font stylesheet fetch — the CSP allowlist is the real fix, not removing the fonts).
- `packages/api-server/src/apps/api-server/app.ts`: matching global header middleware for all `/api/*` responses, following the header pattern already established in the share-viewer sub-app.
- The "Cookie with SameSite Attribute None" finding is Keycloak's own session cookie — not something this repo's code sets — so it's out of scope here.

## Test plan
- [x] `mise run api-server:fix:lint` passes
- [x] `mise run api-server:check:tsc` passes
- [ ] Re-run the ZAP scan against a deployed instance to confirm findings clear
- [ ] Manually smoke-test the UI (fonts render, no CSP console errors) after deploy