### PR TITLE
perf(platform-base): link tools into tool-bin from a mise postinstall hook

### DIFF
--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -12,8 +12,7 @@ RUN --mount=type=cache,target=/root/.npm \
     npm_config_cache=/root/.npm \
     mise install "npm:@agentclientprotocol/claude-agent-acp" &&\
     chown -R 65532 /etc/mise \
-      "$(dirname "$(mise where npm:@agentclientprotocol/claude-agent-acp)")" &&\
-    find /etc/mise -name '*.lock' -exec chmod 644 {} +
+      "$(dirname "$(mise where npm:@agentclientprotocol/claude-agent-acp)")"
 
 # Claude Code phones home (usage telemetry to Statsig, error logs to Datadog
 # intake) — traffic the gateway egress chain would surface for approval. The

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -8,10 +8,6 @@ USER root
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-# Installed as the agent user rather than by root with a chown after: mise
-# writes the install dir and the lockfile owned by the runtime user from the
-# start, so a newly pinned tool cannot be left out of a chown list. Everything
-# it writes to — /etc/mise and MISE_DATA_DIR — is agent-owned in the base image.
 USER 65532
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
     --mount=type=cache,target=/tmp/mise-cache,uid=65532 \

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -3,6 +3,9 @@ FROM ${BASE_IMAGE}
 
 USER root
 
+RUN mkdir -p /etc/claude-code &&\
+    ln -s /etc/AGENTS.md /etc/claude-code/CLAUDE.md
+
 # harness tool pins ride the image as system-level mise config so they always
 # match the installs baked in below (a pin seeded into the persistent workspace
 # would go stale on template upgrade); install by name — a bare `mise install`
@@ -13,7 +16,6 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
     --mount=type=cache,target=/tmp/mise-cache,uid=65532 \
     npm_config_cache=/tmp/npm-cache MISE_CACHE_DIR=/tmp/mise-cache \
     mise install "npm:@agentclientprotocol/claude-agent-acp"
-USER root
 
 # Claude Code phones home (usage telemetry to Statsig, error logs to Datadog
 # intake) — traffic the gateway egress chain would surface for approval. The
@@ -48,15 +50,13 @@ COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 # cc-websearch DDG fallback is intentionally gone, not pending (#1087 revert).
 # harness-history-lib.mjs imports the adapter's own replay conversion; the
 # symlink pins the resolution to whatever version mise installed above
-RUN ln -s "$(mise where npm:@agentclientprotocol/claude-agent-acp)/lib/node_modules/@agentclientprotocol/claude-agent-acp" /usr/local/lib/claude-agent-acp
+RUN ln -s "$(mise where npm:@agentclientprotocol/claude-agent-acp)/lib/node_modules/@agentclientprotocol/claude-agent-acp" /usr/local/share/tool-bin/claude-agent-acp-lib
 RUN set -eu; \
-    cli="$(echo /usr/local/lib/claude-agent-acp/node_modules/@anthropic-ai/claude-agent-sdk-*/claude)"; \
+    cli="$(echo /usr/local/share/tool-bin/claude-agent-acp-lib/node_modules/@anthropic-ai/claude-agent-sdk-*/claude)"; \
     test -x "$cli"; \
-    ln -s "$cli" /usr/local/bin/claude
-ENV CLAUDE_CODE_EXECUTABLE=/usr/local/bin/claude
-RUN ln -s ../.agents/skills /app/working-dir/.claude/skills &&\
-    mkdir -p /etc/claude-code &&\
-    ln -s /etc/AGENTS.md /etc/claude-code/CLAUDE.md
+    ln -s "$cli" /usr/local/share/tool-bin/claude
+ENV CLAUDE_CODE_EXECUTABLE=/usr/local/share/tool-bin/claude
+RUN ln -s ../.agents/skills /app/working-dir/.claude/skills
 COPY managed-settings.json /etc/claude-code/managed-settings.json
 
 COPY --chown=65532:0 workspace/ /app/working-dir/
@@ -67,5 +67,3 @@ COPY --chown=65532:0 dam-skills/ /usr/local/share/dam-skills/
 
 # Override platform-base's manifest to add the Claude-specific harnessConfig block.
 COPY --chown=65532:0 runtime-manifest.yaml /app/runtime-manifest.yaml
-
-USER 65532

--- a/packages/agents/claude-code/Dockerfile
+++ b/packages/agents/claude-code/Dockerfile
@@ -7,12 +7,17 @@ USER root
 # match the installs baked in below (a pin seeded into the persistent workspace
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
-COPY harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-RUN --mount=type=cache,target=/root/.npm \
-    npm_config_cache=/root/.npm \
-    mise install "npm:@agentclientprotocol/claude-agent-acp" &&\
-    chown -R 65532 /etc/mise \
-      "$(dirname "$(mise where npm:@agentclientprotocol/claude-agent-acp)")"
+COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
+# Installed as the agent user rather than by root with a chown after: mise
+# writes the install dir and the lockfile owned by the runtime user from the
+# start, so a newly pinned tool cannot be left out of a chown list. Everything
+# it writes to — /etc/mise and MISE_DATA_DIR — is agent-owned in the base image.
+USER 65532
+RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
+    --mount=type=cache,target=/tmp/mise-cache,uid=65532 \
+    npm_config_cache=/tmp/npm-cache MISE_CACHE_DIR=/tmp/mise-cache \
+    mise install "npm:@agentclientprotocol/claude-agent-acp"
+USER root
 
 # Claude Code phones home (usage telemetry to Statsig, error logs to Datadog
 # intake) — traffic the gateway egress chain would surface for approval. The

--- a/packages/agents/claude-code/harness-history-lib.mjs
+++ b/packages/agents/claude-code/harness-history-lib.mjs
@@ -2,7 +2,7 @@ import { existsSync } from "node:fs";
 import { pathToFileURL } from "node:url";
 
 const ADAPTER_DIR =
-  process.env.CLAUDE_AGENT_ACP_DIR ?? "/usr/local/lib/claude-agent-acp";
+  process.env.CLAUDE_AGENT_ACP_DIR ?? "/usr/local/share/tool-bin/claude-agent-acp-lib";
 
 let modulesPromise;
 

--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -12,8 +12,7 @@ RUN --mount=type=cache,target=/root/.npm \
     mise install "npm:@openai/codex" "npm:@zed-industries/codex-acp" &&\
     chown -R 65532 /etc/mise \
       "$(dirname "$(mise where npm:@openai/codex)")" \
-      "$(dirname "$(mise where npm:@zed-industries/codex-acp)")" &&\
-    find /etc/mise -name '*.lock' -exec chmod 644 {} +
+      "$(dirname "$(mise where npm:@zed-industries/codex-acp)")"
 
 COPY harness-chat.sh /usr/local/bin/harness-chat
 COPY harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -8,10 +8,6 @@ USER root
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-# Installed as the agent user rather than by root with a chown after: mise
-# writes the install dirs and the lockfile owned by the runtime user from the
-# start, so a newly pinned tool cannot be left out of a chown list. Everything
-# it writes to — /etc/mise and MISE_DATA_DIR — is agent-owned in the base image.
 USER 65532
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
     --mount=type=cache,target=/tmp/mise-cache,uid=65532 \

--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -1,27 +1,22 @@
 ARG BASE_IMAGE=platform-base
 FROM ${BASE_IMAGE}
 
-USER root
+USER 65532
 
 # harness tool pins ride the image as system-level mise config so they always
 # match the installs baked in below (a pin seeded into the persistent workspace
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-USER 65532
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
     --mount=type=cache,target=/tmp/mise-cache,uid=65532 \
     npm_config_cache=/tmp/npm-cache MISE_CACHE_DIR=/tmp/mise-cache \
     mise install "npm:@openai/codex" "npm:@zed-industries/codex-acp"
-USER root
 
-COPY harness-chat.sh /usr/local/bin/harness-chat
-COPY harness-terminal.sh /usr/local/bin/harness-terminal
-RUN chmod +x /usr/local/bin/harness-chat /usr/local/bin/harness-terminal
+COPY --chmod=0755 harness-chat.sh /usr/local/bin/harness-chat
+COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chown=65532:0 system-config.toml /etc/codex/config.toml
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
 # placeholder satisfies the CLI startup check; real credential injected on the wire
 ENV OPENAI_API_KEY=dummy-placeholder
-
-USER 65532

--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -7,12 +7,17 @@ USER root
 # match the installs baked in below (a pin seeded into the persistent workspace
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
-COPY harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-RUN --mount=type=cache,target=/root/.npm \
-    mise install "npm:@openai/codex" "npm:@zed-industries/codex-acp" &&\
-    chown -R 65532 /etc/mise \
-      "$(dirname "$(mise where npm:@openai/codex)")" \
-      "$(dirname "$(mise where npm:@zed-industries/codex-acp)")"
+COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
+# Installed as the agent user rather than by root with a chown after: mise
+# writes the install dirs and the lockfile owned by the runtime user from the
+# start, so a newly pinned tool cannot be left out of a chown list. Everything
+# it writes to — /etc/mise and MISE_DATA_DIR — is agent-owned in the base image.
+USER 65532
+RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
+    --mount=type=cache,target=/tmp/mise-cache,uid=65532 \
+    npm_config_cache=/tmp/npm-cache MISE_CACHE_DIR=/tmp/mise-cache \
+    mise install "npm:@openai/codex" "npm:@zed-industries/codex-acp"
+USER root
 
 COPY harness-chat.sh /usr/local/bin/harness-chat
 COPY harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/agents/pi-agent/Dockerfile
+++ b/packages/agents/pi-agent/Dockerfile
@@ -13,8 +13,7 @@ RUN --mount=type=cache,target=/root/.npm \
     chown -R 65532 /etc/mise \
       "$(dirname "$(mise where npm:@earendil-works/pi-coding-agent)")" \
       "$(dirname "$(mise where npm:pi-acp)")" \
-      "$(dirname "$(mise where npm:@zhafron/pi-memory)")" &&\
-    find /etc/mise -name '*.lock' -exec chmod 644 {} +
+      "$(dirname "$(mise where npm:@zhafron/pi-memory)")"
 
 COPY harness-chat.sh /usr/local/bin/harness-chat
 COPY harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/agents/pi-agent/Dockerfile
+++ b/packages/agents/pi-agent/Dockerfile
@@ -7,13 +7,17 @@ USER root
 # match the installs baked in below (a pin seeded into the persistent workspace
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
-COPY harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-RUN --mount=type=cache,target=/root/.npm \
-    mise install "npm:@earendil-works/pi-coding-agent" "npm:pi-acp" "npm:@zhafron/pi-memory" &&\
-    chown -R 65532 /etc/mise \
-      "$(dirname "$(mise where npm:@earendil-works/pi-coding-agent)")" \
-      "$(dirname "$(mise where npm:pi-acp)")" \
-      "$(dirname "$(mise where npm:@zhafron/pi-memory)")"
+COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
+# Installed as the agent user rather than by root with a chown after: mise
+# writes the install dirs and the lockfile owned by the runtime user from the
+# start, so a newly pinned tool cannot be left out of a chown list. Everything
+# it writes to — /etc/mise and MISE_DATA_DIR — is agent-owned in the base image.
+USER 65532
+RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
+    --mount=type=cache,target=/tmp/mise-cache,uid=65532 \
+    npm_config_cache=/tmp/npm-cache MISE_CACHE_DIR=/tmp/mise-cache \
+    mise install "npm:@earendil-works/pi-coding-agent" "npm:pi-acp" "npm:@zhafron/pi-memory"
+USER root
 
 COPY harness-chat.sh /usr/local/bin/harness-chat
 COPY harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/agents/pi-agent/Dockerfile
+++ b/packages/agents/pi-agent/Dockerfile
@@ -8,10 +8,6 @@ USER root
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-# Installed as the agent user rather than by root with a chown after: mise
-# writes the install dirs and the lockfile owned by the runtime user from the
-# start, so a newly pinned tool cannot be left out of a chown list. Everything
-# it writes to — /etc/mise and MISE_DATA_DIR — is agent-owned in the base image.
 USER 65532
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
     --mount=type=cache,target=/tmp/mise-cache,uid=65532 \

--- a/packages/agents/pi-agent/Dockerfile
+++ b/packages/agents/pi-agent/Dockerfile
@@ -1,24 +1,21 @@
 ARG BASE_IMAGE=platform-base
 FROM ${BASE_IMAGE}
 
-USER root
+USER 65532
 
 # harness tool pins ride the image as system-level mise config so they always
 # match the installs baked in below (a pin seeded into the persistent workspace
 # would go stale on template upgrade); install by name — a bare `mise install`
 # would also preinstall every lazy tool from the base image's /etc/mise/config.toml
 COPY --chown=65532:0 harness-tools.toml /etc/mise/conf.d/harness-tools.toml
-USER 65532
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
     --mount=type=cache,target=/tmp/mise-cache,uid=65532 \
     npm_config_cache=/tmp/npm-cache MISE_CACHE_DIR=/tmp/mise-cache \
     mise install "npm:@earendil-works/pi-coding-agent" "npm:pi-acp" "npm:@zhafron/pi-memory"
-USER root
 
-COPY harness-chat.sh /usr/local/bin/harness-chat
-COPY harness-terminal.sh /usr/local/bin/harness-terminal
-RUN chmod +x /usr/local/bin/harness-chat /usr/local/bin/harness-terminal &&\
-ln -s /etc/AGENTS.md /app/working-dir/AGENTS.md &&\
+COPY --chmod=0755 harness-chat.sh /usr/local/bin/harness-chat
+COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
+RUN ln -s /etc/AGENTS.md /app/working-dir/AGENTS.md &&\
 mkdir -p /app/working-dir/.pi/agent &&\
 ln -s ../../.agents/skills /app/working-dir/.pi/agent/skills
 
@@ -26,7 +23,5 @@ COPY --chown=65532:0 workspace/ /app/working-dir/
 
 # Override platform-base's manifest to add the Pi-specific harnessConfig block.
 COPY --chown=65532:0 runtime-manifest.yaml /app/runtime-manifest.yaml
-
-USER 65532
 
 ENV PI_SKIP_VERSION_CHECK=1

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -147,15 +147,20 @@ RUN set -eu; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
     for spec in uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
     tool="${spec%%=*}"; bin="${spec##*=}"; \
-    printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nreal=$(mise which %s 2>/dev/null)\nif [ -x "$real" ]; then\n  ln -sf "$real" /usr/local/share/tool-bin/%s 2>/dev/null\n  exec "$real" "$@"\nfi\nexec mise exec %s -- %s "$@"\n' "$tool" "$bin" "$bin" "$tool" "$bin" > "$bin"; \
+    printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nreal=$(mise which %s 2>/dev/null)\n[ -x "$real" ] && exec "$real" "$@"\nexec mise exec %s -- %s "$@"\n' "$tool" "$bin" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
+# tool-bin is created and handed to the agent user *before* the install: mise's
+# postinstall hook (see mise.toml) links every installed tool's real binary into
+# it — here for the image's own tools, and again whenever the agent installs a
+# tool at runtime. The trailing test fails the build if the hook ever stops
+# firing, which would otherwise show up only as a slow agent.
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
+    mkdir /usr/local/share/tool-bin; chown 65532 /usr/local/share/tool-bin; \
     mise install jq fd rg gh; \
     for t in jq fd rg gh; do chown -R 65532 "/usr/local/share/mise/installs/$t"; done; \
     chown 65532 /etc/mise/mise.lock; chmod 644 /etc/mise/mise.lock; \
-    mkdir /usr/local/share/tool-bin; \
-    chown 65532 /usr/local/share/tool-bin
+    test -x /usr/local/share/tool-bin/jq && test -x /usr/local/share/tool-bin/node
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chmod=755 packages/platform-base/dam-run.mjs /usr/local/bin/dam-run

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -26,14 +26,15 @@ COPY packages/platform-base/mise.toml /etc/mise/config.toml
 RUN --mount=type=cache,target=/root/.cache/mise \
     --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN \
     set -eu; \
+    export MISE_CACHE_DIR=/root/.cache/mise; \
     mkdir /tmp/lockgen; cp /etc/mise/config.toml /tmp/lockgen/mise.toml; \
     cd /tmp/lockgen; mise trust -q; mise lock; \
     cp mise.lock /etc/mise/mise.lock; rm -r /tmp/lockgen
-RUN --mount=type=cache,target=/root/.cache/mise mise install node
+RUN --mount=type=cache,target=/root/.cache/mise MISE_CACHE_DIR=/root/.cache/mise mise install node
 # Python is eager, not a lazy shim: the experiment SDK (#2942) runs loop
 # scripts with python3, and a first-use CPython download would ride the
 # egress gateway mid-experiment (slow at best, policy-blocked at worst).
-RUN --mount=type=cache,target=/root/.cache/mise mise install python
+RUN --mount=type=cache,target=/root/.cache/mise MISE_CACHE_DIR=/root/.cache/mise mise install python
 # mise's CPython bundles pip 26.0.1 (CVE-2026-3219, CVE-2026-8643); self-upgrade
 # until a python release bundles pip >= 26.1.2.
 RUN mise exec python -- python -m pip install --upgrade pip==26.1.2

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -140,14 +140,17 @@ COPY --from=base --chown=65532:0 /etc/mise/ /etc/mise/
 # has no execute bit, which is just a different way to break the import.
 COPY --chmod=0644 packages/experiment-sdk/src/experiment_sdk.py /usr/local/lib/platform-python/experiment_sdk.py
 RUN chmod 0755 /usr/local/lib/platform-python
-# The chmod restores world-readability: mise rewrites the lock 0600, which
-# would lock the runtime agent user out after a root-run install in a derived
-# image build — an unreadable lock degrades every shim call to API lookups.
+# These shims sit at the very end of PATH and serve exactly one call per tool:
+# the install they perform fires mise's postinstall hook, which links the real
+# binary into tool-bin at the front of PATH, so every later call resolves there
+# and never reaches this directory again. MISE_AUTO_INSTALL=false keeps that one
+# call to the tool that was asked for, instead of bulk-installing every other
+# configured-but-absent tool.
 RUN set -eu; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
     for spec in uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
     tool="${spec%%=*}"; bin="${spec##*=}"; \
-    printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nchmod 644 /etc/mise/mise.lock 2>/dev/null\nreal=$(mise which %s 2>/dev/null)\n[ -x "$real" ] && exec "$real" "$@"\nexec mise exec %s -- %s "$@"\n' "$tool" "$bin" "$tool" "$bin" > "$bin"; \
+    printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nexec mise exec %s -- %s "$@"\n' "$tool" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
 # tool-bin is created and handed to the agent user *before* the install: mise's

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -140,12 +140,6 @@ COPY --from=base --chown=65532:0 /etc/mise/ /etc/mise/
 # has no execute bit, which is just a different way to break the import.
 COPY --chmod=0644 packages/experiment-sdk/src/experiment_sdk.py /usr/local/lib/platform-python/experiment_sdk.py
 RUN chmod 0755 /usr/local/lib/platform-python
-# These shims sit at the very end of PATH and serve exactly one call per tool:
-# the install they perform fires mise's postinstall hook, which links the real
-# binary into tool-bin at the front of PATH, so every later call resolves there
-# and never reaches this directory again. MISE_AUTO_INSTALL=false keeps that one
-# call to the tool that was asked for, instead of bulk-installing every other
-# configured-but-absent tool.
 RUN set -eu; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
     for spec in uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
@@ -153,15 +147,6 @@ RUN set -eu; \
     printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nexec mise exec %s -- %s "$@"\n' "$tool" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
-# tool-bin is created and handed to the agent user *before* the install: mise's
-# postinstall hook (see mise.toml) links every installed tool's real binary into
-# it — here for the image's own tools, and again whenever the agent installs a
-# tool at runtime. The trailing test fails the build if the hook ever stops
-# firing, which would otherwise show up only as a slow agent.
-# MISE_CACHE_DIR: HOME is /tmp in this image, so mise would otherwise ignore the
-# cache mount and leave a root-owned /tmp/.cache behind — build residue that a
-# derived image's agent-user install then cannot write into. Same for the state
-# dir it tracks configs in; /tmp is an emptyDir at runtime, so both are dropped.
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
     mkdir /usr/local/share/tool-bin; chown 65532 /usr/local/share/tool-bin; \
     MISE_CACHE_DIR=/root/.cache/mise mise install jq fd rg gh; \

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -28,7 +28,7 @@ RUN --mount=type=cache,target=/root/.cache/mise \
     set -eu; \
     mkdir /tmp/lockgen; cp /etc/mise/config.toml /tmp/lockgen/mise.toml; \
     cd /tmp/lockgen; mise trust -q; mise lock; \
-    cp mise.lock /etc/mise/mise.lock; chmod 644 /etc/mise/mise.lock; rm -r /tmp/lockgen
+    cp mise.lock /etc/mise/mise.lock; rm -r /tmp/lockgen
 RUN --mount=type=cache,target=/root/.cache/mise mise install node
 # Python is eager, not a lazy shim: the experiment SDK (#2942) runs loop
 # scripts with python3, and a first-use CPython download would ride the
@@ -162,7 +162,7 @@ RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
     mkdir /usr/local/share/tool-bin; chown 65532 /usr/local/share/tool-bin; \
     mise install jq fd rg gh; \
     for t in jq fd rg gh; do chown -R 65532 "/usr/local/share/mise/installs/$t"; done; \
-    chown 65532 /etc/mise/mise.lock; chmod 644 /etc/mise/mise.lock; \
+    chown 65532 /etc/mise/mise.lock; \
     test -x /usr/local/share/tool-bin/jq && test -x /usr/local/share/tool-bin/node
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -158,9 +158,14 @@ RUN set -eu; \
 # it — here for the image's own tools, and again whenever the agent installs a
 # tool at runtime. The trailing test fails the build if the hook ever stops
 # firing, which would otherwise show up only as a slow agent.
+# MISE_CACHE_DIR: HOME is /tmp in this image, so mise would otherwise ignore the
+# cache mount and leave a root-owned /tmp/.cache behind — build residue that a
+# derived image's agent-user install then cannot write into. Same for the state
+# dir it tracks configs in; /tmp is an emptyDir at runtime, so both are dropped.
 RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
     mkdir /usr/local/share/tool-bin; chown 65532 /usr/local/share/tool-bin; \
-    mise install jq fd rg gh; \
+    MISE_CACHE_DIR=/root/.cache/mise mise install jq fd rg gh; \
+    rm -rf /tmp/.cache /tmp/.local; \
     for t in jq fd rg gh; do chown -R 65532 "/usr/local/share/mise/installs/$t"; done; \
     chown 65532 /etc/mise/mise.lock; \
     test -x /usr/local/share/tool-bin/jq && test -x /usr/local/share/tool-bin/node

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -141,19 +141,28 @@ COPY --from=base --chown=65532:0 /etc/mise/ /etc/mise/
 COPY --chmod=0644 packages/experiment-sdk/src/experiment_sdk.py /usr/local/lib/platform-python/experiment_sdk.py
 RUN chmod 0755 /usr/local/lib/platform-python
 RUN set -eu; \
+    install -d -o 65532 /usr/local/share/tool-bin; \
     mkdir /usr/local/share/lazy-tools; cd /usr/local/share/lazy-tools; \
     for spec in uv uv=uvx python python=python3 kubectl oc 'npm:@googleworkspace/cli=gws'; do \
     tool="${spec%%=*}"; bin="${spec##*=}"; \
     printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nexec mise exec %s -- %s "$@"\n' "$tool" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
-RUN install -d -o 65532 /usr/local/share/tool-bin
+RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs &&\
+    chown 65532 /app &&\
+    chown -R 65532 /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs /home/agent &&\
+    ldconfig &&\
+    echo 'sshd:x:74:' >> /etc/group &&\
+    echo 'sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/usr/sbin/nologin' >> /etc/passwd &&\
+    sed -i -E '/^[^:]*:[^:]*:65532:/d' /etc/passwd &&\
+    echo 'agent:x:65532:0:Agent User:/home/agent:/bin/bash' >> /etc/passwd
+
 USER 65532
 RUN --mount=type=cache,target=/tmp/mise-cache,uid=65532 set -eu; \
     MISE_CACHE_DIR=/tmp/mise-cache mise install jq fd rg gh; \
     rm -rf /tmp/.local; \
     test -x /usr/local/share/tool-bin/jq && test -x /usr/local/share/tool-bin/node
-USER root
+
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chmod=755 packages/platform-base/dam-run.mjs /usr/local/bin/dam-run
@@ -164,21 +173,10 @@ COPY --chown=65532:0 packages/platform-base/working-dir/.claude/settings.json /a
 COPY --chown=65532:0 packages/platform-base/runtime-manifest.yaml /app/runtime-manifest.yaml
 COPY --chown=65532:0 packages/platform-base/AGENTS.md /etc/AGENTS.md
 
-RUN mkdir -p /home/agent /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs &&\
-    chown 65532 /app &&\
-    chown -R 65532 /etc/pki/ca-trust/source/anchors /etc/pki/ca-trust/extracted /etc/pki/tls/certs /home/agent &&\
-    ldconfig &&\
-    echo 'sshd:x:74:' >> /etc/group &&\
-    echo 'sshd:x:74:74:Privilege-separated SSH:/usr/share/empty.sshd:/usr/sbin/nologin' >> /etc/passwd &&\
-    sed -i -E '/^[^:]*:[^:]*:65532:/d' /etc/passwd &&\
-    echo 'agent:x:65532:0:Agent User:/home/agent:/bin/bash' >> /etc/passwd
-
 COPY --from=builder --chown=65532:0 /deploy/package.json ./
 COPY --from=builder --chown=65532:0 /deploy/node_modules ./node_modules
 COPY --from=builder --chown=65532:0 /app/packages/agent-runtime/dist/ ./dist/
 COPY --from=builder /app/packages/driver-sdk/dist/driver-sdk.mjs /usr/local/lib/driver-sdk.mjs
-
-USER 65532
 
 # Python's TLS clients skip the system trust store the entrypoint installs the
 # platform CA into (httpx/certifi honor SSL_CERT_FILE, requests honors

--- a/packages/platform-base/Dockerfile
+++ b/packages/platform-base/Dockerfile
@@ -147,13 +147,13 @@ RUN set -eu; \
     printf '#!/bin/sh\nexport MISE_AUTO_INSTALL=false\nmise install %s 1>&2\nexec mise exec %s -- %s "$@"\n' "$tool" "$tool" "$bin" > "$bin"; \
     chmod 755 "$bin"; \
     done
-RUN --mount=type=cache,target=/root/.cache/mise set -eu; \
-    mkdir /usr/local/share/tool-bin; chown 65532 /usr/local/share/tool-bin; \
-    MISE_CACHE_DIR=/root/.cache/mise mise install jq fd rg gh; \
-    rm -rf /tmp/.cache /tmp/.local; \
-    for t in jq fd rg gh; do chown -R 65532 "/usr/local/share/mise/installs/$t"; done; \
-    chown 65532 /etc/mise/mise.lock; \
+RUN install -d -o 65532 /usr/local/share/tool-bin
+USER 65532
+RUN --mount=type=cache,target=/tmp/mise-cache,uid=65532 set -eu; \
+    MISE_CACHE_DIR=/tmp/mise-cache mise install jq fd rg gh; \
+    rm -rf /tmp/.local; \
     test -x /usr/local/share/tool-bin/jq && test -x /usr/local/share/tool-bin/node
+USER root
 COPY --chmod=755 packages/platform-base/harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=755 packages/platform-base/harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chmod=755 packages/platform-base/dam-run.mjs /usr/local/bin/dam-run

--- a/packages/platform-base/entrypoint.sh
+++ b/packages/platform-base/entrypoint.sh
@@ -12,13 +12,6 @@
 # writable at build time (see Dockerfile).
 set -eu
 
-# Resolve mise's tools onto PATH once, here, instead of paying mise's startup on
-# every call through a shim. A pod is one long-lived process tree, so everything
-# the harness spawns inherits this; measured on a pod, a shim call costs ~250ms
-# more than the binary it resolves to (#3294). Tools installed later still
-# resolve through their lazy wrapper, which links itself into tool-bin.
-eval "$(mise env 2>/dev/null || true)"
-
 mitm_ca=/etc/platform/ca/ca.crt
 anchor=/etc/pki/ca-trust/source/anchors/platform-mitm-ca.crt
 extracted=/etc/pki/ca-trust/extracted

--- a/packages/platform-base/mise.toml
+++ b/packages/platform-base/mise.toml
@@ -27,8 +27,22 @@ oc = "latest"
 # project's pinned versions into this machine-wide dir; the system and the
 # user's global config are still both in scope. Non-executables and the
 # subdirectories some archives unpack next to their binary (fd ships a README
-# and an autocomplete/ dir in its bin path) are filtered out. Best-effort: a
-# link that cannot be written is a startup-latency wart, never a failed install
-# — mise only warns when a hook exits non-zero. `if`, not `[ ... ] && ln`: mise
-# runs the hook under `sh -o errexit`, where a skipped file would end the loop.
-postinstall = 'mkdir -p /usr/local/share/tool-bin && mise bin-paths -C /etc/mise | while read -r d; do for f in "$d"/*; do if [ -f "$f" ] && [ -x "$f" ]; then ln -sf "$f" /usr/local/share/tool-bin/; fi; done; done'
+# and an autocomplete/ dir in its bin path) are filtered out. `if`, not
+# `[ ... ] && ln`: mise runs the hook under `sh -o errexit`, where a skipped
+# file would end the loop.
+#
+# The chmod is the one place the lockfiles are made world-readable again: mise
+# rewrites them 0600 on every install, and a root-run install — the image
+# builds, a root shell on the VM backend — would otherwise lock the agent user
+# out, degrading its every mise call to a GitHub API lookup. It runs last and
+# swallows its errors, so an install by a user who does not own the lock still
+# gets its binaries linked.
+postinstall = '''
+mkdir -p /usr/local/share/tool-bin
+mise bin-paths -C /etc/mise | while read -r d; do
+  for f in "$d"/*; do
+    if [ -f "$f" ] && [ -x "$f" ]; then ln -sf "$f" /usr/local/share/tool-bin/; fi
+  done
+done
+find /etc/mise -name '*.lock' -exec chmod 644 {} + 2>/dev/null || true
+'''

--- a/packages/platform-base/mise.toml
+++ b/packages/platform-base/mise.toml
@@ -21,7 +21,8 @@ oc = "latest"
 [hooks]
 postinstall = '''
 mkdir -p /usr/local/share/tool-bin
-bin_paths=$(mise bin-paths -C /etc/mise)
+just=$(printf '%s' "${MISE_INSTALLED_TOOLS:-}" | sed 's/},{/}\n{/g' | sed -n 's/.*"name":"\([^"]*\)".*"version":"\([^"]*\)".*/\1@\2/p')
+bin_paths=$(mise bin-paths -C /etc/mise; { [ -z "$just" ] || mise bin-paths $just; } || true)
 for d in $bin_paths; do
   for f in "$d"/*; do
     if [ -f "$f" ] && [ -x "$f" ]; then ln -sf "$f" /usr/local/share/tool-bin/; fi

--- a/packages/platform-base/mise.toml
+++ b/packages/platform-base/mise.toml
@@ -1,5 +1,4 @@
 [settings]
-# The postinstall hook below is gated behind mise's experimental flag.
 experimental = true
 lockfile = true
 minimum_release_age = "7d"
@@ -20,23 +19,6 @@ kubectl = "latest"
 oc = "latest"
 
 [hooks]
-# Every tool mise installs — at image build time, or later by the agent — gets
-# its real binary linked into tool-bin, which leads PATH. Resolving the same
-# tool through a mise shim instead costs ~250ms per call on a pod (#3294).
-# `-C /etc/mise` so that installing from a project directory cannot leak that
-# project's pinned versions into this machine-wide dir; the system and the
-# user's global config are still both in scope. Non-executables and the
-# subdirectories some archives unpack next to their binary (fd ships a README
-# and an autocomplete/ dir in its bin path) are filtered out. `if`, not
-# `[ ... ] && ln`: mise runs the hook under `sh -o errexit`, where a skipped
-# file would end the loop.
-#
-# The chmod is the one place the lockfiles are made world-readable again: mise
-# rewrites them 0600 on every install, and a root-run install — the image
-# builds, a root shell on the VM backend — would otherwise lock the agent user
-# out, degrading its every mise call to a GitHub API lookup. It runs last and
-# swallows its errors, so an install by a user who does not own the lock still
-# gets its binaries linked.
 postinstall = '''
 mkdir -p /usr/local/share/tool-bin
 mise bin-paths -C /etc/mise | while read -r d; do

--- a/packages/platform-base/mise.toml
+++ b/packages/platform-base/mise.toml
@@ -21,7 +21,8 @@ oc = "latest"
 [hooks]
 postinstall = '''
 mkdir -p /usr/local/share/tool-bin
-mise bin-paths -C /etc/mise | while read -r d; do
+bin_paths=$(mise bin-paths -C /etc/mise)
+for d in $bin_paths; do
   for f in "$d"/*; do
     if [ -f "$f" ] && [ -x "$f" ]; then ln -sf "$f" /usr/local/share/tool-bin/; fi
   done

--- a/packages/platform-base/mise.toml
+++ b/packages/platform-base/mise.toml
@@ -1,4 +1,6 @@
 [settings]
+# The postinstall hook below is gated behind mise's experimental flag.
+experimental = true
 lockfile = true
 minimum_release_age = "7d"
 python.compile = false
@@ -16,3 +18,17 @@ python = "3.12"
 # contribution; these make it usable out of the box.
 kubectl = "latest"
 oc = "latest"
+
+[hooks]
+# Every tool mise installs — at image build time, or later by the agent — gets
+# its real binary linked into tool-bin, which leads PATH. Resolving the same
+# tool through a mise shim instead costs ~250ms per call on a pod (#3294).
+# `-C /etc/mise` so that installing from a project directory cannot leak that
+# project's pinned versions into this machine-wide dir; the system and the
+# user's global config are still both in scope. Non-executables and the
+# subdirectories some archives unpack next to their binary (fd ships a README
+# and an autocomplete/ dir in its bin path) are filtered out. Best-effort: a
+# link that cannot be written is a startup-latency wart, never a failed install
+# — mise only warns when a hook exits non-zero. `if`, not `[ ... ] && ln`: mise
+# runs the hook under `sh -o errexit`, where a skipped file would end the loop.
+postinstall = 'mkdir -p /usr/local/share/tool-bin && mise bin-paths -C /etc/mise | while read -r d; do for f in "$d"/*; do if [ -f "$f" ] && [ -x "$f" ]; then ln -sf "$f" /usr/local/share/tool-bin/; fi; done; done'


### PR DESCRIPTION
Follow-up to #3498, which put the real tool binaries on PATH via `tool-bin` but populated it by hand — an `eval "$(mise env)"` at pod boot, plus an `ln -sf` inside each lazy-tool shim. mise can do this itself, and once it does, three other hand-rolled things fall away with it.

## The hook

**`mise.toml`** — a `[hooks] postinstall` in the system config links every installed tool's real binary into `/usr/local/share/tool-bin` (which leads PATH). It fires on every `mise install`: at base-image build, in each derived agent image, and whenever the agent installs a tool at runtime. Needs `experimental = true` — hooks are gated in the pinned mise 2026.6.3.

Three details the hook has to get right, all found while testing:

- `-C /etc/mise` scopes `mise bin-paths` to the system + user-global config, so an install run from inside a project directory cannot leak that project's pinned node version into the machine-wide dir.
- `[ -f ] && [ -x ]` filters the bin path: fd and rg unpack a README, a man page and an `autocomplete/` directory next to their binary.
- `if`, not `[ … ] && ln`: mise runs hooks under `sh -o errexit`, so a skipped non-executable would end the loop early and leave later tools unlinked.

**`entrypoint.sh`** — the `eval "$(mise env)"` is gone. The links do the same job without paying mise's startup at boot, and they persist for tools installed after boot.

## What that lets us delete

**Lazy-tool shims** — down to install + exec:

```sh
#!/bin/sh
export MISE_AUTO_INSTALL=false
mise install uv 1>&2
exec mise exec uv -- uv "$@"
```

Each shim serves exactly one call per tool: its install fires the hook, the hook links the binary into `tool-bin` at the front of PATH, and every later call resolves there without reaching the shim directory again. The `mise which` fast path and the shim's own lockfile `chmod` both go. `MISE_AUTO_INSTALL=false` stays: it keeps that one call from bulk-installing every other configured-but-absent tool.

**Lockfile permissions, now in one place.** mise rewrites `*.lock` 0600 on every install, and a root-run install would lock the agent user out — degrading its every mise call to a GitHub API lookup. Four Dockerfiles each healed that by hand (two `chmod 644` in platform-base, a `find … -exec chmod` in claude-code, codex and pi-agent). The hook runs after every install in every image, so it does it once for all of them, last and error-swallowing so an install by a user who does not own the lock still gets its binaries linked.

**The chowns.** platform-base installed its own tools as root and then chowned each `installs/<tool>` tree and the lockfile; claude-code, codex and pi-agent did the same for their harness CLIs, plus `/etc/mise` and one `$(dirname "$(mise where …)")` per package — a list that goes stale the moment a tool is added. All four now run `mise install` as uid 65532 instead. Everything mise writes (`/etc/mise`, `MISE_DATA_DIR`) is already agent-owned in the base image, and `tool-bin` is created with `install -d -o 65532`, so the right owner is there from the start and every `chown` in these layers is gone.

That needed a fix underneath. `HOME` is `/tmp` in this image, so the root-run installs ignored their `--mount=type=cache,target=/root/.cache/mise` and left a root-owned `/tmp/.cache` and `/tmp/.local` in the layer — which an agent-user install then could not write into. Every mise install now points `MISE_CACHE_DIR` at a cache mount owned by the build user, which makes those mounts effective for the first time and leaves no residue (`/tmp` is an emptyDir at runtime). It also silences the `rm: Permission denied` warnings the entrypoint printed on every boot. Relatedly, codex and pi-agent mounted `/root/.npm` without setting `npm_config_cache`, so npm never read it.

**The user switching.** Each image now groups its root work ahead of a single `USER 65532` and never switches back. platform-base moves its two root-only layers (the lazy-tool shims, which also create `tool-bin`, and the `/home/agent` + `/etc/passwd` layer) above the switch; codex and pi-agent needed root only for `RUN chmod +x` on two harness scripts, now `COPY --chmod=0755`, so they run as the agent user throughout.

claude-code was the hard one: it linked the adapter package into `/usr/local/lib` and the CLI into `/usr/local/bin`, both root-owned, and both paths come from `mise where`, which errors unless the tool is already installed — so the links could not be made before the install, and root could not be left behind. They now go into `tool-bin`, which the agent user owns and which already leads PATH: `tool-bin/claude` (what `CLAUDE_CODE_EXECUTABLE` points at) and `tool-bin/claude-agent-acp-lib` (the adapter directory, named apart from the `claude-agent-acp` binary the hook links there). `harness-history-lib.mjs` follows the adapter to the new path; `CLAUDE_AGENT_ACP_DIR` still overrides it, and the VM image resolves `claude` through PATH, so it needs no change.

**`Dockerfile`** — `tool-bin` exists and belongs to the agent user *before* `mise install` so the hook writes into it, and the layer ends with `test -x tool-bin/{jq,node}` so a hook that stops firing fails the build instead of quietly costing every tool call ~250ms (and, now, leaving the lockfiles unreadable).

## Verification

Built the `runner` target and all three derived agent images on top of it, and ran each as uid 65532:

- `node npm python3 jq rg fd gh` resolve to `/usr/local/share/tool-bin/…`; `python3` is a real binary rather than the lazy shim. So do `claude-agent-acp`, `codex`, `codex-acp`, `pi` and `pi-acp` in their images.
- `/etc/mise/mise.lock` is `-rw-r--r--` and agent-owned in all four images, and `find /usr/local/share/mise/installs ! -user agent` comes back empty — with every hand-rolled `chmod` and `chown` deleted.
- Runtime path: the first `uv` call goes through the lazy shim, the hook (running as uid 65532) links `uv` and `uvx` into `tool-bin`, and a fresh shell resolves `uv` from there.
- `claude --version` runs, `claude-agent-acp-lib/dist/acp-agent.js` resolves, and `harness-history-lib.mjs` imports against its new default.
- `kubectl`'s first call installs kubectl alone — `oc` and `gws` stay absent, so `MISE_AUTO_INSTALL=false` still does its job.
- Removing `experimental = true` reproduces the build failure the assert is there to catch.

The VM backend gains from this too: it copies `tool-bin` from the pod image and has no entrypoint `mise env`, so it previously started with an almost empty `tool-bin`.

Not touched: the venv-and-chown pattern in the Python agent images (gepa, nous, openevolve, shinkaevolve, skydiscover, k-search). It is the same shape but installs into `/opt` rather than through mise, so it is a separate change.