### PR TITLE
fix(e2e): gate on the apiserver route the reset just bounced

### DIFF
--- a/tasks.toml
+++ b/tasks.toml
@@ -175,7 +175,7 @@ mise run e2e:gate
 
 ["e2e:gate"]
 hide = true
-description = "Wait until the e2e cluster stably serves UI + Keycloak on :5555. Shared by `e2e` (via e2e:install) and `e2e:loop`'s warm path."
+description = "Wait until the e2e cluster stably serves UI + API + Keycloak on :5555. Shared by `e2e` (via e2e:install) and `e2e:loop`'s warm path."
 dir = "{{config_root}}"
 raw = true
 run = '''
@@ -190,14 +190,20 @@ else
 fi
 
 # The install (or a warm --rebuild) rolls traefik, keycloak, and the
-# apiserver, and their routes come up at different moments — a single lucky
-# 200 on the UI root is not "serving". Require the UI root AND the keycloak
-# realm to answer on three consecutive ticks before any spec dials in;
-# otherwise the auth specs die at ERR_CONNECTION_REFUSED mid-login-redirect.
-echo "Waiting for the cluster to serve UI + Keycloak on :5555 ..."
+# apiserver — and e2e:reset bounces the apiserver right before this gate runs
+# on both entry points. Their routes come up at different moments — a single
+# lucky 200 on the UI root is not "serving", and the deployment reporting
+# Available doesn't mean Traefik's endpoint for it stopped 502ing (see the
+# UI-restart note in e2e:install). Require the UI root, the apiserver's
+# public readiness route, AND the keycloak realm to answer on three
+# consecutive ticks before any spec dials in; otherwise the auth specs die
+# at ERR_CONNECTION_REFUSED mid-login-redirect or the first /api call lands
+# in the endpoint window.
+echo "Waiting for the cluster to serve UI + API + Keycloak on :5555 ..."
 STREAK=0
 for _ in $(seq 1 100); do
   if curl -fsS -o /dev/null --max-time 3 http://localhost:5555/ 2>/dev/null &&
+     curl -fsS -o /dev/null --max-time 3 http://localhost:5555/api/ready 2>/dev/null &&
      curl -fsS -o /dev/null --max-time 3 http://keycloak.localhost:5555/realms/platform 2>/dev/null; then
     STREAK=$((STREAK + 1))
     [ "$STREAK" -ge 3 ] && break
@@ -207,7 +213,7 @@ for _ in $(seq 1 100); do
   sleep 3
 done
 if [ "$STREAK" -lt 3 ]; then
-  echo "ERROR: e2e cluster is up but not stably routing on :5555 (UI + keycloak)." >&2
+  echo "ERROR: e2e cluster is up but not stably routing on :5555 (UI + API + keycloak)." >&2
   echo "It does not auto-heal — reprovision with 'mise run e2e', or check" >&2
   echo "'LIMA_INSTANCE=$VM_NAME mise run cluster:fix-certs'." >&2
   # Same signature the ztunnel-cert-watchdog keys on (deploy/tasks.toml);


### PR DESCRIPTION
## Context

The original content of this PR (Traefik entrypoint port fix, shared `e2e:gate`, IPv4 pins) is **already on `main`**: #3303 was stacked on this branch and its squash-merge (`b8fd2622`) carried all three commits with it. After rebasing, this PR reduces to the one code-guardian finding that survived verification.

## Problem

`e2e:reset` scales the apiserver to 0 and back immediately before `e2e:gate` runs (on both the fresh `e2e` path and `e2e:loop`'s warm path), but the gate polled only the UI root and the Keycloak realm — the one route that bounced was the one not checked. `kubectl wait --for=condition=Available` covers pod readiness, not Traefik's endpoint window (the same race the `e2e:install` UI-restart note documents), so the specs' first `/api` call could land in a transient 502.

## Fix

Add the apiserver's public readiness route (`/api/ready` — it also 503s until JWKS warm-up completes, so it is a strictly stronger signal than pod-Available) to the gate's three-consecutive-ticks streak condition.

## Code-guardian findings disposition

- ✅ **Fixed**: gate does not poll the component the reset bounced (`tasks.toml:118`) — this PR.
- ❌ **Invalid**: `E2E_VM_NAME` missing at the `e2e:install` → `e2e:gate` call site. Every path into `e2e:install` carries `E2E_VM_NAME` in the process environment (`tasks.toml:110` sets it on the child; `e2e:loop` exports it before bootstrapping), and env vars propagate to nested `mise run` children — the gate always resolves the same VM name as its caller. The claimed fallback is unreachable.
- ❌ **Invalid (would reintroduce the bug)**: moving the Node IPv4 pin into `globalSetup` via `dns.setDefaultResultOrder`. That call sets per-process state, and Playwright runs specs in separate worker processes that do not inherit it — the pin would cover only the runner while the workers' Keycloak/tRPC fetches revert to happy-eyeballs. The `NODE_OPTIONS` env var is inherited by every Node child, which is why it is the right mechanism.
- ⏭️ **Declined**: resolving `APP_PORT` from `values-local.yaml` too. Correct today by the review's own admission (`values-local.yaml` declares no `port`), and `VIRT_ENABLED` above it has the same shape — future-proofing both is a separate cleanup if ever needed.
- Body/validation findings: superseded by this rewrite.

## Validation

The original content was validated 27/27 in-sandbox before it merged via #3303. This follow-up is a one-line addition to the gate's curl chain; an in-sandbox `mise run e2e` revalidation is running and the result will be posted here.