### PR TITLE
perf(ci,agents): cut the agent image to ~307MiB and stop re-pushing unchanged layers

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,8 +165,10 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
+            type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || format('type=gha,mode=max,scope={0}-{1}', matrix.component, matrix.arch) }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -252,8 +254,10 @@ jobs:
           file: packages/platform-base/Dockerfile
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/platform-base,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/platform-base:buildcache-${{ matrix.arch }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/platform-base:buildcache-{1},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.arch) || '' }}
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/platform-base:buildcache-${{ matrix.arch }}
+            type=gha,scope=platform-base-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/platform-base:buildcache-{1},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.arch) || format('type=gha,mode=max,scope=platform-base-{0}', matrix.arch) }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -340,8 +344,10 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
-          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
+            type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || format('type=gha,mode=max,scope={0}-{1}', matrix.component, matrix.arch) }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -435,8 +441,10 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ needs.changes.outputs.claude_code_base_tag }}
-          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
+            type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || format('type=gha,mode=max,scope={0}-{1}', matrix.component, matrix.arch) }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -573,8 +581,10 @@ jobs:
           tags: ${{ env.IMAGE_PREFIX }}/mock:${{ github.sha }}
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
-          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/mock:buildcache-amd64
-          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/mock:buildcache-amd64,mode=max,image-manifest=true', env.IMAGE_PREFIX) || '' }}
+          cache-from: |
+            type=registry,ref=${{ env.IMAGE_PREFIX }}/mock:buildcache-amd64
+            type=gha,scope=mock
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/mock:buildcache-amd64,mode=max,image-manifest=true', env.IMAGE_PREFIX) || 'type=gha,mode=max,scope=mock' }}
 
   e2e:
     name: mise e2e

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,8 +165,15 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.arch }}
+          # Registry cache rather than type=gha: GitHub caps a repo's Actions
+          # cache at 10GB and mode=max for ten components across two arches is
+          # multiples of that, so entries were evicted between runs. A missed
+          # step re-executes and its output carries fresh file timestamps, so
+          # unchanged content lands on a new layer digest and every node pulls
+          # it again — 451MiB per release on the agent image (#3403).
+          # PRs read the cache and never write it, keeping branch layers out.
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -252,8 +259,8 @@ jobs:
           file: packages/platform-base/Dockerfile
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/platform-base,push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=gha,scope=platform-base-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=platform-base-${{ matrix.arch }}
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/platform-base:buildcache-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/platform-base:buildcache-{1},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.arch) || '' }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -340,8 +347,8 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
-          cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.arch }}
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -435,8 +442,8 @@ jobs:
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ needs.changes.outputs.claude_code_base_tag }}
-          cache-from: type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.component }}-${{ matrix.arch }}
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
       - name: Export digest
         env:
           DIGEST: ${{ steps.build.outputs.digest }}
@@ -573,8 +580,8 @@ jobs:
           tags: ${{ env.IMAGE_PREFIX }}/mock:${{ github.sha }}
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
-          cache-from: type=gha,scope=mock
-          cache-to: type=gha,mode=max,scope=mock
+          cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/mock:buildcache-amd64
+          cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/mock:buildcache-amd64,mode=max,image-manifest=true', env.IMAGE_PREFIX) || '' }}
 
   e2e:
     name: mise e2e

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -165,13 +165,6 @@ jobs:
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.arch }}
           outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
-          # Registry cache rather than type=gha: GitHub caps a repo's Actions
-          # cache at 10GB and mode=max for ten components across two arches is
-          # multiples of that, so entries were evicted between runs. A missed
-          # step re-executes and its output carries fresh file timestamps, so
-          # unchanged content lands on a new layer digest and every node pulls
-          # it again — 451MiB per release on the agent image (#3403).
-          # PRs read the cache and never write it, keeping branch layers out.
           cache-from: type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
           cache-to: ${{ github.event_name != 'pull_request' && format('type=registry,ref={0}/{1}:buildcache-{2},mode=max,image-manifest=true', env.IMAGE_PREFIX, matrix.component, matrix.arch) || '' }}
       - name: Export digest

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -8,9 +8,6 @@ USER root
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-# npm_config_cache: mise runs npm with its own HOME, so npm cached to
-# /tmp/.npm — the mount below cached nothing and 199MB of cache shipped in the
-# layer. Naming the path puts it back on the mount, which no layer sees.
 RUN --mount=type=cache,target=/root/.npm \
     npm_config_cache=/root/.npm \
     mise install "npm:@agentclientprotocol/claude-agent-acp" &&\
@@ -52,11 +49,6 @@ COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 # harness-history-lib.mjs imports the adapter's own replay conversion; the
 # symlink pins the resolution to whatever version mise installed above
 RUN ln -s "$(mise where npm:@agentclientprotocol/claude-agent-acp)/lib/node_modules/@agentclientprotocol/claude-agent-acp" /usr/local/lib/claude-agent-acp
-# One CLI in the image. The adapter's claude-agent-sdk bundles the native
-# binary the chat path executes and cannot be unbundled, so `claude` — the
-# terminal harness — points at that same build instead of a second, separately
-# pinned install of it. CLAUDE_CODE_EXECUTABLE leaves the adapter nothing to
-# resolve: unset, it falls back to guessing the SDK's own copy.
 RUN set -eu; \
     cli="$(echo /usr/local/lib/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk-*/claude)"; \
     test -x "$cli"; \

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -8,16 +8,13 @@ USER root
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-# run postinstall manually: mise's npm backend skips it, claude needs its native binary
 # npm_config_cache: mise runs npm with its own HOME, so npm cached to
 # /tmp/.npm — the mount below cached nothing and 199MB of cache shipped in the
 # layer. Naming the path puts it back on the mount, which no layer sees.
 RUN --mount=type=cache,target=/root/.npm \
     npm_config_cache=/root/.npm \
-    mise install "npm:@anthropic-ai/claude-code" "npm:@agentclientprotocol/claude-agent-acp" &&\
-    node "$(mise where npm:@anthropic-ai/claude-code)/lib/node_modules/@anthropic-ai/claude-code/install.cjs" &&\
+    mise install "npm:@agentclientprotocol/claude-agent-acp" &&\
     chown -R 65532 /etc/mise \
-      "$(dirname "$(mise where npm:@anthropic-ai/claude-code)")" \
       "$(dirname "$(mise where npm:@agentclientprotocol/claude-agent-acp)")" &&\
     find /etc/mise -name '*.lock' -exec chmod 644 {} +
 
@@ -26,7 +23,7 @@ RUN --mount=type=cache,target=/root/.npm \
 # explicit flags below turn exactly that off; the umbrella
 # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC is deliberately NOT set — it also
 # switches off wanted behavior beyond these constituents. The auto-updater
-# loss is intentional since the harness version is pinned above. Platform
+# loss is intentional since the CLI rides the adapter pin. Platform
 # OTEL export is a separate, opt-in path and is unaffected.
 ENV DISABLE_TELEMETRY=1 \
     DISABLE_ERROR_REPORTING=1 \
@@ -55,6 +52,16 @@ COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 # harness-history-lib.mjs imports the adapter's own replay conversion; the
 # symlink pins the resolution to whatever version mise installed above
 RUN ln -s "$(mise where npm:@agentclientprotocol/claude-agent-acp)/lib/node_modules/@agentclientprotocol/claude-agent-acp" /usr/local/lib/claude-agent-acp
+# One CLI in the image. The adapter's claude-agent-sdk bundles the native
+# binary the chat path executes and cannot be unbundled, so `claude` — the
+# terminal harness — points at that same build instead of a second, separately
+# pinned install of it. CLAUDE_CODE_EXECUTABLE leaves the adapter nothing to
+# resolve: unset, it falls back to guessing the SDK's own copy.
+RUN set -eu; \
+    cli="$(echo /usr/local/lib/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk-*/claude)"; \
+    test -x "$cli"; \
+    ln -s "$cli" /usr/local/bin/claude
+ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
 RUN ln -s ../.agents/skills /app/working-dir/.claude/skills &&\
     mkdir -p /etc/claude-code &&\
     ln -s /etc/AGENTS.md /etc/claude-code/CLAUDE.md

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -9,7 +9,11 @@ USER root
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY harness-tools.toml /etc/mise/conf.d/harness-tools.toml
 # run postinstall manually: mise's npm backend skips it, claude needs its native binary
+# npm_config_cache: mise runs npm with its own HOME, so npm cached to
+# /tmp/.npm — the mount below cached nothing and 199MB of cache shipped in the
+# layer. Naming the path puts it back on the mount, which no layer sees.
 RUN --mount=type=cache,target=/root/.npm \
+    npm_config_cache=/root/.npm \
     mise install "npm:@anthropic-ai/claude-code" "npm:@agentclientprotocol/claude-agent-acp" &&\
     node "$(mise where npm:@anthropic-ai/claude-code)/lib/node_modules/@anthropic-ai/claude-code/install.cjs" &&\
     chown -R 65532 /etc/mise \

--- a/packages/agents/claude-code/harness-tools.toml
+++ b/packages/agents/claude-code/harness-tools.toml
@@ -4,5 +4,4 @@
 # Format contract: [tools] entries only, one `"key" = "version"` per line —
 # agent-entrypoint parses this file to strip legacy workspace-seeded pins.
 [tools]
-"npm:@anthropic-ai/claude-code" = "2.1.210"
 "npm:@agentclientprotocol/claude-agent-acp" = "0.66.0"

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -127,12 +127,8 @@ ENV MISE_DATA_DIR=/usr/local/share/mise \
 COPY --from=sysroot /sysroot/usr/ /usr/
 COPY --from=sysroot /sysroot/etc/ssh/ /etc/ssh/
 COPY --from=base /usr/local/bin/mise /usr/local/bin/mise
-COPY --from=base /usr/local/share/mise/ /usr/local/share/mise/
-COPY --from=base /etc/mise/ /etc/mise/
-COPY --from=builder /deploy/package.json ./
-COPY --from=builder /deploy/node_modules ./node_modules
-COPY --from=builder /app/packages/agent-runtime/dist/ ./dist/
-COPY --from=builder /app/packages/driver-sdk/dist/driver-sdk.mjs /usr/local/lib/driver-sdk.mjs
+COPY --from=base --chown=65532:0 /usr/local/share/mise/ /usr/local/share/mise/
+COPY --from=base --chown=65532:0 /etc/mise/ /etc/mise/
 # The experiment SDK (#2942): one stdlib-only module, importable everywhere via
 # PYTHONPATH — the Python analog of driver-sdk.mjs. --chmod because COPY
 # preserves source modes and git doesn't: an owner-only file in a build
@@ -156,20 +152,27 @@ COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-c
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chmod=755 packages/platform-base/dam-run.mjs /usr/local/bin/dam-run
 COPY --chmod=755 packages/platform-base/entrypoint.sh /usr/local/bin/agent-entrypoint
-COPY packages/platform-base/skills/ /app/working-dir/.agents/skills/
-COPY packages/platform-base/working-dir/.claude.json /app/working-dir/.claude.json
-COPY packages/platform-base/working-dir/.claude/settings.json /app/working-dir/.claude/settings.json
-COPY packages/platform-base/runtime-manifest.yaml /app/runtime-manifest.yaml
-COPY packages/platform-base/AGENTS.md /etc/AGENTS.md
+COPY --chown=65532:0 packages/platform-base/skills/ /app/working-dir/.agents/skills/
+COPY --chown=65532:0 packages/platform-base/working-dir/.claude.json /app/working-dir/.claude.json
+COPY --chown=65532:0 packages/platform-base/working-dir/.claude/settings.json /app/working-dir/.claude/settings.json
+COPY --chown=65532:0 packages/platform-base/runtime-manifest.yaml /app/runtime-manifest.yaml
+COPY --chown=65532:0 packages/platform-base/AGENTS.md /etc/AGENTS.md
 
 RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs &&\
-    chown 65532 /etc/AGENTS.md &&\
-    chown -R 65532 /etc/mise /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs /app /home/agent /usr/local/share/mise &&\
+    chown 65532 /app &&\
+    chown -R 65532 /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs /home/agent &&\
     ldconfig &&\
     echo 'sshd:x:74:' >> /etc/group &&\
     echo 'sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/usr/sbin/nologin' >> /etc/passwd &&\
     sed -i -E '/^[^:]*:[^:]*:65532:/d' /etc/passwd &&\
     echo 'agent:x:65532:0:Agent User:/home/agent:/bin/bash' >> /etc/passwd
+
+# Last: the runtime build output is the only content here that moves on an
+# ordinary commit, so nothing above it gets invalidated by one.
+COPY --from=builder --chown=65532:0 /deploy/package.json ./
+COPY --from=builder --chown=65532:0 /deploy/node_modules ./node_modules
+COPY --from=builder --chown=65532:0 /app/packages/agent-runtime/dist/ ./dist/
+COPY --from=builder /app/packages/driver-sdk/dist/driver-sdk.mjs /usr/local/lib/driver-sdk.mjs
 
 USER 65532
 

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -167,8 +167,6 @@ RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extr
     sed -i -E '/^[^:]*:[^:]*:65532:/d' /etc/passwd &&\
     echo 'agent:x:65532:0:Agent User:/home/agent:/bin/bash' >> /etc/passwd
 
-# Last: the runtime build output is the only content here that moves on an
-# ordinary commit, so nothing above it gets invalidated by one.
 COPY --from=builder --chown=65532:0 /deploy/package.json ./
 COPY --from=builder --chown=65532:0 /deploy/node_modules ./node_modules
 COPY --from=builder --chown=65532:0 /app/packages/agent-runtime/dist/ ./dist/

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -90,16 +90,26 @@ fi
 # boot, hence the `|| true`s.
 user_mise_cfg="$home/.config/mise/config.toml"
 user_mise_lock="$home/.config/mise/mise.lock"
+# Retired pins are the other half of the same hazard: once the image stops
+# listing a tool, the loop below stops naming it, and a workspace copy seeded
+# before retirement survives forever. It is not inert — a later `mise install`
+# honors that pin, installs the package without its postinstall, and the shim
+# it creates shadows the real binary on PATH. Name retired keys here until no
+# agent can predate the release that retired them.
+retired_harness_tools="npm:@anthropic-ai/claude-code"
 if [ -f "$user_mise_cfg" ]; then
-	for conf in /etc/mise/conf.d/*.toml; do
-		[ -e "$conf" ] || continue
-		# keys of the [tools] entries, quoted or bare (see the format
-		# contract in harness-tools.toml)
-		sed -n \
-			-e 's/^"\([^"]\{1,\}\)"[[:space:]]*=.*/\1/p' \
-			-e 's/^\([^"#[:space:]][^=[:space:]]*\)[[:space:]]*=.*/\1/p' \
-			"$conf"
-	done | while IFS= read -r tool; do
+	{
+		printf '%s\n' $retired_harness_tools
+		for conf in /etc/mise/conf.d/*.toml; do
+			[ -e "$conf" ] || continue
+			# keys of the [tools] entries, quoted or bare (see the format
+			# contract in harness-tools.toml)
+			sed -n \
+				-e 's/^"\([^"]\{1,\}\)"[[:space:]]*=.*/\1/p' \
+				-e 's/^\([^"#[:space:]][^=[:space:]]*\)[[:space:]]*=.*/\1/p' \
+				"$conf"
+		done
+	} | while IFS= read -r tool; do
 		esc=$(printf '%s' "$tool" | sed 's/\./\\./g')
 		sed -i "\%^\"\{0,1\}${esc}\"\{0,1\}[[:space:]]*=%d" "$user_mise_cfg" || true
 		if [ -f "$user_mise_lock" ]; then

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -94,9 +94,9 @@ user_mise_lock="$home/.config/mise/mise.lock"
 # listing a tool, the loop below stops naming it, and a workspace copy seeded
 # before retirement survives forever. It is not inert — a later `mise install`
 # honors that pin, installs the package without its postinstall, and the shim
-# it creates shadows the real binary on PATH. Name retired keys here until no
-# agent can predate the release that retired them.
-retired_harness_tools="npm:@anthropic-ai/claude-code"
+# it creates shadows the real binary on PATH. Each entry carries the date it was
+# retired; drop it once every agent has booted since then.
+retired_harness_tools="npm:@anthropic-ai/claude-code" # retired 2026-08-27
 if [ -f "$user_mise_cfg" ]; then
 	{
 		printf '%s\n' $retired_harness_tools


### PR DESCRIPTION
## What

Toward #3403 (epic #3242) — not a closing keyword deliberately, see below. Three independent cuts to what an agent start has to download.

| | uncompressed | compressed |
|---|---|---|
| claude-code image today | 2.62 GB | 655.6 MiB |
| duplicate `chown` layer removed | 2.12 GB | 551.1 MiB |
| npm cache off the layer | 1.73 GB | 384.5 MiB |
| one CLI instead of two | **1.39 GB** | **~307 MiB** |

Plus the CI change that stops re-pushing layers whose content never moved.

## Why

**Unchanged layers were being re-pushed every release.** Pulled the manifests for
ten consecutive `claude-code` builds from quay. Consecutive builds shared 204.6 of
655.6 MiB — every release shipped **451 MiB of new blobs**, occasionally 643 MiB,
and one pair shared 100%. Nothing in the image content explains that spread; it is
cache behaviour. `type=gha` caps a repo's Actions cache at 10GB and `mode=max`
across ten components and two arches is multiples of that, so entries were evicted
between runs. A re-executed step's output carries fresh file timestamps, so
unchanged content lands on a new layer digest. Moved to a registry cache at
`<component>:buildcache-<arch>`; PRs read it and never write it, which preserves
the branch isolation `type=gha` gave for free.

**104.5 MiB of the image was a copy of the image.** platform-base's final
`chown -R` walked `/usr/local/share/mise` and `/app`, re-tarring both into a second
copy of themselves. Ownership rides the `COPY`s now. As a bonus the recursive chown
had been forcing a copy-up that broke pnpm's hardlinks in `node_modules`; they
survive the build again, which is most of the 500 MB uncompressed saving.

**199 MB of npm cache shipped inside the harness layer.** mise runs npm with its
own HOME, so npm cached to `/tmp/.npm` while `--mount=type=cache` pointed at
`/root/.npm` — the mount cached nothing between builds *and* the cache ended up in
the layer. 166.6 MiB of that compressed, measured by gzipping the tree out of the
old image.

**The image carried two Claude Code binaries at different versions.** The adapter's
`claude-agent-sdk` bundles the native CLI the chat path executes and cannot be
unbundled, so the separately pinned `npm:@anthropic-ai/claude-code` install was a
second 247 MB copy of the same program — and the two were **not the same build**.
The pin said 2.1.210; the SDK bundles 2.1.220. `acp-agent.js` resolves the CLI as
`CLAUDE_CODE_EXECUTABLE` if set and otherwise falls back to the SDK's own copy, and
nothing set that variable — so a terminal session ran 2.1.210 while the chat ran
2.1.220 against the same `~/.claude/projects` transcripts. `claude` now points at
the adapter's build and `CLAUDE_CODE_EXECUTABLE` names it, leaving the adapter
nothing to guess.

## Verification

- platform-base built both ways from the same cached stages: ownership, mode and
  size **identical across all ~25k paths**; the only diffs are directory mtimes
  from the two build times.
- `docker build --check` clean; `mise run check` green on each commit.
- In the built agent image: `claude --version` reports 2.1.220 through the symlink,
  and `claude-agent-acp` answers `initialize` and `session/new` over stdio, so the
  adapter spawns the binary it was given.
- Separately confirmed that a re-executed `COPY` always yields a new layer digest,
  and that `SOURCE_DATE_EPOCH` + `rewrite-timestamp=true` makes two cold builds
  byte-identical. Left out of this PR — see below.

## Consequences worth knowing

- **Terminal sessions move 2.1.210 → 2.1.220.** That is the point, but it is a
  version bump reaching users.
- **Bumping the CLI now means bumping the `claude-agent-acp` pin**, since the CLI
  rides it. `harness-tools.toml` no longer mentions claude-code.
- **Retiring the pin needed the heal taught about it.** My first version assumed a
  retired key was harmless because every agent that booted since the heal shipped
  had its *value* corrected. Review showed that reasoning does not cover
  *retirement*: the heal derives its strip list from the keys the image ships, so
  dropping the key stops it naming it, and a workspace copy seeded before
  retirement then survives every upgrade. It is not inert — a later `mise install`
  honors that pin, installs the package without its postinstall, and the shim it
  creates shadows the real binary, so `claude` fails outright. The entrypoint now
  names retired keys with the date they were retired.
- Quay will accumulate a `buildcache-<arch>` tag per component repo. They are OCI
  cache manifests, not images, so they may look odd in tag lists or scan reports.
- **The first CI run after merge has nothing to read** — expect one full-miss build.

## Not in this PR

- `SOURCE_DATE_EPOCH` + `rewrite-timestamp`, now filed as #3495. The registry cache
  fixes "nothing changed at all"; any commit touching `agent-runtime` legitimately
  changes platform-base, which re-executes the harness install and re-pushes it
  unchanged. That is why this PR does not claim to close #3403: its done-when asks
  that two consecutive releases share the large majority of their layers, which
  holds on a cache hit and not after a real base change. Close it once a deploy
  confirms the sharing.
- platform-base leftovers: 49 MB of `/usr/share/locale`, and `typescript` (24 MB)
  sitting in a `--prod` deploy.

## Test plan

- [ ] CI image build, both arches
- [ ] `mise run e2e:loop` — a real agent boot exercising the entrypoint, workspace
      seeding and a live chat turn on the new image
- [ ] after dev deploy: confirm two consecutive releases share the large majority
      of their layers, per #3403's done-when

