### PR TITLE
feat(runtime): tail-first session replay with load-older paging

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-08-18
+Last verified: 2026-08-20
 
 ## Overview
 
@@ -114,9 +114,11 @@ The schedule↔session link is agent-owned: schedule sessions are typed (`schedu
 
 The harness child process runs for the pod's lifetime, not per-connection. Multiple ACP channels (UI tab WebSockets, the Slack worker, the in-process trigger handler) attach to the same runtime concurrently and engage with sessions implicitly through the `sessionId` they carry on each frame.
 
-Each session is an append-only in-memory log (≤2 MB soft cap, with a truncation sentinel for older history). Every channel keeps a per-session cursor; new events are appended to the log and fanned out to engaged channels at or behind the new sequence number. `session/load` is served from the log on cache hit and falls through to the agent's on-disk store on cold start.
+Each session is an append-only in-memory log (≤2 MB soft cap). Every channel keeps a per-session cursor; new events are appended to the log and fanned out to engaged channels at or behind the new sequence number.
 
-`session/resume` is mediated entirely by the runtime — the frame never reaches the harness. On the hot path (cached metadata) the runtime engages the channel, advances its cursor to the log tail, and returns a synthetic response with no replay. On the cold path (no metadata, e.g. after the pod restarts) the runtime parks the request as a waiter and issues its own `session/load` to rehydrate the harness; replay events populate the log without reaching any client, and on completion every parked resume waiter is served from memory. This shields the UI from per-harness capability differences (some harnesses, like `pi-agent`, don't implement `unstable_resumeSession` at all) and from the cold-subprocess problem on which even resume-capable harnesses would fail.
+`session/load` replays **only the newest tail** of the log, so opening a conversation has a bounded wire cost at any length. A cut opens the replay with a truncation sentinel; a cap cut also carries a cursor (platform metadata), and a load presenting it back is served the older range, page by page, to the eviction floor (sentinel without cursor). Cursors die with the log: a post-restart stale cursor is refused and the client reloads.
+
+Both verbs are runtime-mediated: a hot `session/resume` engages the channel, advances its cursor, and answers synthetically with no replay. A cold request (nothing cached) parks as a waiter while the runtime sends its own `session/load` to rehydrate the harness; replay fills the log without reaching any client, then waiters are served from it: loads the capped tail, resumes no replay. This shields the UI from per-harness capability gaps (`pi-agent` cannot resume) and from the cold-subprocess problem even resume-capable harnesses hit.
 
 #### Prompt delivery
 

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime/__tests__/acp-runtime-history-replay.test.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime/__tests__/acp-runtime-history-replay.test.ts
@@ -1,0 +1,260 @@
+import { describe, it, expect } from "vitest";
+import { createWorld, frames, type Client, type Frame } from "./acp-world.js";
+
+/**
+ * TEST_OVERVIEW: opening a conversation replays its newest tail, not the whole
+ * history.
+ *
+ * The Session Transcript caps what a fresh viewer receives to the last
+ * replayTailEvents entries, marks the cut with a clipped-replay warning that
+ * carries the sequence number the skipped history ends at, and serves the
+ * older ranges on demand when a session/load names that cursor in
+ * `_meta.platform.replayBefore`. A cold transcript (first attach after a pod
+ * restart) is filled by one silent harness load whose replay reaches no
+ * channel; every viewer is then served the same capped tail. Cursors are only
+ * meaningful within one transcript's lifetime, so a page request against a
+ * cold transcript is refused instead of guessed at.
+ */
+
+const SESSION = "sess-history";
+
+interface ReplayedUpdate {
+  kind: string;
+  text?: string;
+  olderBefore?: number;
+}
+
+function replayedUpdates(client: Client): ReplayedUpdate[] {
+  return client.saw("session/update").map((frame) => {
+    const params = frame.params as {
+      update?: {
+        sessionUpdate?: string;
+        content?: { text?: string };
+        _meta?: { platform?: { olderBefore?: number } };
+      };
+    };
+    const update = params.update ?? {};
+    return {
+      kind: update.sessionUpdate ?? "unknown",
+      ...(update.content?.text !== undefined
+        ? { text: update.content.text }
+        : {}),
+      ...(update._meta?.platform?.olderBefore !== undefined
+        ? { olderBefore: update._meta.platform.olderBefore }
+        : {}),
+    };
+  });
+}
+
+function loadPage(id: number, sessionId: string, replayBefore: number): Frame {
+  return {
+    jsonrpc: "2.0",
+    id,
+    method: "session/load",
+    params: {
+      sessionId,
+      cwd: ".",
+      mcpServers: [],
+      _meta: { platform: { replayBefore } },
+    },
+  };
+}
+
+function warmTranscript(
+  world: ReturnType<typeof createWorld>,
+  texts: string[],
+): Client {
+  const alice = world.connect();
+  alice.send(frames.newSession(1));
+  world.harness().replyTo("session/new", { sessionId: SESSION });
+  for (const text of texts) {
+    world.harness().emit(frames.agentMessage(SESSION, text));
+  }
+  return alice;
+}
+
+describe("acp-runtime: history replay", () => {
+  /**
+   * TEST_SCENARIO: Six messages have accumulated and the tail cap is three.
+   * A fresh viewer must receive exactly the newest three, preceded by a
+   * clipped-replay warning whose cursor names the first replayed entry, so
+   * the viewer knows older history exists and where it ends.
+   */
+  it("should replay only the newest tail to a fresh viewer, with a cursor to the rest", () => {
+    const world = createWorld({ replayTailEvents: 3 });
+    warmTranscript(world, ["m1", "m2", "m3", "m4", "m5", "m6"]);
+
+    const bob = world.connect();
+    bob.send(frames.loadSession(1, SESSION));
+
+    expect(replayedUpdates(bob)).toEqual([
+      { kind: "platform_clipped_replay", olderBefore: 4 },
+      { kind: "agent_message_chunk", text: "m4" },
+      { kind: "agent_message_chunk", text: "m5" },
+      { kind: "agent_message_chunk", text: "m6" },
+    ]);
+    expect(bob.reply(1)).toMatchObject({ result: { sessionId: SESSION } });
+  });
+
+  /**
+   * TEST_SCENARIO: A conversation short enough to fit under the cap replays
+   * whole, with no clipped-replay warning — the cap must be invisible until
+   * it actually cuts something.
+   */
+  it("should replay a short conversation in full without a clipped marker", () => {
+    const world = createWorld({ replayTailEvents: 3 });
+    warmTranscript(world, ["m1", "m2"]);
+
+    const bob = world.connect();
+    bob.send(frames.loadSession(1, SESSION));
+
+    expect(replayedUpdates(bob)).toEqual([
+      { kind: "agent_message_chunk", text: "m1" },
+      { kind: "agent_message_chunk", text: "m2" },
+    ]);
+  });
+
+  /**
+   * TEST_SCENARIO: The viewer follows the cursor back through an
+   * eight-message history with a cap of three. Each page returns the three
+   * entries before the cursor and a new cursor, until the final page reaches
+   * the genuine start of the conversation, which carries no marker — the
+   * viewer can tell "more above" from "this is the beginning".
+   */
+  it("should page older history back to the start, cursor by cursor", () => {
+    const world = createWorld({ replayTailEvents: 3 });
+    warmTranscript(world, ["m1", "m2", "m3", "m4", "m5", "m6", "m7", "m8"]);
+
+    const bob = world.connect();
+    bob.send(frames.loadSession(1, SESSION));
+    expect(replayedUpdates(bob)[0]).toEqual({
+      kind: "platform_clipped_replay",
+      olderBefore: 6,
+    });
+
+    const carol = world.connect();
+    carol.send(loadPage(1, SESSION, 6));
+    expect(replayedUpdates(carol)).toEqual([
+      { kind: "platform_clipped_replay", olderBefore: 3 },
+      { kind: "agent_message_chunk", text: "m3" },
+      { kind: "agent_message_chunk", text: "m4" },
+      { kind: "agent_message_chunk", text: "m5" },
+    ]);
+    expect(carol.reply(1)).toMatchObject({ result: { sessionId: SESSION } });
+
+    carol.send(loadPage(2, SESSION, 3));
+    expect(replayedUpdates(carol).slice(4)).toEqual([
+      { kind: "agent_message_chunk", text: "m1" },
+      { kind: "agent_message_chunk", text: "m2" },
+    ]);
+  });
+
+  /**
+   * TEST_SCENARIO: Paging must not disturb the live view. A page request
+   * replays old entries to the asking channel only, and that channel's live
+   * cursor stays where it was — new messages still arrive exactly once.
+   */
+  it("should keep live fan-out intact for a viewer that paged back", () => {
+    const world = createWorld({ replayTailEvents: 3 });
+    warmTranscript(world, ["m1", "m2", "m3", "m4", "m5", "m6"]);
+
+    const bob = world.connect();
+    bob.send(frames.loadSession(1, SESSION));
+    bob.send(loadPage(2, SESSION, 4));
+
+    world.harness().emit(frames.agentMessage(SESSION, "m7"));
+
+    const texts = replayedUpdates(bob)
+      .filter((u) => u.text !== undefined)
+      .map((u) => u.text);
+    expect(texts).toEqual(["m4", "m5", "m6", "m1", "m2", "m3", "m7"]);
+  });
+
+  /**
+   * TEST_SCENARIO: The transcript evicts oldest entries past its byte cap.
+   * When paging bottoms out at the eviction floor, the last page carries a
+   * clipped-replay warning without a cursor: older history existed but is
+   * gone, and the viewer must not be offered a "load more" that cannot load.
+   */
+  it("should mark the eviction floor with a cursor-less clipped marker", () => {
+    const entryBytes = JSON.stringify(
+      frames.agentMessage(SESSION, "m1"),
+    ).length;
+    const world = createWorld({
+      replayTailEvents: 2,
+      logBytesCap: entryBytes * 4,
+    });
+    warmTranscript(world, ["m1", "m2", "m3", "m4", "m5", "m6"]);
+
+    const bob = world.connect();
+    bob.send(frames.loadSession(1, SESSION));
+    const first = replayedUpdates(bob);
+    expect(first[0]?.kind).toBe("platform_clipped_replay");
+    const cursor = first[0]?.olderBefore;
+    expect(cursor).toBeDefined();
+
+    bob.send(loadPage(2, SESSION, cursor!));
+    const paged = replayedUpdates(bob).slice(first.length);
+    expect(paged[0]).toEqual({ kind: "platform_clipped_replay" });
+  });
+
+  /**
+   * TEST_SCENARIO: The pod restarted, so the transcript is cold and a saved
+   * cursor names entries this transcript never held. The runtime must refuse
+   * the page rather than bootstrap and serve arbitrary entries under a stale
+   * numbering.
+   */
+  it("should refuse a page request against a cold transcript", () => {
+    const world = createWorld({ replayTailEvents: 3 });
+
+    const bob = world.connect();
+    bob.send(loadPage(1, SESSION, 42));
+
+    expect(bob.reply(1)).toMatchObject({
+      error: { code: -32602 },
+    });
+    expect(world.harness().received("session/load")).toEqual([]);
+  });
+
+  /**
+   * TEST_SCENARIO: First open after a pod restart. The runtime asks the
+   * harness once, the harness replays the whole conversation, and none of
+   * that replay may reach the viewer live — the viewer gets the capped tail
+   * from the transcript only after the harness finishes, so a long replay
+   * costs the wire only the tail.
+   */
+  it("should fill a cold transcript silently and serve viewers the capped tail", () => {
+    const world = createWorld({ replayTailEvents: 2 });
+
+    const bob = world.connect();
+    bob.send(frames.loadSession(1, SESSION));
+
+    const carol = world.connect();
+    carol.send(frames.loadSession(1, SESSION));
+
+    expect(world.harness().received("session/load")).toHaveLength(1);
+    const forwarded = world.harness().received("session/load")[0];
+    expect((forwarded?.params as { cwd?: string }).cwd).toBe("/workspace");
+
+    for (const text of ["m1", "m2", "m3", "m4"]) {
+      world.harness().emit(frames.agentMessage(SESSION, text));
+    }
+    expect(replayedUpdates(bob)).toEqual([]);
+    expect(replayedUpdates(carol)).toEqual([]);
+
+    world
+      .harness()
+      .replyTo("session/load", { sessionId: SESSION, modes: null });
+
+    for (const viewer of [bob, carol]) {
+      expect(replayedUpdates(viewer)).toEqual([
+        { kind: "platform_clipped_replay", olderBefore: 3 },
+        { kind: "agent_message_chunk", text: "m3" },
+        { kind: "agent_message_chunk", text: "m4" },
+      ]);
+      expect(viewer.reply(1)).toMatchObject({
+        result: { sessionId: SESSION },
+      });
+    }
+  });
+});

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime/acp-runtime.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime/acp-runtime.ts
@@ -37,6 +37,8 @@ const DEFAULT_WARM_START_TIMEOUT_MS = 15 * 1000;
 
 const DEFAULT_LOG_BYTES_CAP = 2 * 1024 * 1024;
 
+const DEFAULT_REPLAY_TAIL_EVENTS = 200;
+
 const DEFAULT_BACKGROUND_WORK_RECHECK_MS = 15 * 1000;
 
 export interface AcpRuntimeStatus {
@@ -62,6 +64,7 @@ export interface AcpRuntimeDeps {
   envReadyAtBoot?: boolean;
   warmStartTimeoutMs?: number;
   logBytesCap?: number;
+  replayTailEvents?: number;
   sessionMetadata?: SessionMetadataStore;
   backgroundWork?: BackgroundWorkRegistry;
   backgroundWorkRecheckMs?: number;
@@ -104,6 +107,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
 
   const transcript = createSessionTranscript({
     logBytesCap,
+    replayTailEvents: deps.replayTailEvents ?? DEFAULT_REPLAY_TAIL_EVENTS,
     engagedChannelsFor(sessionId) {
       const channels: ClientChannel[] = [];
       for (const [channel, sessions] of engagedSessions) {
@@ -498,11 +502,7 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
     const sessionId = extractParamsSessionId(frame);
     if (sessionId) {
       if (bootstrap.has(sessionId)) {
-        transcript.appendReplay(
-          sessionId,
-          line,
-          bootstrap.initiatorOf(sessionId),
-        );
+        transcript.appendReplay(sessionId, line);
       } else {
         transcript.append(sessionId, line);
       }
@@ -554,7 +554,13 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       }
 
       if (method === "session/load" && paramsSid) {
-        if (bootstrap.requestLoad(channel, frame.id, paramsSid)) return;
+        const replayBefore = extractReplayBefore(frame);
+        if (replayBefore !== null) {
+          bootstrap.requestPage(channel, frame.id, paramsSid, replayBefore);
+        } else {
+          bootstrap.requestLoad(channel, frame.id, paramsSid);
+        }
+        return;
       }
 
       const outboundId = nextOutboundId++;
@@ -562,7 +568,6 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
       if (paramsSid) engage(channel, paramsSid);
 
       const promptSessionId = method === "session/prompt" ? paramsSid : null;
-      const attachSessionId = method === "session/load" ? paramsSid : null;
 
       const platformMeta =
         method === "session/new" ? extractPlatformMeta(frame) : null;
@@ -589,13 +594,9 @@ export function createAcpRuntime(deps: AcpRuntimeDeps): AcpRuntime {
         originalId: frame.id,
         method,
         promptSessionId,
-        attachSessionId,
+        attachSessionId: null,
         platformMeta,
       });
-
-      if (method === "session/load" && attachSessionId) {
-        bootstrap.trackClientLoad(attachSessionId, channel);
-      }
 
       if (promptSessionId !== null) {
         deps.sessionMetadata?.recordActivity(promptSessionId);
@@ -694,6 +695,22 @@ function extractPlatformMeta(frame: unknown): PlatformSessionMeta | null {
   if (!isNonNullObject(meta) || !("platform" in meta)) return null;
   const parsed = platformSessionMetaSchema.safeParse(meta.platform);
   return parsed.success ? parsed.data : null;
+}
+
+function extractReplayBefore(frame: unknown): number | null {
+  if (!isNonNullObject(frame)) return null;
+  const params = frame.params;
+  if (!isNonNullObject(params)) return null;
+  const meta = params._meta;
+  if (!isNonNullObject(meta)) return null;
+  const platform = meta.platform;
+  if (!isNonNullObject(platform)) return null;
+  const replayBefore = platform.replayBefore;
+  return typeof replayBefore === "number" &&
+    Number.isInteger(replayBefore) &&
+    replayBefore > 0
+    ? replayBefore
+    : null;
 }
 
 function extractPromptId(frame: unknown): string | null {

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime/session-bootstrap.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime/session-bootstrap.ts
@@ -14,7 +14,6 @@ interface Waiter {
 }
 
 interface BootstrapState {
-  initiatorChannel: ClientChannel | null;
   waiters: Waiter[];
 }
 
@@ -28,11 +27,15 @@ export interface SessionBootstrap {
     channel: ClientChannel,
     originalId: JsonRpcId,
     sessionId: string,
-  ): boolean;
-  trackClientLoad(sessionId: string, initiator: ClientChannel): void;
+  ): void;
+  requestPage(
+    channel: ClientChannel,
+    originalId: JsonRpcId,
+    sessionId: string,
+    beforeSeq: number,
+  ): void;
   onLoadResponse(sessionId: string, frame: unknown): void;
   has(sessionId: string): boolean;
-  initiatorOf(sessionId: string): ClientChannel | null;
   dropChannel(channel: ClientChannel): void;
   clear(): void;
 }
@@ -51,13 +54,15 @@ export interface SessionBootstrapDeps {
  * Session Transcript when it already holds the session, so the harness is not
  * asked twice for the same history. When the transcript is cold (first attach
  * after a pod restart), at most one session/load per session goes to the
- * harness; every other load or resume for that session parks as a waiter.
- * While the load runs, replayed lines fill the transcript and reach only the
- * channel that initiated a client load — a runtime-initiated load has no
- * initiator and its replay reaches nobody. When the response lands, every
- * parked waiter is served from the transcript, or receives the harness's
- * error if the load failed. session/resume never reaches the harness at all:
- * the runtime answers it here, which hides harnesses that cannot resume.
+ * harness; every load or resume for that session parks as a waiter, and the
+ * replayed lines fill the transcript without reaching any channel. When the
+ * response lands, every parked waiter is served from the transcript — a load
+ * gets the transcript's newest tail, a resume gets no replay — or receives the
+ * harness's error if the load failed. session/resume never reaches the harness
+ * at all: the runtime answers it here, which hides harnesses that cannot
+ * resume. requestPage serves older transcript ranges for a load that carries a
+ * replayBefore cursor; a cursor from before a pod restart names entries this
+ * transcript never held, so a cold page is refused rather than bootstrapped.
  */
 export function createSessionBootstrap(
   deps: SessionBootstrapDeps,
@@ -96,6 +101,23 @@ export function createSessionBootstrap(
     if (channel.isOpen()) channel.send(rewriteAuthError(response));
   }
 
+  function park(sessionId: string, waiter: Waiter): void {
+    const boot = bootstrapBySession.get(sessionId);
+    if (boot) {
+      boot.waiters.push(waiter);
+      return;
+    }
+    bootstrapBySession.set(sessionId, { waiters: [waiter] });
+    const outboundId = deps.openLoadRoute(sessionId);
+    const loadFrame = {
+      jsonrpc: "2.0",
+      id: outboundId,
+      method: "session/load",
+      params: { sessionId, cwd: ".", mcpServers: [] },
+    };
+    deps.sendToAgent(rewriteCwd(loadFrame, deps.workingDir));
+  }
+
   return {
     requestResume(channel, originalId, sessionId) {
       deps.engage(channel, sessionId);
@@ -103,43 +125,38 @@ export function createSessionBootstrap(
         respondFromLog("resume", channel, originalId, sessionId);
         return;
       }
-      const boot = bootstrapBySession.get(sessionId);
-      if (boot) {
-        boot.waiters.push({ kind: "resume", channel, originalId });
-        return;
-      }
-      bootstrapBySession.set(sessionId, {
-        initiatorChannel: null,
-        waiters: [{ kind: "resume", channel, originalId }],
-      });
-      const outboundId = deps.openLoadRoute(sessionId);
-      const loadFrame = {
-        jsonrpc: "2.0",
-        id: outboundId,
-        method: "session/load",
-        params: { sessionId, cwd: ".", mcpServers: [] },
-      };
-      deps.sendToAgent(rewriteCwd(loadFrame, deps.workingDir));
+      park(sessionId, { kind: "resume", channel, originalId });
     },
 
     requestLoad(channel, originalId, sessionId) {
       if (deps.transcript.metadataOf(sessionId).cached) {
         respondFromLog("load", channel, originalId, sessionId);
-        return true;
+        return;
       }
-      const boot = bootstrapBySession.get(sessionId);
-      if (boot) {
-        boot.waiters.push({ kind: "load", channel, originalId });
-        return true;
-      }
-      return false;
+      park(sessionId, { kind: "load", channel, originalId });
     },
 
-    trackClientLoad(sessionId, initiator) {
-      bootstrapBySession.set(sessionId, {
-        initiatorChannel: initiator,
-        waiters: [],
+    requestPage(channel, originalId, sessionId, beforeSeq) {
+      const metadata = deps.transcript.metadataOf(sessionId);
+      if (!metadata.cached) {
+        const error = JSON.stringify({
+          jsonrpc: "2.0",
+          id: originalId,
+          error: {
+            code: -32602,
+            message: "replay window expired; load the session again",
+          },
+        });
+        if (channel.isOpen()) channel.send(error);
+        return;
+      }
+      deps.transcript.replayPage(channel, sessionId, beforeSeq);
+      const response = JSON.stringify({
+        jsonrpc: "2.0",
+        id: originalId,
+        result: metadata.value,
       });
+      if (channel.isOpen()) channel.send(rewriteAuthError(response));
     },
 
     onLoadResponse(sessionId, frame) {
@@ -170,16 +187,8 @@ export function createSessionBootstrap(
       return bootstrapBySession.has(sessionId);
     },
 
-    initiatorOf(sessionId) {
-      return bootstrapBySession.get(sessionId)?.initiatorChannel ?? null;
-    },
-
     dropChannel(channel) {
-      for (const [sessionId, state] of bootstrapBySession) {
-        if (state.initiatorChannel === channel) {
-          bootstrapBySession.delete(sessionId);
-          continue;
-        }
+      for (const state of bootstrapBySession.values()) {
         state.waiters = state.waiters.filter((w) => w.channel !== channel);
       }
     },

--- a/packages/agent-runtime/src/modules/acp/services/acp-runtime/session-transcript.ts
+++ b/packages/agent-runtime/src/modules/acp/services/acp-runtime/session-transcript.ts
@@ -22,12 +22,13 @@ export type CachedMetadata =
 export interface SessionTranscript {
   append(sessionId: string, line: string): void;
   appendEcho(sessionId: string, line: string, originator: ClientChannel): void;
-  appendReplay(
-    sessionId: string,
-    line: string,
-    initiator: ClientChannel | null,
-  ): void;
+  appendReplay(sessionId: string, line: string): void;
   catchUp(channel: ClientChannel, sessionId: string): void;
+  replayPage(
+    channel: ClientChannel,
+    sessionId: string,
+    beforeSeq: number,
+  ): void;
   advanceToTail(channel: ClientChannel, sessionId: string): void;
   cacheMetadata(sessionId: string, result: unknown): void;
   metadataOf(sessionId: string): CachedMetadata;
@@ -38,6 +39,7 @@ export interface SessionTranscript {
 
 export interface SessionTranscriptDeps {
   logBytesCap: number;
+  replayTailEvents: number;
   engagedChannelsFor: (sessionId: string) => Iterable<ClientChannel>;
 }
 
@@ -45,7 +47,10 @@ export interface SessionTranscriptDeps {
  * UNIT_BOUNDARY_DESCRIPTION: Keeps each session's message history and tracks how
  * far every attached channel has read it, so a channel that joins late or
  * reconnects receives only what it missed. Sequence numbers, the size cap,
- * eviction, and the truncation warning all stay inside.
+ * eviction, and the truncation warning all stay inside. A fresh viewer gets
+ * only the newest replayTailEvents entries; the clipped-replay warning then
+ * carries the sequence number the skipped history ends at, and replayPage
+ * serves the older ranges on demand without moving any cursor.
  */
 export function createSessionTranscript(
   deps: SessionTranscriptDeps,
@@ -100,13 +105,18 @@ export function createSessionTranscript(
     map.set(sessionId, seq);
   }
 
-  function truncationSentinel(sessionId: string): string {
+  function truncationSentinel(sessionId: string, olderBefore?: number): string {
     return JSON.stringify({
       jsonrpc: "2.0",
       method: "session/update",
       params: {
         sessionId,
-        update: { sessionUpdate: "platform_clipped_replay" },
+        update: {
+          sessionUpdate: "platform_clipped_replay",
+          ...(olderBefore !== undefined
+            ? { _meta: { platform: { olderBefore } } }
+            : {}),
+        },
       },
     });
   }
@@ -135,25 +145,50 @@ export function createSessionTranscript(
       fanOut(sessionId, line, (channel) => channel !== originator);
     },
 
-    appendReplay(sessionId, line, initiator) {
-      fanOut(sessionId, line, (channel) => channel === initiator);
+    appendReplay(sessionId, line) {
+      fanOut(sessionId, line, () => false);
     },
 
     catchUp(channel, sessionId) {
       const log = sessionLogs.get(sessionId);
       if (!log) return;
       const current = cursorFor(channel, sessionId);
-      if (current === 0 && log.truncated && channel.isOpen()) {
-        channel.send(truncationSentinel(sessionId));
+      let pending = log.entries.filter((entry) => entry.seq > current);
+      const capped = current === 0 && pending.length > deps.replayTailEvents;
+      if (capped) pending = pending.slice(-deps.replayTailEvents);
+      if (current === 0 && (capped || log.truncated) && channel.isOpen()) {
+        channel.send(
+          truncationSentinel(sessionId, capped ? pending[0]!.seq : undefined),
+        );
       }
       let lastSeq = current;
-      for (const entry of log.entries) {
-        if (entry.seq <= current) continue;
+      for (const entry of pending) {
         if (!channel.isOpen()) return;
         channel.send(rewriteAuthError(entry.line));
         lastSeq = entry.seq;
       }
       if (lastSeq !== current) setCursor(channel, sessionId, lastSeq);
+    },
+
+    replayPage(channel, sessionId, beforeSeq) {
+      const log = sessionLogs.get(sessionId);
+      if (!log || !channel.isOpen()) return;
+      const older = log.entries.filter((entry) => entry.seq < beforeSeq);
+      const page = older.slice(-deps.replayTailEvents);
+      const first = page[0];
+      if (first === undefined) {
+        if (log.truncated) channel.send(truncationSentinel(sessionId));
+        return;
+      }
+      if (older.length > page.length) {
+        channel.send(truncationSentinel(sessionId, first.seq));
+      } else if (log.truncated) {
+        channel.send(truncationSentinel(sessionId));
+      }
+      for (const entry of page) {
+        if (!channel.isOpen()) return;
+        channel.send(rewriteAuthError(entry.line));
+      }
     },
 
     advanceToTail(channel, sessionId) {

--- a/packages/ui/src/modules/acp/session-projection.ts
+++ b/packages/ui/src/modules/acp/session-projection.ts
@@ -74,8 +74,10 @@ export function applyUpdate(messages: Message[], update: AcpUpdate): Message[] {
     case "platform_prompt_started":
       return setQueuedByPromptId(messages, update.promptId, false);
 
-    case "platform_clipped_replay":
-      return appendNotice(messages, "Older conversation not loaded");
+    case "platform_clipped_replay": {
+      const olderBefore = update._meta?.platform?.olderBefore;
+      return appendClippedMarker(messages, olderBefore);
+    }
 
     case "user_message_chunk":
       return handleUserChunk(messages, update);
@@ -118,6 +120,26 @@ function appendNotice(messages: Message[], text: string): Message[] {
       parts: [{ kind: "text", text }],
       streaming: false,
       notice: true,
+    },
+  ];
+}
+
+function appendClippedMarker(
+  messages: Message[],
+  olderBefore: number | undefined,
+): Message[] {
+  if (olderBefore === undefined) {
+    return appendNotice(messages, "Older conversation not loaded");
+  }
+  return [
+    ...messages,
+    {
+      id: crypto.randomUUID(),
+      role: "assistant",
+      parts: [{ kind: "text", text: "Older messages not shown" }],
+      streaming: false,
+      notice: true,
+      loadOlderBefore: olderBefore,
     },
   ];
 }

--- a/packages/ui/src/modules/acp/types.ts
+++ b/packages/ui/src/modules/acp/types.ts
@@ -12,6 +12,9 @@ export type AcpUpdate =
       sessionUpdate: "platform_prompt_accepted";
     } & PlatformPromptAcceptedParams)
   | ({ sessionUpdate: "platform_prompt_started" } & PlatformPromptStartedParams)
-  | { sessionUpdate: "platform_clipped_replay" };
+  | {
+      sessionUpdate: "platform_clipped_replay";
+      _meta?: { platform?: { olderBefore?: number } };
+    };
 
 export type UpdateHandler = (update: AcpUpdate, sessionId: string) => void;

--- a/packages/ui/src/modules/sessions/components/chat-message.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-message.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef } from "react";
 
 import { cn } from "@/lib/utils";
 
@@ -25,20 +25,27 @@ function LoadOlderMarker({
   before: number;
   onLoadOlder: (before: number) => Promise<void>;
 }) {
-  const [loading, setLoading] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement>(null);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver((entries) => {
+      if (startedRef.current) return;
+      if (!entries.some((entry) => entry.isIntersecting)) return;
+      startedRef.current = true;
+      void onLoadOlder(before);
+    });
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [before, onLoadOlder]);
+
   return (
-    <div className="flex justify-center anim-in">
-      <button
-        type="button"
-        disabled={loading}
-        onClick={() => {
-          setLoading(true);
-          void onLoadOlder(before).finally(() => setLoading(false));
-        }}
-        className="text-[11px] italic text-muted-foreground px-3 py-1 border-t border-b border-border/60 hover:text-foreground disabled:opacity-60"
-      >
-        {loading ? "Loading earlier messages…" : "Load earlier messages"}
-      </button>
+    <div ref={sentinelRef} className="flex justify-center anim-in">
+      <span className="text-[11px] italic text-muted-foreground px-3 py-1 border-t border-b border-border/60">
+        Loading earlier messages…
+      </span>
     </div>
   );
 }

--- a/packages/ui/src/modules/sessions/components/chat-message.tsx
+++ b/packages/ui/src/modules/sessions/components/chat-message.tsx
@@ -1,3 +1,5 @@
+import { useState } from "react";
+
 import { cn } from "@/lib/utils";
 
 import type { Attachment, Message } from "../../../types.js";
@@ -13,6 +15,32 @@ interface Props {
   hasPendingPermission: boolean;
   onRetry: (text: string, attachments?: Attachment[]) => void;
   onFileClick: (path: string) => void;
+  onLoadOlder?: (before: number) => Promise<void>;
+}
+
+function LoadOlderMarker({
+  before,
+  onLoadOlder,
+}: {
+  before: number;
+  onLoadOlder: (before: number) => Promise<void>;
+}) {
+  const [loading, setLoading] = useState(false);
+  return (
+    <div className="flex justify-center anim-in">
+      <button
+        type="button"
+        disabled={loading}
+        onClick={() => {
+          setLoading(true);
+          void onLoadOlder(before).finally(() => setLoading(false));
+        }}
+        className="text-[11px] italic text-muted-foreground px-3 py-1 border-t border-b border-border/60 hover:text-foreground disabled:opacity-60"
+      >
+        {loading ? "Loading earlier messages…" : "Load earlier messages"}
+      </button>
+    </div>
+  );
 }
 
 export function ChatMessage({
@@ -21,8 +49,17 @@ export function ChatMessage({
   hasPendingPermission,
   onRetry,
   onFileClick,
+  onLoadOlder,
 }: Props) {
   if (message.notice) {
+    if (message.loadOlderBefore !== undefined && onLoadOlder) {
+      return (
+        <LoadOlderMarker
+          before={message.loadOlderBefore}
+          onLoadOlder={onLoadOlder}
+        />
+      );
+    }
     return (
       <div className="flex justify-center anim-in">
         <span className="text-[11px] italic text-muted-foreground px-3 py-1 border-t border-b border-border/60">

--- a/packages/ui/src/modules/sessions/hooks/use-acp-history.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-history.ts
@@ -7,35 +7,51 @@ import {
   finalizeAllStreaming,
 } from "../../acp/session-projection.js";
 
+async function collectReplay(
+  agentId: string,
+  sessionId: string,
+  replayBefore?: number,
+): Promise<Message[]> {
+  let replayed: Message[] = [];
+  let ws: WebSocket | null = null;
+  try {
+    const conn = await openInitializedConnection(agentId, (update) => {
+      replayed = applyUpdate(replayed, update);
+    });
+    ws = conn.ws;
+    await conn.connection.loadSession({
+      sessionId,
+      cwd: ".",
+      mcpServers: [],
+      ...(replayBefore !== undefined
+        ? { _meta: { platform: { replayBefore } } }
+        : {}),
+    });
+  } finally {
+    ws?.close();
+  }
+  return finalizeAllStreaming(replayed);
+}
+
 export function useAcpHistory(selectedAgent: string | null): {
   loadHistory: (sid: string) => Promise<Message[]>;
+  loadOlderHistory: (sid: string, before: number) => Promise<Message[]>;
 } {
   const loadHistory = useCallback(
     async (sid: string): Promise<Message[]> => {
       if (!selectedAgent) return [];
-
-      let replayed: Message[] = [];
-      let ws: WebSocket | null = null;
-      try {
-        const conn = await openInitializedConnection(
-          selectedAgent,
-          (update) => {
-            replayed = applyUpdate(replayed, update);
-          },
-        );
-        ws = conn.ws;
-        await conn.connection.loadSession({
-          sessionId: sid,
-          cwd: ".",
-          mcpServers: [],
-        });
-      } finally {
-        ws?.close();
-      }
-      return finalizeAllStreaming(replayed);
+      return collectReplay(selectedAgent, sid);
     },
     [selectedAgent],
   );
 
-  return { loadHistory };
+  const loadOlderHistory = useCallback(
+    async (sid: string, before: number): Promise<Message[]> => {
+      if (!selectedAgent) return [];
+      return collectReplay(selectedAgent, sid, before);
+    },
+    [selectedAgent],
+  );
+
+  return { loadHistory, loadOlderHistory };
 }

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -62,7 +62,7 @@ export function useAcpSession(
 
   const agentOperable = useIsAgentOperable(selectedAgent);
 
-  const { loadHistory } = useAcpHistory(selectedAgent);
+  const { loadHistory, loadOlderHistory } = useAcpHistory(selectedAgent);
 
   const {
     engagedSessionIdRef,
@@ -137,6 +137,28 @@ export function useAcpSession(
     [selectedAgent, loadHistory, resetConnection, setMessages, setSessionId],
   );
 
+  const loadOlderMessages = useCallback(
+    async (before: number) => {
+      const sid = useStore.getState().sessionId;
+      if (!sid) return;
+      try {
+        const page = await loadOlderHistory(sid, before);
+        if (useStore.getState().sessionId !== sid) return;
+        const current = useStore.getState().messages;
+        setMessages([
+          ...page,
+          ...current.filter((m) => m.loadOlderBefore !== before),
+        ]);
+      } catch {
+        const fresh = await loadHistory(sid).catch(() => null);
+        if (fresh && useStore.getState().sessionId === sid) {
+          setMessages(fresh);
+        }
+      }
+    },
+    [loadOlderHistory, loadHistory, setMessages],
+  );
+
   const { sendPrompt, stopAgent } = useAcpPrompt({
     selectedAgent,
     ensureConnection: ensureLive,
@@ -150,6 +172,7 @@ export function useAcpSession(
   return {
     resetSession,
     resumeSession,
+    loadOlderMessages,
     sendPrompt,
     stopAgent,
     busy,

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -223,6 +223,21 @@ export function ChatView() {
   const stickRef = useRef(true);
   const [showJump, setShowJump] = useState(false);
 
+  const loadOlderKeepingScroll = useCallback(
+    async (before: number) => {
+      const el = messagesRef.current;
+      const prevHeight = el?.scrollHeight ?? 0;
+      const prevTop = el?.scrollTop ?? 0;
+      await loadOlderMessages(before);
+      requestAnimationFrame(() => {
+        const grown = messagesRef.current;
+        if (!grown) return;
+        grown.scrollTop = prevTop + (grown.scrollHeight - prevHeight);
+      });
+    },
+    [loadOlderMessages],
+  );
+
   const scrollToBottom = useCallback(() => {
     const el = messagesRef.current;
     if (!el) return;
@@ -638,7 +653,7 @@ export function ChatView() {
                         hasPendingPermission={hasPendingPermission}
                         onRetry={sendPrompt}
                         onFileClick={openFileHandler}
-                        onLoadOlder={loadOlderMessages}
+                        onLoadOlder={loadOlderKeepingScroll}
                       />
                     ))}
                     {!statusLineInThread && <PermissionStatusLine />}

--- a/packages/ui/src/modules/sessions/views/chat-view.tsx
+++ b/packages/ui/src/modules/sessions/views/chat-view.tsx
@@ -185,6 +185,7 @@ export function ChatView() {
   const {
     resetSession,
     resumeSession,
+    loadOlderMessages,
     sendPrompt,
     stopAgent,
     busy,
@@ -637,6 +638,7 @@ export function ChatView() {
                         hasPendingPermission={hasPendingPermission}
                         onRetry={sendPrompt}
                         onFileClick={openFileHandler}
+                        onLoadOlder={loadOlderMessages}
                       />
                     ))}
                     {!statusLineInThread && <PermissionStatusLine />}

--- a/packages/ui/src/types.ts
+++ b/packages/ui/src/types.ts
@@ -75,6 +75,7 @@ export interface Message {
   promptId?: string;
   retryWith?: RetryPayload;
   notice?: boolean;
+  loadOlderBefore?: number;
   error?: {
     message: string;
     retryWith?: RetryPayload;


### PR DESCRIPTION
## Summary

Implements #3385 (epic #3242): opening a conversation now has a bounded wire cost regardless of its length.

**agent-runtime**
- `session/load` replays only the newest tail of the in-memory session log (default 200 events, `replayTailEvents` dep). The clipped-replay sentinel gains a `_meta.platform.olderBefore` cursor when the cut is the cap's doing; a sentinel without a cursor still means history is gone (log eviction).
- A load carrying `_meta.platform.replayBefore` is served the older range from the log, page by page, down to the eviction floor. Pages move no cursors, so live fan-out is untouched.
- Cold client loads are unified with cold resumes: they park as waiters, the runtime rehydrates the harness with its own silent `session/load`, and every waiter is then served the capped tail from the log. The initiator-streaming path is gone — a 1,800-event replay costs the in-pod leg (~40 ms measured), not the wire.
- Stale cursors (minted before a pod restart) are refused with an invalid-params error instead of being guessed at under a new log's numbering.

**UI**
- The cursor-carrying marker renders as a **Load earlier messages** button; the fetched page replaces the marker in place (its own marker continues the chain). On a refused stale cursor the UI falls back to a full reload.

**Docs**: agent-lifecycle page updated (session-inside-the-pod section).

Everything is `_meta`-based and shaped to align with ACP v2's `replayFrom` direction — no protocol divergence, conformant peers ignore it.

## Why

The #3247 benchmark showed transcript transmission dominates session-open latency: 1,760 events ≈ 1.7–4.6 s through the relay, hitting warm loads identically (streaming to the browser is ~1 ms/event; reading the transcript from disk is ~30 ms). Numbers: https://github.com/dam-agents/dam/issues/3247#issuecomment-5294917381

## Test plan

- [x] 8 new runtime scenarios (`acp-runtime-history-replay.test.ts`): tail cap + cursor, under-cap invisibility, paging to the start, live fan-out isolation, eviction floor, stale-cursor refusal, silent cold bootstrap serving multiple waiters
- [x] full acp-runtime suite (50/50), UI suite (302/302), tsc/eslint/prettier on both packages, comment-types, doc-size
- [ ] CI
- [ ] after dev deploy: re-run the #3330 session-load benchmark — long-conversation cold/warm totals should drop from 4.2 s/1.8 s p50 to roughly the short-conversation numbers