### PR TITLE
fix(scripts): comment tooling works in locki sandboxes

### DIFF
--- a/scripts/strip-comments.mjs
+++ b/scripts/strip-comments.mjs
@@ -80,11 +80,28 @@ function loadTypescript() {
 }
 
 export function listFiles(scopes) {
-  const args = ['ls-files', '-z', '--', ...(scopes.length ? scopes : ['.'])];
-  const out = execFileSync('git', args, { cwd: repoRoot, maxBuffer: 64 * 1024 * 1024 });
+  const paths = scopes.length ? scopes : ['.'];
+  // `-z --` is the robust form (NUL-safe, option-injection-proof), but
+  // restricted environments (the locki sandbox's git command bridge) admit
+  // only plain `git ls-files <path>...` — fall back to it and split on
+  // newlines. Source paths in this repo are ASCII, so the fallback is safe.
+  let out;
+  let sep = '\0';
+  const opts = { cwd: repoRoot, maxBuffer: 64 * 1024 * 1024 };
+  try {
+    // stderr swallowed: in the fallback environment this attempt fails by
+    // design and its complaint would print on every run.
+    out = execFileSync('git', ['ls-files', '-z', '--', ...paths], {
+      ...opts,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    out = execFileSync('git', ['ls-files', ...paths], opts);
+    sep = '\n';
+  }
   return out
     .toString('utf8')
-    .split('\0')
+    .split(sep)
     .filter(Boolean)
     .filter((f) => {
       const ext = path.extname(f);


### PR DESCRIPTION
## Problem

`scripts/strip-comments.mjs` and `scripts/check-comment-types.mjs` (which imports the former's `listFiles`) shell out to `git ls-files -z -- <paths>`. The locki sandbox's git command bridge only admits plain `git ls-files <path>...` — so neither tool runs in a sandbox at all, while `CLAUDE.md` instructs agents to run `common:check:comment-types` after every code change. (Found while rebasing #3303 over #3308: the policy check itself was un-runnable in the environment doing the work.)

## Fix

`listFiles` tries the robust form first (`-z --`: NUL-safe, option-injection-proof) and falls back to the plain form split on newlines, swallowing the probe's stderr so restricted environments run silently. Repo source paths are ASCII, so the newline split is safe where the fallback engages; host/CI behavior is byte-identical.

## Validation

In-sandbox: `check-comment-types` passes over the full repo; `strip-comments` dry-run scans 487 UI files, 0 to remove. Host path unaffected (first attempt still taken wherever `-z --` is admitted).