### PR TITLE
fix(ui): rename the cleared model setting option to "Default"

### DIFF
--- a/packages/agents/claude-code/runtime-manifest.yaml
+++ b/packages/agents/claude-code/runtime-manifest.yaml
@@ -23,7 +23,7 @@ drivers:
               name: "Fable"
               description: "Fable 5 · Most capable for the hardest, longest-running tasks"
             - value: opus
-              name: "Opus (recommended)"
+              name: "Opus"
               description: "Opus 5 · Best for everyday, complex tasks"
             - value: sonnet
               name: "Sonnet"
@@ -40,8 +40,8 @@ drivers:
               name: "Auto"
               description: "Use a model classifier to approve/deny permission prompts"
             - value: default
-              name: "Default"
-              description: "Standard behavior, prompts for dangerous operations"
+              name: "Ask for approvals"
+              description: "Ask for permission before dangerous operations"
             - value: acceptEdits
               name: "Accept Edits"
               description: "Auto-accept file edit operations"

--- a/packages/ui/src/components/ui/read-only-field.ts
+++ b/packages/ui/src/components/ui/read-only-field.ts
@@ -1,0 +1,4 @@
+export const READ_ONLY_FIELD_BASE =
+  "flex w-full items-center rounded-md border border-input bg-muted/40 px-4 text-sm text-muted-foreground";
+
+export const READ_ONLY_FIELD = `${READ_ONLY_FIELD_BASE} h-10`;

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-base-config-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-base-config-view.tsx
@@ -4,6 +4,7 @@ import { FormField } from "@/components/form-field";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { PageHeader } from "@/components/ui/page-header";
+import { READ_ONLY_FIELD } from "@/components/ui/read-only-field";
 import { SectionLabel } from "@/components/ui/section-label";
 import { Tooltip } from "@/components/ui/tooltip";
 
@@ -14,7 +15,6 @@ import { useResolvedAgentDisplay } from "../../agents/hooks/use-resolved-agent-d
 import { AgentEgressEditor } from "../../egress-rules/components/agent-egress-editor.js";
 import { routeToPath } from "../../platform/lib/routes.js";
 import { ConnectionsSection } from "../../sandboxes/components/connections-section.js";
-import { READ_ONLY_FIELD } from "../../sandboxes/components/sandbox-setup-section.js";
 import { useSandboxSettingsForm } from "../../sandboxes/hooks/use-sandbox-settings-form.js";
 import { confirmDeleteKnowledgeBase } from "../lib/confirm-delete.js";
 

--- a/packages/ui/src/modules/sandboxes/components/sandbox-model-settings.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-model-settings.tsx
@@ -6,6 +6,10 @@ import {
   useResolvedHarnessConfig,
 } from "../../agents/api/harness-config.js";
 import { ModelSettingsPanel } from "../../sessions/components/model-settings-panel.js";
+import {
+  OptionField,
+  ReadOnlyOptionFace,
+} from "../../sessions/components/option-field.js";
 import type { useHarnessConfigDraft } from "../hooks/use-harness-config-draft.js";
 import { useOperableState, WakeToEditButton } from "./sandbox-wake-to-edit.js";
 
@@ -34,11 +38,23 @@ export function SandboxModelSettings({
     );
   }
 
-  if (!operable && (!hasCatalog || origin === "none")) {
+  if (!operable && !hasCatalog) {
     return (
       <Fallback agentId={agentId} comingUp={comingUp}>
-        Start the agent to load and edit its model settings.
+        Start the sandbox to load and edit its model settings.
       </Fallback>
+    );
+  }
+
+  if (!operable && origin === "none") {
+    return (
+      <Section agentId={agentId} comingUp={comingUp}>
+        {status?.catalog?.options.map((group) => (
+          <OptionField key={group.id} title={group.name}>
+            <ReadOnlyOptionFace label="Unknown" hint="Start sandbox to view" />
+          </OptionField>
+        ))}
+      </Section>
     );
   }
 
@@ -90,7 +106,7 @@ function ModelSettingsSkeleton() {
   );
 }
 
-function Fallback({
+function Section({
   agentId,
   comingUp,
   children,
@@ -105,9 +121,23 @@ function Fallback({
         <SectionLabel>Model settings</SectionLabel>
         <WakeToEditButton agentId={agentId} comingUp={comingUp} />
       </div>
-      <Callout inset>
-        <p className="text-sm text-muted-foreground">{children}</p>
-      </Callout>
+      <Callout inset>{children}</Callout>
     </section>
+  );
+}
+
+function Fallback({
+  agentId,
+  comingUp,
+  children,
+}: {
+  agentId: string;
+  comingUp: boolean;
+  children: React.ReactNode;
+}) {
+  return (
+    <Section agentId={agentId} comingUp={comingUp}>
+      <p className="text-sm text-muted-foreground">{children}</p>
+    </Section>
   );
 }

--- a/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
@@ -4,6 +4,7 @@ import { FormField } from "@/components/form-field";
 import { Callout } from "@/components/ui/callout";
 import { Input } from "@/components/ui/input";
 import { Inset } from "@/components/ui/inset";
+import { READ_ONLY_FIELD } from "@/components/ui/read-only-field";
 import { SectionLabel } from "@/components/ui/section-label";
 
 import { useStore } from "../../../store.js";
@@ -14,9 +15,6 @@ import type { useSandboxSettingsForm } from "../hooks/use-sandbox-settings-form.
 import { HibernationTimeoutField } from "./hibernation-timeout-field.js";
 import { SandboxModelSettings } from "./sandbox-model-settings.js";
 import { SandboxSizeSection } from "./sandbox-size-section.js";
-
-export const READ_ONLY_FIELD =
-  "flex h-10 w-full items-center rounded-md border border-input bg-muted/40 px-4 text-sm text-muted-foreground";
 
 type SandboxSettingsForm = ReturnType<typeof useSandboxSettingsForm>;
 

--- a/packages/ui/src/modules/sandboxes/components/sandbox-wake-to-edit.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-wake-to-edit.tsx
@@ -33,13 +33,13 @@ export function WakeToEditButton({
   if (comingUp)
     return (
       <span className="flex h-9 items-center gap-1.5 text-sm font-medium text-muted-foreground">
-        Agent is starting…
+        Sandbox is starting…
         <Spinner />
       </span>
     );
   return (
     <Button variant="outline" size="sm" onClick={() => wakeAgent.wake(agentId)}>
-      <Play /> Start agent to edit
+      <Play /> Start sandbox to edit
     </Button>
   );
 }

--- a/packages/ui/src/modules/sessions/components/model-settings-panel.tsx
+++ b/packages/ui/src/modules/sessions/components/model-settings-panel.tsx
@@ -9,7 +9,6 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { SectionLabel } from "@/components/ui/section-label";
-import { cn } from "@/lib/utils";
 
 import {
   useHarnessConfigStatus,
@@ -20,6 +19,7 @@ import {
   StaleModelCallout,
   unavailableModel,
 } from "./model-settings-snapshot.js";
+import { OptionField, ReadOnlyOptionFace } from "./option-field.js";
 
 interface Choice {
   id: string;
@@ -131,6 +131,9 @@ export function ModelSettingsPanel({
   );
 }
 
+const CLEARED_LABEL = "Default";
+const CLEARED_DESCRIPTION = "Determined by harness settings";
+
 function OptionGroup({
   title,
   choices,
@@ -145,61 +148,48 @@ function OptionGroup({
   onSelect: (id: string | null) => void;
 }) {
   const selected = value === null ? null : choices.find((c) => c.id === value);
-  const triggerClass =
-    "flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-4 text-sm text-foreground transition-colors";
-  const face = (
-    <>
-      <span className="truncate">{selected?.name ?? "Not set"}</span>
-      <ChevronDown size={14} className="shrink-0 text-muted-foreground" />
-    </>
-  );
+  if (disabled) {
+    return (
+      <OptionField title={title}>
+        <ReadOnlyOptionFace label={selected?.name ?? CLEARED_LABEL} />
+      </OptionField>
+    );
+  }
   return (
-    <div className="mb-4 last:mb-0">
-      <SectionLabel className="mb-1.5 block">{title}</SectionLabel>
-      {disabled ? (
-        <div
-          aria-disabled="true"
-          className={cn(triggerClass, "cursor-not-allowed opacity-50")}
-        >
-          {face}
-        </div>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              aria-label={title}
-              className={cn(
-                triggerClass,
-                "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
-              )}
-            >
-              {face}
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent
-            align="start"
-            className="max-h-72 w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+    <OptionField title={title}>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-label={title}
+            className="flex h-10 w-full items-center justify-between gap-2 rounded-md border border-input bg-transparent px-4 text-sm text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
           >
+            <span className="truncate">{selected?.name ?? CLEARED_LABEL}</span>
+            <ChevronDown size={14} className="shrink-0 text-muted-foreground" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="max-h-72 w-[var(--radix-dropdown-menu-trigger-width)] overflow-y-auto"
+        >
+          <OptionItem
+            label={CLEARED_LABEL}
+            description={CLEARED_DESCRIPTION}
+            active={value === null}
+            onSelect={() => onSelect(null)}
+          />
+          {choices.map((c) => (
             <OptionItem
-              label="Not set"
-              description="Clears the key — the harness picks on its own"
-              active={value === null}
-              onSelect={() => onSelect(null)}
+              key={c.id}
+              label={c.name}
+              detail={c.name === c.id ? undefined : c.id}
+              description={c.description}
+              active={c.id === value}
+              onSelect={() => onSelect(c.id)}
             />
-            {choices.map((c) => (
-              <OptionItem
-                key={c.id}
-                label={c.name}
-                detail={c.name === c.id ? undefined : c.id}
-                description={c.description}
-                active={c.id === value}
-                onSelect={() => onSelect(c.id)}
-              />
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
-    </div>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </OptionField>
   );
 }
 

--- a/packages/ui/src/modules/sessions/components/option-field.tsx
+++ b/packages/ui/src/modules/sessions/components/option-field.tsx
@@ -1,0 +1,49 @@
+import { ChevronDown } from "@carbon/icons-react";
+import type { ReactNode } from "react";
+
+import { READ_ONLY_FIELD_BASE } from "@/components/ui/read-only-field";
+import { SectionLabel } from "@/components/ui/section-label";
+import { cn } from "@/lib/utils";
+
+export function OptionField({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mb-4 last:mb-0">
+      <SectionLabel className="mb-1.5 block">{title}</SectionLabel>
+      {children}
+    </div>
+  );
+}
+
+export function ReadOnlyOptionFace({
+  label,
+  hint,
+}: {
+  label: string;
+  hint?: string;
+}) {
+  return (
+    <div
+      aria-disabled="true"
+      className={cn(
+        READ_ONLY_FIELD_BASE,
+        "min-h-10 cursor-not-allowed justify-between gap-2 py-1.5",
+      )}
+    >
+      <span className="flex min-w-0 flex-col items-start gap-px">
+        <span className="max-w-full truncate">{label}</span>
+        {hint && (
+          <span className="max-w-full truncate text-[11px] leading-snug">
+            {hint}
+          </span>
+        )}
+      </span>
+      <ChevronDown size={14} className="shrink-0" />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #3133. Also covers the placeholder half of #3131.

The cleared option in each Model settings picker named the config mechanism rather than the outcome, and the same words stood in whenever the platform could not read a stopped sandbox — so a deliberate choice and an unknown value looked identical. This is the copy pass agreed on the issue, plus the read-only picker face needed to carry a second line.

Small drifts from the issue, worth a look:

- The "never run" sandbox keeps its own prose. The issue dropped that state as unreachable, but the branch still exists in code and explains itself better than "Unknown" would.
- "Unknown" is a section-level state, for a sandbox that ran but never reported its settings. One that does have a cached snapshot still shows those values, so a cleared key there reads "Default" — the platform did observe it as absent.
- Two "agent" → "sandbox" copy fixes on the wake button and the fallback prose ride along. They are not from this issue.

The Mode and Opus labels live in the claude-code runtime manifest, read from inside the image at hello, so existing sandboxes keep the old labels until the image is rebuilt and they restart.