### PR TITLE
feat: operator-configurable compute request link

### DIFF
--- a/deploy/helm/platform/templates/apiserver/app.yaml
+++ b/deploy/helm/platform/templates/apiserver/app.yaml
@@ -404,6 +404,10 @@ spec:
               value: {{ .Values.terms.version | quote }}
             - name: TERMS_TEXT
               value: {{ .Values.terms.text | quote }}
+            {{- if .Values.links.computeRequest }}
+            - name: LINKS_COMPUTE_REQUEST
+              value: {{ .Values.links.computeRequest | quote }}
+            {{- end }}
             {{- if .Values.clickstack.enabled }}
             # The api-server's own operational telemetry (request traces,
             # per-procedure metrics, logs) exports OTLP straight to the

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -51,6 +51,14 @@ terms:
   # judgment — whitespace edits don't bump this.
   version: ""
 
+# -- Outbound links surfaced in the UI, changeable per install without a
+# rebuild (the api-server serves them over `links.all`).
+links:
+  # Where "Request more" next to the compute meter points — a chat channel,
+  # form, or ticket queue. Complete URL. Empty string uses the bundled
+  # default.
+  computeRequest: ""
+
 # -- Base domain for the app. UI and API share this host; the ingress
 # splits `/api/*` to the api-server and everything else to the UI. Keycloak
 # lives at `keycloak.{domain}`.

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -55,7 +55,7 @@ terms:
 # rebuild (the api-server serves them over `links.all`).
 links:
   # Where "Request more" next to the compute meter points — a chat channel,
-  # form, or ticket queue. Complete URL. Empty string uses the bundled
+  # form, or ticket queue. Complete URL. Empty string uses the UI's bundled
   # default.
   computeRequest: ""
 

--- a/packages/api-server-api/src/context.ts
+++ b/packages/api-server-api/src/context.ts
@@ -12,6 +12,7 @@ import type { LiveEventsService } from "./modules/events/types.js";
 import type { ExperimentsService } from "./modules/experiments/types.js";
 import type { InvocationsQueryService } from "./modules/invocations/types.js";
 import type { KnowledgeBasesService } from "./modules/knowledge-bases/types.js";
+import type { Links } from "./modules/links/types.js";
 import type { FilesService } from "./modules/files/router.js";
 import type { HarnessConfigService } from "./modules/harness-config/types.js";
 import type { SchedulesService } from "./modules/schedules/types.js";
@@ -47,6 +48,7 @@ export interface ApiContext {
   features: FeaturesService;
   files: FilesService;
   harnessConfig: HarnessConfigService;
+  links: Links;
   liveEvents: LiveEventsService;
   metrics: MetricsService;
   terms: TermsService;

--- a/packages/api-server-api/src/index.ts
+++ b/packages/api-server-api/src/index.ts
@@ -513,6 +513,9 @@ export type {
 export { brandSchema } from "./modules/brand/types.js";
 export type { Brand } from "./modules/brand/types.js";
 
+export { linksSchema } from "./modules/links/types.js";
+export type { Links } from "./modules/links/types.js";
+
 export {
   publicAgentViewSchema,
   publicAgentResponseSchema,

--- a/packages/api-server-api/src/modules/links/router.ts
+++ b/packages/api-server-api/src/modules/links/router.ts
@@ -1,0 +1,6 @@
+import { t } from "../../trpc.js";
+import { readAgentProcedure } from "../../auth-procedures.js";
+
+export const linksRouter = t.router({
+  all: readAgentProcedure.query(({ ctx }) => ctx.links),
+});

--- a/packages/api-server-api/src/modules/links/types.ts
+++ b/packages/api-server-api/src/modules/links/types.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const linksSchema = z.object({
-  computeRequest: z.url().nullable(),
+  computeRequest: z.string().nullable(),
 });
 
 export type Links = z.infer<typeof linksSchema>;

--- a/packages/api-server-api/src/modules/links/types.ts
+++ b/packages/api-server-api/src/modules/links/types.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 
 export const linksSchema = z.object({
-  computeRequest: z.url(),
+  computeRequest: z.url().nullable(),
 });
 
 export type Links = z.infer<typeof linksSchema>;

--- a/packages/api-server-api/src/modules/links/types.ts
+++ b/packages/api-server-api/src/modules/links/types.ts
@@ -1,0 +1,7 @@
+import { z } from "zod";
+
+export const linksSchema = z.object({
+  computeRequest: z.url(),
+});
+
+export type Links = z.infer<typeof linksSchema>;

--- a/packages/api-server-api/src/router.ts
+++ b/packages/api-server-api/src/router.ts
@@ -11,6 +11,7 @@ import { egressRulesRouter } from "./modules/egress-rules/router.js";
 import { eventsRouter } from "./modules/events/router.js";
 import { experimentsRouter } from "./modules/experiments/router.js";
 import { knowledgeBasesRouter } from "./modules/knowledge-bases/router.js";
+import { linksRouter } from "./modules/links/router.js";
 import { featuresRouter } from "./modules/features/router.js";
 import { filesRouter } from "./modules/files/router.js";
 import { harnessConfigRouter } from "./modules/harness-config/router.js";
@@ -37,6 +38,7 @@ export const appRouter = t.router({
   artifactLibrary: artifactLibraryRouter,
   features: featuresRouter,
   files: filesRouter,
+  links: linksRouter,
   metrics: metricsRouter,
   terms: termsRouter,
   usage: usageRouter,

--- a/packages/api-server/src/apps/api-server/trpc/context.ts
+++ b/packages/api-server/src/apps/api-server/trpc/context.ts
@@ -282,6 +282,7 @@ export function createApiContextFactory(boot: ApiServerDeps) {
       features,
       files,
       harnessConfig,
+      links: config.links,
       liveEvents,
       metrics,
       terms,

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -234,9 +234,7 @@ export function loadConfig(): Config {
       },
     },
     links: {
-      computeRequest:
-        process.env.LINKS_COMPUTE_REQUEST ||
-        "https://ibm.enterprise.slack.com/archives/C0B3F03NB24",
+      computeRequest: process.env.LINKS_COMPUTE_REQUEST || null,
     },
     terms: {
       version: process.env.TERMS_VERSION,

--- a/packages/api-server/src/config.ts
+++ b/packages/api-server/src/config.ts
@@ -1,4 +1,4 @@
-import { brandSchema } from "api-server-api";
+import { brandSchema, linksSchema } from "api-server-api";
 import { z } from "zod";
 import pkg from "../package.json" with { type: "json" };
 import { durationToMinutesStrict } from "./duration.js";
@@ -109,6 +109,7 @@ const configSchema = z.object({
   shareBaseUrl: z.url({ error: "SHARE_BASE_URL must be a valid URL" }),
   experimentInactivitySeconds: z.coerce.number().int().positive().default(900),
   brand: brandSchema,
+  links: linksSchema,
   terms: z.object({
     version: z.string().min(1, "terms.version must be set"),
     text: z.string().min(1, "terms.text must be set"),
@@ -231,6 +232,11 @@ export function loadConfig(): Config {
           accentLight: process.env.BRAND_THEME_DARK_ACCENT_LIGHT ?? "#0f1f3a",
         },
       },
+    },
+    links: {
+      computeRequest:
+        process.env.LINKS_COMPUTE_REQUEST ||
+        "https://ibm.enterprise.slack.com/archives/C0B3F03NB24",
     },
     terms: {
       version: process.env.TERMS_VERSION,

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -13,4 +13,4 @@ export const MCP_DOCS_URL =
   "https://pages.github.ibm.com/dam-agents/docs/core-concepts/connections/#mcp-servers";
 
 export const COMPUTE_REQUEST_URL =
-  "https://slack.com/app_redirect?channel=DAMBUDGET";
+  "https://ibm.enterprise.slack.com/archives/C0B3F03NB24";

--- a/packages/ui/src/modules/home/components/compute-widget.tsx
+++ b/packages/ui/src/modules/home/components/compute-widget.tsx
@@ -8,6 +8,7 @@ import { COMPUTE_REQUEST_URL } from "../../../constants.js";
 import type { AgentView } from "../../../types.js";
 import { useBudgetReserved } from "../../budgets/api/queries.js";
 import { formatCores, formatGi } from "../../budgets/lib/format.js";
+import { useLinks } from "../../links/api/queries.js";
 import {
   type ComputeCell,
   type ComputeCellState,
@@ -40,6 +41,7 @@ function cellTitle(cell: ComputeCell): string {
 
 export function ComputeWidget({ runningAgents, workingAgentIds }: Props) {
   const { data } = useBudgetReserved();
+  const { data: links } = useLinks();
   if (!data) return null;
 
   const view = computeView(
@@ -61,11 +63,11 @@ export function ComputeWidget({ runningAgents, workingAgentIds }: Props) {
           </Tooltip>
         </span>
         <a
-          href={COMPUTE_REQUEST_URL}
+          href={links?.computeRequest ?? COMPUTE_REQUEST_URL}
           {...externalLinkProps}
           className="text-sm text-muted-foreground/60 transition-colors hover:text-muted-foreground"
         >
-          Need more?
+          Request more
         </a>
       </div>
 

--- a/packages/ui/src/modules/links/api/queries.ts
+++ b/packages/ui/src/modules/links/api/queries.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { trpc } from "../../../trpc.js";
+
+export function useLinks() {
+  return useQuery({
+    ...trpc.links.all.queryOptions(),
+    staleTime: Infinity,
+  });
+}


### PR DESCRIPTION
The "Need more?" link on the home compute widget pointed at a Slack channel that does not exist (`app_redirect?channel=DAMBUDGET`).

- The link now comes from the server: Helm `links.computeRequest` → `LINKS_COMPUTE_REQUEST` env → `links.all` tRPC query, so it can be changed per install without a UI rebuild.
- When unset, the server serves `null` and the UI falls back to its bundled constant, now pointing at #dam-community.
- Label renamed from "Need more?" to "Request more" to make the action clearer.

Requested in Slack by Jamie Jabbour.