### PR TITLE
perf(platform-base): skip trust-store farm rebuild on agent boot

### DIFF
--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -14,12 +14,36 @@ set -eu
 
 mitm_ca=/etc/platform/ca/ca.crt
 anchor=/etc/pki/ca-trust/source/anchors/platform-mitm-ca.crt
+extracted=/etc/pki/ca-trust/extracted
+
+extract_trust_store() (
+	export P11_KIT_NO_USER_CONFIG=1
+	trust extract --format=openssl-bundle --filter=certificates --overwrite --comment "$extracted/openssl/ca-bundle.trust.crt" &&
+		trust extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose server-auth "$extracted/pem/tls-ca-bundle.pem" &&
+		trust extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose email "$extracted/pem/email-ca-bundle.pem" &&
+		trust extract --format=pem-bundle --filter=ca-anchors --overwrite --comment --purpose code-signing "$extracted/pem/objsign-ca-bundle.pem" &&
+		trust extract --format=java-cacerts --filter=ca-anchors --overwrite --purpose server-auth "$extracted/java/cacerts" &&
+		trust extract --format=edk2-cacerts --filter=ca-anchors --overwrite --purpose=server-auth "$extracted/edk2/cacerts.bin" &&
+		trust extract --format=pem-directory-hash --filter=ca-anchors --overwrite --purpose server-auth "$extracted/pem/directory-hash" ||
+		exit 1
+	for link in "$extracted"/pem/directory-hash/*.0; do
+		[ -h "$link" ] || continue
+		name=${link##*/}
+		[ -e "/etc/pki/tls/certs/$name" ] ||
+			ln -sf "$(readlink -f "$link")" "/etc/pki/tls/certs/$name" ||
+			exit 1
+	done
+)
 
 # No CA file mounted means the gateway never intercepts this agent's traffic, so
 # every host returns its real public certificate, which the public CAs cover.
 if [ -s "$mitm_ca" ]; then
-	cp "$mitm_ca" "$anchor" && /usr/sbin/update-ca-trust extract \
-		|| echo "agent-entrypoint: WARNING: could not trust the platform CA; intercepted hosts may fail TLS" >&2
+	trust_t0=$(date +%s)
+	if cp "$mitm_ca" "$anchor" && { extract_trust_store || /usr/sbin/update-ca-trust extract; }; then
+		echo "agent-entrypoint: platform CA trusted in $(($(date +%s) - trust_t0))s"
+	else
+		echo "agent-entrypoint: WARNING: could not trust the platform CA; intercepted hosts may fail TLS" >&2
+	fi
 fi
 
 # $HOME is a shared RWX network volume; cache traffic (mise, uv, npm, ...)


### PR DESCRIPTION
Closes #3401.

## Problem

Every agent boot spent ~18s inside the entrypoint on `update-ca-trust extract` — the single largest platform-owned cost on the boot path (#3246 measurements). Decomposed in a dev pod: the seven trust-store renders cost 2.0s; the remaining ~15s is the stock script deleting and recreating ~300 `/etc/pki/tls/certs` hash symlinks with one `rm`/`ln` process spawn each, which is expensive inside a 1-CPU kata VM.

## Change

The entrypoint now runs the same seven `trust extract` renders verbatim to the real store and adds only the hash links that are missing — the image already ships the farm for the public CAs (verified by scanning the image layers), so only the platform CA's two links are ever new. Store output is byte-identical to the stock script's, Java/EDK2 stores included. On any failure the stock `update-ca-trust extract` runs as the fallback, so worst case is today's behavior.

Expected: **~18s → ~2s on every boot** at dev sandbox sizes.

## Testing

Full matrix on the exact registry base image with the new entrypoint overlaid (Docker):

- CA mounted → CA present in PEM + OpenSSL bundles, Java/EDK2 regenerated, both farm links created (identical to stock output)
- real TLS verify: in-container `curl` against a server signed by a test CA → verify-ok; negative control without the CA fails as expected
- no-CA branch skips extraction, boot continues
- broken tooling → WARNING + fallback + boot continues (this test caught and fixed a silent-failure bug: `set -e` is ignored inside a function invoked in a `||` chain, so the fast path now uses explicit `&& … || exit 1` chaining)
- entrypoint re-run in the same container is idempotent
