### PR TITLE
fix(approvals,channels): refuse unattended egress instead of stalling a channel turn

### DIFF
--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -23,7 +23,7 @@ Channels split along a structural axis that has real consequences for secrets an
 
 The binding itself is the authorization: anyone the messenger admits to the conversation drives the Agent under the Agent's own credentials. There is no per-person access mode, no identity link required to drive a turn, and no allow-list. Every turn relays single-track to the main agent pod; the **binding owner's** Terms-of-Use acceptance gates each turn (the terms bind the party whose credentials run it, not the member who typed); the security log records each allow with basis _place_ and the sender's Slack user id; and the prompt text is speaker-labelled with the sender's Slack mention, so a multi-speaker session stays attributable inside the conversation itself.
 
-Telegram is structurally identical — with no workspace to anchor per-user identity, consent attaches to the conversation and everyone in the bound chat drives the Agent. The two messengers behave the same.
+Telegram is structurally identical — with no workspace to anchor per-user identity, consent attaches to the conversation and everyone in the bound chat drives the Agent.
 
 #### Ambient mode
 
@@ -166,7 +166,7 @@ sequenceDiagram
 
 A few observations the diagram glosses over:
 
-- **The gates are the binding check plus the binding owner's Terms-of-Use acceptance** — no sender identity is resolved. Both messengers behave identically here.
+- **The gates are the binding check plus the binding owner's Terms-of-Use acceptance** — no sender identity is resolved. Both messengers behave identically here. An unallowed host is refused, not held ([egress](security-and-credentials.md)).
 - **An undecodable attachment is withheld, not forwarded.** An inbound image becomes prompt content only when its bytes are a format the harness decodes: the sniffed type outranks the messenger's label, and a label claiming no format is still sniffed. Handed anything else, a harness substitutes an internal error for the picture and the agent reports that as its answer. So what was withheld is named to the sender — separating a format nothing decodes from a download that returned a page instead of the file, the shape a missing permission takes — and to the agent in its prompt, so it never answers blind about a picture it did not receive.
 - **Wake is implicit.** The relay step is the same `ACP relay → wake-if-hibernated → forward` path used by the UI. Channels do not call lifecycle endpoints directly; routing an ACP frame is what wakes the pod ([agent-lifecycle](agent-lifecycle.md), §Wake).
 - **Wake failures are surfaced in human terms.** A cold start announces itself to the Slack sender (requester-only notice); a wake that misses its budget while the pods are still progressing posts a still-starting note and waits one more window before answering, so a healthy-but-slow start never loses the turn. A hard failure (pod crash, bad image, a wedged gateway, reconcile error) replies with copy derived from the classified wake-failure cause — never the internal error string, and never raw controller messages; a cause the platform is itself repairing still invites a retry. Telegram replies with the same copy on wake failures (no early notice, no extended wait).

--- a/docs/architecture/channels.md
+++ b/docs/architecture/channels.md
@@ -1,6 +1,6 @@
 # Channels
 
-Last verified: 2026-08-07
+Last verified: 2026-08-10
 
 ## Overview
 

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -530,6 +530,26 @@ header are gone.
 The HTTP filter on TLS-terminated chains sees method/path; the network
 filter on the catch-all chain sees SNI only.
 
+**Unattended requests are refused, not held.** Holding is only worth
+doing where a verdict can be made. A turn driven from a messenger
+([channels](channels.md)) cannot produce one — the owner is not
+necessarily present, and the conversation's other members are not the
+owner — so a hold raised by such a turn would occupy the entire window
+and deny anyway, with the turn silent throughout. So when the gate sees
+a channel turn open on the agent and no interactive session attached to
+answer for it, it records the request and denies at once. The record is
+the point: it stays actionable in the inbox, a permanent verdict there
+writes the rule the agent's next attempt consumes, and retries reuse
+that one row instead of filing a copy each time. No in-session prompt
+is published on this path — the only consumers are the relay clients
+whose absence defines it. Both signals are read across api-server
+replicas (the replica relaying a turn is rarely the one a Check lands
+on) and fail toward *attended*, so losing them degrades to the ordinary
+hold rather than to silent denial. An attached browser or CLI session
+means someone can decide, so a channel turn running alongside one holds
+as usual; and an agent whose rules allow everything never reaches this
+path, because nothing it requests is unmatched.
+
 **Egress Aliasing.** An Invocation target has no egress identity of its
 own: before any decision, the gate resolves the calling agent to its
 driver — recursively for chained Invocations, up to the root non-target
@@ -552,9 +572,11 @@ Binding a conversation surface — a Slack channel/DM or a Telegram
 chat — lends the Agent, credentials included, to everyone the
 messenger admits there ([channels](channels.md)). Every channel turn
 relays to the main agent pod and runs under the Agent's own
-credential set, gated by the owner's HITL rules and egress rules
-exactly like any other turn; no per-speaker credential selection
-happens. The binding owner's Terms-of-Use acceptance gates each turn
+credential set, gated by the owner's egress rules exactly like any
+other turn; no per-speaker credential selection happens. What such a
+turn cannot do is raise a *hold* — the decision has nowhere to be made
+from a messenger, so an unmatched request is refused rather than
+waited on (above). The binding owner's Terms-of-Use acceptance gates each turn
 — the terms bind the party whose credentials run it — and the
 security log attributes the allow to the messenger-native sender id
 with basis *place*.

--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -1,6 +1,6 @@
 # Security and credentials
 
-Last verified: 2026-08-07
+Last verified: 2026-08-10
 
 ## Overview
 

--- a/packages/api-server/src/__tests__/helpers/turn-attendance.ts
+++ b/packages/api-server/src/__tests__/helpers/turn-attendance.ts
@@ -1,0 +1,10 @@
+import type { ChannelTurnAttendance } from "../../core/turn-attendance.js";
+
+/** Inert channel-turn attendance for the many worker tests that don't exercise
+ *  the egress gate. Passed explicitly rather than defaulted on the worker: the
+ *  real dependency is required there, so a dropped wiring is a type error
+ *  instead of a silently reinstated approval stall. Tests that assert on the
+ *  marker build their own recording stub. */
+export function stubTurnAttendance(): ChannelTurnAttendance {
+  return { openChannelTurn: () => () => {} };
+}

--- a/packages/api-server/src/__tests__/unit/ext-authz-gate.test.ts
+++ b/packages/api-server/src/__tests__/unit/ext-authz-gate.test.ts
@@ -127,6 +127,13 @@ const identityResolver = {
 
 const noMatchRules = { match: async () => null };
 
+/** No channel turn in flight — a hold has somewhere to land, so the gate waits.
+ *  The default for every case that isn't about channel origin. */
+const attended = {
+  hasOpenChannelTurn: async () => false,
+  hasInteractiveSession: async () => false,
+};
+
 /** Drain microtasks so all internal awaits inside `gateRequest` settle. */
 async function flushMicrotasks(): Promise<void> {
   for (let i = 0; i < 20; i++) await Promise.resolve();
@@ -146,6 +153,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: { match: async () => ({ verdict: "allow" }) },
       holdSeconds: 30,
@@ -170,6 +178,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: noMatchRules,
       holdSeconds: 30,
@@ -193,6 +202,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: noMatchRules,
       holdSeconds: 30,
@@ -227,6 +237,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: noMatchRules,
       holdSeconds: 30,
@@ -257,6 +268,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: noMatchRules,
       holdSeconds: 30,
@@ -301,6 +313,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: { match: ruleMatch },
       holdSeconds: 30,
@@ -326,6 +339,7 @@ describe("ext-authz gate", () => {
     const gate = createExtAuthzGate({
       repo: repo.repo,
       bus: bus.bus,
+      attendance: attended,
       identityResolver,
       ruleMatcher: noMatchRules,
       holdSeconds: 30,
@@ -340,5 +354,152 @@ describe("ext-authz gate", () => {
     });
 
     expect(verdict).toBe("deny");
+  });
+
+  describe("unattended channel turns", () => {
+    const unattended = {
+      hasOpenChannelTurn: async () => true,
+      hasInteractiveSession: async () => false,
+    };
+
+    it("denies at once instead of holding, and records the row for the inbox", async () => {
+      const repo = makeFakeRepo();
+      const bus = makeFakeBus();
+      const gate = createExtAuthzGate({
+        repo: repo.repo,
+        bus: bus.bus,
+        attendance: unattended,
+        identityResolver,
+        ruleMatcher: noMatchRules,
+        holdSeconds: 1800,
+        platformAllowedHosts: [],
+      });
+
+      // No timer advance: a held call would still be pending here.
+      const verdict = await gate.gateRequest({
+        agentId: "inst-1",
+        host: "h",
+        method: "GET",
+        path: "/p",
+      });
+
+      expect(verdict).toBe("deny");
+      // The row is what the owner approves later, so it must exist and stay
+      // actionable rather than being expired along with the refusal.
+      expect(repo.inserts).toBe(1);
+      expect(repo.rows[0].status).toBe("pending");
+      expect(repo.expirePendingCalls).toHaveLength(0);
+    });
+
+    it("publishes no in-session prompt — nothing is attached to consume it", async () => {
+      const repo = makeFakeRepo();
+      const bus = makeFakeBus();
+      const gate = createExtAuthzGate({
+        repo: repo.repo,
+        bus: bus.bus,
+        attendance: unattended,
+        identityResolver,
+        ruleMatcher: noMatchRules,
+        holdSeconds: 1800,
+        platformAllowedHosts: [],
+      });
+
+      await gate.gateRequest({
+        agentId: "inst-1",
+        host: "h",
+        method: "GET",
+        path: "/p",
+      });
+
+      expect(bus.publishes).toHaveLength(0);
+    });
+
+    it("reuses one row across retries so the inbox gets a single entry", async () => {
+      const repo = makeFakeRepo();
+      const bus = makeFakeBus();
+      const gate = createExtAuthzGate({
+        repo: repo.repo,
+        bus: bus.bus,
+        attendance: unattended,
+        identityResolver,
+        ruleMatcher: noMatchRules,
+        holdSeconds: 1800,
+        platformAllowedHosts: [],
+      });
+
+      const request = {
+        agentId: "inst-1",
+        host: "h",
+        method: "GET",
+        path: "/p",
+      };
+      expect(await gate.gateRequest(request)).toBe("deny");
+      expect(await gate.gateRequest(request)).toBe("deny");
+      expect(await gate.gateRequest(request)).toBe("deny");
+
+      expect(repo.inserts).toBe(1);
+    });
+
+    it("holds as usual when an interactive session is attached alongside", async () => {
+      const repo = makeFakeRepo();
+      const bus = makeFakeBus();
+      const gate = createExtAuthzGate({
+        repo: repo.repo,
+        bus: bus.bus,
+        attendance: {
+          hasOpenChannelTurn: async () => true,
+          hasInteractiveSession: async () => true,
+        },
+        identityResolver,
+        ruleMatcher: noMatchRules,
+        holdSeconds: 30,
+        platformAllowedHosts: [],
+      });
+
+      const inflight = gate.gateRequest({
+        agentId: "inst-1",
+        host: "h",
+        method: "GET",
+        path: "/p",
+      });
+      await flushMicrotasks();
+
+      // Someone can decide, so the prompt goes out and the call is still open.
+      expect(bus.publishes).toHaveLength(1);
+
+      const id = repo.rows[0].id;
+      repo.resolve(id, "allow");
+      bus.fire(`approval:${id}`, "");
+
+      expect(await inflight).toBe("allow");
+    });
+
+    it("never reaches the attendance check when a rule already decides", async () => {
+      const repo = makeFakeRepo();
+      const bus = makeFakeBus();
+      const hasOpenChannelTurn = vi.fn(async () => true);
+      const gate = createExtAuthzGate({
+        repo: repo.repo,
+        bus: bus.bus,
+        attendance: {
+          hasOpenChannelTurn,
+          hasInteractiveSession: async () => false,
+        },
+        identityResolver,
+        ruleMatcher: { match: async () => ({ verdict: "allow" }) },
+        holdSeconds: 1800,
+        platformAllowedHosts: [],
+      });
+
+      expect(
+        await gate.gateRequest({
+          agentId: "inst-1",
+          host: "allowed.example",
+          method: "GET",
+          path: "/",
+        }),
+      ).toBe("allow");
+      expect(hasOpenChannelTurn).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/api-server/src/__tests__/unit/network-access-copy.test.ts
+++ b/packages/api-server/src/__tests__/unit/network-access-copy.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { channelNetworkAccessGuidance } from "../../modules/channels/infrastructure/network-access-copy.js";
+
+describe("channel network-access guidance", () => {
+  it("names where approval happens, in the install's own brand", () => {
+    const text = channelNetworkAccessGuidance("Acme");
+
+    // Both mentions are interpolated — a half-branded sentence would send the
+    // user looking for a product that isn't what they run.
+    expect(text.match(/Acme/g)).toHaveLength(2);
+    expect(text).not.toContain("undefined");
+  });
+
+  it("is a self-delimited block so it can be concatenated into any prompt", () => {
+    const text = channelNetworkAccessGuidance("Acme");
+
+    expect(text.startsWith("<network-access>")).toBe(true);
+    expect(text.trimEnd().endsWith("</network-access>")).toBe(true);
+  });
+
+  it("states the symptom, the reason, and the recovery", () => {
+    const text = channelNetworkAccessGuidance("Acme");
+
+    // The symptom the agent actually sees on the wire — without it the turn
+    // reads a refusal as the host being down.
+    expect(text).toContain("closed connection");
+    expect(text).toContain("403");
+    expect(text).toContain("cannot be approved from this conversation");
+    expect(text).toContain("already waiting");
+  });
+});

--- a/packages/api-server/src/__tests__/unit/slack-ambient.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-ambient.test.ts
@@ -4,6 +4,7 @@ import { slackThreadKey, type AgentsService } from "api-server-api";
 import type { ContentBlock } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient, SendPromptOpts } from "../../core/acp-client.js";
 import { configureLogger } from "../../core/logger.js";
 import {
@@ -78,6 +79,7 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async (sub) => opts.termsAccepted?.(sub) ?? true,
     "http://ui",
+    stubTurnAttendance(),
     (e) => events.push(e),
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-command-bind.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-command-bind.test.ts
@@ -6,6 +6,7 @@ import {
   type SlackOAuthPending,
 } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient } from "../../core/acp-client.js";
 import { configureLogger } from "../../core/logger.js";
 import { EventType, type DomainEvent } from "../../events.js";
@@ -62,6 +63,7 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     (e) => events.push(e),
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-cross-agent-history.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-cross-agent-history.test.ts
@@ -4,6 +4,7 @@ import type { AgentsService } from "api-server-api";
 import type { ContentBlock } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import {
   agentContextBlock,
   formatSlackTs,
@@ -54,6 +55,7 @@ function harness(boundChannelId = "C1") {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     () => {},
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-dm.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-dm.test.ts
@@ -7,6 +7,7 @@ import {
   type SlackOAuthPending,
 } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient } from "../../core/acp-client.js";
 import { configureLogger } from "../../core/logger.js";
 import {
@@ -68,6 +69,7 @@ function harness(opts: { binding: Binding }) {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     (e) => events.push(e),
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-inbound-images.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-inbound-images.test.ts
@@ -8,6 +8,7 @@ import {
   type SlackOAuthPending,
 } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient } from "../../core/acp-client.js";
 import { configureLogger } from "../../core/logger.js";
 import type { DomainEvent } from "../../events.js";
@@ -103,6 +104,7 @@ function harness() {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     (e) => events.push(e),
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-message-reactions.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-message-reactions.test.ts
@@ -2,6 +2,7 @@ import { createMemoryTtlStore } from "../../core/ttl-store.js";
 import { describe, it, expect } from "vitest";
 import { ChannelType, type AgentsService } from "api-server-api";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import { createChannelManager } from "../../modules/channels/services/channel-manager.js";
 import {
   createFakeSlackGateway,
@@ -66,6 +67,7 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     () => {},
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-multi-channel.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-multi-channel.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import { slackThreadKey, type AgentsService } from "api-server-api";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient, SendPromptOpts } from "../../core/acp-client.js";
 import { configureLogger } from "../../core/logger.js";
 import type { StoredChannelConfig } from "../../modules/channels/stored-channel.js";
@@ -57,6 +58,7 @@ function harness(opts?: {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     () => {},
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-outbound.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-outbound.test.ts
@@ -2,6 +2,7 @@ import { createMemoryTtlStore } from "../../core/ttl-store.js";
 import { describe, it, expect } from "vitest";
 import type { AgentsService } from "api-server-api";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import {
   createFakeSlackGateway,
   type FakeSlackChannel,
@@ -58,6 +59,7 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     () => {},
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-shared-mode.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-shared-mode.test.ts
@@ -4,6 +4,7 @@ import type { AgentsService } from "api-server-api";
 import type { ContentBlock } from "@agentclientprotocol/sdk/dist/schema/types.gen.js";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient } from "../../core/acp-client.js";
 import { configureLogger } from "../../core/logger.js";
 import {
@@ -61,6 +62,7 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async (sub) => opts.termsAccepted?.(sub) ?? true,
     "http://ui",
+    stubTurnAttendance(),
     (e) => events.push(e),
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-turn.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-turn.test.ts
@@ -19,6 +19,7 @@ import {
 import { AgentWakeTimeoutError } from "../../modules/agents/index.js";
 import type { StoredChannelConfig } from "../../modules/channels/stored-channel.js";
 import type { ChannelTurnAttendance } from "../../core/turn-attendance.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 
 const OWNER = "kc|owner-1";
 
@@ -80,8 +81,8 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    opts.attendance ?? stubTurnAttendance(),
     (e) => events.push(e),
-    opts.attendance,
   );
 
   return {

--- a/packages/api-server/src/__tests__/unit/slack-turn.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-turn.test.ts
@@ -18,6 +18,7 @@ import {
 } from "../../events.js";
 import { AgentWakeTimeoutError } from "../../modules/agents/index.js";
 import type { StoredChannelConfig } from "../../modules/channels/stored-channel.js";
+import type { ChannelTurnAttendance } from "../../core/turn-attendance.js";
 
 const OWNER = "kc|owner-1";
 
@@ -44,6 +45,7 @@ function harness(opts: {
   ensureReady?: AgentsService["ensureReady"];
   /** Currently-bound channel; a function so a test can rebind mid-turn. */
   boundChannel?: () => string;
+  attendance?: ChannelTurnAttendance;
 }) {
   const gw = createFakeSlackGateway();
   const events: DomainEvent[] = [];
@@ -79,6 +81,7 @@ function harness(opts: {
     async () => true,
     "http://ui",
     (e) => events.push(e),
+    opts.attendance,
   );
 
   return {
@@ -860,5 +863,93 @@ describe("slack reply / react tools — turns that outlive their relay", () => {
 
     for (const g of gates) g();
     await tick();
+  });
+});
+
+describe("slack turn — network-access framing and attendance", () => {
+  /** Records the open/release calls and whether the marker is held right now,
+   *  so a test can assert the window rather than just the call order. */
+  function recordingAttendance() {
+    const calls: string[] = [];
+    let open = 0;
+    return {
+      calls,
+      isOpen: () => open > 0,
+      attendance: {
+        openChannelTurn(agentId: string) {
+          calls.push(`open:${agentId}`);
+          open++;
+          let released = false;
+          return () => {
+            if (released) return;
+            released = true;
+            calls.push(`release:${agentId}`);
+            open--;
+          };
+        },
+      } satisfies ChannelTurnAttendance,
+    };
+  }
+
+  it("tells the agent an unallowed host can't be approved from the conversation", async () => {
+    let prompt = "";
+    const h = harness({
+      sendPrompt: async (p) => {
+        prompt = typeof p === "string" ? p : JSON.stringify(p);
+        return "ok";
+      },
+    });
+    await h.mention();
+    await tick();
+
+    expect(prompt).toContain("<network-access>");
+    // The three things the turn can't work out for itself: that the refusal is
+    // a permission rather than a broken host, that this conversation isn't
+    // where it's granted, and that looping on the host is not the answer.
+    expect(prompt).toContain("cannot be approved from this conversation");
+    expect(prompt).toContain("only your owner can allow a host, in DAM");
+    expect(prompt).toContain("don't retry the same host in a loop");
+  });
+
+  it("marks the agent channel-driven for the turn and releases it after", async () => {
+    const rec = recordingAttendance();
+    let openDuringTurn = false;
+    const h = harness({
+      attendance: rec.attendance,
+      sendPrompt: async () => {
+        openDuringTurn = rec.isOpen();
+        return "ok";
+      },
+    });
+    await h.mention();
+    await tick();
+
+    // The window that matters is the one the harness runs in — that is when its
+    // egress reaches the gate.
+    expect(openDuringTurn).toBe(true);
+    expect(rec.calls).toEqual(["open:agent-1", "release:agent-1"]);
+    expect(rec.isOpen()).toBe(false);
+  });
+
+  it("releases the marker when the turn fails to wake the agent", async () => {
+    const rec = recordingAttendance();
+    const h = harness({
+      attendance: rec.attendance,
+      ensureReady: async () => {
+        throw new AgentWakeTimeoutError({
+          agentId: "agent-1",
+          timeoutMs: 120_000,
+          durationMs: 120_100,
+          failure: { kind: "agent-pod-not-ready" },
+        });
+      },
+    });
+    await h.mention();
+    await tick();
+
+    // A stranded marker would keep denying this agent's egress fast long after
+    // the turn is gone.
+    expect(rec.isOpen()).toBe(false);
+    expect(rec.calls).toContain("release:agent-1");
   });
 });

--- a/packages/api-server/src/__tests__/unit/slack-user-lookup.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-user-lookup.test.ts
@@ -2,6 +2,7 @@ import { createMemoryTtlStore } from "../../core/ttl-store.js";
 import { describe, it, expect } from "vitest";
 import type { AgentsService } from "api-server-api";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import {
   createFakeSlackGateway,
   type FakeSlackGateway,
@@ -80,6 +81,7 @@ function harness(opts: {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     () => {},
   );
 

--- a/packages/api-server/src/__tests__/unit/slack-wake-failure.test.ts
+++ b/packages/api-server/src/__tests__/unit/slack-wake-failure.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import type { AgentsService } from "api-server-api";
 import { createSlackWorker } from "../../modules/channels/infrastructure/slack.js";
 import { createFakeSlackGateway } from "../../modules/channels/infrastructure/fake-slack-gateway.js";
+import { stubTurnAttendance } from "../helpers/turn-attendance.js";
 import type { AcpClient } from "../../core/acp-client.js";
 import type { DomainEvent } from "../../events.js";
 import { EventType } from "../../events.js";
@@ -53,6 +54,7 @@ function harness(ensureReady: AgentsService["ensureReady"]) {
     { name: "DAM", short: "dam" },
     async () => true,
     "http://ui",
+    stubTurnAttendance(),
     (e) => events.push(e),
   );
 

--- a/packages/api-server/src/__tests__/unit/turn-attendance.test.ts
+++ b/packages/api-server/src/__tests__/unit/turn-attendance.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from "vitest";
+import type { Redis } from "ioredis";
+import {
+  createTurnAttendance,
+  SESSION_PRESENCE_KEY_PREFIX,
+} from "../../core/turn-attendance.js";
+
+/** Minimal in-memory stand-in for the two commands the store uses, plus a
+ *  cursor-walking SCAN so the reader's pagination is exercised rather than
+ *  short-circuited by a single-page fake. */
+function makeFakeRedis(opts?: { failScan?: boolean }) {
+  const keys = new Set<string>();
+  const redis = {
+    set: vi.fn(async (key: string) => {
+      keys.add(key);
+      return "OK";
+    }),
+    del: vi.fn(async (key: string) => {
+      keys.delete(key);
+      return 1;
+    }),
+    scan: vi.fn(async (cursor: string, _m: string, pattern: string) => {
+      if (opts?.failScan) throw new Error("redis down");
+      const re = new RegExp(`^${pattern.replace("*", ".*")}$`);
+      const all = [...keys];
+      // Hand back one key per page so a match on a later page still counts.
+      const i = Number(cursor);
+      const next = i + 1 >= all.length ? "0" : String(i + 1);
+      const page = all[i] !== undefined && re.test(all[i]!) ? [all[i]!] : [];
+      return [next, page] as [string, string[]];
+    }),
+  };
+  return { redis: redis as unknown as Redis, keys, spies: redis };
+}
+
+/** Lets the fire-and-forget write chain settle. */
+async function flush(): Promise<void> {
+  for (let i = 0; i < 20; i++) await Promise.resolve();
+}
+
+describe("turn attendance", () => {
+  it("marks a channel turn open and clears it on release", async () => {
+    const { redis, keys } = makeFakeRedis();
+    const attendance = createTurnAttendance(redis);
+
+    const release = attendance.openChannelTurn("agent-1");
+    await flush();
+    expect(
+      [...keys].some((k) => k.startsWith("channel-turn:agent:agent-1:")),
+    ).toBe(true);
+
+    release();
+    await flush();
+    expect([...keys]).toHaveLength(0);
+    attendance.close();
+  });
+
+  it("keeps the marker until the last of several concurrent turns ends", async () => {
+    const { redis, keys } = makeFakeRedis();
+    const attendance = createTurnAttendance(redis);
+
+    const first = attendance.openChannelTurn("agent-1");
+    const second = attendance.openChannelTurn("agent-1");
+    await flush();
+
+    first();
+    await flush();
+    expect(keys.size).toBe(1);
+
+    second();
+    await flush();
+    expect(keys.size).toBe(0);
+    attendance.close();
+  });
+
+  it("ignores a repeated release so one turn can't drop another's marker", async () => {
+    const { redis, keys } = makeFakeRedis();
+    const attendance = createTurnAttendance(redis);
+
+    const first = attendance.openChannelTurn("agent-1");
+    const second = attendance.openChannelTurn("agent-1");
+    await flush();
+
+    first();
+    first();
+    first();
+    await flush();
+    expect(keys.size).toBe(1);
+
+    second();
+    await flush();
+    expect(keys.size).toBe(0);
+    attendance.close();
+  });
+
+  it("sees a turn held by another replica", async () => {
+    const { redis, keys } = makeFakeRedis();
+    const attendance = createTurnAttendance(redis);
+
+    // Written by a different replica id than this instance's.
+    keys.add("channel-turn:agent:agent-1:other-replica");
+
+    expect(await attendance.hasOpenChannelTurn("agent-1")).toBe(true);
+    expect(await attendance.hasOpenChannelTurn("agent-2")).toBe(false);
+    attendance.close();
+  });
+
+  it("reads its own open turn without a round trip", async () => {
+    const { redis, spies } = makeFakeRedis();
+    const attendance = createTurnAttendance(redis);
+
+    attendance.openChannelTurn("agent-1");
+    expect(await attendance.hasOpenChannelTurn("agent-1")).toBe(true);
+    expect(spies.scan).not.toHaveBeenCalled();
+    attendance.close();
+  });
+
+  it("reports an interactive session from the relays' presence keys", async () => {
+    const { redis, keys } = makeFakeRedis();
+    const attendance = createTurnAttendance(redis);
+
+    expect(await attendance.hasInteractiveSession("agent-1")).toBe(false);
+    keys.add(`${SESSION_PRESENCE_KEY_PREFIX}agent-1:some-replica`);
+    expect(await attendance.hasInteractiveSession("agent-1")).toBe(true);
+    attendance.close();
+  });
+
+  it("fails toward holding when Redis is unreachable", async () => {
+    const { redis } = makeFakeRedis({ failScan: true });
+    const attendance = createTurnAttendance(redis);
+
+    // Both answers must push the gate onto the ordinary hold path rather than
+    // a fast deny: no channel turn known, and assume someone is watching.
+    expect(await attendance.hasOpenChannelTurn("agent-1")).toBe(false);
+    expect(await attendance.hasInteractiveSession("agent-1")).toBe(true);
+    attendance.close();
+  });
+});

--- a/packages/api-server/src/__tests__/unit/turn-attendance.test.ts
+++ b/packages/api-server/src/__tests__/unit/turn-attendance.test.ts
@@ -21,12 +21,18 @@ function makeFakeRedis(opts?: { failScan?: boolean }) {
     }),
     scan: vi.fn(async (cursor: string, _m: string, pattern: string) => {
       if (opts?.failScan) throw new Error("redis down");
-      const re = new RegExp(`^${pattern.replace("*", ".*")}$`);
+      // Every pattern the store issues is a literal prefix plus one trailing
+      // "*", so matching is a prefix test — no glob-to-regex translation to get
+      // subtly wrong. Reject anything else rather than quietly mismatching it.
+      if (!pattern.endsWith("*") || pattern.slice(0, -1).includes("*"))
+        throw new Error(`fake redis: unsupported scan pattern ${pattern}`);
+      const prefix = pattern.slice(0, -1);
       const all = [...keys];
       // Hand back one key per page so a match on a later page still counts.
       const i = Number(cursor);
       const next = i + 1 >= all.length ? "0" : String(i + 1);
-      const page = all[i] !== undefined && re.test(all[i]!) ? [all[i]!] : [];
+      const page =
+        all[i] !== undefined && all[i]!.startsWith(prefix) ? [all[i]!] : [];
       return [next, page] as [string, string[]];
     }),
   };

--- a/packages/api-server/src/apps/api-server/session-presence.ts
+++ b/packages/api-server/src/apps/api-server/session-presence.ts
@@ -1,8 +1,11 @@
 import { randomUUID } from "node:crypto";
 import type { Redis } from "ioredis";
 import { ACTIVE_SESSION_KEY } from "../../modules/agents/infrastructure/labels.js";
+import { SESSION_PRESENCE_KEY_PREFIX } from "../../core/turn-attendance.js";
 
-const KEY_PREFIX = "presence:agent:";
+// Shared with the egress gate, which reads these keys to tell whether anyone
+// is attached to answer an approval hold.
+const KEY_PREFIX = SESSION_PRESENCE_KEY_PREFIX;
 // A replica key vanishes this long after the replica stops refreshing it —
 // crash, OOM, network partition — so a dead replica's sessions stop pinning
 // the agent awake within ~2 minutes (reconcile tick + TTL).

--- a/packages/api-server/src/core/turn-attendance.ts
+++ b/packages/api-server/src/core/turn-attendance.ts
@@ -1,0 +1,141 @@
+import { randomUUID } from "node:crypto";
+import type { Redis } from "ioredis";
+
+/** Per-replica session-presence keys (`<prefix><agentId>:<replicaId>`),
+ *  written by the ACP/terminal/SSH relays while a browser or CLI client is
+ *  attached. Declared here rather than in the relay so the egress gate can
+ *  read the same shape without depending on an app module. */
+export const SESSION_PRESENCE_KEY_PREFIX = "presence:agent:";
+
+/** Same per-replica shape for channel-driven turns, written by the Slack and
+ *  Telegram workers for the length of a turn. */
+const CHANNEL_TURN_KEY_PREFIX = "channel-turn:agent:";
+
+// Matches the session-presence heartbeat: a key vanishes this long after its
+// replica stops refreshing it, so a crashed replica stops claiming a channel
+// turn is open within ~90s rather than for the whole turn ceiling.
+const KEY_TTL_SECONDS = 90;
+const HEARTBEAT_MS = 30_000;
+
+/**
+ * Who is positioned to answer an egress approval for an agent.
+ *
+ * Two independent facts, both unions across api-server replicas — the replica
+ * relaying a channel turn is rarely the one Envoy's ext_authz Check lands on:
+ *
+ * - **an open channel turn** — a Slack or Telegram turn is driving the agent.
+ *   No verdict can be gestured from a messenger, and the conversation's other
+ *   participants aren't the owner, so a hold raised by such a turn has nobody
+ *   to answer it.
+ * - **an attached interactive session** — a browser or CLI is on the agent
+ *   over a relay, which *is* somewhere a verdict can be made.
+ *
+ * Reads fail toward "someone is attending" so a Redis blip degrades to the
+ * ordinary hold rather than silently denying an agent's egress.
+ */
+/** Writer half, consumed by the Slack and Telegram workers. */
+export interface ChannelTurnAttendance {
+  /** Marks a channel-driven turn open on the agent. Call the returned release
+   *  when the turn settles; releases are idempotent and refcounted, so
+   *  concurrent turns on one agent hold the marker until the last one ends. */
+  openChannelTurn(agentId: string): () => void;
+}
+
+export interface TurnAttendance extends ChannelTurnAttendance {
+  hasOpenChannelTurn(agentId: string): Promise<boolean>;
+  hasInteractiveSession(agentId: string): Promise<boolean>;
+  close(): void;
+}
+
+export function createTurnAttendance(redis: Redis): TurnAttendance {
+  const replicaId = randomUUID();
+  const open = new Map<string, number>();
+  const key = (agentId: string) =>
+    `${CHANNEL_TURN_KEY_PREFIX}${agentId}:${replicaId}`;
+
+  // Serialize this replica's writes per agent so a turn shorter than its own
+  // SET can't have its DEL overtaken and leave the marker stranded for a TTL.
+  const writes = new Map<string, Promise<unknown>>();
+  function chain(agentId: string, op: () => Promise<unknown>): void {
+    const prev = writes.get(agentId) ?? Promise.resolve();
+    const next = prev.then(op, op).catch(() => {});
+    writes.set(agentId, next);
+    void next.then(() => {
+      if (writes.get(agentId) === next) writes.delete(agentId);
+    });
+  }
+
+  async function anyKeyMatching(pattern: string): Promise<boolean> {
+    let cursor = "0";
+    do {
+      const [next, keys] = await redis.scan(
+        cursor,
+        "MATCH",
+        pattern,
+        "COUNT",
+        500,
+      );
+      if (keys.length > 0) return true;
+      cursor = next;
+    } while (cursor !== "0");
+    return false;
+  }
+
+  const heartbeat = setInterval(() => {
+    for (const agentId of open.keys()) {
+      chain(agentId, () => redis.set(key(agentId), "1", "EX", KEY_TTL_SECONDS));
+    }
+  }, HEARTBEAT_MS);
+  heartbeat.unref?.();
+
+  return {
+    openChannelTurn(agentId) {
+      const before = open.get(agentId) ?? 0;
+      open.set(agentId, before + 1);
+      if (before === 0) {
+        chain(agentId, () =>
+          redis.set(key(agentId), "1", "EX", KEY_TTL_SECONDS),
+        );
+      }
+
+      let released = false;
+      return () => {
+        if (released) return;
+        released = true;
+        const n = (open.get(agentId) ?? 1) - 1;
+        if (n > 0) {
+          open.set(agentId, n);
+          return;
+        }
+        open.delete(agentId);
+        chain(agentId, () => redis.del(key(agentId)));
+      };
+    },
+
+    async hasOpenChannelTurn(agentId) {
+      // This replica's own turns are authoritative without a round trip.
+      if (open.has(agentId)) return true;
+      try {
+        return await anyKeyMatching(`${CHANNEL_TURN_KEY_PREFIX}${agentId}:*`);
+      } catch {
+        // Unknown, not absent — treat as no channel turn so the hold stands.
+        return false;
+      }
+    },
+
+    async hasInteractiveSession(agentId) {
+      try {
+        return await anyKeyMatching(
+          `${SESSION_PRESENCE_KEY_PREFIX}${agentId}:*`,
+        );
+      } catch {
+        // Unknown, not absent — assume someone is watching and hold.
+        return true;
+      }
+    },
+
+    close() {
+      clearInterval(heartbeat);
+    },
+  };
+}

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -127,6 +127,7 @@ import { createRedisBus } from "./core/redis-bus.js";
 import { createBusRpc } from "./core/bus-rpc.js";
 import { createRedisBlobHandoff } from "./core/blob-handoff.js";
 import { createLeaderLease } from "./core/leader-lease.js";
+import { createTurnAttendance } from "./core/turn-attendance.js";
 import { createSubPseudonymizer } from "./core/sub-pseudonymizer.js";
 import { podBaseUrl } from "./modules/agents/infrastructure/k8s.js";
 
@@ -188,6 +189,11 @@ const sharedRedis = createBullConnection(
   config.redisUrl,
   config.redisPassword ?? undefined,
 ) as import("ioredis").Redis;
+
+// Who can answer an egress approval for an agent: the channel workers mark a
+// turn open for its duration, and the ext_authz gate reads that plus the
+// relays' session-presence keys to decide whether holding is worth anything.
+const turnAttendance = createTurnAttendance(sharedRedis);
 
 // Periodic background work runs as BullMQ job schedulers, one queue per job
 // ("periodic.<name>") — one execution per period across replicas, and a
@@ -489,6 +495,8 @@ const slackWorker = slackGatewayFactory
       { name: config.brand.name, short: config.brand.short },
       isTermsAccepted,
       config.uiBaseUrl,
+      undefined, // emit — keep the default in-process event bus
+      turnAttendance,
     )
   : undefined;
 
@@ -517,6 +525,8 @@ const telegramWorker =
         isTermsAccepted,
         uiBaseUrl: config.uiBaseUrl,
         brandShort: config.brand.short,
+        brandName: config.brand.name,
+        attendance: turnAttendance,
       })
     : undefined;
 
@@ -608,6 +618,7 @@ const {
       return matched ? { verdict: matched.verdict } : null;
     },
   },
+  attendance: turnAttendance,
   wrapperFrameSender,
   holdSeconds: config.approvalHoldSeconds,
   // The presigned link is the per-request authorization for the store, so
@@ -953,6 +964,7 @@ async function shutdown() {
   await runtimeDelivery.queue.close();
   await schedulesBoot.close();
   await redisBus.close();
+  turnAttendance.close();
   await sharedRedis.quit().catch(() => {});
   await sql.end();
   extAuthzGrpcServer.tryShutdown(() => {});

--- a/packages/api-server/src/index.ts
+++ b/packages/api-server/src/index.ts
@@ -495,7 +495,6 @@ const slackWorker = slackGatewayFactory
       { name: config.brand.name, short: config.brand.short },
       isTermsAccepted,
       config.uiBaseUrl,
-      undefined, // emit — keep the default in-process event bus
       turnAttendance,
     )
   : undefined;

--- a/packages/api-server/src/modules/approvals/compose.ts
+++ b/packages/api-server/src/modules/approvals/compose.ts
@@ -13,6 +13,7 @@ import {
 } from "./services/approvals-relay-service.js";
 import {
   createExtAuthzGate,
+  type EgressAttendance,
   type EgressRuleMatcher,
   type ExtAuthzGate,
   type AgentIdentityResolver,
@@ -69,6 +70,7 @@ export interface ComposeApprovalsSystemDeps {
   bus: RedisBus;
   identityResolver: AgentIdentityResolver;
   ruleMatcher: EgressRuleMatcher;
+  attendance: EgressAttendance;
   wrapperFrameSender: WrapperFrameSender;
   holdSeconds: number;
   platformAllowedHosts: readonly string[];
@@ -91,6 +93,7 @@ export function composeApprovalsSystem(deps: ComposeApprovalsSystemDeps): {
     bus: deps.bus,
     identityResolver: deps.identityResolver,
     ruleMatcher: deps.ruleMatcher,
+    attendance: deps.attendance,
     holdSeconds: deps.holdSeconds,
     platformAllowedHosts: deps.platformAllowedHosts,
   });
@@ -126,6 +129,7 @@ export type {
   ExtAuthzGate,
   ExtAuthzGateInput,
   ExtAuthzVerdict,
+  EgressAttendance,
   EgressRuleMatcher,
   AgentIdentityResolver,
 } from "./services/ext-authz-gate.js";

--- a/packages/api-server/src/modules/approvals/services/ext-authz-gate.ts
+++ b/packages/api-server/src/modules/approvals/services/ext-authz-gate.ts
@@ -53,11 +53,20 @@ export interface EgressRuleMatcher {
   ): Promise<{ verdict: ExtAuthzVerdict } | null>;
 }
 
+/** Whether anyone is positioned to answer a hold on this agent. Both facts are
+ *  cross-replica reads and must fail toward "attended" so an infrastructure
+ *  blip degrades to the ordinary hold — see `core/turn-attendance.ts`. */
+export interface EgressAttendance {
+  hasOpenChannelTurn(agentId: string): Promise<boolean>;
+  hasInteractiveSession(agentId: string): Promise<boolean>;
+}
+
 export interface CreateExtAuthzGateDeps {
   repo: ApprovalsRepository;
   bus: RedisBus;
   identityResolver: AgentIdentityResolver;
   ruleMatcher: EgressRuleMatcher;
+  attendance: EgressAttendance;
   /** Bounded synchronous hold; the durable pending row outlives this. */
   holdSeconds: number;
   /** Bare hostnames of platform-provided upstreams (the object store) that
@@ -133,6 +142,18 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
         return matched.verdict;
       }
 
+      // Holding is only worth anything if a human can answer it. A turn driven
+      // from Slack or Telegram can't produce a verdict — the messenger offers
+      // the owner no safe way to decide, and the conversation's other members
+      // aren't the owner — so such a turn would stall for the whole window and
+      // be denied anyway. Refuse it now instead, and leave the row below for
+      // the inbox: a permanent approval there is what the agent's next attempt
+      // consumes. An attached browser or CLI session means someone *can*
+      // decide, so the hold stands even while a channel turn runs alongside.
+      const unattended =
+        (await deps.attendance.hasOpenChannelTurn(identity.agentId)) &&
+        !(await deps.attendance.hasInteractiveSession(identity.agentId));
+
       // Dedupe retried holds: when the agent's CLI retries (Envoy timeout,
       // network blip, api-server restart mid-hold) we want one inbox row
       // per logical decision, not one per retry. Reuse any active pending
@@ -147,6 +168,10 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
       });
       const pendingId = existing?.id ?? randomUUID();
       if (!existing) {
+        // Recorded pending, not expired, on both paths: the row is what the
+        // owner acts on later, and keeping it active is also what makes the
+        // agent's retries reuse one inbox entry instead of filing a new one
+        // each time.
         await deps.repo.insertPending({
           id: pendingId,
           type: "ext_authz",
@@ -156,29 +181,53 @@ export function createExtAuthzGate(deps: CreateExtAuthzGateDeps): ExtAuthzGate {
           payload: { kind: "ext_authz", host, method, path, viaAgentId: via },
           expiresAt: new Date(Date.now() + deps.holdSeconds * 1000),
         });
-        const frame = buildExtAuthzSynthFrame({
-          approvalId: pendingId,
-          host,
-          method,
-          path,
-        });
-        // The prompt surfaces on the policy-bearing agent's channel — under
-        // aliasing that is the driver, whose inbox tray owns the decision.
-        void deps.bus.publish(injectChannelOf(identity.agentId), frame);
-        // Agent egress blocked awaiting a human verdict. correlationId ties
-        // this to the verdict line written when the hold settles (and to the
-        // approval.verdict line in approvals-service).
-        securityLog("warn", "egress.hold", {
+        if (!unattended) {
+          const frame = buildExtAuthzSynthFrame({
+            approvalId: pendingId,
+            host,
+            method,
+            path,
+          });
+          // The prompt surfaces on the policy-bearing agent's channel — under
+          // aliasing that is the driver, whose inbox tray owns the decision.
+          void deps.bus.publish(injectChannelOf(identity.agentId), frame);
+          // Agent egress blocked awaiting a human verdict. correlationId ties
+          // this to the verdict line written when the hold settles (and to the
+          // approval.verdict line in approvals-service).
+          securityLog("warn", "egress.hold", {
+            category: "egress",
+            actor: identity.ownerSub,
+            actorKind: "agent",
+            surface: "ext-authz",
+            agentId: identity.agentId,
+            target: host,
+            decision: "hold",
+            correlationId: pendingId,
+            detail: { method, path, via },
+          });
+        }
+        // Unattended: no in-session prompt is published. The only subscribers
+        // are the relay clients whose absence defines this path, and an
+        // unconsumed frame would leave the inbox row looking answerable
+        // in-session when the request has already been refused.
+      }
+
+      if (unattended) {
+        // correlationId points at the row an owner can still approve, which is
+        // what makes this deny distinguishable from a rule-based one.
+        securityLog("warn", "egress.decision", {
           category: "egress",
           actor: identity.ownerSub,
           actorKind: "agent",
           surface: "ext-authz",
           agentId: identity.agentId,
           target: host,
-          decision: "hold",
+          decision: "deny",
           correlationId: pendingId,
-          detail: { method, path, via },
+          reason: "unattended-channel-turn",
+          detail: { method, path, basis: "unattended", via },
         });
+        return "deny";
       }
 
       const { verdict, reason } = await waitForVerdict(deps, pendingId);

--- a/packages/api-server/src/modules/channels/infrastructure/network-access-copy.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/network-access-copy.ts
@@ -1,0 +1,30 @@
+/** Agent-facing framing for the one failure a channel turn cannot recover
+ *  from on its own, shared by the channel workers.
+ *
+ *  Reaching a host the owner hasn't allowed normally holds the request open
+ *  until a human decides. From a messenger nobody can: the owner isn't
+ *  necessarily present and the conversation's other members aren't the owner,
+ *  so the request is refused as soon as it is recorded. The agent only ever
+ *  sees the wire symptom of that (a closed connection, or a 403 from the
+ *  proxy), which reads like the host being down — so the turn is told what the
+ *  symptom means and what to say, rather than being left to guess or to retry
+ *  into the same refusal.
+ *
+ *  Stated on every channel turn regardless of the agent's rules: an agent
+ *  allowed everything never hits it, and the sentence is conditional, so it
+ *  costs those turns a line and nothing else. */
+export function channelNetworkAccessGuidance(brandName: string): string {
+  return [
+    "<network-access>",
+    "You can only reach hosts your owner has allowed. A request to any " +
+      "other host is refused immediately — you'll see a closed connection " +
+      "or a 403 from the proxy — and it cannot be approved from this " +
+      `conversation: only your owner can allow a host, in ${brandName}. ` +
+      "If it happens, don't retry the same host in a loop. Name the host " +
+      "you needed and why, say that the agent's owner has to allow it in " +
+      `${brandName} (the request is already waiting for them there), and ` +
+      "offer either an approach using hosts you can already reach or to " +
+      "finish the task once it's allowed.",
+    "</network-access>",
+  ].join("\n");
+}

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -1,4 +1,6 @@
 import type { TtlStore } from "../../../core/ttl-store.js";
+import type { ChannelTurnAttendance } from "../../../core/turn-attendance.js";
+import { channelNetworkAccessGuidance } from "./network-access-copy.js";
 import { match, P } from "ts-pattern";
 import {
   ambientThreadKey,
@@ -151,6 +153,7 @@ function slackTurnContract(ctx: {
         ".",
     "If a tool is deferred, load it via ToolSearch first.",
     "</how-to-respond>",
+    channelNetworkAccessGuidance(ctx.brand.name),
   ].join("\n");
 }
 
@@ -684,6 +687,11 @@ export function createSlackWorker(
   isTermsAccepted: (sub: string) => Promise<boolean>,
   uiBaseUrl: string,
   emit: (event: DomainEvent) => void = defaultEmit,
+  /** Marks the agent as driven from a channel for the length of each turn, so
+   *  the egress gate can refuse a request that would otherwise hold for a
+   *  verdict nobody in a Slack conversation can give. Defaults to a no-op for
+   *  tests that don't exercise it. */
+  attendance: ChannelTurnAttendance = { openChannelTurn: () => () => {} },
 ): SlackWorker {
   const brandShort = brand.short;
   let gateway: SlackGateway | null = null;
@@ -698,6 +706,10 @@ export function createSlackWorker(
     threadTs: string;
     eventTs: string;
     sessionId?: string;
+    /** Releases this turn's channel-turn attendance marker; set by
+     *  {@link beginTurn} and paired in {@link endTurn}, so concurrent turns on
+     *  one agent each hold their own and the marker outlives all of them. */
+    releaseAttendance?: () => void;
   };
 
   /** Turns currently driving the harness per agent. A single agent pod
@@ -743,6 +755,7 @@ export function createSlackWorker(
       inFlightTurns.set(instanceName, live);
     }
     live.add(ref);
+    ref.releaseAttendance ??= attendance.openChannelTurn(instanceName);
   }
 
   /** `harnessMayStillRun`: the turn settled on a path that says nothing about
@@ -760,6 +773,11 @@ export function createSlackWorker(
       live.delete(ref);
       if (live.size === 0) inFlightTurns.delete(instanceName);
     }
+    // Released even when the harness may still be running: a late request from
+    // a turn whose relay dropped falls back to the ordinary hold rather than
+    // being refused on the strength of a marker nothing is refreshing.
+    ref.releaseAttendance?.();
+    ref.releaseAttendance = undefined;
     if (opts?.harnessMayStillRun) {
       let lingering = lingeringTurns.get(instanceName);
       if (!lingering) {

--- a/packages/api-server/src/modules/channels/infrastructure/slack.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/slack.ts
@@ -686,12 +686,14 @@ export function createSlackWorker(
   brand: { name: string; short: string },
   isTermsAccepted: (sub: string) => Promise<boolean>,
   uiBaseUrl: string,
-  emit: (event: DomainEvent) => void = defaultEmit,
   /** Marks the agent as driven from a channel for the length of each turn, so
    *  the egress gate can refuse a request that would otherwise hold for a
-   *  verdict nobody in a Slack conversation can give. Defaults to a no-op for
-   *  tests that don't exercise it. */
-  attendance: ChannelTurnAttendance = { openChannelTurn: () => () => {} },
+   *  verdict nobody in a Slack conversation can give. Required: a missing
+   *  wiring here would silently restore the stall this exists to prevent, so
+   *  whether the marker does anything is the store's own business, decided
+   *  where it is built. */
+  attendance: ChannelTurnAttendance,
+  emit: (event: DomainEvent) => void = defaultEmit,
 ): SlackWorker {
   const brandShort = brand.short;
   let gateway: SlackGateway | null = null;

--- a/packages/api-server/src/modules/channels/infrastructure/telegram.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/telegram.ts
@@ -375,22 +375,19 @@ export function createTelegramWorker(deps: {
    *  surface; from the brand config, matching the Slack worker. */
   brandShort: string;
   /** Display brand name, used where the agent is told where its owner acts
-   *  (network-access guidance). Falls back to `brandShort` when unset. */
-  brandName?: string;
+   *  (network-access guidance). */
+  brandName: string;
   emit?: (event: DomainEvent) => void;
   /** Marks the agent as channel-driven for the length of each turn, so the
    *  egress gate can refuse a request no Telegram participant could approve.
-   *  Defaults to a no-op for tests that don't exercise it. */
-  attendance?: ChannelTurnAttendance;
+   *  Required: a missing wiring here would silently restore the stall this
+   *  exists to prevent. */
+  attendance: ChannelTurnAttendance;
   /** Test seam; defaults to the Bot API getChatMember check. */
   isChatAdmin?: (chatId: string, userId: string) => Promise<boolean>;
 }): TelegramWorker {
   const emit = deps.emit ?? defaultEmit;
-  const attendance: ChannelTurnAttendance = deps.attendance ?? {
-    openChannelTurn: () => () => {},
-  };
-  const brandName = deps.brandName ?? deps.brandShort;
-  const { botToken, makeAcpClient, agents } = deps;
+  const { botToken, makeAcpClient, agents, attendance, brandName } = deps;
 
   // One bot for the install. The poller and the in-memory turn state below
   // are single-holder: the Bot API admits one getUpdates consumer per token,

--- a/packages/api-server/src/modules/channels/infrastructure/telegram.ts
+++ b/packages/api-server/src/modules/channels/infrastructure/telegram.ts
@@ -1,4 +1,5 @@
 import type { TtlStore } from "../../../core/ttl-store.js";
+import type { ChannelTurnAttendance } from "../../../core/turn-attendance.js";
 import {
   Actions,
   Card,
@@ -20,6 +21,7 @@ import {
   wakeFailureReasonToken,
 } from "../../agents/index.js";
 import { wakeFailureUserCopy } from "./wake-failure-copy.js";
+import { channelNetworkAccessGuidance } from "./network-access-copy.js";
 import {
   buildAuthorizeUrl,
   generatePkce,
@@ -372,11 +374,22 @@ export function createTelegramWorker(deps: {
   /** Lowercase slash-command name for the unified `/dam bind` / `/dam unbind`
    *  surface; from the brand config, matching the Slack worker. */
   brandShort: string;
+  /** Display brand name, used where the agent is told where its owner acts
+   *  (network-access guidance). Falls back to `brandShort` when unset. */
+  brandName?: string;
   emit?: (event: DomainEvent) => void;
+  /** Marks the agent as channel-driven for the length of each turn, so the
+   *  egress gate can refuse a request no Telegram participant could approve.
+   *  Defaults to a no-op for tests that don't exercise it. */
+  attendance?: ChannelTurnAttendance;
   /** Test seam; defaults to the Bot API getChatMember check. */
   isChatAdmin?: (chatId: string, userId: string) => Promise<boolean>;
 }): TelegramWorker {
   const emit = deps.emit ?? defaultEmit;
+  const attendance: ChannelTurnAttendance = deps.attendance ?? {
+    openChannelTurn: () => () => {},
+  };
+  const brandName = deps.brandName ?? deps.brandShort;
   const { botToken, makeAcpClient, agents } = deps;
 
   // One bot for the install. The poller and the in-memory turn state below
@@ -423,12 +436,16 @@ export function createTelegramWorker(deps: {
       `To reply, call the \`mcp__platform-outbound__send_channel_message\` tool with channel="telegram" and chatId="${thread.id}". If the tool is deferred, load it via ToolSearch first.`,
       "IMPORTANT: Your text output is NOT delivered to Telegram — only tool calls reach the user.",
       "To deliberately stay silent — a group message that isn't for you, or one already handled — call `mcp__platform-outbound__no_reply_needed` instead of replying.",
+      channelNetworkAccessGuidance(brandName),
       "",
       `Message: ${text}`,
     ].join("\n");
 
     let outcome: TurnOutcome = "failure";
     let failureReason: string | undefined;
+    // Held for the whole turn, resumed sessions included: the egress gate reads
+    // this to tell that a refused host has nobody here who could allow it.
+    const releaseAttendance = attendance.openChannelTurn(agentId);
     try {
       await agents().ensureReady(agentId);
       const acp = makeAcpClient(agentId);
@@ -466,6 +483,7 @@ export function createTelegramWorker(deps: {
         await thread.post(wakeFailureUserCopy(err.failure)).catch(() => {});
       }
     } finally {
+      releaseAttendance();
       emitTurn(agentId, outcome, author.userId, failureReason);
     }
   }


### PR DESCRIPTION
Closes #3228.

## Problem

An egress request to a host the owner hasn't allowed is held open while a human decides — 30 minutes by default, with the ACP turn ceiling deliberately sized above the hold so the wait is never cut short. That works for someone sitting in the web app. From Slack or Telegram nobody can answer: the owner isn't necessarily present, and the conversation's other members aren't the owner, so handing them the decision isn't safe. The turn therefore sat silent for the whole window and was denied anyway.

Two things went wrong at once: the wait was dead time, and the agent had no idea approval was even a concept — so once the refusal landed it reported a bare network error, or retried into the same wall.

## What changed

**The gate refuses instead of holding when nobody can answer.** On a rule miss it now asks two questions before holding: is a channel turn open on this agent, and is an interactive session attached? Only when the first is true and the second is false does it refuse immediately.

The second question is what keeps this a narrowing rather than a blanket change: if the owner has a browser or CLI session on the agent, someone *can* decide, so a Slack turn running alongside one still holds and still resolves. Agents whose rules allow everything never reach the path at all — nothing they request is unmatched.

**The request is still recorded, and stays actionable.** The pending row is inserted exactly as before, so it shows up in the inbox, a permanent approval there writes the rule the agent's next attempt consumes, and retries reuse the one row instead of filing a copy each time. What's skipped is only the *wait*, plus the in-session prompt — its only consumers are the relay clients whose absence defines this path, and an unconsumed frame would leave the row looking answerable in-session when the request has already been refused. The deny is logged with its own reason and the row's id as correlation, so it's distinguishable from a rule-based deny.

**Channel turns are told this can happen.** The per-turn framing now states that an unallowed host is refused, that it can't be approved from the conversation, and what to do instead: name the host, point at the owner (the request is already waiting for them), and offer another route or to finish once it's allowed — rather than looping on the host. Shared by both messengers. It's stated unconditionally but phrased conditionally, so an allow-everything agent pays one line and nothing else.

## Why a new cross-replica signal

The gate is handed only the agent, host, method and path — it has never known which session made a request (the gap #2326 documented). The channel workers do know, so they mark the agent as channel-driven for the length of each turn, refcounted so concurrent threads each hold their own marker.

It has to be cross-replica, and #3223 (now on main) makes that sharper rather than softer: the channel workers are single-holder, so only the lease-holding replica ever marks a turn open, while an ext_authz Check still lands on whichever replica Envoy picks. An in-memory marker would have been read as absent on every other replica. The new store mirrors the existing session-presence shape (per-replica key, heartbeat, TTL) and reads the presence keys the relays already write for the "interactive session attached" half — all three relays still take that pin after #3223, and the key prefix moved into one place so the two can't drift.

Both reads **fail toward "attended"**, so a Redis blip degrades to today's hold rather than to silent denial.

## Testing

Rebased onto main at `0a52a37c`. The api-server suite passes (899 tests, 101 files) along with tsc, lint, format and the docs gates re-run directly after the rebase. New coverage:

- gate: denies without waiting, keeps the row pending, publishes no prompt, reuses one row across retries, still holds when an interactive session is attached, and never consults attendance when a rule already decides
- attendance store: refcounting, idempotent release, cross-replica visibility, local short-circuit, and the fail-toward-attended behaviour on a Redis error
- Slack: the guidance reaches the real prompt, and the marker is held across the harness call and released even when the wake fails

One caveat on the full `mise run check`: it aborts locally on the controller's CRD-backwards-compatibility task, which can't resolve the baseline tag through a worktree's gitdir (`reference not found`). That's environmental and unrelated — this branch touches no CRD, controller, or Helm file — so the remaining tasks were run per package instead. CI will run the CRD check properly.

**Not covered by a test:** the Telegram wiring. No unit harness constructs the Telegram worker today (its tests cover the message handler and flows separately), so that path is 3 lines carried by types and review. The shared guidance text it emits is tested directly.

## Notes for review

- **Out of scope, same shape:** scheduled runs have the same problem — nobody is watching, so their holds also expire unseen. Left alone deliberately; an owner who wanders past the inbox can still answer one, and widening the rule to "any unattended turn" is a bigger behaviour change than this issue asks for.
- **Complementary to #3151**, not a substitute: that issue wants approvals delivered to the messenger and answered there. This is the safety valve that should hold whether or not that lands.
- **Follow-up worth considering:** the agent only ever sees the wire symptom of a refusal (a closed connection, or a 403 on the L7 path). Envoy's denied-response body could carry a human-readable reason on TLS-terminated chains, which would beat pre-arming the prompt — but it can't reach the SNI-miss catch-all, which is where most refusals land, so the prompt framing is doing the real work either way.
- **One unrelated line trimmed** in `channels.md`: the page sat 54 characters under its size cap, so a sentence that restated "Telegram is structurally identical" from its own sentence pair made room for the cross-link. The depth lives on `security-and-credentials.md`, which owns egress approvals.
