### PR TITLE
perf(platform-base,ci): resolve tools once per pod, and make layer digests content-only

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,12 @@ concurrency:
 
 env:
   IMAGE_PREFIX: quay.io/dam-agents
+  # Layer digests must depend on content alone. A rebuilt step stamps files with
+  # the build time, so byte-identical content lands on a new digest and every
+  # node re-pulls it; rewrite-timestamp on the image outputs normalizes them to
+  # this instant. It is deliberately a constant rather than the commit time —
+  # a per-commit stamp would make every release differ again (#3495).
+  SOURCE_DATE_EPOCH: "1735689600"
   # Pin mise so the lockfile (mise.lock) stays deterministic. Unpinned,
   # mise-action installs latest and each new release rewrites platform entries
   # and the generated header, churning mise.lock on unrelated PRs. Bump this in
@@ -175,7 +181,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           platforms: linux/${{ matrix.arch }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true,rewrite-timestamp=true
           cache-from: |
             type=registry,ref=${{ env.IMAGE_PREFIX }}/${{ matrix.component }}:buildcache-${{ matrix.arch }}
             type=gha,scope=${{ matrix.component }}-${{ matrix.arch }}
@@ -264,7 +270,7 @@ jobs:
           context: .
           file: packages/platform-base/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/platform-base,push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/platform-base,push-by-digest=true,name-canonical=true,push=true,rewrite-timestamp=true
           cache-from: |
             type=registry,ref=${{ env.IMAGE_PREFIX }}/platform-base:buildcache-${{ matrix.arch }}
             type=gha,scope=platform-base-${{ matrix.arch }}
@@ -352,7 +358,7 @@ jobs:
           context: packages/agents/${{ matrix.component }}
           file: packages/agents/${{ matrix.component }}/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true,rewrite-timestamp=true
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/platform-base:${{ needs.changes.outputs.platform_base_tag }}
           cache-from: |
@@ -449,7 +455,7 @@ jobs:
           context: packages/agents/${{ matrix.component }}
           file: packages/agents/${{ matrix.component }}/Dockerfile
           platforms: linux/${{ matrix.arch }}
-          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true
+          outputs: type=image,name=${{ env.IMAGE_PREFIX }}/${{ matrix.component }},push-by-digest=true,name-canonical=true,push=true,rewrite-timestamp=true
           build-args: |
             BASE_IMAGE=${{ env.IMAGE_PREFIX }}/claude-code:${{ needs.changes.outputs.claude_code_base_tag }}
           cache-from: |

--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -58,6 +58,7 @@ COPY --from=agent /usr/local/sbin/ /usr/local/sbin/
 COPY --from=agent /usr/local/lib/ /usr/local/lib/
 COPY --from=agent /usr/local/share/mise/ /usr/local/share/mise/
 COPY --from=agent /usr/local/share/lazy-tools/ /usr/local/share/lazy-tools/
+COPY --from=agent /usr/local/share/tool-bin/ /usr/local/share/tool-bin/
 COPY --from=agent /etc/mise/ /etc/mise/
 COPY --from=agent /etc/AGENTS.md /etc/AGENTS.md
 # Managed settings carry the Stop/SubagentStop background-work hooks — without

--- a/packages/agents/claude-code-vm/system/agent-runtime.service
+++ b/packages/agents/claude-code-vm/system/agent-runtime.service
@@ -23,7 +23,7 @@ WorkingDirectory=/app
 EnvironmentFile=/etc/platform/env
 Environment=PORT=8080
 Environment=MISE_DATA_DIR=/usr/local/share/mise
-Environment=PATH=/app/node_modules/.bin:/usr/local/share/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/local/share/lazy-tools
+Environment=PATH=/usr/local/share/tool-bin:/app/node_modules/.bin:/usr/local/share/mise/shims:/usr/local/bin:/usr/bin:/bin:/usr/local/share/lazy-tools
 Environment=SSL_CERT_FILE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 Environment=REQUESTS_CA_BUNDLE=/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
 Environment=KUBECONFIG=/etc/rancher/k3s/k3s.yaml

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -150,6 +150,8 @@ RUN set -eu; \
     done
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
     mise install jq fd rg gh; \
+    for t in jq fd rg gh; do chown -R 65532 "/usr/local/share/mise/installs/$t"; done; \
+    chown 65532 /etc/mise/mise.lock; chmod 644 /etc/mise/mise.lock; \
     mkdir /usr/local/share/tool-bin; \
     chown 65532 /usr/local/share/tool-bin
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -143,13 +143,13 @@ RUN chmod 0755 /usr/local/lib/platform-python
 # image build — an unreadable lock degrades every shim call to API lookups.
 RUN set -eu; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
-    for spec in gh uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
+    for spec in uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
     tool="${spec%%=*}"; bin="${spec##*=}"; \
     printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nreal=$(mise which %s 2>/dev/null)\nif [ -x "$real" ]; then\n  ln -sf "$real" /usr/local/share/tool-bin/%s 2>/dev/null\n  exec "$real" "$@"\nfi\nexec mise exec %s -- %s "$@"\n' "$tool" "$bin" "$bin" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
-    mise install jq fd rg; \
+    mise install jq fd rg gh; \
     mkdir /usr/local/share/tool-bin; \
     chown 65532 /usr/local/share/tool-bin
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -122,7 +122,7 @@ WORKDIR /app
 ENV MISE_DATA_DIR=/usr/local/share/mise \
     MISE_PROVENANCE_API_FAILURES_FATAL=false \
     MISE_NODE_VERIFY=false \
-    PATH="/app/node_modules/.bin:/usr/local/share/mise/shims:$PATH:/usr/local/share/lazy-tools"
+    PATH="/usr/local/share/tool-bin:/app/node_modules/.bin:/usr/local/share/mise/shims:$PATH:/usr/local/share/lazy-tools"
 
 COPY --from=sysroot /sysroot/usr/ /usr/
 COPY --from=sysroot /sysroot/etc/ssh/ /etc/ssh/
@@ -145,9 +145,14 @@ RUN set -eu; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
     for spec in jq fd rg gh uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
     tool="${spec%%=*}"; bin="${spec##*=}"; \
-    printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nexec mise exec %s -- %s "$@"\n' "$tool" "$tool" "$bin" > "$bin"; \
+    printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nreal=$(mise which %s 2>/dev/null)\nif [ -x "$real" ]; then\n  ln -sf "$real" /usr/local/share/tool-bin/%s 2>/dev/null\n  exec "$real" "$@"\nfi\nexec mise exec %s -- %s "$@"\n' "$tool" "$bin" "$bin" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
+RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
+    mise install jq fd rg; \
+    mkdir /usr/local/share/tool-bin; \
+    for bin in jq fd rg; do ln -s "$(mise which "$bin")" "/usr/local/share/tool-bin/$bin"; done; \
+    chown 65532 /usr/local/share/tool-bin
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chmod=755 packages/platform-base/dam-run.mjs /usr/local/bin/dam-run

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -149,10 +149,8 @@ RUN set -eu; \
     chmod 755 "$bin"; \
     done
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
-    eager="jq fd rg"; \
-    mise install $eager; \
+    mise install jq fd rg; \
     mkdir /usr/local/share/tool-bin; \
-    for bin in $eager; do ln -s "$(mise which "$bin")" "/usr/local/share/tool-bin/$bin"; done; \
     chown 65532 /usr/local/share/tool-bin
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -143,15 +143,16 @@ RUN chmod 0755 /usr/local/lib/platform-python
 # image build — an unreadable lock degrades every shim call to API lookups.
 RUN set -eu; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
-    for spec in jq fd rg gh uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
+    for spec in gh uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
     tool="${spec%%=*}"; bin="${spec##*=}"; \
     printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nreal=$(mise which %s 2>/dev/null)\nif [ -x "$real" ]; then\n  ln -sf "$real" /usr/local/share/tool-bin/%s 2>/dev/null\n  exec "$real" "$@"\nfi\nexec mise exec %s -- %s "$@"\n' "$tool" "$bin" "$bin" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
-    mise install jq fd rg; \
+    eager="jq fd rg"; \
+    mise install $eager; \
     mkdir /usr/local/share/tool-bin; \
-    for bin in jq fd rg; do ln -s "$(mise which "$bin")" "/usr/local/share/tool-bin/$bin"; done; \
+    for bin in $eager; do ln -s "$(mise which "$bin")" "/usr/local/share/tool-bin/$bin"; done; \
     chown 65532 /usr/local/share/tool-bin
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -111,7 +111,8 @@ FROM registry.access.redhat.com/hi/core-runtime:latest AS runner
 USER root
 WORKDIR /app
 # MISE_PROVENANCE_API_FAILURES_FATAL: the lazy-tools shims (below) run `mise
-# install` on every jq/fd/rg/gh call. mise re-verifies each tool's GitHub
+# install` until the tool is resolved — uv, uvx, kubectl, oc and gws, the tiers
+# that stayed lazy. mise re-verifies each tool's GitHub
 # artifact attestation against api.github.com, and a long-lived agent doing
 # this thousands of times/hr exhausts the per-token rate limit — every call
 # then loops on 429s (observed on dev: one agent driving ~1k 429/hr). Keeping

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -12,6 +12,13 @@
 # writable at build time (see Dockerfile).
 set -eu
 
+# Resolve mise's tools onto PATH once, here, instead of paying mise's startup on
+# every call through a shim. A pod is one long-lived process tree, so everything
+# the harness spawns inherits this; measured on a pod, a shim call costs ~250ms
+# more than the binary it resolves to (#3294). Tools installed later still
+# resolve through their lazy wrapper, which links itself into tool-bin.
+eval "$(mise env 2>/dev/null || true)"
+
 mitm_ca=/etc/platform/ca/ca.crt
 anchor=/etc/pki/ca-trust/source/anchors/platform-mitm-ca.crt
 extracted=/etc/pki/ca-trust/extracted


### PR DESCRIPTION
## What

Toward #3294 — deliberately not a closing keyword; see **Why #3294 stays open** below. The entrypoint resolves mise's tools onto `PATH` once per pod, so a tool call no longer pays mise's startup.

## Why

`jq` on the pod was not jq — it was a symlink to a 91MB mise binary that re-resolved its toolchain on every invocation. Measured on the pod in #3294: **282ms per call against 17ms** for the real binary, 438ms for `gh`.

It is not only the tools the issue named. `node` and `python3` were on shims too — 21ms against 12ms, and 14ms against 6ms measured here — and the harness calls both constantly.

## What mise actually recommends, since it matters here

Their container guidance is `mise exec` or shims-on-PATH, and their shims page says outright that the performance difference is *"probably not going to be noticeable"*. That is not wrong; it assumes you are comparing per-call cost against `mise activate`'s per-shell-prompt cost. A pod has no prompt, and the harness invokes tools programmatically in loops, so the cost is paid per call and never amortises. Their guidance targets short-lived CI jobs where paying 250ms a handful of times is irrelevant.

I checked for a supported fast path: 148 settings, and the only shim-related one is `windows_shim_mode`. The caching settings govern activation's env resolution, not shim startup. There is no fast-shim mode.

So resolving paths onto `PATH` is the only mechanism that removes the cost — and it is native (`mise env`), just not the variant their container page suggests.

## How

- **Boot:** `eval "$(mise env)"` in the entrypoint. Covers every installed tool, in derived images too, with no per-image step. **36ms, once.**
- **Eager:** jq, fd, rg and **gh** are installed at build — for egress rather than speed, since a lazy first use has to reach the network through the gateway; the same argument the Dockerfile already makes for python. gh moved to this tier during review: it is the tool agents reach for most, the platform already provisions its credentials into the pod, and mise downloads gh *from GitHub*, so a lazy first use had to reach GitHub through the egress gateway to obtain it. 11MB for jq, fd and rg; 12.5MB gzipped for gh.
- **Lazy:** kubectl, oc, uv, uvx and gws still install on demand. Their wrapper links the resolved binary into `tool-bin` and hands off, so only the first call pays.

## Verified on the built agent image

| | before | after |
|---|---|---|
| boot resolution | — | 36 ms once |
| jq | 12 ms/call | **1 ms** |
| python3 | 14 ms/call | **6 ms** |
| node | 21 ms/call | **14 ms** |
| gh | 438 ms every call on a pod | **16 ms**, no install step |
| kubectl (still lazy) | — | 11.6 s first, **21 ms** after |

`node`, `python3`, `npm`, `jq`, `fd`, `rg`, `gh` and the ACP adapter all resolve to real binaries; `claude` still resolves to the single-binary symlink from #3469.

## Notes

- Every figure above is from a container on a laptop. The numbers that matter are the pod's, where mise's startup dominates on 1 CPU — that is the unchecked box below.
- `tool-bin` links live in the image layer, not the workspace, so a template upgrade resets them rather than leaving a stale link to an old install path.
- Separate finding, not folded in: our eight hand-written `lazy-tools` wrappers duplicate `mise tool-stub`, which is mise's native lazy-loading mechanism. Replacing them would be tidier but changes nothing about speed — worth its own issue.

## Test plan

- [x] `mise run check`; `docker build --check` clean; base and agent images build
- [x] timings, coverage and the lazy handoff verified on the built agent image
- [ ] on a dev pod: confirm the ~282ms per call is gone, and that boot has not regressed


---

# Second change: layer digests that depend on content

Folded in at the author's request, and it closes #3495.

## Why

Measured on the registry after this morning's merges: two consecutive main builds thirteen minutes apart still shipped **193.8 MiB of new layers out of 302.2**, so every node re-pulled two thirds of the image for content that had not changed. The layers responsible were the mise toolchain COPY (92.7 MiB), the harness install (89.2 MiB), node_modules (10.5 MiB) and the system RUN (1.2 MiB) — all byte-identical between the two builds, all restamped with the build time.

The registry cache from #3469 only covers the case where *nothing* changed. Every main push rebuilds platform-base from scratch (`RESOLVE_NO_REUSE=1`), and a re-executed step stamps fresh timestamps, so identical content lands on a new digest.

This is what #3403's done-when actually asked for — "two consecutive releases share the large majority of their layers" — and it was not met by the merge that closed it.

## How

Image outputs get `rewrite-timestamp=true`, normalizing layer file timestamps to a fixed `SOURCE_DATE_EPOCH`.

**Fixed, not the commit time.** A per-commit stamp would make every release differ again, which is the thing being fixed. The cost is that file mtimes inside the image are a constant date.

## Verified on the real image

Two cold rebuilds of platform-base's runner stage with the cache disabled:

| | before | after |
|---|---|---|
| identical layers | 0 of 46 runner layers | **46 of 47** |
| bytes differing | all of them | **1.2 MiB of 221 MiB (0.5%)** |

The one layer that still differs is the system `RUN` — its `ldconfig` writes `/etc/ld.so.cache`, whose content genuinely varies between builds, so no amount of timestamp rewriting will fix it. 1.2 MiB per release is acceptable.

## Note on scope

Two unrelated changes now share this PR — tool resolution and build reproducibility. They are together because both are platform-base build changes and one deploy verifies both. Split them if you would rather review separately.



## Why #3294 stays open

#3294 states its ask in pod measurements — 282 ms against 17 ms — and every number above is from a container on a laptop, where the same ratio holds but the absolute cost is an order of magnitude smaller. Merging on laptop numbers would end an issue whose acceptance criterion has not been met in the environment it names.

That is the same objection this PR's second half makes about #3403, so it would be inconsistent to do it here. Take the pod measurement after this merges, and let that evidence — not this PR — be what ends #3294.

## Known exclusions

Two image builds ship without `rewrite-timestamp`, so #3495's property does not hold for them. `build-mock` is an e2e fixture, rebuilt per run and never pulled by an agent, and it uses the `push`/`tags` form rather than `outputs`, so adding the flag means restructuring the step for an image whose digest stability buys nothing. The VM containerDisk is the other: its payload is a qcow2 that bootc-image-builder regenerates, which is not byte-reproducible, so a timestamp rewrite on the wrapper image would not stabilise the digest — unlike the fixture it *is* pulled by nodes, so its re-pull cost stands until the disk build itself is reproducible — that remaining gap is tracked in #3513. Stated rather than left as the odd ones out.

## Propagation, after review

A `PATH` change in platform-base has to reach every hand-written `PATH`. The VM backend has two — the Containerfile's copies from the agent stage, and the systemd unit that spells `PATH` out — and neither knew about `tool-bin`, so on a VM the wrapper's `ln -sf` failed silently (it is `2>/dev/null`) and the lazy tier stayed unaccelerated. Both fixed. Grepping `lazy-tools` confirms those two files are the whole set.

