### PR TITLE
fix(ui): add read-only reason dialog to the schedule edit path

### DIFF
--- a/packages/ui/src/components/ui/confirm-dialog.tsx
+++ b/packages/ui/src/components/ui/confirm-dialog.tsx
@@ -1,4 +1,9 @@
-import { TrashCan, Warning, WarningAlt } from "@carbon/icons-react";
+import {
+  Information,
+  TrashCan,
+  Warning,
+  WarningAlt,
+} from "@carbon/icons-react";
 import type { ReactNode } from "react";
 
 import {
@@ -14,7 +19,13 @@ import {
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 
-export type ConfirmDialogKind = "default" | "destructive";
+export type ConfirmDialogKind = "default" | "destructive" | "info";
+
+const KIND_ICON = {
+  default: Warning,
+  destructive: WarningAlt,
+  info: Information,
+} as const satisfies Record<ConfirmDialogKind, typeof Warning>;
 
 export interface ConfirmDialogProps {
   open: boolean;
@@ -46,6 +57,7 @@ export function ConfirmDialog({
   onCancel,
 }: ConfirmDialogProps) {
   const destructive = kind === "destructive";
+  const Icon = KIND_ICON[kind];
   const resolvedConfirmLabel =
     confirmLabel ?? (showCancel ? (destructive ? "Remove" : "Confirm") : "OK");
 
@@ -66,11 +78,12 @@ export function ConfirmDialog({
                 destructive ? "bg-destructive/10" : "bg-primary/10",
               )}
             >
-              {destructive ? (
-                <WarningAlt className="h-4 w-4 text-destructive" />
-              ) : (
-                <Warning className="h-4 w-4 text-primary" />
-              )}
+              <Icon
+                className={cn(
+                  "h-4 w-4",
+                  destructive ? "text-destructive" : "text-primary",
+                )}
+              />
             </div>
             <AlertDialogTitle>{title}</AlertDialogTitle>
           </div>

--- a/packages/ui/src/modules/platform/store/dialog.ts
+++ b/packages/ui/src/modules/platform/store/dialog.ts
@@ -11,6 +11,9 @@ export interface ConfirmOptions {
   cancelLabel?: string;
 }
 
+/** An alert has one button, so it takes everything but the cancel label. */
+export type AlertOptions = Omit<ConfirmOptions, "cancelLabel">;
+
 export interface DialogState {
   type: "alert" | "confirm";
   title: string;
@@ -23,7 +26,11 @@ export interface DialogState {
 
 export interface DialogSlice {
   dialog: DialogState | null;
-  showAlert: (message: ReactNode, title?: string) => Promise<void>;
+  showAlert: (
+    message: ReactNode,
+    title?: string,
+    options?: AlertOptions,
+  ) => Promise<void>;
   showConfirm: (
     message: ReactNode,
     title?: string,
@@ -39,14 +46,15 @@ export const createDialogSlice: StateCreator<
   DialogSlice
 > = (set, get) => ({
   dialog: null,
-  showAlert: (message, title = "Error") =>
+  showAlert: (message, title = "Error", options) =>
     new Promise<void>((resolve) => {
       set({
         dialog: {
           type: "alert",
           title,
           message,
-          kind: "default",
+          kind: options?.kind ?? "default",
+          confirmLabel: options?.confirmLabel,
           resolve: () => resolve(),
         },
       });

--- a/packages/ui/src/modules/schedules/components/schedule-card.tsx
+++ b/packages/ui/src/modules/schedules/components/schedule-card.tsx
@@ -19,16 +19,16 @@ import { formatDateTime, timeUntil } from "@/lib/format-time";
 
 import { useStore } from "../../../store.js";
 import type { Schedule } from "../../../types.js";
+import { useAgentDisplayName } from "../../agents/api/queries.js";
 import {
   useDeleteSchedule,
   useResetScheduleSession,
   useToggleSchedule,
 } from "../api/mutations.js";
 import { scheduleCadenceText } from "../lib/schedule-format.js";
+import { scheduleLock } from "../lib/schedule-lock.js";
 import { ScheduleDetails } from "./schedule-details.js";
-
-const NOT_EDITABLE_HINT =
-  "Cron and agent-created schedules can't be edited here.";
+import { scheduleLockNotice } from "./schedule-lock-notice.js";
 
 interface Props {
   schedule: Schedule;
@@ -45,16 +45,40 @@ export function ScheduleCard({
   onEdit,
   onViewResults,
 }: Props) {
-  const { id, name, type, enabled, sessionMode, createdBy, status } = schedule;
+  const { id, name, enabled, sessionMode, status } = schedule;
   const showConfirm = useStore((s) => s.showConfirm);
+  const showAlert = useStore((s) => s.showAlert);
+  const selectAgent = useStore((s) => s.selectAgent);
+  const sandboxName = useAgentDisplayName(schedule.agentId);
   const toggleSchedule = useToggleSchedule();
   const deleteSchedule = useDeleteSchedule();
   const resetScheduleSession = useResetScheduleSession();
 
-  const canEdit = type === "rrule" && createdBy !== "agent";
+  const lock = scheduleLock(schedule);
   const cadence = scheduleCadenceText(schedule);
   const nextRunHint =
     enabled && status?.nextRun ? timeUntil(status.nextRun) : null;
+
+  /** A locked schedule opens its reason rather than a dead menu item — a
+   *  disabled item swallows the pointer, so its tooltip never reliably showed
+   *  and keyboard users got nothing at all. */
+  const handleEdit = async () => {
+    if (!lock) {
+      onEdit();
+      return;
+    }
+    const { title, body, action } = scheduleLockNotice(lock, sandboxName);
+    if (!action) {
+      await showAlert(body, title, { kind: "info", confirmLabel: "Close" });
+      return;
+    }
+    const confirmed = await showConfirm(body, title, {
+      kind: "info",
+      confirmLabel: action,
+      cancelLabel: "Close",
+    });
+    if (confirmed) selectAgent(schedule.agentId);
+  };
 
   const handleDelete = async () => {
     if (
@@ -130,15 +154,9 @@ export function ScheduleCard({
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent>
-            {canEdit ? (
-              <DropdownMenuItem onSelect={onEdit}>
-                Edit schedule
-              </DropdownMenuItem>
-            ) : (
-              <span title={NOT_EDITABLE_HINT}>
-                <DropdownMenuItem disabled>Edit schedule</DropdownMenuItem>
-              </span>
-            )}
+            <DropdownMenuItem onSelect={handleEdit}>
+              Edit schedule
+            </DropdownMenuItem>
             {sessionMode === "continuous" && (
               <DropdownMenuItem onSelect={handleReset}>
                 Reset session

--- a/packages/ui/src/modules/schedules/components/schedule-lock-notice.tsx
+++ b/packages/ui/src/modules/schedules/components/schedule-lock-notice.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from "react";
+
+import type { ScheduleLock } from "../lib/schedule-lock.js";
+
+interface Notice {
+  title: string;
+  body: ReactNode;
+  /** Label for the action that resolves the notice, when one exists. */
+  action?: string;
+}
+
+/** What to tell the user in place of the schedule form. Each notice names only
+ *  the reason that applies, so the reader knows which schedule they have. */
+export function scheduleLockNotice(
+  lock: ScheduleLock,
+  sandboxName: string,
+): Notice {
+  if (lock === "agent-managed") {
+    return {
+      title: "This schedule is managed by the sandbox",
+      action: "Open chat",
+      body: (
+        <div className="flex flex-col gap-3">
+          <p>
+            {sandboxName} created this schedule, so changes must be made through
+            the sandbox.
+          </p>
+          <p>
+            Editing it here may cause it to become out of sync with the sandbox
+            configuration.
+          </p>
+          <p>
+            Ask the sandbox in chat to change when it runs or what it does. You
+            can pause or delete it here anytime.
+          </p>
+        </div>
+      ),
+    };
+  }
+  return {
+    title: "This schedule uses the older cron format",
+    body: (
+      <div className="flex flex-col gap-3">
+        <p>
+          It runs on a cron expression in UTC. The editor works with the newer
+          format only, so it can&apos;t show this schedule&apos;s timing without
+          rewriting it.
+        </p>
+        <p>
+          To change when it runs, delete this schedule and create a new one. You
+          can pause it here anytime.
+        </p>
+      </div>
+    ),
+  };
+}

--- a/packages/ui/src/modules/schedules/lib/schedule-lock.ts
+++ b/packages/ui/src/modules/schedules/lib/schedule-lock.ts
@@ -1,0 +1,16 @@
+import type { Schedule } from "../../../types.js";
+
+/** Why the schedule form can't open a schedule. */
+export type ScheduleLock = "agent-managed" | "legacy-cron";
+
+/**
+ * Agent-created outranks the cron format: an agent can create either format,
+ * and asking it in chat is the way out whichever one it picked. A user's own
+ * cron schedule predates the rrule editor, which would rewrite its timing
+ * rather than show it.
+ */
+export function scheduleLock(schedule: Schedule): ScheduleLock | null {
+  if (schedule.createdBy === "agent") return "agent-managed";
+  if (schedule.type !== "rrule") return "legacy-cron";
+  return null;
+}


### PR DESCRIPTION
Closes #3217.

"Edit schedule" was greyed out with no reason on screen. A tooltip existed, but it sat on a span wrapping the disabled item — disabled items swallow the pointer, so it often didn't show, and keyboard and screen-reader users never got it. It also named both read-only reasons at once, so you still couldn't tell which schedule you had.

The item is now always clickable. It either opens the form, or a dialog with the one reason that applies:

- **Agent-created** — "This schedule is managed by the sandbox", with an Open chat button. Copy follows Jenna's mockup.
- **Cron** — the editor only understands the newer format, and opening it would rewrite the schedule's timing instead of showing it. So it says that, and says to delete and recreate instead.

Agent-created wins when both apply, because agents can create either format and asking in chat is the way out either way.

`ui:check` and `ui:test` clean, verified manually.
