### PR TITLE
fix: say 50 MB in the channel tool cap copy and relay server detail in CLI file errors

### DIFF
--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -142,7 +142,7 @@ export function createMcpSession(
 
   server.tool(
     "send_channel_message",
-    `Send a message to a connected channel (slack or telegram) for this agent. Pass chatId to address a specific chat: an id from describe_channel, or on Slack a user id (U…) to send that person a direct message. Omit chatId for the default chat (Slack: the agent's bound channel; Telegram: the last-active chat). Messages are posted as the bot, attributed to this agent. Optionally attach a single file by setting attachment.path — accepts an absolute path on the agent pod (e.g. ${agentHome}/work/report.md) or a path relative to your workspace (e.g. report.md). 10 MiB cap.`,
+    `Send a message to a connected channel (slack or telegram) for this agent. Pass chatId to address a specific chat: an id from describe_channel, or on Slack a user id (U…) to send that person a direct message. Omit chatId for the default chat (Slack: the agent's bound channel; Telegram: the last-active chat). Messages are posted as the bot, attributed to this agent. Optionally attach a single file by setting attachment.path — accepts an absolute path on the agent pod (e.g. ${agentHome}/work/report.md) or a path relative to your workspace (e.g. report.md). 50 MB cap.`,
     {
       channel: z.enum([ChannelType.Slack, ChannelType.Telegram]),
       text: z.string(),
@@ -191,7 +191,7 @@ export function createMcpSession(
             }
             if (err.data?.code === "PAYLOAD_TOO_LARGE") {
               return errorResult(
-                `attachment ${attachment.path} exceeds the 10 MB per-file cap`,
+                `attachment ${attachment.path} exceeds the 50 MB per-file cap`,
               );
             }
           }

--- a/packages/cli/src/modules/file/commands/get.ts
+++ b/packages/cli/src/modules/file/commands/get.ts
@@ -11,7 +11,7 @@ import {
   printResolveError,
 } from "../../agent/commands/errors.js";
 import { resolveActiveHost } from "../../shared/preflight.js";
-import { printTrpcError } from "../../shared/trpc/print.js";
+import { printTrpcError, serverDetail } from "../../shared/trpc/print.js";
 import { createAgentTrpcClient } from "../../shared/trpc/trpc-client.js";
 import {
   EXIT_BELOW_FLOOR,
@@ -172,10 +172,11 @@ function printTrpcReadError(e: unknown, path: string, host: string): void {
     return;
   }
   if (code === "PAYLOAD_TOO_LARGE") {
+    const detail = serverDetail(e);
     process.stderr.write(
-      `error: ${path} exceeds the 10 MB cap for tRPC-based reads. ` +
-        `Streaming transfer for individual large files isn't implemented yet ` +
-        `(use \`dam import\` for bulk transfer).\n`,
+      `error: ${path} exceeds the server's per-file cap` +
+        (detail ? ` (${detail})` : "") +
+        `. Streaming transfer for individual large files isn't implemented yet.\n`,
     );
     return;
   }

--- a/packages/cli/src/modules/file/commands/put.ts
+++ b/packages/cli/src/modules/file/commands/put.ts
@@ -10,7 +10,7 @@ import {
   printResolveError,
 } from "../../agent/commands/errors.js";
 import { resolveActiveHost } from "../../shared/preflight.js";
-import { printTrpcError } from "../../shared/trpc/print.js";
+import { printTrpcError, serverDetail } from "../../shared/trpc/print.js";
 import { createAgentTrpcClient } from "../../shared/trpc/trpc-client.js";
 import {
   EXIT_BELOW_FLOOR,
@@ -125,9 +125,10 @@ function printTrpcUploadError(
   remotePath: string,
   host: string,
 ): void {
-  const trpcErr = e instanceof TRPCClientError ? e : undefined;
-  const code = trpcErr?.data?.code as string | undefined;
-  const message = (trpcErr?.data?.message as string | undefined) ?? "";
+  const code =
+    e instanceof TRPCClientError
+      ? (e.data?.code as string | undefined)
+      : undefined;
   if (code === "CONFLICT") {
     process.stderr.write(
       `error: ${remotePath} already exists on the agent; pass --overwrite to clobber\n`,
@@ -135,13 +136,14 @@ function printTrpcUploadError(
     return;
   }
   if (code === "FORBIDDEN") {
-    process.stderr.write(`error: forbidden path: ${message || remotePath}\n`);
+    process.stderr.write(`error: forbidden path: ${remotePath}\n`);
     return;
   }
   if (code === "PAYLOAD_TOO_LARGE") {
+    const detail = serverDetail(e);
     process.stderr.write(
       `error: ${remotePath} exceeds the server's per-file cap` +
-        (message ? ` (${message})` : "") +
+        (detail ? ` (${detail})` : "") +
         `. Streaming transfer for individual large files isn't implemented yet ` +
         `(use \`dam import\` for bulk transfer).\n`,
     );

--- a/packages/cli/src/modules/shared/trpc/print.ts
+++ b/packages/cli/src/modules/shared/trpc/print.ts
@@ -1,9 +1,16 @@
+import { TRPCClientError } from "@trpc/client";
 import type { AuthRequiredError, TransportError } from "../errors.js";
 import { formatAuthRejection } from "../auth-message.js";
 import { classifyTrpcError } from "./classify.js";
 
 export function formatTransportError(reason: string, host: string): string {
   return `cannot reach server \`${host}\`: ${reason}`;
+}
+
+export function serverDetail(e: unknown): string {
+  if (!(e instanceof TRPCClientError)) return "";
+  const code = e.data?.code as string | undefined;
+  return e.message && e.message !== code ? e.message : "";
 }
 
 export function printServiceError(


### PR DESCRIPTION
## What

Two user-facing surfaces still said the per-file attachment cap was **10 MB** when the gate is 50 MiB, and both CLI file-transfer error printers were wrong in different ways: the upload printer read a field that is always empty, and the read printer restated the cap as a literal and pointed the user at an upload-direction command.

## Scope changed — the UI half is now on `main`

This PR originally also corrected the UI upload toasts and the file-preview hint. **#3319 delivered that independently** and better: both upload toasts now render `formatBytes(MAX_UPLOAD_BYTES)`, derived from the constant and rounded, and the preview hint no longer names a number at all. Those commits were dropped in the rebase because their subject no longer exists. See the comment below.

What remains is the channel-tool copy and the CLI printers. The branch touches no UI files.

## Which value is right

50 MB. The copy was stale, not the constant.

Commit 54ecf340 (#1417) raised the real ceiling from 10 MB to 50 MB: it set agent-runtime's `MAX_FILE_SIZE` to 50 MiB ([`files.ts:25`](packages/agent-runtime/src/modules/files.ts)), raised the transport guard to 70 MB to cover base64 overhead, and updated `docs/architecture/cli.md`. It missed the user-facing strings. Channel attachments upload through `trpc.files.upload` on agent-runtime, so 50 MB is the cap that actually applies to them. One `MAX_FILE_SIZE` gates both `readFileSafe` (`files.ts:117`) and `uploadFileSafe` (`files.ts:262`) — there is a single server number here, not two.

## Changes

**Channels** — `packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts`: the `send_channel_message` tool description and its `PAYLOAD_TOO_LARGE` result both said 10 MB.

**CLI** — the printers relay what the server actually said:

- `packages/cli/src/modules/shared/trpc/print.ts` — new `serverDetail`, shared by both printers.
- `packages/cli/src/modules/file/commands/put.ts` — two bugs, both pre-existing:
  - The detail was read from `data.message`, which is **always** undefined. At the locked `@trpc/server` 11.16.0 (`packages/cli/package.json` declares `^11.16.0`, so the lockfile is what holds it), `getErrorShape` puts the message at the top level and `data` carries only `code` / `httpStatus` / `path`. The `(detail)` parenthetical therefore never appeared.
  - Reading the top-level `message` instead is correct for the service-level check but wrong for `FORBIDDEN`: that route's only reason is the generic string `"forbidden path"`, so relaying it produces `error: forbidden path: forbidden path` and drops the remote path — the only identifying text the line carries. The `FORBIDDEN` branch now prints `remotePath` directly.
- `packages/cli/src/modules/file/commands/get.ts` — drops the hardcoded cap for the server's own figures, which is what `docs/architecture/cli.md:114` already says the CLI does. The same line also pointed the user at `dam import` for "bulk transfer", which copies local files *into* the agent and so cannot help a failed read. No bulk-download command exists to name instead, so the pointer is gone rather than swapped. `put.ts` keeps it, where the direction matches.

**`serverDetail` and why it exists.** A `TRPCError` raised with no message falls back to its own code name. `incomingMessageToRequest` raises exactly that for the 70 MB transport body cap, so relaying the message verbatim prints `exceeds the server's per-file cap (PAYLOAD_TOO_LARGE)`. Base64 inflates 4/3, so uploads between 50.0 and 52.5 MiB reach the service check and get real figures, while anything larger trips the message-less body cap first. `serverDetail` returns `""` when the message only echoes the code, so the parenthetical is dropped rather than filled with a code name.

No gate changes — every one already used 50 MiB. What changes is the channel-tool copy, plus the two CLI printer bugs above, which do alter emitted stderr.

## Verification

The tRPC facts above were confirmed against a live client/server round trip at the locked 11.16.0, not read off the types. Observed, driving the real branch bodies:

| case | printed |
|---|---|
| `FORBIDDEN` on `../etc/passwd` | `error: forbidden path: ../etc/passwd` |
| upload 51 MiB (service check) | `error: a.bin exceeds the server's per-file cap (file 53477376 bytes (max 52428800)). …` |
| upload 60 MiB (transport cap) | `error: b.bin exceeds the server's per-file cap. …` |

`data.message` was `undefined` in every case, confirming the old read was dead.

Re-run at this head, after the rebase onto `006c44d3`: `mise run common:check:comment-types`, `cli:check`, `cli:test` (154 passed), `api-server:check`. The four changed files are byte-identical to the pre-rebase head, so the earlier verification still applies. `ui:check` / `ui:test` are no longer relevant — the branch touches no UI.

## Known follow-up, deliberately not in this PR

The MCP message restates the cap as a literal because `api-server` cannot import agent-runtime's `MAX_FILE_SIZE`. The clean fix is to export the byte cap from a contract package beside the files schema and have the enforcer and every client derive from that one import. `packages/ui` now has the same duplication in `MAX_UPLOAD_BYTES`. That is a wider refactor than a copy fix, so it is not here — worth doing if the cap moves again.
