### PR TITLE
perf(agents): bump claude-agent-acp pin to 0.66.0

### DIFF
--- a/packages/agents/claude-code/harness-tools.toml
+++ b/packages/agents/claude-code/harness-tools.toml
@@ -5,4 +5,4 @@
 # agent-entrypoint parses this file to strip legacy workspace-seeded pins.
 [tools]
 "npm:@anthropic-ai/claude-code" = "2.1.210"
-"npm:@agentclientprotocol/claude-agent-acp" = "0.59.0"
+"npm:@agentclientprotocol/claude-agent-acp" = "0.66.0"


### PR DESCRIPTION
## Summary

One-line pin bump that removes the dominant session-latency stall found in #3247's benchmark (epic #3242).

Deployed 0.59.0 unconditionally awaits a context-window control request that fresh sessions never service until their first turn (upstream agentclientprotocol/claude-agent-acp#886, fixed by #894 in 0.60.0). The observable damage on our platform, measured with the #3247 benchmark and a local adapter probe:

| operation | 0.59.0 (deployed) | 0.66.0 + CLI 2.1.210 |
|---|---|---|
| `session/new` | 4s / 12.8s / 68.9s (variable stall) | ~0.5s |
| cold `session/load` (short) | 2.6-3.9s | ~0.5s, full correct replay |

Every new chat, fresh-schedule fire, and channel thread pays the session/new cost today; every cold conversation open pays the load cost.

- 0.66.0 (not 0.69.0): newest version outside the repo's 7-day `minimumReleaseAge` window, and the exact version verified locally
- verified against the image's pinned claude-code CLI **2.1.210** (the adapter drives whatever `CLAUDE_CODE_EXECUTABLE` points at) — session/new, cold session/load, and replay event kinds/counts all correct
- `harness-tools.toml` is COPY'd into the image before `mise install`, so the pin alone changes the built adapter

## Test plan

- [x] local probe: adapter 0.66.0 + CLI 2.1.210 — session/new ~0.5s, cold load ~0.5s, 22/22 replay events with correct kinds
- [ ] CI image build
- [ ] after dev deploy: re-run `mise run bench:session-load` (#3330) against the dev bench agent to confirm the cold-load numbers move

Full findings: https://github.com/dam-agents/dam/issues/3247#issuecomment-5294917381