### PR TITLE
chore(deploy): size the api-server as a control plane

### DIFF
--- a/deploy/helm/platform/values-local.yaml
+++ b/deploy/helm/platform/values-local.yaml
@@ -12,19 +12,6 @@ apiServer:
     repository: platform-api-server
     tag: latest
     pullPolicy: Never
-  # The catalogue default (500m) is a chat-workload sizing. On this VM every
-  # agent, driver and experiment status poll funnels through this one pod while
-  # a nous campaign drives the node's load average past its core count — at
-  # half a core the event loop misses its health probe, the kubelet restarts
-  # the container, and every driver polling through the waypoint takes a 503
-  # it cannot retry. The control plane must outrank the workloads it serves.
-  resources:
-    requests:
-      cpu: "500m"
-      memory: "512Mi"
-    limits:
-      cpu: "2"
-      memory: "1Gi"
 
 controller:
   image:

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -807,13 +807,17 @@ apiServer:
     # -- Path-style addressing, needed by SeaweedFS and most self-hosted
     # stores. Set false for AWS S3.
     forcePathStyle: true
+  # Every session stream, agent status poll and driver request funnels through
+  # this one pod, so it is sized as a control plane and not as a chat backend.
+  # Half a core let the event loop miss its health probe under load, and the
+  # kubelet restart took every in-flight request with it.
   resources:
     requests:
-      cpu: 100m
-      memory: 256Mi
-    limits:
-      cpu: 500m
+      cpu: "500m"
       memory: 512Mi
+    limits:
+      cpu: "2"
+      memory: 1Gi
 
 # -- Controller (Go reconciler + scheduler)
 controller:


### PR DESCRIPTION
## What

Raises the chart's `apiServer.resources` to the sizing `values-local.yaml`
already ran with, and drops the now-redundant local override.

| | before | after |
|---|---|---|
| requests | 100m / 256Mi | **500m / 512Mi** |
| limits | 500m / 512Mi | **2 CPU / 1Gi** |

## Why

Every session stream, agent status poll and driver request funnels through this
one pod. The old sizing was a chat-backend shape: at half a core the event loop
misses its health probe under load, the kubelet restarts the container, and
in-flight requests die with it. `values-local.yaml` had already been corrected
for exactly this on the lima VM — this promotes that sizing to the catalogue
default so dev and prod get it too, and removes the override that was
compensating for the default.

Measured on `dam-dev` (idle, ~30 min uptime): the pod sits at **221–224Mi**,
already 86% of the old 256Mi request, with the old 512Mi limit only ~2.3x its
idle floor.

## Notes

No `ResourceQuota` on `dam-dev`, so the raised request is schedulable as-is; it
lifts the namespace's total CPU request from ~2.6 to ~3.0 cores.

Separate findings on other components' sizing (the collector is running against
its `memory_limiter` threshold) are being raised on their own — not in this PR.

## Test plan

- `mise run helm:check` — lint + render pass
- Rendered `dam-platform-apiserver` Deployment carries `requests: 500m/512Mi`,
  `limits: 2/1Gi`