### PR TITLE
feat(connections): edit a GitHub App connection's repositories and permissions

### DIFF
--- a/docs/architecture/security-and-credentials.md
+++ b/docs/architecture/security-and-credentials.md
@@ -300,6 +300,19 @@ Each connected service produces one K8s Secret per `(owner, connection)`:
   working Connection into a rejected renewal. The read needs the app's private
   key and is authenticated the same way minting is; it stores nothing.
 
+  The subset is **editable in place**, which is the one part of a Connection's
+  configuration that is: what an agent should be allowed to do changes as its
+  work does, and rebuilding the Connection to add a repository would mean
+  re-pasting the key and re-granting it to every agent. Editing re-reads the
+  installation using the Connection's own stored key — never asking for it a
+  second time — and re-mints immediately, so the narrower token replaces the
+  live one rather than waiting out the current one's hour. The new subset is
+  proven by that mint before it is stored, so one the installation cannot
+  cover fails the edit instead of parking the Connection at its next renewal.
+  Nothing else moves: the credential, the contributions, and every agent grant
+  are untouched, and because the token is read gateway-side the change lands
+  without an Agent-spec patch or a pod roll.
+
 **Multi-host connections.** A single OAuth connection can inject the
 same token on more than one host with **different auth schemes per
 host**, all from one K8s Secret. The Secret carries a JSON

--- a/packages/api-server-api/src/modules/connections/router.ts
+++ b/packages/api-server-api/src/modules/connections/router.ts
@@ -11,6 +11,8 @@ import {
   connectionDiscoverMcpInputSchema,
   connectionProbeClusterCaInputSchema,
   connectionProbeGitHubAppInputSchema,
+  connectionProbeGitHubAppForConnectionInputSchema,
+  connectionUpdateGitHubAppScopeInputSchema,
   connectionGetAgentConnectionsInputSchema,
   connectionIdInputSchema,
   connectionSetAgentConnectionsInputSchema,
@@ -69,6 +71,16 @@ export const connectionsRouter = t.router({
     .mutation(({ ctx, input }) =>
       ctx.connections.probeGitHubAppInstallation(input),
     ),
+
+  probeGitHubAppInstallationForConnection: manageCredentialsProcedure
+    .input(connectionProbeGitHubAppForConnectionInputSchema)
+    .mutation(({ ctx, input }) =>
+      ctx.connections.probeGitHubAppInstallationForConnection(input),
+    ),
+
+  updateGitHubAppScope: manageCredentialsProcedure
+    .input(connectionUpdateGitHubAppScopeInputSchema)
+    .mutation(({ ctx, input }) => ctx.connections.updateGitHubAppScope(input)),
 
   update: manageCredentialsProcedure
     .input(connectionUpdateInputSchema)

--- a/packages/api-server-api/src/modules/connections/schemas.ts
+++ b/packages/api-server-api/src/modules/connections/schemas.ts
@@ -150,6 +150,22 @@ export const connectionProbeGitHubAppInputSchema = z.object({
   host: z.string().min(1).optional(),
 });
 
+// The same read for an existing connection, which supplies its own app
+// identity and key — so editing never asks for the private key again.
+export const connectionProbeGitHubAppForConnectionInputSchema = z.object({
+  connectionId: z.string().min(1),
+});
+
+// Replaces a github-app connection's narrowing. Same all-string shape as
+// create; an omitted or blank field clears that half rather than leaving the
+// previous value in place, so the form always states the whole scope.
+export const connectionUpdateGitHubAppScopeInputSchema = z.object({
+  id: z.string().min(1),
+  repositories: z.string().optional(),
+  repositoryIds: z.string().optional(),
+  permissions: z.string().optional(),
+});
+
 const noneCreateInput = z.object({
   ...commonFields,
   authKind: z.literal("none"),

--- a/packages/api-server-api/src/modules/connections/types.ts
+++ b/packages/api-server-api/src/modules/connections/types.ts
@@ -142,6 +142,17 @@ export const connectionView = z.object({
   // Only for an OAuth connection storing its own client secret — an
   // operator-supplied one is deploy config, not replaceable per connection.
   hasClientSecret: z.boolean().optional(),
+  // The narrowing a github-app connection currently mints against, so it can
+  // be shown and edited rather than only set once at create. Absent means the
+  // installation's full authority. Carries no secret — names, ids, and levels
+  // are all things the user chose.
+  githubAppScope: z
+    .object({
+      repositories: z.array(z.string()).optional(),
+      repositoryIds: z.array(z.number().int()).optional(),
+      permissions: z.record(z.string(), z.string()).optional(),
+    })
+    .optional(),
 });
 export type ConnectionView = z.infer<typeof connectionView>;
 
@@ -263,6 +274,25 @@ export interface ConnectionsService {
     host?: string;
     templateId: string;
   }): Promise<GitHubAppInstallationProbe>;
+
+  // The same read for a connection that already exists, which knows its own
+  // app and holds its own key — so editing a scope never asks for the private
+  // key a second time.
+  probeGitHubAppInstallationForConnection(input: {
+    connectionId: string;
+  }): Promise<GitHubAppInstallationProbe>;
+
+  // Replaces which repositories and permissions the connection mints against,
+  // preserving identity, credential, and every agent grant. The new scope is
+  // proven by minting against it before it is stored, and the fresh token
+  // replaces the live one — so the change takes effect at once rather than at
+  // the next renewal. An omitted field clears that half of the narrowing.
+  updateGitHubAppScope(input: {
+    id: string;
+    repositories?: string;
+    repositoryIds?: string;
+    permissions?: string;
+  }): Promise<void>;
 
   startOAuth(
     connectionId: string,

--- a/packages/api-server/src/__tests__/unit/connections-client-credentials-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-client-credentials-service.test.ts
@@ -122,6 +122,9 @@ function makeService(
     githubAppEngine: createGitHubAppEngine(),
     oauthCallbackUrl: "https://cb.example/oauth/callback",
     brandName: "Test",
+    // The advisory lock is Postgres-side; the section itself is what these
+    // tests exercise, so run it straight through.
+    connectionLock: (_key, fn) => fn(),
   });
   return { svc, rows, stored, deleted, tokenCalls };
 }

--- a/packages/api-server/src/__tests__/unit/connections-github-app-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-github-app-service.test.ts
@@ -81,7 +81,7 @@ function makeSecretStoreFake() {
 }
 
 function makeService(
-  respond: () => Response = () =>
+  respond: (url: string) => Response = () =>
     new Response(
       JSON.stringify({ token: "ghs_1", expires_at: "2027-01-15T13:00:00Z" }),
       { status: 201, headers: { "content-type": "application/json" } },
@@ -90,11 +90,17 @@ function makeService(
   const { repo, rows } = makeRepoFake();
   const { store, stored, deleted } = makeSecretStoreFake();
   const tokenCalls: string[] = [];
+  const tokenBodies: (string | undefined)[] = [];
   const githubAppEngine = createGitHubAppEngine({
     now: () => NOW_MS,
-    fetchImpl: (async (url: RequestInfo | URL) => {
+    fetchImpl: (async (url: RequestInfo | URL, init?: RequestInit) => {
       tokenCalls.push(String(url));
-      return respond();
+      if (String(url).includes("/access_tokens")) {
+        tokenBodies.push(
+          typeof init?.body === "string" ? init.body : undefined,
+        );
+      }
+      return respond(String(url));
     }) as typeof fetch,
   });
   const oauthFlow: OAuthFlowService = {
@@ -120,7 +126,7 @@ function makeService(
     oauthCallbackUrl: "https://cb.example/oauth/callback",
     brandName: "Test",
   });
-  return { svc, rows, stored, deleted, tokenCalls };
+  return { svc, rows, stored, deleted, tokenCalls, tokenBodies };
 }
 
 function createInput(overrides: Record<string, string> = {}) {
@@ -275,5 +281,200 @@ describe("github-app connection create", () => {
 
     expect(stored.get(SECRET_PATH)!.private_key).toBe(PRIVATE_KEY_PEM.trim());
     expect(rows.get(id)!.auth).toEqual(authBefore);
+  });
+});
+
+describe("github-app scope editing", () => {
+  const okToken = () =>
+    new Response(
+      JSON.stringify({ token: "ghs_2", expires_at: "2027-01-15T13:00:00Z" }),
+      { status: 201, headers: { "content-type": "application/json" } },
+    );
+
+  it("re-mints against the new scope and stores it", async () => {
+    const { svc, rows, stored, tokenBodies } = makeService(okToken);
+    const id = await svc.createFromTemplate(createInput());
+
+    await svc.updateGitHubAppScope({
+      id,
+      repositoryIds: "12 34",
+      permissions: "contents:read",
+    });
+
+    // The edit mints again rather than waiting for the next renewal, so the
+    // live token is the narrowed one.
+    expect(JSON.parse(tokenBodies.at(-1)!)).toEqual({
+      repository_ids: [12, 34],
+      permissions: { contents: "read" },
+    });
+    const auth = rows.get(id)!.auth;
+    if (auth.kind !== "github-app") throw new Error("kind");
+    expect(auth.repositoryIds).toEqual([12, 34]);
+    expect(auth.permissions).toEqual({ contents: "read" });
+    expect(stored.get(SECRET_PATH)!.access_token).toBe("ghs_2");
+    expect(
+      stored.get(SECRET_PATH)![sdsFileKeyForHost("api.github.com")],
+    ).toContain("ghs_2");
+  });
+
+  it("keeps the credential and the connection's identity", async () => {
+    const { svc, rows, stored } = makeService(okToken);
+    const id = await svc.createFromTemplate(createInput());
+    const before = rows.get(id)!;
+
+    await svc.updateGitHubAppScope({ id, repositoryIds: "12" });
+
+    const after = rows.get(id)!;
+    expect(after.name).toBe(before.name);
+    expect(after.contributions).toEqual(before.contributions);
+    expect(stored.get(SECRET_PATH)!.private_key).toBe(PRIVATE_KEY_PEM.trim());
+  });
+
+  // Clearing is a widening, so it has to reach GitHub as "no body" rather than
+  // leaving the previous narrowing quietly in place.
+  it("clears the scope back to the full installation", async () => {
+    const { svc, rows, tokenBodies } = makeService(okToken);
+    const id = await svc.createFromTemplate(
+      createInput({ repositories: "docs", permissions: "contents:read" }),
+    );
+
+    await svc.updateGitHubAppScope({ id });
+
+    expect(tokenBodies.at(-1)).toBeUndefined();
+    const auth = rows.get(id)!.auth;
+    if (auth.kind !== "github-app") throw new Error("kind");
+    expect(auth).not.toHaveProperty("repositories");
+    expect(auth).not.toHaveProperty("repositoryIds");
+    expect(auth).not.toHaveProperty("permissions");
+  });
+
+  it("replaces a name-based scope rather than merging with it", async () => {
+    const { svc, rows } = makeService(okToken);
+    const id = await svc.createFromTemplate(
+      createInput({ repositories: "docs" }),
+    );
+
+    await svc.updateGitHubAppScope({ id, repositoryIds: "12" });
+
+    const auth = rows.get(id)!.auth;
+    if (auth.kind !== "github-app") throw new Error("kind");
+    expect(auth.repositoryIds).toEqual([12]);
+    expect(auth).not.toHaveProperty("repositories");
+  });
+
+  // Proven before it is stored, exactly as create does — otherwise a scope the
+  // installation cannot cover would park the connection an hour later instead
+  // of failing the edit the user is looking at.
+  it("leaves everything untouched when GitHub rejects the new scope", async () => {
+    let mints = 0;
+    const { svc, rows, stored } = makeService((url) => {
+      if (!url.includes("/access_tokens")) return okToken();
+      mints += 1;
+      // The create's mint succeeds; the edit's is refused.
+      return mints === 1
+        ? okToken()
+        : new Response("no access to that repository", { status: 422 });
+    });
+    const id = await svc.createFromTemplate(createInput());
+    const authBefore = rows.get(id)!.auth;
+    const tokenBefore = stored.get(SECRET_PATH)!.access_token;
+
+    await expect(
+      svc.updateGitHubAppScope({ id, repositoryIds: "999" }),
+    ).rejects.toThrow();
+
+    expect(rows.get(id)!.auth).toEqual(authBefore);
+    expect(stored.get(SECRET_PATH)!.access_token).toBe(tokenBefore);
+  });
+
+  // The mint proves the credential still works, which is what un-parks a
+  // connection everywhere else in this module.
+  it("clears a refresh-failure marker on a successful re-scope", async () => {
+    const { svc, rows } = makeService(okToken);
+    const id = await svc.createFromTemplate(createInput());
+    const created = rows.get(id)!;
+    if (created.auth.kind !== "github-app") throw new Error("kind");
+    rows.set(id, {
+      ...created,
+      auth: { ...created.auth, refreshFailedAt: 1700000000 },
+    });
+    expect((await svc.getConnection(id))?.status).toBe("expired");
+
+    await svc.updateGitHubAppScope({ id, repositoryIds: "12" });
+
+    const auth = rows.get(id)!.auth;
+    if (auth.kind !== "github-app") throw new Error("kind");
+    expect(auth.refreshFailedAt).toBeUndefined();
+    expect((await svc.getConnection(id))?.status).toBe("active");
+  });
+
+  it("rejects an id that is not a whole number before reaching GitHub", async () => {
+    const { svc } = makeService(okToken);
+    const id = await svc.createFromTemplate(createInput());
+    await expect(
+      svc.updateGitHubAppScope({ id, repositoryIds: "12abc" }),
+    ).rejects.toThrow(/whole number/);
+  });
+
+  it("refuses a connection that is not a GitHub App installation", async () => {
+    const { svc } = makeService(okToken);
+    const id = await svc.createFromTemplate({
+      templateId: "github-pat",
+      name: "pat",
+      authKind: "header" as const,
+      value: "ghp_x",
+    });
+    await expect(svc.updateGitHubAppScope({ id })).rejects.toThrow(
+      /not a GitHub App/,
+    );
+  });
+
+  it("surfaces the stored scope on the connection view", async () => {
+    const { svc } = makeService(okToken);
+    const id = await svc.createFromTemplate(
+      createInput({ repositories: "docs", permissions: "contents:read" }),
+    );
+    expect((await svc.getConnection(id))?.githubAppScope).toEqual({
+      repositories: ["docs"],
+      permissions: { contents: "read" },
+    });
+  });
+
+  it("omits the scope from the view when nothing is narrowed", async () => {
+    const { svc } = makeService(okToken);
+    const id = await svc.createFromTemplate(createInput());
+    expect((await svc.getConnection(id))?.githubAppScope).toBeUndefined();
+  });
+
+  // The connection already holds its key, so editing must never ask for it.
+  it("probes the installation using the connection's stored key", async () => {
+    const { svc, tokenCalls } = makeService((url) =>
+      url.endsWith("/app/installations/987654")
+        ? new Response(
+            JSON.stringify({
+              permissions: { contents: "write" },
+              repository_selection: "selected",
+              account: { login: "dam-agents" },
+            }),
+            { status: 200, headers: { "content-type": "application/json" } },
+          )
+        : url.includes("/installation/repositories")
+          ? new Response(
+              JSON.stringify({ repositories: [{ id: 12, name: "docs" }] }),
+              { status: 200, headers: { "content-type": "application/json" } },
+            )
+          : okToken(),
+    );
+    const id = await svc.createFromTemplate(createInput());
+
+    const probe = await svc.probeGitHubAppInstallationForConnection({
+      connectionId: id,
+    });
+
+    expect(probe.permissions).toEqual({ contents: "write" });
+    expect(probe.repositories).toEqual([{ id: 12, name: "docs" }]);
+    expect(tokenCalls).toContain(
+      "https://api.github.com/app/installations/987654",
+    );
   });
 });

--- a/packages/api-server/src/__tests__/unit/connections-github-app-service.test.ts
+++ b/packages/api-server/src/__tests__/unit/connections-github-app-service.test.ts
@@ -8,6 +8,7 @@ import { buildCatalog } from "../../modules/connections/domain/catalog.js";
 import { createOAuthEngine } from "../../modules/connections/infrastructure/oauth-engine.js";
 import { createGitHubAppEngine } from "../../modules/connections/infrastructure/github-app-engine.js";
 import { sdsFileKeyForHost } from "../../modules/connections/domain/connection-sds.js";
+import { gitHubAppMintLockKey } from "../../modules/connections/services/github-app.js";
 import type { ConnectionsRepository } from "../../modules/connections/infrastructure/connections-repository.js";
 import type { SecretStore } from "../../modules/secret-store/index.js";
 import type { OAuthFlowService } from "../../modules/connections/services/oauth-flow.js";
@@ -103,6 +104,7 @@ function makeService(
       return respond(String(url));
     }) as typeof fetch,
   });
+  const lockKeys: string[] = [];
   const oauthFlow: OAuthFlowService = {
     startOAuth: async () => {
       throw new Error("startOAuth must not be called for github-app");
@@ -125,8 +127,14 @@ function makeService(
     githubAppEngine,
     oauthCallbackUrl: "https://cb.example/oauth/callback",
     brandName: "Test",
+    // The advisory lock is Postgres-side; the section itself is what these
+    // tests exercise, so run it straight through and record the key.
+    connectionLock: <T>(key: string, fn: () => Promise<T>): Promise<T> => {
+      lockKeys.push(key);
+      return fn();
+    },
   });
-  return { svc, rows, stored, deleted, tokenCalls, tokenBodies };
+  return { svc, rows, stored, deleted, tokenCalls, tokenBodies, lockKeys };
 }
 
 function createInput(overrides: Record<string, string> = {}) {
@@ -406,6 +414,18 @@ describe("github-app scope editing", () => {
     if (auth.kind !== "github-app") throw new Error("kind");
     expect(auth.refreshFailedAt).toBeUndefined();
     expect((await svc.getConnection(id))?.status).toBe("active");
+  });
+
+  // The refresh loop names the same key for the same connection; if these two
+  // ever diverge the section stops being mutual and the race is back.
+  it("runs the edit under the connection's mint lock", async () => {
+    const { svc, lockKeys } = makeService(okToken);
+    const id = await svc.createFromTemplate(createInput());
+    lockKeys.length = 0;
+
+    await svc.updateGitHubAppScope({ id, repositoryIds: "12" });
+
+    expect(lockKeys).toEqual([gitHubAppMintLockKey(id)]);
   });
 
   it("rejects an id that is not a whole number before reaching GitHub", async () => {

--- a/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
@@ -7,6 +7,7 @@ import {
   type ConnectionAuthConfig,
 } from "api-server-api";
 import { remintGitHubAppOne } from "../../modules/connections/services/oauth-refresh.js";
+import { gitHubAppMintLockKey } from "../../modules/connections/services/github-app.js";
 import { createGitHubAppEngine } from "../../modules/connections/infrastructure/github-app-engine.js";
 import { sdsFileKeyForHost } from "../../modules/connections/domain/connection-sds.js";
 import type { SecretStore } from "../../modules/secret-store/index.js";
@@ -50,13 +51,10 @@ const CONN: Connection = {
 
 function makeDeps(opts: {
   privateKey: string | null;
-  /** 0 models a concurrent edit landing mid-mint, which makes the guarded
-   *  write match nothing and sends the re-mint round again. */
-  updateRowCount?: number;
-  /** What the re-read returns on that second pass. */
+  /** What the re-read inside the critical section returns — an edit that
+   *  completed while this tick was queued behind the lock. */
   reReadAuth?: ConnectionAuthConfig;
 }) {
-  const updateRowCount = opts.updateRowCount ?? 1;
   const reReadAuth = opts.reReadAuth ?? AUTH;
   const putCalls: { path: string; fields: Record<string, string> }[] = [];
   const secretStore = {
@@ -77,9 +75,7 @@ function makeDeps(opts: {
     update: () => ({
       set: (row: { auth: unknown }) => {
         dbUpdates.push(row);
-        // The guarded write reports how many rows it matched; one means no
-        // concurrent edit overtook this pass.
-        return { where: async () => ({ rowCount: updateRowCount }) };
+        return { where: async () => ({ rowCount: 1 }) };
       },
     }),
     // Only read when a guarded write matched nothing.
@@ -105,14 +101,22 @@ function makeDeps(opts: {
     }) as typeof fetch,
   });
 
+  const lockKeys: string[] = [];
   return {
     githubAppEngine,
     secretStore,
     db,
+    // The real lock is a Postgres advisory lock; what these tests care about is
+    // that the section runs under one, and under which key.
+    connectionLock: <T>(key: string, fn: () => Promise<T>): Promise<T> => {
+      lockKeys.push(key);
+      return fn();
+    },
     putCalls,
     dbUpdates,
     tokenCalls,
     tokenBodies,
+    lockKeys,
   };
 }
 
@@ -195,7 +199,10 @@ describe("github-app re-mint with a stored scope", () => {
   const SCOPED_CONN: Connection = { ...CONN, auth: SCOPED_AUTH };
 
   it("re-mints asking for the same subset", async () => {
-    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
+    const deps = makeDeps({
+      privateKey: PRIVATE_KEY_PEM,
+      reReadAuth: SCOPED_AUTH,
+    });
     await remintGitHubAppOne(SCOPED_CONN, SCOPED_AUTH, deps);
 
     expect(deps.tokenBodies).toHaveLength(1);
@@ -236,7 +243,7 @@ describe("github-app re-mint with picked repository ids", () => {
   const ID_CONN: Connection = { ...CONN, auth: ID_AUTH };
 
   it("re-mints asking for the same repository ids", async () => {
-    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
+    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM, reReadAuth: ID_AUTH });
     await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
     expect(JSON.parse(deps.tokenBodies[0]!)).toEqual({
       repository_ids: [12, 34],
@@ -253,42 +260,34 @@ describe("github-app re-mint with picked repository ids", () => {
   // Protecting the stored scope is not enough on its own: the token this tick
   // writes must match it too, or the connection carries authority the edit just
   // removed until the next renewal.
-  it("re-mints against the edited scope when an edit lands mid-mint", async () => {
+  it("mints against the scope as it stands inside the lock, not the one the tick carried in", async () => {
     const EDITED: ConnectionAuthConfig = {
       ...ID_AUTH,
       repositoryIds: [99],
       permissions: { contents: "read" },
     };
+    // The tick was queued behind an edit that has since completed, so the auth
+    // it carried in is stale by the time it holds the lock.
     const deps = makeDeps({
       privateKey: PRIVATE_KEY_PEM,
-      // The guarded write matches nothing — the edit moved the horizon.
-      updateRowCount: 0,
       reReadAuth: EDITED,
     });
 
     await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
 
-    // First pass used the pre-edit scope; the second re-mints against what the
-    // edit stored, so the token left in the Secret is the narrower one.
-    expect(deps.tokenBodies).toHaveLength(2);
-    expect(JSON.parse(deps.tokenBodies[0]!)).toMatchObject({
-      repository_ids: [12, 34],
-    });
-    expect(JSON.parse(deps.tokenBodies[1]!)).toEqual({
+    expect(deps.tokenBodies).toHaveLength(1);
+    expect(JSON.parse(deps.tokenBodies[0]!)).toEqual({
       repository_ids: [99],
       permissions: { contents: "read" },
     });
-    expect(deps.putCalls).toHaveLength(2);
   });
 
-  it("gives up rather than looping when the connection keeps changing", async () => {
-    const deps = makeDeps({
-      privateKey: PRIVATE_KEY_PEM,
-      updateRowCount: 0,
-      reReadAuth: ID_AUTH,
-    });
+  // Both the edit and the refresh must name the same key, or the section is
+  // not mutual and the whole arrangement is decorative.
+  it("runs under the connection's mint lock", async () => {
+    const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
     await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
-    expect(deps.tokenBodies).toHaveLength(2);
+    expect(deps.lockKeys).toEqual([gitHubAppMintLockKey(ID_CONN.id)]);
   });
 
   it("id-scoped auth round-trips through the wire schema", () => {

--- a/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
@@ -60,7 +60,10 @@ function makeDeps(opts: { privateKey: string | null }) {
     },
   } as unknown as SecretStore;
 
-  const dbUpdates: { auth: ConnectionAuthConfig }[] = [];
+  // The re-mint writes `auth` as a server-side jsonb merge, so what lands here
+  // is a SQL fragment rather than a replacement object — which is the point:
+  // the keys it does not name cannot be clobbered.
+  const dbUpdates: { auth: unknown }[] = [];
   const db = {
     update: () => ({
       set: (row: { auth: ConnectionAuthConfig }) => {
@@ -98,6 +101,22 @@ function makeDeps(opts: { privateKey: string | null }) {
   };
 }
 
+/** The `auth` value the re-mint writes, flattened to text. It is a jsonb-merge
+ *  fragment rather than a replacement object, so this is how a test can say
+ *  which keys the write names — and, more importantly, which it does not. */
+function authWrite(auth: unknown): string {
+  const chunks = (auth as { queryChunks?: unknown[] }).queryChunks ?? [];
+  return chunks
+    .map((chunk) => {
+      const value = (chunk as { value?: unknown }).value;
+      if (Array.isArray(value)) return value.join("");
+      // Table and column chunks carry no literal text worth matching on.
+      if (value === undefined || typeof value === "object") return "";
+      return String(value);
+    })
+    .join(" ");
+}
+
 describe("github-app re-mint", () => {
   it("signs with the stored key, hits the installation endpoint, and hot-swaps token + SDS", async () => {
     const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
@@ -117,11 +136,12 @@ describe("github-app re-mint", () => {
     expect(deps.putCalls[0].fields.private_key).toBeUndefined();
 
     expect(deps.dbUpdates).toHaveLength(1);
-    const updated = deps.dbUpdates[0].auth;
-    if (updated.kind !== "github-app") throw new Error("wrong kind");
-    expect(updated.expiresAt).toBe(
-      Math.floor(Date.parse("2027-01-15T13:00:00Z") / 1000),
-    );
+    // The horizon is merged into the stored auth server-side, and the failure
+    // marker cleared, without replacing the row's `auth`.
+    const write = authWrite(deps.dbUpdates[0].auth);
+    expect(write).toContain("jsonb_set");
+    expect(write).toContain("expiresAt");
+    expect(write).toContain("refreshFailedAt");
   });
 
   it("throws (leaving state untouched) when the private key is gone", async () => {
@@ -170,17 +190,17 @@ describe("github-app re-mint with a stored scope", () => {
     });
   });
 
-  it("keeps the scope on the row it writes back", async () => {
+  // The scope survives by not being written at all: the tick merges only the
+  // keys it owns, so a re-scope that lands mid-mint is not overwritten by the
+  // copy this tick read before it.
+  it("never names the scope in the row it writes back", async () => {
     const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
     await remintGitHubAppOne(SCOPED_CONN, SCOPED_AUTH, deps);
 
-    const updated = deps.dbUpdates[0].auth;
-    if (updated.kind !== "github-app") throw new Error("wrong kind");
-    expect(updated.repositories).toEqual(["docs"]);
-    expect(updated.permissions).toEqual({
-      contents: "read",
-      metadata: "read",
-    });
+    const write = authWrite(deps.dbUpdates[0].auth);
+    expect(write).toContain("expiresAt");
+    expect(write).not.toContain("repositories");
+    expect(write).not.toContain("permissions");
   });
 
   it("scoped auth round-trips through the wire schema", () => {
@@ -209,12 +229,10 @@ describe("github-app re-mint with picked repository ids", () => {
     });
   });
 
-  it("keeps the ids on the row it writes back", async () => {
+  it("never names the ids in the row it writes back", async () => {
     const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
     await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
-    const updated = deps.dbUpdates[0].auth;
-    if (updated.kind !== "github-app") throw new Error("wrong kind");
-    expect(updated.repositoryIds).toEqual([12, 34]);
+    expect(authWrite(deps.dbUpdates[0].auth)).not.toContain("repositoryIds");
   });
 
   it("id-scoped auth round-trips through the wire schema", () => {

--- a/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
+++ b/packages/api-server/src/__tests__/unit/oauth-refresh-github-app.test.ts
@@ -48,7 +48,16 @@ const CONN: Connection = {
   ],
 };
 
-function makeDeps(opts: { privateKey: string | null }) {
+function makeDeps(opts: {
+  privateKey: string | null;
+  /** 0 models a concurrent edit landing mid-mint, which makes the guarded
+   *  write match nothing and sends the re-mint round again. */
+  updateRowCount?: number;
+  /** What the re-read returns on that second pass. */
+  reReadAuth?: ConnectionAuthConfig;
+}) {
+  const updateRowCount = opts.updateRowCount ?? 1;
+  const reReadAuth = opts.reReadAuth ?? AUTH;
   const putCalls: { path: string; fields: Record<string, string> }[] = [];
   const secretStore = {
     getField: async () => opts.privateKey,
@@ -66,10 +75,16 @@ function makeDeps(opts: { privateKey: string | null }) {
   const dbUpdates: { auth: unknown }[] = [];
   const db = {
     update: () => ({
-      set: (row: { auth: ConnectionAuthConfig }) => {
+      set: (row: { auth: unknown }) => {
         dbUpdates.push(row);
-        return { where: async () => {} };
+        // The guarded write reports how many rows it matched; one means no
+        // concurrent edit overtook this pass.
+        return { where: async () => ({ rowCount: updateRowCount }) };
       },
+    }),
+    // Only read when a guarded write matched nothing.
+    select: () => ({
+      from: () => ({ where: async () => [{ auth: reReadAuth }] }),
     }),
   } as unknown as Db;
 
@@ -233,6 +248,47 @@ describe("github-app re-mint with picked repository ids", () => {
     const deps = makeDeps({ privateKey: PRIVATE_KEY_PEM });
     await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
     expect(authWrite(deps.dbUpdates[0].auth)).not.toContain("repositoryIds");
+  });
+
+  // Protecting the stored scope is not enough on its own: the token this tick
+  // writes must match it too, or the connection carries authority the edit just
+  // removed until the next renewal.
+  it("re-mints against the edited scope when an edit lands mid-mint", async () => {
+    const EDITED: ConnectionAuthConfig = {
+      ...ID_AUTH,
+      repositoryIds: [99],
+      permissions: { contents: "read" },
+    };
+    const deps = makeDeps({
+      privateKey: PRIVATE_KEY_PEM,
+      // The guarded write matches nothing — the edit moved the horizon.
+      updateRowCount: 0,
+      reReadAuth: EDITED,
+    });
+
+    await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
+
+    // First pass used the pre-edit scope; the second re-mints against what the
+    // edit stored, so the token left in the Secret is the narrower one.
+    expect(deps.tokenBodies).toHaveLength(2);
+    expect(JSON.parse(deps.tokenBodies[0]!)).toMatchObject({
+      repository_ids: [12, 34],
+    });
+    expect(JSON.parse(deps.tokenBodies[1]!)).toEqual({
+      repository_ids: [99],
+      permissions: { contents: "read" },
+    });
+    expect(deps.putCalls).toHaveLength(2);
+  });
+
+  it("gives up rather than looping when the connection keeps changing", async () => {
+    const deps = makeDeps({
+      privateKey: PRIVATE_KEY_PEM,
+      updateRowCount: 0,
+      reReadAuth: ID_AUTH,
+    });
+    await remintGitHubAppOne(ID_CONN, ID_AUTH, deps);
+    expect(deps.tokenBodies).toHaveLength(2);
   });
 
   it("id-scoped auth round-trips through the wire schema", () => {

--- a/packages/api-server/src/modules/connections/compose.ts
+++ b/packages/api-server/src/modules/connections/compose.ts
@@ -1,5 +1,6 @@
 import type { Db } from "db";
 import type { ConnectionsService } from "api-server-api";
+import { createXactLock } from "../../core/xact-lock.js";
 import { createConnectionsRepository } from "./infrastructure/connections-repository.js";
 import {
   createOAuthEngine,
@@ -130,5 +131,8 @@ export function composeConnectionsForOwner(opts: {
     githubAppEngine: opts.githubAppEngine,
     oauthCallbackUrl: opts.oauthCallbackUrl,
     brandName: opts.brandName,
+    // Serializes a scope edit against the refresh loop's re-mint of the same
+    // connection, which writes the same token and the same row.
+    connectionLock: createXactLock(opts.db),
   });
 }

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -25,6 +25,7 @@ import {
   gitHubAppApiBase,
   normalizePrivateKeyPem,
 } from "../domain/build-connection.js";
+import { parseGitHubAppScope } from "../domain/github-app-scope.js";
 import {
   tokenRejectionOf,
   withoutRefreshFailureMarker,
@@ -89,6 +90,9 @@ export function createConnectionsService(deps: {
                     conn.auth.connectedAt * 1000,
                   ).toISOString(),
                 }
+              : {}),
+            ...(conn.auth.kind === "github-app"
+              ? githubAppScopeView(conn.auth)
               : {}),
           }
         : {};
@@ -275,6 +279,36 @@ export function createConnectionsService(deps: {
   // own rejection is the most useful thing to show, so it rides the BAD_REQUEST.
   // Only the OAuth error code, though — a token-endpoint message embeds the
   // provider's raw body, which could echo credential material.
+  /** Loads a connection the caller owns and narrows it to the github-app
+   *  shape, so the scope endpoints share one ownership and kind check. */
+  async function requireGitHubAppConnection(id: string): Promise<{
+    conn: Connection;
+    auth: Extract<Connection["auth"], { kind: "github-app" }>;
+  }> {
+    const conn = await deps.repo.get(id, deps.ownerId);
+    if (!conn) throw new TRPCError({ code: "NOT_FOUND" });
+    if (conn.auth.kind !== "github-app") {
+      throw new TRPCError({
+        code: "BAD_REQUEST",
+        message: "This connection is not a GitHub App installation.",
+      });
+    }
+    return { conn, auth: conn.auth };
+  }
+
+  async function readPrivateKey(
+    auth: Extract<Connection["auth"], { kind: "github-app" }>,
+  ): Promise<string> {
+    const pem = await deps.secretStore.getField(auth.privateKeyRef);
+    if (!pem) {
+      throw new TRPCError({
+        code: "PRECONDITION_FAILED",
+        message: "This connection's private key is missing.",
+      });
+    }
+    return pem;
+  }
+
   async function rejectIfInvalid<T>(mint: () => Promise<T>): Promise<T> {
     try {
       return await mint();
@@ -708,7 +742,100 @@ export function createConnectionsService(deps: {
         });
       });
     },
+
+    async probeGitHubAppInstallationForConnection(input) {
+      const { conn, auth } = await requireGitHubAppConnection(
+        input.connectionId,
+      );
+      const privateKeyPem = await readPrivateKey(auth);
+      return rejectIfInvalid(() =>
+        deps.githubAppEngine.readInstallation({
+          id: `connection:${conn.id}:${conn.templateId}`,
+          appId: auth.appId,
+          installationId: auth.installationId,
+          privateKeyPem,
+          apiBaseUrl: auth.apiBaseUrl,
+        }),
+      );
+    },
+
+    async updateGitHubAppScope(input) {
+      const { conn, auth } = await requireGitHubAppConnection(input.id);
+      const privateKeyPem = await readPrivateKey(auth);
+
+      // Rebuilt rather than merged: the caller states the whole scope, so an
+      // omitted half clears rather than silently keeping the old narrowing.
+      // Rebuilding also drops any refresh-failure marker, which is what we
+      // want — the mint below proves the credential works, and that is exactly
+      // what un-parks a connection everywhere else.
+      const scope = parseGitHubAppScope(input);
+      const nextAuth: Connection["auth"] = {
+        kind: "github-app",
+        appId: auth.appId,
+        installationId: auth.installationId,
+        privateKeyRef: auth.privateKeyRef,
+        accessTokenRef: auth.accessTokenRef,
+        apiBaseUrl: auth.apiBaseUrl,
+        ...(auth.connectedAt ? { connectedAt: auth.connectedAt } : {}),
+        ...(auth.host ? { host: auth.host } : {}),
+        ...(scope.repositories ? { repositories: scope.repositories } : {}),
+        ...(scope.repositoryIds ? { repositoryIds: scope.repositoryIds } : {}),
+        ...(scope.permissions ? { permissions: scope.permissions } : {}),
+      };
+
+      // Proven before it is stored, exactly as create does: a subset the
+      // installation does not cover fails the edit instead of parking the
+      // connection at its next renewal.
+      const minted = await rejectIfInvalid(() =>
+        mintGitHubAppToken(deps.githubAppEngine, {
+          connectionRef: `connection:${conn.id}:${conn.templateId}`,
+          auth: nextAuth as Extract<Connection["auth"], { kind: "github-app" }>,
+          privateKeyPem,
+        }),
+      );
+
+      // The new token replaces the live one, so the narrowing takes effect now
+      // rather than at the next renewal. Contributions are unchanged — same
+      // hosts, same injections — so no Agent spec moves and no pod rolls.
+      await deps.secretStore.putFields(auth.accessTokenRef, {
+        access_token: minted.accessToken,
+        ...buildConnectionSdsFields(conn.contributions, minted.accessToken),
+      });
+      await deps.repo.updateAuth(conn.id, {
+        ...nextAuth,
+        expiresAt: minted.expiresAt,
+      });
+
+      securityLog("info", "connection.scope_update", {
+        category: "credential",
+        actor: deps.ownerId,
+        actorKind: "user",
+        target: conn.id,
+        result: "success",
+        detail: {
+          templateId: conn.templateId,
+          repositories: scope.repositories?.length ?? 0,
+          repositoryIds: scope.repositoryIds?.length ?? 0,
+          permissions: Object.keys(scope.permissions ?? {}).length,
+        },
+      });
+    },
   };
+}
+
+/** The narrowing a github-app connection mints against, for display and for
+ *  pre-filling its editor. Omitted entirely when nothing is narrowed, so the
+ *  view says "full installation authority" by absence, exactly as the stored
+ *  auth does. */
+function githubAppScopeView(
+  auth: Extract<Connection["auth"], { kind: "github-app" }>,
+): { githubAppScope?: NonNullable<ConnectionView["githubAppScope"]> } {
+  const scope = {
+    ...(auth.repositories ? { repositories: auth.repositories } : {}),
+    ...(auth.repositoryIds ? { repositoryIds: auth.repositoryIds } : {}),
+    ...(auth.permissions ? { permissions: auth.permissions } : {}),
+  };
+  return Object.keys(scope).length > 0 ? { githubAppScope: scope } : {};
 }
 
 // Metadata only: a provider's raw body could echo credential material.

--- a/packages/api-server/src/modules/connections/services/connections-service.ts
+++ b/packages/api-server/src/modules/connections/services/connections-service.ts
@@ -42,7 +42,8 @@ import type { GitHubAppEngine } from "../infrastructure/github-app-engine.js";
 import type { ContributionFanOut } from "./contribution-fanout.js";
 import type { OAuthFlowService } from "./oauth-flow.js";
 import { mintClientCredentialsToken } from "./client-credentials.js";
-import { mintGitHubAppToken } from "./github-app.js";
+import { gitHubAppMintLockKey, mintGitHubAppToken } from "./github-app.js";
+import type { XactLock } from "../../../core/xact-lock.js";
 import { refreshOAuthAccessToken } from "./oauth-token.js";
 import { emit, EventType } from "../../../events.js";
 import { securityLog } from "../../../core/security-log.js";
@@ -59,6 +60,9 @@ export function createConnectionsService(deps: {
   githubAppEngine: GitHubAppEngine;
   oauthCallbackUrl: string;
   brandName: string;
+  /** Serializes a connection's mint → token write → auth write against the
+   *  refresh loop doing the same for the same connection. */
+  connectionLock: XactLock;
 }): ConnectionsService {
   function toView(conn: Connection): ConnectionView {
     const template = deps.templates.get(conn.templateId);
@@ -783,27 +787,38 @@ export function createConnectionsService(deps: {
         ...(scope.permissions ? { permissions: scope.permissions } : {}),
       };
 
-      // Proven before it is stored, exactly as create does: a subset the
-      // installation does not cover fails the edit instead of parking the
-      // connection at its next renewal.
-      const minted = await rejectIfInvalid(() =>
-        mintGitHubAppToken(deps.githubAppEngine, {
-          connectionRef: `connection:${conn.id}:${conn.templateId}`,
-          auth: nextAuth as Extract<Connection["auth"], { kind: "github-app" }>,
-          privateKeyPem,
-        }),
-      );
+      // Mint, token write, and auth write are one critical section against the
+      // refresh loop, which runs the same sequence for the same connection. The
+      // token lives in a store no database transaction can bind, so ordering
+      // the two by hand is what keeps the stored scope and the live token
+      // describing the same authority.
+      await deps.connectionLock(gitHubAppMintLockKey(conn.id), async () => {
+        // Proven before it is stored, exactly as create does: a subset the
+        // installation does not cover fails the edit instead of parking the
+        // connection at its next renewal.
+        const token = await rejectIfInvalid(() =>
+          mintGitHubAppToken(deps.githubAppEngine, {
+            connectionRef: `connection:${conn.id}:${conn.templateId}`,
+            auth: nextAuth as Extract<
+              Connection["auth"],
+              { kind: "github-app" }
+            >,
+            privateKeyPem,
+          }),
+        );
 
-      // The new token replaces the live one, so the narrowing takes effect now
-      // rather than at the next renewal. Contributions are unchanged — same
-      // hosts, same injections — so no Agent spec moves and no pod rolls.
-      await deps.secretStore.putFields(auth.accessTokenRef, {
-        access_token: minted.accessToken,
-        ...buildConnectionSdsFields(conn.contributions, minted.accessToken),
-      });
-      await deps.repo.updateAuth(conn.id, {
-        ...nextAuth,
-        expiresAt: minted.expiresAt,
+        // The new token replaces the live one, so the narrowing takes effect
+        // now rather than at the next renewal. Contributions are unchanged —
+        // same hosts, same injections — so no Agent spec moves, no pod rolls.
+        await deps.secretStore.putFields(auth.accessTokenRef, {
+          access_token: token.accessToken,
+          ...buildConnectionSdsFields(conn.contributions, token.accessToken),
+        });
+        await deps.repo.updateAuth(conn.id, {
+          ...nextAuth,
+          expiresAt: token.expiresAt,
+        });
+        return token;
       });
 
       securityLog("info", "connection.scope_update", {

--- a/packages/api-server/src/modules/connections/services/github-app.ts
+++ b/packages/api-server/src/modules/connections/services/github-app.ts
@@ -6,6 +6,15 @@ export type GitHubAppAuth = Extract<
   { kind: "github-app" }
 >;
 
+/** Critical section covering one connection's mint → token write → auth write.
+ *  A scope edit and the refresh loop's re-mint both run that sequence against
+ *  the same token and the same row, and the token lives in a store no database
+ *  transaction can bind — so interleaving them can leave the stored scope and
+ *  the live token describing different authority. Both sides take this. */
+export function gitHubAppMintLockKey(connectionId: string): string {
+  return `github-app-mint:${connectionId}`;
+}
+
 /** One installation-token exchange, shared by connection create, private-key
  *  rotation, and the refresh loop. Maps the stored auth config onto the engine's
  *  mint call; `expiresAt` is always set (the engine falls back to a 1h horizon).

--- a/packages/api-server/src/modules/connections/services/oauth-refresh.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh.ts
@@ -29,7 +29,8 @@ import { securityLog } from "../../../core/security-log.js";
 import type { SecretStore } from "../../secret-store/index.js";
 import { mintClientCredentialsToken } from "./client-credentials.js";
 import { refreshOAuthAccessToken } from "./oauth-token.js";
-import { mintGitHubAppToken } from "./github-app.js";
+import { gitHubAppMintLockKey, mintGitHubAppToken } from "./github-app.js";
+import { createXactLock, type XactLock } from "../../../core/xact-lock.js";
 
 export interface OAuthRefreshLoop {
   /** One idempotent refresh pass — scheduled via the shared periodic-jobs
@@ -371,24 +372,28 @@ export async function remintGitHubAppOne(
     githubAppEngine: GitHubAppEngine;
     secretStore: SecretStore;
     db: Db;
+    /** Defaults to the Postgres advisory lock; injectable for tests. */
+    connectionLock?: XactLock;
   },
 ): Promise<void> {
   const privateKeyPem = await deps.secretStore.getField(auth.privateKeyRef);
   if (!privateKeyPem) {
     throw new Error(`private key missing at ${auth.privateKeyRef.path}`);
   }
+  const withLock = deps.connectionLock ?? createXactLock(deps.db);
 
-  // A github-app connection's scope is editable in place, so the copy this
-  // tick read can go stale between reading it and minting from it. Minting
-  // against a stale scope is not a metadata problem — the *token* written below
-  // would carry authority the user has just removed, for as long as it lives.
-  //
-  // So the write is guarded on the horizon this pass minted against: an edit
-  // moves it, the guard matches nothing, and the second pass re-mints from what
-  // the edit stored. Two passes are enough — a third would mean two edits
-  // landing inside one mint.
-  let current = auth;
-  for (let pass = 0; pass < 2; pass++) {
+  // A github-app connection's scope is editable in place, so this sequence
+  // races an edit doing the same thing to the same connection. Guarding the row
+  // alone cannot settle it: the token lives in a store no database transaction
+  // binds, so the two writes can still land in an order that leaves the stored
+  // scope and the live token describing different authority. Both sides take
+  // the same lock instead, so one finishes before the other starts.
+  await withLock(gitHubAppMintLockKey(conn.id), async () => {
+    // Re-read inside the section: the copy this tick carried in may predate an
+    // edit that has since completed, and minting from it would hand back the
+    // authority that edit removed.
+    const current = (await readGitHubAppAuth(deps.db, conn.id)) ?? auth;
+
     const next = await mintGitHubAppToken(deps.githubAppEngine, {
       connectionRef: `connection:${conn.id}:${conn.templateId}`,
       auth: current,
@@ -401,30 +406,15 @@ export async function remintGitHubAppOne(
     });
 
     // Merge the two keys this tick owns rather than writing back the whole
-    // `auth` it read: the keys it does not name cannot be clobbered, so a
-    // concurrent edit keeps its scope. Same shape as the failure-marker write.
-    const result = await deps.db
+    // `auth` it read: the keys it does not name cannot be clobbered.
+    await deps.db
       .update(connectionsTable)
       .set({
         auth: sql`jsonb_set(${connectionsTable.auth}, '{expiresAt}', to_jsonb(${next.expiresAt}::bigint)) - 'refreshFailedAt'`,
         updatedAt: new Date(),
       })
-      .where(
-        and(
-          eq(connectionsTable.id, conn.id),
-          sql`${connectionsTable.auth} ->> 'expiresAt' IS NOT DISTINCT FROM ${current.expiresAt === undefined ? null : String(current.expiresAt)}`,
-        ),
-      );
-    if (((result as unknown as { rowCount?: number }).rowCount ?? 0) > 0)
-      return;
-
-    // The guard matched nothing: something re-minted this connection while we
-    // were in flight, and the token we just wrote may be the wider one. Re-read
-    // and go again so the stored token ends up matching the stored scope.
-    const fresh = await readGitHubAppAuth(deps.db, conn.id);
-    if (!fresh) return;
-    current = fresh;
-  }
+      .where(eq(connectionsTable.id, conn.id));
+  });
 }
 
 /** The connection's current github-app auth, or null if it is gone or is no

--- a/packages/api-server/src/modules/connections/services/oauth-refresh.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh.ts
@@ -378,26 +378,66 @@ export async function remintGitHubAppOne(
     throw new Error(`private key missing at ${auth.privateKeyRef.path}`);
   }
 
-  const next = await mintGitHubAppToken(deps.githubAppEngine, {
-    connectionRef: `connection:${conn.id}:${conn.templateId}`,
-    auth,
-    privateKeyPem,
-  });
+  // A github-app connection's scope is editable in place, so the copy this
+  // tick read can go stale between reading it and minting from it. Minting
+  // against a stale scope is not a metadata problem — the *token* written below
+  // would carry authority the user has just removed, for as long as it lives.
+  //
+  // So the write is guarded on the horizon this pass minted against: an edit
+  // moves it, the guard matches nothing, and the second pass re-mints from what
+  // the edit stored. Two passes are enough — a third would mean two edits
+  // landing inside one mint.
+  let current = auth;
+  for (let pass = 0; pass < 2; pass++) {
+    const next = await mintGitHubAppToken(deps.githubAppEngine, {
+      connectionRef: `connection:${conn.id}:${conn.templateId}`,
+      auth: current,
+      privateKeyPem,
+    });
 
-  await deps.secretStore.putFields(auth.accessTokenRef, {
-    access_token: next.accessToken,
-    ...buildConnectionSdsFields(conn.contributions, next.accessToken),
-  });
-  // Merge the two keys this tick owns rather than writing back the whole `auth`
-  // it read at the start. A github-app connection's scope is editable in place,
-  // so a re-scope that landed while this mint was in flight would otherwise be
-  // overwritten by the pre-edit copy — quietly restoring authority the user had
-  // just taken away. Same shape as the failure-marker write above.
-  await deps.db
-    .update(connectionsTable)
-    .set({
-      auth: sql`jsonb_set(${connectionsTable.auth}, '{expiresAt}', to_jsonb(${next.expiresAt}::bigint)) - 'refreshFailedAt'`,
-      updatedAt: new Date(),
-    })
-    .where(eq(connectionsTable.id, conn.id));
+    await deps.secretStore.putFields(auth.accessTokenRef, {
+      access_token: next.accessToken,
+      ...buildConnectionSdsFields(conn.contributions, next.accessToken),
+    });
+
+    // Merge the two keys this tick owns rather than writing back the whole
+    // `auth` it read: the keys it does not name cannot be clobbered, so a
+    // concurrent edit keeps its scope. Same shape as the failure-marker write.
+    const result = await deps.db
+      .update(connectionsTable)
+      .set({
+        auth: sql`jsonb_set(${connectionsTable.auth}, '{expiresAt}', to_jsonb(${next.expiresAt}::bigint)) - 'refreshFailedAt'`,
+        updatedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(connectionsTable.id, conn.id),
+          sql`${connectionsTable.auth} ->> 'expiresAt' IS NOT DISTINCT FROM ${current.expiresAt === undefined ? null : String(current.expiresAt)}`,
+        ),
+      );
+    if (((result as unknown as { rowCount?: number }).rowCount ?? 0) > 0)
+      return;
+
+    // The guard matched nothing: something re-minted this connection while we
+    // were in flight, and the token we just wrote may be the wider one. Re-read
+    // and go again so the stored token ends up matching the stored scope.
+    const fresh = await readGitHubAppAuth(deps.db, conn.id);
+    if (!fresh) return;
+    current = fresh;
+  }
+}
+
+/** The connection's current github-app auth, or null if it is gone or is no
+ *  longer a github-app connection. */
+async function readGitHubAppAuth(
+  db: Db,
+  id: string,
+): Promise<Extract<ConnectionAuthConfig, { kind: "github-app" }> | null> {
+  const rows = (await db
+    .select()
+    .from(connectionsTable)
+    .where(eq(connectionsTable.id, id))) as { auth: unknown }[];
+  const parsed = authConfigSchema.safeParse(rows[0]?.auth);
+  if (!parsed.success || parsed.data.kind !== "github-app") return null;
+  return parsed.data;
 }

--- a/packages/api-server/src/modules/connections/services/oauth-refresh.ts
+++ b/packages/api-server/src/modules/connections/services/oauth-refresh.ts
@@ -388,12 +388,16 @@ export async function remintGitHubAppOne(
     access_token: next.accessToken,
     ...buildConnectionSdsFields(conn.contributions, next.accessToken),
   });
-  const updatedAuth: ConnectionAuthConfig = {
-    ...withoutRefreshFailureMarker(auth),
-    expiresAt: next.expiresAt,
-  };
+  // Merge the two keys this tick owns rather than writing back the whole `auth`
+  // it read at the start. A github-app connection's scope is editable in place,
+  // so a re-scope that landed while this mint was in flight would otherwise be
+  // overwritten by the pre-edit copy — quietly restoring authority the user had
+  // just taken away. Same shape as the failure-marker write above.
   await deps.db
     .update(connectionsTable)
-    .set({ auth: updatedAuth, updatedAt: new Date() })
+    .set({
+      auth: sql`jsonb_set(${connectionsTable.auth}, '{expiresAt}', to_jsonb(${next.expiresAt}::bigint)) - 'refreshFailedAt'`,
+      updatedAt: new Date(),
+    })
     .where(eq(connectionsTable.id, conn.id));
 }

--- a/packages/ui/src/modules/connections/api/mutations.ts
+++ b/packages/ui/src/modules/connections/api/mutations.ts
@@ -70,6 +70,30 @@ export function useProbeGitHubAppInstallation() {
   });
 }
 
+// The same read for a connection that already exists — it supplies its own app
+// identity and key, so the editor never asks for the private key again.
+export function useProbeGitHubAppInstallationForConnection() {
+  return useMutation({
+    ...trpc.connections.probeGitHubAppInstallationForConnection.mutationOptions(),
+    meta: { suppressErrorToast: true },
+  });
+}
+
+// The dialog renders a rejected scope on the form, so no global toast here
+// either; the list refreshes because the stored scope is part of the view.
+export function useUpdateGitHubAppScope() {
+  return useMutation({
+    ...trpc.connections.updateGitHubAppScope.mutationOptions(),
+    meta: {
+      invalidates: [
+        trpc.connections.list.queryKey(),
+        trpc.connections.getAgentConnections.queryKey(),
+      ],
+      suppressErrorToast: true,
+    },
+  });
+}
+
 /**
  * Verifies an Anthropic credential against Anthropic before save. Returns
  * `{ ok: true } | { ok: false; message }` rather than throwing — callers

--- a/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
@@ -15,6 +15,9 @@ export interface RowGrantControls {
 export interface RowMaintenanceActions {
   onReauthenticate?: () => void;
   onUpdateCredential?: () => void;
+  /** Change what the connection is allowed to do, where that is a property of
+   *  the connection rather than of the credential (GitHub App scope). */
+  onEditScope?: () => void;
   /** A consent popup for this row is already open. */
   busy?: boolean;
 }

--- a/packages/ui/src/modules/connections/components/connection-catalog-modal.tsx
+++ b/packages/ui/src/modules/connections/components/connection-catalog-modal.tsx
@@ -113,9 +113,11 @@ export function ConnectionCatalogModal({
     );
   };
 
-  if (maintenance.updating) {
-    // The credential dialog replaces the catalogue while open — stacking two
-    // modals would trap focus in whichever mounted last.
+  if (maintenance.updating || maintenance.editingScope) {
+    // A maintenance dialog replaces the catalogue while open — stacking two
+    // modals would trap focus in whichever mounted last. Both kinds must be
+    // named here: one left out is a menu item that does nothing, and its state
+    // then lingers to shadow the next dialog opened from another row.
     return <ConnectionMaintenanceDialog maintenance={maintenance} />;
   }
 

--- a/packages/ui/src/modules/connections/components/connection-edit-github-app-scope-dialog.tsx
+++ b/packages/ui/src/modules/connections/components/connection-edit-github-app-scope-dialog.tsx
@@ -117,10 +117,19 @@ export function ConnectionEditGithubAppScopeDialog({
         ? save.error.message
         : "Couldn't update the scope. Please try again.";
 
-  // Without a repository list there is nothing to choose from, so the
-  // repository half is passed through exactly as stored rather than rewritten
-  // from an empty selection — which would silently widen the connection.
-  const repositoriesLocked = Boolean(installation?.repositoriesUnavailable);
+  // Editing repositories needs a complete picture of the installation. Without
+  // one, the repository half is passed through exactly as stored rather than
+  // rewritten from a selection built against a partial list — which would
+  // silently drop whatever the list did not cover.
+  //
+  // Truncation only matters when the connection narrows by *name*: an id the
+  // list omits is still carried through the selection, but a name can only be
+  // matched against what came back, so beyond the cap it is indistinguishable
+  // from one the installation has genuinely dropped.
+  const namesToResolve = (connection.githubAppScope?.repositories ?? []).length;
+  const repositoriesLocked =
+    Boolean(installation?.repositoriesUnavailable) ||
+    Boolean(installation?.repositoriesTruncated && namesToResolve > 0);
 
   const repositoryPayload = repositoriesLocked
     ? {
@@ -182,10 +191,11 @@ export function ConnectionEditGithubAppScopeDialog({
           <>
             {repositoriesLocked ? (
               <Callout tone="muted" size="sm">
-                Couldn&rsquo;t list this installation&rsquo;s repositories, so
-                they can&rsquo;t be changed here — saving keeps the ones this
-                connection already uses. Permissions below are still the
-                installation&rsquo;s own.
+                {installation.repositoriesUnavailable
+                  ? "Couldn’t list this installation’s repositories, so they can’t be changed here"
+                  : "This installation has more repositories than can be listed here, and this connection names them individually, so they can’t be changed here"}
+                {" — saving keeps the ones this connection already uses. "}
+                Permissions below are still the installation&rsquo;s own.
               </Callout>
             ) : (
               <>
@@ -212,7 +222,10 @@ export function ConnectionEditGithubAppScopeDialog({
               selection={permissions}
               onChange={setPermission}
             />
-            {unresolvedNames.length > 0 && (
+            {/* Only meaningful against a complete list: when the listing was
+                partial, an unmatched name is preserved rather than dropped, so
+                the locked callout above already covers it. */}
+            {!repositoriesLocked && unresolvedNames.length > 0 && (
               <Callout tone="danger" size="sm">
                 This connection also names {unresolvedNames.join(", ")}, which
                 the installation no longer lists. Saving will drop{" "}

--- a/packages/ui/src/modules/connections/components/connection-edit-github-app-scope-dialog.tsx
+++ b/packages/ui/src/modules/connections/components/connection-edit-github-app-scope-dialog.tsx
@@ -1,0 +1,256 @@
+import { TRPCClientError } from "@trpc/client";
+import type { ConnectionView } from "api-server-api";
+import { useEffect, useState } from "react";
+
+import {
+  DialogBody,
+  DialogFooter,
+  DialogHeader,
+  Modal,
+} from "@/components/modal";
+import { Button } from "@/components/ui/button";
+import { Callout } from "@/components/ui/callout";
+
+import {
+  useProbeGitHubAppInstallationForConnection,
+  useUpdateGitHubAppScope,
+} from "../api/mutations.js";
+import {
+  PermissionSection,
+  RepositorySection,
+} from "../forms/github-app-scope-sections.js";
+import {
+  type PermissionLevel,
+  writePermissions,
+  writeRepositoryIds,
+} from "../lib/github-app-scope-fields.js";
+
+/** Changes which repositories and permissions an existing GitHub App
+ *  connection mints against, without recreating it. The connection already
+ *  holds its app identity and private key, so this reads the installation on
+ *  the user's behalf and never asks for the key again. */
+export function ConnectionEditGithubAppScopeDialog({
+  connection,
+  onClose,
+}: {
+  connection: ConnectionView;
+  onClose: () => void;
+}) {
+  const probe = useProbeGitHubAppInstallationForConnection();
+  const save = useUpdateGitHubAppScope();
+  const installation = probe.data;
+
+  // Seeded from what the connection mints against today, so the dialog opens
+  // showing the current scope rather than an empty one.
+  const [repoIds, setRepoIds] = useState<Set<number>>(
+    () => new Set(connection.githubAppScope?.repositoryIds ?? []),
+  );
+  const [permissions, setPermissions] = useState<
+    Record<string, PermissionLevel>
+  >(
+    () =>
+      (connection.githubAppScope?.permissions ?? {}) as Record<
+        string,
+        PermissionLevel
+      >,
+  );
+
+  // Names that the connection narrows by but the installation no longer lists,
+  // so saving would drop them. Surfaced rather than silently discarded.
+  const [unresolvedNames, setUnresolvedNames] = useState<string[]>([]);
+
+  const { mutate: runProbe } = probe;
+  useEffect(() => {
+    runProbe(
+      { connectionId: connection.id },
+      {
+        onSuccess: (result) => {
+          // A connection narrowed by name — created before the picker, or from
+          // the CLI — has no ids to seed from. Resolve them against the
+          // installation so an untouched Save keeps the same repositories
+          // instead of clearing the selection and widening the token.
+          const names = connection.githubAppScope?.repositories ?? [];
+          if (names.length === 0) return;
+          const byName = new Map(
+            result.repositories.map((r) => [r.name, r.id] as const),
+          );
+          // Split before touching state: an updater that appended to `missing`
+          // would build a different list each time React invoked it.
+          const resolved: number[] = [];
+          const missing: string[] = [];
+          for (const name of names) {
+            const id = byName.get(name);
+            if (id === undefined) missing.push(name);
+            else resolved.push(id);
+          }
+          setRepoIds((prev) => new Set([...prev, ...resolved]));
+          setUnresolvedNames(missing);
+        },
+      },
+    );
+  }, [runProbe, connection.id, connection.githubAppScope?.repositories]);
+
+  const toggleRepo = (id: number, checked: boolean) => {
+    setRepoIds((prev) => {
+      const next = new Set(prev);
+      if (checked) next.add(id);
+      else next.delete(id);
+      return next;
+    });
+  };
+
+  const setPermission = (name: string, level: PermissionLevel | "off") => {
+    setPermissions((prev) => {
+      const next = { ...prev };
+      if (level === "off") delete next[name];
+      else next[name] = level;
+      return next;
+    });
+  };
+
+  // A rejected scope is about what was just chosen, so the server's words
+  // belong in the dialog. A transport failure isn't — it would misattribute.
+  const saveError =
+    save.error === null
+      ? undefined
+      : isBadRequest(save.error)
+        ? save.error.message
+        : "Couldn't update the scope. Please try again.";
+
+  // Without a repository list there is nothing to choose from, so the
+  // repository half is passed through exactly as stored rather than rewritten
+  // from an empty selection — which would silently widen the connection.
+  const repositoriesLocked = Boolean(installation?.repositoriesUnavailable);
+
+  const repositoryPayload = repositoriesLocked
+    ? {
+        repositoryIds: writeRepositoryIds(
+          connection.githubAppScope?.repositoryIds ?? [],
+        ),
+        repositories: (connection.githubAppScope?.repositories ?? []).join(" "),
+      }
+    : { repositoryIds: writeRepositoryIds([...repoIds]) };
+
+  const submit = async () => {
+    try {
+      await save.mutateAsync({
+        id: connection.id,
+        ...repositoryPayload,
+        permissions: writePermissions(permissions),
+      });
+      onClose();
+    } catch {
+      // Rendered inline from the mutation's error below.
+    }
+  };
+
+  // Ids kept from the stored scope that the probe did not list — a repository
+  // beyond the page cap, or one the installation has since dropped. They are
+  // preserved on save, so say so rather than leaving them invisible.
+  const keptUnlisted = installation
+    ? [...repoIds].filter(
+        (id) => !installation.repositories.some((r) => r.id === id),
+      ).length
+    : 0;
+
+  const narrowedRepos = repositoriesLocked
+    ? (connection.githubAppScope?.repositoryIds?.length ?? 0) +
+      (connection.githubAppScope?.repositories?.length ?? 0)
+    : repoIds.size;
+  const narrowed = narrowedRepos > 0 || Object.keys(permissions).length > 0;
+
+  return (
+    <Modal widthClass="w-[560px]">
+      <DialogHeader
+        title="Edit repositories & permissions"
+        subtitle={connection.name}
+        onClose={onClose}
+        closeTestId="edit-scope-close"
+      />
+      <DialogBody className="flex flex-col gap-4">
+        {probe.isPending && (
+          <p className="text-sm text-muted-foreground">
+            Reading the installation…
+          </p>
+        )}
+        {probe.isError && (
+          <Callout tone="danger" size="sm">
+            Couldn&rsquo;t read this installation: {probe.error.message}
+          </Callout>
+        )}
+        {installation && (
+          <>
+            {repositoriesLocked ? (
+              <Callout tone="muted" size="sm">
+                Couldn&rsquo;t list this installation&rsquo;s repositories, so
+                they can&rsquo;t be changed here — saving keeps the ones this
+                connection already uses. Permissions below are still the
+                installation&rsquo;s own.
+              </Callout>
+            ) : (
+              <>
+                <RepositorySection
+                  installation={installation}
+                  selected={repoIds}
+                  onToggle={toggleRepo}
+                />
+                {keptUnlisted > 0 && (
+                  <Callout tone="muted" size="sm">
+                    {keptUnlisted} selected{" "}
+                    {keptUnlisted === 1 ? "repository is" : "repositories are"}{" "}
+                    not in the list above
+                    {installation.repositoriesTruncated
+                      ? " (it shows only the first page of a large installation)"
+                      : ""}
+                    . They stay selected when you save.
+                  </Callout>
+                )}
+              </>
+            )}
+            <PermissionSection
+              installation={installation}
+              selection={permissions}
+              onChange={setPermission}
+            />
+            {unresolvedNames.length > 0 && (
+              <Callout tone="danger" size="sm">
+                This connection also names {unresolvedNames.join(", ")}, which
+                the installation no longer lists. Saving will drop{" "}
+                {unresolvedNames.length === 1 ? "it" : "them"}.
+              </Callout>
+            )}
+            {!narrowed && (
+              <Callout tone="danger" size="sm">
+                Nothing selected — saving gives this connection everything the
+                app installation can do.
+              </Callout>
+            )}
+          </>
+        )}
+        {saveError && (
+          <Callout tone="danger" size="sm">
+            {saveError}
+          </Callout>
+        )}
+      </DialogBody>
+      <DialogFooter>
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button
+          disabled={!installation || save.isPending}
+          onClick={() => void submit()}
+          data-testid="edit-scope-submit"
+        >
+          {save.isPending ? "Saving…" : "Save"}
+        </Button>
+      </DialogFooter>
+    </Modal>
+  );
+}
+
+/** A scope the installation does not cover comes back as BAD_REQUEST with
+ *  GitHub's own words. */
+function isBadRequest(err: unknown): err is Error {
+  return err instanceof TRPCClientError && err.data?.code === "BAD_REQUEST";
+}

--- a/packages/ui/src/modules/connections/components/connection-row-actions.tsx
+++ b/packages/ui/src/modules/connections/components/connection-row-actions.tsx
@@ -109,6 +109,14 @@ export function ConnectionRowActions({
               {reauthLabel}
             </DropdownMenuItem>
           )}
+          {maintenance?.onEditScope && (
+            <DropdownMenuItem
+              onSelect={maintenance.onEditScope}
+              data-testid={`catalog-edit-scope-${connection.id}`}
+            >
+              Edit repositories &amp; permissions
+            </DropdownMenuItem>
+          )}
           {maintenance?.onUpdateCredential && (
             <DropdownMenuItem
               onSelect={maintenance.onUpdateCredential}

--- a/packages/ui/src/modules/connections/components/connection-update-credential-dialog.tsx
+++ b/packages/ui/src/modules/connections/components/connection-update-credential-dialog.tsx
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 import { useUpdateConnection } from "../api/mutations.js";
 import { credentialCopyFor } from "../forms/field-copy.js";
 import { LabeledInput } from "../forms/labeled-input.js";
+import { ConnectionEditGithubAppScopeDialog } from "./connection-edit-github-app-scope-dialog.js";
 
 /** The dialog half of `useConnectionMaintenance`: owns the `updating` guard so
  *  a surface wiring the row actions can't forget the mount. Render it either
@@ -24,8 +25,18 @@ export function ConnectionMaintenanceDialog({
   maintenance: {
     updating: ConnectionView | null;
     closeUpdate: () => void;
+    editingScope?: ConnectionView | null;
+    closeEditScope?: () => void;
   };
 }) {
+  if (maintenance.editingScope && maintenance.closeEditScope) {
+    return (
+      <ConnectionEditGithubAppScopeDialog
+        connection={maintenance.editingScope}
+        onClose={maintenance.closeEditScope}
+      />
+    );
+  }
   if (!maintenance.updating) return null;
   return (
     <ConnectionUpdateCredentialDialog

--- a/packages/ui/src/modules/connections/forms/github-app-scope-picker.tsx
+++ b/packages/ui/src/modules/connections/forms/github-app-scope-picker.tsx
@@ -1,20 +1,14 @@
-import type {
-  ConnectionTemplateInput,
-  GitHubAppInstallationProbe,
-} from "api-server-api";
+import type { ConnectionTemplateInput } from "api-server-api";
 import { useEffect, useRef } from "react";
 import { type Control, useWatch } from "react-hook-form";
 
 import { Button } from "@/components/ui/button";
 import { Callout } from "@/components/ui/callout";
-import { CheckboxItem } from "@/components/ui/checkbox";
-import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import { useProbeGitHubAppInstallation } from "../api/mutations.js";
 import {
   canProbe,
-  levelsUpTo,
   type PermissionLevel,
   readPermissions,
   readRepositoryIds,
@@ -22,6 +16,10 @@ import {
   writeRepositoryIds,
 } from "../lib/github-app-scope-fields.js";
 import type { TemplateFormValues } from "../lib/template-form-schema.js";
+import {
+  PermissionSection,
+  RepositorySection,
+} from "./github-app-scope-sections.js";
 import { TemplateFieldInput } from "./template-field-input.js";
 
 interface Props {
@@ -209,93 +207,5 @@ export function GithubAppScopePicker({
         fallbackInputs.map((input) => textInput(input.name))
       )}
     </div>
-  );
-}
-
-function RepositorySection({
-  installation,
-  selected,
-  onToggle,
-}: {
-  installation: GitHubAppInstallationProbe;
-  selected: Set<number>;
-  onToggle: (id: number, checked: boolean) => void;
-}) {
-  if (installation.repositories.length === 0) return null;
-  return (
-    <fieldset className="flex flex-col gap-2">
-      <legend className="text-sm font-medium">Repositories</legend>
-      <p className="text-xs text-muted-foreground">
-        Nothing ticked means every repository the installation can reach.
-        {installation.repositorySelection === "all" &&
-          " This app is installed on every repository in the account, so that set grows as the account does — tick the ones this agent needs to pin it."}
-      </p>
-      <div className="flex max-h-56 flex-col gap-1 overflow-y-auto">
-        {installation.repositories.map((repo) => (
-          <CheckboxItem
-            key={repo.id}
-            label={repo.name}
-            labelClassName="font-mono"
-            checked={selected.has(repo.id)}
-            onCheckedChange={(checked) => onToggle(repo.id, checked === true)}
-            testId={`github-app-repo-${repo.name}`}
-          />
-        ))}
-      </div>
-    </fieldset>
-  );
-}
-
-function PermissionSection({
-  installation,
-  selection,
-  onChange,
-}: {
-  installation: GitHubAppInstallationProbe;
-  selection: Record<string, PermissionLevel>;
-  onChange: (name: string, level: PermissionLevel | "off") => void;
-}) {
-  const granted = Object.keys(installation.permissions).sort();
-  if (granted.length === 0) return null;
-  return (
-    <fieldset className="flex flex-col gap-2">
-      <legend className="text-sm font-medium">Permissions</legend>
-      <p className="text-xs text-muted-foreground">
-        All off means every permission the app was granted. A permission can be
-        set no higher than the installation holds it.
-      </p>
-      <div className="flex flex-col gap-1">
-        {granted.map((name) => (
-          <div
-            key={name}
-            className="flex items-center justify-between gap-4 rounded-md px-2 py-1 hover:bg-muted/50"
-          >
-            <span className="font-mono text-sm">{name}</span>
-            <RadioGroup
-              className="flex flex-row gap-3"
-              value={selection[name] ?? "off"}
-              onValueChange={(level) =>
-                onChange(name, level as PermissionLevel | "off")
-              }
-              aria-label={`Level for ${name}`}
-            >
-              <RadioGroupItem
-                value="off"
-                label="Off"
-                testId={`github-app-perm-${name}-off`}
-              />
-              {levelsUpTo(installation.permissions[name]).map((level) => (
-                <RadioGroupItem
-                  key={level}
-                  value={level}
-                  label={level[0].toUpperCase() + level.slice(1)}
-                  testId={`github-app-perm-${name}-${level}`}
-                />
-              ))}
-            </RadioGroup>
-          </div>
-        ))}
-      </div>
-    </fieldset>
   );
 }

--- a/packages/ui/src/modules/connections/forms/github-app-scope-sections.tsx
+++ b/packages/ui/src/modules/connections/forms/github-app-scope-sections.tsx
@@ -1,0 +1,102 @@
+import type { GitHubAppInstallationProbe } from "api-server-api";
+
+import { CheckboxItem } from "@/components/ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+
+import {
+  levelsUpTo,
+  type PermissionLevel,
+} from "../lib/github-app-scope-fields.js";
+
+/** The two halves of a GitHub App scope, rendered from a probed installation.
+ *  Both take the selection as plain props and report changes back, so the
+ *  create form (which keeps the selection in its react-hook-form fields) and
+ *  the edit dialog (which keeps it in local state) can share them. */
+
+export function RepositorySection({
+  installation,
+  selected,
+  onToggle,
+}: {
+  installation: GitHubAppInstallationProbe;
+  selected: Set<number>;
+  onToggle: (id: number, checked: boolean) => void;
+}) {
+  if (installation.repositories.length === 0) return null;
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium">Repositories</legend>
+      <p className="text-xs text-muted-foreground">
+        Nothing ticked means every repository the installation can reach.
+        {installation.repositorySelection === "all" &&
+          " This app is installed on every repository in the account, so that set grows as the account does — tick the ones this agent needs to pin it."}
+      </p>
+      <div className="flex max-h-56 flex-col gap-1 overflow-y-auto">
+        {installation.repositories.map((repo) => (
+          <CheckboxItem
+            key={repo.id}
+            label={repo.name}
+            labelClassName="font-mono"
+            checked={selected.has(repo.id)}
+            onCheckedChange={(checked) => onToggle(repo.id, checked === true)}
+            testId={`github-app-repo-${repo.name}`}
+          />
+        ))}
+      </div>
+    </fieldset>
+  );
+}
+
+export function PermissionSection({
+  installation,
+  selection,
+  onChange,
+}: {
+  installation: GitHubAppInstallationProbe;
+  selection: Record<string, PermissionLevel>;
+  onChange: (name: string, level: PermissionLevel | "off") => void;
+}) {
+  const granted = Object.keys(installation.permissions).sort();
+  if (granted.length === 0) return null;
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-sm font-medium">Permissions</legend>
+      <p className="text-xs text-muted-foreground">
+        All off means every permission the app was granted. A permission can be
+        set no higher than the installation holds it.
+      </p>
+      <div className="flex flex-col gap-1">
+        {granted.map((name) => (
+          <div
+            key={name}
+            className="flex items-center justify-between gap-4 rounded-md px-2 py-1 hover:bg-muted/50"
+          >
+            <span className="font-mono text-sm">{name}</span>
+            <RadioGroup
+              className="flex flex-row gap-3"
+              value={selection[name] ?? "off"}
+              onValueChange={(level) =>
+                onChange(name, level as PermissionLevel | "off")
+              }
+              aria-label={`Level for ${name}`}
+            >
+              <RadioGroupItem
+                value="off"
+                label="Off"
+                testId={`github-app-perm-${name}-off`}
+              />
+              {levelsUpTo(installation.permissions[name]).map((level) => (
+                <RadioGroupItem
+                  key={level}
+                  value={level}
+                  label={level[0].toUpperCase() + level.slice(1)}
+                  testId={`github-app-perm-${name}-${level}`}
+                />
+              ))}
+            </RadioGroup>
+          </div>
+        ))}
+      </div>
+    </fieldset>
+  );
+}

--- a/packages/ui/src/modules/connections/hooks/use-connection-maintenance.ts
+++ b/packages/ui/src/modules/connections/hooks/use-connection-maintenance.ts
@@ -8,7 +8,21 @@ import { useReauthenticateConnection } from "./use-reauthenticate-connection.js"
  *  the surfaces listing connections can't drift on what each auth kind gets. */
 export function useConnectionMaintenance() {
   const [updating, setUpdating] = useState<ConnectionView | null>(null);
+  const [editingScope, setEditingScope] = useState<ConnectionView | null>(null);
   const { reauthenticate, busyId } = useReauthenticateConnection();
+
+  // At most one dialog is open at a time, and opening either clears the other.
+  // Two live slots would let one shadow the other — a stale scope target would
+  // render its editor when a later row asked for the credential dialog, bound
+  // to a connection the user is no longer looking at.
+  const openUpdate = (connection: ConnectionView) => {
+    setEditingScope(null);
+    setUpdating(connection);
+  };
+  const openEditScope = (connection: ConnectionView) => {
+    setUpdating(null);
+    setEditingScope(connection);
+  };
 
   const rowActions = (
     connection: ConnectionView,
@@ -21,13 +35,20 @@ export function useConnectionMaintenance() {
           onReauthenticate: () => void reauthenticate(connection),
           busy: busyId === connection.id,
           ...(connection.hasClientSecret
-            ? { onUpdateCredential: () => setUpdating(connection) }
+            ? { onUpdateCredential: () => openUpdate(connection) }
             : {}),
         };
       case "header":
       case "client-credentials":
+        return { onUpdateCredential: () => openUpdate(connection) };
+      // A GitHub App connection additionally owns which repositories and
+      // permissions it mints against, and that is editable in place — the
+      // credential and every grant stay put.
       case "github-app":
-        return { onUpdateCredential: () => setUpdating(connection) };
+        return {
+          onUpdateCredential: () => openUpdate(connection),
+          onEditScope: () => openEditScope(connection),
+        };
       case "none":
         return undefined;
     }
@@ -37,5 +58,7 @@ export function useConnectionMaintenance() {
     rowActions,
     updating,
     closeUpdate: () => setUpdating(null),
+    editingScope,
+    closeEditScope: () => setEditingScope(null),
   };
 }


### PR DESCRIPTION
Follow-up to #3225. Narrowing was fixed at create, so adding a repository meant rebuilding the connection — re-pasting the private key and re-granting it to every agent using it.

## What changed

A GitHub App connection's repositories and permissions are now editable in place, from the connection row's ⋮ menu.

This is the **one** part of a connection's configuration that is editable, and it stays cheap because nothing else moves. The contributions are unchanged — same hosts, same injections — so there's no Agent-spec patch and no pod roll. The narrower token swaps in gateway-side via SDS, and every existing agent grant keeps working; the agents just start using a smaller token.

Structurally it's the operation the private-key rotation already performs: mint, write token + SDS to the same Secret, update stored auth.

**Editing never asks for the key again.** The connection already holds its app identity and private key, so a second probe entry point re-reads the installation on the user's behalf.

**The new scope is proven before it's stored,** by minting against it — same fail-closed property as create. A subset the installation can't cover fails the edit you're looking at, rather than parking the connection an hour later.

**Take effect is immediate.** The proving mint's token replaces the live one, so the narrowing applies now rather than at the next renewal.

## Notes for the reviewer

- **Replace, not merge.** The caller states the whole scope; an omitted half clears. Clearing both is a deliberate widening back to the full installation, and the dialog says so plainly before you save.
- **Name-narrowed connections.** A connection created with repository *names* (CLI `--repositories`, or the create form's typed fallback) has no ids to seed the picker from. Those names are resolved against the installation so an untouched Save keeps the same repositories rather than clearing them — the obvious silent-widening trap. Names the installation no longer lists are called out as being dropped.
- **When the repository list can't be read,** repositories become read-only and are passed through exactly as stored, so permissions stay editable without the repository half being rewritten from an empty selection.
- **`RepositorySection`/`PermissionSection` moved** to their own module, unchanged, so the create picker and the edit dialog share them.

## One change outside the feature, deliberately

The github-app re-mint in the refresh loop now merges only the horizon and failure marker into stored auth, instead of writing back the whole copy it read at the start of the tick. With the scope mutable, a whole-object write let a refresh that began before an edit overwrite it afterwards — silently restoring authority the user had just removed. It uses the same `jsonb_set` shape the failure-marker write in that file already uses. The three tests that asserted the old whole-object write now assert the anti-clobber property instead: the write names the horizon and never names the scope.

## Verification

- `api-server` 873 tests, `ui` 256, `cli` 154 — all pass. Typecheck, lint, and format verified per package directly.
- Reviewed adversarially before commit: 17 candidate findings, 12 confirmed after verification (several duplicates of the same root), all fixed. The ones worth naming:
  - **The catalogue never mounted the dialog**, so the new menu item did nothing there — and the un-cleared state then shadowed the next credential dialog, rendering the scope editor bound to a *different* connection than the row the user clicked. Fixed at the guard and at the root, by making the two dialog slots mutually exclusive.
  - **The widening trap above**, where the dialog claimed the selection was preserved while Save posted an empty id set.
  - **A `tsc` failure I'd have shipped**: I ran the type check before adding my last test, and vitest doesn't typecheck. Caught here, fixed, and re-verified after.
  - An impure `setState` updater that duplicated names under StrictMode's double invoke.
