### PR TITLE
refactor(agent-runtime): one bounded subprocess runner

### DIFF
--- a/packages/agent-runtime/src/__tests__/unit/git-protocol-client.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/git-protocol-client.test.ts
@@ -1,0 +1,104 @@
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { runOnce } from "../../core/run-once.js";
+import { createGitProtocolClient } from "../../modules/skills/infrastructure/git-protocol-client.js";
+
+/**
+ * TEST_OVERVIEW: the git client drives real git through the shared subprocess
+ * runner.
+ *
+ * Skill install clones and inspects repositories, so this client is the path a
+ * user actually feels when adding a skill from git. It had no coverage while it
+ * hand-rolled its own spawn; these tests exercise it against a repository
+ * created on disk, so the capture path (reading a sha out of stdout), the
+ * discard path (clone), and the failure mapping are all checked against a real
+ * subprocess rather than a stub.
+ */
+
+let tmp: string;
+let origin: string;
+
+async function git(cwd: string, ...args: string[]): Promise<void> {
+  const result = await runOnce({
+    command: [
+      "git",
+      "-c",
+      "user.email=bench@example.com",
+      "-c",
+      "user.name=Bench",
+      "-C",
+      cwd,
+      ...args,
+    ],
+    timeoutMs: 30_000,
+  });
+  if (!result.ok) throw new Error(JSON.stringify(result.error));
+}
+
+beforeEach(async () => {
+  tmp = await fs.mkdtemp(path.join(os.tmpdir(), "git-protocol-"));
+  origin = path.join(tmp, "origin");
+  await fs.mkdir(origin);
+  await git(origin, "init", "--quiet", "--initial-branch=main");
+  await fs.writeFile(path.join(origin, "SKILL.md"), "# skill\n", "utf8");
+  await git(origin, "add", "SKILL.md");
+  await git(origin, "commit", "--quiet", "-m", "add skill");
+});
+
+afterEach(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("git protocol client", () => {
+  /**
+   * TEST_SCENARIO: A shallow clone of a real repository lands the working
+   * tree at the destination — the path skill install takes for a git source.
+   */
+  it("should shallow-clone a repository onto disk", async () => {
+    const client = createGitProtocolClient();
+    const dest = path.join(tmp, "clone");
+
+    const result = await client.cloneShallow(`file://${origin}`, dest, 1);
+
+    expect(result.ok).toBe(true);
+    expect(await fs.readFile(path.join(dest, "SKILL.md"), "utf8")).toBe(
+      "# skill\n",
+    );
+  });
+
+  /**
+   * TEST_SCENARIO: Reading the last commit that touched a file goes through
+   * the capture path, so stdout must arrive intact and trimmed enough to use
+   * as a sha.
+   */
+  it("should read the sha that last touched a path", async () => {
+    const client = createGitProtocolClient();
+
+    const result = await client.lastTouchingSha(origin, "SKILL.md");
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.trim()).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  /**
+   * TEST_SCENARIO: A source that does not exist must come back as a domain
+   * failure carrying git's own complaint, not an exception and not a silent
+   * empty clone.
+   */
+  it("should report a missing source as a fetch failure", async () => {
+    const client = createGitProtocolClient();
+    const missing = `file://${path.join(tmp, "nope")}`;
+
+    const result = await client.cloneShallow(missing, path.join(tmp, "out"));
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("SourceFetchFailed");
+    if (result.error.kind !== "SourceFetchFailed") return;
+    expect(result.error.detail).toContain("exited");
+  });
+});

--- a/packages/agent-runtime/src/__tests__/unit/run-once.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/run-once.test.ts
@@ -9,9 +9,10 @@ import { describeFailure, runOnce } from "../../core/run-once.js";
  * unit, so the properties they each got subtly wrong are pinned here once: a
  * deadline that kills, a byte budget on retained output, decoding that
  * survives a multi-byte character split across stream chunks, and failure
- * reported as a value rather than thrown. Output is either retained and
- * returned or relayed line by line; a relaying caller streams without
- * retaining, so a long build cannot be capped out of existence.
+ * reported as a value rather than thrown — including the errors spawn raises
+ * synchronously. Output is either retained and returned or relayed line by
+ * line; a relaying caller streams without retaining, so a long build cannot be
+ * capped out of existence, and only one partial line is ever held.
  */
 
 const node = (script: string): string[] => ["node", "-e", script];
@@ -149,5 +150,42 @@ describe("runOnce", () => {
     if (!result.ok) return;
     expect(result.value.stdout).toBe("");
     expect(lines.sort()).toEqual(["err", "first", "last", "second"]);
+  });
+
+  /**
+   * TEST_SCENARIO: spawn rejects a malformed argv synchronously, before any
+   * event can fire. A runner whose contract is "failure is a value" must
+   * report that the same way, so no caller has to attach a catch.
+   */
+  it("should report a malformed argv as a failure value, not a rejection", async () => {
+    const result = await runOnce({ command: [""], timeoutMs: 5_000 });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("not-spawnable");
+  });
+
+  /**
+   * TEST_SCENARIO: A stream can produce megabytes without ever sending a
+   * newline — a build writing a progress meter with carriage returns does
+   * exactly this. The line-reassembly buffer must stay bounded, so the partial
+   * line is relayed instead of growing for the length of the run.
+   */
+  it("should relay a partial line rather than buffer a newline-less stream without bound", async () => {
+    const lines: string[] = [];
+    const result = await runOnce({
+      command: node(
+        "for (let i = 0; i < 3; i++) process.stdout.write('x'.repeat(1024 * 1024))",
+      ),
+      timeoutMs: 20_000,
+      onLine: (line) => lines.push(line),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stdout).toBe("");
+    expect(lines.length).toBeGreaterThan(1);
+    expect(Math.max(...lines.map((line) => line.length))).toBeLessThan(
+      3 * 1024 * 1024,
+    );
+    expect(lines.join("").length).toBe(3 * 1024 * 1024);
   });
 });

--- a/packages/agent-runtime/src/__tests__/unit/run-once.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/run-once.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from "vitest";
+
+import { describeFailure, runOnce } from "../../core/run-once.js";
+
+/**
+ * TEST_OVERVIEW: one subprocess, run to completion, reported as a value.
+ *
+ * Every caller that used to hand-roll spawn/decode/deadline now shares this
+ * unit, so the properties they each got subtly wrong are pinned here once: a
+ * deadline that kills, a byte budget on retained output, decoding that
+ * survives a multi-byte character split across stream chunks, and failure
+ * reported as a value rather than thrown. Output is either retained and
+ * returned or relayed line by line; a relaying caller streams without
+ * retaining, so a long build cannot be capped out of existence.
+ */
+
+const node = (script: string): string[] => ["node", "-e", script];
+
+describe("runOnce", () => {
+  /**
+   * TEST_SCENARIO: A command that succeeds returns its captured streams, with
+   * stdout and stderr kept apart.
+   */
+  it("should return captured stdout and stderr on success", async () => {
+    const result = await runOnce({
+      command: node(
+        "process.stdout.write('out'); process.stderr.write('warn')",
+      ),
+      timeoutMs: 5_000,
+    });
+    expect(result).toEqual({
+      ok: true,
+      value: { stdout: "out", stderr: "warn" },
+    });
+  });
+
+  /**
+   * TEST_SCENARIO: A non-zero exit is a value, not an exception, and carries
+   * the code plus stderr so a caller can build its own message.
+   */
+  it("should report a non-zero exit as a failure value", async () => {
+    const result = await runOnce({
+      command: node("process.stderr.write('boom'); process.exit(3)"),
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({ kind: "exited", code: 3, stderr: "boom" });
+    expect(describeFailure(["git", "clone"], result.error)).toBe(
+      "git clone exited 3: boom",
+    );
+  });
+
+  /**
+   * TEST_SCENARIO: A command that outlives its deadline is killed and
+   * reported as timed out — the promise must never hang on the child.
+   */
+  it("should kill and report a command that outlives its deadline", async () => {
+    const result = await runOnce({
+      command: node("setTimeout(() => {}, 60000)"),
+      timeoutMs: 20,
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "timed-out", timeoutMs: 20 },
+    });
+  });
+
+  /**
+   * TEST_SCENARIO: A binary that does not exist fails as not-spawnable rather
+   * than throwing out of the promise.
+   */
+  it("should report an unspawnable command as a failure value", async () => {
+    const result = await runOnce({
+      command: ["definitely-not-a-real-binary-xyz"],
+      timeoutMs: 5_000,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error.kind).toBe("not-spawnable");
+  });
+
+  /**
+   * TEST_SCENARIO: An empty command is a programming error, reported the same
+   * way rather than crashing on a missing binary name.
+   */
+  it("should reject an empty command", async () => {
+    const result = await runOnce({ command: [], timeoutMs: 5_000 });
+    expect(result).toEqual({
+      ok: false,
+      error: { kind: "not-spawnable", message: "empty command" },
+    });
+  });
+
+  /**
+   * TEST_SCENARIO: The byte budget is enforced in bytes, not UTF-16 units,
+   * and exceeding it kills the child instead of buffering without bound.
+   */
+  it("should cap retained output by bytes", async () => {
+    const result = await runOnce({
+      command: node("process.stdout.write('日'.repeat(1000))"),
+      timeoutMs: 5_000,
+      maxOutputBytes: 100,
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toEqual({
+      kind: "output-capped",
+      maxOutputBytes: 100,
+    });
+  });
+
+  /**
+   * TEST_SCENARIO: The pipe delivers bytes, so a chunk boundary can land
+   * inside a multi-byte character. Decoding per chunk would substitute
+   * U+FFFD; the runner must reassemble the character exactly.
+   */
+  it("should reassemble a multi-byte character split across chunks", async () => {
+    const script = `
+      const text = "překlad — 日本語";
+      const bytes = Buffer.from(text, "utf8");
+      const cut = Buffer.byteLength("překlad — ", "utf8") + 1;
+      process.stdout.write(bytes.subarray(0, cut));
+      setTimeout(() => process.stdout.write(bytes.subarray(cut)), 30);
+    `;
+    const result = await runOnce({ command: node(script), timeoutMs: 5_000 });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stdout).toBe("překlad — 日本語");
+    expect(result.value.stdout).not.toContain("�");
+  });
+
+  /**
+   * TEST_SCENARIO: A relaying caller gets whole lines as they arrive, from
+   * both streams, including a final line with no trailing newline — and
+   * nothing is retained, so streaming a long run cannot trip the budget.
+   */
+  it("should relay whole lines without retaining them", async () => {
+    const lines: string[] = [];
+    const result = await runOnce({
+      command: node(
+        "process.stdout.write('first\\nsec'); process.stderr.write('err\\n'); setTimeout(() => process.stdout.write('ond\\nlast'), 20)",
+      ),
+      timeoutMs: 5_000,
+      maxOutputBytes: 4,
+      onLine: (line) => lines.push(line),
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.value.stdout).toBe("");
+    expect(lines.sort()).toEqual(["err", "first", "last", "second"]);
+  });
+});

--- a/packages/agent-runtime/src/__tests__/unit/run-once.test.ts
+++ b/packages/agent-runtime/src/__tests__/unit/run-once.test.ts
@@ -46,7 +46,7 @@ describe("runOnce", () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toEqual({ kind: "exited", code: 3, stderr: "boom" });
-    expect(describeFailure(["git", "clone"], result.error)).toBe(
+    expect(describeFailure("git clone", result.error)).toBe(
       "git clone exited 3: boom",
     );
   });

--- a/packages/agent-runtime/src/core/run-once.ts
+++ b/packages/agent-runtime/src/core/run-once.ts
@@ -1,4 +1,5 @@
-import { spawn } from "node:child_process";
+import { type ChildProcessByStdio, spawn } from "node:child_process";
+import type { Readable } from "node:stream";
 import { StringDecoder } from "node:string_decoder";
 
 import { err, ok, type Result } from "./result.js";
@@ -6,6 +7,8 @@ import { err, ok, type Result } from "./result.js";
 const DEFAULT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
 
 const MAX_DESCRIBED_STDERR = 500;
+
+const MAX_PENDING_LINE_BYTES = 1024 * 1024;
 
 export interface RunOnceOptions {
   command: readonly string[];
@@ -56,12 +59,18 @@ export function describeFailure(
  * (SIGKILL on expiry, and the timeout is required — an unbounded subprocess is
  * never intended), a byte budget on retained output, and decoding that
  * reassembles multi-byte characters split across stream chunks. Failure is a
- * value, never an exception, because callers disagree about policy: some log
- * and continue, some reject, some fall back to another source. Output is
- * either retained and returned, or — when onLine is given — relayed line by
- * line and not retained at all, which is what a caller streaming a long build
- * into a log wants; only retained output is capped. Long-lived children (the
- * harness, a PTY, sshd) are out of scope: they have lifecycles, not results.
+ * value, never an exception — including the errors spawn raises
+ * synchronously on a malformed argv, cwd or env — because callers disagree
+ * about policy: some log and continue, some reject, some fall back to another
+ * source. Output is either retained and returned, or — when onLine is given —
+ * relayed line by line and not retained at all, which is what a caller
+ * streaming a long build into a log wants. maxOutputBytes caps retained
+ * output as one budget across both streams, because what it bounds is the
+ * memory this runner holds; a relaying caller retains nothing, so it is capped
+ * only by the 1 MB bound on one partial line, which is flushed as a line when
+ * a stream produces that many bytes without a newline. Long-lived children
+ * (the harness, a PTY, sshd) are out of scope: they have lifecycles, not
+ * results.
  */
 export function runOnce(opts: RunOnceOptions): Promise<RunOnceResult> {
   const maxOutputBytes = opts.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
@@ -74,11 +83,19 @@ export function runOnce(opts: RunOnceOptions): Promise<RunOnceResult> {
       return;
     }
 
-    const child = spawn(bin, args, {
-      cwd: opts.cwd,
-      env: opts.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    let child: ChildProcessByStdio<null, Readable, Readable>;
+    try {
+      child = spawn(bin, args, {
+        cwd: opts.cwd,
+        env: opts.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      resolve(
+        err({ kind: "not-spawnable", message: (error as Error).message }),
+      );
+      return;
+    }
 
     let settled = false;
     let stdout = "";
@@ -103,13 +120,21 @@ export function runOnce(opts: RunOnceOptions): Promise<RunOnceResult> {
     ): (() => void) => {
       const decoder = new StringDecoder("utf8");
       let pending = "";
+      let pendingBytes = 0;
       stream.on("data", (chunk: Buffer) => {
         const text = decoder.write(chunk);
         if (relay) {
           pending += text;
+          pendingBytes += chunk.length;
           const lines = pending.split("\n");
           pending = lines.pop() ?? "";
+          if (lines.length > 0) pendingBytes = Buffer.byteLength(pending);
           for (const line of lines) if (line) relay(line);
+          if (pendingBytes > MAX_PENDING_LINE_BYTES) {
+            relay(pending);
+            pending = "";
+            pendingBytes = 0;
+          }
           return;
         }
         retainedBytes += chunk.length;

--- a/packages/agent-runtime/src/core/run-once.ts
+++ b/packages/agent-runtime/src/core/run-once.ts
@@ -30,20 +30,21 @@ export type ProcessFailure =
 export type RunOnceResult = Result<ProcessOutput, ProcessFailure>;
 
 export function describeFailure(
-  command: readonly string[],
+  subject: string,
   failure: ProcessFailure,
 ): string {
-  const name = command.join(" ");
   switch (failure.kind) {
     case "not-spawnable":
-      return `${name} failed to start: ${failure.message}`;
+      return `${subject} failed to start: ${failure.message}`;
     case "timed-out":
-      return `${name} timed out after ${failure.timeoutMs}ms`;
+      return `${subject} timed out after ${failure.timeoutMs}ms`;
     case "output-capped":
-      return `${name} produced more than ${failure.maxOutputBytes} bytes of output`;
+      return `${subject} produced more than ${failure.maxOutputBytes} bytes of output`;
     case "exited": {
       const trimmed = failure.stderr.trim().slice(0, MAX_DESCRIBED_STDERR);
-      return `${name} exited ${failure.code}` + (trimmed ? `: ${trimmed}` : "");
+      return (
+        `${subject} exited ${failure.code}` + (trimmed ? `: ${trimmed}` : "")
+      );
     }
   }
 }

--- a/packages/agent-runtime/src/core/run-once.ts
+++ b/packages/agent-runtime/src/core/run-once.ts
@@ -1,0 +1,148 @@
+import { spawn } from "node:child_process";
+import { StringDecoder } from "node:string_decoder";
+
+import { err, ok, type Result } from "./result.js";
+
+const DEFAULT_MAX_OUTPUT_BYTES = 8 * 1024 * 1024;
+
+const MAX_DESCRIBED_STDERR = 500;
+
+export interface RunOnceOptions {
+  command: readonly string[];
+  timeoutMs: number;
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  maxOutputBytes?: number;
+  onLine?: (line: string) => void;
+}
+
+export interface ProcessOutput {
+  stdout: string;
+  stderr: string;
+}
+
+export type ProcessFailure =
+  | { kind: "not-spawnable"; message: string }
+  | { kind: "timed-out"; timeoutMs: number }
+  | { kind: "output-capped"; maxOutputBytes: number }
+  | { kind: "exited"; code: number | null; stderr: string };
+
+export type RunOnceResult = Result<ProcessOutput, ProcessFailure>;
+
+export function describeFailure(
+  command: readonly string[],
+  failure: ProcessFailure,
+): string {
+  const name = command.join(" ");
+  switch (failure.kind) {
+    case "not-spawnable":
+      return `${name} failed to start: ${failure.message}`;
+    case "timed-out":
+      return `${name} timed out after ${failure.timeoutMs}ms`;
+    case "output-capped":
+      return `${name} produced more than ${failure.maxOutputBytes} bytes of output`;
+    case "exited": {
+      const trimmed = failure.stderr.trim().slice(0, MAX_DESCRIBED_STDERR);
+      return `${name} exited ${failure.code}` + (trimmed ? `: ${trimmed}` : "");
+    }
+  }
+}
+
+/**
+ * UNIT_BOUNDARY_DESCRIPTION: Runs one short-lived subprocess to completion and
+ * reports what happened, so no caller hand-rolls the spawn/decode/deadline
+ * block. It owns the parts that are easy to get subtly wrong: a deadline
+ * (SIGKILL on expiry, and the timeout is required — an unbounded subprocess is
+ * never intended), a byte budget on retained output, and decoding that
+ * reassembles multi-byte characters split across stream chunks. Failure is a
+ * value, never an exception, because callers disagree about policy: some log
+ * and continue, some reject, some fall back to another source. Output is
+ * either retained and returned, or — when onLine is given — relayed line by
+ * line and not retained at all, which is what a caller streaming a long build
+ * into a log wants; only retained output is capped. Long-lived children (the
+ * harness, a PTY, sshd) are out of scope: they have lifecycles, not results.
+ */
+export function runOnce(opts: RunOnceOptions): Promise<RunOnceResult> {
+  const maxOutputBytes = opts.maxOutputBytes ?? DEFAULT_MAX_OUTPUT_BYTES;
+  const relay = opts.onLine;
+
+  return new Promise<RunOnceResult>((resolve) => {
+    const [bin, ...args] = opts.command;
+    if (bin === undefined) {
+      resolve(err({ kind: "not-spawnable", message: "empty command" }));
+      return;
+    }
+
+    const child = spawn(bin, args, {
+      cwd: opts.cwd,
+      env: opts.env,
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    let settled = false;
+    let stdout = "";
+    let stderr = "";
+    let retainedBytes = 0;
+
+    const settle = (result: RunOnceResult): void => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      settle(err({ kind: "timed-out", timeoutMs: opts.timeoutMs }));
+    }, opts.timeoutMs);
+
+    const readStream = (
+      stream: NodeJS.ReadableStream,
+      retain: (text: string) => void,
+    ): (() => void) => {
+      const decoder = new StringDecoder("utf8");
+      let pending = "";
+      stream.on("data", (chunk: Buffer) => {
+        const text = decoder.write(chunk);
+        if (relay) {
+          pending += text;
+          const lines = pending.split("\n");
+          pending = lines.pop() ?? "";
+          for (const line of lines) if (line) relay(line);
+          return;
+        }
+        retainedBytes += chunk.length;
+        retain(text);
+        if (retainedBytes > maxOutputBytes) {
+          child.kill("SIGKILL");
+          settle(err({ kind: "output-capped", maxOutputBytes }));
+        }
+      });
+      return () => {
+        const tail = pending + decoder.end();
+        if (relay) {
+          if (tail) relay(tail);
+          return;
+        }
+        retain(tail);
+      };
+    };
+
+    const flushStdout = readStream(child.stdout, (text) => (stdout += text));
+    const flushStderr = readStream(child.stderr, (text) => (stderr += text));
+
+    child.on("error", (error) =>
+      settle(err({ kind: "not-spawnable", message: error.message })),
+    );
+
+    child.on("close", (code) => {
+      flushStdout();
+      flushStderr();
+      if (code !== 0) {
+        settle(err({ kind: "exited", code, stderr }));
+        return;
+      }
+      settle(ok({ stdout, stderr }));
+    });
+  });
+}

--- a/packages/agent-runtime/src/modules/acp/infrastructure/__tests__/history-provider.test.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/__tests__/history-provider.test.ts
@@ -170,6 +170,6 @@ describe("exec history provider", () => {
       log: (msg) => messages.push(msg),
     });
     expect(await provider.fetch("sess-a")).toBeNull();
-    expect(messages.join("\n")).toContain("output exceeded 10 bytes");
+    expect(messages.join("\n")).toContain("more than 10 bytes");
   });
 });

--- a/packages/agent-runtime/src/modules/acp/infrastructure/history-provider.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/history-provider.ts
@@ -1,6 +1,6 @@
-import { spawn } from "node:child_process";
-import { StringDecoder } from "node:string_decoder";
 import { Worker } from "node:worker_threads";
+
+import { describeFailure, runOnce } from "../../../core/run-once.js";
 
 export interface HistoryProvider {
   fetch(sessionId: string): Promise<string[] | null>;
@@ -56,62 +56,26 @@ export function createExecHistoryProvider(
   const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxOutputBytes = deps.maxOutputBytes ?? MAX_EXEC_OUTPUT_BYTES;
   return {
-    fetch(sessionId) {
-      return new Promise((resolve) => {
-        const [bin, ...args] = deps.command;
-        if (!bin) {
-          resolve(null);
-          return;
-        }
-        const child = spawn(bin, [...args, sessionId], {
-          cwd: deps.cwd,
-          stdio: ["ignore", "pipe", "pipe"],
-        });
-        const stdoutDecoder = new StringDecoder("utf8");
-        const stderrDecoder = new StringDecoder("utf8");
-        let stdout = "";
-        let stdoutBytes = 0;
-        let stderr = "";
-        let settled = false;
-        const finish = (lines: string[] | null, reason?: string): void => {
-          if (settled) return;
-          settled = true;
-          clearTimeout(timer);
-          if (reason) deps.log(`history provider for ${sessionId}: ${reason}`);
-          resolve(lines);
-        };
-        const timer = setTimeout(() => {
-          child.kill("SIGKILL");
-          finish(null, `timed out after ${timeoutMs}ms`);
-        }, timeoutMs);
-        child.stdout.on("data", (d: Buffer) => {
-          stdoutBytes += d.length;
-          stdout += stdoutDecoder.write(d);
-          if (stdoutBytes > maxOutputBytes) {
-            child.kill("SIGKILL");
-            finish(null, `output exceeded ${maxOutputBytes} bytes`);
-          }
-        });
-        child.stderr.on("data", (d: Buffer) => {
-          stderr += stderrDecoder.write(d);
-        });
-        child.on("error", (error) =>
-          finish(null, `failed to start: ${error.message}`),
-        );
-        child.on("close", (code) => {
-          stdout += stdoutDecoder.end();
-          if (code !== 0) {
-            finish(null, `exited ${code}: ${stderr.trim().slice(0, 200)}`);
-            return;
-          }
-          const lines = validateLines(sessionId, stdout.split("\n"));
-          if (lines === null) {
-            finish(null, "emitted an invalid frame");
-            return;
-          }
-          finish(lines);
-        });
+    async fetch(sessionId) {
+      const command = [...deps.command, sessionId];
+      const result = await runOnce({
+        command,
+        cwd: deps.cwd,
+        timeoutMs,
+        maxOutputBytes,
       });
+      if (!result.ok) {
+        deps.log(
+          `history provider for ${sessionId}: ${describeFailure(command, result.error)}`,
+        );
+        return null;
+      }
+      const lines = validateLines(sessionId, result.value.stdout.split("\n"));
+      if (lines === null) {
+        deps.log(`history provider for ${sessionId}: emitted an invalid frame`);
+        return null;
+      }
+      return lines;
     },
   };
 }

--- a/packages/agent-runtime/src/modules/acp/infrastructure/history-provider.ts
+++ b/packages/agent-runtime/src/modules/acp/infrastructure/history-provider.ts
@@ -57,6 +57,10 @@ export function createExecHistoryProvider(
   const maxOutputBytes = deps.maxOutputBytes ?? MAX_EXEC_OUTPUT_BYTES;
   return {
     async fetch(sessionId) {
+      if (deps.command.length === 0) {
+        deps.log(`history provider for ${sessionId}: no command declared`);
+        return null;
+      }
       const command = [...deps.command, sessionId];
       const result = await runOnce({
         command,
@@ -66,7 +70,7 @@ export function createExecHistoryProvider(
       });
       if (!result.ok) {
         deps.log(
-          `history provider for ${sessionId}: ${describeFailure(command, result.error)}`,
+          `history provider for ${sessionId}: ${describeFailure(command.join(" "), result.error)}`,
         );
         return null;
       }

--- a/packages/agent-runtime/src/modules/git.ts
+++ b/packages/agent-runtime/src/modules/git.ts
@@ -1,8 +1,9 @@
-import { spawn } from "node:child_process";
 import { mergedSpawnEnv, type RuntimeEnvReader } from "../core/runtime-env.js";
+import { describeFailure, runOnce } from "../core/run-once.js";
 
 const GH_TOKEN_ENV = "GH_TOKEN";
 const SETUP_TIMEOUT_MS = 10_000;
+const SETUP_COMMAND = ["gh", "auth", "setup-git"];
 
 export function configureGitCredentialHelper(
   envReader: RuntimeEnvReader,
@@ -11,25 +12,11 @@ export function configureGitCredentialHelper(
   const env = mergedSpawnEnv(envReader);
   if (!env[GH_TOKEN_ENV]) return;
 
-  const proc = spawn("gh", ["auth", "setup-git"], {
-    stdio: ["ignore", "ignore", "pipe"],
+  void runOnce({
+    command: SETUP_COMMAND,
+    timeoutMs: SETUP_TIMEOUT_MS,
     env,
-  });
-  const stderr: Buffer[] = [];
-  const timer = setTimeout(() => {
-    proc.kill("SIGKILL");
-    log(`gh auth setup-git timed out after ${SETUP_TIMEOUT_MS}ms`);
-  }, SETUP_TIMEOUT_MS);
-  proc.stderr?.on("data", (c: Buffer) => stderr.push(c));
-  proc.on("error", (e) => {
-    clearTimeout(timer);
-    log(`gh auth setup-git failed: ${e.message}`);
-  });
-  proc.on("close", (code) => {
-    clearTimeout(timer);
-    if (code !== 0)
-      log(
-        `gh auth setup-git exited ${code}: ${Buffer.concat(stderr).toString().trim()}`,
-      );
+  }).then((result) => {
+    if (!result.ok) log(describeFailure(SETUP_COMMAND, result.error));
   });
 }

--- a/packages/agent-runtime/src/modules/git.ts
+++ b/packages/agent-runtime/src/modules/git.ts
@@ -17,6 +17,6 @@ export function configureGitCredentialHelper(
     timeoutMs: SETUP_TIMEOUT_MS,
     env,
   }).then((result) => {
-    if (!result.ok) log(describeFailure(SETUP_COMMAND, result.error));
+    if (!result.ok) log(describeFailure(SETUP_COMMAND.join(" "), result.error));
   });
 }

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/workspace-command-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/workspace-command-plugin.ts
@@ -80,6 +80,6 @@ async function runCommand(
     onLine: (line) => log(`[workspace-command] ${line}`),
   });
   if (!result.ok) {
-    throw new Error(describeFailure(["workspace command"], result.error));
+    throw new Error(describeFailure("workspace command", result.error));
   }
 }

--- a/packages/agent-runtime/src/modules/runtime-channel/drivers/workspace-command-plugin.ts
+++ b/packages/agent-runtime/src/modules/runtime-channel/drivers/workspace-command-plugin.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import type {
@@ -7,6 +6,8 @@ import type {
   Plugin,
   WorkspaceCommandEventPayload,
 } from "agent-runtime-api";
+
+import { describeFailure, runOnce } from "../../../core/run-once.js";
 
 const IMPL_NAME = "workspace-command";
 
@@ -66,36 +67,19 @@ async function sentinelExists(path: string): Promise<boolean> {
   }
 }
 
-function runCommand(
+async function runCommand(
   command: string,
   cwd: string,
   log: (msg: string) => void,
 ): Promise<void> {
-  return new Promise<void>((resolve, reject) => {
-    const proc = spawn("bash", ["-lc", command], {
-      cwd,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-    const relay = (chunk: Buffer) => {
-      const text = chunk.toString("utf8").replace(/\n$/, "");
-      if (text) log(`[workspace-command] ${text}`);
-    };
-    proc.stdout?.on("data", relay);
-    proc.stderr?.on("data", relay);
-    const timer = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(
-        new Error(`workspace command timed out after ${COMMAND_TIMEOUT_MS}ms`),
-      );
-    }, COMMAND_TIMEOUT_MS);
-    proc.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
-    proc.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) resolve();
-      else reject(new Error(`workspace command exited with code ${code}`));
-    });
+  const argv = ["bash", "-lc", command];
+  const result = await runOnce({
+    command: argv,
+    cwd,
+    timeoutMs: COMMAND_TIMEOUT_MS,
+    onLine: (line) => log(`[workspace-command] ${line}`),
   });
+  if (!result.ok) {
+    throw new Error(describeFailure(["workspace command"], result.error));
+  }
 }

--- a/packages/agent-runtime/src/modules/skills/infrastructure/git-protocol-client.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/git-protocol-client.ts
@@ -1,7 +1,8 @@
-import { spawn } from "node:child_process";
 import * as fs from "node:fs/promises";
 import type { Result, SkillsDomainError } from "agent-runtime-api";
 import { err, ok } from "agent-runtime-api";
+
+import { describeFailure, runOnce } from "../../../core/run-once.js";
 
 const COMMAND_TIMEOUT_MS = 60_000;
 
@@ -100,69 +101,12 @@ export function createGitProtocolClient(): GitProtocolClient {
 }
 
 async function runProc(cmd: string, args: string[]): Promise<void> {
-  await new Promise<void>((resolve, reject) => {
-    const proc = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
-    const stderrChunks: Buffer[] = [];
-    const timer = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(
-        new Error(
-          `${cmd} ${args.join(" ")} timed out after ${COMMAND_TIMEOUT_MS}ms`,
-        ),
-      );
-    }, COMMAND_TIMEOUT_MS);
-    proc.stderr?.on("data", (c: Buffer) => stderrChunks.push(c));
-    proc.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
-    proc.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve();
-        return;
-      }
-      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
-      reject(
-        new Error(
-          `${cmd} ${args.join(" ")} exited ${code}${stderr ? `: ${stderr}` : ""}`,
-        ),
-      );
-    });
-  });
+  await runCapture(cmd, args);
 }
 
 async function runCapture(cmd: string, args: string[]): Promise<string> {
-  return await new Promise<string>((resolve, reject) => {
-    const proc = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
-    const timer = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(
-        new Error(
-          `${cmd} ${args.join(" ")} timed out after ${COMMAND_TIMEOUT_MS}ms`,
-        ),
-      );
-    }, COMMAND_TIMEOUT_MS);
-    proc.stdout?.on("data", (c: Buffer) => stdoutChunks.push(c));
-    proc.stderr?.on("data", (c: Buffer) => stderrChunks.push(c));
-    proc.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
-    proc.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve(Buffer.concat(stdoutChunks).toString("utf8"));
-        return;
-      }
-      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
-      reject(
-        new Error(
-          `${cmd} ${args.join(" ")} exited ${code}${stderr ? `: ${stderr}` : ""}`,
-        ),
-      );
-    });
-  });
+  const command = [cmd, ...args];
+  const result = await runOnce({ command, timeoutMs: COMMAND_TIMEOUT_MS });
+  if (!result.ok) throw new Error(describeFailure(command, result.error));
+  return result.value.stdout;
 }

--- a/packages/agent-runtime/src/modules/skills/infrastructure/git-protocol-client.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/git-protocol-client.ts
@@ -107,6 +107,7 @@ async function runProc(cmd: string, args: string[]): Promise<void> {
 async function runCapture(cmd: string, args: string[]): Promise<string> {
   const command = [cmd, ...args];
   const result = await runOnce({ command, timeoutMs: COMMAND_TIMEOUT_MS });
-  if (!result.ok) throw new Error(describeFailure(command, result.error));
+  if (!result.ok)
+    throw new Error(describeFailure(command.join(" "), result.error));
   return result.value.stdout;
 }

--- a/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
@@ -1,4 +1,3 @@
-import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
@@ -12,6 +11,7 @@ import type {
   SourcePathReason,
 } from "agent-runtime-api";
 import { err, ok, SKILL_SOURCE_ROOTS } from "agent-runtime-api";
+import { describeFailure, runOnce } from "../../../core/run-once.js";
 import { parseFrontmatter } from "../domain/frontmatter.js";
 import type { SkillName } from "../domain/skill-name.js";
 import { judgeOrigin } from "../domain/skill-origin.js";
@@ -617,36 +617,8 @@ function hasNullBytes(buf: Buffer): boolean {
 }
 
 async function runProc(cmd: string, args: string[]): Promise<string> {
-  return new Promise<string>((resolve, reject) => {
-    const proc = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
-    const stdoutChunks: Buffer[] = [];
-    const stderrChunks: Buffer[] = [];
-    const timer = setTimeout(() => {
-      proc.kill("SIGKILL");
-      reject(
-        new Error(
-          `${cmd} ${args.join(" ")} timed out after ${COMMAND_TIMEOUT_MS}ms`,
-        ),
-      );
-    }, COMMAND_TIMEOUT_MS);
-    proc.stdout?.on("data", (c: Buffer) => stdoutChunks.push(c));
-    proc.stderr?.on("data", (c: Buffer) => stderrChunks.push(c));
-    proc.on("error", (e) => {
-      clearTimeout(timer);
-      reject(e);
-    });
-    proc.on("close", (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve(Buffer.concat(stdoutChunks).toString("utf8"));
-        return;
-      }
-      const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
-      reject(
-        new Error(
-          `${cmd} ${args.join(" ")} exited ${code}${stderr ? `: ${stderr}` : ""}`,
-        ),
-      );
-    });
-  });
+  const command = [cmd, ...args];
+  const result = await runOnce({ command, timeoutMs: COMMAND_TIMEOUT_MS });
+  if (!result.ok) throw new Error(describeFailure(command, result.error));
+  return result.value.stdout;
 }

--- a/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
+++ b/packages/agent-runtime/src/modules/skills/infrastructure/local-skill-repository.ts
@@ -619,6 +619,7 @@ function hasNullBytes(buf: Buffer): boolean {
 async function runProc(cmd: string, args: string[]): Promise<string> {
   const command = [cmd, ...args];
   const result = await runOnce({ command, timeoutMs: COMMAND_TIMEOUT_MS });
-  if (!result.ok) throw new Error(describeFailure(command, result.error));
+  if (!result.ok)
+    throw new Error(describeFailure(command.join(" "), result.error));
   return result.value.stdout;
 }


### PR DESCRIPTION
Follow-up to @tomkis's observation on #3400: almost none of `history-provider.ts` was about history. Stacked on #3400 because the exec provider is one of the six sites and only exists on that branch.

## The problem

Six hand-rolled spawn blocks, disagreeing on everything that matters:

| site | stdout | on failure | decode | output cap |
|---|---|---|---|---|
| `git.ts` | ignored | log, never throws | concat at end | none |
| `workspace-command-plugin.ts` | relayed to log | reject | **per chunk** | none |
| `local-skill-repository.ts` | captured | reject with stderr | concat at end | none |
| `git-protocol-client.ts` ×2 | one ignores, one captures | reject with stderr | concat at end | none |
| `history-provider.ts` (exec) | captured | resolve `null` | StringDecoder | 32 MB |

The UTF-16 and chunk-boundary bugs that came out of the last review round were in the generic half of that table, and `workspace-command-plugin.ts` still had the same per-chunk `toString()` — a chunk boundary inside a multi-byte character silently substitutes U+FFFD.

## The shape

`core/run-once.ts` owns the mechanics and nothing about any caller's domain:

- **deadline is required** — an unbounded subprocess is never intended, so it is not defaultable;
- **byte-true budget** on retained output, so `String.length` can never stand in for a byte count again;
- **`StringDecoder`** end to end, including the trailing partial sequence at close;
- **failure is a value**, not an exception — the callers genuinely disagree about policy (log and continue, reject, fall back to another source), and an exception would force one on all of them. Follows the existing `core/result.ts` convention. That includes the errors `spawn` raises *synchronously* on a malformed argv, `cwd` or `env`: they map to the same `not-spawnable` value instead of escaping as a rejection, so no caller needs a `catch` to honour the contract.
- **capture or relay** — pass `onLine` and you get whole lines with nothing retained, which is what streaming a long build into a log wants. `maxOutputBytes` is one budget across **both** retained streams, because what it bounds is the memory the runner holds. A relaying caller retains nothing, so the only buffer there is the partial line being reassembled, and that is flushed as a line at 1 MB — a build writing a carriage-return progress meter never sends a newline, and that must not grow for the length of the run.

`describeFailure()` renders any failure uniformly, so the four sites that build error strings stop each inventing their own.

## Out of scope, deliberately

`create-child-agent-process`, `ssh.ts`, `pod-service.ts` and the terminal PTY keep their own `spawn`. They are long-lived children with lifecycles, not results — forcing them under a "run once, bounded, collect output" contract is how a helper like this turns into a framework.

## Behavior changes worth knowing

- Every **capturing** site now caps retained output; only the history provider did before. The one relaying site — `workspace-command` — retains nothing, so what is bounded there is one partial line, not total output: a long build still streams in full.
- `maxOutputBytes` is a combined stdout+stderr budget. The exec history provider previously counted stdout alone against its 32 MB, so a history command writing tens of megabytes to stderr now trips the cap it would once have survived.
- `workspace-command` relays whole lines instead of raw chunks (fixes its decode bug as a side effect) and its failure message renders through `describeFailure`.
- Messages are uniform, with stderr clamped to 500 chars for log hygiene — the old exec provider clamped at 200, the others were unbounded.
- `git.ts` now pipes stdout instead of ignoring it (tiny output, and the cap protects it).

Net −202/+53 across the six sites, plus the runner and 10 tests covering what none of the sites tested individually: deadline kills, byte cap, split-multibyte reassembly, non-zero exit, unspawnable binary, empty command, a malformed argv that `spawn` rejects synchronously, line relay including a final line with no newline, and a newline-less stream that must not buffer without bound. Plus a `git-protocol-client` spec driving real `git` on disk — that client had no test at all. Runtime 253/253.

