### PR TITLE
feat(ui): rotate tips on the waits that show a spinner

### DIFF
--- a/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
+++ b/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
@@ -13,6 +13,7 @@ import type {
   AgentDisplayState,
 } from "../utils/agent-resolver.js";
 import { OverlayFrame } from "./overlay-frame.js";
+import { StartupTip } from "./startup-tip.js";
 
 interface OverlayCopy {
   /** Omitted for transient states, where a `Spinner` stands in for the icon. */
@@ -76,6 +77,7 @@ export function AgentUnavailableOverlay({
         <p className="max-w-105 text-sm text-muted-foreground">
           Loading agent…
         </p>
+        <StartupTip />
       </OverlayFrame>
     );
   }
@@ -93,6 +95,7 @@ export function AgentUnavailableOverlay({
         <p className="max-w-105 text-sm text-muted-foreground">
           Lost contact with the agent. Reconnecting…
         </p>
+        <StartupTip />
       </OverlayFrame>
     );
   }
@@ -116,6 +119,11 @@ export function AgentUnavailableOverlay({
         <StatusBadge state={state} />
       </div>
       <p className="max-w-105 text-sm text-muted-foreground">{description}</p>
+      {/* Tied to the spinner, not to a state list: a spinner means the wait is
+          the platform's to finish, which is exactly when a tip fills the time.
+          The icon states want an action from the user, and a tip would sit
+          between them and it. */}
+      {!Icon && <StartupTip />}
       {agent.podTerminationReason && (
         <p className="flex items-center gap-1.5 max-w-105 font-mono text-sm text-danger">
           <Warning size={14} className="shrink-0" />

--- a/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
+++ b/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
@@ -119,7 +119,6 @@ export function AgentUnavailableOverlay({
         <StatusBadge state={state} />
       </div>
       <p className="max-w-105 text-sm text-muted-foreground">{description}</p>
-      {/* Tied to the spinner: the icon states want an action, not a tip. */}
       {!Icon && <StartupTip sandbox={agent.name} />}
       {agent.podTerminationReason && (
         <p className="flex items-center gap-1.5 max-w-105 font-mono text-sm text-danger">

--- a/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
+++ b/packages/ui/src/modules/agents/components/agent-unavailable-overlay.tsx
@@ -77,7 +77,7 @@ export function AgentUnavailableOverlay({
         <p className="max-w-105 text-sm text-muted-foreground">
           Loading agent…
         </p>
-        <StartupTip />
+        <StartupTip sandbox={name} />
       </OverlayFrame>
     );
   }
@@ -95,7 +95,7 @@ export function AgentUnavailableOverlay({
         <p className="max-w-105 text-sm text-muted-foreground">
           Lost contact with the agent. Reconnecting…
         </p>
-        <StartupTip />
+        <StartupTip sandbox={agent.name} />
       </OverlayFrame>
     );
   }
@@ -119,11 +119,8 @@ export function AgentUnavailableOverlay({
         <StatusBadge state={state} />
       </div>
       <p className="max-w-105 text-sm text-muted-foreground">{description}</p>
-      {/* Tied to the spinner, not to a state list: a spinner means the wait is
-          the platform's to finish, which is exactly when a tip fills the time.
-          The icon states want an action from the user, and a tip would sit
-          between them and it. */}
-      {!Icon && <StartupTip />}
+      {/* Tied to the spinner: the icon states want an action, not a tip. */}
+      {!Icon && <StartupTip sandbox={agent.name} />}
       {agent.podTerminationReason && (
         <p className="flex items-center gap-1.5 max-w-105 font-mono text-sm text-danger">
           <Warning size={14} className="shrink-0" />

--- a/packages/ui/src/modules/agents/components/startup-tip.tsx
+++ b/packages/ui/src/modules/agents/components/startup-tip.tsx
@@ -1,0 +1,100 @@
+import { Idea } from "@carbon/icons-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+import { Callout } from "@/components/ui/callout";
+import { cn } from "@/lib/utils";
+
+import { startupTips } from "../startup-tips.js";
+
+/** Time a tip stays put, measured start-of-transition to start-of-transition. */
+const ROTATE_MS = 8_000;
+/** Each direction of the swap. The text is replaced while the card is at zero
+ *  opacity, so the outgoing and incoming tips never share the screen — two
+ *  different sentences at partial opacity is unreadable in a way that two
+ *  fading images is not. */
+const FADE_MS = 250;
+/** The spinner, the sandbox name and its badge should land first; the tip
+ *  arrives after them rather than competing for the same first glance. */
+const ENTER_DELAY_MS = 1_000;
+
+/** A tip other than `current`, so the rotation never appears to stall on a
+ *  repeat. Random rather than sequential: the same sandbox gets restarted a
+ *  lot, and a fixed order turns into one memorized loop. */
+function pickNext(current: number, count: number): number {
+  if (count < 2) return current;
+  return (current + 1 + Math.floor(Math.random() * (count - 1))) % count;
+}
+
+/**
+ * Rotating tips for every wait that shows a spinner. Two jobs: teach the
+ * feature set to someone whose first minutes would otherwise be spent on a
+ * static screen, and let the movement itself be the evidence that the wait
+ * hasn't stalled.
+ *
+ * Read-only text on purpose — a link would pull the user off the screen
+ * mid-wait, and they came to use the sandbox, not to read docs.
+ */
+export function StartupTip() {
+  const tips = useMemo(startupTips, []);
+  const [index, setIndex] = useState(() =>
+    Math.floor(Math.random() * tips.length),
+  );
+  const [shown, setShown] = useState(false);
+  // The rotation reads the live index without listing it as a dependency —
+  // otherwise every swap would tear down and restart the timer, and each tip
+  // would get its full dwell only by accident. Nothing else may enter these
+  // deps either: anything that changes mid-wait restarts the countdown, which
+  // is what a hover-to-pause flag did before it was removed.
+  const indexRef = useRef(index);
+  const swapRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    const enter = setTimeout(() => setShown(true), ENTER_DELAY_MS);
+    // Rotation is clocked from the end of the entrance, so the first tip gets
+    // the same dwell as every one after it.
+    let rotate: ReturnType<typeof setInterval> | undefined;
+    const start = setTimeout(() => {
+      if (tips.length < 2) return;
+      rotate = setInterval(() => {
+        setShown(false);
+        swapRef.current = setTimeout(() => {
+          indexRef.current = pickNext(indexRef.current, tips.length);
+          setIndex(indexRef.current);
+          setShown(true);
+        }, FADE_MS);
+      }, ROTATE_MS);
+    }, ENTER_DELAY_MS + FADE_MS);
+
+    return () => {
+      clearTimeout(enter);
+      clearTimeout(start);
+      clearTimeout(swapRef.current);
+      clearInterval(rotate);
+    };
+  }, [tips.length]);
+
+  // 480px holds every tip in two lines at the length budget `startupTips`
+  // keeps to. A tip that outgrows it wraps to three and shoves the centered
+  // column up mid-wait, so the budget is the thing to preserve, not this width.
+  //
+  // The card carries the opacity, not the text inside it: fading the whole box
+  // keeps its border and the icon tile in step with the words. It stays mounted
+  // throughout, so the layout beneath never moves.
+  return (
+    <Callout
+      className={cn(
+        "flex w-full max-w-120 min-h-22 items-start gap-3 p-5 text-left motion-safe:transition-opacity",
+        // Reduced motion skips the fades and the entrance entirely.
+        shown ? "opacity-100" : "opacity-0 motion-reduce:opacity-100",
+      )}
+      style={{ transitionDuration: `${FADE_MS}ms` }}
+    >
+      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+        <Idea size={16} className="text-muted-foreground" />
+      </span>
+      <p className="flex-1 text-sm leading-relaxed text-muted-foreground">
+        {tips[index]}
+      </p>
+    </Callout>
+  );
+}

--- a/packages/ui/src/modules/agents/components/startup-tip.tsx
+++ b/packages/ui/src/modules/agents/components/startup-tip.tsx
@@ -33,12 +33,16 @@ export function StartupTip({ sandbox }: { sandbox: string }) {
   const [index, setIndex] = useState(() =>
     Math.floor(Math.random() * tips.length),
   );
-  const [shown, setShown] = useState(false);
+  /** The card arriving, once. The tip inside it is opaque from the start so
+   *  the whole box — border, icon, text — fades in as one thing. */
+  const [revealed, setRevealed] = useState(false);
+  /** The tip crossfading on a rotation, from then on. */
+  const [shown, setShown] = useState(true);
   const indexRef = useRef(index);
   const swapRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
-    const enter = setTimeout(() => setShown(true), ENTER_DELAY_MS);
+    const enter = setTimeout(() => setRevealed(true), ENTER_DELAY_MS);
     let rotate: ReturnType<typeof setInterval> | undefined;
     const start = setTimeout(() => {
       if (tips.length < 2) return;
@@ -61,21 +65,38 @@ export function StartupTip({ sandbox }: { sandbox: string }) {
   }, [tips.length]);
 
   return (
-    <Callout className="w-full max-w-120 min-h-22 p-5 text-left">
-      <div
-        className={cn(
-          "flex items-start gap-3 motion-safe:transition-opacity",
-          shown
-            ? "opacity-100 duration-600"
-            : "opacity-0 duration-300 motion-reduce:opacity-100",
-        )}
-      >
+    <Callout
+      className={cn(
+        "w-full max-w-120 min-h-22 p-5 text-left motion-safe:transition-opacity duration-600",
+        revealed ? "opacity-100" : "opacity-0 motion-reduce:opacity-100",
+      )}
+    >
+      <div className="flex items-start gap-3">
         <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
           <Idea size={16} className="text-foreground" />
         </span>
-        <p className="flex-1 text-sm leading-relaxed text-muted-foreground">
-          {render(tips[index]!)}
-        </p>
+        {/* Every tip is laid out in the same grid cell, so the box is as tall
+            as the longest one wraps at the current width and no rotation
+            resizes it. The column above is vertically centred: a card that
+            grew by a line would shift the spinner and the sandbox name, and at
+            mobile widths the tips wrap to two, three, and four lines. */}
+        <div className="grid flex-1">
+          {tips.map((tip, i) => (
+            <p
+              key={tip}
+              aria-hidden={i !== index}
+              className={cn(
+                "col-start-1 row-start-1 text-sm leading-relaxed text-muted-foreground motion-safe:transition-opacity",
+                i === index && shown
+                  ? "opacity-100 duration-600"
+                  : "pointer-events-none select-none opacity-0 duration-300",
+                i === index && "motion-reduce:opacity-100",
+              )}
+            >
+              {render(tip)}
+            </p>
+          ))}
+        </div>
       </div>
     </Callout>
   );

--- a/packages/ui/src/modules/agents/components/startup-tip.tsx
+++ b/packages/ui/src/modules/agents/components/startup-tip.tsx
@@ -6,19 +6,16 @@ import { cn } from "@/lib/utils";
 
 import { startupTips } from "../startup-tips.js";
 
-const ROTATE_MS = 8_000;
+const ROTATE_MS = 6_000;
 const FADE_OUT_MS = 300;
 const FADE_IN_MS = 600;
-/** Lets the spinner and sandbox name land before the tip arrives. */
 const ENTER_DELAY_MS = 1_000;
 
-/** A tip other than `current`, so a swap never lands on the same text. */
 function pickNext(current: number, count: number): number {
   if (count < 2) return current;
   return (current + 1 + Math.floor(Math.random() * (count - 1))) % count;
 }
 
-/** Backtick spans render as code, matching the command tips in the list. */
 function render(tip: string) {
   return tip.split(/`([^`]+)`/g).map((part, i) =>
     i % 2 === 1 ? (
@@ -31,25 +28,18 @@ function render(tip: string) {
   );
 }
 
-/**
- * Rotating tips for every wait that shows a spinner (#3211). The movement
- * doubles as the evidence that the wait has not stalled.
- */
 export function StartupTip({ sandbox }: { sandbox: string }) {
   const tips = useMemo(() => startupTips(sandbox), [sandbox]);
   const [index, setIndex] = useState(() =>
     Math.floor(Math.random() * tips.length),
   );
   const [shown, setShown] = useState(false);
-  // Read by the interval without entering its deps, so a swap never restarts
-  // the countdown.
   const indexRef = useRef(index);
   const swapRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     const enter = setTimeout(() => setShown(true), ENTER_DELAY_MS);
     let rotate: ReturnType<typeof setInterval> | undefined;
-    // Clocked from the end of the entrance so the first tip gets a full dwell.
     const start = setTimeout(() => {
       if (tips.length < 2) return;
       rotate = setInterval(() => {

--- a/packages/ui/src/modules/agents/components/startup-tip.tsx
+++ b/packages/ui/src/modules/agents/components/startup-tip.tsx
@@ -6,53 +6,50 @@ import { cn } from "@/lib/utils";
 
 import { startupTips } from "../startup-tips.js";
 
-/** Time a tip stays put, measured start-of-transition to start-of-transition. */
 const ROTATE_MS = 8_000;
-/** Each direction of the swap. The text is replaced while the card is at zero
- *  opacity, so the outgoing and incoming tips never share the screen — two
- *  different sentences at partial opacity is unreadable in a way that two
- *  fading images is not. */
-const FADE_MS = 250;
-/** The spinner, the sandbox name and its badge should land first; the tip
- *  arrives after them rather than competing for the same first glance. */
+const FADE_OUT_MS = 300;
+const FADE_IN_MS = 600;
+/** Lets the spinner and sandbox name land before the tip arrives. */
 const ENTER_DELAY_MS = 1_000;
 
-/** A tip other than `current`, so the rotation never appears to stall on a
- *  repeat. Random rather than sequential: the same sandbox gets restarted a
- *  lot, and a fixed order turns into one memorized loop. */
+/** A tip other than `current`, so a swap never lands on the same text. */
 function pickNext(current: number, count: number): number {
   if (count < 2) return current;
   return (current + 1 + Math.floor(Math.random() * (count - 1))) % count;
 }
 
+/** Backtick spans render as code, matching the command tips in the list. */
+function render(tip: string) {
+  return tip.split(/`([^`]+)`/g).map((part, i) =>
+    i % 2 === 1 ? (
+      <code key={i} className="font-mono text-[13px]">
+        {part}
+      </code>
+    ) : (
+      part
+    ),
+  );
+}
+
 /**
- * Rotating tips for every wait that shows a spinner. Two jobs: teach the
- * feature set to someone whose first minutes would otherwise be spent on a
- * static screen, and let the movement itself be the evidence that the wait
- * hasn't stalled.
- *
- * Read-only text on purpose — a link would pull the user off the screen
- * mid-wait, and they came to use the sandbox, not to read docs.
+ * Rotating tips for every wait that shows a spinner (#3211). The movement
+ * doubles as the evidence that the wait has not stalled.
  */
-export function StartupTip() {
-  const tips = useMemo(startupTips, []);
+export function StartupTip({ sandbox }: { sandbox: string }) {
+  const tips = useMemo(() => startupTips(sandbox), [sandbox]);
   const [index, setIndex] = useState(() =>
     Math.floor(Math.random() * tips.length),
   );
   const [shown, setShown] = useState(false);
-  // The rotation reads the live index without listing it as a dependency —
-  // otherwise every swap would tear down and restart the timer, and each tip
-  // would get its full dwell only by accident. Nothing else may enter these
-  // deps either: anything that changes mid-wait restarts the countdown, which
-  // is what a hover-to-pause flag did before it was removed.
+  // Read by the interval without entering its deps, so a swap never restarts
+  // the countdown.
   const indexRef = useRef(index);
   const swapRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
 
   useEffect(() => {
     const enter = setTimeout(() => setShown(true), ENTER_DELAY_MS);
-    // Rotation is clocked from the end of the entrance, so the first tip gets
-    // the same dwell as every one after it.
     let rotate: ReturnType<typeof setInterval> | undefined;
+    // Clocked from the end of the entrance so the first tip gets a full dwell.
     const start = setTimeout(() => {
       if (tips.length < 2) return;
       rotate = setInterval(() => {
@@ -61,9 +58,9 @@ export function StartupTip() {
           indexRef.current = pickNext(indexRef.current, tips.length);
           setIndex(indexRef.current);
           setShown(true);
-        }, FADE_MS);
+        }, FADE_OUT_MS);
       }, ROTATE_MS);
-    }, ENTER_DELAY_MS + FADE_MS);
+    }, ENTER_DELAY_MS + FADE_IN_MS);
 
     return () => {
       clearTimeout(enter);
@@ -73,28 +70,23 @@ export function StartupTip() {
     };
   }, [tips.length]);
 
-  // 480px holds every tip in two lines at the length budget `startupTips`
-  // keeps to. A tip that outgrows it wraps to three and shoves the centered
-  // column up mid-wait, so the budget is the thing to preserve, not this width.
-  //
-  // The card carries the opacity, not the text inside it: fading the whole box
-  // keeps its border and the icon tile in step with the words. It stays mounted
-  // throughout, so the layout beneath never moves.
   return (
-    <Callout
-      className={cn(
-        "flex w-full max-w-120 min-h-22 items-start gap-3 p-5 text-left motion-safe:transition-opacity",
-        // Reduced motion skips the fades and the entrance entirely.
-        shown ? "opacity-100" : "opacity-0 motion-reduce:opacity-100",
-      )}
-      style={{ transitionDuration: `${FADE_MS}ms` }}
-    >
-      <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
-        <Idea size={16} className="text-muted-foreground" />
-      </span>
-      <p className="flex-1 text-sm leading-relaxed text-muted-foreground">
-        {tips[index]}
-      </p>
+    <Callout className="w-full max-w-120 min-h-22 p-5 text-left">
+      <div
+        className={cn(
+          "flex items-start gap-3 motion-safe:transition-opacity",
+          shown
+            ? "opacity-100 duration-600"
+            : "opacity-0 duration-300 motion-reduce:opacity-100",
+        )}
+      >
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted">
+          <Idea size={16} className="text-foreground" />
+        </span>
+        <p className="flex-1 text-sm leading-relaxed text-muted-foreground">
+          {render(tips[index]!)}
+        </p>
+      </div>
     </Callout>
   );
 }

--- a/packages/ui/src/modules/agents/startup-tips.ts
+++ b/packages/ui/src/modules/agents/startup-tips.ts
@@ -1,12 +1,5 @@
 import { getBrand } from "../../brand.js";
 
-/**
- * The tip list from #3211, with the brand and the open sandbox filled in.
- * Backticks mark a command; `StartupTip` renders those spans as code.
- *
- * Called at render rather than evaluated at import: the brand arrives from
- * `/api/brand` after this module is first read.
- */
 export function startupTips(sandbox: string): readonly string[] {
   const { name, short } = getBrand();
   return [

--- a/packages/ui/src/modules/agents/startup-tips.ts
+++ b/packages/ui/src/modules/agents/startup-tips.ts
@@ -1,31 +1,46 @@
 import { getBrand } from "../../brand.js";
 
 /**
- * One-liners shown while a sandbox starts. Read at render, not at import: the
- * brand arrives from `/api/brand` after this module is first evaluated, so a
- * module-level array would freeze the bundled fallback name.
+ * The tip list from #3211, with the brand and the open sandbox filled in.
+ * Backticks mark a command; `StartupTip` renders those spans as code.
  *
- * Two rules for adding one:
- *
- * - **Keep it under ~100 characters.** That is what fits the tip card in two
- *   lines; a longer one wraps to three and shifts the centered column while
- *   the user is watching it.
- * - **Describe something the product does today.** A tip is read at the moment
- *   someone is deciding what this thing is for, so a stale one costs more than
- *   no tip at all.
+ * Called at render rather than evaluated at import: the brand arrives from
+ * `/api/brand` after this module is first read.
  */
-export function startupTips(): readonly string[] {
+export function startupTips(sandbox: string): readonly string[] {
   const { name, short } = getBrand();
   return [
-    "Sandboxes sleep when idle and wake when you open a chat. Files, sessions, and skills survive the nap.",
-    "Add a GitHub repo as a skill source, or drop a .md file on the Skills page to write one in place.",
-    `Publish a skill you wrote back to its source repo as a pull request, without leaving ${name}.`,
-    "Model, mode, and effort live on the sandbox's configuration page. Changes apply to your next session.",
-    "Link a Slack or Telegram channel to a sandbox and you can talk to the same agent from there.",
-    `There's a command line too — \`${short} chat\` opens a session straight from your terminal.`,
-    "Agents publish artifacts — pages, markdown, code, files — to your library, shareable by link.",
-    "A running sandbox holds compute against your budget. Stop an idle one to free room for another.",
+    "Idle sandboxes hibernate to save resources, then wake the instant you or a schedule ping them.",
+    "Your workspace survives between runs. Pick up exactly where the sandbox left off.",
+    `Open a local terminal with the ${name} CLI: \`${short} chat ${sandbox}\``,
     "Approvals are enforced outside the sandbox, so a compromised agent cannot approve itself.",
-    "Credentials are injected on the wire by the gateway. The agent never holds your tokens.",
+    "Connect a sandbox to Slack or Telegram, then talk to it there. Config › Channels.",
+    `Open this sandbox in VS Code: \`${short} ssh connect -x code ${sandbox}\``,
+    "Run a sandbox on a schedule to handle routine tasks. Config › Schedules.",
+    "Choose the trusted defaults network preset to stop a sandbox reaching untrusted domains.",
+    "Bring your local CLAUDE.md, .claude/, and skills straight into a cloud sandbox.",
+    "You do not have to wait your turn. Type while the sandbox works and your message queues.",
+    "File paths the sandbox writes in chat are clickable. They open the file beside the conversation.",
+    "Set the hibernation timeout to 0 to stop a sandbox sleeping, for background work with no open session.",
+    "Drop a .md file on the Skills page to turn it into a skill.",
+    "Drop a whole folder into Files to upload it. node_modules and .venv are skipped for you.",
+    "Publish a skill you wrote here as a pull request, then track it to get later updates back.",
+    "Artifacts outlive the sandbox. Share a public link, browse versions, or set an expiry.",
+    "Allow a blocked request once, always, or for the whole host. Each choice writes a real rule.",
+    `Add an MCP server by URL and ${name} works out its authorization for you. Config › Connections.`,
+    "Schedules take quiet hours and a timezone, so a nightly run stays quiet overnight.",
+    "Turn on ambient mode and a sandbox reads along in a Slack channel without an @-mention.",
+    "You can attach connections to inject API keys without baking secrets into the image.",
+    "Scheduled runs wake the sandbox automatically — no need to keep it running between jobs.",
+    "Template updates roll out new images without losing your sandbox's persistent state.",
+    "Network egress is deny-by-default. Connections allowlist only the hosts your agent needs.",
+    "Run one goal across several variants at once and watch them chart live with Experiments.",
+    "Point a knowledge base at your docs and ask it questions in chat.",
+    "Artifact previews open beside the chat, so you can read the result and keep talking.",
+    "Give an artifact an expiry and it deletes itself later. Useful for a one-off share.",
+    "Ask a sandbox to publish its work as an artifact, then share the link with colleagues.",
+    "An artifact keeps every version. Step back through its history in the preview.",
+    "See what a sandbox costs. Settings › Usage breaks spend down by model and by day.",
+    `Create an API key in Settings › API keys to use the ${name} CLI without a browser.`,
   ];
 }

--- a/packages/ui/src/modules/agents/startup-tips.ts
+++ b/packages/ui/src/modules/agents/startup-tips.ts
@@ -1,0 +1,31 @@
+import { getBrand } from "../../brand.js";
+
+/**
+ * One-liners shown while a sandbox starts. Read at render, not at import: the
+ * brand arrives from `/api/brand` after this module is first evaluated, so a
+ * module-level array would freeze the bundled fallback name.
+ *
+ * Two rules for adding one:
+ *
+ * - **Keep it under ~100 characters.** That is what fits the tip card in two
+ *   lines; a longer one wraps to three and shifts the centered column while
+ *   the user is watching it.
+ * - **Describe something the product does today.** A tip is read at the moment
+ *   someone is deciding what this thing is for, so a stale one costs more than
+ *   no tip at all.
+ */
+export function startupTips(): readonly string[] {
+  const { name, short } = getBrand();
+  return [
+    "Sandboxes sleep when idle and wake when you open a chat. Files, sessions, and skills survive the nap.",
+    "Add a GitHub repo as a skill source, or drop a .md file on the Skills page to write one in place.",
+    `Publish a skill you wrote back to its source repo as a pull request, without leaving ${name}.`,
+    "Model, mode, and effort live on the sandbox's configuration page. Changes apply to your next session.",
+    "Link a Slack or Telegram channel to a sandbox and you can talk to the same agent from there.",
+    `There's a command line too — \`${short} chat\` opens a session straight from your terminal.`,
+    "Agents publish artifacts — pages, markdown, code, files — to your library, shareable by link.",
+    "A running sandbox holds compute against your budget. Stop an idle one to free room for another.",
+    "Approvals are enforced outside the sandbox, so a compromised agent cannot approve itself.",
+    "Credentials are injected on the wire by the gateway. The agent never holds your tokens.",
+  ];
+}


### PR DESCRIPTION
Rotating tip card on the sandbox startup screen, so the wait teaches something and its movement shows the start hasn't stalled.

Closes #3211

Tips are the list from the issue comment, with the brand and open sandbox name filled in at render (never hardcoded). Shown randomized, as the issue asks.

Two things that go beyond the issue, say the word and I'll pull them:

- Shown on every wait that renders a spinner — loading, reconnecting, starting, preparing workspace, hibernating — not just `starting`. Gated on the spinner, so the icon states (hibernated, error, over budget) stay untouched; those want a click.
- Card is 480px and rotates at 8s with a full fade; the prototype is 420px, 6s, and dips to 0.4. Deliberate, from review feedback, but it is a departure.

No pause control on the rotating text — WCAG 2.2.2 wants one. Worth a follow-up.