### PR TITLE
docs(guidelines): add house rules for brevity, personal data, attribution and user stories

### DIFF
--- a/.agents/skills/draft-issue/SKILL.md
+++ b/.agents/skills/draft-issue/SKILL.md
@@ -6,7 +6,7 @@ description: >
 
 # Draft an Issue
 
-Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for the issue types, style, and the per-type templates.
+Follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) for the content shape — the whole document, every section.
 
 ## Workflow
 

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -41,13 +41,14 @@ Draft a GitHub issue and file it after the user approves. For the content shape,
 
 5. **Draft inline.** Produce the draft following [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md), using the decided type's template. Present the full draft (title + body, plus the Epic line if one was suggested) in the chat. Do not file yet.
 
-6. **Append the Filed by footer.** You file under a shared credential, so the body must credit the person who asked — see **Attribution** in the guidelines doc for the format and the fallback order. Resolve the requester's GitHub handle first:
+6. **Decide whether the body needs a Filed by footer.** You file under a credential you don't own, so check whether that credential's owner is the person who asked — see **Attribution** in the guidelines doc for the rule, the format, and the fallback order.
 
    ```sh
-   gh api "search/users?q=<name-or-email>" --jq '.items[].login'
+   gh api user --jq .login                                   # the account you file as
+   gh api "search/users?q=<name-or-email>" --jq '.items[].login'   # the requester
    ```
 
-   Put the footer at the end of the body you present in step 5, so the approved body already carries it. Never file a body without the footer, and never credit the credential owner instead.
+   Same person: no footer — GitHub already credits them. Different person: append the footer at the end of the body you present in step 5, so the approved body already carries it. Never credit the account you file as instead of the requester.
 
 7. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval. Approval covers the type and any epic suggestion too — if the user changes either, that's a revision.
 
@@ -61,7 +62,7 @@ After approval, file with `gh issue create`. Do not use the GitHub MCP tools (`m
 
 - `--repo owner/repo` — infer from git remote or prior context; ask if ambiguous
 - `--title "..."` — exactly as approved
-- `--body "..."` — exactly as approved, including the **Filed by** footer, minus the **Epic** line (it's draft metadata, applied as the parent relationship below, not body text); pass via a HEREDOC so markdown formatting survives
+- `--body "..."` — exactly as approved, including the **Filed by** footer if step 6 called for one, minus the **Epic** line (it's draft metadata, applied as the parent relationship below, not body text); pass via a HEREDOC so markdown formatting survives
 - `--label foo --label bar` — only if the user specified labels
 
 Example:

--- a/.agents/skills/file-issue/SKILL.md
+++ b/.agents/skills/file-issue/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[what the issue is about]"
 
 # File an Issue
 
-Draft a GitHub issue and file it after the user approves. For the content shape — the issue types (epic, feature, task, bug, research task), style, and the per-type templates — follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md). This skill layers the workflow (understand → decide type → research → dedupe → draft → approve → file) on top of those guidelines.
+Draft a GitHub issue and file it after the user approves. For the content shape, follow [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md) — the whole document, every section. This skill layers the workflow (understand → decide type → research → dedupe → draft → attribute → approve → file) on top of those guidelines.
 
 ## Workflow
 
@@ -41,11 +41,19 @@ Draft a GitHub issue and file it after the user approves. For the content shape 
 
 5. **Draft inline.** Produce the draft following [docs/guidelines/issue-guidelines.md](../../../docs/guidelines/issue-guidelines.md), using the decided type's template. Present the full draft (title + body, plus the Epic line if one was suggested) in the chat. Do not file yet.
 
-6. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval. Approval covers the type and any epic suggestion too — if the user changes either, that's a revision.
+6. **Append the Filed by footer.** You file under a shared credential, so the body must credit the person who asked — see **Attribution** in the guidelines doc for the format and the fallback order. Resolve the requester's GitHub handle first:
+
+   ```sh
+   gh api "search/users?q=<name-or-email>" --jq '.items[].login'
+   ```
+
+   Put the footer at the end of the body you present in step 5, so the approved body already carries it. Never file a body without the footer, and never credit the credential owner instead.
+
+7. **Get explicit approval.** Ask whether to file as-is or revise. NEVER file without explicit approval. Approval covers the type and any epic suggestion too — if the user changes either, that's a revision.
 
    **Every revision invalidates the previous approval.** If the user requests any change after approving — even a small one — you must present the revised draft and get a fresh, explicit "file it" before sending to GitHub. Do not assume the original approval carries over.
 
-7. **File via `gh` CLI.** Use `gh issue create`. Infer the repo from context (current working directory's git remote, or a repo mentioned earlier in the session). If unclear, ask. Then apply the relationships (below) and return the issue URL.
+8. **File via `gh` CLI.** Use `gh issue create`. Infer the repo from context (current working directory's git remote, or a repo mentioned earlier in the session). If unclear, ask. Then apply the relationships (below) and return the issue URL.
 
 ## Filing
 
@@ -53,7 +61,7 @@ After approval, file with `gh issue create`. Do not use the GitHub MCP tools (`m
 
 - `--repo owner/repo` — infer from git remote or prior context; ask if ambiguous
 - `--title "..."` — exactly as approved
-- `--body "..."` — exactly as approved, minus the **Epic** line (it's draft metadata, applied as the parent relationship below, not body text); pass via a HEREDOC so markdown formatting survives
+- `--body "..."` — exactly as approved, including the **Filed by** footer, minus the **Epic** line (it's draft metadata, applied as the parent relationship below, not body text); pass via a HEREDOC so markdown formatting survives
 - `--label foo --label bar` — only if the user specified labels
 
 Example:
@@ -67,6 +75,10 @@ gh issue create --repo owner/repo --title "Short declarative title" --body "$(ca
 ## Proposed solution
 
 ...
+
+---
+
+_Filed by @requester-handle_
 EOF
 )"
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -61,7 +61,7 @@ This is the one place a real person is named — see **No personal data** above.
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the problem, not the component and not the fix (see **State the problem, not the solution** above). Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - A long artifact is unreadable in the chat view's narrow column`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer, unless the person filing is the person who asked — see [Attribution](#attribution).
+Every template starts with a **Title** — short, declarative, no jargon; names the problem, not the component and not the fix, except in a **task**, whose title may name the work (see **State the problem, not the solution** above). Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - A long artifact is unreadable in the chat view's narrow column`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer, unless the account you file as belongs to the person who asked — see [Attribution](#attribution).
 
 ### Epic
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -36,10 +36,10 @@ An agent files under a shared credential, so GitHub credits the credential owner
 ```markdown
 ---
 
-_Filed by @jamiejabbouribm_
+_Filed by @<github-handle>_
 ```
 
-Use the requester's GitHub handle so the footer @-mentions them and they follow the thread. If the handle cannot be resolved, fall back — in order — to any identifier that reaches them: their Slack handle, then their full name. A best-effort footer beats a missing one; never drop the footer because the handle is unknown, and never substitute the credential owner.
+Use the requester's GitHub handle so the footer @-mentions them and they follow the thread. If the handle cannot be resolved, fall back in order: their full name, then their Slack handle. A best-effort footer beats a missing one; never drop the footer because the handle is unknown, and never substitute the credential owner.
 
 This is the one place a real person is named — see **No personal data** above. The footer credits a *team member* who asked for the work. It never names a user, a reporter, or a research participant.
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -26,8 +26,24 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - It's fine to flag open questions or naming uncertainty — invite the reader to push back.
 - Concise but complete. If a subsection has nothing to say, cut it.
 - **Be brief.** One idea per sentence. Active voice. Cut filler, restatement, and any sentence that carries no new fact. A reader should get the problem from the first paragraph. Length is not thoroughness.
-- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Keep source links in the discussion where the ask came from, not in the issue. Check screenshots for names before attaching them.
+- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Keep source links in the discussion where the ask came from, not in the issue. Check screenshots for names before attaching them. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
 - **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
+
+## Attribution
+
+Anyone on the team can ask for an issue and approve it. One explicit approval from the person who asked is enough to file — filing is capture, not prioritization, so it needs no second sign-off.
+
+An agent files under a shared credential, so GitHub credits the credential owner rather than the person who asked. **An agent filing an issue must always end the body with a Filed by footer** naming that person:
+
+```markdown
+---
+
+_Filed by @jamiejabbouribm_
+```
+
+Use the requester's GitHub handle so the footer @-mentions them and they follow the thread. If the handle cannot be resolved, fall back — in order — to any identifier that reaches them: their Slack handle, then their full name. A best-effort footer beats a missing one; never drop the footer because the handle is unknown, and never substitute the credential owner.
+
+This is the one place a real person is named — see **No personal data** above. The footer credits a *team member* who asked for the work. It never names a user, a reporter, or a research participant.
 
 ## Templates
 
@@ -83,9 +99,9 @@ The **Problem** describes what's wrong or missing today from the user's point of
 
 ## User Stories
 
-<The value from each user's perspective, in the form "As a <role>, I want <capability> so that <benefit>." One per distinct need. For example: "As an operator, I want to see a schedule's last run status so that I can tell at a glance whether it's healthy.">
+<The value from the user's perspective, in the form "As a user, I want <capability> so that <benefit>." One per distinct need. The role is always "a user" — never a narrower persona like "an operator", "a designer", or "a PM", even when the ask came from one person's workflow, because naming a narrow role makes the issue read as if it only serves that group and narrows how the team scopes it. For example: "As a user, I want to see a schedule's last run status so that I can tell at a glance whether it's healthy.">
 
-- As a <role>, I want <capability> so that <benefit>.
+- As a user, I want <capability> so that <benefit>.
 
 ## Scope
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -29,6 +29,7 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Do not link a message that identifies a person, even when that message is what motivated the issue — describe what the report showed instead. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
 - **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
 - **"As a user" always.** A user story's role is always "a user" — never a narrower persona like "an operator", "a designer", or "a PM", even when the ask came from one person's workflow. A narrow role makes the issue read as if it only serves that group, and it narrows how the team scopes the work.
+- **State the problem, not the solution.** This holds hardest in the **title** — name the problem or the misbehaviour, never the fix. "Network approval requests demand an answer before the user is ready" states a problem; "Add a dismiss button to approval toasts" prescribes an answer. Watch for a title that commands a change: "add", "let users", "make it possible to", "support" all smuggle a solution into the one line everyone reads. A prescribed fix constrains whoever picks the issue up; they should judge the approach themselves. **Goal** states the user-visible outcome, not the mechanism. Put a solution you have in mind under **Proposed solution**, with the reasoning, and leave the genuine alternatives in **Open Questions**.
 
 ## Attribution
 
@@ -60,7 +61,7 @@ This is the one place a real person is named — see **No personal data** above.
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - Expand an artifact to full screen from the chat view`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer, unless the person filing is the person who asked — see [Attribution](#attribution).
+Every template starts with a **Title** — short, declarative, no jargon; names the problem, not the component and not the fix (see **State the problem, not the solution** above). Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - A long artifact is unreadable in the chat view's narrow column`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer, unless the person filing is the person who asked — see [Attribution](#attribution).
 
 ### Epic
 
@@ -98,10 +99,10 @@ _Filed by @<github-handle>_
 
 ### Feature
 
-The **Problem** describes what's wrong or missing today from the user's point of view — a concrete scenario if it sharpens it, and why it matters. The **Goal** is what success looks like as user-visible outcome. The **User Stories** break the goal into the concrete things different users want to do and why. Keep it problem-first: if you have a solution in mind, put it under **Proposed solution** and explain the reasoning — otherwise leave it open.
+The **Problem** describes what's wrong or missing today from the user's point of view — a concrete scenario if it sharpens it, and why it matters. The **Goal** is what success looks like as user-visible outcome. The **User Stories** break the goal into the concrete things different users want to do and why. Keep it problem-first: if you have a solution in mind, put it under **Proposed solution** and explain the reasoning — otherwise leave it open. A feature is the type most likely to name a solution in its title; write the title from the **Problem**, not from the fix.
 
 ```markdown
-**Title:** <`UI - ` if the web UI; then short, declarative>
+**Title:** <`UI - ` if the web UI; then short, declarative — the problem the user has, not the feature that fixes it>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
 ## Context
@@ -150,7 +151,7 @@ _Filed by @<github-handle>_
 A task states the work and what it unblocks. It's the one type where naming engineering work is expected — keep it as plain as the work allows.
 
 ```markdown
-**Title:** <`UI - ` if the web UI; then short, declarative>
+**Title:** <`UI - ` if the web UI; then short, declarative — the work needed, not a chosen implementation>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
 ## Context

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -32,7 +32,13 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 
 ## Attribution
 
-An agent files under a shared credential, so GitHub credits the credential owner rather than the person who asked. **An agent filing an issue must always end the body with a Filed by footer** naming that person:
+GitHub credits the account that files the issue. **When that account is not the person who asked for the work, end the body with a Filed by footer** naming the person who did:
+
+- An **agent** files under a credential it does not own, so compare that credential's owner to the requester. Filing another person's ask needs the footer; filing the credential owner's own ask does not.
+- A **person filing on someone else's behalf** needs the footer too, for the same reason.
+- A person filing their own ask does **not** need it. GitHub already credits the right person, and a footer would just repeat the author.
+
+The format:
 
 ```markdown
 ---
@@ -48,13 +54,13 @@ Use the requester's GitHub handle so the footer @-mentions them and they follow 
 _Filed by <full name or Slack handle>_
 ```
 
-A best-effort footer beats a missing one; never drop the footer because the handle is unknown, and never substitute the credential owner.
+A best-effort footer beats a missing one; when the footer is required, never drop it because the handle is unknown, and never substitute the account that files.
 
 This is the one place a real person is named — see **No personal data** above. The footer credits a *team member* who asked for the work. It never names a user, a reporter, or a research participant.
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - Expand an artifact to full screen from the chat view`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer when an agent files the issue — see [Attribution](#attribution).
+Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - Expand an artifact to full screen from the chat view`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer, unless the person filing is the person who asked — see [Attribution](#attribution).
 
 ### Epic
 
@@ -82,6 +88,8 @@ An epic defines the value, not a single fix, and gives enough shape that issues 
 ## Open Questions
 
 <Key decisions or unknowns.>
+
+<omit this footer if you are the person who asked>
 
 ---
 
@@ -130,6 +138,8 @@ The **Problem** describes what's wrong or missing today from the user's point of
 
 <optional — links to designs, research, related issues, docs, or other supporting material>
 
+<omit this footer if you are the person who asked>
+
 ---
 
 _Filed by @<github-handle>_
@@ -158,6 +168,8 @@ A task states the work and what it unblocks. It's the one type where naming engi
 ## Done when
 
 <The observable end state — how we know it's finished.>
+
+<omit this footer if you are the person who asked>
 
 ---
 
@@ -191,6 +203,8 @@ Lead with observed vs. expected behavior. Reproduction steps should be minimal a
 ## Steps to Reproduce
 
 1. <minimal, numbered steps>
+
+<omit this footer if you are the person who asked>
 
 ---
 
@@ -236,6 +250,8 @@ A research task defines what we need to learn and why, before committing to buil
 ## Additional resources
 
 <optional — links to existing research, related issues, docs, or other supporting material>
+
+<omit this footer if you are the person who asked>
 
 ---
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -26,7 +26,7 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - It's fine to flag open questions or naming uncertainty — invite the reader to push back.
 - Concise but complete. If a subsection has nothing to say, cut it.
 - **Be brief.** One idea per sentence. Active voice. Cut filler, restatement, and any sentence that carries no new fact. A reader should get the problem from the first paragraph. Length is not thoroughness.
-- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Keep source links in the discussion where the ask came from, not in the issue. Check screenshots for names before attaching them. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
+- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Do not link a message that identifies a person, even when that message is what motivated the issue — describe what the report showed instead. Check screenshots for names before attaching them. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
 - **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
 
 ## Attribution

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -26,7 +26,7 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - It's fine to flag open questions or naming uncertainty — invite the reader to push back.
 - Concise but complete. If a subsection has nothing to say, cut it.
 - **Be brief.** One idea per sentence. Active voice. Cut filler, restatement, and any sentence that carries no new fact. A reader should get the problem from the first paragraph. Length is not thoroughness.
-- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Do not link a message that identifies a person, even when that message is what motivated the issue — describe what the report showed instead. Check screenshots for names before attaching them. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
+- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Do not link a message that identifies a person, even when that message is what motivated the issue — describe what the report showed instead. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
 - **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
 
 ## Attribution

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -25,10 +25,13 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - Bold the key noun in a bullet when it introduces a concept (e.g. "**heartbeat** — a recurring self-scheduled check").
 - It's fine to flag open questions or naming uncertainty — invite the reader to push back.
 - Concise but complete. If a subsection has nothing to say, cut it.
+- **Be brief.** One idea per sentence. Active voice. Cut filler, restatement, and any sentence that carries no new fact. A reader should get the problem from the first paragraph. Length is not thoroughness.
+- **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Keep source links in the discussion where the ask came from, not in the issue. Check screenshots for names before attaching them.
+- **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed.
+Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - Expand an artifact to full screen from the chat view`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed.
 
 ### Epic
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -29,7 +29,7 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Do not link a message that identifies a person, even when that message is what motivated the issue — describe what the report showed instead. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
 - **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
 - **"As a user" always.** A user story's role is always "a user" — never a narrower persona like "an operator", "a designer", or "a PM", even when the ask came from one person's workflow. A narrow role makes the issue read as if it only serves that group, and it narrows how the team scopes the work.
-- **State the problem, not the solution.** This holds hardest in the **title** — name the problem or the misbehaviour, never the fix. "Network approval requests demand an answer before the user is ready" states a problem; "Add a dismiss button to approval toasts" prescribes an answer. Watch for a title that commands a change: "add", "let users", "make it possible to", "support" all smuggle a solution into the one line everyone reads. A prescribed fix constrains whoever picks the issue up; they should judge the approach themselves. **Goal** states the user-visible outcome, not the mechanism. Put a solution you have in mind under **Proposed solution**, with the reasoning, and leave the genuine alternatives in **Open Questions**.
+- **State the problem, not the solution.** This holds hardest in the **title** — name the problem or the misbehaviour, never the fix. "Network approval requests demand an answer before the user is ready" states a problem; "Add a dismiss button to approval toasts" prescribes an answer. Watch for a title that commands a change: "add", "let users", "make it possible to", "support" all smuggle a solution into the one line everyone reads. A prescribed fix constrains whoever picks the issue up; they should judge the approach themselves. A **task** is the exception — the work itself is the point, so its title may name the work ("Upgrade the node runtime"); it still must not name a chosen implementation. **Goal** states the user-visible outcome, not the mechanism. Put a solution you have in mind under **Proposed solution**, with the reasoning, and leave the genuine alternatives in **Open Questions**.
 
 ## Attribution
 
@@ -90,7 +90,7 @@ An epic defines the value, not a single fix, and gives enough shape that issues 
 
 <Key decisions or unknowns.>
 
-<omit this footer if you are the person who asked>
+<omit this footer if the account you file as belongs to the person who asked>
 
 ---
 
@@ -139,7 +139,7 @@ The **Problem** describes what's wrong or missing today from the user's point of
 
 <optional — links to designs, research, related issues, docs, or other supporting material>
 
-<omit this footer if you are the person who asked>
+<omit this footer if the account you file as belongs to the person who asked>
 
 ---
 
@@ -170,7 +170,7 @@ A task states the work and what it unblocks. It's the one type where naming engi
 
 <The observable end state — how we know it's finished.>
 
-<omit this footer if you are the person who asked>
+<omit this footer if the account you file as belongs to the person who asked>
 
 ---
 
@@ -205,7 +205,7 @@ Lead with observed vs. expected behavior. Reproduction steps should be minimal a
 
 1. <minimal, numbered steps>
 
-<omit this footer if you are the person who asked>
+<omit this footer if the account you file as belongs to the person who asked>
 
 ---
 
@@ -252,7 +252,7 @@ A research task defines what we need to learn and why, before committing to buil
 
 <optional — links to existing research, related issues, docs, or other supporting material>
 
-<omit this footer if you are the person who asked>
+<omit this footer if the account you file as belongs to the person who asked>
 
 ---
 

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -28,6 +28,7 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 - **Be brief.** One idea per sentence. Active voice. Cut filler, restatement, and any sentence that carries no new fact. A reader should get the problem from the first paragraph. Length is not thoroughness.
 - **No personal data.** This repo is public. Never name a person — no real names, Slack display names, GitHub logins, or emails — in the body, in Context, or in a quoted report. Attribute to a role instead: "a user", "a researcher", "the team". Do not link a message that identifies a person, even when that message is what motivated the issue — describe what the report showed instead. The one deliberate exception is the **Filed by** footer — see [Attribution](#attribution).
 - **One bullet, one line.** Do not hard-wrap bullet or paragraph text, and do not indent continuation lines. Let the client wrap. Hard-wrapped bullets render as ragged, oddly indented text.
+- **"As a user" always.** A user story's role is always "a user" — never a narrower persona like "an operator", "a designer", or "a PM", even when the ask came from one person's workflow. A narrow role makes the issue read as if it only serves that group, and it narrows how the team scopes the work.
 
 ## Attribution
 
@@ -39,13 +40,21 @@ An agent files under a shared credential, so GitHub credits the credential owner
 _Filed by @<github-handle>_
 ```
 
-Use the requester's GitHub handle so the footer @-mentions them and they follow the thread. If the handle cannot be resolved, fall back in order: their full name, then their Slack handle. A best-effort footer beats a missing one; never drop the footer because the handle is unknown, and never substitute the credential owner.
+Use the requester's GitHub handle so the footer @-mentions them and they follow the thread. If the handle cannot be resolved, fall back in order: their full name, then their Slack handle. Write a fallback without the `@` sigil — GitHub resolves a bare first name to an unrelated real account, so `@` on anything but a handle credits a stranger:
+
+```markdown
+---
+
+_Filed by <full name or Slack handle>_
+```
+
+A best-effort footer beats a missing one; never drop the footer because the handle is unknown, and never substitute the credential owner.
 
 This is the one place a real person is named — see **No personal data** above. The footer credits a *team member* who asked for the work. It never names a user, a reporter, or a research participant.
 
 ## Templates
 
-Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - Expand an artifact to full screen from the chat view`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed.
+Every template starts with a **Title** — short, declarative, no jargon; names the change, not the component. Prefix the title with `UI - ` when the problem is in the web UI (e.g. `UI - Expand an artifact to full screen from the chat view`) — that prefix is how the board groups UI work. Every template then leads with **Context** — why we're here, what led to this. Features, tasks, bugs, and research tasks may carry an **Epic** line; it's metadata for the draft, not part of the issue body — the epic link is applied when the issue is filed. Every template ends with the **Filed by** footer when an agent files the issue — see [Attribution](#attribution).
 
 ### Epic
 
@@ -73,6 +82,10 @@ An epic defines the value, not a single fix, and gives enough shape that issues 
 ## Open Questions
 
 <Key decisions or unknowns.>
+
+---
+
+_Filed by @<github-handle>_
 ```
 
 ### Feature
@@ -80,7 +93,7 @@ An epic defines the value, not a single fix, and gives enough shape that issues 
 The **Problem** describes what's wrong or missing today from the user's point of view — a concrete scenario if it sharpens it, and why it matters. The **Goal** is what success looks like as user-visible outcome. The **User Stories** break the goal into the concrete things different users want to do and why. Keep it problem-first: if you have a solution in mind, put it under **Proposed solution** and explain the reasoning — otherwise leave it open.
 
 ```markdown
-**Title:** <short, declarative>
+**Title:** <`UI - ` if the web UI; then short, declarative>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
 ## Context
@@ -97,7 +110,7 @@ The **Problem** describes what's wrong or missing today from the user's point of
 
 ## User Stories
 
-<The value from the user's perspective, in the form "As a user, I want <capability> so that <benefit>." One per distinct need. The role is always "a user" — never a narrower persona like "an operator", "a designer", or "a PM", even when the ask came from one person's workflow, because naming a narrow role makes the issue read as if it only serves that group and narrows how the team scopes it. For example: "As a user, I want to see a schedule's last run status so that I can tell at a glance whether it's healthy.">
+<The value from the user's perspective, in the form "As a user, I want <capability> so that <benefit>." One per distinct need. The role is always "a user" — see **Style** above. For example: "As a user, I want to see a schedule's last run status so that I can tell at a glance whether it's healthy.">
 
 - As a user, I want <capability> so that <benefit>.
 
@@ -116,6 +129,10 @@ The **Problem** describes what's wrong or missing today from the user's point of
 ## Additional resources
 
 <optional — links to designs, research, related issues, docs, or other supporting material>
+
+---
+
+_Filed by @<github-handle>_
 ```
 
 ### Task
@@ -123,7 +140,7 @@ The **Problem** describes what's wrong or missing today from the user's point of
 A task states the work and what it unblocks. It's the one type where naming engineering work is expected — keep it as plain as the work allows.
 
 ```markdown
-**Title:** <short, declarative>
+**Title:** <`UI - ` if the web UI; then short, declarative>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
 ## Context
@@ -141,6 +158,10 @@ A task states the work and what it unblocks. It's the one type where naming engi
 ## Done when
 
 <The observable end state — how we know it's finished.>
+
+---
+
+_Filed by @<github-handle>_
 ```
 
 ### Bug
@@ -148,7 +169,7 @@ A task states the work and what it unblocks. It's the one type where naming engi
 Lead with observed vs. expected behavior. Reproduction steps should be minimal and numbered.
 
 ```markdown
-**Title:** <short, declarative — the misbehavior, not the suspected cause>
+**Title:** <`UI - ` if the web UI; then short, declarative — the misbehavior, not the suspected cause>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
 ## Context
@@ -170,6 +191,10 @@ Lead with observed vs. expected behavior. Reproduction steps should be minimal a
 ## Steps to Reproduce
 
 1. <minimal, numbered steps>
+
+---
+
+_Filed by @<github-handle>_
 ```
 
 ### Research Task
@@ -177,7 +202,7 @@ Lead with observed vs. expected behavior. Reproduction steps should be minimal a
 A research task defines what we need to learn and why, before committing to build. The value is the knowledge it produces, so it's done when it produces an answer someone can act on — not when "research happened."
 
 ```markdown
-**Title:** <short, declarative — the question, not the answer>
+**Title:** <`UI - ` if the web UI; then short, declarative — the question, not the answer>
 **Epic:** <#NNN — epic title, if one clearly fits>
 
 ## Context
@@ -211,4 +236,8 @@ A research task defines what we need to learn and why, before committing to buil
 ## Additional resources
 
 <optional — links to existing research, related issues, docs, or other supporting material>
+
+---
+
+_Filed by @<github-handle>_
 ```

--- a/docs/guidelines/issue-guidelines.md
+++ b/docs/guidelines/issue-guidelines.md
@@ -31,8 +31,6 @@ Features, tasks, bugs, and research tasks can attach to an epic. If the issue cl
 
 ## Attribution
 
-Anyone on the team can ask for an issue and approve it. One explicit approval from the person who asked is enough to file — filing is capture, not prioritization, so it needs no second sign-off.
-
 An agent files under a shared credential, so GitHub credits the credential owner rather than the person who asked. **An agent filing an issue must always end the body with a Filed by footer** naming that person:
 
 ```markdown


### PR DESCRIPTION
## Motivation

I taught these issue-writing rules to my agent one correction at a time, so they only live in that agent's private memory. Moving them into the guidelines doc means every agent reads the same rules and our issues come out consistent.

## Changes

Added to **Style**:

- **Be brief.** One idea per sentence, active voice, cut filler. Length is not thoroughness.
- **No personal data.** This repo is public. Never name a person; attribute to a role instead. Do not link a message that identifies a person, even when it motivated the issue.
- **One bullet, one line.** No hard-wrapping or hanging indents, they render as ragged text.
- **"As a user" always.** A user story's role is always "a user", never a narrower persona like "an operator". A narrow role makes the issue read as if it only serves that group and narrows how the team scopes it. The Feature template's placeholder and example are updated to match.
- **State the problem, not the solution.** A title names the problem or the misbehaviour, never the fix. "Add", "let users", "support" and "make it possible to" smuggle a solution into the one line everyone reads. A task is the exception: the work is the point, so its title may name the work. The rule also rewrote the Templates preamble, the Feature prose, and all four non-epic **Title** placeholders.

New **Attribution** section:

- **When the account that files is not the person who asked, the body ends with a Filed by footer** naming the requester. An agent files under a credential it does not own, so it compares that credential's owner to the requester: another person's ask needs the footer, the credential owner's own ask does not. A person filing on someone else's behalf needs it too. A person filing their own ask does not — GitHub already credits them. The doc gives the exact format:

  ```markdown
  ---

  _Filed by @<github-handle>_
  ```

- Use the GitHub handle so the footer @-mentions them. If it cannot be resolved, fall back in order: their full name, then their Slack handle, written without the `@` sigil — `@` on anything but a handle credits a stranger. When the footer is required, a best-effort footer beats a missing one, and never substitute the account that files.
- Called out as the one deliberate exception to **No personal data**: the footer credits a team member, never a user or a research participant.

**Templates**:

- Prefix a title with `UI - ` when the problem is in the web UI. That prefix is how the board groups UI work, and a missing prefix makes the issue invisible to that grouping. The prefix is in every non-epic **Title** placeholder.
- Each template carries the **Filed by** footer, with the omit-condition stated above it.

**Agent skills** — the new Attribution rule needs a step in the filing loop, so two skills change behaviour:

- `file-issue`: a new step 6 decides whether the body needs a **Filed by** footer. It resolves the filing account and the requester with `gh api user` and `gh api "search/users?q=…"`, then appends the footer to the body presented for approval. Later steps are renumbered, and the `--body` bullet now says the approved body includes the footer.
- `draft-issue`: the pointer to the guidelines doc now names the whole document, not a list of sections, so a drafting agent reads Attribution too.

No product or platform code changes. The behaviour change is in the two agent skills above.
