### PR TITLE
fix(deploy): size the collector, object store and Keycloak to measured use

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -311,13 +311,15 @@ clickstack:
     # default. Only applied when the exporter creates the tables — changing it later
     # requires ALTER TABLE ... MODIFY TTL by hand.
     ttl: 720h
-    # The memory_limiter processor starts refusing OTLP ingest at
-    # limit_percentage (80) of this limit. At 512Mi that threshold is 410Mi and
-    # the collector idles at 387Mi, which is how it accumulated 99 SIGKILLs.
+    # The memory_limiter processor refuses OTLP ingest above its soft limit,
+    # which upstream defines as limit_percentage minus spike_limit_percentage
+    # of this limit — 55% with the values in templates/clickstack/collector.yaml.
+    # At 512Mi that put refusal at 281Mi with the collector idling at 387Mi,
+    # which is how it accumulated 99 SIGKILLs. At 1Gi the soft limit is 563Mi.
     resources:
       requests:
         cpu: 100m
-        memory: 384Mi
+        memory: 448Mi
       limits:
         cpu: "1"
         memory: 1Gi

--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -284,13 +284,16 @@ seaweedfs:
   secretAccessKey: null
   storage: 10Gi
   storageClass: ""
+  # Measured at 283Mi idle on a store holding little content, so the old 128Mi
+  # request under-accounted it by more than half and left it high on the
+  # kubelet's eviction order. The footprint grows with what the library holds.
   resources:
     requests:
       cpu: 50m
-      memory: 128Mi
+      memory: 320Mi
     limits:
       cpu: 500m
-      memory: 512Mi
+      memory: 1Gi
 
 # -- Agent-telemetry backend (ClickStack). Off by default. Requires the clickstack-operators
 # chart installed out-of-band first (deploy/tasks.toml). See docs/architecture/observability.md.
@@ -308,13 +311,16 @@ clickstack:
     # default. Only applied when the exporter creates the tables — changing it later
     # requires ALTER TABLE ... MODIFY TTL by hand.
     ttl: 720h
+    # The memory_limiter processor starts refusing OTLP ingest at
+    # limit_percentage (80) of this limit. At 512Mi that threshold is 410Mi and
+    # the collector idles at 387Mi, which is how it accumulated 99 SIGKILLs.
     resources:
       requests:
         cpu: 100m
-        memory: 256Mi
+        memory: 384Mi
       limits:
         cpu: "1"
-        memory: 512Mi
+        memory: 1Gi
 
   # --- forwarded to the clickstack subchart ---
   # Third-party images pinned to the quay.io/dam-agents mirror (mirror these by hand):
@@ -504,13 +510,18 @@ keycloak:
     # Required for sslmode verify-ca/verify-full when the DB presents a private CA.
     caCert: ""
 
+  # Idles at 623Mi, above the old 512Mi request, which put it high on the
+  # kubelet's eviction order. No explicit heap size is set, so the JVM sizes
+  # its heap as a percentage of the limit and non-heap has to fit in what is
+  # left — at a 1Gi limit a filled heap leaves too little for metaspace,
+  # threads and code cache.
   resources:
     requests:
       cpu: 200m
-      memory: 512Mi
+      memory: 768Mi
     limits:
       cpu: "1"
-      memory: 1Gi
+      memory: 1536Mi
 
 # -- Ingress (hostnames derived from `domain` and `urls` values above)
 #


### PR DESCRIPTION
## What

Three components whose memory requests sat below their measured idle footprint.
Follows #3463, which did the same for the api-server.

| component | requests | limits |
|---|---|---|
| clickstack collector | 256Mi → **448Mi** | 512Mi → **1Gi** |
| seaweedfs | 128Mi → **320Mi** | 512Mi → **1Gi** |
| keycloak | 512Mi → **768Mi** | 1Gi → **1536Mi** |

CPU is untouched everywhere — none of the three came close to its CPU limit.

## Why

Sampled `kubectl top` on `dam-dev` every 30s for 5 minutes. **The cluster was
idle**, so every figure below is a floor, not a peak.

**Collector — the one with a failure record.** `restartCount: 99`, exit 137. Its
`memory_limiter` processor refuses OTLP ingest above its *soft* limit, which
upstream defines as `limit_percentage` minus `spike_limit_percentage` — with the
configured 80 and 25 that is 55% of the container limit. At 512Mi refusal began
at **281Mi**, and the collector idles at **387Mi**: it was already ~105Mi *past*
the point where it back-pressures ingest, with no agent load at all. At 1Gi the
soft limit moves to 563Mi, which the idle footprint clears with room to spare.

**seaweedfs — request understated by more than half.** Idles at **283Mi**
against a 128Mi request, on a store that currently holds very little. Usage that
far above the request is exactly the profile the kubelet evicts first, which is
not where an object store belongs.

**keycloak — over its own request.** Idles at **623Mi** against a 512Mi request.
The limit moves too, for a mechanical reason: no explicit `-Xmx` is set
anywhere in the templates, so the JVM sizes its heap as a percentage of the
container limit. At a 1Gi limit a filled heap leaves too little for metaspace,
threads and code cache. 1536Mi rather than 2Gi keeps that ceiling modest —
raising the limit raises what the JVM will grow into.

Each request is set above the figure that justifies it, so none of the three is
left sitting above its own request.

## Not in this PR

Three things the same sweep turned up that need a decision rather than a bump:

- **clickhouse** draws ~1.1 CPU *sustained while idle* against a 500m request —
  2.6x over. Either the request badly under-accounts it for scheduling or
  something is spinning. Worth a look before resizing.
- **clickstack-app** has no requests or limits at all — 620Mi unbounded,
  BestEffort QoS. It comes from the subchart, so fixing it means an override.
- **postgres** at 500m/512Mi is comfortable at idle, but it backs the
  api-server; with #3463 sizing that as a control plane, its database is the
  next ceiling.

## Notes

Raises the chart's total memory requests by ~896Mi. `deploy/lima-k3s.yaml`
tracks the platform stack at ~5GiB against a 20GiB VM, so this stays well
inside what the dev VM schedules alongside agent workloads.

## Test plan

- `mise run helm:check` — lint + render pass
- Rendered manifests carry the new values on all three (collector `448Mi/1Gi`,
  seaweedfs `320Mi/1Gi`, keycloak `768Mi/1536Mi`)