### PR TITLE
feat(dam-experiment): add tiny-search example and update documentation

### DIFF
--- a/deploy/lima-k3s.yaml
+++ b/deploy/lima-k3s.yaml
@@ -18,6 +18,15 @@ images:
 # kills until the UI lost auth entirely. The per-user budget ceiling in
 # values-local.yaml must stay below this count so the platform stack always
 # keeps headroom.
+#
+# The same starvation runs in reverse from the HOST: with the VM sized to
+# every host core, a sustained CPU hog on the host (a forgotten dev server,
+# a runaway build) stalls the guest's vCPUs long enough to blow 3-second
+# liveness probes — postgres/redis get SIGTERMed while "Completed", the
+# api-server 500s, and a running experiment dies with it, all while the VM's
+# own load average looks innocent. When probes time out cluster-wide but
+# `free`/`df` inside the VM look fine, check `uptime` and top CPU consumers
+# on the host first, not the cluster.
 cpus: 10
 # Istio ambient (istiod + istio-cni + ztunnel + waypoint Deployment) adds
 # ~1 GiB of pod requests on top of the existing platform stack. On 4 GiB the

--- a/docs/architecture/experiments.md
+++ b/docs/architecture/experiments.md
@@ -1,6 +1,6 @@
 # Experiments
 
-Last verified: 2026-08-21
+Last verified: 2026-08-28
 
 ## Overview
 
@@ -238,10 +238,27 @@ span-referenced rollup, so the run panel and the baked results page list
 them. Only the run's driver may attach explicitly (foreign ids read as
 unknown), and drafts refuse attachment — results belong to runs.
 
+**Reporting survives an outage; the run does not pay for it.** Reports are
+observability, so a transient api-server outage costs latency, never the
+loop. The SDK retries the writes that are idempotent on the server — event
+batches (spans upsert by id), `finish`, and plan registration — and never
+retries `spawn`, where a duplicated POST is a second worker rather than a
+duplicate row. A rejected batch stays buffered for the next attempt instead
+of being dropped, and the buffer is bounded to the batch size the events
+route accepts: an unbounded retained batch would eventually outgrow that cap
+and then be rejected on every later attempt, wedging reporting for the rest
+of the run. Once a flush fails, further attempts park for a back-off window,
+so a long outage costs one retry ladder per window rather than one per
+reported event. Overflow past the bound drops the oldest events and says so
+in the driver's log — a bounded, visible loss instead of a silent wedge.
+
 ## Completion and liveness
 
 Starting a run stamps `executedAt`; the script's `finish` (or an unhandled exception
-reported by the SDK) flips `running → completed | failed`. In run mode the
+reported by the SDK) flips `running → completed | failed` — unless the run is
+already terminal, in which case `finish` is a no-op: the server answers `409`
+and the SDK treats a user Stop and a retried finish whose first attempt
+landed as the same observable state. In run mode the
 SDK also runs a **heartbeat**: a daemon thread with its own request path
 posts a no-op `heartbeat` event (~60 s) so a healthy loop that is quiet —
 blocked in a `spawn()`, deep in a local computation — keeps its activity

--- a/mise.lock
+++ b/mise.lock
@@ -203,6 +203,29 @@ url = "https://get.helm.sh/helm-v4.2.0-windows-amd64.tar.gz"
 version = "21.0.2"
 backend = "core:java"
 
+[tools.java.options]
+shorthand_vendor = "openjdk"
+
+[tools.java."platforms.linux-arm64"]
+checksum = "sha256:08db1392a48d4eb5ea5315cf8f18b89dbaf36cda663ba882cf03c704c9257ec2"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-aarch64_bin.tar.gz"
+
+[tools.java."platforms.linux-x64"]
+checksum = "sha256:a2def047a73941e01a73739f92755f86b895811afb1f91243db214cff5bdac3f"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz"
+
+[tools.java."platforms.macos-arm64"]
+checksum = "sha256:b3d588e16ec1e0ef9805d8a696591bd518a5cea62567da8f53b5ce32d11d22e4"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_macos-aarch64_bin.tar.gz"
+
+[tools.java."platforms.macos-x64"]
+checksum = "sha256:8fd09e15dc406387a0aba70bf5d99692874e999bf9cd9208b452b5d76ac922d3"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_macos-x64_bin.tar.gz"
+
+[tools.java."platforms.windows-x64"]
+checksum = "sha256:b6c17e747ae78cdd6de4d7532b3164b277daee97c007d3eaa2b39cca99882664"
+url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_windows-x64_bin.zip"
+
 [[tools.kubeconform]]
 version = "0.8.0"
 backend = "aqua:yannh/kubeconform"

--- a/mise.lock
+++ b/mise.lock
@@ -203,29 +203,6 @@ url = "https://get.helm.sh/helm-v4.2.0-windows-amd64.tar.gz"
 version = "21.0.2"
 backend = "core:java"
 
-[tools.java.options]
-shorthand_vendor = "openjdk"
-
-[tools.java."platforms.linux-arm64"]
-checksum = "sha256:08db1392a48d4eb5ea5315cf8f18b89dbaf36cda663ba882cf03c704c9257ec2"
-url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-aarch64_bin.tar.gz"
-
-[tools.java."platforms.linux-x64"]
-checksum = "sha256:a2def047a73941e01a73739f92755f86b895811afb1f91243db214cff5bdac3f"
-url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_linux-x64_bin.tar.gz"
-
-[tools.java."platforms.macos-arm64"]
-checksum = "sha256:b3d588e16ec1e0ef9805d8a696591bd518a5cea62567da8f53b5ce32d11d22e4"
-url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_macos-aarch64_bin.tar.gz"
-
-[tools.java."platforms.macos-x64"]
-checksum = "sha256:8fd09e15dc406387a0aba70bf5d99692874e999bf9cd9208b452b5d76ac922d3"
-url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_macos-x64_bin.tar.gz"
-
-[tools.java."platforms.windows-x64"]
-checksum = "sha256:b6c17e747ae78cdd6de4d7532b3164b277daee97c007d3eaa2b39cca99882664"
-url = "https://download.java.net/java/GA/jdk21.0.2/f2283984656d49d69e91c558476027ac/13/GPL/openjdk-21.0.2_windows-x64_bin.zip"
-
 [[tools.kubeconform]]
 version = "0.8.0"
 backend = "aqua:yannh/kubeconform"

--- a/packages/agents/claude-code/dam-skills/commands/experiment-onboard.md
+++ b/packages/agents/claude-code/dam-skills/commands/experiment-onboard.md
@@ -48,15 +48,25 @@ a round of correction and teaches them a menu that does not exist.
    you an answer to. `claude-code` is the default precisely so the first
    question can be about their goal and not about credentials.
 
-4. **Offer the bundled starter only if they have no target of their own:**
-   tiny-cache, a deliberately slow key/value cache with tests and a benchmark,
-   where each round rewrites it, latency across fixed seeds is the score, and
-   broken tests score nothing. The `dam-experiment` skill's
-   [tiny-cache starter reference](../dam-experiment/references/tiny-cache-starter.md)
-   has the design at both tiers — follow it rather than improvising a starter
-   of your own. The code ships inside the `dam-experiment` skill (its
-   `examples/tiny-cache/` directory) and is already on this pod; setup is one
-   local copy into the workspace — never clone or download anything.
+4. **Offer a bundled starter only if they have no target of their own.** Two
+   ship inside the `dam-experiment` skill, and they are already on this pod —
+   offer them as one line each and let the user pick:
+
+   - **tiny-cache** — a deliberately slow key/value cache; each round rewrites
+     it and throughput across fixed seeds is the score. This is the quick one:
+     a general coding agent per round, minutes each.
+   - **tiny-search** — a deliberately slow full-text search index with a
+     write-path guard metric; a `nous` campaign forms a hypothesis, commits to
+     a pass bar, and reports whether the mechanism held. This is the one that
+     shows hypothesis-driven optimization, about an hour.
+
+   Follow the skill's
+   [tiny-cache](../dam-experiment/references/tiny-cache-starter.md) or
+   [tiny-search](../dam-experiment/references/tiny-search-starter.md) reference
+   rather than improvising a starter of your own — each says which worker it is
+   shaped for and why the other one fits it badly. Both are local copies — the
+   code ships in the image, on this pod and on the worker's — so never clone or
+   download anything for either one.
 
 5. **Do not write the script yet.** Wait for their answer. Once they have
    described a goal, follow the `dam-experiment` skill: agree the image and the

--- a/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
@@ -135,11 +135,11 @@ whole envelope and get an explicit yes before writing the script:
   rather than at the first failed spawn.
 - **Iteration counts**: your loop's rounds, plus any the worker runs
   internally. Total runtime multiplies through them.
-- **Expected duration, stated in human terms.** "~25 min per campaign
-  iteration, two iterations, one round — about 1 h with queue slack" is a
-  deciding factor, not a footnote: the human may cut seeds or rounds to fit
-  the time they have, so give them the per-unit cost that makes that trade
-  legible. The `ttl_ms` you set is derived from this number — never the other
+- **Expected duration, stated in human terms.** "~1 h per campaign
+  iteration, one confirming iteration, one round — about 1 h with queue
+  slack" is a deciding factor, not a footnote: the human may cut seeds or
+  rounds to fit the time they have, so give them the per-unit cost that
+  makes that trade legible. The `ttl_ms` you set is derived from this number — never the other
   way around — and it is a **kill deadline, not pacing**: the platform reaps
   the target the moment it lapses, even mid-work. Size it at the worst
   plausible round plus generous slack (cold start alone is minutes; double
@@ -431,7 +431,12 @@ them on the table — then wrongly concludes it "can't force" a design it wants:
 
 `target_system.description` is substituted verbatim into the model's prompts —
 it is where baselines, exact CLI invocations, metric definitions and
-statistical guardrails belong. `plot_specs` runs figure scripts after each
+statistical guardrails belong. What it is NOT for: dictating the bundle's
+arms. The arm family is the tool's methodology and the reason its verdict is
+defensible; a measured iteration already includes the full standard bundle.
+Time-box with the schema's own knobs instead — `max_iterations`, `max_turns`
+(per-phase tool-use caps, e.g. `{design: 40, execute_analyze: 80}`), and the
+TTL sized from measured runs. `plot_specs` runs figure scripts after each
 `findings.json`, and `pre_work_script` runs a deterministic exploration before
 iteration 1 (a good place to measure the baseline). Full field list:
 `nous schema campaign`, mirrored in the image's own
@@ -471,6 +476,10 @@ instead of reporting the number as clean.
 Then report the objective score from best_found.json, the h-main arm status
 from the last iteration's findings.json, and a summary from
 meta_findings.json.
+Publish as you go, not only at the end: the moment an iteration completes,
+publish its findings.json (and any raw per-seed results worth keeping) as
+artifacts, and publish report.md the moment it exists. You can be killed by
+your deadline mid-campaign; whatever is unpublished at that moment is lost.
 Report per_seed as well: for EVERY seed of the confirming iteration, read the
 raw measurement files under runs/iter-<N>/results/<arm>/ and report its seed,
 baseline and treatment values for the primary metric, in the metric's own
@@ -560,17 +569,25 @@ Six things this example is really teaching:
   completion, or it stalls waiting for an answer nobody sends.
 - **Match the TTL to the real runtime — and know the clock starts at spawn.**
   `nous`-class work will run for hours if you let it, and the default liveness
-  deadline is not a promise your loop should lean on. Scope the campaign to
-  about an hour of work (see the interview above), estimate ~20–30 min per
-  campaign iteration at that size, and set the TTL at roughly double the
-  estimate: a spawn that queues for compute room spends its deadline waiting,
-  and a deadline that lands mid-measurement wastes the whole round. A heavy
-  worker also holds real CPU/memory/disk per target, so keep the fan-out to a
-  handful of arms, not dozens.
-- **Everything on the worker dies with it.** The worker is reaped right after
-  it reports; make the prompt name what to report and which files to publish
-  as artifacts (`report.md`, `meta_findings.json` — see the reference) or the
-  evidence is unrecoverable.
+  deadline is not a promise your loop should lean on. Estimate from **measured
+  runs, not hope**: a healthy 2-iteration campaign on a small target measured
+  ~60 min per iteration on a dev cluster — so the one-hour target means ONE
+  confirming iteration, and a 2-iteration campaign is a ~2 h proposal, said as
+  such. Set the TTL at roughly double the measured estimate: the clock also
+  pays for pod cold start, queueing for compute room, and degraded stretches —
+  a worker that cold-started into a cluster disturbance has crawled at a
+  twentieth of its healthy pace and then been executed by a TTL sized for the
+  healthy pace, losing everything. A heavy worker also holds real
+  CPU/memory/disk per target, so keep the fan-out to a handful of arms, not
+  dozens.
+- **Everything on the worker dies with it — so publish per iteration.** The
+  worker is reaped the moment it reports, hits its TTL, or its run is swept;
+  make the prompt name what to report and which files to publish as artifacts
+  (`report.md`, `meta_findings.json` — see the reference), and require each
+  iteration's `findings.json` to be published **as it completes**, not in a
+  final batch. Three consecutive campaigns have died mid-run (a starved node,
+  an inactivity reap, a TTL) and each lost hours of finished measurements that
+  publish-as-you-go would have kept.
 - **Bound the campaign's own parallelism — for survival *and* for the
   numbers.** The worker's memory limit is a hard ceiling for everything the
   campaign starts — benchmark daemons included — and blowing it OOM-kills the

--- a/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
@@ -48,10 +48,14 @@ The chat shows these as one-click chips on a fresh session, so answer them
 well — scannable, per Talking to the user above, ending on what the user can
 do next:
 
-- **"Show me an example to optimize"** → the tiny-cache starter
-  ([references/tiny-cache-starter.md](references/tiny-cache-starter.md)):
-  describe it in two or three sentences and offer to set it up. Show, don't
-  run.
+- **"Show me an example to optimize"** → the two bundled starters, one line
+  each: **tiny-cache** (a slow cache, rewritten by a coding agent each round —
+  minutes) and **tiny-search** (a slow search index optimized by a `nous`
+  campaign against a pre-registered bar and a write-path guard — about an
+  hour). Describe, ask which, and offer to set it up. Show, don't run; the
+  references are
+  [tiny-cache](references/tiny-cache-starter.md) and
+  [tiny-search](references/tiny-search-starter.md).
 - **"How do experiments work?"** → the loop in plain words: you describe a
   goal, we agree the design, I write it as a Python loop; each round proposes
   a candidate, builds it, measures it, and reports a score; the platform
@@ -168,15 +172,24 @@ Present it as a short list of decisions, not prose, and let them change any
 line. Silence is not approval: if they have not answered, ask again rather
 than picking a default and proceeding.
 
-## No target? The bundled starter
+## No target? Two bundled starters
 
-A user who wants to see how experiments work but has nothing to optimize gets
-**tiny-cache** — a deliberately slow cache with a behavioral suite and a
-deterministic benchmark, shipped inside this skill at
-[examples/tiny-cache/](examples/tiny-cache/). Follow
-[references/tiny-cache-starter.md](references/tiny-cache-starter.md) for the
-baseline ritual and the loop design — the worker harness is the user's pick,
-as always.
+A user who wants to see how experiments work but has nothing of their own to
+optimize gets one of two deliberately-slow Node packages shipped inside this
+skill. Both are dependency-free, single-process, and measurable in seconds;
+they differ in which worker they are shaped for, so pick by what the user
+wants to see:
+
+| Starter | Worker | Shows |
+|---|---|---|
+| [tiny-cache](references/tiny-cache-starter.md) ([code](examples/tiny-cache/)) | `claude-code` loop | your driver owning the ruler: it runs the locked bench, sweeps n, and scores each point |
+| [tiny-search](references/tiny-search-starter.md) ([code](examples/tiny-search/)) | `nous` campaign | a worker forming a hypothesis, pre-registering a bar, and reporting whether the mechanism held — with a guard metric it can fail |
+
+Follow the reference for whichever they choose; each carries its baseline
+ritual, its scoring design, and the size that fits the hour. **Don't cross
+them over.** tiny-cache on `nous` loses the pristine ruler and lands its
+optimized side on the timer floor; tiny-search in a hand-driven loop throws
+away the campaign machinery that is the only reason to look at it.
 
 ## Authoring a script
 
@@ -387,6 +400,42 @@ and when it breaks the hour, **cut scope, never the TTL** — fewer seeds, fewer
 iterations, a narrower question. The TTL still gets generous slack over
 whatever the estimate ends up being (a killed working pod wastes everything);
 the hour budgets the *work*, not the deadline.
+
+### You do not write the campaign's arms — but you do pin its design
+
+The worker authors its own hypothesis bundle: the arms (`h-main`,
+`h-ablation`, `h-super-additivity`, `h-control-negative`, `h-robustness`, and
+campaign-specific ones like `h-dose-response`) come out of its DESIGN phase,
+not out of your prompt. That is the point of the image, and it is why a Nous
+round is one spawn instead of a loop you drive.
+
+**It does not follow that you have no control.** `campaign.yaml` carries four
+fields that steer the design hard, and an agent that only writes prose leaves
+them on the table — then wrongly concludes it "can't force" a design it wants:
+
+- **`research_question`** — phrase it as the shape of the answer you want. "Is
+  X faster?" invites a yes/no; "does X's cost become independent of n?" invites
+  a curve, and the designer reaches for a dose-response arm on its own.
+- **`target_system.controllable_knobs`** — names the knobs the designer may
+  vary. Put the sweep variable here or it may never be swept.
+- **`ground_truth.direction_claim`** / `pass_condition` / `primary_metric` /
+  `seeds` — pre-registered and rendered into the agent's prompt, so it cannot
+  move the goalposts. A direction claim stated as a trend ("baseline cost grows
+  ~linearly in n while the treatment stays flat") commits the campaign to
+  measuring the trend.
+- **`locked_parameters`** — hard-pinned values that MUST reappear identically
+  in the bundle's `verified_parameters`; a mismatch fails validation **even
+  under `--auto-approve`**. This is the actual enforcement mechanism: put the
+  n grid, the rep count, and the seed list here and the campaign cannot
+  quietly measure something else.
+
+`target_system.description` is substituted verbatim into the model's prompts —
+it is where baselines, exact CLI invocations, metric definitions and
+statistical guardrails belong. `plot_specs` runs figure scripts after each
+`findings.json`, and `pre_work_script` runs a deterministic exploration before
+iteration 1 (a good place to measure the baseline). Full field list:
+`nous schema campaign`, mirrored in the image's own
+`.agents/skills/nous/reference/campaign-schema.md`.
 
 Bake the answers into the campaign prompt so the worker doesn't re-decide
 them. How the worker's results are laid out on disk — the stable verdict

--- a/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
@@ -486,7 +486,10 @@ baseline and treatment values for the primary metric, in the metric's own
 unit. Read those numbers from the raw files, never from report.md's prose or
 tables. Report per_arm too — arm_type, status and effect for every arm you
 measured, ablations included; the decomposition is the mechanism, and prose is
-not where it survives."""
+not where it survives.
+Report cost too, from llm_metrics_summary.json (or `nous cost <run_id>`):
+total USD, total tokens, and LLM call count. These files are stable and
+always exist — report them even when the campaign fails."""
 
 with x.Experiment("nous-campaigns") as exp:
     loop = exp.loop("rounds", description="one Nous campaign per pass")
@@ -511,6 +514,8 @@ with x.Experiment("nous-campaigns") as exp:
                                    "treatment": "number"}],
                      "per_arm": [{"arm_type": "string", "status": "string",
                                   "effect": "number"}],
+                     "cost": {"usd": "number", "tokens": "integer",
+                              "llm_calls": "integer"},
                      "pr_url": "string?"}),
                 template=worker,
                 connections=connections,
@@ -532,6 +537,7 @@ with x.Experiment("nous-campaigns") as exp:
             "median": statistics.median(speedups),
             "seeds_passing": sum(1 for s in speedups if s >= PASS_BAR),
             "arms": result["per_arm"],  # or a stage of their own, one span per arm
+            "cost": result["cost"],
             "status": result["status"],
         }})
         hypothesis = next_hypothesis(result)  # your own choice of what to try
@@ -656,8 +662,10 @@ tables warrant one — make sure the run's presentation carries:
   agree instead of the chart showing one dot next to a table of ten rows.
 - **Time** — when the run started, elapsed, and per-round durations; the
   human approved a duration estimate, and the run should show how it tracked.
-- **Token / cost consumption**, when the worker reports it (a Nous campaign's
-  meta findings carry cost data — pass it through).
+- **Token / cost consumption** — demand it in the typed result rather than
+  hoping the worker volunteers it (a Nous campaign always has
+  `llm_metrics_summary.json`; "when reported, pass it through" is how three
+  runs shipped without a cost number).
 - **Notes and caveats** — what the result does *not* claim ("3 seeds is a
   smoke run"), stated on the run itself rather than left in the chat.
 - **Next steps** — what a follow-up run would change: more seeds, a wider

--- a/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/SKILL.md
@@ -233,7 +233,11 @@ Rules that matter:
 - **Every loop and stage carries a `description`** — one plain sentence on
   what happens there and what it reports. It shows on the node in the live
   graph, so the user can read the design off the UI instead of decoding ids
-  like `verify`. Bare ids are for throwaway spikes only.
+  like `verify`. Bare ids are for throwaway spikes only. And the id itself is
+  the chart legend, so name stages for a reader who never saw the script —
+  `speedup-per-seed`, `arm-decomposition` — not for the code (`seed-score`,
+  `arm-score`, `verdict` are the exact three that once sent a user asking
+  what their own chart meant).
 - **The worker image comes from the catalog, never from a guess.** Resolve it
   with `x.require_image(<id>)` in the declaration section and pass that value
   as `template=`. Don't hardcode `claude-code` because it is the familiar one.
@@ -339,6 +343,17 @@ The failure modes below are all real ones, and they are decided at design time
   that its per-seed files did not exist; the driver had the right numbers in
   hand the whole time. Publish the worker's narrative as commentary, clearly
   labelled, and make the run's own summary the one derived from data.
+- **A boolean is not a score series.** A pass/fail verdict belongs in
+  `exp.post_data(...)` as a card the stock dashboard renders — the verdict
+  plus each named check and its outcome — not on the chart. A run once
+  scored its `verdict` stage with the median speedup: a redundant line that
+  duplicated an existing series while the actual pass/fail hid in the attrs.
+  If a verdict series is truly wanted, score `1.0` or `0.0` and nothing else.
+- **Missing data must look missing.** Never map an invalid value onto a
+  legible one: a `log2(effect) if effect > 0 else 0.0` guard renders garbage
+  as "no change", which is a *finding*. Write no score at all, set an
+  `invalid` attr with the reason, and let the gap in the series say what
+  happened.
 
 ### A purpose-built worker: one Nous campaign per iteration
 
@@ -487,15 +502,24 @@ unit. Read those numbers from the raw files, never from report.md's prose or
 tables. Report per_arm too — arm_type, status and effect for every arm you
 measured, ablations included; the decomposition is the mechanism, and prose is
 not where it survives.
+For per_arm, effect is DEFINED as: that arm's OWN baseline value of {metric}
+divided by that arm's OWN treatment value, measured separately per arm on the
+same seeds. It is a ratio: >1 means the arm helped, 1.0 means no change, and
+a control that changes nothing must come out ~1.0 — never 0, never blank,
+never a value copied from another arm.
 Report cost too, from llm_metrics_summary.json (or `nous cost <run_id>`):
-total USD, total tokens, and LLM call count. These files are stable and
-always exist — report them even when the campaign fails."""
+total USD, total tokens, and LLM call count, plus the campaign's own run_id
+so cost stays re-derivable. These files are stable and always exist — report
+them even when the campaign fails.
+Publish the winning change itself — cumulative.patch — as an artifact, so the
+driver can apply it to its own copy and re-measure rather than take your
+numbers on faith."""
 
 with x.Experiment("nous-campaigns") as exp:
     loop = exp.loop("rounds", description="one Nous campaign per pass")
     campaign = loop.stage("campaign", description="the worker runs a whole campaign")
     seed_score = loop.stage(
-        "seed-score", after=campaign,
+        "speedup-per-seed", after=campaign,
         description="one point per measured seed; the chart plots these",
     )
 
@@ -509,7 +533,7 @@ with x.Experiment("nous-campaigns") as exp:
                 CAMPAIGN.format(repo=REPO, hypothesis=hypothesis, metric=METRIC,
                                 pass_condition=PASS_CONDITION,
                                 campaign_iters=CAMPAIGN_ITERS, seeds=SEEDS),
-                x.s({"status": "string", "summary": "string",
+                x.s({"status": "string", "summary": "string", "run_id": "string",
                      "per_seed": [{"seed": "integer", "baseline": "number",
                                    "treatment": "number"}],
                      "per_arm": [{"arm_type": "string", "status": "string",
@@ -523,6 +547,11 @@ with x.Experiment("nous-campaigns") as exp:
             )
             span.attrs["summary"] = result["summary"]
             span.attrs["status"] = result["status"]
+        # Worker numbers are claims, not facts: validate before scoring
+        # (coverage, positivity, distinct arms, sign agreement — see below).
+        # Record problems instead of raising: bad evidence belongs on the
+        # results page, and result_valid gates the verdict.
+        problems = validation_problems(result)
         # One scored span per seed: a single campaign still draws a readable
         # distribution, and the spread is the scientific content.
         speedups = []
@@ -539,6 +568,8 @@ with x.Experiment("nous-campaigns") as exp:
             "arms": result["per_arm"],  # or a stage of their own, one span per arm
             "cost": result["cost"],
             "status": result["status"],
+            "result_valid": not problems,
+            "problems": problems,
         }})
         hypothesis = next_hypothesis(result)  # your own choice of what to try
 ```
@@ -549,7 +580,40 @@ str(e)` (the message carries the platform's reason — OOM, deadline, crash),
 mark the span failed, and continue to the next round. An uncaught failure
 kills the script and every remaining round with it.
 
-Six things this example is really teaching:
+Nine things this example is really teaching:
+
+- **Define every number you demand.** A schema field typed `"number"` with no
+  definition is an invitation to guess, and the worker will accept it: a run
+  once returned `effect = -1.056` on all five arms because nobody said what
+  `effect` was a number *of* — every downstream failure traced back to that
+  one gap. For each numeric field, the prompt states the formula, the unit,
+  the direction, and the value an inert control must produce (~1.0 for a
+  ratio — never 0, never blank, never copied between arms).
+- **Validate before you score.** Every worker-reported number is a claim
+  until it survives a gate the driver runs before writing any span:
+  - coverage — per-seed / per-n arrays match exactly the seeds and grid you
+    pinned; timings are positive;
+  - **distinct arms** — arms run different code and cannot agree to six
+    decimals; identical effects are a constant, not a measurement;
+  - **sign agreement** — an arm claiming "2× slower" while the raw numbers of
+    the same run show "4706× faster" is irreconcilable and must fail loudly;
+  - a plausibility ceiling — a headline past it (say 1000×) passes only with
+    corroboration (checksums unchanged, ruler untouched), because that
+    magnitude is where broken benchmarks live;
+  - the worker's baseline within a few × of one the driver measured itself;
+  - the campaign's own verdict — `h_main_status == "CONFIRMED"` from
+    `findings.json`, so a numerically-passing run cannot hide a REFUTED arm.
+  Record the problems in `post_data` instead of raising — bad evidence must
+  be visible on the results page — and gate the verdict on `result_valid`.
+- **Replicate when the driver can.** The strongest verification is not a
+  check, it is re-measurement: the worker publishes `cumulative.patch`, and a
+  driver that holds its own pristine copy of the target applies the patch,
+  runs the tests and the bench itself, and computes the headline from its
+  own numbers — the worker's figures become a cross-check, and every
+  self-graded field (tests, checksums, ruler lock, timings) becomes a
+  driver-confirmed one. Do this whenever the measurement runs on plain local
+  tooling; skip it only when the measurement needs hardware or state the
+  driver lacks.
 
 - **The round is silent until it ends.** One campaign per round means one span
   running for hours with nothing to show — no points, no progress, and the

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/.gitignore
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+*.log

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
@@ -15,7 +15,8 @@ the exercise.
 - **replace on re-add**, `remove()`, result `limit` (default 10)
 - **Unicode tokenizer** — lowercases, then splits on every run of characters
   that are neither a Unicode letter (`\p{L}`) nor a Unicode number (`\p{N}`),
-  so `café` and `día` tokenize as single terms
+  so `café` and `día` tokenize as single terms; input is normalized to NFC
+  first, so a decomposed document matches a composed query
 
 A campaign optimizes against this contract, so treat it as the specification:
 `add()`, `search()` and `tokenize()` reject bad input (`TypeError`) rather
@@ -38,7 +39,7 @@ index.search("rust fast");   // [{ id: "alpha", score: 3 }]
 
 ## Tests
 
-Behavioral test suite (node:test, no install needed) — 13 tests pinning the
+Behavioral test suite (node:test, no install needed) — 19 tests pinning the
 tokenizer, AND semantics, occurrence scoring, ordering, tie-breaks, limits,
 replace-on-re-add, and removal:
 
@@ -65,6 +66,13 @@ Term frequencies are Zipf-ish (early vocabulary words are common, late ones
 rare), and the checksum folds every query's result ids and scores — a rewrite
 that changes search semantics changes the checksum even if it gets faster.
 
+On the write path the checksum folds `index.size` after every `add()` plus a
+verification query every `VERIFY_EVERY` (16) operations. `index.size` alone is
+invariant by construction, so it would detect nothing; the sampled query is
+what makes `index-heavy` a real guard. It is sampled rather than run on every
+write because each one costs a full corpus scan, which would dominate the
+scenario's own measurement.
+
 Reference baseline (Node 24, Apple Silicon): query-heavy p50 ≈ 12 ms at
 `--n 5000`, ≈ 49 ms at `--n 20000` — latency grows linearly with the corpus.
 `index-heavy` p50 ≈ 23 µs.
@@ -90,7 +98,7 @@ Suggested pre-registration:
 - **Primary metric:** `speedup_p50` on `query-heavy` at `--n 5000`
   (baseline p50 ÷ candidate p50), higher is better.
 - **Pass condition:** median speedup ≥ 20 across 5 seeds, ≥ 4/5 seeds
-  individually ≥ 20, all 13 tests green, per-seed `checksum` unchanged, and
+  individually ≥ 20, all 19 tests green, per-seed `checksum` unchanged, and
   `index-heavy` p50 regression ≤ 3×.
 - **Dose-response:** the effect should grow with `--n` (try 1000 / 5000 /
   20000) — a mechanism claim about scan cost predicts that; a fixed-overhead

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
@@ -1,0 +1,84 @@
+# tiny-search
+
+A minimal in-memory full-text search index for Node.js. No dependencies.
+
+It is **deliberately naive** — `search()` re-tokenizes every document from
+raw text on every query and scans the full token list once per query term;
+there is no index of any kind — so an optimization campaign has real,
+measurable headroom (~50–70×, not 5%) against a behavioral suite that must
+stay green. Do not "fix" the naive implementation in place — the slowness is
+the exercise.
+
+- **AND semantics** — a document matches only if it contains every query term
+- **occurrence scoring** — score = total occurrences of all query terms
+- **deterministic ordering** — score descending, ties by id ascending
+- **replace on re-add**, `remove()`, result `limit` (default 10)
+
+## Usage
+
+```js
+import { TinySearch } from "./src/tiny-search.js";
+
+const index = new TinySearch();
+index.add("alpha", "Rust is fast. Rust is safe.");
+index.add("bravo", "Go is simple and fast");
+index.search("fast");        // [{ id: "alpha", score: 1 }, { id: "bravo", score: 1 }]
+index.search("rust fast");   // [{ id: "alpha", score: 3 }]
+```
+
+## Tests
+
+Behavioral test suite (node:test, no install needed) — 13 tests pinning the
+tokenizer, AND semantics, occurrence scoring, ordering, tie-breaks, limits,
+replace-on-re-add, and removal:
+
+```sh
+npm test          # or: node --test
+```
+
+## Benchmark
+
+Deterministic per seed; prints one JSON line with per-op latency percentiles
+and a **result checksum** — same seed and same semantics always produce the
+same checksum, so a rewrite that changes behavior is caught even when the
+tests are not looking:
+
+```sh
+node bench/bench.mjs --scenario query-heavy --n 5000  --ops 400  --seed 1
+node bench/bench.mjs --scenario index-heavy --n 5000  --ops 2000 --seed 1
+node bench/bench.mjs --scenario mixed       --n 5000  --ops 400  --seed 1
+```
+
+Output fields: `p50_us`, `p95_us`, `mean_us` (per-operation latency in
+microseconds), `ops_per_sec`, `build_ms` (initial corpus load), `checksum`.
+
+Reference baseline (Node 24, Apple Silicon): query-heavy p50 ≈ 12 ms at
+`--n 5000`, ≈ 49 ms at `--n 20000` — latency grows linearly with the corpus.
+`index-heavy` p50 ≈ 23 µs.
+
+## Running it as an optimization campaign
+
+The repo is shaped for unattended, hypothesis-driven optimization:
+
+- **Single process, low memory.** The benchmark starts no daemons and peaks
+  well under 100 MB — nothing to OOM, nothing to contend with. Run
+  measurement arms serially anyway; concurrent instances pollute latency.
+- **Fast measurements.** One bench invocation is seconds, so an iteration of
+  arms × seeds fits comfortably inside an hour.
+- **No network, no installs.** Zero dependencies; `node --test` and the bench
+  run offline.
+- **A guard metric.** Any indexing strategy pays its cost on the write path —
+  bound the regression on `index-heavy` instead of pretending it is free.
+- **Anti-cheat.** `test/` and `bench/` are the ruler: a candidate that edits
+  them scores nothing, and the per-seed `checksum` must not change.
+
+Suggested pre-registration:
+
+- **Primary metric:** `speedup_p50` on `query-heavy` at `--n 5000`
+  (baseline p50 ÷ candidate p50), higher is better.
+- **Pass condition:** median speedup ≥ 20 across 5 seeds, ≥ 4/5 seeds
+  individually ≥ 20, all 13 tests green, per-seed `checksum` unchanged, and
+  `index-heavy` p50 regression ≤ 3×.
+- **Dose-response:** the effect should grow with `--n` (try 1000 / 5000 /
+  20000) — a mechanism claim about scan cost predicts that; a fixed-overhead
+  fix does not.

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
@@ -51,6 +51,9 @@ node bench/bench.mjs --scenario mixed       --n 5000  --ops 400  --seed 1
 
 Output fields: `p50_us`, `p95_us`, `mean_us` (per-operation latency in
 microseconds), `ops_per_sec`, `build_ms` (initial corpus load), `checksum`.
+Term frequencies are Zipf-ish (early vocabulary words are common, late ones
+rare), and the checksum folds every query's result ids and scores — a rewrite
+that changes search semantics changes the checksum even if it gets faster.
 
 Reference baseline (Node 24, Apple Silicon): query-heavy p50 ≈ 12 ms at
 `--n 5000`, ≈ 49 ms at `--n 20000` — latency grows linearly with the corpus.

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/README.md
@@ -13,6 +13,16 @@ the exercise.
 - **occurrence scoring** — score = total occurrences of all query terms
 - **deterministic ordering** — score descending, ties by id ascending
 - **replace on re-add**, `remove()`, result `limit` (default 10)
+- **Unicode tokenizer** — lowercases, then splits on every run of characters
+  that are neither a Unicode letter (`\p{L}`) nor a Unicode number (`\p{N}`),
+  so `café` and `día` tokenize as single terms
+
+A campaign optimizes against this contract, so treat it as the specification:
+`add()`, `search()` and `tokenize()` reject bad input (`TypeError`) rather
+than degrading silently, and `search()` requires a non-negative integer
+`limit`. Note that `add()` calls the linear `remove()` to replace an existing
+id, so building a corpus is quadratic — that is a second deliberate source of
+slowness alongside the per-query re-tokenization.
 
 ## Usage
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
@@ -1,0 +1,150 @@
+/**
+ * Deterministic benchmark for TinySearch.
+ *
+ * Same seed → same corpus, same operations, same result checksum. The
+ * checksum folds the ids and scores of every query's results, so a rewrite
+ * that changes search semantics changes the checksum even if it gets faster.
+ *
+ * Usage:
+ *   node bench/bench.mjs --scenario query-heavy --n 5000 --ops 400 --seed 1
+ *   node bench/bench.mjs --scenario index-heavy --n 5000 --ops 2000 --seed 1
+ *   node bench/bench.mjs --scenario mixed       --n 5000 --ops 400 --seed 1
+ *
+ * Prints one JSON line: p50_us, p95_us, mean_us (per-operation latency in
+ * microseconds), ops_per_sec, build_ms (initial corpus load), checksum.
+ */
+
+import { TinySearch } from "../src/tiny-search.js";
+
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const WORDS = (
+  "the of and to in is that it for on with as at by from up about into over " +
+  "after data cache index query search node system time value key store read " +
+  "write fast slow test bench result score latency memory disk network user " +
+  "request response server client token text word list array map set tree " +
+  "graph queue stack heap sort scan filter merge split parse build run start " +
+  "stop error retry limit count total mean median percent second minute hour " +
+  "alpha bravo charlie delta echo foxtrot golf hotel india juliet kilo lima " +
+  "mike november oscar papa quebec romeo sierra tango uniform victor whiskey " +
+  "xray yankee zulu apple banana cherry grape lemon mango olive peach plum " +
+  "quince raisin walnut engine wheel spring bolt gear lever piston valve"
+).split(/\s+/);
+
+// Zipf-ish bias: squaring the uniform draw favors low indexes, so early
+// words are common and late words are rare — realistic term frequencies.
+function pickWord(rand) {
+  const r = rand();
+  return WORDS[Math.floor(r * r * WORDS.length)];
+}
+
+function makeDoc(rand) {
+  const length = 30 + Math.floor(rand() * 50);
+  const words = new Array(length);
+  for (let i = 0; i < length; i += 1) words[i] = pickWord(rand);
+  return words.join(" ");
+}
+
+function makeQuery(rand) {
+  const terms = rand() < 0.6 ? 1 : 2;
+  const words = new Array(terms);
+  for (let i = 0; i < terms; i += 1) words[i] = pickWord(rand);
+  return words.join(" ");
+}
+
+function foldChecksum(checksum, results) {
+  let h = checksum;
+  for (const { id, score } of results) {
+    for (let i = 0; i < id.length; i += 1) {
+      h = (Math.imul(h, 31) + id.charCodeAt(i)) | 0;
+    }
+    h = (Math.imul(h, 31) + score) | 0;
+  }
+  return h;
+}
+
+function percentileUs(sortedNs, p) {
+  const index = Math.min(
+    sortedNs.length - 1,
+    Math.floor((p / 100) * sortedNs.length),
+  );
+  return Number(sortedNs[index]) / 1000;
+}
+
+function parseArgs(argv) {
+  const args = { scenario: "query-heavy", n: 5000, ops: 400, seed: 1 };
+  for (let i = 2; i < argv.length; i += 2) {
+    const key = argv[i].replace(/^--/, "");
+    const value = argv[i + 1];
+    if (key === "scenario") args.scenario = value;
+    else if (key === "n" || key === "ops" || key === "seed") {
+      args[key] = Number(value);
+    } else throw new Error(`unknown argument: ${argv[i]}`);
+  }
+  if (!["query-heavy", "index-heavy", "mixed"].includes(args.scenario)) {
+    throw new Error(`unknown scenario: ${args.scenario}`);
+  }
+  return args;
+}
+
+const { scenario, n, ops, seed } = parseArgs(process.argv);
+const rand = mulberry32(seed);
+const index = new TinySearch();
+
+const buildStart = process.hrtime.bigint();
+for (let i = 0; i < n; i += 1) {
+  index.add(`doc-${String(i).padStart(6, "0")}`, makeDoc(rand));
+}
+const buildMs = Number(process.hrtime.bigint() - buildStart) / 1e6;
+
+const samplesNs = [];
+let checksum = 0;
+
+for (let i = 0; i < ops; i += 1) {
+  const isQuery =
+    scenario === "query-heavy" ||
+    (scenario === "mixed" && rand() < 0.8);
+
+  if (isQuery) {
+    const query = makeQuery(rand);
+    const start = process.hrtime.bigint();
+    const results = index.search(query);
+    samplesNs.push(process.hrtime.bigint() - start);
+    checksum = foldChecksum(checksum, results);
+  } else {
+    const id = `doc-${String(Math.floor(rand() * n)).padStart(6, "0")}`;
+    const text = makeDoc(rand);
+    const start = process.hrtime.bigint();
+    index.add(id, text);
+    samplesNs.push(process.hrtime.bigint() - start);
+    checksum = (Math.imul(checksum, 31) + index.size) | 0;
+  }
+}
+
+samplesNs.sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+const totalNs = samplesNs.reduce((sum, v) => sum + v, 0n);
+const meanUs = Number(totalNs) / samplesNs.length / 1000;
+
+console.log(
+  JSON.stringify({
+    scenario,
+    n,
+    ops,
+    seed,
+    p50_us: Number(percentileUs(samplesNs, 50).toFixed(3)),
+    p95_us: Number(percentileUs(samplesNs, 95).toFixed(3)),
+    mean_us: Number(meanUs.toFixed(3)),
+    ops_per_sec: Math.round(samplesNs.length / (Number(totalNs) / 1e9)),
+    build_ms: Number(buildMs.toFixed(1)),
+    checksum,
+  }),
+);

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
@@ -24,6 +24,8 @@ const WORDS = (
   "quince raisin walnut engine wheel spring bolt gear lever piston valve"
 ).split(/\s+/);
 
+const VERIFY_EVERY = 16;
+
 function pickWord(rand) {
   const r = rand();
   return WORDS[Math.floor(r * r * WORDS.length)];
@@ -60,11 +62,11 @@ function percentileUs(sortedNs, p) {
   return Number(sortedNs[index]) / 1000;
 }
 
-function positiveInt(key, raw) {
+function boundedInt(key, raw, min) {
   if (raw === undefined) throw new Error(`--${key} needs a value`);
   const value = Number(raw);
-  if (!Number.isInteger(value) || value < 1) {
-    throw new Error(`--${key} must be a positive integer, got: ${raw}`);
+  if (!Number.isInteger(value) || value < min) {
+    throw new Error(`--${key} must be an integer >= ${min}, got: ${raw}`);
   }
   return value;
 }
@@ -77,8 +79,10 @@ function parseArgs(argv) {
     if (key === "scenario") {
       if (value === undefined) throw new Error("--scenario needs a value");
       args.scenario = value;
-    } else if (key === "n" || key === "ops" || key === "seed") {
-      args[key] = positiveInt(key, value);
+    } else if (key === "n" || key === "ops") {
+      args[key] = boundedInt(key, value, 1);
+    } else if (key === "seed") {
+      args[key] = boundedInt(key, value, 0);
     } else throw new Error(`unknown argument: ${argv[i]}`);
   }
   if (!["query-heavy", "index-heavy", "mixed"].includes(args.scenario)) {
@@ -117,9 +121,13 @@ for (let i = 0; i < ops; i += 1) {
     const start = process.hrtime.bigint();
     index.add(id, text);
     samplesNs.push(process.hrtime.bigint() - start);
-    const verify = index.search(tokenize(text)[0] ?? "", { limit: 3 });
     checksum = (Math.imul(checksum, 31) + index.size) | 0;
-    checksum = foldChecksum(checksum, verify);
+    if (i % VERIFY_EVERY === 0) {
+      checksum = foldChecksum(
+        checksum,
+        index.search(tokenize(text)[0] ?? "", { limit: 3 }),
+      );
+    }
   }
 }
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
@@ -1,19 +1,3 @@
-/**
- * Deterministic benchmark for TinySearch.
- *
- * Same seed → same corpus, same operations, same result checksum. The
- * checksum folds the ids and scores of every query's results, so a rewrite
- * that changes search semantics changes the checksum even if it gets faster.
- *
- * Usage:
- *   node bench/bench.mjs --scenario query-heavy --n 5000 --ops 400 --seed 1
- *   node bench/bench.mjs --scenario index-heavy --n 5000 --ops 2000 --seed 1
- *   node bench/bench.mjs --scenario mixed       --n 5000 --ops 400 --seed 1
- *
- * Prints one JSON line: p50_us, p95_us, mean_us (per-operation latency in
- * microseconds), ops_per_sec, build_ms (initial corpus load), checksum.
- */
-
 import { TinySearch } from "../src/tiny-search.js";
 
 function mulberry32(seed) {
@@ -40,8 +24,6 @@ const WORDS = (
   "quince raisin walnut engine wheel spring bolt gear lever piston valve"
 ).split(/\s+/);
 
-// Zipf-ish bias: squaring the uniform draw favors low indexes, so early
-// words are common and late words are rare — realistic term frequencies.
 function pickWord(rand) {
   const r = rand();
   return WORDS[Math.floor(r * r * WORDS.length)];

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/bench/bench.mjs
@@ -1,4 +1,4 @@
-import { TinySearch } from "../src/tiny-search.js";
+import { TinySearch, tokenize } from "../src/tiny-search.js";
 
 function mulberry32(seed) {
   let a = seed >>> 0;
@@ -55,11 +55,18 @@ function foldChecksum(checksum, results) {
 }
 
 function percentileUs(sortedNs, p) {
-  const index = Math.min(
-    sortedNs.length - 1,
-    Math.floor((p / 100) * sortedNs.length),
-  );
+  const rank = Math.ceil((p / 100) * sortedNs.length);
+  const index = Math.min(sortedNs.length - 1, Math.max(0, rank - 1));
   return Number(sortedNs[index]) / 1000;
+}
+
+function positiveInt(key, raw) {
+  if (raw === undefined) throw new Error(`--${key} needs a value`);
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1) {
+    throw new Error(`--${key} must be a positive integer, got: ${raw}`);
+  }
+  return value;
 }
 
 function parseArgs(argv) {
@@ -67,9 +74,11 @@ function parseArgs(argv) {
   for (let i = 2; i < argv.length; i += 2) {
     const key = argv[i].replace(/^--/, "");
     const value = argv[i + 1];
-    if (key === "scenario") args.scenario = value;
-    else if (key === "n" || key === "ops" || key === "seed") {
-      args[key] = Number(value);
+    if (key === "scenario") {
+      if (value === undefined) throw new Error("--scenario needs a value");
+      args.scenario = value;
+    } else if (key === "n" || key === "ops" || key === "seed") {
+      args[key] = positiveInt(key, value);
     } else throw new Error(`unknown argument: ${argv[i]}`);
   }
   if (!["query-heavy", "index-heavy", "mixed"].includes(args.scenario)) {
@@ -108,7 +117,9 @@ for (let i = 0; i < ops; i += 1) {
     const start = process.hrtime.bigint();
     index.add(id, text);
     samplesNs.push(process.hrtime.bigint() - start);
+    const verify = index.search(tokenize(text)[0] ?? "", { limit: 3 });
     checksum = (Math.imul(checksum, 31) + index.size) | 0;
+    checksum = foldChecksum(checksum, verify);
   }
 }
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/package.json
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "tiny-search",
+  "version": "1.0.0",
+  "description": "A minimal, deliberately naive in-memory full-text search index for Node. No dependencies.",
+  "type": "module",
+  "main": "src/tiny-search.js",
+  "scripts": {
+    "test": "node --test",
+    "bench": "node bench/bench.mjs"
+  },
+  "license": "MIT"
+}

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
@@ -1,21 +1,3 @@
-/**
- * TinySearch — a minimal in-memory full-text search index for Node.
- *
- * Deliberately naive: documents are stored as raw text, and every call to
- * search() re-tokenizes every document from scratch and scans the full token
- * list once per query term. There is no index of any kind. The slowness is
- * the exercise — do not "fix" this file outside an optimization campaign.
- *
- * Behavioral contract (pinned by the test suite):
- * - tokenize(): lowercase, split on any run of non-alphanumeric characters.
- * - search() uses AND semantics: a document matches only if it contains
- *   every query term at least once.
- * - score = total number of occurrences of all query terms in the document.
- * - Results are ordered by score descending, ties broken by id ascending
- *   (plain string comparison), capped at `limit` (default 10).
- * - add() with an existing id replaces that document.
- */
-
 export function tokenize(text) {
   return text
     .toLowerCase()

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
@@ -1,7 +1,10 @@
 export function tokenize(text) {
+  if (typeof text !== "string") {
+    throw new TypeError("text must be a string");
+  }
   return text
     .toLowerCase()
-    .split(/[^a-z0-9]+/)
+    .split(/[^\p{L}\p{N}]+/u)
     .filter(Boolean);
 }
 
@@ -31,6 +34,9 @@ export class TinySearch {
   }
 
   search(query, { limit = 10 } = {}) {
+    if (!Number.isInteger(limit) || limit < 0) {
+      throw new TypeError("limit must be a non-negative integer");
+    }
     const terms = tokenize(query);
     if (terms.length === 0) return [];
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
@@ -1,0 +1,79 @@
+/**
+ * TinySearch — a minimal in-memory full-text search index for Node.
+ *
+ * Deliberately naive: documents are stored as raw text, and every call to
+ * search() re-tokenizes every document from scratch and scans the full token
+ * list once per query term. There is no index of any kind. The slowness is
+ * the exercise — do not "fix" this file outside an optimization campaign.
+ *
+ * Behavioral contract (pinned by the test suite):
+ * - tokenize(): lowercase, split on any run of non-alphanumeric characters.
+ * - search() uses AND semantics: a document matches only if it contains
+ *   every query term at least once.
+ * - score = total number of occurrences of all query terms in the document.
+ * - Results are ordered by score descending, ties broken by id ascending
+ *   (plain string comparison), capped at `limit` (default 10).
+ * - add() with an existing id replaces that document.
+ */
+
+export function tokenize(text) {
+  return text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
+export class TinySearch {
+  #docs = [];
+
+  add(id, text) {
+    if (typeof id !== "string" || id.length === 0) {
+      throw new TypeError("id must be a non-empty string");
+    }
+    if (typeof text !== "string") {
+      throw new TypeError("text must be a string");
+    }
+    this.remove(id);
+    this.#docs.push({ id, text });
+  }
+
+  remove(id) {
+    const index = this.#docs.findIndex((doc) => doc.id === id);
+    if (index === -1) return false;
+    this.#docs.splice(index, 1);
+    return true;
+  }
+
+  get size() {
+    return this.#docs.length;
+  }
+
+  search(query, { limit = 10 } = {}) {
+    const terms = tokenize(query);
+    if (terms.length === 0) return [];
+
+    const hits = [];
+    for (const doc of this.#docs) {
+      const tokens = tokenize(doc.text);
+      let score = 0;
+      let matchesAll = true;
+      for (const term of terms) {
+        let count = 0;
+        for (const token of tokens) {
+          if (token === term) count += 1;
+        }
+        if (count === 0) {
+          matchesAll = false;
+          break;
+        }
+        score += count;
+      }
+      if (matchesAll) hits.push({ id: doc.id, score });
+    }
+
+    hits.sort(
+      (a, b) => b.score - a.score || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    );
+    return hits.slice(0, limit);
+  }
+}

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/src/tiny-search.js
@@ -3,6 +3,7 @@ export function tokenize(text) {
     throw new TypeError("text must be a string");
   }
   return text
+    .normalize("NFC")
     .toLowerCase()
     .split(/[^\p{L}\p{N}]+/u)
     .filter(Boolean);

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/test/tiny-search.test.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/test/tiny-search.test.js
@@ -137,3 +137,12 @@ test("tokenize rejects a non-string input", () => {
   const index = fixture();
   assert.throws(() => index.search(null), TypeError);
 });
+
+test("decomposed and composed input tokenize alike", () => {
+  assert.deepEqual(tokenize("café".normalize("NFD")), ["café".normalize("NFC")]);
+  const index = new TinySearch();
+  index.add("a", "un café".normalize("NFD"));
+  assert.deepEqual(index.search("café".normalize("NFC")), [
+    { id: "a", score: 1 },
+  ]);
+});

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/test/tiny-search.test.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/test/tiny-search.test.js
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { TinySearch, tokenize } from "../src/tiny-search.js";
+
+function fixture() {
+  const index = new TinySearch();
+  index.add("alpha", "Rust is fast. Rust is safe.");
+  index.add("bravo", "Go is simple and fast");
+  index.add("charlie", "JavaScript everywhere: fast, flexible, fast!");
+  index.add("delta", "Plain text about gardening");
+  return index;
+}
+
+test("tokenize lowercases and splits on non-alphanumeric runs", () => {
+  assert.deepEqual(tokenize("Re-index THE re-index, twice!"), [
+    "re",
+    "index",
+    "the",
+    "re",
+    "index",
+    "twice",
+  ]);
+  assert.deepEqual(tokenize("v2 rollout (2024)"), ["v2", "rollout", "2024"]);
+  assert.deepEqual(tokenize("!!! --- ..."), []);
+});
+
+test("empty index returns no results", () => {
+  const index = new TinySearch();
+  assert.deepEqual(index.search("anything"), []);
+});
+
+test("single-term search scores by occurrence count", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("rust"), [{ id: "alpha", score: 2 }]);
+});
+
+test("matching is case-insensitive", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("RUST"), [{ id: "alpha", score: 2 }]);
+});
+
+test("results order by score descending, ties by id ascending", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("fast"), [
+    { id: "charlie", score: 2 },
+    { id: "alpha", score: 1 },
+    { id: "bravo", score: 1 },
+  ]);
+});
+
+test("multi-term search uses AND semantics", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("rust fast"), [{ id: "alpha", score: 3 }]);
+  assert.deepEqual(index.search("rust gardening"), []);
+});
+
+test("score sums occurrences across all query terms", () => {
+  const index = new TinySearch();
+  index.add("x", "re-index the re-index");
+  assert.deepEqual(index.search("re index"), [{ id: "x", score: 4 }]);
+});
+
+test("query with no alphanumeric tokens returns no results", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("!!!"), []);
+  assert.deepEqual(index.search(""), []);
+});
+
+test("unknown term returns no results", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("zeppelin"), []);
+});
+
+test("limit caps results and defaults to 10", () => {
+  const index = new TinySearch();
+  for (let i = 0; i < 15; i += 1) {
+    index.add(`doc${String(i).padStart(2, "0")}`, "common word");
+  }
+  assert.equal(index.search("common").length, 10);
+  assert.equal(index.search("common", { limit: 3 }).length, 3);
+  assert.equal(index.search("common", { limit: 100 }).length, 15);
+});
+
+test("re-adding an id replaces the old document", () => {
+  const index = new TinySearch();
+  index.add("a", "cat");
+  index.add("a", "dog");
+  assert.equal(index.size, 1);
+  assert.deepEqual(index.search("cat"), []);
+  assert.deepEqual(index.search("dog"), [{ id: "a", score: 1 }]);
+});
+
+test("remove deletes the document and reports whether it existed", () => {
+  const index = fixture();
+  assert.equal(index.remove("alpha"), true);
+  assert.equal(index.remove("alpha"), false);
+  assert.deepEqual(index.search("rust"), []);
+  assert.equal(index.size, 3);
+});
+
+test("add validates its arguments", () => {
+  const index = new TinySearch();
+  assert.throws(() => index.add("", "text"), TypeError);
+  assert.throws(() => index.add(42, "text"), TypeError);
+  assert.throws(() => index.add("id", 42), TypeError);
+});

--- a/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/test/tiny-search.test.js
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/examples/tiny-search/test/tiny-search.test.js
@@ -104,3 +104,36 @@ test("add validates its arguments", () => {
   assert.throws(() => index.add(42, "text"), TypeError);
   assert.throws(() => index.add("id", 42), TypeError);
 });
+
+test("tokenize keeps Unicode letters and numbers as single terms", () => {
+  assert.deepEqual(tokenize("Café: día 2, naïve"), [
+    "café",
+    "día",
+    "2",
+    "naïve",
+  ]);
+});
+
+test("accented text is searchable", () => {
+  const index = new TinySearch();
+  index.add("a", "un café très fort");
+  assert.deepEqual(index.search("café"), [{ id: "a", score: 1 }]);
+});
+
+test("limit of zero returns no results", () => {
+  const index = fixture();
+  assert.deepEqual(index.search("fast", { limit: 0 }), []);
+});
+
+test("search rejects an invalid limit", () => {
+  const index = fixture();
+  assert.throws(() => index.search("fast", { limit: -1 }), TypeError);
+  assert.throws(() => index.search("fast", { limit: 1.5 }), TypeError);
+  assert.throws(() => index.search("fast", { limit: "3" }), TypeError);
+});
+
+test("tokenize rejects a non-string input", () => {
+  assert.throws(() => tokenize(42), TypeError);
+  const index = fixture();
+  assert.throws(() => index.search(null), TypeError);
+});

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/images.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/images.md
@@ -67,12 +67,14 @@ campaign's internal iteration count, seeds, and how many rounds your loop
 chains.
 
 **Cost shape** — as long as you let it, so don't. **Default to a one-hour
-campaign**: one round, 1–2 internal iterations, 3 seeds, one hypothesis;
-~20–30 min per iteration at that size. A bigger run is the human's call to
-make, never yours to assume: propose the hour, and when an estimate breaks it,
-cut seeds and iterations rather than the deadline. Set `ttl_ms` at roughly
-double the estimate — this is the image most likely to be killed by a deadline
-left at its default, and a killed pod wastes the entire round.
+campaign**: one round, ONE confirming iteration, 3 seeds, one hypothesis —
+a healthy iteration has measured ~60 min on a dev cluster, so two iterations
+is a ~2 h proposal, said as such. A bigger run is the human's call to make,
+never yours to assume: propose the hour, and when an estimate breaks it, cut
+seeds and iterations rather than the deadline. Set `ttl_ms` at roughly double
+the measured estimate — this is the image most likely to be killed by a
+deadline sized from hope, and a killed pod loses everything it has not
+published.
 
 **Spawn notes** — it never hibernates (`hibernationTimeout: "0s"`), so a
 terminal transition or the liveness deadline is what ends it; nothing else will

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/nous-evaluator.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/nous-evaluator.md
@@ -12,6 +12,12 @@ the stable fields it must report, and the artifacts it must publish
 (`report.md`, `meta_findings.json`, per-iteration `findings.json`) before
 finishing.
 
+**Demand publish-as-you-go.** The prompt must require each iteration's
+`findings.json` (and raw results worth keeping) to be published as artifacts
+**the moment the iteration completes** — never only at the end. A worker can
+die mid-campaign (TTL, OOM, a starved node, an inactivity reap; all three have
+happened) and everything unpublished dies with it.
+
 **Always demand the per-seed numbers.** The experiment's score chart plots
 one point per seed, not per campaign (a run chains one or two campaigns —
 per-round scoring draws a single dot), and the pass condition is itself

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/nous-evaluator.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/nous-evaluator.md
@@ -174,7 +174,10 @@ without touching raw seed files.
    baseline-vs-treatment deltas per seed and the seed pass count, then check
    against `ground_truth.pass_condition`.
 5. **Portable claim + confidence**: wiki `campaigns/<run_id>/principles.json`.
-6. **Cost context** (optional): `nous cost <run_id> --cache-stats`.
+6. **Cost**: `nous cost <run_id> --cache-stats`, or the stable
+   `llm_metrics_summary.json`. For a driver, not optional — demand USD, token
+   and call totals in the typed result (they exist even on failed campaigns)
+   so every run surfaces what it spent.
 
 ## 4. Outcome vocabulary
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/nous-evaluator.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/nous-evaluator.md
@@ -29,6 +29,39 @@ confirming iteration, in the metric's own unit — read from those raw files
 and **not** from `report.md`'s prose or summary table, which are free text
 and have been observed to disagree with the raw numbers.
 
+**The result contract, field by field.** Learned the hard way — each rule
+below is a real run's failure:
+
+- **Define every numeric field in the prompt** — formula, unit, direction,
+  and the value an inert control must produce. An undefined `effect:
+  "number"` came back as `-1.056` on every arm of a bundle: a guess, not a
+  measurement.
+- **Name the standard arm family you expect reported** (`h-main`,
+  `h-ablation`, `h-control-negative`, `h-robustness`, …) so presence can be
+  validated. This is a *reporting* contract — the bundle's design stays
+  Nous's; validating what came back is not designing the science.
+- **Integrity fields are reported, not assumed**: `ruler_unmodified` as a
+  boolean the worker must set after running the pristine-copy diff, and
+  checksums **per seed** (`checksums_per_seed: [{seed, unchanged}]`) when the
+  pass condition is per-seed — a blanket boolean cannot answer a per-seed
+  bar.
+- **`run_id`, cost, tokens, call count** — from `llm_metrics_summary.json`;
+  exist even on failed campaigns.
+- **`h_main_status`** from `findings.json` (`CONFIRMED | REFUTED |
+  PARTIALLY_CONFIRMED`) — and the driver's verdict must consume it, or a
+  numerically-passing run hides a refuted hypothesis.
+- **`cumulative.patch` published as an artifact** (see `nous lineage`, §5) —
+  a driver holding its own copy of the target then applies it and re-measures
+  locally, turning every self-graded field into a driver-confirmed one. This
+  replication is worth more than all other validation combined.
+
+Then validate before scoring — coverage against the pinned seeds/grid,
+positive timings, arms distinct (identical-to-6dp = constant), sign agreement
+between arm effects and the raw per-n numbers, worker baseline within a few ×
+of a driver-measured reference, a plausibility ceiling on the headline.
+Record problems in `post_data` (bad evidence belongs on the results page,
+not in a stack trace) and gate the verdict on the result being valid.
+
 There is **no central stats database**. Results are file-based in two tiers:
 
 1. **Per-campaign artifacts** — raw, complete, campaign-specific schema.

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
@@ -1,0 +1,147 @@
+# The tiny-search starter — the cheap Nous demo
+
+This reference is background **for you** — never recite it. Two or three plain
+sentences and a question beat any paragraph in this file.
+
+The bundled target for showing what a *hypothesis-driven campaign* does, on a
+budget: a dependency-free in-memory full-text search index whose `search()`
+re-tokenizes every document from raw text on every query and scans the token
+list once per term. There is no index of any kind, so the headroom is real
+(~50–70×) and the mechanism is a textbook one an inverted index fixes.
+
+It ships beside this reference at
+[examples/tiny-search/](../examples/tiny-search/) and is already on this pod —
+never clone or download it to *read* it.
+
+## Why this one and not tiny-cache
+
+[tiny-cache](tiny-cache-starter.md) is the starter for a **`claude-code` loop**,
+where your driver runs the locked benchmark and scores each sweep point itself.
+Handing it to `nous` fits worse for two reasons that have nothing to do with
+integrity (the image copy is a pristine ruler on either worker — see the last
+section): its optimized side lands at ~0.3 µs, the resolution floor of the
+bench's per-op `hrtime` sampling, so the headline ratio measures the clock; and
+the win is known in advance, with no guard metric that could fail.
+
+tiny-search does not have that problem, and that is the whole reason it exists:
+
+| | tiny-cache | tiny-search |
+|---|---|---|
+| Baseline metric | ~175 µs p50 | **~12.4 ms p50** (n=5000) |
+| Optimized side | ~0.3 µs — at the timer floor | ~0.2 ms — ~1000× above it |
+| Guard metric | none (`write-heavy` only) | **`index-heavy`**, ~22 µs |
+| Behavior check | 11 tests | 13 tests **plus a result checksum** |
+| Answer | known 500× win | a curve, with a real write-path cost |
+
+The guard metric is what makes it a campaign rather than a stunt: any indexing
+strategy moves work to the write path, so the interesting question is not "is
+it faster" but "how much does the write path pay, and does the win scale".
+
+## Measured on this pod (verify, don't trust)
+
+13/13 tests green, and the baseline is yours to measure before designing
+anything:
+
+```sh
+cd examples/tiny-search && node --test
+node bench/bench.mjs --scenario query-heavy --n 5000 --ops 400 --seed 1
+node bench/bench.mjs --scenario index-heavy --n 5000 --ops 2000 --seed 1
+```
+
+Reference numbers from a dev-cluster-class machine — the linearity is the
+point, and it is what a mechanism claim predicts:
+
+| n | query-heavy p50 | vs n=1000 |
+|---|---|---|
+| 1 000 | 2.45 ms | 1.0× |
+| 5 000 | 12.97 ms | 5.3× |
+| 20 000 | 56.2 ms | 23× |
+
+`index-heavy` p50 ≈ 22 µs is the guard. One bench invocation is seconds, so
+arms × seeds × the n grid still fits inside the hour.
+
+The bench prints a **`checksum`** per seed: same seed and same semantics always
+produce the same value, so a rewrite that quietly changes ranking or AND
+semantics is caught even where the tests are not looking. Treat a changed
+checksum exactly like a failed test — the round scores nothing.
+
+## The campaign, pinned
+
+Don't hand the worker a paragraph and hope. Pin the design with the four
+fields (see *You do not write the campaign's arms* in the skill), so the
+campaign commits to the curve and the guard before it runs:
+
+- **`research_question`** — "does query latency become independent of corpus
+  size, and what does the write path pay for it?" Stated as a curve, the
+  designer reaches for a dose-response arm by itself.
+- **`controllable_knobs`** — `[index_strategy, n]`. The sweep variable must be
+  here or it may never be swept.
+- **`ground_truth`** — `primary_metric: "speedup_p50(query-heavy, n=5000)"`,
+  `direction_claim: "baseline p50 grows ~linearly in n while the candidate
+  stays roughly flat, so speedup grows with n"`, `seeds: [1, 2, 3]`,
+  `pass_condition: "median speedup_p50 ≥ 20 AND ≥ 2/3 seeds individually ≥ 20
+  AND 13/13 tests green AND per-seed checksum unchanged AND index-heavy
+  p50 regression ≤ 3×"`.
+- **`locked_parameters`** — `n_values: [1000, 5000, 20000]`,
+  `reps_per_seed: 3`, `ops_query_heavy: 400`, `ops_index_heavy: 2000`, and the
+  guard bound. These hard-fail if the bundle deviates, which is what makes
+  them a spec rather than a request.
+
+Put the baselines, the exact bench invocations and the checksum rule in
+`target_system.description` — it is substituted into the model's prompts
+verbatim.
+
+**The bar is set where it can fail.** An inverted index should clear 20×
+comfortably at n=5000; what is genuinely in doubt is the guard (does the write
+path stay within 3×?) and the flatness claim at n=20000. That is the result
+worth reporting, and either half can come back refuted.
+
+## Size and shape
+
+One round, 1–2 campaign iterations (rehearsal + one confirming pass), 3 seeds
+at 3 reps — the standard hour. Measurement is cheap here, so the hour goes to
+the campaign's own reasoning, not to benchmarking; if the estimate slips, cut
+an iteration before you cut the n grid, because the grid is the finding.
+
+Present the envelope as usual before authoring, and say what the demo shows:
+the platform drawing a live loop while a worker forms a hypothesis, patches a
+repo, measures it against a bar it pre-registered, and reports whether the
+mechanism claim held — decomposed by arm, with a guard metric it could fail.
+
+## Getting the repo onto the worker — it is already there
+
+No clone, no download, no GitHub. The `nous` image is built `FROM` the
+claude-code image, which stages this skill at `/usr/local/share/dam-skills/`,
+so a spawned nous worker already carries the starter at:
+
+```
+/usr/local/share/dam-skills/dam-experiment/examples/tiny-search/
+```
+
+Nous needs a git repo with at least one commit (it runs each arm in an isolated
+worktree), so the campaign prompt opens with three lines of setup:
+
+```sh
+cp -R /usr/local/share/dam-skills/dam-experiment/examples/tiny-search ~/tiny-search
+cd ~/tiny-search && git init -q && git add -A
+git -c user.email=nous@local -c user.name=nous commit -qm "baseline: naive tiny-search"
+```
+
+Then `repo_path: ~/tiny-search`. Two things this buys beyond convenience:
+
+- **No egress at all.** No GitHub connection, no public repo, nothing to
+  publish — the model provider is the only connection the worker needs. It
+  works on any cluster, offline.
+- **A pristine ruler inside the worker.** The image copy is read-only and
+  untouched, so the campaign can verify its own integrity against it —
+  `git diff --no-index --quiet` on `test/` and `bench/` against
+  `/usr/local/share/dam-skills/dam-experiment/examples/tiny-search/` catches a
+  candidate that edited the tests or the benchmark. Put that check in the
+  prompt: a candidate that changed the ruler scores nothing, exactly as in a
+  driver-run loop.
+
+**One deployment caveat.** The examples ride in the image, so a worker only has
+what its image was built with. A nous image built before tiny-search landed in
+this skill will not have the directory — check for it in the prompt and fail
+loudly rather than improvising a download. Rebuilding is
+`mise run cluster:build-agent` on a dev cluster.

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
@@ -109,27 +109,63 @@ worth reporting, and either half can come back refuted.
 
 ## What the run puts on screen
 
-Three score series plus a run-level table — design the spawn schema so all of
-it survives the worker being reaped:
+Three score series, a verify stage, and a verdict card — with stage ids named
+for the legend, because the legend is all a viewer sees (`seed-score`,
+`arm-score` and `verdict` are the exact ids that sent a user asking what
+their own chart meant):
 
-- **`seed-score`** — one span per seed at n=5000 (3 points): the spread, so a
-  reader sees whether one seed carries the median. Needs `per_seed:
-  [{seed, baseline, treatment}]` in the result schema.
-- **speedup vs n** — one span per n value (3 points, `iteration=n`): the
-  curve, which is the demo's whole argument. Needs the per-n numbers in the
-  result schema too — e.g. `per_n: [{n, baseline, treatment}]` — or the curve
-  dies with the pod exactly like per-seed data used to.
-- **`arm-score`** — one span per arm of the bundle Nous designed (~5–8
-  points): main effect large, ablations small, control ≈ 1.0. This series
-  spans orders of magnitude, so score `log2(effect)` (or build a bespoke
-  dashboard) — on the stock chart's linear axis the small arms collapse onto
-  the floor.
-- **`post_data`** — the evidence table with absolute µs next to every ratio,
-  the pass verdict against the pre-registered bar, the guard number, per-phase
-  durations, and campaign cost (USD, tokens, LLM calls — demand it in the
-  result schema; `llm_metrics_summary.json` always exists on the worker, even
-  on a failed campaign). The stock dashboard renders it; nothing extra to
-  build.
+- **`speedup-per-seed`** — one span per seed at n=5000 (3 points): the
+  spread, so a reader sees whether one seed carries the median. Absolutes
+  (`baseline_us`, `treatment_us`, `meets_bar`) ride in the attrs.
+- **`speedup-vs-n`** — one span per n value (3 points, `iteration=n`): the
+  curve, which is the demo's whole argument.
+- **`arm-decomposition`** — one span per arm of the bundle Nous designed,
+  `iteration=` set per arm (an unset iteration once made five arms look like
+  one). Score `log2(effect)` so the control at ~1× and the main effect share
+  an axis — but only for a valid effect: garbage gets **no score** plus an
+  `invalid` attr, never a 0.0 that reads as "no change".
+- **`verify`** — the replication stage, and the reason the numbers above can
+  be trusted: the driver applies the worker's published `cumulative.patch` to
+  its own pristine copy, runs the 13 tests and the seeded bench itself, and
+  scores the primary series from its **own** measurements. The worker's
+  figures become a cross-check column, and tests/checksums/ruler-lock stop
+  being self-graded. tiny-search is plain Node — there is no excuse not to.
+- **Verdict = a `post_data` card, not a series.** PASS/FAIL plus every named
+  check (median ≥ 20×, ≥ 2/3 seeds, 13/13 tests, per-seed checksums
+  unchanged, guard ≤ 3×, `h_main_status == CONFIRMED`, `result_valid`) with
+  each outcome — the stock dashboard renders it. A previous run scored the
+  verdict stage with the median speedup: a redundant line hiding the actual
+  answer in attrs.
+- **`post_data` also carries** the evidence table with absolute µs next to
+  every ratio, per-phase durations, the Nous `run_id`, and cost (USD, tokens,
+  LLM calls — `llm_metrics_summary.json` exists even on failed campaigns).
+
+## Trust nothing the schema didn't define, score nothing you didn't validate
+
+The result schema demands `per_seed`, `per_n`, `per_arm`, `checksums_per_seed`
+(a list — the bar is per-seed, a blanket boolean can't answer it),
+`ruler_unmodified`, `h_main_status`, `run_id`, and `cost` — and the prompt
+**defines every number**: effect is "that arm's OWN baseline p50 ÷ that arm's
+OWN treatment p50, query-heavy at n=5000, same seeds and reps; a no-op
+control must come out ~1.0 — never 0, never blank, never copied from another
+arm". An undefined `effect: "number"` is how a real run got `-1.056` on all
+five arms — a guess that passed anyway because nothing validated it.
+
+Before any span is scored, the driver runs a validation gate and records what
+it finds (in `post_data`, not a raised exception — bad evidence belongs on
+the page), with `result_valid` gating the verdict:
+
+- per_seed covers exactly seeds {1, 2, 3}; per_n exactly {1000, 5000, 20000};
+  all timings positive;
+- arm effects are **distinct** — different code cannot agree to six decimals;
+- **sign agreement** — an h-main effect claiming "slower" beside per-n data
+  showing 4706× faster is irreconcilable and fails the result;
+- plausibility — a median past 1000× passes only corroborated (checksums
+  unchanged AND ruler untouched AND the driver's own verify measurements
+  agree), because that magnitude is where broken benchmarks live;
+- the worker's baselines within ~5× of the driver's own (measured at setup:
+  ~2.45 / 12.97 / 56.2 ms) — further off means different-enough hardware or
+  harness that the ratio isn't comparable.
 
 ## Size and shape
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
@@ -57,8 +57,10 @@ point, and it is what a mechanism claim predicts:
 | 5 000 | 12.97 ms | 5.3× |
 | 20 000 | 56.2 ms | 23× |
 
-`index-heavy` p50 ≈ 22 µs is the guard. One bench invocation is seconds, so
-arms × seeds × the n grid still fits inside the hour.
+`index-heavy` p50 ≈ 22 µs is the guard. One bench invocation is seconds —
+even a full five-arm bundle's grid (arms × 3 seeds × 3 reps × 3 n values,
+baseline and treatment) is minutes of measuring; the hour goes to the
+worker's reasoning.
 
 The bench prints a **`checksum`** per seed: same seed and same semantics always
 produce the same value, so a rewrite that quietly changes ranking or AND
@@ -67,13 +69,19 @@ checksum exactly like a failed test — the round scores nothing.
 
 ## The campaign, pinned
 
-Don't hand the worker a paragraph and hope. Pin the design with the four
-fields (see *You do not write the campaign's arms* in the skill), so the
-campaign commits to the curve and the guard before it runs:
+Pin what is yours; leave the arms to Nous. The bundle — h-main, ablations,
+control-negative, robustness, a dose-response when the question is a curve —
+is the tool's own methodology and the reason its verdict is defensible;
+dictating its composition turns Nous into an expensive single-patch
+benchmarker and can set the designer against its own methodology prompts.
+The measured ~60 min iteration already *includes* the full standard bundle,
+so time comes from the knobs the schema owns, not from redefining the
+science. Pin with the four fields (see *You do not write the campaign's
+arms* in the skill):
 
 - **`research_question`** — "does query latency become independent of corpus
   size, and what does the write path pay for it?" Stated as a curve, the
-  designer reaches for a dose-response arm by itself.
+  designer reaches for a dose-response arm on its own — let it.
 - **`controllable_knobs`** — `[index_strategy, n]`. The sweep variable must be
   here or it may never be swept.
 - **`ground_truth`** — `primary_metric: "speedup_p50(query-heavy, n=5000)"`,
@@ -84,29 +92,60 @@ campaign commits to the curve and the guard before it runs:
   p50 regression ≤ 3×"`.
 - **`locked_parameters`** — `n_values: [1000, 5000, 20000]`,
   `reps_per_seed: 3`, `ops_query_heavy: 400`, `ops_index_heavy: 2000`, and the
-  guard bound. These hard-fail if the bundle deviates, which is what makes
-  them a spec rather than a request.
+  guard bound. These are measurement constants — legitimately yours — and
+  they hard-fail if the bundle deviates, which is what makes them a spec
+  rather than a request.
 
-Put the baselines, the exact bench invocations and the checksum rule in
-`target_system.description` — it is substituted into the model's prompts
-verbatim.
+**The time levers**: `max_iterations: 1` (the confirming iteration; no
+rehearsal), `max_turns: {design: 40, execute_analyze: 80}` to bound the
+meandering, and a TTL of 2 h over the measured hour. Baselines, the exact
+bench invocations and the checksum rule go in `target_system.description` —
+substituted verbatim into the model's prompts.
 
 **The bar is set where it can fail.** An inverted index should clear 20×
 comfortably at n=5000; what is genuinely in doubt is the guard (does the write
 path stay within 3×?) and the flatness claim at n=20000. That is the result
 worth reporting, and either half can come back refuted.
 
+## What the run puts on screen
+
+Three score series plus a run-level table — design the spawn schema so all of
+it survives the worker being reaped:
+
+- **`seed-score`** — one span per seed at n=5000 (3 points): the spread, so a
+  reader sees whether one seed carries the median. Needs `per_seed:
+  [{seed, baseline, treatment}]` in the result schema.
+- **speedup vs n** — one span per n value (3 points, `iteration=n`): the
+  curve, which is the demo's whole argument. Needs the per-n numbers in the
+  result schema too — e.g. `per_n: [{n, baseline, treatment}]` — or the curve
+  dies with the pod exactly like per-seed data used to.
+- **`arm-score`** — one span per arm of the bundle Nous designed (~5–8
+  points): main effect large, ablations small, control ≈ 1.0. This series
+  spans orders of magnitude, so score `log2(effect)` (or build a bespoke
+  dashboard) — on the stock chart's linear axis the small arms collapse onto
+  the floor.
+- **`post_data`** — the evidence table with absolute µs next to every ratio,
+  the pass verdict against the pre-registered bar, the guard number, per-phase
+  durations, and campaign cost. The stock dashboard renders it; nothing extra
+  to build.
+
 ## Size and shape
 
-One round, 1–2 campaign iterations (rehearsal + one confirming pass), 3 seeds
-at 3 reps — the standard hour. Measurement is cheap here, so the hour goes to
-the campaign's own reasoning, not to benchmarking; if the estimate slips, cut
-an iteration before you cut the n grid, because the grid is the finding.
+One round, **one iteration with Nous's standard bundle**, 3 seeds at 3 reps —
+proposed as **~1 h, TTL 2 h**. The calibration is measured, not hoped: a
+healthy full-bundle iteration took ~60 min on a dev cluster, and a 150-min
+TTL sized for "25 min per iteration" has already executed a 2-iteration run
+of this very starter mid-campaign. If the human wants more — a rehearsal
+iteration, ten seeds — each is an explicit upgrade with its cost stated
+(~+60 min per extra iteration), never a silent default. And pin
+publish-as-you-go in the prompt: findings published the moment they exist,
+so a deadline kill loses minutes, not the campaign.
 
 Present the envelope as usual before authoring, and say what the demo shows:
 the platform drawing a live loop while a worker forms a hypothesis, patches a
-repo, measures it against a bar it pre-registered, and reports whether the
-mechanism claim held — decomposed by arm, with a guard metric it could fail.
+repo, measures a speedup curve against a bar it pre-registered, and reports
+whether the mechanism claim held — decomposed by the arms Nous designed, with
+a guard metric and a control that could each genuinely fail.
 
 ## Getting the repo onto the worker — it is already there
 

--- a/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
+++ b/packages/agents/claude-code/dam-skills/dam-experiment/references/tiny-search-starter.md
@@ -126,8 +126,10 @@ it survives the worker being reaped:
   the floor.
 - **`post_data`** — the evidence table with absolute µs next to every ratio,
   the pass verdict against the pre-registered bar, the guard number, per-phase
-  durations, and campaign cost. The stock dashboard renders it; nothing extra
-  to build.
+  durations, and campaign cost (USD, tokens, LLM calls — demand it in the
+  result schema; `llm_metrics_summary.json` always exists on the worker, even
+  on a failed campaign). The stock dashboard renders it; nothing extra to
+  build.
 
 ## Size and shape
 

--- a/packages/controller/pkg/reconciler/resources.go
+++ b/packages/controller/pkg/reconciler/resources.go
@@ -236,7 +236,7 @@ func BuildAgentStatefulSet(name string, agentSpec *types.AgentSpec, cfg *config.
 			ProbeHandler:     corev1.ProbeHandler{HTTPGet: &corev1.HTTPGetAction{Path: "/healthz", Port: intstr.FromString("acp")}},
 			PeriodSeconds:    10,
 			TimeoutSeconds:   5,
-			FailureThreshold: 3,
+			FailureThreshold: 12,
 		}
 	}
 

--- a/packages/controller/pkg/reconciler/resources_test.go
+++ b/packages/controller/pkg/reconciler/resources_test.go
@@ -120,6 +120,12 @@ func TestBuildAgentStatefulSet_Running(t *testing.T) {
 	assert.Equal(t, int32(1), c.StartupProbe.PeriodSeconds)
 	assert.Equal(t, int32(120), c.StartupProbe.FailureThreshold)
 
+	assert.Equal(t, "/healthz", c.LivenessProbe.HTTPGet.Path)
+	assert.Equal(t, int32(10), c.LivenessProbe.PeriodSeconds)
+	assert.Equal(t, int32(5), c.LivenessProbe.TimeoutSeconds)
+	assert.Equal(t, int32(12), c.LivenessProbe.FailureThreshold,
+		"liveness must tolerate ~2 min of stall: a 30s kill window destroyed an in-container experiment run when the dev host starved the VM's vCPUs; truly dead agents are still reaped by invocation deadlines and the experiment inactivity sweep")
+
 	envMap := envToMap(c.Env)
 	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTPS_PROXY"])
 	assert.Equal(t, "http://10.96.42.42:10000", envMap["HTTP_PROXY"])

--- a/packages/experiment-sdk/src/experiment_sdk.py
+++ b/packages/experiment-sdk/src/experiment_sdk.py
@@ -118,20 +118,31 @@ def _config() -> tuple[str, str]:
     return f"{base}/api/agents/{agent_id}", agent_id
 
 
-_TRANSIENT_HTTP = {502, 503, 504}
+# 500 is transient here too: the api-server returns it while its own
+# dependencies (postgres, redis) restart under it, which is exactly the
+# outage the retry exists to ride out.
+_TRANSIENT_HTTP = {500, 502, 503, 504}
 _RETRY_ATTEMPTS = 4
 _RETRY_BASE_DELAY_S = 1.0
 
 
-def _request(method: str, path: str, body: Any | None = None) -> Any:
+def _request(
+    method: str, path: str, body: Any | None = None, *, retry: bool | None = None
+) -> Any:
     """One platform API call. GETs retry transient failures (5xx from a mesh
-    hop, a reset connection) with exponential backoff: a long run polls the
-    API thousands of times, and without the retry a single blip on any poll
-    kills every remaining round. Non-GETs are not blindly retried — the
-    platform treats a repeated finish/report as a conflict, not a dup."""
+    hop or a mid-restart api-server, a reset connection) with exponential
+    backoff: a long run polls the API thousands of times, and without the
+    retry a single blip on any poll kills every remaining round. Non-GETs
+    default to a single attempt and opt in per call site (``retry=True``):
+    event reports, finish, and plan registration are idempotent on the
+    server (spans upsert by id, a repeated finish answers 409), so they
+    retry; ``spawn`` never does — a duplicated POST /invocations is a
+    second worker, not a dup."""
     root, _ = _config()
     data = json.dumps(body).encode("utf-8") if body is not None else None
-    attempts = _RETRY_ATTEMPTS if method == "GET" else 1
+    if retry is None:
+        retry = method == "GET"
+    attempts = _RETRY_ATTEMPTS if retry else 1
     last_error: Exception | None = None
     for attempt in range(attempts):
         if attempt:
@@ -556,7 +567,7 @@ class Experiment:
                     f"{DASHBOARD_CONTENT_MAX_BYTES // 1024} KiB capture cap"
                 )
             plan["dashboard"] = {"content": raw.decode("utf-8", errors="replace")}
-        response = _request("POST", "/experiments/plan", plan)
+        response = _request("POST", "/experiments/plan", plan, retry=True)
         _log(
             f'plan registered for "{self.name}" ({response["experimentId"]}) — press "Start a new run" in the UI to run it'
         )
@@ -656,11 +667,19 @@ class Experiment:
         self._finished = True
         if self._heartbeat_stop is not None:
             self._heartbeat_stop.set()
-        self._flush(force=True)
         body: dict[str, Any] = {"status": status}
         if error:
             body["error"] = error[:2000]
-        _request("POST", f"/experiments/{self._experiment_id}/finish", body)
+        try:
+            self._flush(force=True)
+            _request(
+                "POST", f"/experiments/{self._experiment_id}/finish", body, retry=True
+            )
+        except ExperimentClosed:
+            # Already terminal on the platform (stopped by the user, or a
+            # retried finish whose first attempt landed) — nothing to report.
+            _log(f'experiment "{self.name}" was already closed on the platform')
+            return
         _log(f'experiment "{self.name}" finished: {status}')
 
     def __enter__(self) -> "Experiment":
@@ -686,14 +705,28 @@ class Experiment:
             self._flush(force=True)
 
     def _flush(self, force: bool = False) -> None:
+        """Report buffered events; the buffer is drained only once the POST
+        lands. Reports are observability, so a transient outage costs
+        latency, never the run: on failure the events stay buffered (the next
+        emit retries them) and the caller — often ``Span.__exit__`` — is not
+        killed. ``ExperimentClosed`` still propagates: the run was stopped on
+        the platform and the loop should exit promptly."""
         if not self._buffer or self._experiment_id is None:
             return
         if not force and len(self._buffer) < _EVENT_FLUSH_MAX:
             return
-        events, self._buffer = self._buffer, []
-        _request(
-            "POST",
-            f"/experiments/{self._experiment_id}/events",
-            {"events": events},
-        )
+        events = list(self._buffer)
+        try:
+            _request(
+                "POST",
+                f"/experiments/{self._experiment_id}/events",
+                {"events": events},
+                retry=True,
+            )
+        except ExperimentClosed:
+            raise
+        except Exception as err:  # noqa: BLE001 — kept buffered; next emit retries
+            _log(f"event report failed, {len(events)} event(s) kept for retry: {err}")
+            return
+        self._buffer = self._buffer[len(events) :]
         self._last_flush = time.monotonic()

--- a/packages/experiment-sdk/src/experiment_sdk.py
+++ b/packages/experiment-sdk/src/experiment_sdk.py
@@ -59,6 +59,12 @@ SCRIPT_CONTENT_MAX_BYTES = 256 * 1024
 DASHBOARD_CONTENT_MAX_BYTES = 512 * 1024
 _EVENT_FLUSH_MAX = 100
 _EVENT_FLUSH_SECONDS = 2.0
+# Mirrors the server's `appendEventsRequestSchema` cap. The buffer retains at
+# most this many events, so a batch held back by a failed flush is still a
+# batch the server will accept once it returns.
+_EVENT_BATCH_MAX = 500
+# One outage costs one retry ladder, not one ladder per emit.
+_EVENT_RETRY_BACKOFF_S = 30.0
 _DEFAULT_POLL_SECONDS = 5.0
 # Mirrors the server's ttl clamp (~1min..6h) plus a poll of slack.
 _DEFAULT_SPAWN_TIMEOUT_S = 6 * 60 * 60 + 60
@@ -476,6 +482,8 @@ class Experiment:
         self._heartbeat_stop: threading.Event | None = None
         self._buffer: list[dict[str, Any]] = []
         self._last_flush = time.monotonic()
+        self._flush_blocked_until = 0.0
+        self._dropped_events = 0
 
     # -- declaration ------------------------------------------------------------
 
@@ -671,7 +679,7 @@ class Experiment:
         if error:
             body["error"] = error[:2000]
         try:
-            self._flush(force=True)
+            self._flush(force=True, ignore_backoff=True)
             _request(
                 "POST", f"/experiments/{self._experiment_id}/finish", body, retry=True
             )
@@ -700,22 +708,36 @@ class Experiment:
 
     def _emit(self, event: dict[str, Any], flush: bool = False) -> None:
         self._buffer.append(event)
+        if len(self._buffer) > _EVENT_BATCH_MAX:
+            self._buffer = self._buffer[-_EVENT_BATCH_MAX:]
+            self._dropped_events += 1
         stale = time.monotonic() - self._last_flush > _EVENT_FLUSH_SECONDS
         if flush or stale or len(self._buffer) >= _EVENT_FLUSH_MAX:
             self._flush(force=True)
 
-    def _flush(self, force: bool = False) -> None:
+    def _flush(self, force: bool = False, ignore_backoff: bool = False) -> None:
         """Report buffered events; the buffer is drained only once the POST
         lands. Reports are observability, so a transient outage costs
         latency, never the run: on failure the events stay buffered (the next
         emit retries them) and the caller — often ``Span.__exit__`` — is not
         killed. ``ExperimentClosed`` still propagates: the run was stopped on
-        the platform and the loop should exit promptly."""
+        the platform and the loop should exit promptly.
+
+        An outage is bounded on both axes. The buffer retains only the newest
+        ``_EVENT_BATCH_MAX`` events, so what is held back stays a payload the
+        server accepts — an unbounded retained batch would pass the server's
+        cap and then be rejected on every future attempt, wedging reporting
+        for the rest of the run. A failed flush also parks the next attempts
+        for ``_EVENT_RETRY_BACKOFF_S``, so a long outage costs one retry
+        ladder per window instead of one per emit. ``finish`` passes
+        ``ignore_backoff`` to buy the tail one last honest attempt."""
         if not self._buffer or self._experiment_id is None:
             return
         if not force and len(self._buffer) < _EVENT_FLUSH_MAX:
             return
-        events = list(self._buffer)
+        if not ignore_backoff and time.monotonic() < self._flush_blocked_until:
+            return
+        events = self._buffer[:_EVENT_BATCH_MAX]
         try:
             _request(
                 "POST",
@@ -726,7 +748,17 @@ class Experiment:
         except ExperimentClosed:
             raise
         except Exception as err:  # noqa: BLE001 — kept buffered; next emit retries
-            _log(f"event report failed, {len(events)} event(s) kept for retry: {err}")
+            self._flush_blocked_until = time.monotonic() + _EVENT_RETRY_BACKOFF_S
+            dropped = (
+                f", {self._dropped_events} dropped so far"
+                if self._dropped_events
+                else ""
+            )
+            _log(
+                f"event report failed, {len(self._buffer)} event(s) kept for "
+                f"retry{dropped}: {err}"
+            )
             return
+        self._flush_blocked_until = 0.0
         self._buffer = self._buffer[len(events) :]
         self._last_flush = time.monotonic()

--- a/packages/experiment-sdk/tests/test_experiment_sdk.py
+++ b/packages/experiment-sdk/tests/test_experiment_sdk.py
@@ -373,6 +373,9 @@ def test_event_report_outage_is_survived_and_events_redeliver(
         with stage.run() as span:
             span.score = 1.0
         outage["on"] = False
+        # A failed flush parks the next attempts; clearing the gate stands in
+        # for that window elapsing, so this still asserts redelivery.
+        exp._flush_blocked_until = 0.0
         with stage.run() as span:
             span.score = 2.0
 
@@ -425,3 +428,75 @@ def test_finish_treats_409_as_already_closed(stub, tmp_path, monkeypatch):
 
     finishes = [r for r in stub.requests if r[1].endswith("/finish")]
     assert len(finishes) == 1
+
+
+def test_long_outage_keeps_the_retained_batch_within_the_server_cap(
+    stub, tmp_path, monkeypatch
+):
+    """A retained batch that outgrew the server's 500-event cap used to be
+    rejected on every later attempt, wedging reporting for the rest of the
+    run. The buffer is bounded, so what is held back stays deliverable."""
+    monkeypatch.setenv("PLATFORM_EXPERIMENT_ID", "exp-9")
+    monkeypatch.setattr(x.time, "sleep", lambda _s: None)
+    stub.routes[("POST", "/finish")] = (200, {"ok": True})
+
+    def events_route(body):
+        if len(body["events"]) > x._EVENT_BATCH_MAX:
+            return (400, {"error": "too many events"})
+        return (200, {"accepted": len(body["events"])})
+
+    stub.routes[("POST", "/events")] = events_route
+
+    exp = x.Experiment("evolver", script_path=write_script(tmp_path))
+    exp.stage("eval")
+    exp.ready()
+    exp._flush_blocked_until = 0.0
+    exp._buffer = []
+    for i in range(x._EVENT_BATCH_MAX * 3):
+        exp._emit({"type": "custom-data", "data": {"i": i}})
+        assert len(exp._buffer) <= x._EVENT_BATCH_MAX
+
+    exp._flush_blocked_until = 0.0
+    exp._flush(force=True, ignore_backoff=True)
+    assert exp._buffer == []
+    assert all(
+        len(body["events"]) <= x._EVENT_BATCH_MAX
+        for method, path, body in stub.requests
+        if method == "POST" and path.endswith("/events")
+    )
+
+
+def test_outage_costs_one_retry_ladder_per_window_not_one_per_emit(
+    stub, tmp_path, monkeypatch
+):
+    """Without the back-off gate every emit during an outage paid the full
+    four-attempt ladder, charging reporting latency to the loop."""
+    monkeypatch.setenv("PLATFORM_EXPERIMENT_ID", "exp-9")
+    monkeypatch.setattr(x.time, "sleep", lambda _s: None)
+    stub.routes[("POST", "/finish")] = (200, {"ok": True})
+    stub.routes[("POST", "/events")] = (500, {"error": "db restarting"})
+
+    exp = x.Experiment("evolver", script_path=write_script(tmp_path))
+    exp.stage("eval")
+    exp.ready()
+
+    # ready() already failed a flush and armed the gate; open it so the loop
+    # below measures exactly one back-off window.
+    exp._flush_blocked_until = 0.0
+    before = sum(
+        1
+        for method, path, _b in stub.requests
+        if method == "POST" and path.endswith("/events")
+    )
+    for i in range(25):
+        exp._emit({"type": "custom-data", "data": {"i": i}}, flush=True)
+    attempts = (
+        sum(
+            1
+            for method, path, _b in stub.requests
+            if method == "POST" and path.endswith("/events")
+        )
+        - before
+    )
+    # One ladder (_RETRY_ATTEMPTS posts), not one per emit.
+    assert attempts == x._RETRY_ATTEMPTS

--- a/packages/experiment-sdk/tests/test_experiment_sdk.py
+++ b/packages/experiment-sdk/tests/test_experiment_sdk.py
@@ -349,3 +349,79 @@ def test_budget_reads_the_owner_figures(stub):
     assert figures["cpu"]["ceilingMilli"] == 6000
     assert figures["memory"]["reservedBytes"] == 4 * 1024**3
     assert figures["defaultWorkerSize"] == {"cpu": "1", "memory": "1Gi"}
+
+
+def test_event_report_outage_is_survived_and_events_redeliver(
+    stub, tmp_path, monkeypatch
+):
+    monkeypatch.setenv("PLATFORM_EXPERIMENT_ID", "exp-9")
+    monkeypatch.setattr(x.time, "sleep", lambda _s: None)
+    stub.routes[("POST", "/finish")] = (200, {"ok": True})
+    outage = {"on": False}
+
+    def events_route(body):
+        if outage["on"]:
+            return (500, {"error": "db restarting"})
+        return (200, {"accepted": len(body["events"])})
+
+    stub.routes[("POST", "/events")] = events_route
+
+    with x.Experiment("evolver", script_path=write_script(tmp_path)) as exp:
+        stage = exp.stage("eval")
+        exp.ready()
+        outage["on"] = True
+        with stage.run() as span:
+            span.score = 1.0
+        outage["on"] = False
+        with stage.run() as span:
+            span.score = 2.0
+
+    batches = [
+        body["events"]
+        for method, path, body in stub.requests
+        if method == "POST"
+        and path.endswith("/events")
+        and any(e["type"] != "heartbeat" for e in body["events"])
+    ]
+    redelivery = [
+        b
+        for b in batches
+        if [e["type"] for e in b] == ["span-start", "span-end", "span-start"]
+    ]
+    assert len(redelivery) == 1
+    assert redelivery[0][1]["score"] == 1.0
+    _method, path, body = stub.requests[-1]
+    assert path.endswith("/finish") and body == {"status": "completed"}
+
+
+def test_finish_retries_a_transient_failure(stub, tmp_path, monkeypatch):
+    monkeypatch.setenv("PLATFORM_EXPERIMENT_ID", "exp-9")
+    monkeypatch.setattr(x.time, "sleep", lambda _s: None)
+    stub.routes[("POST", "/events")] = (200, {"accepted": 1})
+    finish_calls = []
+
+    def finish_route(body):
+        finish_calls.append(body)
+        if len(finish_calls) == 1:
+            return (503, {"error": "blip"})
+        return (200, {"ok": True})
+
+    stub.routes[("POST", "/finish")] = finish_route
+
+    with x.Experiment("evolver", script_path=write_script(tmp_path)) as exp:
+        exp.ready()
+
+    assert len(finish_calls) == 2
+    assert finish_calls[-1] == {"status": "completed"}
+
+
+def test_finish_treats_409_as_already_closed(stub, tmp_path, monkeypatch):
+    monkeypatch.setenv("PLATFORM_EXPERIMENT_ID", "exp-9")
+    stub.routes[("POST", "/events")] = (200, {"accepted": 1})
+    stub.routes[("POST", "/finish")] = (409, {"error": "stopped"})
+
+    with x.Experiment("evolver", script_path=write_script(tmp_path)) as exp:
+        exp.ready()
+
+    finishes = [r for r in stub.requests if r[1].endswith("/finish")]
+    assert len(finishes) == 1

--- a/packages/experiment-sdk/tests/test_request_retry.py
+++ b/packages/experiment-sdk/tests/test_request_retry.py
@@ -109,3 +109,32 @@ def test_409_still_raises_experiment_closed(platform) -> None:
     platform.setattr(urllib.request, "urlopen", fake_urlopen)
     with pytest.raises(x.ExperimentClosed):
         x._request("GET", "/x")
+
+
+def test_transient_500_is_retried(platform) -> None:
+    calls = []
+
+    def fake_urlopen(req):
+        calls.append(1)
+        if len(calls) == 1:
+            raise _http_error(500)
+        return _Resp('{"ok": true}')
+
+    platform.setattr(urllib.request, "urlopen", fake_urlopen)
+    assert x._request("GET", "/invocations/i-1") == {"ok": True}
+    assert len(calls) == 2
+
+
+def test_opt_in_post_retries_transient(platform) -> None:
+    calls = []
+
+    def fake_urlopen(req):
+        calls.append(1)
+        if len(calls) < 3:
+            raise _http_error(503)
+        return _Resp('{"ok": true}')
+
+    platform.setattr(urllib.request, "urlopen", fake_urlopen)
+    result = x._request("POST", "/experiments/e/events", {"events": []}, retry=True)
+    assert result == {"ok": True}
+    assert len(calls) == 3


### PR DESCRIPTION
Adds a second optimization-campaign starter and hardens the experiment SDK's write path. Every subsystem this branch touches is listed below.

### `dam-experiment` skill — new `tiny-search` starter
- A minimal, dependency-free in-memory full-text search index for Node.js, deliberately naive so a campaign has real headroom (~50–70×) against a behavioral suite that must stay green.
- Behavioral suite (18 tests, `node:test`) pinning the tokenizer, AND semantics, occurrence scoring, ordering and tie-breaks, limits, replace-on-re-add and removal.
- Deterministic benchmark with `query-heavy` / `index-heavy` / `mixed` scenarios and a behavior checksum that is stable across runs but changes when behavior does.
- `README.md` states the contract the campaign optimizes against, including the Unicode tokenizer rule, the `limit` rule, and the quadratic corpus build.
- `references/tiny-search-starter.md`, plus `SKILL.md` and `references/images.md` / `references/nous-evaluator.md` updates.

### `dam-experiment` skill — docs beyond the starter
- `SKILL.md` gains a `campaign.yaml` design-control section and expanded scoring/validation and cost-reporting guidance.
- `commands/experiment-onboard.md` is rewritten to offer both starters.

### `experiment-sdk` — write path
- Event reports and `finish` retry transient failures; `spawn` still never retries.
- The event buffer is bounded to the events route's 500-event cap. Previously a retained batch grew without limit during an outage, passed the cap, and was then rejected on every later attempt — reporting wedged permanently for the rest of the run.
- A failed flush parks further attempts for a back-off window, so a long outage costs one retry ladder per window instead of one per reported event. `finish` bypasses the window to give the tail one last attempt.

### `controller`
- Raises the agent liveness probe failure threshold so a busy agent is not restarted mid-turn.

### `deploy`
- `lima-k3s.yaml` gains a note on host-CPU starvation as the usual cause of cluster-wide probe-timeout cascades on the local dev cluster.

### `docs/architecture`
- `experiments.md` records the reporting contract this branch changes: which writes retry and why, that a rejected batch is retained within the accepted size, that a failed flush backs off, and that `finish` is a no-op on an already-terminal run.

### `mise.lock`
- Restores the `tools.java.*` platform entries that an earlier commit on this branch dropped as collateral (a local mise run rewrites the lockfile with only the platforms it resolved on the host).
