### PR TITLE
fix(deploy): e2e renders only the mock agent template

### DIFF
--- a/deploy/helm/platform/values-e2e.yaml
+++ b/deploy/helm/platform/values-e2e.yaml
@@ -11,8 +11,14 @@ e2e:
 nfsProvisioner:
   enabled: false
 
-# Only the mock image is built for the e2e cluster — disable claude-code,
-# the one other template values-local.yaml leaves enabled.
+# Only the mock image is built for the e2e cluster, so every template
+# values-local.yaml leaves enabled must be disabled here: one that renders
+# into the agent ConfigMap makes cluster:install load an image CI never built,
+# and the e2e job pulls only controller/api-server/ui/keycloak/mock. nous is
+# listed even though values-local disables it too — re-enabling it there for a
+# campaign must not take e2e down with it.
 agentTemplates:
   claude-code:
+    enabled: false
+  nous:
     enabled: false

--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -100,7 +100,7 @@ agentTemplates:
       tag: latest
 
   nous:
-    enabled: true
+    enabled: false
     image:
       repository: platform-nous
       tag: latest


### PR DESCRIPTION
main's `mise e2e` has been red since #3318. Every open PR inherits the failure.

```
[agents:nous:image] $ # Nous installs from its public GitHub repo at build time (no vendoring). The
Loading images into k3s...
Error response from daemon: reference does not exist
```

## What happened

#3318 enabled the `nous` agent template in `values-local.yaml`. `values-e2e.yaml` is layered on top of it for the e2e cluster and disables templates **by enumeration** — its comment asserted claude-code was "the one other template values-local.yaml leaves enabled", which stopped being true in that same commit.

So the e2e render became `mock` + `nous`:

| render | before this PR | after |
|---|---|---|
| e2e (`values-local` + `values-e2e`) | `mock`, **`nous`** | `mock` |
| local (`values-local`) | `claude-code`, `mock`, `nous` | `claude-code`, `mock` |

From there the failure is mechanical. `cluster:install` puts every rendered template's image into `AGENT_IMAGES` whether or not a build ran (`deploy/tasks.toml`), and in CI `SKIP_IMAGE_BUILD=1` makes `agents:nous:image` exit immediately. The e2e job pulls only `controller api-server ui keycloak mock` (`cd.yml`), and `build-workloads` is skipped by design on PRs (`resolve-image.sh`: PRs never build workloads). `platform-nous:latest` is therefore never in the daemon, and `docker save` reports it as `reference does not exist`.

## The change

- **`values-local.yaml`** — `nous.enabled` back to `false`, matching every other workload. The sizing comments and `resources` block from #3318 stay in place, so re-enabling it for a campaign is a one-word edit with the tuning intact.
- **`values-e2e.yaml`** — an explicit `nous` disable is kept even though values-local now disables it too, so enabling it locally for a campaign cannot take e2e down again. The stale comment is replaced with the actual invariant and the reason it matters.

@Tomas2D heads-up: this turns nous off for a local `cluster:install`, which #3318 deliberately enabled. Flipping the one line in `values-local.yaml` brings it back and e2e stays green.

## Known fragility, not fixed here

`values-e2e.yaml` still disables templates by enumeration, so the next template enabled in `values-local.yaml` breaks e2e the same way — with an opaque daemon error three jobs removed from the edit. `tasks.toml` already exports `E2E_MOCK_ONLY=1`, which nothing in the repo reads; that dead flag is the natural home for a structural fix, but it carries a real design question (should e2e install a template whose image it cannot pull, or not render it at all?) and does not belong in an unbreak-main change.

## Verification

Both renders checked above, `mise run helm:check` passes. CI's own e2e job on this branch is the real test.