### PR TITLE
fix(experiments): invoke dam-experiment skill on generic experiment asks

### DIFF
--- a/docs/architecture/experiments.md
+++ b/docs/architecture/experiments.md
@@ -1,6 +1,6 @@
 # Experiments
 
-Last verified: 2026-08-17
+Last verified: 2026-08-18
 
 ## Overview
 
@@ -44,7 +44,14 @@ destination has nothing to show and the user has nothing to click.
 So creating one is a first-class flow: an **experiment sandbox** is an Agent
 carrying the `experiment` [Agent Kind](knowledge-bases.md) whose Install Command
 copies the `dam-experiment` authoring skill and an `/experiment-onboard` command
-out of a path staged in the image. It rides the same kinded-create rail as a
+out of a path staged in the image, and appends a sandbox-purpose note to
+`~/.agents/AGENTS.md` so every session — not only the greeted first one — opens
+knowing that "experiment" means a platform Experiment. AGENTS.md is the source
+of truth and a symlink makes Claude Code read it, mirroring the image's
+`/etc/AGENTS.md` pattern at `$HOME` level. The note rides the shared append-only
+primitive (`buildAppendAgentsMdCommand` in the agents module), so later writers
+compose instead of clobbering each other.
+It rides the same kinded-create rail as a
 Knowledge Base, differing only in the marker and the command; nothing is fetched
 over the network, because the kit ships with the image. The skill used to be baked
 into every Claude Code sandbox's seeded workspace — moving it behind the marker is
@@ -61,8 +68,8 @@ plan earns a container too. There is no backfill and nothing disappears.
 Opening a fresh experiment sandbox **greets the user**: the UI hidden-sends
 `/experiment-onboard` so the agent opens by asking what to optimize. It waits until the
 sandbox reports that skill among its installed skills, so it never runs a command
-the Install Command has not delivered yet — the copy installs the command before
-the skill precisely so the skill's presence implies both.
+the Install Command has not delivered yet — the skill is copied last precisely so
+its presence implies the command and the purpose note both landed.
 
 ## Resources
 

--- a/docs/architecture/experiments.md
+++ b/docs/architecture/experiments.md
@@ -44,14 +44,14 @@ destination has nothing to show and the user has nothing to click.
 So creating one is a first-class flow: an **experiment sandbox** is an Agent
 carrying the `experiment` [Agent Kind](knowledge-bases.md) whose Install Command
 copies the `dam-experiment` authoring skill and an `/experiment-onboard` command
-out of a path staged in the image, and appends a sandbox-purpose note to
-`~/.agents/AGENTS.md` so every session — not only the greeted first one — opens
-knowing that "experiment" means a platform Experiment. AGENTS.md is the source
-of truth and a symlink makes Claude Code read it, mirroring the image's
-`/etc/AGENTS.md` pattern at `$HOME` level. The note rides the shared append-only
-primitive (`buildAppendAgentsMdCommand` in the agents module), so later writers
-compose instead of clobbering each other.
-It rides the same kinded-create rail as a
+out of a path staged in the image, and appends a sandbox-purpose note to the
+pod's user-level AGENTS.md so every session — not only the greeted first one —
+opens knowing that "experiment" means a platform Experiment. AGENTS.md is the
+source of truth and a symlink makes Claude Code read it, mirroring the image's
+`/etc/AGENTS.md` pattern at `$HOME` level. The note rides a shared append
+primitive in the agents module that skips sections already present, so a
+replayed install or a later writer composes instead of duplicating or
+clobbering. It rides the same kinded-create rail as a
 Knowledge Base, differing only in the marker and the command; nothing is fetched
 over the network, because the kit ships with the image. The skill used to be baked
 into every Claude Code sandbox's seeded workspace — moving it behind the marker is

--- a/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dam-experiment
-description: Author a DAM Experiment — a Python loop script (produce/eval/select, genetic algorithms, benchmark sweeps) the platform observes live with a graph, per-stage progress, and score charts. Use when asked to create, plan, or run an experiment, an optimization loop, or an iterate-and-score campaign. Provides the python experiment_sdk (Experiment/stage/span + spawn) and the plan → "Start a new run" workflow.
+description: Use for any request to create, plan, set up, or run an experiment, compare models/prompts/approaches, test ideas and compare results, or build a benchmark sweep, optimization loop, or iterate-and-score campaign. Every experiment in this sandbox is a platform Experiment — a Python loop script (produce/eval/select, genetic algorithms) the platform observes live with a graph, per-stage progress, and score charts. Provides the python experiment_sdk (Experiment/stage/span + spawn) and the plan → "Start a new run" workflow.
 allowed-tools: Bash(python3 *), Write
 ---
 

--- a/packages/api-server/src/__tests__/unit/agents-md.test.ts
+++ b/packages/api-server/src/__tests__/unit/agents-md.test.ts
@@ -8,11 +8,24 @@ describe("buildAppendAgentsMdCommand", () => {
     expect(command).not.toMatch(/[^>]> /);
   });
 
-  it("links CLAUDE.md to AGENTS.md only when nothing is there yet", () => {
+  it("links CLAUDE.md to AGENTS.md only when nothing is there yet, dangling links included", () => {
     const command = buildAppendAgentsMdCommand("hello");
     expect(command).toContain(
-      '[ -e "$HOME/.claude/CLAUDE.md" ] || ln -s "$HOME/.agents/AGENTS.md" "$HOME/.claude/CLAUDE.md"',
+      '[ -e "$HOME/.claude/CLAUDE.md" ] || [ -L "$HOME/.claude/CLAUDE.md" ] || ln -s "$HOME/.agents/AGENTS.md" "$HOME/.claude/CLAUDE.md"',
     );
+  });
+
+  it("skips the append when the section's first non-empty line is already present", () => {
+    const command = buildAppendAgentsMdCommand("\n## Purpose\nbody");
+    expect(command).toContain(
+      `grep -qsxF '## Purpose' "$HOME/.agents/AGENTS.md" || printf`,
+    );
+  });
+
+  it("appends unconditionally when the section has no non-empty line", () => {
+    const command = buildAppendAgentsMdCommand("\n\n");
+    expect(command).not.toContain("grep");
+    expect(command).toContain('>> "$HOME/.agents/AGENTS.md"');
   });
 
   it("creates the directories before writing", () => {

--- a/packages/api-server/src/__tests__/unit/agents-md.test.ts
+++ b/packages/api-server/src/__tests__/unit/agents-md.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { buildAppendAgentsMdCommand } from "../../modules/agents/index.js";
+
+describe("buildAppendAgentsMdCommand", () => {
+  it("appends to the harness-agnostic AGENTS.md instead of overwriting", () => {
+    const command = buildAppendAgentsMdCommand("hello");
+    expect(command).toContain('>> "$HOME/.agents/AGENTS.md"');
+    expect(command).not.toMatch(/[^>]> /);
+  });
+
+  it("links CLAUDE.md to AGENTS.md only when nothing is there yet", () => {
+    const command = buildAppendAgentsMdCommand("hello");
+    expect(command).toContain(
+      '[ -e "$HOME/.claude/CLAUDE.md" ] || ln -s "$HOME/.agents/AGENTS.md" "$HOME/.claude/CLAUDE.md"',
+    );
+  });
+
+  it("creates the directories before writing", () => {
+    const command = buildAppendAgentsMdCommand("hello");
+    const mkdirAt = command.indexOf('mkdir -p "$HOME/.agents" "$HOME/.claude"');
+    const writeAt = command.indexOf("printf");
+    expect(mkdirAt).toBeGreaterThan(-1);
+    expect(writeAt).toBeGreaterThan(mkdirAt);
+  });
+
+  it("stays a single line regardless of section newlines", () => {
+    const command = buildAppendAgentsMdCommand("line one\nline two");
+    expect(command).not.toContain("\n");
+    expect(command).toContain("'line one'");
+    expect(command).toContain("'line two'");
+  });
+
+  it("escapes single quotes in the section", () => {
+    const command = buildAppendAgentsMdCommand("it's");
+    expect(command).toContain(`'it'\\''s'`);
+  });
+});

--- a/packages/api-server/src/__tests__/unit/experiment-install-command.test.ts
+++ b/packages/api-server/src/__tests__/unit/experiment-install-command.test.ts
@@ -23,6 +23,13 @@ describe("buildExperimentInstallCommand", () => {
     expect(skillAt).toBeGreaterThan(commandsAt);
   });
 
+  it("records the sandbox purpose in AGENTS.md before the skill lands", () => {
+    const purposeAt = command.indexOf('"$HOME/.agents/AGENTS.md"');
+    const skillCopyAt = command.lastIndexOf(EXPERIMENT_SKILL_NAME);
+    expect(purposeAt).toBeGreaterThan(-1);
+    expect(skillCopyAt).toBeGreaterThan(purposeAt);
+  });
+
   it("fails the run rather than half-installing", () => {
     expect(command).toContain("set -eu");
   });

--- a/packages/api-server/src/modules/agents/domain/agents-md.ts
+++ b/packages/api-server/src/modules/agents/domain/agents-md.ts
@@ -1,0 +1,10 @@
+export function buildAppendAgentsMdCommand(section: string): string {
+  const lines = [...section.split("\n"), ""].map(
+    (line) => `'${line.replaceAll("'", "'\\''")}'`,
+  );
+  return [
+    'mkdir -p "$HOME/.agents" "$HOME/.claude"',
+    `printf '%s\\n' ${lines.join(" ")} >> "$HOME/.agents/AGENTS.md"`,
+    '[ -e "$HOME/.claude/CLAUDE.md" ] || ln -s "$HOME/.agents/AGENTS.md" "$HOME/.claude/CLAUDE.md"',
+  ].join("; ");
+}

--- a/packages/api-server/src/modules/agents/domain/agents-md.ts
+++ b/packages/api-server/src/modules/agents/domain/agents-md.ts
@@ -1,10 +1,14 @@
 export function buildAppendAgentsMdCommand(section: string): string {
-  const lines = [...section.split("\n"), ""].map(
-    (line) => `'${line.replaceAll("'", "'\\''")}'`,
-  );
+  const quote = (line: string) => `'${line.replaceAll("'", "'\\''")}'`;
+  const rawLines = section.split("\n");
+  const lines = [...rawLines, ""].map(quote);
+  const marker = rawLines.find((line) => line.trim() !== "");
+  const append = `printf '%s\\n' ${lines.join(" ")} >> "$HOME/.agents/AGENTS.md"`;
   return [
     'mkdir -p "$HOME/.agents" "$HOME/.claude"',
-    `printf '%s\\n' ${lines.join(" ")} >> "$HOME/.agents/AGENTS.md"`,
-    '[ -e "$HOME/.claude/CLAUDE.md" ] || ln -s "$HOME/.agents/AGENTS.md" "$HOME/.claude/CLAUDE.md"',
+    marker === undefined
+      ? append
+      : `grep -qsxF ${quote(marker)} "$HOME/.agents/AGENTS.md" || ${append}`,
+    '[ -e "$HOME/.claude/CLAUDE.md" ] || [ -L "$HOME/.claude/CLAUDE.md" ] || ln -s "$HOME/.agents/AGENTS.md" "$HOME/.claude/CLAUDE.md"',
   ].join("; ");
 }

--- a/packages/api-server/src/modules/agents/index.ts
+++ b/packages/api-server/src/modules/agents/index.ts
@@ -40,6 +40,7 @@ export {
   AgentStoppedError,
   isAgentStoppedError,
 } from "./domain/agent-stopped.js";
+export { buildAppendAgentsMdCommand } from "./domain/agents-md.js";
 export {
   deleteChannelsByAgent,
   listChannelsByOwner,

--- a/packages/api-server/src/modules/experiments/domain/install-command.ts
+++ b/packages/api-server/src/modules/experiments/domain/install-command.ts
@@ -1,11 +1,22 @@
 import { STAGED_SKILLS_DIR } from "agent-runtime-api";
 import { EXPERIMENT_SKILL_NAME } from "api-server-api";
+import { buildAppendAgentsMdCommand } from "../../agents/index.js";
+
+const SANDBOX_PURPOSE = [
+  "## Sandbox purpose",
+  "",
+  "This sandbox exists to author and run platform Experiments. Treat every",
+  "experiment-shaped request (create, plan, set up, or run an experiment,",
+  "compare models/prompts/approaches, benchmark, optimize) as a platform",
+  `Experiment and invoke the \`${EXPERIMENT_SKILL_NAME}\` skill first.`,
+].join("\n");
 
 export function buildExperimentInstallCommand(): string {
   return [
     "set -eu",
     'mkdir -p "$HOME/.claude/commands" "$HOME/.agents/skills"',
     `cp -R "${STAGED_SKILLS_DIR}/commands/." "$HOME/.claude/commands/"`,
+    buildAppendAgentsMdCommand(SANDBOX_PURPOSE),
     `cp -R "${STAGED_SKILLS_DIR}/${EXPERIMENT_SKILL_NAME}" "$HOME/.agents/skills/"`,
   ].join("; ");
 }


### PR DESCRIPTION
Refs #3263 (the existing-sandboxes acceptance criterion stays open, see Out of scope)

## Problem

The `dam-experiment` skill only kicked in reliably when the user said "DAM experiment". A plain "create an experiment" often got a generic script instead of the Experiment SDK, even inside an experiment sandbox.

## Changes

1. **Skill description rewrite** — leads with trigger phrasings (create/plan/set up/run an experiment, compare models/prompts/approaches, benchmark, optimize) and never mentions DAM. Nothing left to disambiguate: in this sandbox, every experiment is a platform Experiment. Explicit "DAM experiment" phrasing still matches trivially.

2. **Sandbox purpose in AGENTS.md** — the experiment Install Command now appends a short purpose note to `~/.agents/AGENTS.md`, so every session (not only the greeted first one) opens knowing what this sandbox is for. Claude Code reads it via a `~/.claude/CLAUDE.md` symlink, mirroring the image's `/etc/AGENTS.md` pattern at $HOME level.

3. **Shared primitive** — `buildAppendAgentsMdCommand` in the agents module, exported for any kind to reuse. Append-only, so multiple writers compose instead of clobbering. Single-line output regardless of content newlines, single quotes escaped, symlink creation guarded so it never overwrites an existing file.

The skill copy stays last in the install command, so the greeting's "skill present" gate still implies everything landed.

## Out of scope

Existing sandboxes keep their stale skill copy (install runs once into persistent $HOME). A re-sync for those is a separate discussion.

## Testing

- Unit tests for the primitive (append semantics, ordering, escaping, guarded symlink) and install-command ordering.
- Ran the generated command twice against a fake $HOME: sections compose, symlink resolves, content readable via CLAUDE.md.
- `api-server:check`, `docs:check`, `common:check`, comment-types all green.
