### PR TITLE
fix(ui): match the skill source error band to its design

### DIFF
--- a/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
+++ b/packages/ui/src/modules/sandboxes/components/skills/skill-source-card.tsx
@@ -3,7 +3,7 @@ import {
   ChevronUp,
   Launch,
   OverflowMenuHorizontal,
-  WarningAlt,
+  Warning,
 } from "@carbon/icons-react";
 import type { ScanFailure, Skill, SkillRef, SkillSource } from "api-server-api";
 import { useRef, useState } from "react";
@@ -35,7 +35,11 @@ function repoLabel(source: SkillSource): string {
 /** Why a source's scan failed: the cause on one line, the fix beneath it. Both
  *  come from the server's verdict, which is closed-set — the card never renders
  *  a raw error message, so a parser or transport string can't reach the user.
- *  "Manage connections" appears only where connections are the fix. */
+ *  "Manage connections" appears only where connections are the fix.
+ *
+ *  Only the heading, the icon and the link carry the danger colour; the fix
+ *  beneath reads as body text. Colouring the whole band red makes it shout
+ *  where it should explain, and leaves nothing to draw the eye to the cause. */
 function SourceError({
   failure,
   onManageConnections,
@@ -46,10 +50,10 @@ function SourceError({
   const canManage = onManageConnections && isConnectionFailure(failure);
   return (
     <div className="flex items-start gap-2 border-t border-border bg-danger-light px-4 py-3 text-sm text-danger">
-      <WarningAlt size={16} className="mt-px shrink-0" />
+      <Warning size={16} className="mt-px shrink-0" />
       <div className="min-w-0 flex-1">
         <p className="font-semibold">{failure.title}</p>
-        <p>{failure.detail}</p>
+        <p className="text-muted-foreground">{failure.detail}</p>
       </div>
       {canManage && (
         <Button


### PR DESCRIPTION
Follow-up to #3237. The scan-error band that PR introduced differs from the frame in #3236 in two ways, both there since the band was built.

## Icon

The design uses the circle warning; the band renders the triangle one. Confirmed from geometry rather than by eye — the rendered path was `M14.5,14h-13…` (Carbon `WarningAlt`, a triangle) where the mock shows `M8,1C4.1,1,1,4.1,1,8…` (Carbon `Warning`, a circle).

## Body text colour

The design puts only the heading in red and the fix sentence in body grey. The band set `text-danger` on its container, so the fix sentence inherited red too.

Ink sampled from the mock against the light-theme tokens:

| element | design | token | before |
|---|---|---|---|
| heading | rgb(196, 36, 27) | `--c-danger` `#dc2626` ✓ | red ✓ |
| **body** | **rgb(81, 86, 91)** | **`--muted-foreground` `#4d5358`** | **red ✗** |
| icon | rgb(201, 55, 47) | `--c-danger` ✓ | red ✓ |
| link | rgb(197, 41, 32) | `--c-danger` ✓ | red ✓ |
| background | rgb(252, 243, 242) | `--c-danger-light` `#fef2f2` ✓ | ✓ |

The body sample lands within antialiasing distance of `#4d5358`, so the mock is using the token rather than a one-off grey.

`text-danger` stays on the container so the icon, heading and link keep inheriting it — the link renders with `text-current` and depends on that.

## Verification

Rendered on the local cluster against a sandbox with no GitHub connection scanning a private source. Computed values after the change:

- light — heading `rgb(220, 38, 38)`, body `rgb(77, 83, 88)`, band `rgb(254, 242, 242)`
- dark — heading `rgb(248, 113, 113)`, body `rgb(168, 162, 158)`, band `rgb(58, 21, 21)`

The mock only covers light, so dark is a judgement call: `--muted-foreground` there is a warm grey on the dark danger band. Contrast holds in both — 7.1:1 light, 6.4:1 dark, against a 4.5:1 floor.

Applies to all three source-scan verdicts, since they share this band.
