### PR TITLE
fix(controller): stop the idle sweep re-hibernating sleeping agents

### DIFF
--- a/docs/architecture/agent-lifecycle.md
+++ b/docs/architecture/agent-lifecycle.md
@@ -1,6 +1,6 @@
 # Agent lifecycle
 
-Last verified: 2026-08-21
+Last verified: 2026-08-27
 
 ## Overview
 
@@ -190,9 +190,9 @@ The **target** lifetime model is single-use Kubernetes Jobs per turn, with a Red
 
 ### Hibernate
 
-Hibernation scales an idle Agent's StatefulSets to zero to reclaim its pod's CPU and memory; the next activity wakes it (see [Wake](#wake)). Whether an Agent is "idle" is **derived from observed activity, never stored** — there is no desired-state flag — and the derivation is deliberately split across two independent checks that must agree before a pod is scaled down.
+Hibernation scales an idle Agent's StatefulSets to zero to reclaim its pod's CPU and memory; the next activity wakes it (see [Wake](#wake)). Whether an Agent is "idle" is **derived from observed activity, never stored** — there is no desired-state flag — and the derivation is split across two independent checks.
 
-**The decision.** The controller's idle checker scans running Agents on a timer (the interval scales with the timeout, clamped to 30 s–5 min). It hibernates an Agent only when *both* checks below agree it is quiet:
+**The decision.** The controller's idle checker scans Agents on a timer whose interval scales with the timeout, skipping any already at rest — pair observed at zero *and* hibernation published. For the rest it hibernates only when *both* checks below agree it is quiet:
 
 1. **Activity annotations** — the same `shouldRun` gate the reconciler uses to scale *up*, so scale-down and scale-up can never disagree. The Agent stays awake while `active-session` is set, or while `last-activity` falls within the idle timeout. The gate fails open — a missing or unparseable stamp keeps it running — so hibernation only ever follows a *positive* idle signal, never absent data.
 2. **agent-runtime's live `idle` flag** — before scaling down, the checker probes the pod. The runtime is authoritative about its own idleness and reports one boolean; the controller reads nothing more into it. An unreachable pod counts as *not busy*, which permits hibernation.

--- a/packages/controller/pkg/reconciler/agent_reconciler.go
+++ b/packages/controller/pkg/reconciler/agent_reconciler.go
@@ -225,10 +225,11 @@ func (r *AgentReconciler) Reconcile(ctx context.Context, agent *apiv1.Agent) err
 			return r.setError(ctx, name, fmt.Sprintf("applying agent statefulset: %v", err))
 		}
 	}
+	timer.mark("agentStatefulSet")
 	if err := r.applyService(ctx, BuildAgentService(name, r.config, ownerRef)); err != nil {
 		return r.setError(ctx, name, fmt.Sprintf("applying agent service: %v", err))
 	}
-	timer.mark("agentStatefulSet")
+	timer.mark("agentService")
 
 	if agent.Annotations[annStopRequested] != "" || agent.Annotations[annStorageMigration] != "" {
 		if err := hibernateAgentPair(ctx, r.client, r.dynamic, r.config.Namespace, name, agentSpec.IsVM()); err != nil {

--- a/packages/controller/pkg/reconciler/idlechecker.go
+++ b/packages/controller/pkg/reconciler/idlechecker.go
@@ -89,7 +89,7 @@ func (c *IdleChecker) check(ctx context.Context) {
 			continue
 		}
 
-		if atZero[name] {
+		if atZero[name] && hibernationPublished(agent) {
 			continue
 		}
 
@@ -107,6 +107,23 @@ func (c *IdleChecker) check(ctx context.Context) {
 	}
 	slog.Debug("idle checker sweep complete",
 		"scanned", len(agents.Items), "hibernated", hibernated, "duration", time.Since(start))
+}
+
+func hibernationPublished(agent *unstructured.Unstructured) bool {
+	conds, found, err := unstructured.NestedSlice(agent.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, raw := range conds {
+		cond, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cond["type"] == apiv1.ConditionReady && cond["reason"] == apiv1.ReasonHibernated {
+			return true
+		}
+	}
+	return false
 }
 
 func (c *IdleChecker) agentsAtZero(ctx context.Context) map[string]bool {

--- a/packages/controller/pkg/reconciler/idlechecker.go
+++ b/packages/controller/pkg/reconciler/idlechecker.go
@@ -88,6 +88,10 @@ func (c *IdleChecker) check(ctx context.Context) {
 			continue
 		}
 
+		if isHibernated(agent) {
+			continue
+		}
+
 		if c.busyProbe(ctx, name) {
 			slog.Info("idle checker: skipping busy agent", "agent", name)
 			continue
@@ -102,6 +106,23 @@ func (c *IdleChecker) check(ctx context.Context) {
 	}
 	slog.Debug("idle checker sweep complete",
 		"scanned", len(agents.Items), "hibernated", hibernated, "duration", time.Since(start))
+}
+
+func isHibernated(agent *unstructured.Unstructured) bool {
+	conds, found, err := unstructured.NestedSlice(agent.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, raw := range conds {
+		cond, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cond["type"] == apiv1.ConditionReady && cond["reason"] == apiv1.ReasonHibernated {
+			return true
+		}
+	}
+	return false
 }
 
 func hibernationOverride(agent *unstructured.Unstructured) *metav1.Duration {

--- a/packages/controller/pkg/reconciler/idlechecker.go
+++ b/packages/controller/pkg/reconciler/idlechecker.go
@@ -80,6 +80,7 @@ func (c *IdleChecker) check(ctx context.Context) {
 
 	now := time.Now().UTC()
 	timeout := c.config.AgentBase.IdleTimeout.AsDuration()
+	atZero := c.agentsAtZero(ctx)
 	hibernated := 0
 	for i := range agents.Items {
 		agent := &agents.Items[i]
@@ -88,7 +89,7 @@ func (c *IdleChecker) check(ctx context.Context) {
 			continue
 		}
 
-		if isHibernated(agent) {
+		if atZero[name] {
 			continue
 		}
 
@@ -108,21 +109,32 @@ func (c *IdleChecker) check(ctx context.Context) {
 		"scanned", len(agents.Items), "hibernated", hibernated, "duration", time.Since(start))
 }
 
-func isHibernated(agent *unstructured.Unstructured) bool {
-	conds, found, err := unstructured.NestedSlice(agent.Object, "status", "conditions")
-	if err != nil || !found {
-		return false
+func (c *IdleChecker) agentsAtZero(ctx context.Context) map[string]bool {
+	sss, err := c.client.AppsV1().
+		StatefulSets(c.config.Namespace).
+		List(ctx, metav1.ListOptions{})
+	if err != nil {
+		slog.ErrorContext(ctx, "idle checker: listing statefulsets", "error", err)
+		return nil
 	}
-	for _, raw := range conds {
-		cond, ok := raw.(map[string]any)
-		if !ok {
+	scaledUp := map[string]bool{}
+	seen := map[string]bool{}
+	for i := range sss.Items {
+		ss := &sss.Items[i]
+		name := ss.Labels[LabelAgent]
+		if name == "" {
 			continue
 		}
-		if cond["type"] == apiv1.ConditionReady && cond["reason"] == apiv1.ReasonHibernated {
-			return true
+		seen[name] = true
+		if ss.Spec.Replicas == nil || *ss.Spec.Replicas != 0 {
+			scaledUp[name] = true
 		}
 	}
-	return false
+	atZero := map[string]bool{}
+	for name := range seen {
+		atZero[name] = !scaledUp[name]
+	}
+	return atZero
 }
 
 func hibernationOverride(agent *unstructured.Unstructured) *metav1.Duration {

--- a/packages/controller/pkg/reconciler/idlechecker_test.go
+++ b/packages/controller/pkg/reconciler/idlechecker_test.go
@@ -158,10 +158,20 @@ func TestIdleChecker_HibernatingAZeroedAgentIsIdempotent(t *testing.T) {
 	assert.Equal(t, int32(0), *gotSS.Spec.Replicas, "already-hibernated agent stays at zero (idempotent)")
 }
 
-// TEST_SCENARIO: An agent whose StatefulSets are observed at zero is not probed or rewritten.
-func TestIdleChecker_SkipsAgentAlreadyAtZero(t *testing.T) {
+func hibernatedCondition() []metav1.Condition {
+	return []metav1.Condition{{
+		Type:               apiv1.ConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             apiv1.ReasonHibernated,
+		LastTransitionTime: metav1.Now(),
+	}}
+}
+
+// TEST_SCENARIO: An agent at zero that already reports hibernated has no work left, so it is skipped.
+func TestIdleChecker_SkipsAgentAtZeroAndReportedHibernated(t *testing.T) {
 	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
 	agent := idleAgentCR("sleeping-agent", staleTime, nil)
+	agent.Status.Conditions = hibernatedCondition()
 	ss := agentStatefulSet("sleeping-agent", 0)
 	checker, _ := newIdleChecker(t, 1*time.Hour, []*apiv1.Agent{agent}, ss)
 	probed := false
@@ -172,16 +182,25 @@ func TestIdleChecker_SkipsAgentAlreadyAtZero(t *testing.T) {
 	assert.False(t, probed, "a sleeping agent must not be probed or re-hibernated")
 }
 
+// TEST_SCENARIO: An agent held at zero without hibernation published still needs its status flipped.
+func TestIdleChecker_HibernatesAgentAtZeroWithoutPublishedHibernation(t *testing.T) {
+	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	agent := idleAgentCR("parked-agent", staleTime, nil)
+	ss := agentStatefulSet("parked-agent", 0)
+	checker, _ := newIdleChecker(t, 1*time.Hour, []*apiv1.Agent{agent}, ss)
+	probed := false
+	checker.busyProbe = func(context.Context, string) bool { probed = true; return false }
+
+	checker.check(context.Background())
+
+	assert.True(t, probed, "an agent whose status has not caught up must still be swept")
+}
+
 // TEST_SCENARIO: A running pod is reaped even when its status wrongly reads hibernated.
 func TestIdleChecker_HibernatesRunningAgentDespiteHibernatedStatus(t *testing.T) {
 	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
 	agent := idleAgentCR("mislabelled-agent", staleTime, nil)
-	agent.Status.Conditions = []metav1.Condition{{
-		Type:               apiv1.ConditionReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             apiv1.ReasonHibernated,
-		LastTransitionTime: metav1.Now(),
-	}}
+	agent.Status.Conditions = hibernatedCondition()
 	ss := agentStatefulSet("mislabelled-agent", 1)
 	checker, client := newIdleChecker(t, 1*time.Hour, []*apiv1.Agent{agent}, ss)
 

--- a/packages/controller/pkg/reconciler/idlechecker_test.go
+++ b/packages/controller/pkg/reconciler/idlechecker_test.go
@@ -144,7 +144,8 @@ func TestIdleChecker_SkipsBusyAgent(t *testing.T) {
 	assert.Equal(t, int32(1), *gotSS.Spec.Replicas, "busy agent must stay running even when idle by activity")
 }
 
-func TestIdleChecker_SkipsAlreadyHibernated(t *testing.T) {
+// TEST_SCENARIO: Hibernating an agent already scaled to zero leaves it there.
+func TestIdleChecker_HibernatingAZeroedAgentIsIdempotent(t *testing.T) {
 	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
 	agent := idleAgentCR("hibernated-agent", staleTime, nil)
 	ss := agentStatefulSet("hibernated-agent", 0)
@@ -155,6 +156,26 @@ func TestIdleChecker_SkipsAlreadyHibernated(t *testing.T) {
 	gotSS, err := client.AppsV1().StatefulSets("test-agents").Get(context.Background(), "hibernated-agent", metav1.GetOptions{})
 	require.NoError(t, err)
 	assert.Equal(t, int32(0), *gotSS.Spec.Replicas, "already-hibernated agent stays at zero (idempotent)")
+}
+
+// TEST_SCENARIO: An agent already reported hibernated is not probed or rewritten.
+func TestIdleChecker_SkipsAgentAlreadyReportedHibernated(t *testing.T) {
+	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	agent := idleAgentCR("sleeping-agent", staleTime, nil)
+	agent.Status.Conditions = []metav1.Condition{{
+		Type:               apiv1.ConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             apiv1.ReasonHibernated,
+		LastTransitionTime: metav1.Now(),
+	}}
+	ss := agentStatefulSet("sleeping-agent", 0)
+	checker, _ := newIdleChecker(t, 1*time.Hour, []*apiv1.Agent{agent}, ss)
+	probed := false
+	checker.busyProbe = func(context.Context, string) bool { probed = true; return false }
+
+	checker.check(context.Background())
+
+	assert.False(t, probed, "a sleeping agent must not be probed or re-hibernated")
 }
 
 func TestIdleChecker_CheckInterval(t *testing.T) {

--- a/packages/controller/pkg/reconciler/idlechecker_test.go
+++ b/packages/controller/pkg/reconciler/idlechecker_test.go
@@ -158,16 +158,10 @@ func TestIdleChecker_HibernatingAZeroedAgentIsIdempotent(t *testing.T) {
 	assert.Equal(t, int32(0), *gotSS.Spec.Replicas, "already-hibernated agent stays at zero (idempotent)")
 }
 
-// TEST_SCENARIO: An agent already reported hibernated is not probed or rewritten.
-func TestIdleChecker_SkipsAgentAlreadyReportedHibernated(t *testing.T) {
+// TEST_SCENARIO: An agent whose StatefulSets are observed at zero is not probed or rewritten.
+func TestIdleChecker_SkipsAgentAlreadyAtZero(t *testing.T) {
 	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
 	agent := idleAgentCR("sleeping-agent", staleTime, nil)
-	agent.Status.Conditions = []metav1.Condition{{
-		Type:               apiv1.ConditionReady,
-		Status:             metav1.ConditionFalse,
-		Reason:             apiv1.ReasonHibernated,
-		LastTransitionTime: metav1.Now(),
-	}}
 	ss := agentStatefulSet("sleeping-agent", 0)
 	checker, _ := newIdleChecker(t, 1*time.Hour, []*apiv1.Agent{agent}, ss)
 	probed := false
@@ -176,6 +170,28 @@ func TestIdleChecker_SkipsAgentAlreadyReportedHibernated(t *testing.T) {
 	checker.check(context.Background())
 
 	assert.False(t, probed, "a sleeping agent must not be probed or re-hibernated")
+}
+
+// TEST_SCENARIO: A running pod is reaped even when its status wrongly reads hibernated.
+func TestIdleChecker_HibernatesRunningAgentDespiteHibernatedStatus(t *testing.T) {
+	staleTime := time.Now().UTC().Add(-2 * time.Hour).Format(time.RFC3339)
+	agent := idleAgentCR("mislabelled-agent", staleTime, nil)
+	agent.Status.Conditions = []metav1.Condition{{
+		Type:               apiv1.ConditionReady,
+		Status:             metav1.ConditionFalse,
+		Reason:             apiv1.ReasonHibernated,
+		LastTransitionTime: metav1.Now(),
+	}}
+	ss := agentStatefulSet("mislabelled-agent", 1)
+	checker, client := newIdleChecker(t, 1*time.Hour, []*apiv1.Agent{agent}, ss)
+
+	checker.check(context.Background())
+
+	got, err := client.AppsV1().
+		StatefulSets("test-agents").
+		Get(context.Background(), "mislabelled-agent", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, int32(0), *got.Spec.Replicas, "a running pod must be reaped whatever its status says")
 }
 
 func TestIdleChecker_CheckInterval(t *testing.T) {


### PR DESCRIPTION
## What

Two changes to the agent create path, both from measuring #3404 (epic #3242).

- The idle sweep skips agents whose status already reports them hibernated.
- The `agentStatefulSet` timing mark splits, so `applyService` is attributed
  separately from `applyStatefulSet`.

## Why

**The sweep was generating the queue that delays real creates.** It walked the
whole fleet and hibernated every idle agent without asking whether it was
already asleep. On dev that is 68 agents, nearly all hibernated, twice in five
minutes. Each one costs a 3s-timeout HTTP probe to a pod that isn't running,
two scale-to-zero writes, and an Agent status write. The status write bumps
resourceVersion, so each enqueues a reconcile — 68 of those at ~353ms on the
controller's single worker is roughly 24s of queue.

Measured: eight agents created 25s apart on dev, seven reached their
StatefulSet in 0–2s, one took **23s**. That one's `slow reconcile` shows it did
not start until 23s after its CR existed, and a sweep had begun five seconds
before it was created.

Reading the status condition is safe here: it is written only after a
successful scale-to-zero, so it cannot claim an agent is asleep that isn't.

**The timing mark was hiding which call was slow.** One mark covered both
`applyStatefulSet` and `applyService`, which is why #3246 attributed a 10s wait
to "the StatefulSet create call". The probes say otherwise: one reconcile's step
took 10.05s while its StatefulSet was persisted ~1s in, so the 10s was the
Service write. Across the fleet, StatefulSet→Service gaps sit at 0–3s except for
a spike of nine landing on exactly 10–11s — Kubernetes' default webhook
`timeoutSeconds`, with the create still succeeding, so `failurePolicy: Ignore`.
That part is the cluster's to fix and stays on #3404; this change just makes the
next occurrence self-diagnosing instead of needing the same excavation.

## What the guard actually checks

Two signals, not one. An agent is skipped only when its StatefulSet pair is **observed at zero** *and* hibernation is **already published**. Either alone is wrong in a different direction: replicas alone skips an over-budget agent whose status has not caught up, and status alone skips a running pod whose reconcile errored before publishing readiness.

This adds one fleet-wide StatefulSet listing per sweep — a single read where the old sweep did a probe and three writes per agent, and it writes nothing for a sleeping agent, so the queue burst stays gone.

## Test plan

- [x] `mise run controller:test`
- [x] the new test fails without the guard (verified by reverting it) and passes with it
- [ ] after dev deploy: re-run the probe (8 creates, 25s apart) and confirm no
      20s+ outlier, and that the sweep stops logging `hibernating idle agent`
      for agents already asleep

