### PR TITLE
feat(bob): update Bob Shell to 2.0

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/mcp-entry-plugin.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/mcp-entry-plugin.test.ts
@@ -80,6 +80,18 @@ describe("mcp-entry plugin", () => {
     ).toThrow(/cannot be set/);
   });
 
+  it("reserves only what the active branch builds", async () => {
+    // A urlKey dialect never emits `type`/`url`, so setting them is additive.
+    await bind({ urlKey: "httpUrl", extraFields: { type: "sse" } })(
+      [entry("outbound", "http://hs/mcp")],
+      ctx,
+    );
+    expect(readConfig(".bob/settings/mcp.json").mcpServers.outbound).toEqual({
+      httpUrl: "http://hs/mcp",
+      type: "sse",
+    });
+  });
+
   it("keeps headers alongside a urlKey entry", async () => {
     await bind({ urlKey: "httpUrl" })(
       [

--- a/packages/agent-runtime/src/__tests__/unit/mcp-entry-plugin.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/mcp-entry-plugin.test.ts
@@ -73,6 +73,13 @@ describe("mcp-entry plugin", () => {
     });
   });
 
+  it("rejects an `extraFields` key the driver builds itself", () => {
+    expect(() => bind({ extraFields: { url: "" } })).toThrow(/cannot be set/);
+    expect(() =>
+      bind({ urlKey: "httpUrl", extraFields: { httpUrl: "x" } }),
+    ).toThrow(/cannot be set/);
+  });
+
   it("keeps headers alongside a urlKey entry", async () => {
     await bind({ urlKey: "httpUrl" })(
       [

--- a/packages/agent-runtime/src/__tests__/unit/mcp-entry-plugin.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/mcp-entry-plugin.test.ts
@@ -49,13 +49,27 @@ describe("mcp-entry plugin", () => {
     });
   });
 
-  it("keys the URL under `urlKey` when set (Bob's httpUrl dialect)", async () => {
+  it("keys the URL under `urlKey` when set (Bob 1.x's httpUrl dialect)", async () => {
     await bind({ urlKey: "httpUrl" })(
       [entry("outbound", "http://hs/mcp")],
       ctx,
     );
     expect(readConfig(".bob/settings/mcp.json").mcpServers).toEqual({
       outbound: { httpUrl: "http://hs/mcp" },
+    });
+  });
+
+  it("merges `extraFields` into every entry (Bob 2.0's transportType)", async () => {
+    await bind({ extraFields: { transportType: "http" } })(
+      [entry("outbound", "http://hs/mcp")],
+      ctx,
+    );
+    expect(readConfig(".bob/settings/mcp.json").mcpServers).toEqual({
+      outbound: {
+        type: "http",
+        url: "http://hs/mcp",
+        transportType: "http",
+      },
     });
   });
 

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
@@ -17,13 +17,34 @@ const DEFAULT_KEY_PATH = "mcpServers";
 // the entry, for those naming the transport in a sibling field (Bob 2.0 wants
 // `transportType:"http"` — without it it treats the server as SSE, which the
 // platform's streamable endpoint rejects).
-const bindingSchema = z.object({
-  impl: z.literal(IMPL_NAME),
-  path: z.string().min(1),
-  keyPath: z.string().optional(),
-  urlKey: z.string().min(1).optional(),
-  extraFields: z.record(z.string(), z.unknown()).optional(),
-});
+// `extraFields` adds siblings, never restates the transport: the keys the driver
+// builds itself stay reserved, so a manifest typo (`url: ""`) fails the binding
+// parse instead of silently clobbering the contributed URL.
+const OWNED_KEYS = ["type", "url", "headers"] as const;
+
+const bindingSchema = z
+  .object({
+    impl: z.literal(IMPL_NAME),
+    path: z.string().min(1),
+    keyPath: z.string().optional(),
+    urlKey: z.string().min(1).optional(),
+    extraFields: z.record(z.string(), z.string()).optional(),
+  })
+  .superRefine((b, ctx) => {
+    const reserved = new Set<string>([
+      ...OWNED_KEYS,
+      ...(b.urlKey ? [b.urlKey] : []),
+    ]);
+    for (const key of Object.keys(b.extraFields ?? {})) {
+      if (reserved.has(key)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["extraFields", key],
+          message: `"${key}" is built by the driver and cannot be set via extraFields`,
+        });
+      }
+    }
+  });
 
 export function createMcpEntryPlugin(): Plugin {
   const fileOps = createFileOps();

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
@@ -11,14 +11,18 @@ import { expandHome } from "../../../core/expand-home.js";
 const IMPL_NAME = "mcp-entry";
 const DEFAULT_KEY_PATH = "mcpServers";
 
-// MCP config is a JSON object merged under `keyPath`. `urlKey` covers harness
-// dialects: default entry is `{type:"http",url}`, but some harnesses key the
-// transport off the property name (Bob puts streamable-HTTP under `httpUrl`).
+// MCP config is a JSON object merged under `keyPath`. Two knobs cover harness
+// dialects: `urlKey` for harnesses that key the transport off the property name
+// (Bob 1.x put streamable-HTTP under `httpUrl`), and `extraFields`, merged over
+// the entry, for those naming the transport in a sibling field (Bob 2.0 wants
+// `transportType:"http"` — without it it treats the server as SSE, which the
+// platform's streamable endpoint rejects).
 const bindingSchema = z.object({
   impl: z.literal(IMPL_NAME),
   path: z.string().min(1),
   keyPath: z.string().optional(),
   urlKey: z.string().min(1).optional(),
+  extraFields: z.record(z.string(), z.unknown()).optional(),
 });
 
 export function createMcpEntryPlugin(): Plugin {
@@ -39,7 +43,7 @@ export function createMcpEntryPlugin(): Plugin {
           `plugin "${IMPL_NAME}" invalid binding: ${parsed.error.message}`,
         );
       }
-      const { path, keyPath, urlKey } = parsed.data;
+      const { path, keyPath, urlKey, extraFields } = parsed.data;
       const effectiveKey = keyPath ?? DEFAULT_KEY_PATH;
       let stateStore: McpEntryStateStore | undefined;
 
@@ -50,13 +54,11 @@ export function createMcpEntryPlugin(): Plugin {
         const entries: Record<string, unknown> = {};
         for (const c of contributions) {
           if (c.kind !== "mcp-entry") continue;
-          entries[c.name] = urlKey
-            ? { [urlKey]: c.url, ...(c.headers ? { headers: c.headers } : {}) }
-            : {
-                type: "http",
-                url: c.url,
-                ...(c.headers ? { headers: c.headers } : {}),
-              };
+          entries[c.name] = {
+            ...(urlKey ? { [urlKey]: c.url } : { type: "http", url: c.url }),
+            ...(c.headers ? { headers: c.headers } : {}),
+            ...extraFields,
+          };
         }
         const names = Object.keys(entries);
         const targetPath = expandHome(path, ctx.agentHome);

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/mcp-entry-plugin.ts
@@ -19,8 +19,12 @@ const DEFAULT_KEY_PATH = "mcpServers";
 // platform's streamable endpoint rejects).
 // `extraFields` adds siblings, never restates the transport: the keys the driver
 // builds itself stay reserved, so a manifest typo (`url: ""`) fails the binding
-// parse instead of silently clobbering the contributed URL.
-const OWNED_KEYS = ["type", "url", "headers"] as const;
+// parse instead of silently clobbering the contributed URL. Which keys those are
+// depends on the branch in play — a `urlKey` dialect never builds `type`/`url`,
+// so reserving them there would reject a field the driver does not own.
+function ownedKeys(urlKey: string | undefined): string[] {
+  return ["headers", ...(urlKey ? [urlKey] : ["type", "url"])];
+}
 
 const bindingSchema = z
   .object({
@@ -31,10 +35,7 @@ const bindingSchema = z
     extraFields: z.record(z.string(), z.string()).optional(),
   })
   .superRefine((b, ctx) => {
-    const reserved = new Set<string>([
-      ...OWNED_KEYS,
-      ...(b.urlKey ? [b.urlKey] : []),
-    ]);
+    const reserved = new Set(ownedKeys(b.urlKey));
     for (const key of Object.keys(b.extraFields ?? {})) {
       if (reserved.has(key)) {
         ctx.addIssue({

--- a/packages/agents/bob/Dockerfile
+++ b/packages/agents/bob/Dockerfile
@@ -3,8 +3,8 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-ARG BOBSHELL_VERSION=1.0.6
-ARG BOBSHELL_SHA256=6ec51abec4251d41ec45709030988b90baa659f535fc8d14dd003023dd163a5b
+ARG BOBSHELL_VERSION=2.0.0
+ARG BOBSHELL_SHA256=de2d773e7e7a79cddf671d1019c8852f58b4c4472f96eccf4a23b9feac620812
 RUN --mount=type=cache,target=/root/.npm \
     curl -fsSL "https://s3.us-south.cloud-object-storage.appdomain.cloud/bob-shell/bobshell-${BOBSHELL_VERSION}.tgz" -o /tmp/bobshell.tgz &&\
     echo "${BOBSHELL_SHA256} /tmp/bobshell.tgz" | sha256sum -c - &&\
@@ -16,17 +16,15 @@ RUN --mount=type=cache,target=/root/.npm \
 COPY bob-acp-shim.mjs /app/bob-acp-shim.mjs
 COPY harness-chat.sh /usr/local/bin/harness-chat
 COPY harness-terminal.sh /usr/local/bin/harness-terminal
-# context.fileName is a lookup *name* (~/.bob/<name>, project root, parents),
-# not a path — so instructions ride in via the ~/.bob/AGENTS.md symlink below.
+# 2.0's RuleLoader reads <workspace>/.bob/rules/ (every file appended to the
+# system prompt); the 1.x context.fileName lookup and system-defaults.json are
+# gone, so platform instructions ride in as a rules file instead.
 RUN chmod 755 /usr/local/bin/harness-chat /usr/local/bin/harness-terminal &&\
-    mkdir -p /etc/bobshell &&\
-    printf '{"context":{"fileName":["AGENTS.md"]}}\n' >/etc/bobshell/system-defaults.json &&\
-    mkdir -p /app/working-dir/.bob &&\
-    ln -s /etc/AGENTS.md /app/working-dir/.bob/AGENTS.md &&\
+    mkdir -p /app/working-dir/.bob/rules &&\
+    ln -s /etc/AGENTS.md /app/working-dir/.bob/rules/platform.md &&\
     ln -s ../.agents/skills /app/working-dir/.bob/skills
 
 COPY --chown=65532:0 runtime-manifest.yaml /app/runtime-manifest.yaml
 COPY --chown=65532:0 workspace/ /app/working-dir/
-ENV BOBSHELL_DEFAULT_AUTH_TYPE=api-key
 
 USER 65532

--- a/packages/agents/bob/README.md
+++ b/packages/agents/bob/README.md
@@ -78,7 +78,7 @@ Bob 2.0 persists every task to SQLite on the PVC (`~/.bob/db/bob.db`, tables `ta
 
 - **`session/list`** — one entry per non-archived task (title from the task row, `_meta.platform.mode: chat`).
 - **`session/load`** — replays the task's stored messages as `user_message_chunk` / `agent_message_chunk` updates.
-- **Resume (prompt into a loaded task)** — native: the shim runs `bob run --resume <task-id> -p <prompt>`. No transcript re-injection; Bob reloads its own context. On `--resume` Bob re-emits the task's stored history on the stream first — the shim drops everything until the echo of the new prompt.
+- **Resume (prompt into a loaded task)** — native: the shim runs `bob run --resume <task-id> -- <prompt>` (the prompt is positional). No transcript re-injection; Bob reloads its own context. The stream carries only the new turn — `--resume` does not re-emit stored history, verified against tasks with several assistant turns — so nothing needs filtering beyond the prompt echo. The turn must run in the task's own workspace or Bob rejects the task outright.
 
 ACP session ids issued by `session/new` are shim-generated (`bob-<uuid>`); the sessionId↔taskId binding is learned from the first turn's `result.stats.task_id` and persisted to `~/.bob/platform-shim-sessions.json` so loaded sessions stay resumable across pod restarts.
 

--- a/packages/agents/bob/README.md
+++ b/packages/agents/bob/README.md
@@ -6,15 +6,17 @@ Platform agent running [Bob Shell](https://internal.bob.ibm.com/docs/shell) — 
 
 | Component | Source | Purpose |
 |---|---|---|
-| Harness | `bobshell` (installed from `bob.ibm.com/download/bobshell.sh`) | Bob CLI in `--experimental-acp` mode + native TUI |
-| ACP bridge | `bob-acp-shim.mjs` | Translates Bob's session/update events into the shape the platform UI expects; auto-approves `session/request_permission` (Bob emits it only for file edits in yolo — see autonomy posture below); stages chat attachments into the workspace so Bob can read them (it can't consume `resource_link` blocks in ACP mode); emulates `session/list` + `session/load` from Bob's on-disk chats so the sidebar and chat resume work (see below) |
-| Storage | `/home/agent` PVC | Bob's session index lives under `~/.bob/`; chat history under `~/.bob/tmp/<projectHash>/chats/`; survives pod restarts |
+| Harness | `bobshell` 2.x (installed from the `bob-shell` COS bucket tarball) | Bob CLI: `bob run --format stream-json` for chat turns + `bob chat` TUI for terminal |
+| ACP bridge | `bob-acp-shim.mjs` | ACP agent for agent-runtime; spawns one `bob run` per prompt turn and translates its stream-json events into `session/update` frames; serves `session/list` + `session/load` from Bob's task DB; continues tasks with the native `--resume <task-id>` |
+| Storage | `/home/agent` PVC | Bob's task history lives in SQLite under `~/.bob/db/bob.db`; settings under `~/.bob/settings/`; survives pod restarts |
+
+Bob 2.0 removed the `--experimental-acp` mode the previous shim bridged, so the shim is now itself the ACP endpoint rather than a frame-by-frame translator. The headless contract it builds on: `bob run --format stream-json` emits `message` (with `isReasoning` separating thoughts from answers), `tool_use`, `tool_result`, `result` (whose `stats.task_id` names the created/resumed task), and `error` events.
 
 ## Authentication
 
-Bob expects `BOBSHELL_API_KEY` in the pod env. On the platform the agent only ever sees a **placeholder** — the real key is materialized at the Envoy sidecar, never in the agent container.
+Bob expects `BOBSHELL_API_KEY` in the pod env (2.0 renamed it to `BOB_API_KEY`, but the old name is a supported alias — Bob copies it over and errors only if both are set to different values). On the platform the agent only ever sees a **placeholder** — the real key is materialized at the Envoy sidecar, never in the agent container.
 
-1. **Open Settings → Providers → Bob Shell** and paste your Bob API key. The provider preset creates a secret pinned to `api.us-east.bob.ibm.com` (the host Bob's bundle uses for `/v1/model/info`, `/key/info`, `/chat/completions` etc. with the current opaque api-key format) with `Authorization: Apikey {value}` injection plus a twin entry on the same host that handles the `?key=` URL parameter Bob appends to several admin endpoints. `BOBSHELL_API_KEY` is seeded as `dummy-placeholder` — the literal content is irrelevant because Envoy overwrites the wire value, but it must not start with `sk-`/`pk-` or Bob's bundle would silently downgrade to the legacy `prod.ibm-bob-staging.cloud.ibm.com` backend (which only accepts JWT keys). The Advanced disclosure lets you set the default model and tenant-scoping flags (see below) — those flow as additional env-mappings rather than free-form env vars in the agent dialog.
+1. **Open Settings → Providers → Bob Shell** and paste your Bob API key. The provider preset creates a secret pinned to `api.us-east.bob.ibm.com` (unchanged in 2.0) with `Authorization: Apikey {value}` injection plus a twin entry on the same host that handles the `?key=` URL parameter Bob appends to several admin endpoints. `BOBSHELL_API_KEY` is seeded as `dummy-placeholder` — the literal content is irrelevant because Envoy overwrites the wire value, but it must not start with `sk-`/`pk-` or Bob's bundle would silently downgrade to the legacy `prod.ibm-bob-staging.cloud.ibm.com` backend (which only accepts JWT keys). The Advanced disclosure lets you set the default model and tenant-scoping flags (see below) — those flow as additional env-mappings rather than free-form env vars in the agent dialog.
 
 2. **Grant the secret to the Bob agent instance** from Configure Agent → Secrets. The next pod restart picks up `BOBSHELL_API_KEY` and any pinned `BOB_*` envs along with the Envoy filter chain.
 
@@ -26,23 +28,15 @@ Some Bob backends (`/key/info?key=<value>`) read the credential from a URL query
 
 ## Autonomy posture
 
-Bob runs with `bob --experimental-acp --yolo --auth-method api-key` (in [`bob-acp-shim.mjs`](bob-acp-shim.mjs)) and the shim auto-approves any `session/request_permission` Bob emits, so the platform UI never shows a per-tool confirmation chip for Bob.
+`bob run` (headless) has no per-tool prompt channel and no `--auto-approve` flag — approvals ride the settings file. The shim merge-writes `~/.bob/settings/settings.json` on startup with the platform posture: `approval.autoApprovalEnabled: true`, all permission groups (`read`, `edit`, `execute`, `browser`, `mcp`) allowed, a wildcard `execute_command` allowlist, and `outsideWorkspaceAllowed: true`. This is the 2.x equivalent of 1.x `--yolo`; there is no per-tool HITL in either surface.
 
-What each approval mode actually does over ACP (verified empirically against 1.0.6):
+The same settings apply to the terminal TUI (`bob chat`), so terminal sessions auto-approve too — unlike 1.x, where the TUI ran in `auto_edit` and asked before risky tools. Approval granularity is a Bob-side concern; the trust boundary is the platform's, not Bob's: every outbound HTTP request goes through the per-instance Envoy egress sidecar (ADR-033/038) with `ext_authz` / egress-rules enforcement, the agent container has no SA token, no Secret volume mounts, and no Envoy config it can rewrite.
 
-| mode | file edits | shell exec |
-|---|---|---|
-| `default` | tool not in the model's tool list | tool not in the list |
-| `auto_edit` | run auto-approved, no permission request | tool not in the list |
-| `yolo` | emit `session/request_permission` (kind=edit) — the shim auto-approves | run directly, never asks |
-
-`--yolo` is the only mode with shell exec, and non-yolo modes hide (rather than gate) the missing tools — so yolo is the only generally useful setting for a coding agent, and per-tool HITL is upstream-limited to edits. The trust boundary is the platform's, not Bob's (below).
-
-The trust boundary is the per-instance Envoy egress sidecar (ADR-033/038): every outbound HTTP request goes through the credential gateway with `ext_authz` / egress-rules enforcement, the agent container has no SA token, no Secret volume mounts, and no Envoy config it can rewrite.
+Bob's own guardrail that remains active: `session.maxTurns` (Bob default 100) ends a runaway task, and `--max-cost` (below) caps spend per task.
 
 ## Configuration
 
-Bob accepts settings from two channels: env vars it reads directly (resolved by Bob's runtime) and CLI flags that have no env equivalent (the harness scripts translate platform env vars into the right flag). The Bob Shell provider preset pins the most common ones; the rest stay free-form in **Configure Agent → Env**.
+Bob 2.x accepts settings from `~/.bob/settings/settings.json` (merged by the shim from the env vars below) and CLI flags (translated by the harness scripts). The Bob Shell provider preset pins the most common ones; the rest stay free-form in **Configure Agent → Env**.
 
 ### Pinned via the Bob Shell provider (Settings → Providers → Bob Shell → Advanced)
 
@@ -51,11 +45,11 @@ These ride on the secret's `envMappings`, so every agent granted the Bob secret 
 | Env var | Translated to | Effect |
 |---|---|---|
 | `BOBSHELL_API_KEY` | n/a (env-only) | API key the Envoy sidecar swaps to the real value on the wire. Always emitted. |
-| `BOB_SHELL_MODEL` | n/a (env-only) | Default model for new sessions. Examples: `premium-shell`, `codestral-2508`, `claude-sonnet-5`. Empty → Bob's built-in default. |
-| `BOB_INSTANCE_ID` | `--instance-id` | Sets the `x-instance-id` header on Bob's outbound API calls (IBM tenant scoping). |
-| `BOB_TEAM_ID` | `--team-id` | Sets the `x-team-id` header. |
-| `BOB_MAX_COINS` | `--max-coins` | Budget cap — Bob exits with code 1 if exceeded. |
-| `BOB_CHAT_MODE` | `--chat-mode` | One of `plan`, `code`, `advanced`, `ask`. Sets the default chat persona for new sessions. |
+| `BOB_SHELL_MODEL` | `session.model` in settings | Default model for new tasks. Examples: `premium-shell`, `codestral-2508`, `claude-sonnet-5`. Empty → Bob's built-in default. |
+| `BOB_INSTANCE_ID` | `bob chat --instance-id` (terminal only) | IBM tenant scoping. `bob run` has no instance flag in 2.x — headless instance selection goes through Bob profiles, so this pin does not apply to chat-mode sessions. |
+| `BOB_TEAM_ID` | `--team-id` | Team ID for `general`-type API keys. |
+| `BOB_MAX_COINS` | `--max-cost` + `session.maxCost` | Per-task cost cap — Bob stops the task when exceeded. |
+| `BOB_CHAT_MODE` | `--mode` | One of `agent`, `plan`, `ask` (2.0 merged `code`/`advanced` into `agent`; legacy pinned values are mapped onto `agent`). Sets the default mode for new sessions. |
 
 Per-agent overrides for any of these still work — set the same env name in **Configure Agent → Env** and it wins over the inherited pin.
 
@@ -65,35 +59,29 @@ Less common toggles, not surfaced on the provider card.
 
 | Env var | Effect |
 |---|---|
-| `BOBSHELL_HIDE_ENVS` | Set to `1` to suppress the env-var banner Bob prints at startup. |
-| `BOB_SHELL_PRE_CHECK_AUTO_APPROVED` | Set to `1` to make Bob run a safety pre-check before executing auto-approved commands. Recommended on top of `--yolo`. |
-| `BOB_SHELL_SYSTEM_MD` | Path to a markdown file appended to Bob's system prompt. Lives on the workspace PVC. |
+| `BOB_LOG_LEVEL` | Bob's log level: `debug`, `info`, `warn`, `error`, `silent`. |
 | `IBM_TELEMETRY_ENABLED` | Set to `false` to opt out of Bob's telemetry. |
-| `BOB_RESUME_MAX_MESSAGES` | Cap on how many trailing messages of a resumed chat the shim prepends as context to the first prompt (default `40`). Higher = better continuity, more tokens/coins. |
+| `BOB_SHIM_TRACE` | Set to `1` to log every shim frame (client↔shim↔bob) to the pod log. |
 
-Settings that **cannot** be configured this way without changes to the shim:
-
-- **Per-tool HITL** — Bob's ACP emits `client.requestPermission()` only for file edits in yolo (see the approval-mode table above); shell exec never asks, and non-yolo modes hide the tools instead of gating them. Forwarding the edit requests to the UI inbox instead of auto-approving would be a shim change; a full claude-code-style approval toggle is upstream-limited.
-- **Auth method** — the shim spawns Bob with `--auth-method api-key`. OAuth / Vertex paths would need a different shim invocation.
-- **Sandbox** — Bob's `--sandbox` runs commands inside a separate sandbox subprocess. Overlaps with the platform's K8s-level sandboxing model (ADR-033); leave off.
+Gone in 2.0 (silently ignored if set): `BOBSHELL_HIDE_ENVS`, `BOB_SHELL_PRE_CHECK_AUTO_APPROVED`, `BOB_SHELL_SYSTEM_MD` (custom instructions now ride the `.bob/rules/` directory — the image links the platform instructions there), `BOB_RESUME_MAX_MESSAGES` (resume is native now).
 
 ## Harness scripts
 
 | Script | Behavior |
 |---|---|
-| `harness-chat.sh` | Translates the `BOB_*` env vars and `exec`s `node /app/bob-acp-shim.mjs`. Bob's ACP advertises `loadSession: false` and has no session listing, so the shim emulates both from Bob's on-disk chats (see [Session history](#session-history)). |
-| `harness-terminal.sh` | Same flag translation, then `exec bob --approval-mode=auto_edit --auth-method api-key`. TUI mode is interactive — `auto_edit` lets Bob prompt the user in the terminal for risky tools; `--yolo` (which the ACP shim must use) would auto-approve everything. Each terminal open starts a **fresh** Bob TUI session — Bob persists sessions in a project-scoped numeric index, not per-UUID files (the way pi-agent and claude-code do), so `$HARNESS_SESSION_ID` can't be mapped one-to-one. Users can browse prior sessions from inside the TUI with `--list-sessions` if needed. |
+| `harness-chat.sh` | `exec`s `node /app/bob-acp-shim.mjs`. The shim merge-writes the settings posture, serves ACP, and spawns `bob run --format stream-json` per prompt turn. |
+| `harness-terminal.sh` | Writes the settings posture (`--settings-only`), translates the `BOB_*` env into `bob chat` flags, then `exec`s the TUI. Each terminal open starts a **fresh** Bob task — Bob's task index can't be mapped onto `$HARNESS_SESSION_ID`; users can resume prior tasks from inside the TUI with `bob -r`. |
 
 ## Session history
 
-Bob's ACP has no session listing and its `loadSession` is disabled (`agentCapabilities.loadSession: false`, and the agent object has no `loadSession` method), so the platform sidebar would be empty and past chats unreachable. Bob does, however, persist every chat to `~/.bob/tmp/<projectHash>/chats/session-*.json`, and the shim uses that as the source of truth:
+Bob 2.0 persists every task to SQLite on the PVC (`~/.bob/db/bob.db`, tables `tasks` + `messages`), and the shim serves ACP history straight from it:
 
-- **`session/list`** — the shim scans the `chats/` dir and returns one entry per file (title from the first user message, `_meta.platform.mode: chat`).
-- **`session/load`** — the shim replays the file's messages as `user_message_chunk` / `agent_message_chunk` updates (agent text run through the same `<thinking>` filter as the live stream), and patches the `initialize` response to advertise `loadSession: true`.
-- **Resume (prompt into a loaded chat)** — Bob can't continue a session it didn't create in the current process, so the shim lazily issues its own `session/new`, maps the old↔new `sessionId` (rewriting ids both ways from then on), and prepends a transcript of the prior conversation to the first prompt so Bob resumes with context. The transcript is capped at `BOB_RESUME_MAX_MESSAGES` (default 40) trailing messages; it costs tokens/coins.
+- **`session/list`** — one entry per non-archived task (title from the task row, `_meta.platform.mode: chat`).
+- **`session/load`** — replays the task's stored messages as `user_message_chunk` / `agent_message_chunk` updates.
+- **Resume (prompt into a loaded task)** — native: the shim runs `bob run --resume <task-id> -p <prompt>`. No transcript re-injection; Bob reloads its own context. On `--resume` Bob re-emits the task's stored history on the stream first — the shim drops everything until the echo of the new prompt.
 
-This is a shim emulation, not a native capability — if a future Bob release implements ACP `listSessions` / `loadSession`, drop the emulation and let the frames pass through.
+ACP session ids issued by `session/new` are shim-generated (`bob-<uuid>`); the sessionId↔taskId binding is learned from the first turn's `result.stats.task_id` and persisted to `~/.bob/platform-shim-sessions.json` so loaded sessions stay resumable across pod restarts.
 
 ## Persistence
 
-The `/home/agent` PVC keeps Bob's session index and chat history under `~/.bob/` (chats at `~/.bob/tmp/<projectHash>/chats/`), plus whatever Bob writes during a session (workspace files, MCP server configs). Survives pod restarts and image rebuilds.
+The `/home/agent` PVC keeps Bob's task DB (`~/.bob/db/`), settings (`~/.bob/settings/`), logs, and whatever Bob writes during a session (workspace files, MCP server configs). Survives pod restarts and image rebuilds.

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -1,550 +1,246 @@
 #!/usr/bin/env node
-// ACP translation shim for Bob Shell.
+// ACP bridge for Bob Shell 2.x.
 //
-// Bob speaks ACP protocol-correctly but uses Cline/Roo conventions that don't
-// match platform UI expectations. This shim sits between agent-runtime and bob,
-// translating on the way out (bob→client) and handling a few agent→client
-// requests locally where the platform client has no useful implementation.
+// Bob 2.0 removed the `--experimental-acp` mode this shim used to translate;
+// the headless surface is now `bob run --format stream-json` plus a native
+// `--resume <task-id>`. The shim is therefore a small ACP *agent* on
+// stdin/stdout: agent-runtime speaks ACP to it, and each prompt turn spawns
+// one `bob run` whose stream-json events are translated to session/update
+// frames.
 //
 // ──────────────────────────────────────────────────────────────────────────
-// Translation table (bob → platform UI)
+// Translation table (bob run stream-json → ACP session/update)
 //
-//   session/update
-//     agent_message_chunk              → processed by a <thinking>…</thinking>
-//                                         state machine. Bob emits reasoning
-//                                         (same content as agent_thought_chunk)
-//                                         wrapped in <thinking> tags, and the
-//                                         actual user-facing answer AFTER the
-//                                         closing </thinking>. Default state
-//                                         is *inside thinking* because bob
-//                                         skips the opening tag in some cases.
-//                                         "[using tool X: …]" meta hints are
-//                                         stripped. Text outside the thinking
-//                                         block is emitted as agent_message.
-//     agent_thought_chunk (cumulative) → re-emit as incremental delta. Bob
-//                                         re-sends the full thought on every
-//                                         token; platform UI appends, so without
-//                                         delta computation we'd duplicate.
-//     tool_call kind="think"           → DROP. Synthetic "attempt_completion"
-//                                         wrapper; the real text lives in its
-//                                         tool_call_update.content.
-//     tool_call_update on think id     → on status=completed, extract nested
-//                                         text and emit as final
-//                                         agent_message_chunk.
-//     all other session/update types   → passthrough (real tool_calls for
-//                                         shell exec, their updates, etc.).
+//   message role=user                  → DROP. Echo of the submitted prompt
+//                                        (and, on --resume, a replay of the
+//                                        task's history — see replay gate).
+//   message role=assistant isReasoning → agent_thought_chunk
+//   message role=assistant             → agent_message_chunk
+//   tool_use                           → tool_call (in_progress, kind mapped
+//                                        from the tool name)
+//   tool_result                        → tool_call_update (completed/failed)
+//   result                             → records stats.task_id as the
+//                                        session's bob task id; resolves the
+//                                        prompt with stopReason end_turn.
+//   error                              → surfaced as agent_message_chunk
+//                                        (budget/turn caps land here).
 //
-//   agent→client JSON-RPC requests
-//     session/request_permission       → intercepted. Bob bundles the tool
-//                                         payload inside params.toolCall for
-//                                         permission-gated tools (e.g. file
-//                                         edits). We promote it to a
-//                                         session/update:tool_call (in_progress)
-//                                         so platform UI shows a chip, then auto-
-//                                         approve with the first allow-type
-//                                         option. Bob's own tool_call_update
-//                                         closes the chip later.
-//     fs/*                             → dispatched to local handlers below.
-//                                         platform UI has no-op stubs that would
-//                                         silently swallow writes; the shim
-//                                         runs in the same container as the
-//                                         agent workdir, so local I/O is the
-//                                         right target. Unknown fs/* methods
-//                                         are rejected with Method not found
-//                                         so bob can fall back.
-//     everything else                  → passthrough. If agent-runtime/UI
-//                                         can't handle it, the standard JSON-
-//                                         RPC "Method not found" will reach
-//                                         bob.
-//
-//   client→agent stdin (human → bob)   → piped through unchanged.
+// Replay gate: on --resume bob re-emits the task's stored messages before the
+// new turn. Everything is dropped until the user-message echo matching the
+// submitted prompt (first assistant stream chunk as fallback).
 //
 // ──────────────────────────────────────────────────────────────────────────
 // Session history (list / load / resume)
 //
-// Bob's ACP has no session listing and a disabled `loadSession`, but it does
-// persist every chat to `$HOME/.bob/tmp/<projectHash>/chats/session-*.json`
-// (survives restarts on the PVC). The shim serves history from that store:
-//   initialize   → advertise loadSession + sessionCapabilities.list.
-//   session/list → scan chats/, one session per file.
-//   session/load → replay the file's messages as user/agent chunks.
-//   session/prompt into a loaded session → Bob can't continue a session it
-//     didn't create this process, so spawn a fresh session/new, map old↔new
-//     sessionId, and prepend the prior transcript (capped at
-//     BOB_RESUME_MAX_MESSAGES, default 40) to the first prompt.
+// Bob 2.0 persists tasks in SQLite (`~/.bob/db/bob.db`, tables tasks +
+// messages) on the PVC. The shim serves ACP history straight from it:
+//   session/list → SELECT from tasks, one session per task.
+//   session/load → replay the task's messages as user/agent chunks.
+//   session/prompt → `bob run --resume <taskId>` — native continuation, no
+//     transcript re-injection.
+// ACP session ids issued by session/new are shim-generated; the sessionId ↔
+// taskId mapping is persisted to `~/.bob/platform-shim-sessions.json` so a
+// pod restart keeps loaded sessions resumable.
+//
+// Settings: `bob run` has no yolo/auto-approve flag — approvals ride
+// `~/.bob/settings/settings.json`. ensureSettings() merge-writes the platform
+// posture (license consent, all permission groups approved, wildcard command
+// allowlist, model/mode/cost from the BOB_* env). The trust boundary is the
+// platform's Envoy gateway + K8s isolation, not Bob's approval layer.
 //
 // Set BOB_SHIM_TRACE=1 to log every inbound and outbound frame to stderr.
 // ──────────────────────────────────────────────────────────────────────────
 import { spawn } from "node:child_process";
-import {
-  copyFileSync,
-  mkdirSync,
-  promises as fsp,
-  readdirSync,
-  readFileSync,
-} from "node:fs";
+import { randomUUID } from "node:crypto";
+import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import readline from "node:readline";
+import { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
 
 const TRACE = process.env.BOB_SHIM_TRACE === "1";
-const thinkToolCallIds = new Set();
-let lastThoughtText = "";
+const BOB_HOME = process.env.HOME || "/home/agent";
+const BOB_DB_PATH = join(BOB_HOME, ".bob", "db", "bob.db");
+const SETTINGS_PATH = join(BOB_HOME, ".bob", "settings", "settings.json");
+const SESSION_MAP_PATH = join(BOB_HOME, ".bob", "platform-shim-sessions.json");
+const UPLOADS_ROOT = resolve(BOB_HOME, ".uploads");
 
-// Shim-faked ACP setSessionMode: `<mode>X</mode>` prepended per prompt.
 const AVAILABLE_MODES = [
-  { id: "ask", name: "Ask" },
-  { id: "code", name: "Code" },
+  { id: "agent", name: "Agent" },
   { id: "plan", name: "Plan" },
-  { id: "advanced", name: "Advanced" },
+  { id: "ask", name: "Ask" },
 ];
-let currentModeId = (() => {
-  const env = process.env.BOB_CHAT_MODE;
-  if (env && AVAILABLE_MODES.some((m) => m.id === env)) return env;
-  return "ask";
-})();
-const pendingNewSessionIds = new Set();
-// Session workspace (ACP cwd) — the only dir Bob's read guard allows; set on session/new.
-let sessionCwd = process.cwd();
-// Chat uploads land here; only files under it get staged into the workspace.
-const UPLOADS_ROOT = resolve(process.env.HOME || "/home/agent", ".uploads");
-let pendingModeSwitch = null;
 
-// agent_message_chunk state machine. Bob wraps reasoning in <thinking>…</thinking>;
-// user-facing text is what's outside. Default state is "inside" — Bob omits the
-// opening tag on direct-answer turns. messageCarry holds the tail in case a tag is
-// split across token boundaries.
-//
-// outsideBuf accumulates out-of-thinking text for meta-hint filtering: Bob peppers
-// "[using tool X: …]" status lines across many tokens, so we strip complete
-// "[using tool … ]" segments and keep the tail while a "[using tool" is still open.
-const THINK_OPEN = "<thinking>";
-const THINK_CLOSE = "</thinking>";
-const META_COMPLETE = /\[using tool [^\]]*\]\n?/g;
-const META_UNCLOSED = /\[using tool [^\]]*$/;
-const META_PREFIX = "[using tool ";
+// BOB_CHAT_MODE may still carry a 1.x value pinned on an existing provider
+// secret; 2.0 merged code+advanced into agent.
+function normalizeMode(mode) {
+  if (mode === "code" || mode === "advanced") return "agent";
+  return AVAILABLE_MODES.some((m) => m.id === mode) ? mode : null;
+}
+let currentModeId = normalizeMode(process.env.BOB_CHAT_MODE) ?? "agent";
 
 function isNonNullObject(v) {
   return typeof v === "object" && v !== null;
 }
 
-// Longest suffix of s that is a proper prefix of tag — the part of a tag that
-// may have been split across chunk boundaries and must be held back.
-function partialSuffixLen(s, tag) {
-  const max = Math.min(s.length, tag.length - 1);
-  for (let n = max; n > 0; n--) {
-    if (s.endsWith(tag.slice(0, n))) return n;
-  }
-  return 0;
+function trace(dir, line) {
+  if (TRACE) process.stderr.write(`[${dir}] ${line}\n`);
 }
-let messageState = "inside";
-let messageCarry = "";
-let outsideBuf = "";
-let lastSessionId = null;
 
-// ── session history state ───────────────────────────────────────────────────
-const BOB_HOME = process.env.HOME || "/home/agent";
-const CHATS_GLOB_ROOT = join(BOB_HOME, ".bob", "tmp");
-const RESUME_MAX_MESSAGES = (() => {
-  const n = Number.parseInt(process.env.BOB_RESUME_MAX_MESSAGES ?? "", 10);
-  return Number.isInteger(n) && n > 0 ? n : 40;
+// ── settings bootstrap ──────────────────────────────────────────────────────
+// Also runnable standalone (`--settings-only`) so harness-terminal can share it.
+
+export function ensureSettings() {
+  let existing = {};
+  try {
+    existing = JSON.parse(readFileSync(SETTINGS_PATH, "utf8"));
+  } catch {
+    /* first boot */
+  }
+  const maxCost = Number(process.env.BOB_MAX_COINS ?? process.env.BOB_MAX_COST);
+  const settings = {
+    ...existing,
+    licenseConsent: true,
+    session: {
+      ...(isNonNullObject(existing.session) ? existing.session : {}),
+      defaultMode: currentModeId,
+      ...(process.env.BOB_SHELL_MODEL ? { model: process.env.BOB_SHELL_MODEL } : {}),
+      ...(Number.isFinite(maxCost) && maxCost > 0 ? { maxCost } : {}),
+    },
+    approval: {
+      ...(isNonNullObject(existing.approval) ? existing.approval : {}),
+      autoApprovalEnabled: true,
+      outsideWorkspaceAllowed: true,
+      allowed_permissions: ["read", "edit", "execute", "browser", "mcp"],
+      allowedExecutors: [
+        { toolId: "execute_command", approvedCommands: ["*"], deniedCommands: [] },
+      ],
+    },
+  };
+  mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
+  writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n");
+}
+
+// ── sessionId ↔ taskId mapping ──────────────────────────────────────────────
+
+const sessionToTask = new Map();
+(() => {
+  try {
+    const stored = JSON.parse(readFileSync(SESSION_MAP_PATH, "utf8"));
+    for (const [sid, tid] of Object.entries(stored)) sessionToTask.set(sid, tid);
+  } catch {
+    /* no mapping yet */
+  }
 })();
 
-// Client (or runtime) initialize request id → patch its result to enable load.
-const pendingInitIds = new Set();
-// Resume mapping for sessions the client loaded but Bob has no live copy of.
-//   loadedSessions:      oldSid → { transcript: string, injected: bool }
-//   oldToNew / newToOld: bidirectional sid mapping once a live Bob session exists
-//   resumeNewSessionIds: shim-initiated session/new request id → oldSid
-//   pendingResumePrompts:oldSid → queued client prompt frames awaiting newSid
-const loadedSessions = new Map();
-const oldToNew = new Map();
-const newToOld = new Map();
-const resumeNewSessionIds = new Map();
-const pendingResumePrompts = new Map();
-
-// Read Bob's on-disk chats. Each file is one session; returns newest-first.
-function readBobChatFiles() {
-  const out = [];
-  let projectDirs;
+function bindTask(sessionId, taskId) {
+  if (!taskId || sessionToTask.get(sessionId) === taskId) return;
+  sessionToTask.set(sessionId, taskId);
   try {
-    projectDirs = readdirSync(CHATS_GLOB_ROOT, { withFileTypes: true });
-  } catch {
-    return out;
+    writeFileSync(
+      SESSION_MAP_PATH,
+      JSON.stringify(Object.fromEntries(sessionToTask), null, 2) + "\n",
+    );
+  } catch (err) {
+    process.stderr.write(`[bob-acp-shim] session map write failed: ${err.message}\n`);
   }
-  for (const pd of projectDirs) {
-    if (!pd.isDirectory()) continue;
-    const chatsDir = join(CHATS_GLOB_ROOT, pd.name, "chats");
-    let files;
+}
+
+function taskIdFor(sessionId) {
+  return sessionToTask.get(sessionId) ?? null;
+}
+
+function sessionIdFor(taskId) {
+  for (const [sid, tid] of sessionToTask) if (tid === taskId) return sid;
+  return taskId;
+}
+
+// ── task store (bob.db, read-only) ──────────────────────────────────────────
+
+function withDb(fn) {
+  let db;
+  try {
+    db = new DatabaseSync(BOB_DB_PATH, { readOnly: true });
+    return fn(db);
+  } catch (err) {
+    trace("db", `read failed: ${err.message}`);
+    return null;
+  } finally {
     try {
-      files = readdirSync(chatsDir);
-    } catch {
-      continue;
-    }
-    for (const name of files) {
-      if (!name.endsWith(".json")) continue;
-      const path = join(chatsDir, name);
-      try {
-        const data = JSON.parse(readFileSync(path, "utf8"));
-        if (typeof data?.sessionId !== "string") continue;
-        out.push(data);
-      } catch {
-        /* skip unreadable/partial files */
-      }
-    }
+      db?.close();
+    } catch {}
   }
-  out.sort((a, b) =>
-    String(b.lastUpdated ?? "").localeCompare(String(a.lastUpdated ?? "")),
-  );
-  return out;
 }
 
-function findBobChat(sessionId) {
-  return readBobChatFiles().find((c) => c.sessionId === sessionId) ?? null;
+function listTasks() {
+  return (
+    withDb((db) =>
+      db
+        .prepare(
+          `SELECT id, title, first_message, directory, updated_at
+             FROM tasks
+            WHERE task_type = 'normal' AND time_archived IS NULL
+            ORDER BY updated_at DESC`,
+        )
+        .all(),
+    ) ?? []
+  );
 }
 
-function titleFromChat(chat) {
-  const firstUser = (chat.messages ?? []).find(
-    (m) => m?.type === "user" && typeof m.content === "string",
+function taskMessages(taskId) {
+  return (
+    withDb((db) =>
+      db
+        .prepare(
+          `SELECT role, data FROM messages WHERE task_id = ? ORDER BY created_at ASC`,
+        )
+        .all(taskId),
+    ) ?? []
   );
-  const raw = (firstUser?.content ?? "").replace(/\s+/g, " ").trim();
+}
+
+function taskTitle(task) {
+  const raw = String(task.title || task.first_message || "")
+    .replace(/\s+/g, " ")
+    .trim();
   if (!raw) return "Untitled session";
   return raw.length > 120 ? raw.slice(0, 119) + "…" : raw;
 }
 
-// Strip a stored bob-shell message's <thinking> block and "[using tool …]"
-// hints, leaving the user-facing answer.
-function userFacingText(content) {
-  if (typeof content !== "string") return "";
-  let text = content;
-  const close = text.lastIndexOf(THINK_CLOSE);
-  if (close !== -1) text = text.slice(close + THINK_CLOSE.length);
-  return text.replace(META_COMPLETE, "").trim();
+// messages.data is Bob's serialized message JSON; content is a string (or
+// block list on some tool messages). Extract user-facing text, or "".
+function messageText(data) {
+  let m;
+  try {
+    m = JSON.parse(data);
+  } catch {
+    return "";
+  }
+  if (typeof m?.content === "string") return m.content;
+  if (Array.isArray(m?.content)) {
+    return m.content
+      .map((b) => (typeof b?.text === "string" ? b.text : ""))
+      .filter(Boolean)
+      .join("");
+  }
+  return "";
 }
 
-// Bob puts the final answer in an `attempt_completion` toolCall; `content` is
-// often just the <thinking> block. Prefer the toolCall, fall back to content.
-function assistantAnswer(message) {
-  const calls = Array.isArray(message?.toolCalls) ? message.toolCalls : [];
-  const results = calls
-    .filter((t) => t?.name === "attempt_completion" && typeof t?.args?.result === "string")
-    .map((t) => t.args.result.trim())
-    .filter(Boolean);
-  if (results.length > 0) return results.join("\n\n");
-  return userFacingText(message?.content);
-}
-
-function buildTranscript(chat) {
-  const msgs = (chat.messages ?? []).slice(-RESUME_MAX_MESSAGES);
-  const lines = [];
-  for (const m of msgs) {
-    if (m?.type === "user" && typeof m.content === "string") {
-      lines.push(`User: ${m.content.trim()}`);
-    } else if (m?.type === "bob-shell") {
-      const t = assistantAnswer(m);
-      if (t) lines.push(`Assistant: ${t}`);
-    }
-  }
-  return lines.join("\n\n");
-}
-
-const bob = spawn("bob", ["--experimental-acp", "--yolo", "--auth-method", "api-key", ...process.argv.slice(2)], {
-  stdio: ["pipe", "pipe", "inherit"],
-  cwd: process.cwd(),
-  env: process.env,
-});
-
-const clientStdin = readline.createInterface({ input: process.stdin });
-clientStdin.on("line", (line) => {
-  if (TRACE) process.stderr.write(`[client→shim] ${line}\n`);
-  handleClientLine(line);
-});
-clientStdin.on("close", () => {
-  try { bob.stdin.end(); } catch {}
-});
-
-function forwardToBob(line) {
-  if (!bob.stdin.writable) return;
-  bob.stdin.write(line + "\n");
-}
-
-function handleClientLine(line) {
-  let f;
-  try { f = JSON.parse(line); } catch { return forwardToBob(line); }
-
-  const isClientRequest = f.id !== undefined && typeof f.method === "string";
-
-  if (isClientRequest && f.method === "initialize") {
-    // Track so the response can advertise loadSession (Bob reports false).
-    pendingInitIds.add(f.id);
-    // Bob rejects initialize without clientCapabilities.fs; some clients send
-    // none. The shim answers fs/* itself, so it can always advertise fs.
-    if (isNonNullObject(f.params)) {
-      const cc = isNonNullObject(f.params.clientCapabilities) ? f.params.clientCapabilities : {};
-      f.params.clientCapabilities = {
-        ...cc,
-        fs: { readTextFile: true, writeTextFile: true, ...(isNonNullObject(cc.fs) ? cc.fs : {}) },
-      };
-      return forwardToBob(JSON.stringify(f));
-    }
-    return forwardToBob(line);
-  }
-
-  if (isClientRequest && f.method === "session/new") {
-    pendingNewSessionIds.add(f.id);
-    if (typeof f.params?.cwd === "string") sessionCwd = f.params.cwd;
-    return forwardToBob(line);
-  }
-
-  if (isClientRequest && f.method === "session/list") {
-    const sessions = readBobChatFiles().map((chat) => ({
-      sessionId: chat.sessionId,
-      // Last-seen prompt cwd, not the chat's original cwd (Bob doesn't store
-      // it). Fine for the sidebar; revisit if a consumer needs per-session cwd.
-      cwd: sessionCwd,
-      title: titleFromChat(chat),
-      updatedAt: chat.lastUpdated ?? chat.startTime ?? null,
-      // Tag as chat so agent-runtime's list enrichment doesn't decode a
-      // store-less session as terminal.
-      _meta: { platform: { mode: "chat" } },
-    }));
-    emitToClient({ jsonrpc: "2.0", id: f.id, result: { sessions } });
-    return;
-  }
-
-  if (isClientRequest && f.method === "session/load") {
-    handleSessionLoad(f);
-    return;
-  }
-
-  if (isClientRequest && f.method === "session/set_mode") {
-    const modeId = typeof f.params?.modeId === "string" ? f.params.modeId : null;
-    const sessionId = f.params?.sessionId;
-    if (modeId && modeId !== currentModeId && AVAILABLE_MODES.some((m) => m.id === modeId)) {
-      currentModeId = modeId;
-      pendingModeSwitch = modeId;
-      if (sessionId) {
-        emitToClient({
-          jsonrpc: "2.0",
-          method: "session/update",
-          params: {
-            sessionId,
-            update: { sessionUpdate: "current_mode_update", currentModeId: modeId },
-          },
-        });
-      }
-    }
-    emitToClient({ jsonrpc: "2.0", id: f.id, result: null });
-    return;
-  }
-
-  if (isClientRequest && f.method === "session/prompt" && Array.isArray(f.params?.prompt)) {
-    // Bob rejects resource_link blocks (#441); stage each and pass a text path pointer.
-    f.params.prompt = f.params.prompt.map((b) =>
-      b?.type === "resource_link" ? { type: "text", text: stageAttachment(b) } : b,
-    );
-    // One-shot mode switch: prepend an instruction so the LLM calls the switch-mode tool.
-    if (pendingModeSwitch) {
-      const firstText = f.params.prompt.find(
-        (p) => p?.type === "text" && typeof p?.text === "string",
-      );
-      if (firstText) {
-        firstText.text = `[System: switch to ${pendingModeSwitch} mode now using the switch-mode tool, then continue.]\n\n${firstText.text}`;
-        pendingModeSwitch = null;
-      }
-    }
-    // Resume: a prompt into a loaded session Bob never created this process —
-    // route it onto a lazily-spawned fresh Bob session.
-    const sid = f.params?.sessionId;
-    if (typeof sid === "string" && loadedSessions.has(sid) && !oldToNew.has(sid)) {
-      queueResumePrompt(sid, f);
-      return;
-    }
-    return forwardToBob(JSON.stringify(rewriteClientSessionId(f)));
-  }
-
-  // Any other client request carrying a loaded session's id (cancel, set_mode
-  // already handled above) must target Bob's live session id.
-  if (isClientRequest && typeof f.params?.sessionId === "string" && oldToNew.has(f.params.sessionId)) {
-    return forwardToBob(JSON.stringify(rewriteClientSessionId(f)));
-  }
-
-  forwardToBob(line);
-}
-
-// Rewrite a client frame's sessionId from the loaded (old) id to Bob's live id.
-function rewriteClientSessionId(f) {
-  const sid = f.params?.sessionId;
-  const mapped = typeof sid === "string" ? oldToNew.get(sid) : undefined;
-  if (!mapped) return f;
-  return { ...f, params: { ...f.params, sessionId: mapped } };
-}
-
-// Answer session/load locally: replay the stored conversation to the client and
-// register the session as resumable. No frame reaches Bob (it can't load).
-function handleSessionLoad(f) {
-  const sid = f.params?.sessionId;
-  const chat = typeof sid === "string" ? findBobChat(sid) : null;
-  if (!chat) {
-    emitToClient({
-      jsonrpc: "2.0",
-      id: f.id,
-      error: { code: -32602, message: `Unknown session: ${sid}` },
-    });
-    return;
-  }
-  for (const m of chat.messages ?? []) {
-    if (m?.type === "user" && typeof m.content === "string") {
-      update(sid, {
-        sessionUpdate: "user_message_chunk",
-        content: { type: "text", text: m.content },
-      });
-    } else if (m?.type === "bob-shell") {
-      const text = assistantAnswer(m);
-      if (text) emitAgentMessage(sid, text);
-    }
-  }
-  // Register for lazy resume; the live Bob session is created on first prompt.
-  loadedSessions.set(sid, { transcript: buildTranscript(chat), injected: false });
-  emitToClient({
-    jsonrpc: "2.0",
-    id: f.id,
-    result: {
-      modes: {
-        availableModes: AVAILABLE_MODES.map((m) => ({ ...m })),
-        currentModeId,
-      },
-    },
-  });
-}
-
-// Queue a resume prompt and ensure a fresh Bob session is being created for the
-// loaded session (coalesced per session via resumeNewSessionIds).
-function queueResumePrompt(oldSid, frame) {
-  const queue = pendingResumePrompts.get(oldSid) ?? [];
-  queue.push(frame);
-  pendingResumePrompts.set(oldSid, queue);
-  const alreadyRequesting = [...resumeNewSessionIds.values()].includes(oldSid);
-  if (alreadyRequesting) return;
-  const reqId = `shim-resume-${oldSid}`;
-  resumeNewSessionIds.set(reqId, oldSid);
-  sendToBob({
-    jsonrpc: "2.0",
-    id: reqId,
-    method: "session/new",
-    params: { cwd: sessionCwd, mcpServers: [] },
-  });
-}
-
-// Bob answered a shim-initiated resume session/new: wire the mapping and flush.
-function onResumeSessionCreated(reqId, newSid) {
-  const oldSid = resumeNewSessionIds.get(reqId);
-  resumeNewSessionIds.delete(reqId);
-  if (!oldSid || typeof newSid !== "string") return;
-  oldToNew.set(oldSid, newSid);
-  newToOld.set(newSid, oldSid);
-  const queue = pendingResumePrompts.get(oldSid) ?? [];
-  pendingResumePrompts.delete(oldSid);
-  const state = loadedSessions.get(oldSid);
-  for (const frame of queue) {
-    const routed = { ...frame, params: { ...frame.params, sessionId: newSid } };
-    if (state && !state.injected && state.transcript) {
-      const firstText = routed.params.prompt.find(
-        (p) => p?.type === "text" && typeof p?.text === "string",
-      );
-      const preamble =
-        "[System: this continues an earlier conversation. Transcript below for context; do not greet again.]\n\n" +
-        state.transcript +
-        "\n\n[End of prior transcript. The user's new message follows.]\n\n";
-      if (firstText) firstText.text = preamble + firstText.text;
-      else routed.params.prompt.unshift({ type: "text", text: preamble });
-      state.injected = true;
-    }
-    forwardToBob(JSON.stringify(routed));
+function messageRole(data) {
+  try {
+    return JSON.parse(data)?.role;
+  } catch {
+    return undefined;
   }
 }
 
-// Copy an upload into the workspace so Bob's read guard (workspace + temp only) can see it.
-function stageAttachment(block) {
-  let src = typeof block.uri === "string" ? block.uri : "";
-  const name = typeof block.name === "string" && block.name ? ` "${block.name}"` : "";
-  const mime = block.mimeType ? ` (${block.mimeType})` : "";
-  if (src.startsWith("file://")) {
-    try {
-      src = fileURLToPath(src);
-    } catch {
-      /* keep the raw uri */
-    }
-  } else if (/^[a-z][a-z0-9+.-]*:/i.test(src)) {
-    // Non-file scheme (http, data, …): nothing to stage, and resolve() below
-    // would mangle the URI into a bogus workspace path. Pass it through as-is.
-    return `[Attached link${name}${mime}: ${src}]`;
-  }
-  // Resolve before the containment check so `..` can't escape UPLOADS_ROOT and
-  // smuggle an arbitrary file past Bob's read guard.
-  src = resolve(src);
-  if (src === UPLOADS_ROOT || src.startsWith(UPLOADS_ROOT + sep)) {
-    try {
-      const destDir = join(sessionCwd, ".attachments");
-      mkdirSync(destDir, { recursive: true });
-      const dest = join(destDir, basename(src));
-      copyFileSync(src, dest);
-      src = dest;
-    } catch (err) {
-      if (TRACE) process.stderr.write(`[bob-acp-shim] stage failed: ${err.message}\n`);
-    }
-  }
-  return `[Attached file${name}${mime}: ${src}]`;
-}
-
-function sendToBob(frame) {
-  if (!bob.stdin.writable) return;
-  const line = JSON.stringify(frame);
-  if (TRACE) process.stderr.write(`[shim→bob] ${line}\n`);
-  bob.stdin.write(line + "\n");
-}
+// ── ACP plumbing ────────────────────────────────────────────────────────────
 
 function emitToClient(frame) {
   const line = JSON.stringify(frame);
-  if (TRACE) process.stderr.write(`[shim→client] ${line}\n`);
+  trace("shim→client", line);
   process.stdout.write(line + "\n");
 }
-
-function passthrough(line) {
-  if (TRACE) process.stderr.write(`[bob→client] ${line}\n`);
-  process.stdout.write(line + "\n");
-}
-
-let buf = "";
-bob.stdout.on("data", (chunk) => {
-  buf += chunk.toString();
-  const lines = buf.split("\n");
-  buf = lines.pop();
-  for (const line of lines) if (line.trim()) handleLine(line);
-});
-
-for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
-  process.on(sig, () => bob.kill(sig));
-}
-
-bob.on("exit", (code, signal) => {
-  if (signal) {
-    // Drop the forwarding handler before re-raising: with it installed the
-    // re-raised signal would just call bob.kill() on the already-dead child
-    // and the shim would hang until the pod's SIGKILL grace period expires.
-    process.removeAllListeners(signal);
-    process.kill(process.pid, signal);
-  } else {
-    process.exit(code ?? 0);
-  }
-});
-
-bob.on("error", (err) => {
-  process.stderr.write(`[bob-acp-shim] spawn error: ${err.message}\n`);
-  process.exit(1);
-});
-
-// ── emitters ──────────────────────────────────────────────────────────────
 
 function update(sessionId, update) {
   emitToClient({ jsonrpc: "2.0", method: "session/update", params: { sessionId, update } });
@@ -558,312 +254,387 @@ function emitThoughtChunk(sessionId, text) {
   update(sessionId, { sessionUpdate: "agent_thought_chunk", content: { type: "text", text } });
 }
 
-function emitToolCallOpen(sessionId, toolCall) {
-  if (!toolCall?.toolCallId) return;
-  update(sessionId, {
-    sessionUpdate: "tool_call",
-    toolCallId: toolCall.toolCallId,
-    status: toolCall.status ?? "in_progress",
-    title: toolCall.title,
-    content: toolCall.content ?? [],
-    locations: toolCall.locations ?? [],
-    kind: toolCall.kind,
+function respond(id, result) {
+  emitToClient({ jsonrpc: "2.0", id, result });
+}
+
+function respondError(id, code, message) {
+  emitToClient({ jsonrpc: "2.0", id, error: { code, message } });
+}
+
+// ── session state ───────────────────────────────────────────────────────────
+
+// sessionId → { cwd, running: Promise (turn serialization), child, cancelled }
+const sessions = new Map();
+
+function sessionState(sessionId) {
+  let s = sessions.get(sessionId);
+  if (!s) {
+    s = { cwd: process.cwd(), running: Promise.resolve(), child: null, cancelled: false };
+    sessions.set(sessionId, s);
+  }
+  return s;
+}
+
+// ── attachments ─────────────────────────────────────────────────────────────
+// Chat uploads land under ~/.uploads; copy them into the workspace so Bob's
+// read guard can see them, and hand Bob a text pointer (it takes no
+// resource_link blocks).
+
+function stageAttachment(block, cwd) {
+  let src = typeof block.uri === "string" ? block.uri : "";
+  const name = typeof block.name === "string" && block.name ? ` "${block.name}"` : "";
+  const mime = block.mimeType ? ` (${block.mimeType})` : "";
+  if (src.startsWith("file://")) {
+    try {
+      src = fileURLToPath(src);
+    } catch {
+      /* keep the raw uri */
+    }
+  } else if (/^[a-z][a-z0-9+.-]*:/i.test(src)) {
+    return `[Attached link${name}${mime}: ${src}]`;
+  }
+  // Resolve before the containment check so `..` can't escape UPLOADS_ROOT.
+  src = resolve(src);
+  if (src === UPLOADS_ROOT || src.startsWith(UPLOADS_ROOT + sep)) {
+    try {
+      const destDir = join(cwd, ".attachments");
+      mkdirSync(destDir, { recursive: true });
+      const dest = join(destDir, basename(src));
+      copyFileSync(src, dest);
+      src = dest;
+    } catch (err) {
+      trace("bob-acp-shim", `stage failed: ${err.message}`);
+    }
+  }
+  return `[Attached file${name}${mime}: ${src}]`;
+}
+
+function promptToText(promptBlocks, cwd) {
+  const parts = [];
+  for (const b of promptBlocks ?? []) {
+    if (b?.type === "text" && typeof b.text === "string") parts.push(b.text);
+    else if (b?.type === "resource_link") parts.push(stageAttachment(b, cwd));
+  }
+  return parts.join("\n\n");
+}
+
+// ── tool kind mapping (bob tool name → ACP tool_call kind) ─────────────────
+
+function toolKind(name) {
+  const n = String(name ?? "");
+  if (n.includes("command") || n.includes("execute")) return "execute";
+  if (n.includes("read")) return "read";
+  if (n.includes("write") || n.includes("diff") || n.includes("edit")) return "edit";
+  if (n.includes("search") || n.includes("list")) return "search";
+  if (n.includes("browser") || n.includes("fetch") || n.includes("url")) return "fetch";
+  return "other";
+}
+
+// ── prompt turn: spawn bob run and translate its stream ─────────────────────
+
+function buildRunArgs(state, taskId, promptText) {
+  const args = [
+    "run",
+    "--format",
+    "stream-json",
+    "--accept-license",
+    "--trust",
+    "-w",
+    state.cwd,
+    "--mode",
+    currentModeId,
+  ];
+  if (process.env.BOB_TEAM_ID) args.push("--team-id", process.env.BOB_TEAM_ID);
+  const maxCost = Number(process.env.BOB_MAX_COINS ?? process.env.BOB_MAX_COST);
+  if (Number.isFinite(maxCost) && maxCost > 0) args.push("--max-cost", String(maxCost));
+  if (taskId) args.push("--resume", taskId);
+  // Positional prompt; `--` keeps a leading-dash prompt out of option parsing.
+  args.push("--", promptText);
+  return args;
+}
+
+function runTurn(sessionId, requestId, promptText) {
+  const state = sessionState(sessionId);
+  const taskId = taskIdFor(sessionId);
+  const args = buildRunArgs(state, taskId, promptText);
+  state.cancelled = false;
+
+  return new Promise((resolveTurn) => {
+    trace("shim→bob", `bob ${args.join(" ")}`);
+    const child = spawn("bob", args, {
+      stdio: ["ignore", "pipe", "inherit"],
+      cwd: state.cwd,
+      env: process.env,
+    });
+    state.child = child;
+
+    // Replay gate: drop history bob re-emits on --resume until the echo of
+    // this turn's prompt (or the first live stream chunk).
+    let replayDone = !taskId;
+    let sawResult = false;
+    let lastError = null;
+    let buf = "";
+
+    const handleEvent = (ev) => {
+      switch (ev.type) {
+        case "message": {
+          if (ev.role === "user") {
+            if (!replayDone && ev.content === promptText) replayDone = true;
+            return; // echo — the client already renders its own prompt
+          }
+          if (ev.role !== "assistant" || typeof ev.content !== "string") return;
+          replayDone = true;
+          if (ev.isReasoning) emitThoughtChunk(sessionId, ev.content);
+          else emitAgentMessage(sessionId, ev.content);
+          return;
+        }
+        case "tool_use": {
+          if (!replayDone) return;
+          update(sessionId, {
+            sessionUpdate: "tool_call",
+            toolCallId: String(ev.tool_id ?? randomUUID()),
+            status: "in_progress",
+            title: String(ev.tool_name ?? "tool"),
+            kind: toolKind(ev.tool_name),
+            rawInput: ev.parameters,
+            content: [],
+            locations: [],
+          });
+          return;
+        }
+        case "tool_result": {
+          if (!replayDone) return;
+          const failed = ev.status === "error";
+          const text = failed ? ev.error?.message : ev.output;
+          update(sessionId, {
+            sessionUpdate: "tool_call_update",
+            toolCallId: String(ev.tool_id ?? ""),
+            status: failed ? "failed" : "completed",
+            content:
+              typeof text === "string" && text.length > 0
+                ? [{ type: "content", content: { type: "text", text } }]
+                : [],
+          });
+          return;
+        }
+        case "result": {
+          sawResult = true;
+          const tid = ev.stats?.task_id;
+          if (typeof tid === "string" && tid) bindTask(sessionId, tid);
+          return;
+        }
+        case "error": {
+          lastError = String(ev.message ?? "unknown error");
+          if (replayDone) emitAgentMessage(sessionId, `\n${lastError}\n`);
+          return;
+        }
+        default:
+          return;
+      }
+    };
+
+    child.stdout.on("data", (chunk) => {
+      buf += chunk.toString();
+      const lines = buf.split("\n");
+      buf = lines.pop();
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        trace("bob→shim", line);
+        try {
+          handleEvent(JSON.parse(line));
+        } catch {
+          process.stderr.write(`[bob] ${line}\n`);
+        }
+      }
+    });
+
+    child.on("error", (err) => {
+      state.child = null;
+      respondError(requestId, -32603, `bob spawn failed: ${err.message}`);
+      resolveTurn();
+    });
+
+    child.on("exit", (code) => {
+      state.child = null;
+      if (state.cancelled) respond(requestId, { stopReason: "cancelled" });
+      else if (sawResult) respond(requestId, { stopReason: "end_turn" });
+      else respondError(requestId, -32603, lastError ?? `bob run exited with code ${code}`);
+      resolveTurn();
+    });
   });
 }
 
-// ── fs dispatcher ─────────────────────────────────────────────────────────
-// Add a new entry to extend support (e.g. fs/delete_file). Each handler
-// receives the JSON-RPC params and returns the `result` value to send back.
+// ── ACP request handlers ────────────────────────────────────────────────────
 
-const fsHandlers = {
-  async "fs/read_text_file"(params) {
-    const path = requireString(params, "path");
-    let content;
-    try {
-      content = await fsp.readFile(path, "utf8");
-    } catch (err) {
-      // Bob's create-new-file flow reads before writing; ENOENT → empty.
-      if (err?.code === "ENOENT") content = "";
-      else throw err;
-    }
-    const line = Number.isInteger(params?.line) ? params.line : null;
-    const limit = Number.isInteger(params?.limit) ? params.limit : null;
-    if (line !== null || limit !== null) {
-      const lines = content.split("\n");
-      const start = line !== null ? Math.max(0, line - 1) : 0;
-      const end = limit !== null ? start + limit : lines.length;
-      content = lines.slice(start, end).join("\n");
-    }
-    return { content };
-  },
-
-  async "fs/write_text_file"(params) {
-    const path = requireString(params, "path");
-    const content = typeof params?.content === "string" ? params.content : "";
-    await fsp.mkdir(dirname(path), { recursive: true });
-    await fsp.writeFile(path, content, "utf8");
-    return null;
-  },
-};
-
-function requireString(params, key) {
-  const v = params?.[key];
-  if (typeof v !== "string" || !v) {
-    const err = new Error(`${key} is required`);
-    err.jsonrpcCode = -32602;
-    throw err;
-  }
-  return v;
+function handleInitialize(f) {
+  respond(f.id, {
+    protocolVersion: 1,
+    agentCapabilities: {
+      loadSession: true,
+      sessionCapabilities: { list: {}, close: {} },
+      promptCapabilities: { image: false, audio: false, embeddedContext: false },
+    },
+    authMethods: [],
+  });
 }
 
-async function dispatchFsRequest(frame) {
-  const handler = fsHandlers[frame.method];
-  if (!handler) {
-    sendToBob({
-      jsonrpc: "2.0",
-      id: frame.id,
-      error: { code: -32601, message: `Method not found: ${frame.method}` },
-    });
+function handleSessionNew(f) {
+  const sessionId = `bob-${randomUUID()}`;
+  const state = sessionState(sessionId);
+  if (typeof f.params?.cwd === "string") state.cwd = f.params.cwd;
+  respond(f.id, {
+    sessionId,
+    modes: { availableModes: AVAILABLE_MODES.map((m) => ({ ...m })), currentModeId },
+  });
+}
+
+function handleSessionList(f) {
+  const sessions = listTasks().map((t) => ({
+    sessionId: sessionIdFor(t.id),
+    cwd: t.directory,
+    title: taskTitle(t),
+    updatedAt: Number.isFinite(t.updated_at) ? new Date(t.updated_at).toISOString() : null,
+    // Tag as chat so agent-runtime's list enrichment doesn't decode a
+    // store-less session as terminal.
+    _meta: { platform: { mode: "chat" } },
+  }));
+  respond(f.id, { sessions });
+}
+
+function handleSessionLoad(f) {
+  const sid = f.params?.sessionId;
+  const taskId = typeof sid === "string" ? taskIdFor(sid) ?? sid : null;
+  const rows = taskId ? taskMessages(taskId) : [];
+  if (rows.length === 0) {
+    respondError(f.id, -32602, `Unknown session: ${sid}`);
     return;
   }
-  try {
-    const result = await handler(frame.params);
-    sendToBob({ jsonrpc: "2.0", id: frame.id, result });
-  } catch (err) {
-    sendToBob({
-      jsonrpc: "2.0",
-      id: frame.id,
-      error: { code: err?.jsonrpcCode ?? -32603, message: err?.message ?? String(err) },
-    });
+  bindTask(sid, taskId);
+  const state = sessionState(sid);
+  const dir = withDb((db) =>
+    db.prepare(`SELECT directory FROM tasks WHERE id = ?`).get(taskId),
+  );
+  if (typeof dir?.directory === "string" && dir.directory) state.cwd = dir.directory;
+  for (const row of rows) {
+    const role = row.role || messageRole(row.data);
+    const text = messageText(row.data);
+    if (!text) continue;
+    if (role === "user") {
+      update(sid, {
+        sessionUpdate: "user_message_chunk",
+        content: { type: "text", text },
+      });
+    } else if (role === "assistant") {
+      emitAgentMessage(sid, text);
+    }
   }
+  respond(f.id, {
+    modes: { availableModes: AVAILABLE_MODES.map((m) => ({ ...m })), currentModeId },
+  });
 }
 
-function flushOutside(sessionId, finalize) {
-  if (!outsideBuf) return;
-  // Strip complete "[using tool ...]" segments.
-  outsideBuf = outsideBuf.replace(META_COMPLETE, "");
-  // If a still-unclosed "[using tool" start is present, hold everything from
-  // that point onward until the closer arrives (or until turn end, when we
-  // conservatively drop it).
-  const unclosedAt = outsideBuf.search(META_UNCLOSED);
-  if (unclosedAt !== -1 && !finalize) {
-    const emit = outsideBuf.slice(0, unclosedAt);
-    outsideBuf = outsideBuf.slice(unclosedAt);
-    if (emit) emitAgentMessage(sessionId, emit);
+function handleSessionSetMode(f) {
+  const modeId = normalizeMode(f.params?.modeId);
+  const sessionId = f.params?.sessionId;
+  if (modeId && modeId !== currentModeId) {
+    currentModeId = modeId;
+    if (sessionId) {
+      update(sessionId, { sessionUpdate: "current_mode_update", currentModeId: modeId });
+    }
+  }
+  respond(f.id, null);
+}
+
+function handleSessionPrompt(f) {
+  const sessionId = f.params?.sessionId;
+  if (typeof sessionId !== "string") {
+    respondError(f.id, -32602, "sessionId is required");
     return;
   }
-  if (finalize) {
-    outsideBuf = outsideBuf.replace(META_UNCLOSED, "");
-  } else {
-    // META_UNCLOSED only matches once the full "[using tool " prefix has
-    // arrived; hold back a shorter partial ("[usi…") split across chunks too.
-    const keep = partialSuffixLen(outsideBuf, META_PREFIX);
-    if (keep > 0) {
-      const emit = outsideBuf.slice(0, outsideBuf.length - keep);
-      outsideBuf = outsideBuf.slice(outsideBuf.length - keep);
-      if (emit) emitAgentMessage(sessionId, emit);
-      return;
-    }
+  const state = sessionState(sessionId);
+  const promptText = promptToText(f.params?.prompt, state.cwd);
+  if (!promptText.trim()) {
+    respond(f.id, { stopReason: "end_turn" });
+    return;
   }
-  if (outsideBuf) emitAgentMessage(sessionId, outsideBuf);
-  outsideBuf = "";
+  // Serialize turns per session; bob locks the task row while running.
+  state.running = state.running.then(() => runTurn(sessionId, f.id, promptText));
 }
 
-function processMessageChunk(sessionId, text) {
-  lastSessionId = sessionId;
-  let buf = messageCarry + text;
-  messageCarry = "";
-
-  while (buf.length > 0) {
-    if (messageState === "inside") {
-      const idx = buf.indexOf(THINK_CLOSE);
-      if (idx === -1) {
-        // Retain a short tail so a </thinking> split across chunks matches next time.
-        messageCarry = buf.slice(-(THINK_CLOSE.length - 1));
-        return;
-      }
-      messageState = "outside";
-      buf = buf.slice(idx + THINK_CLOSE.length);
-      continue;
-    }
-
-    const idx = buf.indexOf(THINK_OPEN);
-    if (idx === -1) {
-      // Hold back a suffix that could be the start of a <thinking> tag split
-      // across chunks — without this the partial tag leaks to the user AND the
-      // state machine misses the flip to "inside", streaming the reasoning as
-      // a visible message. The carry re-enters via messageCarry next chunk.
-      const keep = partialSuffixLen(buf, THINK_OPEN);
-      messageCarry = keep > 0 ? buf.slice(buf.length - keep) : "";
-      outsideBuf += keep > 0 ? buf.slice(0, buf.length - keep) : buf;
-      flushOutside(sessionId, false);
-      return;
-    }
-    outsideBuf += buf.slice(0, idx);
-    flushOutside(sessionId, false);
-    messageState = "inside";
-    buf = buf.slice(idx + THINK_OPEN.length);
+function handleSessionCancel(f) {
+  const sessionId = f.params?.sessionId;
+  const state = typeof sessionId === "string" ? sessions.get(sessionId) : null;
+  if (state?.child) {
+    state.cancelled = true;
+    state.child.kill("SIGINT");
   }
+  if (f.id !== undefined) respond(f.id, null);
 }
 
-function flushMessageStateAtTurnEnd() {
-  if (lastSessionId) {
-    // A held-back partial-tag suffix is ordinary text at turn end — no more
-    // chunks are coming that could complete the tag.
-    if (messageState === "outside" && messageCarry) outsideBuf += messageCarry;
-    flushOutside(lastSessionId, true);
+// The task lives in bob.db; only the in-memory turn state goes (the persisted
+// sessionId↔taskId binding stays so the session remains loadable).
+function handleSessionClose(f) {
+  const sessionId = f.params?.sessionId;
+  const state = typeof sessionId === "string" ? sessions.get(sessionId) : null;
+  if (state) {
+    state.child?.kill("SIGTERM");
+    sessions.delete(sessionId);
   }
-  messageState = "inside";
-  messageCarry = "";
-  outsideBuf = "";
-  lastThoughtText = "";
-  thinkToolCallIds.clear();
+  if (f.id !== undefined) respond(f.id, null);
 }
 
-function pickAllowOption(options) {
-  if (!Array.isArray(options)) return null;
-  const allow =
-    options.find((o) => o?.kind === "allow_always") ??
-    options.find((o) => o?.kind === "allow_once");
-  return allow?.optionId ?? options[0]?.optionId ?? null;
-}
-
-// ── stdout handler ────────────────────────────────────────────────────────
-
-function handleLine(line) {
-  if (TRACE) process.stderr.write(`[bob→shim] ${line}\n`);
+function handleClientLine(line) {
   let f;
   try {
     f = JSON.parse(line);
   } catch {
-    // Non-JSON line (e.g. Bob's "Migrated MCP settings …" startup print) is
-    // never an ACP frame — keep it off the client stream, log to stderr.
-    process.stderr.write(`[bob] ${line}\n`);
     return;
   }
+  const isRequest = typeof f.method === "string";
+  if (!isRequest) return;
 
-  // Resume: Bob's reply to a shim-initiated session/new — wire the mapping,
-  // don't forward (the client already holds its loaded session).
-  if (f.id !== undefined && resumeNewSessionIds.has(f.id)) {
-    if (f.result?.sessionId) onResumeSessionCreated(f.id, f.result.sessionId);
-    return;
-  }
-
-  // Rewrite Bob's live session id back to the loaded id the client knows.
-  if (typeof f.params?.sessionId === "string" && newToOld.has(f.params.sessionId)) {
-    f = { ...f, params: { ...f.params, sessionId: newToOld.get(f.params.sessionId) } };
-    line = JSON.stringify(f);
-  }
-
-  // Agent→client RPC requests from bob: { id, method, params } with no result/error.
-  const isAgentRequest = f.id !== undefined && typeof f.method === "string";
-
-  if (f.id !== undefined && pendingInitIds.has(f.id)) {
-    pendingInitIds.delete(f.id);
-    if (isNonNullObject(f.result) && isNonNullObject(f.result.agentCapabilities)) {
-      // Advertise the capabilities the shim emulates (Bob reports neither):
-      // loadSession gates session/load, sessionCapabilities.list gates
-      // session/list — clients skip un-advertised methods.
-      const caps = f.result.agentCapabilities;
-      caps.loadSession = true;
-      caps.sessionCapabilities = {
-        ...(isNonNullObject(caps.sessionCapabilities) ? caps.sessionCapabilities : {}),
-        list: {},
-      };
+  switch (f.method) {
+    case "initialize":
+      return handleInitialize(f);
+    case "session/new":
+      return handleSessionNew(f);
+    case "session/list":
+      return handleSessionList(f);
+    case "session/load":
+      return handleSessionLoad(f);
+    case "session/set_mode":
+      return handleSessionSetMode(f);
+    case "session/prompt":
+      return handleSessionPrompt(f);
+    case "session/cancel":
+      return handleSessionCancel(f);
+    case "session/close":
+      return handleSessionClose(f);
+    default: {
+      if (f.id !== undefined) respondError(f.id, -32601, `Method not found: ${f.method}`);
     }
-    process.stdout.write(JSON.stringify(f) + "\n");
-    return;
   }
+}
 
-  if (isAgentRequest && f.method === "session/request_permission") {
-    emitToolCallOpen(f.params?.sessionId, f.params?.toolCall);
-    const optionId = pickAllowOption(f.params?.options);
-    sendToBob({
-      jsonrpc: "2.0",
-      id: f.id,
-      result: optionId
-        ? { outcome: { outcome: "selected", optionId } }
-        : { outcome: { outcome: "cancelled" } },
+// ── main ────────────────────────────────────────────────────────────────────
+
+const settingsOnly = process.argv.includes("--settings-only");
+ensureSettings();
+if (!settingsOnly) {
+  const clientStdin = readline.createInterface({ input: process.stdin });
+  clientStdin.on("line", (line) => {
+    trace("client→shim", line);
+    handleClientLine(line);
+  });
+  clientStdin.on("close", () => {
+    for (const s of sessions.values()) s.child?.kill("SIGTERM");
+    process.exit(0);
+  });
+  for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+    process.on(sig, () => {
+      for (const s of sessions.values()) s.child?.kill(sig);
+      process.exit(0);
     });
-    return;
-  }
-
-  if (isAgentRequest && f.method.startsWith("fs/")) {
-    dispatchFsRequest(f);
-    return;
-  }
-
-  // Reset streaming state at turn boundary (session/prompt reply).
-  if (f.id !== undefined && f.result?.stopReason) {
-    flushMessageStateAtTurnEnd();
-    return passthrough(line);
-  }
-
-  if (f.id !== undefined && pendingNewSessionIds.has(f.id)) {
-    pendingNewSessionIds.delete(f.id);
-    if (f.result) {
-      const patched = {
-        ...f,
-        result: {
-          ...f.result,
-          modes: {
-            availableModes: AVAILABLE_MODES.map((m) => ({ ...m })),
-            currentModeId,
-          },
-        },
-      };
-      process.stdout.write(JSON.stringify(patched) + "\n");
-      return;
-    }
-    return passthrough(line);
-  }
-
-  if (f.method !== "session/update" || !f.params?.update) return passthrough(line);
-
-  const { sessionId, update: u } = f.params;
-
-  switch (u.sessionUpdate) {
-    case "agent_message_chunk": {
-      const text = u.content?.text;
-      if (typeof text !== "string") return;
-      processMessageChunk(sessionId, text);
-      return;
-    }
-
-    case "agent_thought_chunk": {
-      const text = u.content?.text;
-      if (typeof text !== "string") return passthrough(line);
-      lastSessionId = sessionId;
-      const delta = text.startsWith(lastThoughtText)
-        ? text.slice(lastThoughtText.length)
-        : text;
-      lastThoughtText = text;
-      if (delta) emitThoughtChunk(sessionId, delta);
-      return;
-    }
-
-    case "tool_call": {
-      if (u.kind === "think") {
-        thinkToolCallIds.add(u.toolCallId);
-        return;
-      }
-      return passthrough(line);
-    }
-
-    case "tool_call_update": {
-      if (!thinkToolCallIds.has(u.toolCallId)) return passthrough(line);
-      if (u.status !== "completed") return;
-      for (const part of u.content ?? []) {
-        const inner = part?.content;
-        if (inner?.type === "text" && typeof inner.text === "string" && inner.text.length > 0) {
-          emitAgentMessage(sessionId, inner.text);
-        }
-      }
-      thinkToolCallIds.delete(u.toolCallId);
-      return;
-    }
-
-    default:
-      return passthrough(line);
   }
 }

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -11,9 +11,8 @@
 // ──────────────────────────────────────────────────────────────────────────
 // Translation table (bob run stream-json → ACP session/update)
 //
-//   message role=user                  → DROP. Echo of the submitted prompt
-//                                        (and, on --resume, a replay of the
-//                                        task's history — see replay gate).
+//   message role=user                  → DROP. Echo of the submitted prompt;
+//                                        the client renders its own.
 //   message role=assistant isReasoning → agent_thought_chunk
 //   message role=assistant             → agent_message_chunk
 //   tool_use                           → tool_call (in_progress, kind mapped
@@ -25,9 +24,13 @@
 //   error                              → surfaced as agent_message_chunk
 //                                        (budget/turn caps land here).
 //
-// Replay gate: on --resume bob re-emits the task's stored messages before the
-// new turn. Everything is dropped until the user-message echo matching the
-// submitted prompt (first assistant stream chunk as fallback).
+// `bob run --resume` does NOT re-emit the task's stored messages: the stream
+// starts at the new prompt's echo. Verified against tasks carrying several
+// assistant turns and tool messages. So every event of a turn is live and the
+// translation above needs no gating — if a future release starts replaying, the
+// fix is to bound the replay by the stored message count, not to guess at the
+// first live chunk (any "wait for the first assistant message" heuristic opens
+// mid-replay, since replayed history contains assistant turns of its own).
 //
 // ──────────────────────────────────────────────────────────────────────────
 // Session history (list / load / resume)
@@ -413,9 +416,6 @@ function runTurn(sessionId, requestId, promptText) {
     });
     state.child = child;
 
-    // Replay gate: drop history bob re-emits on --resume until the echo of
-    // this turn's prompt (or the first live stream chunk).
-    let replayDone = !taskId;
     let sawResult = false;
     let lastError = null;
     let buf = "";
@@ -423,18 +423,13 @@ function runTurn(sessionId, requestId, promptText) {
     const handleEvent = (ev) => {
       switch (ev.type) {
         case "message": {
-          if (ev.role === "user") {
-            if (!replayDone && ev.content === promptText) replayDone = true;
-            return; // echo — the client already renders its own prompt
-          }
+          if (ev.role === "user") return; // echo — the client renders its own
           if (ev.role !== "assistant" || typeof ev.content !== "string") return;
-          replayDone = true;
           if (ev.isReasoning) emitThoughtChunk(sessionId, ev.content);
           else emitAgentMessage(sessionId, ev.content);
           return;
         }
         case "tool_use": {
-          if (!replayDone) return;
           update(sessionId, {
             sessionUpdate: "tool_call",
             toolCallId: String(ev.tool_id ?? randomUUID()),
@@ -448,7 +443,6 @@ function runTurn(sessionId, requestId, promptText) {
           return;
         }
         case "tool_result": {
-          if (!replayDone) return;
           const failed = ev.status === "error";
           const text = failed ? ev.error?.message : ev.output;
           update(sessionId, {
@@ -470,7 +464,7 @@ function runTurn(sessionId, requestId, promptText) {
         }
         case "error": {
           lastError = String(ev.message ?? "unknown error");
-          if (replayDone) emitAgentMessage(sessionId, `\n${lastError}\n`);
+          emitAgentMessage(sessionId, `\n${lastError}\n`);
           return;
         }
         default:
@@ -536,7 +530,10 @@ function handleSessionNew(f) {
 function handleSessionList(f) {
   const sessions = listTasks().map((t) => ({
     sessionId: sessionIdFor(t.id),
-    cwd: t.directory,
+    // `tasks.directory` is always "" — 2.0 binds a task to its workspace via
+    // project_id and inserts an empty string here — so report the workspace the
+    // harness actually runs in rather than a blank.
+    cwd: process.cwd(),
     title: taskTitle(t),
     updatedAt: Number.isFinite(t.updated_at) ? new Date(t.updated_at).toISOString() : null,
     // Tag as chat so agent-runtime's list enrichment doesn't decode a
@@ -555,11 +552,10 @@ function handleSessionLoad(f) {
     return;
   }
   bindTask(sid, taskId);
-  const state = sessionState(sid);
-  const dir = withDb((db) =>
-    db.prepare(`SELECT directory FROM tasks WHERE id = ?`).get(taskId),
-  );
-  if (typeof dir?.directory === "string" && dir.directory) state.cwd = dir.directory;
+  // Deliberately no cwd restore from the task: `tasks.directory` is always "".
+  // The turn keeps the client-supplied cwd (the platform sends "."), which
+  // resolves to the harness's workspace — the one the task belongs to. Running a
+  // --resume from any other directory makes bob reject the task outright.
   for (const row of rows) {
     const role = row.role || messageRole(row.data);
     const text = messageText(row.data);

--- a/packages/agents/bob/bob-acp-shim.mjs
+++ b/packages/agents/bob/bob-acp-shim.mjs
@@ -47,12 +47,24 @@
 // posture (license consent, all permission groups approved, wildcard command
 // allowlist, model/mode/cost from the BOB_* env). The trust boundary is the
 // platform's Envoy gateway + K8s isolation, not Bob's approval layer.
+// ensureRules() re-asserts the platform instructions link on every start, which
+// image seeding alone can't do for an agent that predates the 2.0 layout.
 //
 // Set BOB_SHIM_TRACE=1 to log every inbound and outbound frame to stderr.
 // ──────────────────────────────────────────────────────────────────────────
 import { spawn } from "node:child_process";
 import { randomUUID } from "node:crypto";
-import { copyFileSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  copyFileSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readlinkSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { basename, dirname, join, resolve, sep } from "node:path";
 import readline from "node:readline";
 import { DatabaseSync } from "node:sqlite";
@@ -64,6 +76,9 @@ const BOB_DB_PATH = join(BOB_HOME, ".bob", "db", "bob.db");
 const SETTINGS_PATH = join(BOB_HOME, ".bob", "settings", "settings.json");
 const SESSION_MAP_PATH = join(BOB_HOME, ".bob", "platform-shim-sessions.json");
 const UPLOADS_ROOT = resolve(BOB_HOME, ".uploads");
+const RULES_DIR = join(BOB_HOME, ".bob", "rules");
+const PLATFORM_RULE_PATH = join(RULES_DIR, "platform.md");
+const PLATFORM_INSTRUCTIONS = "/etc/AGENTS.md";
 
 const AVAILABLE_MODES = [
   { id: "agent", name: "Agent" },
@@ -119,6 +134,35 @@ export function ensureSettings() {
   };
   mkdirSync(dirname(SETTINGS_PATH), { recursive: true });
   writeFileSync(SETTINGS_PATH, JSON.stringify(settings, null, 2) + "\n");
+}
+
+// The image seeds ~/.bob/rules/platform.md, but $HOME is seeded from the image
+// only on first boot (the init script's `.initialized` guard), so an agent
+// created before this layout keeps a 1.x `.bob/AGENTS.md` that 2.0 never reads
+// — it would run with no platform instructions at all. Re-assert the link on
+// every start. Never fatal: no rules is a degraded agent, not a dead one.
+export function ensureRules() {
+  try {
+    if (!existsSync(PLATFORM_INSTRUCTIONS)) return;
+    mkdirSync(RULES_DIR, { recursive: true });
+    if (
+      lstatSync(PLATFORM_RULE_PATH, { throwIfNoEntry: false })?.isSymbolicLink() &&
+      readlinkSync(PLATFORM_RULE_PATH) === PLATFORM_INSTRUCTIONS
+    ) {
+      return;
+    }
+    rmSync(PLATFORM_RULE_PATH, { force: true });
+    try {
+      symlinkSync(PLATFORM_INSTRUCTIONS, PLATFORM_RULE_PATH);
+    } catch {
+      // $HOME on the VM backend is unprivileged virtiofs, where a non-root
+      // symlink() EPERMs (same constraint the platform-base entrypoint hits on
+      // ~/.cache). A copy goes stale on image update; rules beat no rules.
+      copyFileSync(PLATFORM_INSTRUCTIONS, PLATFORM_RULE_PATH);
+    }
+  } catch (err) {
+    process.stderr.write(`[bob-acp-shim] rules bootstrap failed: ${err.message}\n`);
+  }
 }
 
 // ── sessionId ↔ taskId mapping ──────────────────────────────────────────────
@@ -621,6 +665,7 @@ function handleClientLine(line) {
 
 const settingsOnly = process.argv.includes("--settings-only");
 ensureSettings();
+ensureRules();
 if (!settingsOnly) {
   const clientStdin = readline.createInterface({ input: process.stdin });
   clientStdin.on("line", (line) => {

--- a/packages/agents/bob/harness-chat.sh
+++ b/packages/agents/bob/harness-chat.sh
@@ -1,12 +1,4 @@
 #!/bin/sh
-# The shim emulates session list/load/resume from Bob's on-disk chats
-# (see bob-acp-shim.mjs); $HARNESS_SESSION_ID resume is handled there.
-#
-# Tenant scoping / budget cap / chat mode are CLI-only, so translate
-# the platform env vars into flags here.
-set --
-[ -n "$BOB_INSTANCE_ID" ] && set -- "$@" --instance-id "$BOB_INSTANCE_ID"
-[ -n "$BOB_TEAM_ID" ]     && set -- "$@" --team-id     "$BOB_TEAM_ID"
-[ -n "$BOB_MAX_COINS" ]   && set -- "$@" --max-coins   "$BOB_MAX_COINS"
-[ -n "$BOB_CHAT_MODE" ]   && set -- "$@" --chat-mode   "$BOB_CHAT_MODE"
+# The shim reads the BOB_* env itself (bob run flags + settings merge) and
+# emulates session list/load from Bob's task DB; see bob-acp-shim.mjs.
 exec node /app/bob-acp-shim.mjs "$@"

--- a/packages/agents/bob/harness-terminal.sh
+++ b/packages/agents/bob/harness-terminal.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Write the platform settings posture (license consent, approval config,
-# model) before handing over to Bob's TUI.
+# model) and re-assert the platform instructions link before handing over to
+# Bob's TUI.
 node /app/bob-acp-shim.mjs --settings-only
 
 # 2.0 merged the code/advanced chat modes into agent; BOB_CHAT_MODE may still

--- a/packages/agents/bob/harness-terminal.sh
+++ b/packages/agents/bob/harness-terminal.sh
@@ -1,20 +1,18 @@
 #!/bin/sh
-# TUI is interactive — auto_edit lets Bob prompt the user for risky tools
-# in the terminal itself (yolo would auto-approve everything, no prompts).
-#
-# BOBSHELL_NO_RELAUNCH=true: bob re-execs itself with stdio:"inherit"
-# at startup, which breaks the TTY chain in node-pty (relaunched
-# child sees isTTY=false → "No input provided via stdin" → exits).
-#
-# Session resume isn't wired up — bob's TUI keys sessions by a
-# project-scoped index, not by UUID, so $HARNESS_SESSION_ID can't
-# map. Each terminal open starts fresh; use --list-sessions inside.
-#
-# Tenant / budget / chat-mode flags translated from platform env.
-export BOBSHELL_NO_RELAUNCH=true
+# Write the platform settings posture (license consent, approval config,
+# model) before handing over to Bob's TUI.
+node /app/bob-acp-shim.mjs --settings-only
+
+# 2.0 merged the code/advanced chat modes into agent; BOB_CHAT_MODE may still
+# carry a 1.x value pinned on an existing provider secret.
+mode="$BOB_CHAT_MODE"
+case "$mode" in code|advanced) mode=agent ;; esac
+
 set --
 [ -n "$BOB_INSTANCE_ID" ] && set -- "$@" --instance-id "$BOB_INSTANCE_ID"
 [ -n "$BOB_TEAM_ID" ]     && set -- "$@" --team-id     "$BOB_TEAM_ID"
-[ -n "$BOB_MAX_COINS" ]   && set -- "$@" --max-coins   "$BOB_MAX_COINS"
-[ -n "$BOB_CHAT_MODE" ]   && set -- "$@" --chat-mode   "$BOB_CHAT_MODE"
-exec bob --approval-mode=auto_edit --auth-method api-key "$@"
+[ -n "$BOB_MAX_COINS" ]   && set -- "$@" --max-cost    "$BOB_MAX_COINS"
+[ -n "$mode" ]            && set -- "$@" --mode        "$mode"
+# Each terminal open starts a fresh TUI task; Bob's numeric task index can't
+# map onto $HARNESS_SESSION_ID. Users can resume prior tasks with `bob -r`.
+exec bob chat --accept-license "$@"

--- a/packages/agents/bob/runtime-manifest.yaml
+++ b/packages/agents/bob/runtime-manifest.yaml
@@ -15,9 +15,13 @@ drivers:
     impl: mcp-entry
     path: "$HOME/.bob/settings/mcp.json"
     keyPath: mcpServers
-    # Streamable-HTTP servers go under `httpUrl` (exact casing); `url` is SSE,
-    # which 400s against the platform's streamable MCP endpoint.
-    urlKey: httpUrl
+    # 2.0 keys remote servers off `url` + `transportType` (verified against what
+    # `bob mcp add -t http` writes). 1.x's `httpUrl` is not read at all — the
+    # entry then loads with an empty URL and never connects. `transportType` is
+    # required: absent it, 2.0 treats the server as SSE, which 400s against the
+    # platform's streamable MCP endpoint.
+    extraFields:
+      transportType: http
 
   skill-ref:
     impl: skill-install

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -237,6 +237,7 @@ export {
   bobEnvMappings,
   bobPinsFromEnvMappings,
   BOB_CHAT_MODES,
+  normalizeBobChatMode,
   IBM_LITELLM_HOST,
   BOB_HOST,
   PROVIDER_TEMPLATE_IDS,

--- a/packages/api-server-api/src/modules/connections/providers.ts
+++ b/packages/api-server-api/src/modules/connections/providers.ts
@@ -96,7 +96,9 @@ export function bobPinsFromEnvMappings(
   return pins;
 }
 
-export const BOB_CHAT_MODES = ["plan", "code", "advanced", "ask"] as const;
+// Bob 2.0 merged the code/advanced modes into agent; the harness still maps
+// legacy pinned values onto agent for existing secrets.
+export const BOB_CHAT_MODES = ["agent", "plan", "ask"] as const;
 
 export interface ProviderPresetMode {
   key: string;

--- a/packages/api-server-api/src/modules/connections/providers.ts
+++ b/packages/api-server-api/src/modules/connections/providers.ts
@@ -53,7 +53,10 @@ export interface BobModelPins {
   model?: string;
   agentId?: string;
   teamId?: string;
-  maxCoins?: string;
+  // 2.0 renamed the concept coins → cost (`--max-cost`). The env name stays
+  // BOB_MAX_COINS: it is pinned on secrets created before the rename, and the
+  // harness reads either spelling. The identifiers follow the current concept.
+  maxCost?: string;
   chatMode?: string;
 }
 
@@ -72,7 +75,7 @@ export function bobEnvMappings(pins: BobModelPins = {}): EnvMapping[] {
   push("BOB_SHELL_MODEL", pins.model);
   push("BOB_INSTANCE_ID", pins.agentId);
   push("BOB_TEAM_ID", pins.teamId);
-  push("BOB_MAX_COINS", pins.maxCoins);
+  push("BOB_MAX_COINS", pins.maxCost);
   push("BOB_CHAT_MODE", pins.chatMode);
   return out;
 }
@@ -86,12 +89,12 @@ export function bobPinsFromEnvMappings(
   const model = lookup("BOB_SHELL_MODEL");
   const agentId = lookup("BOB_INSTANCE_ID");
   const teamId = lookup("BOB_TEAM_ID");
-  const maxCoins = lookup("BOB_MAX_COINS");
+  const maxCost = lookup("BOB_MAX_COINS");
   const chatMode = lookup("BOB_CHAT_MODE");
   if (model) pins.model = model;
   if (agentId) pins.agentId = agentId;
   if (teamId) pins.teamId = teamId;
-  if (maxCoins) pins.maxCoins = maxCoins;
+  if (maxCost) pins.maxCost = maxCost;
   // Same normalization as the UI's read path: a stored legacy mode reads back as
   // the mode it became, so a re-save can't be blocked by it.
   if (chatMode) pins.chatMode = normalizeBobChatMode(chatMode);

--- a/packages/api-server-api/src/modules/connections/providers.ts
+++ b/packages/api-server-api/src/modules/connections/providers.ts
@@ -92,13 +92,28 @@ export function bobPinsFromEnvMappings(
   if (agentId) pins.agentId = agentId;
   if (teamId) pins.teamId = teamId;
   if (maxCoins) pins.maxCoins = maxCoins;
-  if (chatMode) pins.chatMode = chatMode;
+  // Same normalization as the UI's read path: a stored legacy mode reads back as
+  // the mode it became, so a re-save can't be blocked by it.
+  if (chatMode) pins.chatMode = normalizeBobChatMode(chatMode);
   return pins;
 }
 
-// Bob 2.0 merged the code/advanced modes into agent; the harness still maps
-// legacy pinned values onto agent for existing secrets.
 export const BOB_CHAT_MODES = ["agent", "plan", "ask"] as const;
+
+// Bob 2.0 merged the 1.x code/advanced modes into agent. Secrets pinned before
+// the upgrade still carry the old value, so a stored pin must be normalized
+// wherever it is read back — never rejected, or the connection becomes
+// un-editable over a field the runtime itself tolerates. Fresh input stays
+// strict against BOB_CHAT_MODES.
+const BOB_LEGACY_CHAT_MODES: Record<string, (typeof BOB_CHAT_MODES)[number]> = {
+  code: "agent",
+  advanced: "agent",
+};
+
+export function normalizeBobChatMode(mode: string | undefined): string {
+  const trimmed = mode?.trim() ?? "";
+  return BOB_LEGACY_CHAT_MODES[trimmed] ?? trimmed;
+}
 
 export interface ProviderPresetMode {
   key: string;

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -222,8 +222,10 @@ const BOB: HeaderConnectionTemplate = {
       envName: "BOB_MAX_COINS",
       label: "Max cost",
       hint: "Per-task cost cap (Bob 2.x --max-cost); Bob stops the task when exceeded.",
-      pattern: "^[1-9]\\d*$",
-      patternHint: "a positive integer",
+      // A cost, not a coin count: a task can settle well under a unit (observed
+      // ~0.10), so an integer-only cap could not express anything below 1.
+      pattern: "^(?:[1-9]\\d*(?:\\.\\d+)?|0?\\.\\d*[1-9]\\d*)$",
+      patternHint: "a positive amount, e.g. 0.50 or 5",
     },
     {
       inputName: "chatMode",

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -209,7 +209,7 @@ const BOB: HeaderConnectionTemplate = {
       inputName: "instanceId",
       envName: "BOB_INSTANCE_ID",
       label: "Instance ID",
-      hint: "IBM tenant scoping. Bob 2.x applies it in terminal (TUI) sessions only; chat-mode headless runs select the instance via Bob profiles.",
+      hint: "IBM tenant scoping. Applies to terminal (TUI) sessions; chat sessions ignore it.",
     },
     {
       inputName: "teamId",
@@ -228,8 +228,8 @@ const BOB: HeaderConnectionTemplate = {
     {
       inputName: "chatMode",
       envName: "BOB_CHAT_MODE",
-      label: "Chat mode",
-      hint: `Default chat persona. One of: ${BOB_CHAT_MODES.join(", ")}.`,
+      label: "Mode",
+      hint: `Default mode for new sessions. One of: ${BOB_CHAT_MODES.join(", ")}.`,
       enumValues: BOB_CHAT_MODES,
     },
   ],

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -218,7 +218,7 @@ const BOB: HeaderConnectionTemplate = {
       hint: "Sets the x-team-id header.",
     },
     {
-      inputName: "maxCoins",
+      inputName: "maxCost",
       envName: "BOB_MAX_COINS",
       label: "Max cost",
       hint: "Per-task cost cap (Bob 2.x --max-cost); Bob stops the task when exceeded.",

--- a/packages/api-server/src/modules/connections/domain/catalog.ts
+++ b/packages/api-server/src/modules/connections/domain/catalog.ts
@@ -209,7 +209,7 @@ const BOB: HeaderConnectionTemplate = {
       inputName: "instanceId",
       envName: "BOB_INSTANCE_ID",
       label: "Instance ID",
-      hint: "Sets the x-instance-id header (IBM tenant scoping).",
+      hint: "IBM tenant scoping. Bob 2.x applies it in terminal (TUI) sessions only; chat-mode headless runs select the instance via Bob profiles.",
     },
     {
       inputName: "teamId",
@@ -220,8 +220,8 @@ const BOB: HeaderConnectionTemplate = {
     {
       inputName: "maxCoins",
       envName: "BOB_MAX_COINS",
-      label: "Max coins",
-      hint: "Budget cap; Bob exits when exceeded.",
+      label: "Max cost",
+      hint: "Per-task cost cap (Bob 2.x --max-cost); Bob stops the task when exceeded.",
       pattern: "^[1-9]\\d*$",
       patternHint: "a positive integer",
     },

--- a/packages/cli/src/modules/connection/commands/connect.ts
+++ b/packages/cli/src/modules/connection/commands/connect.ts
@@ -152,7 +152,7 @@ export function buildConnectCommand(deps: {
         '      --private-key "$(cat app.pem)"\n' +
         "  dam connection connect github-enterprise-app --host ghe.acme.com \\\n" +
         '      --app-id 123456 --installation-id 987654 --private-key "$(cat app.pem)"\n' +
-        "  dam connection connect bob --value sk-… --config model=premium-shell --config chatMode=code\n" +
+        "  dam connection connect bob --value sk-… --config model=premium-shell --config chatMode=agent\n" +
         "  dam connection connect https://mcp.example.com\n" +
         "  dam connection connect https://mcp.example.com --auth none\n",
     )

--- a/packages/ui/src/__tests__/unit/bob-legacy-pin.test.ts
+++ b/packages/ui/src/__tests__/unit/bob-legacy-pin.test.ts
@@ -1,0 +1,26 @@
+import type { ConnectionView } from "api-server-api";
+import { describe, expect, test } from "vitest";
+
+import { bobPinsFromConnection } from "../../modules/providers/components/provider-item.js";
+
+const connWithMode = (mode: string) =>
+  ({
+    contributions: [{ kind: "env", name: "BOB_CHAT_MODE", placeholder: mode }],
+  }) as unknown as ConnectionView;
+
+describe("bobPinsFromConnection", () => {
+  // A secret pinned before 2.0 must stay editable: the edit dialog validates the
+  // pin it reads back, so surfacing a retired mode verbatim disabled Save and
+  // locked the user out of rotating the credential.
+  test.each(["code", "advanced"])("normalizes the retired %s mode", (mode) => {
+    expect(bobPinsFromConnection(connWithMode(mode)).chatMode).toBe("agent");
+  });
+
+  test("leaves a current mode and an absent pin alone", () => {
+    expect(bobPinsFromConnection(connWithMode("plan")).chatMode).toBe("plan");
+    expect(
+      bobPinsFromConnection({ contributions: [] } as unknown as ConnectionView)
+        .chatMode,
+    ).toBeUndefined();
+  });
+});

--- a/packages/ui/src/__tests__/unit/bob-legacy-pin.test.ts
+++ b/packages/ui/src/__tests__/unit/bob-legacy-pin.test.ts
@@ -3,24 +3,24 @@ import { describe, expect, test } from "vitest";
 
 import { bobPinsFromConnection } from "../../modules/providers/components/provider-item.js";
 
-const connWithMode = (mode: string) =>
-  ({
-    contributions: [{ kind: "env", name: "BOB_CHAT_MODE", placeholder: mode }],
-  }) as unknown as ConnectionView;
+type Contributions = Pick<ConnectionView, "contributions">;
+
+const withMode = (mode: string): Contributions => ({
+  contributions: [{ kind: "env", name: "BOB_CHAT_MODE", placeholder: mode }],
+});
 
 describe("bobPinsFromConnection", () => {
   // A secret pinned before 2.0 must stay editable: the edit dialog validates the
   // pin it reads back, so surfacing a retired mode verbatim disabled Save and
   // locked the user out of rotating the credential.
   test.each(["code", "advanced"])("normalizes the retired %s mode", (mode) => {
-    expect(bobPinsFromConnection(connWithMode(mode)).chatMode).toBe("agent");
+    expect(bobPinsFromConnection(withMode(mode)).chatMode).toBe("agent");
   });
 
   test("leaves a current mode and an absent pin alone", () => {
-    expect(bobPinsFromConnection(connWithMode("plan")).chatMode).toBe("plan");
+    expect(bobPinsFromConnection(withMode("plan")).chatMode).toBe("plan");
     expect(
-      bobPinsFromConnection({ contributions: [] } as unknown as ConnectionView)
-        .chatMode,
+      bobPinsFromConnection({ contributions: [] }).chatMode,
     ).toBeUndefined();
   });
 });

--- a/packages/ui/src/modules/providers/components/bob/form.tsx
+++ b/packages/ui/src/modules/providers/components/bob/form.tsx
@@ -24,6 +24,8 @@ const bobCredentialSchema = z
     chatMode: z.string(),
   })
   .superRefine((data, ctx) => {
+    // Carries the empty-credential state to `isValid`, which disables submit; no
+    // message is rendered for it, so give any *further* value issue a home first.
     if (stripWhitespace(data.value).length === 0) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
@@ -31,11 +33,16 @@ const bobCredentialSchema = z
         message: "Required",
       });
     }
-    if (data.maxCost.trim() !== "" && !/^[1-9]\d*$/.test(data.maxCost.trim())) {
+    // Keep in step with the `maxCost` pattern in the server-side catalog: a cost
+    // cap has to be able to sit below a whole unit.
+    if (
+      data.maxCost.trim() !== "" &&
+      !/^(?:[1-9]\d*(?:\.\d+)?|0?\.\d*[1-9]\d*)$/.test(data.maxCost.trim())
+    ) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["maxCost"],
-        message: "Must be a positive integer",
+        message: "Must be a positive amount, e.g. 0.50 or 5",
       });
     }
     const cm = data.chatMode.trim();
@@ -84,9 +91,6 @@ export function BobForm({
   );
 
   const isEdit = variant === "edit";
-  // The empty-credential case is conveyed by the disabled submit, so the schema's
-  // one issue on `value` needs no message rendered under the field. Add rendering
-  // here if a value check ever fails for a reason the button can't express.
   const submitDisabled = isSubmitting || !isValid;
 
   const onSubmit = handleSubmit(async (values) => {

--- a/packages/ui/src/modules/providers/components/bob/form.tsx
+++ b/packages/ui/src/modules/providers/components/bob/form.tsx
@@ -167,7 +167,7 @@ export function BobForm({
           />
           <PinField
             label="Instance ID"
-            hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping for outbound API calls."
+            hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping; Bob 2.x applies it in terminal (TUI) sessions only."
             error={errors.agentId?.message}
             register={register("agentId")}
           />
@@ -178,15 +178,15 @@ export function BobForm({
             register={register("teamId")}
           />
           <PinField
-            label="Max coins"
-            hint="BOB_MAX_COINS → --max-coins. Budget cap; Bob exits when exceeded."
+            label="Max cost"
+            hint="BOB_MAX_COINS → --max-cost. Per-task cost cap; Bob stops the task when exceeded."
             placeholder="(no cap)"
             error={errors.maxCoins?.message}
             register={register("maxCoins")}
           />
           <PinField
-            label="Chat mode"
-            hint={`BOB_CHAT_MODE → --chat-mode. One of: ${BOB_CHAT_MODES.join(", ")}.`}
+            label="Mode"
+            hint={`BOB_CHAT_MODE → --mode. One of: ${BOB_CHAT_MODES.join(", ")}.`}
             placeholder="(Bob default)"
             list="bob-chat-modes"
             error={errors.chatMode?.message}

--- a/packages/ui/src/modules/providers/components/bob/form.tsx
+++ b/packages/ui/src/modules/providers/components/bob/form.tsx
@@ -20,7 +20,7 @@ const bobCredentialSchema = z
     model: z.string(),
     agentId: z.string(),
     teamId: z.string(),
-    maxCoins: z.string(),
+    maxCost: z.string(),
     chatMode: z.string(),
   })
   .superRefine((data, ctx) => {
@@ -31,13 +31,10 @@ const bobCredentialSchema = z
         message: "Required",
       });
     }
-    if (
-      data.maxCoins.trim() !== "" &&
-      !/^[1-9]\d*$/.test(data.maxCoins.trim())
-    ) {
+    if (data.maxCost.trim() !== "" && !/^[1-9]\d*$/.test(data.maxCost.trim())) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        path: ["maxCoins"],
+        path: ["maxCost"],
         message: "Must be a positive integer",
       });
     }
@@ -68,7 +65,7 @@ export function BobForm({
   onCancel?: () => void;
 }) {
   const pins = initialPins ?? {};
-  const { register, handleSubmit, watch, formState } = useForm<FormValues>({
+  const { register, handleSubmit, formState } = useForm<FormValues>({
     resolver: zodResolver(bobCredentialSchema),
     mode: "onChange",
     defaultValues: {
@@ -76,7 +73,7 @@ export function BobForm({
       model: pins.model ?? "",
       agentId: pins.agentId ?? "",
       teamId: pins.teamId ?? "",
-      maxCoins: pins.maxCoins ?? "",
+      maxCost: pins.maxCost ?? "",
       chatMode: pins.chatMode ?? "",
     },
   });
@@ -87,8 +84,10 @@ export function BobForm({
   );
 
   const isEdit = variant === "edit";
+  // The empty-credential case is conveyed by the disabled submit, so the schema's
+  // one issue on `value` needs no message rendered under the field. Add rendering
+  // here if a value check ever fails for a reason the button can't express.
   const submitDisabled = isSubmitting || !isValid;
-  const value = watch("value");
 
   const onSubmit = handleSubmit(async (values) => {
     await onSave({
@@ -97,7 +96,7 @@ export function BobForm({
         model: values.model.trim() || undefined,
         agentId: values.agentId.trim() || undefined,
         teamId: values.teamId.trim() || undefined,
-        maxCoins: values.maxCoins.trim() || undefined,
+        maxCost: values.maxCost.trim() || undefined,
         chatMode: values.chatMode.trim() || undefined,
       },
     });
@@ -139,14 +138,6 @@ export function BobForm({
         </Button>
       </div>
 
-      {errors.value &&
-        value.length > 0 &&
-        errors.value.message !== "Required" && (
-          <div className="text-xs font-medium text-destructive">
-            {errors.value.message}
-          </div>
-        )}
-
       <DisclosureToggle
         open={advancedOpen}
         onToggle={() => setAdvancedOpen((o) => !o)}
@@ -181,8 +172,8 @@ export function BobForm({
             label="Max cost"
             hint="BOB_MAX_COINS → --max-cost. Per-task cost cap; Bob stops the task when exceeded."
             placeholder="(no cap)"
-            error={errors.maxCoins?.message}
-            register={register("maxCoins")}
+            error={errors.maxCost?.message}
+            register={register("maxCost")}
           />
           <PinField
             label="Mode"

--- a/packages/ui/src/modules/providers/components/bob/form.tsx
+++ b/packages/ui/src/modules/providers/components/bob/form.tsx
@@ -167,7 +167,7 @@ export function BobForm({
           />
           <PinField
             label="Instance ID"
-            hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping; Bob 2.x applies it in terminal (TUI) sessions only."
+            hint="BOB_INSTANCE_ID → --instance-id. IBM tenant scoping; applies to terminal (TUI) sessions, chat sessions ignore it."
             error={errors.agentId?.message}
             register={register("agentId")}
           />

--- a/packages/ui/src/modules/providers/components/provider-connect-dialog.tsx
+++ b/packages/ui/src/modules/providers/components/provider-connect-dialog.tsx
@@ -146,7 +146,7 @@ function bobConfigInputs(pins: BobModelPins): Record<string, string> {
   if (pins.model) out.model = pins.model;
   if (pins.agentId) out.instanceId = pins.agentId;
   if (pins.teamId) out.teamId = pins.teamId;
-  if (pins.maxCoins) out.maxCoins = pins.maxCoins;
+  if (pins.maxCost) out.maxCost = pins.maxCost;
   if (pins.chatMode) out.chatMode = pins.chatMode;
   return out;
 }

--- a/packages/ui/src/modules/providers/components/provider-item.ts
+++ b/packages/ui/src/modules/providers/components/provider-item.ts
@@ -33,7 +33,7 @@ export function bobPinsFromConnection(conn: ConnectionView): BobModelPins {
     model: env.get("BOB_SHELL_MODEL"),
     agentId: env.get("BOB_INSTANCE_ID"),
     teamId: env.get("BOB_TEAM_ID"),
-    maxCoins: env.get("BOB_MAX_COINS"),
+    maxCost: env.get("BOB_MAX_COINS"),
     chatMode: chatMode ? normalizeBobChatMode(chatMode) : chatMode,
   };
 }

--- a/packages/ui/src/modules/providers/components/provider-item.ts
+++ b/packages/ui/src/modules/providers/components/provider-item.ts
@@ -1,4 +1,5 @@
 import type { ConnectionView } from "api-server-api";
+import { normalizeBobChatMode } from "api-server-api";
 
 import type { BobModelPins } from "../../../types.js";
 
@@ -24,11 +25,15 @@ export function bobPinsFromConnection(conn: ConnectionView): BobModelPins {
       .filter((c): c is Extract<typeof c, { kind: "env" }> => c.kind === "env")
       .map((c) => [c.name, c.placeholder] as const),
   );
+  // A pre-2.0 secret can pin a mode 2.0 merged away; normalize on the way out so
+  // the edit form shows (and validates) a mode that still exists, instead of
+  // going invalid at mount over a field the user never touched.
+  const chatMode = env.get("BOB_CHAT_MODE");
   return {
     model: env.get("BOB_SHELL_MODEL"),
     agentId: env.get("BOB_INSTANCE_ID"),
     teamId: env.get("BOB_TEAM_ID"),
     maxCoins: env.get("BOB_MAX_COINS"),
-    chatMode: env.get("BOB_CHAT_MODE"),
+    chatMode: chatMode ? normalizeBobChatMode(chatMode) : chatMode,
   };
 }

--- a/packages/ui/src/modules/providers/components/provider-item.ts
+++ b/packages/ui/src/modules/providers/components/provider-item.ts
@@ -19,7 +19,11 @@ export function providerRef(item: ProviderItem): ProviderRef {
 
 // Bob's config inputs ride as `env` contributions whose placeholder holds the
 // (non-secret) value, keyed by the same env names the legacy pins use.
-export function bobPinsFromConnection(conn: ConnectionView): BobModelPins {
+// Takes only what it reads, so a caller (or a test) needs nothing but the
+// contributions — no stand-in for the rest of a ConnectionView.
+export function bobPinsFromConnection(
+  conn: Pick<ConnectionView, "contributions">,
+): BobModelPins {
   const env = new Map(
     conn.contributions
       .filter((c): c is Extract<typeof c, { kind: "env" }> => c.kind === "env")


### PR DESCRIPTION
## Summary

Bob Shell 2.0 ([changelog](https://bob.ibm.com/docs/shell/changelog)) removed the `--experimental-acp` mode our integration was built on, so this is a rewrite of the integration layer rather than a version bump. Three follow-up commits fix breakage found while verifying the rewrite against a live agent and in review.

### What changed in Bob 2.0 (relevant to us)

- CLI moved to subcommands (`bob chat` / `bob run` / `bob mcp`); `--experimental-acp`, `--yolo`, `--auth-method`, `--chat-mode` and `--max-coins` are gone
- headless surface is now `bob run --format stream-json` with native `--resume <task-id>`; the prompt is positional
- task history moved from per-chat JSON files to SQLite (`~/.bob/db/bob.db`)
- approvals moved from CLI flags to `~/.bob/settings/settings.json`
- chat modes `code`/`advanced` merged into `agent`
- instructions come from `<workspace>/AGENTS.md` and `.bob/rules[-<mode>]/`; the `system-defaults.json` + `context.fileName` lookup is gone
- remote MCP servers are keyed `url` + `transportType`; 1.x's `httpUrl` is not read
- `--instance-id` exists only on `bob chat`, not `bob run`

### Commits

**1. `feat(bob): update Bob Shell to 2.0`**

- **bob-acp-shim.mjs** — rewritten. The shim is now itself the ACP agent: one `bob run --format stream-json` per prompt turn, events translated to `session/update` frames (`isReasoning` → thought chunks, `tool_use`/`tool_result` → tool_call frames). `session/list`/`session/load` are served from the task DB; resume is native (no transcript re-injection). The sessionId↔taskId binding is learned from `result.stats.task_id` and persisted on the PVC.
- **Settings posture** — the shim merge-writes license consent, `autoApprovalEnabled`, all permission groups and a wildcard `execute_command` allowlist: the 2.x equivalent of 1.x `--yolo`. Applies to the TUI too (2.0 has no per-surface approval config), so terminal sessions now auto-approve — the trust boundary remains the platform's Envoy gateway + K8s isolation (ADR-033/038).
- **Dockerfile** — bobshell 2.0.0 (+ new SHA256); platform instructions ride `.bob/rules/platform.md`.
- **harness scripts / provider catalog / UI form** — new flags (`--mode`, `--max-cost`, `--accept-license`); `BOB_CHAT_MODES` → `agent/plan/ask`, with legacy `code`/`advanced` values pinned on existing secrets normalized onto `agent`.

Credential injection is untouched: the host (`api.us-east.bob.ibm.com`), the `Apikey` scheme and the `?key=` twin-secret all still apply; `BOBSHELL_API_KEY` is a supported alias of the new `BOB_API_KEY`.

**2. `fix(bob): re-assert platform instructions on agents upgraded to 2.0`**

`$HOME` is seeded from the image only on first boot (the init script's `.initialized` guard), so an agent created before the 2.0 layout never receives `.bob/rules/platform.md`. The stale `~/.bob/AGENTS.md` such a PVC still carries is not a path 2.0 reads (`AGENTS.md` is read from the workspace root), leaving the agent with **no platform instructions at all**. `ensureRules()` re-links it on every start, sharing the bootstrap `harness-terminal` already invokes via `--settings-only`; falls back to a copy where `$HOME` is unprivileged virtiofs and never fails the boot.

**3. `fix(bob): write MCP entries in the schema Bob 2.0 reads`**

The manifest put the server URL under `httpUrl`. 2.0 does not read that key, so the entry loaded with an empty URL and `platform-outbound` never connected — the agent had none of its `mcp__platform-outbound__*` tools. `transportType` is load-bearing, not cosmetic: absent it `bob mcp list` reports the server as sse, and SSE 400s against the platform's streamable endpoint. The mcp-entry driver could express neither shape, so it gains an optional `extraFields` merged over each entry.

**4. `fix(bob): drop the replay gate — bob run --resume does not replay history`**

The rewrite assumed `--resume` re-emits the task's stored messages before the new turn and gated the stream until the prompt echo, with the first assistant chunk as a fallback. Measured against two live tasks (one carrying two assistant turns and three tool messages), nothing is replayed — the stream opens at the echo. The assumption came from the fake `bob` used to test the rewrite, which emitted an invented replay. The gate was not inert: `replayDone` starts false on every resumed turn, so a turn opening with a tool call lost its chip whenever the echo did not match `promptText` byte-for-byte (measured: 0 → 1 `tool_call` frames). Also dropped two spots leaning on `tasks.directory`, which 2.0 always stores as `""`.

**5. `fix(bob): keep a pre-2.0 pinned mode editable, close the extraFields shape`**

Narrowing `BOB_CHAT_MODES` left the provider dialog rejecting a value every other layer tolerates: a secret pinned to `code`/`advanced` disabled Save at mount, blocking credential rotation. `normalizeBobChatMode()` gives the legacy mapping one home in the contract package and both read-back paths normalize through it, while fresh input stays strict. Plus: `extraFields` can no longer restate the keys the driver builds (`type`, `url`, `headers`, the active `urlKey` are reserved at parse time), the README lost the replay paragraph commit 4 invalidated, and the catalog's mode label was aligned with the form's.

**6. `refactor(bob): settle the coins/cost vocabulary, drop a dead error branch`**

Review follow-ups. 2.0 renamed the concept coins → cost and the labels moved with it, so the identifiers follow: `BobModelPins.maxCost`, the catalog `inputName`, the form field — while `BOB_MAX_COINS` stays the wire name, pinned on pre-rename secrets. Safe for stored connections: `inputName` is only matched against the template spec in-flight, so nothing persists under it. Separately, the form's credential-error branch could never render (the schema's only `value` issue carries the exact message the branch excluded); deleting it drops a dead path and its coupling to a display string, and takes the `watch("value")` subscription with it.

**7. `fix(bob): reserve only the keys a dialect builds, allow a sub-unit cost cap`**

Review follow-ups. The reserved-key guard was a static list, so a `urlKey` dialect — which builds `[urlKey]`, never `type`/`url` — rejected `type` with a message claiming the driver builds it; reserved keys now come from the branch in play. `--max-cost` is money, not a coin count (`MaxCostReachedError` carries it as a plain number, and an observed task settled at ~0.10), so the integer-only pattern could not express a cap below 1 — the catalog pattern and the form refinement now take a positive decimal. `dam connection connect --help` advertised `--config chatMode=code`, which the narrowed enum rejects; the example now uses `agent`.

## Testing

**Automated — committed, runs in CI.** `tsc` + lint + format clean across the five touched packages; agent-runtime 221, api-server 835, ui 246 unit tests pass. New cases cover the mcp-entry driver (`extraFields` merge, reserved-key rejection, per-branch reserving) and legacy chat-mode normalization.

**Manual — not committed.** Everything below was run by hand against the real 2.0 binary and the local k3s cluster. No test in this diff guards it; see Known gaps.

- In-cluster on a live agent with a real Bob credential: runs 2.0.0; the MCP fix confirmed end-to-end (the agent calls `list_schedules`, the platform MCP server answers `status: success`); and a follow-up prompt into a loaded chat emits only the live answer, with `session/load` rendering the stored conversation separately.
- `--resume` measured on two stored tasks, one carrying two assistant turns and three tool messages: the stream opens at the new prompt's echo and replays nothing. This is the evidence commit 4 rests on.
- The dropped gate: an ad-hoc stdio harness driving the shim against a stubbed `bob` took a resumed turn's opening tool call from 0 → 1 `tool_call`/`tool_call_update` frames once the gate was gone.
- Rules fix against a PVC whose `.initialized` predates the change (so image seeding provably did not run), plus container runs for idempotency and for leaving user-authored rule files untouched.
- MCP schema derived from what `bob mcp add -t http` writes, then each candidate shape checked through `bob mcp list`.
- Cost-cap pattern checked against both call sites — the UI's unanchored `new RegExp`, and the server wrapping it in `^(?:…)$`.

## Known gaps (not addressed here)

- **A driver-shape change does not reach existing agents.** The runtime skips dispatch when the contribution hash is unchanged, and commit 3 changes only what the driver writes, not the contributions — so on a template upgrade an existing agent keeps the old `mcp.json` and stays without MCP tools. Cleared `runtime-state.json` by hand to verify in-cluster. A fix (force one dispatch per pod boot; the drivers are declarative and idempotent) touches core runtime behaviour for every agent and is deliberately left out of this PR. **This is the one gap worth settling before a release.**
- **Sessions created under 1.x disappear from the sidebar.** They live in `~/.bob/tmp/<hash>/chats/`, the new shim reads only `bob.db`, and 2.0 ships no chat importer. New sessions are unaffected.
- `urlKey` in the mcp-entry driver has no in-tree consumer since commit 3; kept as a dialect knob (and now covered by the reserved-key check) rather than removed here.
- **The shim has no automated coverage.** `packages/agents/bob` is not a JS workspace package (no `package.json`, no vitest), so the stream-json → `session/update` translation, the task-DB reads and the `--resume` contract rest on the manual runs above — nothing guards a reintroduced replay gate. A harness needs test infrastructure for the agent-image packages, which is out of scope here.

