### PR TITLE
docs(adr): pod-owned live updates for session and workspace state

### DIFF
--- a/docs/adrs/084-pod-owned-live-updates.md
+++ b/docs/adrs/084-pod-owned-live-updates.md
@@ -1,0 +1,55 @@
+---
+id: 084
+title: Pod-owned live updates over the agent's own tRPC surface
+status: accepted
+subsystem: platform-topology
+tags: [live-updates, sessions, workspace, acp, hibernation]
+summary: Pod-owned state is read and watched over the agent-runtime's own tRPC surface relayed over WebSocket; a Watch lives only as long as its subscriber and emits topic-plus-ids notices, never state.
+---
+
+# ADR-084: Pod-owned live updates over the agent's own tRPC surface
+
+**Date:** 2026-08-25
+**Status:** Accepted
+**Owner:** @jezekra1
+
+## Context
+
+The live-updates work ([ADR-083](083-eventing-layering.md)) replaced polling with pushed invalidation notices everywhere the api-server could observe the write. Two surfaces stayed on timers because their truth lives inside the pod: the session list at five seconds, and the workspace listing plus the open file at two seconds each. Three things since have made that residue expensive rather than merely untidy. The file panel's readiness check runs on every proxied call and patches the Agent record each time, and once the controller stopped reconciling on every resync that patch storm became the dominant steady-state reconcile load, sitting in front of the readiness-latency work the resync change was a prerequisite for. A new Home feed polls the session list for every running agent, opening and closing a WebSocket per agent per tick — the cross-agent session listing [ADR-055](055-agent-owned-session-metadata.md) assumed did not exist. And the session list is reached by opening a throwaway ACP connection purely to carry one read.
+
+## Decision
+
+Pod-owned state — the session list, the workspace directories a client has open, and the open file — is read and observed over the agent-runtime's own tRPC surface, exposed over WebSocket and relayed by the api-server, rather than over ACP or on a timer. A **Watch** exists only while a subscriber is attached and emits notices carrying a topic and ids, never state, so an unobserved agent produces no traffic.
+
+The rules this sets:
+
+- **A notice means "re-read", never "here is the value."** Every consumer must have a query path. This holds even for liveness: a terminal session's working state has no falling edge to push, so the pod times it out and emits a notice like any other change.
+- **Sync-on-subscribe is the whole loss bound.** Every subscription opens with a notice meaning "re-read everything you map", and there is no steady-state poll behind it. A dropped connection, a pod restart and a hibernate-wake cycle all heal the same way.
+- **The harness stays authoritative over which sessions exist.** The platform composes its view by union and enrichment, never by maintaining a competing list. Session creation stays on ACP, because the harness mints the id.
+- **A workspace Watch covers exactly the directories a client has open, non-recursively.** How it detects change is private to the pod, so storage without filesystem notification degrades internally rather than on the wire.
+- **Owner-wide observation is a distinct subscription whose existence is the signal.** It cannot ride the per-owner notice stream, which takes no input and which every tab mounts unconditionally. A lease-elected holder keeps pod-facing connections bounded by running agents rather than by tabs.
+- **Watching does not keep an agent alive; being used does.** A user-facing relay checks readiness passively, takes no session pin, and refreshes the activity stamp periodically while open. Server-held streams refresh nothing — they exist for every running agent of every watching owner, and a stamp from one would pin the fleet awake.
+
+## Consequences
+
+- **Easier:** every fixed-interval poll against a pod goes away — the five-second session list, both two-second file polls, and the Home feed's one-WebSocket-per-running-agent tick. Activity stamping drops from once per proxied call, currently around thirty Agent-record patches a minute per open file panel, to one per open view per interval, and the controller's full reconcile per patch goes with it.
+- **Easier:** composing the session list inside the pod closes a gap ADR-055 promised and never implemented — sessions present in the pod's own store but not yet in the harness's are never listed today, which is why a schedule-fired session is absent rather than merely late.
+- **Harder:** two readers still take the ACP path — channel workers open a client per turn to match a thread, and the CLI has its own — so the response intercept survives until they migrate, leaving two compositions of one view in the interim. That is the divergence ADR-055 was written to remove, reintroduced with a different seam.
+- **Harder:** removing the steady-state poll removes the net that hid a broken notice path. A lost notice now shows as a stale panel until the next subscribe. This is deliberate — a slow fallback would have kept such a bug invisible — but it moves the failure from degraded to wrong.
+- **Harder:** a per-agent WebSocket relay is a fourth relay to admit, authorize and audit, on a surface whose existing three each carry their own activity and pin semantics. The new one needs a third policy, distinct from both.
+- **Committed-to:** the pod's own tRPC surface, not ACP, is where platform-owned session reads live. A Watch's lifetime is its subscription, which is the only thing making "unobserved agent, no traffic" true rather than aspirational. And notices never carry state, so any future consumer must bring a query path rather than treating the stream as a feed.
+
+## Alternatives Considered
+
+- **ACP notifications on the connection a tab already holds** — pod-to-client notices already exist there, but a filesystem watch is not an ACP concern, and it would leave the UI with two unrelated notification mechanisms.
+- **Reporting to the harness port and projecting into the per-owner notice stream** — that port refuses WebSocket upgrades and exposes one route, and "is anyone watching" becomes a cross-replica reference count pushed back down to the pod.
+- **A new topic on the existing per-owner notice stream** — it takes no input, so a watch set has nowhere to live, and every tab subscribes unconditionally, so watches could not be scoped to observers.
+- **Server-sent events through the existing HTTP proxy** — the proxy forwards no abort signal, so a closed tab leaves the pod watching, and a reconnect against a hibernating agent wakes it through the per-call readiness check.
+- **A server-side session projection so hibernated agents appear in the feed** — deferred, not rejected: the Home work documents that limitation as deliberate, with tracking read state server-side named as its own decision.
+- **Keeping a slow poll as the loss bound** — converges no faster than sync-on-subscribe and masks a broken notice path, which is the failure mode hardest to notice.
+
+## Amends
+
+- **ADR-055** — its committed-to clause naming `_meta.platform.*` as the wire format narrows to writes. That choice rested on every reader already holding an ACP connection; a per-agent tRPC relay makes the premise false. The agent remains the sole source of truth for session existence and metadata, and there is still no server-side session store.
+- **ADR-049** — its committed-to "per-directory cache keying as the unit of subscription; any future shift from polling to push delivery will reuse this shape" is honored rather than changed: a Watch covers exactly the open directories, and the set a client declares is the same one it already sends to read them.
+- **ADR-083** — unchanged in layering, extended in origin. An invalidation notice may now originate in a pod rather than only from a domain event inside the api-server. Thin, advisory, schema-parsed on receipt, and loss bounded by reconciliation all still hold.

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -78,6 +78,7 @@ Generated projection of the ADR log. Read this first when authoring a new decisi
 | 081 | [Admit a blocked start by hibernating the owner's idle agents early](081-admit-by-hibernation.md) |  | budgets | The per-user budget gate may admit an over-budget start by hibernating that owner's unattended idle agents ahead of their timeout, longest-idle first, instead of refusing until the user frees room by hand. |
 | 082 | [Prompt delivery is measured by the server, not inferred by the client](082-server-authoritative-prompt-delivery.md) |  | agent-lifecycle | The runtime tells the originating channel what happened to each identified prompt via two ephemeral notifications, and the client's delivery indicator is a state machine driven only by those frames. |
 | 083 | [Eventing layers by guarantee — in-process sagas, Redis signals, BullMQ work](083-eventing-layering.md) |  | platform-topology | Domain events stay in-process and non-durable, consumed by sagas that forward cross-replica signals to Redis pub/sub or enqueue durable work as BullMQ jobs; no single distributed bus. |
+| 084 | [Pod-owned live updates over the agent's own tRPC surface](084-pod-owned-live-updates.md) |  | platform-topology | Pod-owned state is read and watched over the agent-runtime's own tRPC surface relayed over WebSocket; a Watch lives only as long as its subscriber and emits topic-plus-ids notices, never state. |
 
 ## Superseded
 

--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -1,6 +1,6 @@
 # Ubiquitous Language
 
-Domain terms used across this project. Each term is scoped to its bounded context, except for the cross-cutting Substrate vocabulary below.
+Domain terms used across this project. Each term is scoped to its bounded context, except for the cross-cutting Substrate and Live Updates vocabulary below.
 
 Two registers live in this file. The **domain vocabulary** (from [Substrate](#substrate) down) is the language code and docs use. [User-Facing Terminology](#user-facing-terminology) is the language the GUI uses. They are deliberately not the same list: a domain term is not automatically a word users read, and several domain terms are never shown.
 
@@ -45,6 +45,21 @@ Persistence vocabulary shared by every bounded context. See [`docs/architecture/
 | Spare | An unclaimed Workspace Volume in the Warm Pool — provisioned and bound, waiting to be claimed. Carries a pool label and an available marker, and deliberately **no** owning-Agent label, so the orphan-volume sweep ignores it. |
 | Claim (verb) | To assign a Spare to a newly created Agent: the controller relabels the Spare to that Agent in one atomic update, and the Agent mounts it as its Workspace Volume. A claimed Spare becomes an ordinary owned Workspace Volume — destroyed on Agent deletion, never returned to the pool. Distinct from the Kubernetes noun *PersistentVolumeClaim*. |
 | Storage Migration | The controller's one-time, interrupt-safe drain of legacy shared-writable (RWX) Workspace Volumes onto ReadWriteOnce storage: force the Agent down, copy onto a fresh volume in a checksum-verified Job, re-point the Agent, delete the old volume, restore the prior run state. A no-op once no RWX volume remains; removed with the transitional window. |
+
+## Live Updates
+
+Eventing and cache-freshness vocabulary shared by every bounded context. Three words that sound interchangeable are not — each names one delivery guarantee, and using the wrong one hides which guarantee a reader gets. See [`docs/architecture/platform-topology.md`](architecture/platform-topology.md) for the layering.
+
+| Term | Definition |
+|------|-----------|
+| Domain Event | An in-process, synchronous, at-most-once, non-durable announcement a service emits after its write commits. Its only consumers are Sagas running in the emitting process. Never crosses a process boundary, and nothing may depend on one arriving |
+| Saga | An in-process consumer of Domain Events — the audit trail, usage rollups, per-agent cleanups. A Saga that must reach another replica forwards a Signal; it never forwards the Domain Event itself |
+| Signal | A thin cross-replica message on the shared Redis bus — an id and a topic, never entity state. The consumer re-reads truth from the store on receipt. Reserved for this meaning: an in-process announcement is a Domain Event, and a browser-bound invalidation notice is a Live Event |
+| Live Event | The per-owner invalidation notice a browser tab receives on its live-events subscription: a Topic plus ids, **never entity state**. Means "re-read this over the query path", never "here is the new value". Schema-parsed on receipt and dropped on mismatch, so replicas on different versions cannot poison a stream |
+| Topic | The family a Live Event names, which the client maps to a query family. Coarse by design — a Topic invalidates whole families rather than splicing individual entities |
+| Sync | The Live Event every (re)subscribed stream opens with, meaning "re-read everything you map". The loss bound for the whole mechanism: reconnects heal by refetch rather than replay, so no Live Event needs delivery guarantees. Also what an overflowing queue collapses to, since by contract it is the full recovery |
+| Watch | A pod-side observer of pod-owned truth (the session list, watched workspace directories, the open file) that emits Live Events for changes only the pod can see. Its lifetime **is** the subscription: an unobserved Agent has no Watch and produces no traffic. Coalesces under load, and how it detects change — filesystem notifications or an internal diff — is private to the pod |
+| Snapshot | Pod-owned truth kept server-side as display state, so a surface still renders while its Agent is hibernated. Carries the moment it was captured and whether a pod confirmed it or it is merely what an apply asserted. Never re-asserted onto the pod, and the live read always wins when the Agent is up. The harness-config snapshot on the `agents` row is the reference implementation |
 
 ## Agents (bounded context)
 


### PR DESCRIPTION
ADR-084. The session list and the Files panel are the last surfaces that poll, because their truth lives inside the agent pod and there was no server-side moment to emit from. This records how they stop polling.

**Decision.** Pod-owned state — the session list, the workspace directories a client has open, and the open file — is read and observed over the agent-runtime's own tRPC surface, exposed over WebSocket and relayed by the api-server, rather than over ACP or on a timer. A Watch exists only while a subscriber is attached and emits notices carrying a topic and ids, never state, so an unobserved agent produces no traffic.

Also adds a cross-cutting **Live Updates** section to `docs/ubiquitous-language.md`, which had no entry for any of this vocabulary. Three words that sound interchangeable are not, and the glossary now says which delivery guarantee each one carries: **Domain Event** (in-process, at-most-once), **Signal** (thin cross-replica Redis message), **Live Event** (per-owner browser invalidation notice). Plus Topic, Sync, and the two new terms, Watch and Snapshot.

## What it amends

- **ADR-055** — narrows its committed-to `_meta.platform.*` wire format to *writes*. That choice assumed every reader already held an ACP connection; a per-agent tRPC relay makes the premise false. The agent remains the sole source of truth for session existence, and there is still no server-side session store.
- **ADR-049** — its "per-directory cache keying as the unit of subscription" is honoured rather than changed: a Watch covers exactly the open directories.
- **ADR-083** — layering unchanged, origin extended: an invalidation notice may now originate in a pod, not only from a domain event in the api-server.

No `supersedes` field: ADR-055's core holds, so marking it superseded wholesale would be false. It uses an `Amends` section, following ADR-055's own precedent with ADR-019.

Implementation lands separately in #3450, which is decomposed into eight sub-issues. Refs #3307.