### PR TITLE
chore: lock java platforms in mise.lock

### DIFF
--- a/mise.lock
+++ b/mise.lock
@@ -203,6 +203,29 @@ url = "https://get.helm.sh/helm-v4.2.0-windows-amd64.tar.gz"
 version = "21.0.2"
 backend = "core:java"
 
+[tools.java.options]
+shorthand_vendor = "openjdk"
+
+[tools.java."platforms.linux-arm64"]
+checksum = "sha256:08db1392a48d4eb5ea5315cf8f18b89dbaf36cda663ba882cf03c704c9257ec2"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-aarch64_bin.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha256:a2def047a73941e01a73739f92755f86b895811afb1f91243db214cff5bdac3f"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha256:b3d588e16ec1e0ef9805d8a696591bd518a5cea62567da8f53b5ce32d11d22e4"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_macos-aarch64_bin.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha256:8fd09e15dc406387a0aba70bf5d99692874e999bf9cd9208b452b5d76ac922d3"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_macos-x64_bin.tar.gz"
+
+[tools.java."platforms.windows-x64"]
+checksum = "sha256:b6c17e747ae78cdd6de4d7532b3164b277daee97c007d3eaa2b39cca99882664"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_windows-x64_bin.zip"
+
 [[tools.kubeconform]]
 version = "0.8.0"
 backend = "aqua:yannh/kubeconform"


### PR DESCRIPTION
The `java` entry in `mise.lock` was incomplete:

```toml
[[tools.java]]
version = "21.0.2"
backend = "core:java"
```

No `options`, no `platforms.*`. Every `mise install` fills those in, so the working tree goes dirty on its own. That blocks `mise run release:new`, which refuses to start unless `git status --porcelain` is empty.

This commits what mise generates: the openjdk vendor shorthand plus sha256 checksums for all 5 platforms, from the official `download.java.net` URLs. Platform-independent, so it is the same for everyone.

Verified: running `mise install` again after this produces no further changes, so the lock is stable and not churning. No CI job or git hook validates `mise.lock`, so nothing else is affected.

Not a mise version skew issue — local mise is `2026.7.15`, the same version used in `aaa19036 chore: regen mise.lock with mise 2026.7.15`.

https://claude.ai/code/session_01PQvgQoDfv8A1asV6m8eXoA
