### PR TITLE
fix(ui): use chevrons for left nav collapse toggle

### DIFF
--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -2,13 +2,13 @@ import {
   Book,
   type CarbonIconType,
   Chemistry,
-  Close,
+  ChevronLeft,
+  ChevronRight,
   ContainerSoftware,
   Email,
   Folders,
   Home,
   Settings,
-  SidePanelOpen,
 } from "@carbon/icons-react";
 
 import { BrandLogo } from "@/components/brand-logo";
@@ -143,11 +143,11 @@ export function IconRail({
               )}
             >
               {expandedNav ? (
-                <Close size={16} />
+                <ChevronLeft size={16} />
               ) : (
                 <>
                   <BrandLogo className="opacity-0 transition-opacity hover-capable:opacity-100 group-hover:opacity-0 group-focus-visible:opacity-0" />
-                  <SidePanelOpen
+                  <ChevronRight
                     size={16}
                     className="absolute transition-opacity hover-capable:opacity-0 group-hover:opacity-100 group-focus-visible:opacity-100"
                   />


### PR DESCRIPTION
Replaces the x icon on the expanded left nav with a left chevron, and the hover icon on the collapsed rail with a right chevron.

The x made it look like the whole window could be closed, but the button only collapses the nav. Requested in https://github.com/dam-agents/dam/issues/3233#issuecomment-5347188990.

Closes nothing (issue #3233 is already closed); follow-up to it.