### PR TITLE
refactor(controller): fix the agent home at /home/agent

### DIFF
--- a/deploy/helm/platform/templates/agent-templates.yaml
+++ b/deploy/helm/platform/templates/agent-templates.yaml
@@ -10,9 +10,9 @@ through at reconcile time to `controller.agent.templateDefaults.*` (chart
 fallback) or `controller.agent.base.*` (chart-only policy).
 
 The literal string `$HOME` in mount paths is substituted
-HERE (chart render time) using the template's `agentHome` if set, else
-`controller.agent.templateDefaults.agentHome`. The rendered spec ships
-absolute paths — the controller and agent-runtime never see `$HOME`.
+HERE (chart render time) with the fixed agent home (/home/agent). The
+rendered spec ships absolute paths — the controller and agent-runtime
+never see `$HOME`.
 */}}
 apiVersion: v1
 kind: ConfigMap
@@ -29,12 +29,11 @@ data:
          template entry (`agentTemplates.foo: null`) has no fields. */}}
   {{- $isVM := and $tmpl.backend (eq ($tmpl.backend.type | default "") "vm") }}
   {{- if or (not $isVM) $.Values.virtualization.enabled }}
-  {{- $home := $tmpl.agentHome | default $.Values.controller.agent.templateDefaults.agentHome }}
+  {{- $home := "/home/agent" }}
   {{ $name }}.yaml: |
     version: agent-platform.ai/v1
     image: "{{ $tmpl.image.repository }}:{{ $tmpl.image.tag | default $.Chart.AppVersion }}"
     description: {{ $tmpl.description | quote }}
-    agentHome: {{ $home | quote }}
     {{- with $tmpl.displayName }}
     name: {{ . | quote }}
     {{- end }}

--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -253,8 +253,6 @@ spec:
               value: {{ .Values.keycloak.inspectorRole | quote }}
             {{- end }}
             {{- end }}
-            - name: AGENT_HOME
-              value: {{ .Values.controller.agent.templateDefaults.agentHome | quote }}
             - name: AGENT_IDLE_TIMEOUT
               value: {{ .Values.controller.agent.base.idleTimeout | quote }}
             # Same Helm value the controller's AGENT_TEMPLATE_DEFAULTS carries,

--- a/deploy/helm/platform/templates/controller/deployment.yaml
+++ b/deploy/helm/platform/templates/controller/deployment.yaml
@@ -57,10 +57,10 @@ spec:
             - name: AGENT_BASE
               value: {{ .Values.controller.agent.base | toJson | quote }}
             # `$HOME` literals in mount paths are substituted at
-            # chart render time using templateDefaults.agentHome, so the
+            # chart render time with the fixed agent home, so the
             # controller and api-server only ever see absolute paths.
             - name: AGENT_TEMPLATE_DEFAULTS
-              value: {{ .Values.controller.agent.templateDefaults | toJson | replace "$HOME" .Values.controller.agent.templateDefaults.agentHome | quote }}
+              value: {{ .Values.controller.agent.templateDefaults | toJson | replace "$HOME" "/home/agent" | quote }}
             # Warm PVC pool (#692): pre-provisioned spare workspace volumes a new
             # agent claims instantly. Disabled by default; see controller.warmPool.
             - name: WARM_POOL
@@ -150,8 +150,6 @@ spec:
               value: {{ .Values.controller.envoyImage | default "mirror.gcr.io/envoyproxy/envoy:distroless-v1.37.2" | quote }}
             - name: ENVOY_PORT
               value: {{ .Values.controller.envoyPort | default 10000 | quote }}
-            - name: AGENT_HOME
-              value: {{ .Values.controller.agent.templateDefaults.agentHome | quote }}
             # ext-authz uses per-agent Services rendered by the
             # controller (one Service per agent, AuthorizationPolicy-gated
             # to the agent's own SA principal). The host is computed at

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -838,8 +838,7 @@ controller:
   #                           can override (template wins when set).
   #   3. agentTemplates.*   — per-template values (further down).
   # Use the literal string `$HOME` in mount paths; the chart substitutes
-  # it at render time with the template's `agentHome` if set, else
-  # `templateDefaults.agentHome`.
+  # it at render time with the fixed agent home (/home/agent).
   agent:
     base:
       # Cluster details (immutable per-agent)
@@ -934,13 +933,8 @@ controller:
       # ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
     templateDefaults:
-      # HOME inside agent containers — set as the `HOME` env var and used at
-      # chart render time to substitute any literal `$HOME` in mount paths.
-      # Per-template `agentTemplates[i].agentHome` overrides
-      # this for that template's agents. Must match the image's user
-      # HOME or pod-files materialization breaks silently. Also plumbed to
-      # api-server for pod-files producers (currently one global value).
-      agentHome: /home/agent
+      # (agentHome is retired: the agent home is fixed at /home/agent; a value
+      # still set here is ignored with a startup warning.)
 
       # Left unset so Kubernetes applies its native, tag-based pull policy:
       # `Always` for a mutable `:latest` (so a repushed tag is actually

--- a/packages/agent-runtime-api/src/index.ts
+++ b/packages/agent-runtime-api/src/index.ts
@@ -63,6 +63,7 @@ export {
   STAGED_SKILLS_DIR,
   dedupeByName,
 } from "./modules/skills/source-roots.js";
+export { AGENT_HOME_DIR, AGENT_WORK_DIR } from "./modules/workspace/paths.js";
 export type { DedupeByNameResult } from "./modules/skills/source-roots.js";
 export type { SshDomainError, SshService } from "./modules/ssh/types.js";
 export type {

--- a/packages/agent-runtime-api/src/modules/workspace/paths.ts
+++ b/packages/agent-runtime-api/src/modules/workspace/paths.ts
@@ -1,0 +1,4 @@
+// UNIT_BOUNDARY_DESCRIPTION: the agent's home and workspace paths, fixed rather than configured — the image bakes this home into its user, the controller sets it as HOME on the pod, and agent-runtime and the harness MCP surface both resolve paths against it, so the value has to agree across all of them (a Go copy lives in the controller's reconciler).
+export const AGENT_HOME_DIR = "/home/agent";
+
+export const AGENT_WORK_DIR = `${AGENT_HOME_DIR}/work`;

--- a/packages/agent-runtime/src/modules/config.ts
+++ b/packages/agent-runtime/src/modules/config.ts
@@ -6,8 +6,6 @@ const schema = z.object({
     .string()
     .default("false")
     .transform((v) => v === "true"),
-  HOME_DIR: z.string().default("/home/agent"),
-  WORK_DIR: z.string().default("/home/agent/work"),
   IMAGE_WORKSPACE_DIR: z.string().default("/app/working-dir"),
   API_SERVER_URL: z.string().default(""),
   BACKGROUND_WORK_HOLDS: z

--- a/packages/agent-runtime/src/server.ts
+++ b/packages/agent-runtime/src/server.ts
@@ -12,6 +12,8 @@ import { WebSocketServer, type WebSocket as WsWebSocket } from "ws";
 import { createHTTPHandler } from "@trpc/server/adapters/standalone";
 import { appRouter } from "agent-runtime-api/router";
 import {
+  AGENT_HOME_DIR,
+  AGENT_WORK_DIR,
   STAGED_SKILLS_DIR,
   backgroundWorkReportSchema,
   type AgentRuntimeContext,
@@ -53,10 +55,10 @@ import {
 const __dir = dirname(fileURLToPath(import.meta.url));
 const homeDir = config.PLATFORM_DEV
   ? join(__dir, "../working-dir")
-  : config.HOME_DIR;
+  : AGENT_HOME_DIR;
 const workDir = config.PLATFORM_DEV
   ? join(__dir, "../working-dir")
-  : config.WORK_DIR;
+  : AGENT_WORK_DIR;
 
 try {
   mkdirSync(workDir, { recursive: true });

--- a/packages/api-server/src/__tests__/unit/channel-mcp-tools.test.ts
+++ b/packages/api-server/src/__tests__/unit/channel-mcp-tools.test.ts
@@ -56,7 +56,6 @@ async function mcpHarness(opts?: {
     channelManager,
     k8s: { namespace: "platform" },
     maxArtifactBytes: 10 * 1024 * 1024,
-    agentHome: "/home/agent",
     supportsMessageReactions: opts?.supportsMessageReactions ?? true,
   } as unknown as McpSessionDeps);
 

--- a/packages/api-server/src/__tests__/unit/schedule-mcp-tools.test.ts
+++ b/packages/api-server/src/__tests__/unit/schedule-mcp-tools.test.ts
@@ -63,7 +63,6 @@ async function mcpHarness() {
     channelManager: {},
     k8s: { namespace: "platform" },
     maxArtifactBytes: 10 * 1024 * 1024,
-    agentHome: "/home/agent",
     schedules,
   } as unknown as McpSessionDeps);
 

--- a/packages/api-server/src/apps/harness-api-server/app.ts
+++ b/packages/api-server/src/apps/harness-api-server/app.ts
@@ -116,7 +116,6 @@ export function startHarnessApiServerApp(deps: HarnessApiServerAppDeps) {
   const app = createHarnessRouter({
     channelManager,
     k8s: k8sClient,
-    agentHome: config.agentHome,
     runtimeHello,
     composeSkills: (owner) =>
       composeSkillsModule({

--- a/packages/api-server/src/apps/harness-api-server/harness-router.ts
+++ b/packages/api-server/src/apps/harness-api-server/harness-router.ts
@@ -22,7 +22,6 @@ export function createHarnessRouter(deps: {
   channelManager: ChannelManager;
   k8s: K8sClient;
   composeSkills: (owner: string) => SkillsService;
-  agentHome: string;
   schedulesServiceFor: (owner: string) => SchedulesService;
   experimentsServiceFor: (owner: string) => ExperimentsService;
   artifactLibraryFor: (owner: string) => ArtifactLibraryServiceImpl;
@@ -39,7 +38,6 @@ export function createHarnessRouter(deps: {
     channelManager: deps.channelManager,
     k8s: deps.k8s,
     composeSkills: deps.composeSkills,
-    agentHome: deps.agentHome,
     schedulesServiceFor: deps.schedulesServiceFor,
     artifactLibraryFor: deps.artifactLibraryFor,
     invocationsServiceFor: deps.invocationsServiceFor,

--- a/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
+++ b/packages/api-server/src/apps/harness-api-server/mcp-endpoint.ts
@@ -3,7 +3,11 @@ import type { Hono } from "hono";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
 import { createTRPCClient, httpBatchLink, TRPCClientError } from "@trpc/client";
-import type { AppRouter } from "agent-runtime-api";
+import {
+  AGENT_HOME_DIR,
+  AGENT_WORK_DIR,
+  type AppRouter,
+} from "agent-runtime-api";
 import type { ExperimentsService } from "api-server-api";
 import { z } from "zod";
 import { TRPCError } from "@trpc/server";
@@ -27,8 +31,9 @@ import type { ArtifactLibraryServiceImpl } from "../../modules/artifact-library/
 
 const SESSION_TTL_MS = 30 * 60 * 1000;
 
-function resolveWorkspacePath(input: string, agentHome: string): string {
-  const workDir = `${agentHome}/work`;
+function resolveWorkspacePath(input: string): string {
+  const agentHome = AGENT_HOME_DIR;
+  const workDir = AGENT_WORK_DIR;
   if (input.startsWith("/")) {
     return input.startsWith(`${agentHome}/`)
       ? input.slice(agentHome.length + 1)
@@ -104,7 +109,6 @@ export interface McpSessionDeps {
   artifactLibrary: ArtifactLibraryServiceImpl;
   invocations: InvocationsService;
   experiments: ExperimentsService;
-  agentHome: string;
   supportsUserLookup: boolean;
   supportsMessageReactions: boolean;
 }
@@ -113,7 +117,8 @@ export function createMcpSession(
   agentId: string,
   deps: McpSessionDeps,
 ): McpSession {
-  const { agentHome, schedules } = deps;
+  const { schedules } = deps;
+  const agentHome = AGENT_HOME_DIR;
   const server = new McpServer({
     name: `platform-${agentId}`,
     version: "1.0.0",
@@ -178,7 +183,7 @@ export function createMcpSession(
       let resolved: ChannelAttachment | undefined;
       let attachmentAudit: Record<string, unknown> | undefined;
       if (attachment) {
-        const resolvedPath = resolveWorkspacePath(attachment.path, agentHome);
+        const resolvedPath = resolveWorkspacePath(attachment.path);
         let file: { content: string; binary: boolean; mimeType?: string };
         try {
           file = await runtimeClient.files.read.query({ path: resolvedPath });
@@ -830,7 +835,6 @@ export interface MountMcpDeps {
   artifactLibraryFor: (owner: string) => ArtifactLibraryServiceImpl;
   invocationsServiceFor: (owner: string) => InvocationsService;
   experimentsServiceFor: (owner: string) => ExperimentsService;
-  agentHome: string;
 }
 
 export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
@@ -892,7 +896,6 @@ export function mountMcpRoutes(app: Hono, deps: MountMcpDeps) {
       artifactLibrary,
       invocations,
       experiments,
-      agentHome: deps.agentHome,
       supportsUserLookup,
       supportsMessageReactions,
     });

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -65,7 +65,6 @@ const configSchema = z.object({
   keycloakApiClientSecret: z.string().default(""),
   keycloakRequiredRole: z.string().optional(),
   keycloakInspectorRole: z.string().optional(),
-  agentHome: z.string().default("/home/agent"),
   agentIdleTimeoutMinutes: z.number().int().min(0),
   agentDefaultCpuLimit: positiveQuantitySchema.default("1"),
   agentDefaultMemoryLimit: positiveQuantitySchema.default("1Gi"),
@@ -174,7 +173,6 @@ export function loadConfig(): Config {
     keycloakApiClientSecret: process.env.KEYCLOAK_API_CLIENT_SECRET,
     keycloakRequiredRole: process.env.KEYCLOAK_REQUIRED_ROLE,
     keycloakInspectorRole: process.env.KEYCLOAK_INSPECTOR_ROLE,
-    agentHome: process.env.AGENT_HOME,
     agentIdleTimeoutMinutes: durationToMinutesStrict(
       process.env.AGENT_IDLE_TIMEOUT ?? "1h",
     ),

--- a/packages/controller/pkg/config/config.go
+++ b/packages/controller/pkg/config/config.go
@@ -225,6 +225,9 @@ func LoadFromEnv() (*Config, error) {
 	if cfg.AgentTemplateDefaults.Init != "" {
 		slog.Warn("controller.agent.templateDefaults.init is deprecated and ignored — first-boot home seeding moved into the agent image's boot (#3242); remove it from your values")
 	}
+	if cfg.AgentTemplateDefaults.AgentHome != "" {
+		slog.Warn("controller.agent.templateDefaults.agentHome is deprecated and ignored — the agent home is fixed at /home/agent; remove it from your values")
+	}
 	if v := os.Getenv("STORAGE_MIGRATION"); v != "" {
 		dec := json.NewDecoder(strings.NewReader(v))
 		dec.DisallowUnknownFields()
@@ -254,9 +257,6 @@ func LoadFromEnv() (*Config, error) {
 	cfg.HarnessServerURL = os.Getenv("PLATFORM_HARNESS_SERVER_URL")
 	cfg.HarnessServerPort = envOrDefaultInt("PLATFORM_HARNESS_SERVER_PORT", 4001)
 	cfg.AgentProbesEnabled = envOrDefaultBool("AGENT_PROBES_ENABLED", true)
-	if cfg.AgentTemplateDefaults.AgentHome == "" {
-		cfg.AgentTemplateDefaults.AgentHome = envOrDefault("AGENT_HOME", "/home/agent")
-	}
 	cfg.EnvoyImage = envOrDefault("ENVOY_IMAGE", "mirror.gcr.io/envoyproxy/envoy:distroless-v1.37.2")
 	cfg.EnvoyPort = envOrDefaultInt("ENVOY_PORT", 10000)
 	cfg.EnvoyMitmCAIssuer = envOrDefault("ENVOY_MITM_CA_ISSUER", "platform-mitm-ca-issuer")

--- a/packages/controller/pkg/config/config_test.go
+++ b/packages/controller/pkg/config/config_test.go
@@ -36,7 +36,7 @@ func TestLoadFromEnv_Defaults(t *testing.T) {
 	assert.Equal(t, "platform-agents", cfg.Namespace)
 	assert.Equal(t, "default", cfg.ReleaseNamespace)
 	assert.Equal(t, "platform-controller", cfg.LeaseName)
-	assert.Equal(t, "/home/agent", cfg.AgentTemplateDefaults.AgentHome)
+	assert.Empty(t, cfg.AgentTemplateDefaults.AgentHome)
 	assert.Equal(t, "platform-extauthz-inst-1.default.svc.cluster.local", cfg.ExtAuthzHostFor("inst-1"))
 }
 

--- a/packages/controller/pkg/reconciler/agent_reconciler_test.go
+++ b/packages/controller/pkg/reconciler/agent_reconciler_test.go
@@ -73,7 +73,6 @@ func setupReconciler(t *testing.T, agent *apiv1.Agent, objects ...runtime.Object
 			},
 		},
 		AgentTemplateDefaults: config.AgentTemplateDefaults{
-			AgentHome:       "/home/agent",
 			ImagePullPolicy: "IfNotPresent",
 			StorageSize:     "10Gi",
 		},

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -18,6 +18,8 @@ import (
 
 const AgentContainerName = "agent"
 
+const agentHomeDir = "/home/agent"
+
 func portInt32(p int) int32 {
 	if p < 0 || p > 65535 {
 		panic(fmt.Sprintf("port out of range: %d (must be 0..65535)", p))
@@ -85,10 +87,7 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 	if pullPolicy == "" {
 		pullPolicy = defaults.ImagePullPolicy
 	}
-	agentHome := agentSpec.AgentHome
-	if agentHome == "" {
-		agentHome = defaults.AgentHome
-	}
+	agentHome := agentHomeDir
 	specMounts := resolveSpecMounts(agentSpec, defaults)
 	specEnv := configEnvToTypes(defaults.Env)
 

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -31,7 +31,6 @@ var testConfig = &config.Config{
 		},
 	},
 	AgentTemplateDefaults: config.AgentTemplateDefaults{
-		AgentHome:       "/home/agent",
 		ImagePullPolicy: "IfNotPresent",
 		StorageSize:     "10Gi",
 	},

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -35,7 +35,6 @@ func migrationConfig() *config.Config {
 			},
 		},
 		AgentTemplateDefaults: config.AgentTemplateDefaults{
-			AgentHome:   "/home/agent",
 			StorageSize: "10Gi",
 		},
 		StorageMigration: config.StorageMigration{

--- a/packages/controller/pkg/reconciler/vm_resources.go
+++ b/packages/controller/pkg/reconciler/vm_resources.go
@@ -67,10 +67,7 @@ const vmAgentUID = 65532
 
 func BuildVMCloudInitSecret(name string, agentSpec *types.AgentSpec, cfg *config.Config, ownerRef metav1.OwnerReference, gatewayClusterIP, caCrt string) (*corev1.Secret, error) {
 	defaults := cfg.AgentTemplateDefaults
-	agentHome := agentSpec.AgentHome
-	if agentHome == "" {
-		agentHome = defaults.AgentHome
-	}
+	agentHome := agentHomeDir
 
 	envFile := ""
 	for _, e := range agentPlatformEnv(name, cfg, agentHome, agentProxyAddr(cfg, gatewayClusterIP)) {


### PR DESCRIPTION
## Problem

The agent-home location looked configurable — `controller.agent.templateDefaults.agentHome`, per-template `agentHome`, `AGENT_HOME` env on both the controller and api-server, and an Agent CR spec field — but the knob was never wired through:

- **agent-runtime never honored it.** It anchors all its state (session metadata, runtime-env snapshots, trigger bindings, SSH, skills paths) at `/home/agent` via config keys nothing ever sets. Any install actually turning the knob would get a split-brain pod: the harness and shell in the configured home on the persistent volume, the runtime's state under `/home/agent` on the ephemeral overlay — silently lost on every pod restart.
- **api-server's template assembly never copied a template's `agentHome` into the Agent spec**, so the CR field the controller reads was never written by anything.

A configuration option that half the system ignores is worse than no option. (Surfaced by review on #3417; pre-existing, unrelated to that change.)

## Change

Fix the agent home at `/home/agent`, end to end:

- Chart: `templateDefaults.agentHome` removed; `$HOME` in mount paths substitutes the constant; `AGENT_HOME` env dropped from the controller and api-server deployments; rendered template specs no longer carry `agentHome`.
- Controller and agent-runtime read constants; the runtime's dead `HOME_DIR`/`WORK_DIR` config keys are gone.
- Upgrade-safe deprecation, same pattern as `accessMode`: the config struct keeps `AgentHome` so a still-set value logs a startup warning instead of failing the strict decode and crash-looping; the CR's `spec.agentHome` is retained but no longer read.

## Testing

- controller suite green (config default/parse tests updated to the retained-unread contract), staticcheck, build
- agent-runtime 208/208, api-server 1094/1094, helm render green

## Notes for reviewers

- No install sets any of these today (verified on dev: all agents and templates on defaults), so behavior is identical everywhere.
- Merge-order note: touches `resources.go`/`config.go` near regions #3417 also edits — whichever merges second gets a trivial rebase.
