### PR TITLE
style(ui): drop the blue from inline code in agent responses

### DIFF
--- a/packages/ui/src/App.css
+++ b/packages/ui/src/App.css
@@ -475,11 +475,11 @@
 .prose code {
   font-family: var(--font-mono);
   font-size: 0.86em;
-  background: var(--muted);
+  background: transparent;
   border: 1px solid var(--border-ui);
-  border-radius: 6px;
-  padding: 0.1em 0.36em;
-  color: var(--c-accent-hover);
+  border-radius: 4px;
+  padding: 0.15em 0.5em;
+  color: var(--foreground);
 }
 .prose pre {
   background: var(--muted) !important;


### PR DESCRIPTION
Inline code in agent responses was blue and boxed, so a long answer read as a page of blue chips and the marks looked clickable. It is now neutral text on the page background, outlined only.

Closes #3209

Values come from the design: the border is `--border-ui`, the fill is the page background showing through, the text is `--foreground`, with a 4px radius and slightly wider padding. Font family and size are unchanged, and dark mode follows the same tokens.

Styling only, per the scope note on the issue. Deciding what inline code is *for* — and how agents should write it — is not touched here, and the open question about UI labels and status values is still open.
