### PR TITLE
fix(ui): surface the required provider across create and save flows

### DIFF
--- a/packages/ui/src/components/ui/rich-select.tsx
+++ b/packages/ui/src/components/ui/rich-select.tsx
@@ -1,4 +1,4 @@
-import { Checkmark, ChevronDown } from "@carbon/icons-react";
+import { Checkmark, ChevronDown, WarningFilled } from "@carbon/icons-react";
 import type { ReactNode } from "react";
 
 import { CARD_SURFACE } from "@/components/ui/card";
@@ -29,6 +29,7 @@ interface Props<T extends string> {
   placeholder: string;
   ariaLabel?: string;
   disabled?: boolean;
+  invalid?: boolean;
   testId?: string;
 }
 
@@ -39,6 +40,7 @@ export function RichSelect<T extends string>({
   placeholder,
   ariaLabel,
   disabled = false,
+  invalid = false,
   testId,
 }: Props<T>) {
   const selected = options.find((o) => o.value === value);
@@ -48,10 +50,13 @@ export function RichSelect<T extends string>({
         <button
           type="button"
           disabled={disabled}
+          aria-invalid={invalid || undefined}
           data-testid={testId}
           className={cn(
             CARD_SURFACE,
             "group flex min-h-[76px] w-full items-center gap-3.5 p-4 text-left transition-colors hover:border-muted-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-foreground",
+            invalid &&
+              "border-destructive hover:border-destructive data-[state=open]:border-destructive",
           )}
         >
           {ariaLabel && <span className="sr-only">{ariaLabel}</span>}
@@ -76,6 +81,9 @@ export function RichSelect<T extends string>({
             <p className="flex-1 text-[15px] text-muted-foreground">
               {placeholder}
             </p>
+          )}
+          {invalid && (
+            <WarningFilled size={18} className="shrink-0 text-destructive" />
           )}
           <ChevronDown
             size={18}

--- a/packages/ui/src/modules/agents/components/create-agent-inline.tsx
+++ b/packages/ui/src/modules/agents/components/create-agent-inline.tsx
@@ -83,6 +83,7 @@ export function CreateAgentInline({ onCreated }: Props) {
           selected={providerRef}
           onSelect={setProviderRef}
           autoSelectFirst
+          required
         />
       </div>
 

--- a/packages/ui/src/modules/platform/store/navigation.ts
+++ b/packages/ui/src/modules/platform/store/navigation.ts
@@ -100,9 +100,9 @@ export const createNavigationSlice: StateCreator<
     history.pushState(
       null,
       "",
-      routeToPath({ view: "knowledge-base-config", agentId }),
+      routeToPath({ view: "sandbox-home", agentId, sandboxSection: "setup" }),
     );
-    set({ view: "knowledge-base-config", agentId });
+    set({ view: "sandbox-home", agentId, sandboxSection: "setup" });
   },
   mobileScreen: "sessions",
   setMobileScreen: (screen) => set({ mobileScreen: screen }),

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -32,7 +32,8 @@ export function ProviderSelect({
   allow,
   recommended,
 }: Props) {
-  const { itemByType, typeByConnectionId, isPending } = useProviderItems();
+  const { itemByType, typeByConnectionId, isPending, isSuccess } =
+    useProviderItems();
   const [connecting, setConnecting] = useState<ProviderPresetType | null>(null);
   const [connected, setConnected] = useState<{
     id: string;
@@ -43,31 +44,31 @@ export function ProviderSelect({
     [allow, recommended],
   );
 
-  const selectedType = selected
+  const resolvedType = selected
     ? (typeByConnectionId.get(selected.id) ??
       (connected?.id === selected.id ? connected.type : null))
     : null;
+  const selectedType =
+    resolvedType && rows.some((row) => row.type === resolvedType)
+      ? resolvedType
+      : null;
 
-  const firstConnected = useMemo(
-    () => rows.map((r) => itemByType.get(r.type)).find(Boolean),
-    [rows, itemByType],
+  const autoSelectTarget = useMemo(
+    () =>
+      autoSelectFirst
+        ? rows.map((r) => itemByType.get(r.type)).find(Boolean)
+        : undefined,
+    [autoSelectFirst, rows, itemByType],
   );
 
   useEffect(() => {
-    if (isPending || selectedType) return;
-    if (autoSelectFirst && firstConnected) {
-      onSelect(providerRef(firstConnected));
+    if (!isSuccess || selectedType) return;
+    if (autoSelectTarget) {
+      onSelect(providerRef(autoSelectTarget));
     } else if (selected) {
       onSelect(null);
     }
-  }, [
-    isPending,
-    selectedType,
-    autoSelectFirst,
-    firstConnected,
-    selected,
-    onSelect,
-  ]);
+  }, [isSuccess, selectedType, autoSelectTarget, selected, onSelect]);
 
   const pick = async (type: ProviderPresetType) => {
     if (type === selectedType) return;
@@ -110,9 +111,7 @@ export function ProviderSelect({
         placeholder="Select a provider"
         ariaLabel="Provider"
         disabled={disabled}
-        invalid={
-          required && !selectedType && !(autoSelectFirst && firstConnected)
-        }
+        invalid={required && isSuccess && !selectedType && !autoSelectTarget}
         testId="provider-select"
       />
       {connecting && (

--- a/packages/ui/src/modules/providers/components/provider-select.tsx
+++ b/packages/ui/src/modules/providers/components/provider-select.tsx
@@ -13,10 +13,11 @@ import { type ProviderRef, providerRef } from "./provider-item.js";
 
 interface Props {
   selected: ProviderRef | null;
-  onSelect: (ref: ProviderRef) => void;
+  onSelect: (ref: ProviderRef | null) => void;
   confirmSwitch?: () => Promise<boolean>;
   autoSelectFirst?: boolean;
   disabled?: boolean;
+  required?: boolean;
   allow?: readonly ProviderPresetType[];
   recommended?: ProviderPresetType;
 }
@@ -27,6 +28,7 @@ export function ProviderSelect({
   confirmSwitch,
   autoSelectFirst = false,
   disabled = false,
+  required = false,
   allow,
   recommended,
 }: Props) {
@@ -46,11 +48,26 @@ export function ProviderSelect({
       (connected?.id === selected.id ? connected.type : null))
     : null;
 
+  const firstConnected = useMemo(
+    () => rows.map((r) => itemByType.get(r.type)).find(Boolean),
+    [rows, itemByType],
+  );
+
   useEffect(() => {
-    if (!autoSelectFirst || selected) return;
-    const first = rows.map((r) => itemByType.get(r.type)).find(Boolean);
-    if (first) onSelect(providerRef(first));
-  }, [autoSelectFirst, selected, itemByType, rows, onSelect]);
+    if (isPending || selectedType) return;
+    if (autoSelectFirst && firstConnected) {
+      onSelect(providerRef(firstConnected));
+    } else if (selected) {
+      onSelect(null);
+    }
+  }, [
+    isPending,
+    selectedType,
+    autoSelectFirst,
+    firstConnected,
+    selected,
+    onSelect,
+  ]);
 
   const pick = async (type: ProviderPresetType) => {
     if (type === selectedType) return;
@@ -93,6 +110,9 @@ export function ProviderSelect({
         placeholder="Select a provider"
         ariaLabel="Provider"
         disabled={disabled}
+        invalid={
+          required && !selectedType && !(autoSelectFirst && firstConnected)
+        }
         testId="provider-select"
       />
       {connecting && (

--- a/packages/ui/src/modules/providers/hooks/use-provider-items.ts
+++ b/packages/ui/src/modules/providers/hooks/use-provider-items.ts
@@ -6,7 +6,7 @@ import { useAppConnections } from "../../connections/api/queries.js";
 import type { ProviderItem } from "../components/provider-item.js";
 
 export function useProviderItems() {
-  const { data: connections = [], isPending } = useAppConnections();
+  const { data: connections = [], isPending, isSuccess } = useAppConnections();
 
   const { itemByType, typeByConnectionId } = useMemo(() => {
     const itemByType = new Map<ProviderPresetType, ProviderItem>();
@@ -21,5 +21,5 @@ export function useProviderItems() {
     return { itemByType, typeByConnectionId };
   }, [connections]);
 
-  return { itemByType, typeByConnectionId, isPending };
+  return { itemByType, typeByConnectionId, isPending, isSuccess };
 }

--- a/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-setup-section.tsx
@@ -86,6 +86,7 @@ export function SandboxSetupSection({ f }: Props) {
             onSelect={f.selectProvider}
             confirmSwitch={confirmSwitch}
             disabled={f.saving}
+            required={f.formReady}
           />
         </Inset>
         <p className="mt-3 text-xs text-muted-foreground">

--- a/packages/ui/src/modules/sandboxes/components/setup/setup-sections.tsx
+++ b/packages/ui/src/modules/sandboxes/components/setup/setup-sections.tsx
@@ -41,7 +41,7 @@ export function ProviderSection({
   policy,
 }: {
   selected: ProviderRef | null;
-  onSelect: (ref: ProviderRef) => void;
+  onSelect: (ref: ProviderRef | null) => void;
   policy: ReturnType<typeof setupProviderPolicy>;
 }) {
   return (
@@ -52,6 +52,7 @@ export function ProviderSection({
           selected={selected}
           onSelect={onSelect}
           autoSelectFirst
+          required
           allow={policy.allow}
           recommended={policy.recommended}
         />

--- a/packages/ui/src/modules/sandboxes/hooks/use-provider-staging.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-provider-staging.ts
@@ -31,12 +31,12 @@ export function useProviderStaging({
     return connId ? { id: connId } : null;
   }, [assignedAppIds, providerAppIds]);
 
-  const selectProvider = (ref: ProviderRef) =>
+  const selectProvider = (ref: ProviderRef | null) =>
     setAssignedAppIds(
       [
         ...new Set([
           ...getAssignedAppIds().filter((id) => !providerAppIds.has(id)),
-          ref.id,
+          ...(ref ? [ref.id] : []),
         ]),
       ].sort(),
     );

--- a/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-sandbox-settings-form.ts
@@ -154,7 +154,8 @@ export function useSandboxSettingsForm() {
   });
 
   const dirty = isDirty || net.dirty || harnessDraft.dirty;
-  const isSubmitDisabled = saving || !formReady || !dirty;
+  const isSubmitDisabled =
+    saving || !formReady || !dirty || selectedProvider === null;
 
   useUnsavedGuard(dirty);
 
@@ -194,6 +195,7 @@ export function useSandboxSettingsForm() {
     control,
     errors,
     saving,
+    formReady,
     selectedProvider,
     selectProvider,
     currentPreset,

--- a/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
@@ -47,7 +47,7 @@ export function useSectionSummaries(agent: AgentView | null): {
   warnings: SectionWarnings;
 } {
   const { data: templates = [] } = useTemplates();
-  const { data: apps = [], isPending: appsPending } = useAppConnections();
+  const { data: apps = [], isSuccess: appsLoaded } = useAppConnections();
   const connectionsQuery = useAgentConnections(agent?.id ?? null);
   const { data: schedules = [] } = useSchedules(agent?.id ?? null);
   const skillsState = useSkillsState(agent?.id ?? null);
@@ -74,11 +74,11 @@ export function useSectionSummaries(agent: AgentView | null): {
   );
 
   const missingProvider = useMemo(() => {
-    if (appsPending || !connectionsQuery.data) return false;
+    if (!appsLoaded || !connectionsQuery.data) return false;
     return !connectionsQuery.data.connections.some((c) =>
       providerAppIds.has(c.connectionId),
     );
-  }, [appsPending, connectionsQuery.data, providerAppIds]);
+  }, [appsLoaded, connectionsQuery.data, providerAppIds]);
 
   const staleModel = useStaleModel(agent?.id ?? null);
   const sourceCount = useSkillSourceCount(agent?.id ?? null);

--- a/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
+++ b/packages/ui/src/modules/sandboxes/hooks/use-section-summaries.ts
@@ -30,6 +30,8 @@ type SectionSummaries = Partial<Record<SandboxSection, string>>;
 type SectionWarnings = Partial<Record<SandboxSection, string>>;
 
 const STALE_MODEL_WARNING = "Saved model not offered by the current provider";
+const NO_PROVIDER_WARNING =
+  "No provider connected — the agent cannot reach a model";
 
 const plural = (n: number, word: string) => `${n} ${word}${n === 1 ? "" : "s"}`;
 
@@ -45,7 +47,7 @@ export function useSectionSummaries(agent: AgentView | null): {
   warnings: SectionWarnings;
 } {
   const { data: templates = [] } = useTemplates();
-  const { data: apps = [] } = useAppConnections();
+  const { data: apps = [], isPending: appsPending } = useAppConnections();
   const connectionsQuery = useAgentConnections(agent?.id ?? null);
   const { data: schedules = [] } = useSchedules(agent?.id ?? null);
   const skillsState = useSkillsState(agent?.id ?? null);
@@ -70,6 +72,13 @@ export function useSectionSummaries(agent: AgentView | null): {
       ),
     [apps],
   );
+
+  const missingProvider = useMemo(() => {
+    if (appsPending || !connectionsQuery.data) return false;
+    return !connectionsQuery.data.connections.some((c) =>
+      providerAppIds.has(c.connectionId),
+    );
+  }, [appsPending, connectionsQuery.data, providerAppIds]);
 
   const staleModel = useStaleModel(agent?.id ?? null);
   const sourceCount = useSkillSourceCount(agent?.id ?? null);
@@ -163,6 +172,10 @@ export function useSectionSummaries(agent: AgentView | null): {
       artifacts: artifactsSummary,
       usage: usageSummary,
     },
-    warnings: staleModel.stale ? { setup: STALE_MODEL_WARNING } : {},
+    warnings: missingProvider
+      ? { setup: NO_PROVIDER_WARNING }
+      : staleModel.stale
+        ? { setup: STALE_MODEL_WARNING }
+        : {},
   };
 }


### PR DESCRIPTION
Closes #3376

The provider field now shows the standard error state (red border, warning icon) immediately when it is empty, in all three creation flows and on an existing agent's provider card. Submit on agent settings is disabled while the provider is missing, and the Setup nav item gets a warning dot.

A draft holding a provider whose connection was deleted is repaired automatically: the first connected provider is re-selected, or the value is cleared so the error state and disabled Create button apply.

LiteLLM pre-selection already worked (recommended providers sort first in auto-select) and is unchanged.