### PR TITLE
perf(platform-base): seed home in the image boot instead of an init container

### DIFF
--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -114,10 +114,6 @@ data:
     skillSources:
       {{- toYaml . | nindent 6 }}
     {{- end }}
-    {{- with $tmpl.init }}
-    init: |
-      {{- . | nindent 6 }}
-    {{- end }}
   {{- end }}
   {{- end }}
   {{- end }}

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -979,16 +979,6 @@ controller:
       # set unconditionally by the controller.
       env: []
       skillSources: []
-      # Shell-expanded at runtime — HOME is set on the init container.
-      # Templates that need extras (e.g. pip install) REPLACE this entirely.
-      init: |
-        #!/bin/bash
-        # Seed home from image on first boot
-        if [ ! -f $HOME/.initialized ]; then
-          cp -rn /app/working-dir/. $HOME/ 2>/dev/null || true
-          touch $HOME/.initialized
-        fi
-        mkdir -p $HOME/work
 
     # -- Size the controller materializes into any Agent spec that lacks a
     # limits dimension (#1900): fill-if-absent on reconcile, never touching

--- a/docs/architecture/persistence.md
+++ b/docs/architecture/persistence.md
@@ -104,6 +104,8 @@ Two domain resources are deliberately not CRDs:
 
 Each `agent` reconciles into a StatefulSet whose `volumeClaimTemplates` are derived from the Agent's declared mounts. A mount marked `persist: true` becomes a PVC; a non-persisted mount becomes an `emptyDir` that dies with the pod. PVCs are `ReadWriteOnce` on ordinary single-writer storage — the agent pod is the volume's only writer, so no install needs a shared filesystem class. (Workspaces created before the RWO cutover sit on `ReadWriteMany` volumes until the storage migration below drains them.)
 
+A home volume mounts empty and shadows whatever the image bakes at that path, so the image's boot seeds it on the volume's first boot from the staged workspace: a no-clobber copy behind a sentinel file, run once per volume, so image content lands exactly once and files the user later edits are never overwritten by a restarted or upgraded image. The seed lives in the image's own boot sequence — the container entrypoint, replayed by the VM boot — with no separate init container, and the Agent CR's `spec.init` field (and a Template's `init`) is retained but no longer read.
+
 The default Claude Code template persists the workspace and `$HOME`. Together these hold:
 
 - the **workspace** itself — git checkouts, tool caches (`node_modules`, `.venv`, mise), and any artifacts the agent has produced.

--- a/docs/architecture/skills.md
+++ b/docs/architecture/skills.md
@@ -93,7 +93,7 @@ The reconciled `state` read has a consumer beyond the Skills surface: the Experi
 
 Every Local Skill carries a **provenance** verdict, judged by the agent-runtime at read time. The reference is the set of **pristine roots** in the image — exactly two sanctioned locations, both immutable and always in-pod, so no build-time manifest or on-PVC marker is needed (a marker was tried and reverted — third-party baked skills aren't ours to stamp, and the PVC is agent-writable anyway):
 
-1. the **pristine workspace copy** — the directory the first-boot init seeds onto the PVC and never touches again, and
+1. the **pristine workspace copy** — the directory the image's first-boot seed copies onto the PVC and never touches again, and
 2. the **staged-skills dir** — the one place images put system skills that must *not* reach every agent (an Agent Kind's Install Command copies them onto the PVC at create; the shared constant lives in the agent-runtime contract package).
 
 This is a deliberate convention, not a growing list: an image-shipped skill anywhere else will misclassify as user-authored, so new features ship their skills through one of these two locations.

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -1,6 +1,6 @@
 import http from "node:http";
 import { monitorEventLoopDelay } from "node:perf_hooks";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import headlessPkg from "@xterm/headless";
@@ -57,6 +57,14 @@ const homeDir = config.PLATFORM_DEV
 const workDir = config.PLATFORM_DEV
   ? join(__dir, "../working-dir")
   : config.WORK_DIR;
+
+try {
+  mkdirSync(workDir, { recursive: true });
+} catch (err) {
+  process.stderr.write(
+    `[server] could not create workDir ${workDir}: ${(err as Error).message}\n`,
+  );
+}
 
 function skillRefPaths(manifest: RuntimeManifest, home: string): string[] {
   const binding = resolveDrivers(manifest)["skill-ref"] as

--- a/packages/api-server/src/modules/agents/domain/spec-assembly.ts
+++ b/packages/api-server/src/modules/agents/domain/spec-assembly.ts
@@ -44,7 +44,6 @@ export function assembleSpecFromTemplate(
     image: tmplSpec.image,
     description: opts.description ?? tmplSpec.description,
     mounts: tmplSpec.mounts,
-    init: tmplSpec.init,
     env: tmplSpec.env,
     resources: concreteResources(tmplSpec.resources, opts.size, defaultLimits),
     imagePullPolicy: tmplSpec.imagePullPolicy,

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -222,6 +222,9 @@ func LoadFromEnv() (*Config, error) {
 	if cfg.AgentBase.AccessMode != "" {
 		slog.Warn("controller.agent.base.accessMode is deprecated and ignored — workspace volumes are always ReadWriteOnce (#2988); remove it from your values")
 	}
+	if cfg.AgentTemplateDefaults.Init != "" {
+		slog.Warn("controller.agent.templateDefaults.init is deprecated and ignored — first-boot home seeding moved into the agent image's boot (#3242); remove it from your values")
+	}
 	if v := os.Getenv("STORAGE_MIGRATION"); v != "" {
 		dec := json.NewDecoder(strings.NewReader(v))
 		dec.DisallowUnknownFields()

--- a/packages/controller/pkg/reconciler/iptables_init_test.go
+++ b/packages/controller/pkg/reconciler/iptables_init_test.go
@@ -89,9 +89,8 @@ func TestBuildAgentStatefulSet_IptablesInitRunsFirst(t *testing.T) {
 	ss := BuildAgentStatefulSet("my-instance", testAgent, &cfg, configMapOwnerRef(testOwnerCM), "10.96.42.42")
 
 	ics := ss.Spec.Template.Spec.InitContainers
-	require.Len(t, ics, 2, "egress-lockdown + user init")
-	assert.Equal(t, "egress-lockdown", ics[0].Name, "lockdown must run before the user init")
-	assert.Equal(t, "init", ics[1].Name)
+	require.Len(t, ics, 1, "egress-lockdown is the only init container")
+	assert.Equal(t, "egress-lockdown", ics[0].Name)
 
 	agent := ss.Spec.Template.Spec.Containers[0]
 	require.NotNil(t, agent.SecurityContext)

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -206,26 +206,12 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 		resourceReqs.Requests = nil
 	}
 
-	initScript := agentSpec.Init
-	if initScript == "" {
-		initScript = defaults.Init
-	}
 	var initContainers []corev1.Container
 	if ic := buildIptablesInitContainer(cfg, gatewayClusterIP); ic != nil {
 		initContainers = append(initContainers, *ic)
 	}
 	if ic := buildNPGateInitContainer(cfg, gatewayClusterIP); ic != nil {
 		initContainers = append(initContainers, *ic)
-	}
-	if initScript != "" {
-		initContainers = append(initContainers, corev1.Container{
-			Name:            "init",
-			Image:           agentSpec.Image,
-			ImagePullPolicy: corev1.PullPolicy(pullPolicy),
-			Command:         []string{"sh", "-c", initScript},
-			Env:             []corev1.EnvVar{{Name: "HOME", Value: agentHome}},
-			VolumeMounts:    volumeMounts,
-		})
 	}
 
 	var pullSecrets []corev1.LocalObjectReference

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -205,19 +205,8 @@ func TestBuildAgentStatefulSet_DefaultsToRunningReplicas(t *testing.T) {
 	assert.Equal(t, int32(1), *ss.Spec.Replicas)
 }
 
-func TestBuildAgentStatefulSet_InitContainer(t *testing.T) {
+func TestBuildAgentStatefulSet_IgnoresSpecInit(t *testing.T) {
 	ss := BuildAgentStatefulSet("my-instance", testAgent, testConfig, configMapOwnerRef(testOwnerCM), "")
-	require.Len(t, ss.Spec.Template.Spec.InitContainers, 1, "only the user-defined init runs")
-	ic := ss.Spec.Template.Spec.InitContainers[0]
-	assert.Equal(t, "init", ic.Name)
-	assert.Equal(t, "ghcr.io/myorg/agent:latest", ic.Image)
-	assert.Equal(t, []string{"sh", "-c", testAgent.Init}, ic.Command)
-}
-
-func TestBuildAgentStatefulSet_NoUserInitWhenEmpty(t *testing.T) {
-	agent := *testAgent
-	agent.Init = ""
-	ss := BuildAgentStatefulSet("my-instance", &agent, testConfig, configMapOwnerRef(testOwnerCM), "")
 	assert.Empty(t, ss.Spec.Template.Spec.InitContainers)
 }
 

--- a/packages/controller/pkg/reconciler/vm_resources.go
+++ b/packages/controller/pkg/reconciler/vm_resources.go
@@ -118,14 +118,9 @@ func BuildVMCloudInitSecret(name string, agentSpec *types.AgentSpec, cfg *config
 		"mkdir -p /tmp/agent-cache && chown %[1]d:%[1]d /tmp/agent-cache && { [ -L %[2]s/.cache ] || rm -rf %[2]s/.cache; } && ln -sfn /tmp/agent-cache %[2]s/.cache || true",
 		vmAgentUID, shellQuote(agentHome),
 	)})
-
-	initScript := agentSpec.Init
-	if initScript == "" {
-		initScript = defaults.Init
-	}
-	if initScript != "" {
-		cc.BootCmd = append(cc.BootCmd, []string{"env", "HOME=" + agentHome, "bash", "-c", initScript})
-	}
+	cc.BootCmd = append(cc.BootCmd, []string{"env", "HOME=" + agentHome, "sh", "-c",
+		`[ -f "$HOME/.initialized" ] || { cp -rn /app/working-dir/. "$HOME/" 2>/dev/null || true; touch "$HOME/.initialized"; }; mkdir -p "$HOME/work"`,
+	})
 
 	body, err := yaml.Marshal(cc)
 	if err != nil {

--- a/packages/controller/pkg/reconciler/vm_test.go
+++ b/packages/controller/pkg/reconciler/vm_test.go
@@ -25,7 +25,7 @@ func vmAgentCR() *apiv1.Agent {
 		{Path: "/home/agent", Persist: true, Size: "10Gi"},
 		{Path: "/scratchpad", Persist: false},
 	}
-	a.Spec.Init = "touch $HOME/.initialized"
+	a.Spec.Init = "echo custom-init-ignored"
 	return a
 }
 
@@ -143,8 +143,8 @@ func TestVMBackendReconcilesVirtualMachine(t *testing.T) {
 		"mount -t virtiofs 'scratchpad'",
 		"ephemeral mounts have no virtiofs device to mount",
 	)
-	assert.Contains(t, userdata, "HOME=/home/agent")
-	assert.Contains(t, userdata, ".initialized")
+	assert.NotContains(t, userdata, "custom-init-ignored", "spec.init is retained but no longer read")
+	assert.Contains(t, userdata, ".initialized", "the static first-boot seed rides userdata")
 	assert.Contains(t, userdata, "ln -sfn /tmp/agent-cache")
 }
 

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -46,6 +46,14 @@ if [ -s "$mitm_ca" ]; then
 	fi
 fi
 
+home="${HOME:-/home/agent}"
+if [ ! -f "$home/.initialized" ]; then
+	cp -rn /app/working-dir/. "$home/" 2>/dev/null || true
+	touch "$home/.initialized"
+	echo "agent-entrypoint: seeded home from image workspace"
+fi
+mkdir -p "$home/work"
+
 # $HOME is a shared RWX network volume; cache traffic (mise, uv, npm, ...)
 # would hammer it, so ~/.cache points at pod-local disk (/tmp is an emptyDir)
 # instead. Caches are disposable, so a pre-existing real directory (older
@@ -53,7 +61,6 @@ fi
 # swap idempotent when the owner pod and a fork pod boot the volume together.
 # The symlink persists on the volume but /tmp is fresh every pod, so the
 # target is (re)created each boot to keep the link from dangling.
-home="${HOME:-/home/agent}"
 mkdir -p /tmp/agent-cache
 # On the VM backend $HOME is unprivileged virtiofs, where a non-root caller
 # cannot create symlinks (virtiofsd lacks CAP_CHOWN, the guest kernel returns


### PR DESCRIPTION
Part of #3242 (from the #3246 start-latency measurements).

## Problem

The seed-home `init` container costs a container create/start in the kata VM on every boot (#3246 measured the create-path init step at ~1s, and wake-path np-gate+init at ~3s combined) — for a job that is a ~100ms no-clobber copy paid once per volume. The copy itself cannot move to image build time: the home volume is provisioned per agent and mounts empty, shadowing image content.

## Change

- The **container entrypoint** now runs the exact `cp -rn` + sentinel + `mkdir work` sequence the init container ran — same coreutils semantics, no reimplementation — honoring `$HOME` (which the controller sets from `agentHome`, so per-template home overrides keep working exactly as they did with the init container).
- The **VM boot** replays the same static step in cloud-init, next to the existing cache-symlink step.
- **agent-runtime** ensures the work directory at boot, covering images that don't run the platform entrypoint.
- The **controller** no longer renders the `init` container. `spec.init` and a Template's `init` are retained but no longer read (the `spec.env` precedent), and a still-set `controller.agent.templateDefaults.init` logs a deprecation warning at startup instead of failing the strict config decode. The chart's default `templateDefaults.init` is removed.
- Docs: seeding contract in `persistence.md`; `skills.md`'s pristine-root wording updated.

## Review response (Code Guardian round 1)

The first revision reimplemented the copy in TypeScript (`fs.cpSync`); the review found three real criticals there (strict-decode crash-loop, `cpSync` symlink rewriting, an uncatchable `std::filesystem` abort — both reproduced locally). Rather than hand-rolling `cp -rn` semantics in JS, this revision deletes that code and keeps coreutils `cp -rn` itself, which also resolves the `HOME_DIR` finding (the entrypoint honors `$HOME`). The runtime-wide "`HOME_DIR` is never set" gap the review surfaced predates this PR and will be filed separately.

## Testing

- Docker, on the registry base image with the new entrypoint overlaid: empty home volume seeds (files + sentinel + `work/`), a user-edited file survives, re-run is a silent no-op; `HOME` override honored.
- controller suite green, including: no init containers rendered; a set `spec.init` ignored on both backends; the static seed present in VM userdata.
- agent-runtime suite 208/208; helm render green.
- Measured before/after boot timing on a local cluster to follow as a PR comment once this revision is deployed there (baseline per #3246: init step ~1s create / np-gate+init ~3s wake).

## Compatibility

Seeding responsibility moves from the controller (init container) to the agent image (boot), and the two upgrade independently:

| Controller | Agent image | First boot of an empty volume | Already-seeded volumes |
|---|---|---|---|
| old | new | both seed — benign (both no-clobber + sentinel) | no-op |
| new | new | image boot seeds | no-op |
| new | pre-change | **nobody seeds** | no-op (sentinel present) |

Existing agents are unaffected (their volumes carry the sentinel), and post-upgrade creates get post-change images via their template. The exposed slice: agents created but never woken before the upgrade, custom images built on a pre-change `platform-base`, installs pinning agent images independently of the chart. On such an agent the home never seeds (agent-runtime still ensures `work/`), until the agent's image is advanced or the agent is recreated. Suggest a release-note line rather than a compatibility shim.
