### PR TITLE
feat(ci): publish the dev chart without waiting for agent image builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -632,14 +632,17 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+  # Releases wait for every image the chart names. A v* chart pins content tags
+  # and is immutable once pushed, so it must never reference a tag that was
+  # never built. merge-workloads is spelled out rather than left to the implicit
+  # success() (see e2e); on a tag it always runs, so the skipped branch is only
+  # defensive.
   publish:
+    name: publish release
     needs: [changes, merge-images, merge-agents, merge-workloads, appversion]
-    # merge-workloads skips on main pushes where every workload was reused —
-    # the implicit success() would skip publish with it, so spell out all the
-    # direct needs (see e2e). A failed workload build must still block the
-    # chart: it would pin a source-sha tag that was never pushed.
     if: >-
-      ${{ github.event_name == 'push' && !cancelled() &&
+      ${{ github.event_name == 'push' &&
+          startsWith(github.ref, 'refs/tags/v') && !cancelled() &&
           needs.changes.result == 'success' &&
           needs.appversion.result == 'success' &&
           needs.merge-images.result == 'success' &&
@@ -676,34 +679,73 @@ jobs:
       - name: Build Helm chart dependencies
         run: mise run helm:deps
 
-      # Pin content-tagged images (source sha, pushed by merge-images /
-      # merge-workloads) so the chart only moves a tag — and only rolls the
-      # Keycloak pod or rebuilds a workload — when the image inputs actually
-      # changed. The repo default stays `""` (appVersion fallback) for charts
-      # rendered from git.
       - name: Pin content-tagged image tags
         env:
           SOURCE_SHAS: ${{ needs.changes.outputs.source_shas }}
-        run: |
-          set -euo pipefail
-          for comp in keycloak $(scripts/resolve-image.sh list-workloads); do
-            tag="$(jq -re --arg c "$comp" '.[$c]' <<< "$SOURCE_SHAS")"
-            sed -i "s|^\\(\\s*\\)tag: \"\" # @ci-pin ${comp}-image-tag$|\\1tag: \"$tag\"|" deploy/helm/platform/values.yaml
-          done
-          # every marker must have been consumed — a leftover means the
-          # component list and the values.yaml markers drifted apart
-          ! grep -n '@ci-pin .*-image-tag' deploy/helm/platform/values.yaml
+        run: scripts/pin-image-tags.sh "$SOURCE_SHAS"
 
-      - name: Push Helm chart (release)
-        if: startsWith(github.ref, 'refs/tags/v')
+      - name: Push Helm chart
         env:
           VERSION: ${{ steps.version.outputs.version }}
           COMPOSITE: ${{ needs.appversion.outputs.composite }}
         run: |
           helm package deploy/helm/platform --version "$VERSION" --app-version "$COMPOSITE"
           helm push "platform-${VERSION}.tgz" oci://quay.io/dam-agents/charts
-      - name: Push Helm chart (main)
-        if: github.ref == 'refs/heads/main'
+
+      - name: Publish CLI to npm
+        env:
+          NPM_TAG: ${{ steps.version.outputs.npmTag }}
+        run: |
+          mise run setup
+          mise run cli:build
+          pnpm --filter @dam-agents/cli publish --access public --no-git-checks --provenance --tag "$NPM_TAG"
+
+  # Dev charts don't wait for the agent image chain — that wait is most of the
+  # time between a merge and a usable chart. `needs` is static, so publishing
+  # early requires a job that doesn't list those merges at all; hence the split
+  # from `publish` above.
+  #
+  # The tradeoff: between this job and merge-agents the 0.0.0-main chart names
+  # agent images whose tags aren't pushed yet, so creating or upgrading an agent
+  # fails to pull and recovers on its own once the tags land. If an agent build
+  # fails outright, that window lasts until the next green main run. Acceptable
+  # on the dev channel only — releases keep the strict gate.
+  publish-dev:
+    name: publish dev chart
+    needs: [changes, merge-images, appversion]
+    if: >-
+      ${{ github.event_name == 'push' &&
+          github.ref == 'refs/heads/main' && !cancelled() &&
+          needs.changes.result == 'success' &&
+          needs.appversion.result == 'success' &&
+          needs.merge-images.result == 'success' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+        with:
+          cache: false
+      - uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+      - name: Log in to Helm OCI registry
+        env:
+          QUAY_USERNAME: ${{ secrets.QUAY_USERNAME }}
+          QUAY_PASSWORD: ${{ secrets.QUAY_PASSWORD }}
+        run: echo "$QUAY_PASSWORD" | helm registry login quay.io --username "$QUAY_USERNAME" --password-stdin
+
+      - name: Build Helm chart dependencies
+        run: mise run helm:deps
+
+      - name: Pin content-tagged image tags
+        env:
+          SOURCE_SHAS: ${{ needs.changes.outputs.source_shas }}
+        run: scripts/pin-image-tags.sh "$SOURCE_SHAS"
+
+      - name: Push Helm chart
         env:
           RUN_NUMBER: ${{ github.run_number }}
           COMPOSITE: ${{ needs.appversion.outputs.composite }}
@@ -712,15 +754,6 @@ jobs:
           helm push "platform-0.0.0-main.${RUN_NUMBER}.tgz" oci://quay.io/dam-agents/charts
           helm package deploy/helm/platform --version 0.0.0-main --app-version "$COMPOSITE"
           helm push platform-0.0.0-main.tgz oci://quay.io/dam-agents/charts
-
-      - name: Publish CLI to npm
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          NPM_TAG: ${{ steps.version.outputs.npmTag }}
-        run: |
-          mise run setup
-          mise run cli:build
-          pnpm --filter @dam-agents/cli publish --access public --no-git-checks --provenance --tag "$NPM_TAG"
 
   go-vuln:
     name: mise controller:scan:govulncheck

--- a/docs/guidelines/release-process.md
+++ b/docs/guidelines/release-process.md
@@ -68,4 +68,14 @@ On every `v*` tag push, the release jobs in [`cd.yml`](../../.github/workflows/c
   - The keycloak image tag is pinned to a content tag (the commit that last touched its inputs) rather than the release version, so upgrading to a release that didn't change the image doesn't restart Keycloak
 - Publishes `@dam-agents/cli` to npm (stable tags get `latest`, RC tags get `rc`)
 
-On every push to `main` (no tag), CD builds images and pushes a dev Helm chart (`0.0.0-main.*`).
+A release waits for every image the chart names, so a `v*` chart never references
+a tag that was never built.
+
+On every push to `main` (no tag), CD builds images and pushes a dev Helm chart
+(`0.0.0-main.*`). The dev chart does **not** wait for the agent image chain — it
+publishes as soon as the platform images are merged, which is most of the time
+between a merge and a usable chart. For the few minutes until the agent images
+are tagged, the dev chart names agent images that aren't pullable yet: creating
+or upgrading an agent fails to pull and recovers on its own once the tags land.
+If an agent build fails outright, that window lasts until the next green `main`
+run. This tradeoff is deliberate and applies to the dev channel only.

--- a/scripts/pin-image-tags.sh
+++ b/scripts/pin-image-tags.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Rewrite the chart's `@ci-pin` markers to content tags before packaging.
+#
+# A marker line looks like:
+#   tag: "" # @ci-pin keycloak-image-tag
+# and becomes:
+#   tag: "<source sha of the component>"
+#
+# Content tags pin an image to the commit that last touched its inputs, so
+# upgrading to a chart that didn't change the image doesn't roll the pod (or
+# rebuild the workload). The repo default stays `""` — charts rendered straight
+# from git keep the appVersion fallback.
+#
+# Both publish jobs call this, so the marker set and the component list can't
+# drift apart between the dev and release paths.
+#
+# Usage: pin-image-tags.sh <source-shas-json> [values-file]
+# Written for bash 3.2 (macOS) and portable sed — no GNU-only \s or `sed -i`.
+set -euo pipefail
+
+SOURCE_SHAS="${1:?source-shas JSON required}"
+VALUES="${2:-deploy/helm/platform/values.yaml}"
+here="$(cd "$(dirname "$0")" && pwd)"
+
+[ -f "$VALUES" ] || { echo "no such values file: $VALUES" >&2; exit 1; }
+
+for comp in keycloak $("$here/resolve-image.sh" list-workloads); do
+  tag="$(jq -re --arg c "$comp" '.[$c]' <<< "$SOURCE_SHAS")"
+  [ -n "$tag" ] || { echo "empty source sha for $comp" >&2; exit 1; }
+  tmp="$(mktemp)"
+  sed "s|^\([[:space:]]*\)tag: \"\" # @ci-pin ${comp}-image-tag\$|\1tag: \"$tag\"|" \
+    "$VALUES" > "$tmp"
+  mv "$tmp" "$VALUES"
+done
+
+# Every marker must have been consumed — a leftover means the component list
+# and the values.yaml markers drifted apart.
+! grep -n '@ci-pin .*-image-tag' "$VALUES"


### PR DESCRIPTION
## Motivation

On `main`, the Helm chart is the last thing to publish and it sits behind the whole agent image chain:

```
check → merge-platform-base → build-agents → merge-agents → build-workloads → merge-workloads → publish
```

Measured over recent `main` runs, that is **~19 minutes** from push to a usable dev chart, of which **~10 minutes is the agent chain alone** (`k-search` dominates `build-agents` at 6–8 min).

Agent images intentionally rebuild on every push — `claude-code`, `codex`, `pi-agent` and `k-search` install their upstream harness unpinned (`mise install "npm:@anthropic-ai/claude-code"`, `KSEARCH_REF=main`), so a rebuild is *how* a new upstream release reaches the image. **That cadence is deliberate and is left untouched here.** The chart simply stops waiting for it.

## Changes

- **Split `publish` into `publish` (releases) and `publish-dev` (main).** A job waits for everything in `needs` to settle regardless of its `if:`, so the only way to publish before the agent merges is a job that doesn't list them.
- **`publish-dev` needs only `changes`, `merge-images`, `appversion`** — the dev chart goes out as soon as the platform images are merged. It still waits on `check` transitively via `merge-images`, so broken code is never published.
- **Releases are unchanged.** `publish` keeps its exact gate, including `merge-agents` success, now scoped to `v*` refs. Both RC and stable releases are `v*` tags, and non-PR events already force a full rebuild, so staging and production keep publishing only once every image the chart names exists.
- **The `@ci-pin` rewrite moves to `scripts/pin-image-tags.sh`** so the two publish jobs can't drift on the marker set or component list. Behaviour is identical; the script is portable (no GNU-only `\s` or `sed -i`).

Expected: push → dev chart drops from **~19 min to ~9 min**.

## Tradeoff

Between `publish-dev` and `merge-agents`, the `0.0.0-main` chart names agent images whose tags aren't pushed yet. Creating or upgrading an agent fails to pull during that window and **recovers on its own** once the tags land. If an agent build fails outright, the window lasts until the next green `main` run.

Accepted for the dev channel only, and documented in `release-process.md`. It's also not a new class of skew — `docs/architecture/connections.md` already treats *"older agent on newer server"* as the supported common case, and `agentRuntimeVersion` is explicitly diagnostic-only. Agent upgrades are user-initiated.

## Notes

- This does **not** shorten the run itself, so `main` runs still serialise behind the concurrency group (`build-claude-code-vm` is a 15 min tail that gates nothing). Reducing that is separate work.
- Builds on the `@ci-pin` mechanism from #3207, extending its two-channel shape rather than changing it.

## Validation

- `mise run check` — passes except the known `crd-backwards-compatibility` worktree/go-git `reference not found` failure, **reproduced identically on an unmodified tree** (no CRDs touched here)
- `mise run common:check:zizmor` — no findings
- `scripts/resolve-image.sh --self-check` — OK
- `helm lint` — OK
- Full pin + `helm template` simulation against the real `values.yaml`: all seven `@ci-pin` markers resolve to content tags, every other image keeps the appVersion fallback, leftover-marker assertion fires correctly, and the script exits non-zero on a missing component sha
