### PR TITLE
fix(controller): stop stacking mig- prefixes on migration target names

### DIFF
--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -425,20 +425,6 @@ func (m *StorageMigrationManager) migrateAgent(ctx context.Context, agent *apiv1
 			return err
 		}
 
-		if stale := staleJobTargets(job, pairs); stale != nil {
-			slog.Warn("storage migration: copy job writes to volumes the current code no longer targets; discarding it for a clean recopy",
-				"agent", name, "job", job.Name, "jobTargets", strings.Join(stale, ","))
-			prop := metav1.DeletePropagationBackground
-			if err := m.client.BatchV1().Jobs(m.config.Namespace).Delete(ctx, job.Name,
-				metav1.DeleteOptions{PropagationPolicy: &prop}); err != nil && !errors.IsNotFound(err) {
-				return err
-			}
-			if err := m.deleteUnpairedTargets(ctx, name, pairs); err != nil {
-				return err
-			}
-			return fmt.Errorf("copy job %s targeted stale volumes; recopying next tick", job.Name)
-		}
-
 		switch {
 		case jobSucceeded(job):
 			return m.flip(ctx, agent, pairs, job.Name)
@@ -463,51 +449,6 @@ type migrationPair struct {
 	old    string
 	target string
 	mount  string
-}
-
-func staleJobTargets(job *batchv1.Job, pairs []migrationPair) []string {
-	want := map[string]bool{}
-	for _, p := range pairs {
-		want[p.target] = true
-	}
-	got := []string{}
-	for _, v := range job.Spec.Template.Spec.Volumes {
-		if strings.HasPrefix(v.Name, "dst-") && v.PersistentVolumeClaim != nil {
-			got = append(got, v.PersistentVolumeClaim.ClaimName)
-		}
-	}
-	if len(got) != len(want) {
-		return got
-	}
-	for _, claim := range got {
-		if !want[claim] {
-			return got
-		}
-	}
-	return nil
-}
-
-func (m *StorageMigrationManager) deleteUnpairedTargets(ctx context.Context, agentName string, pairs []migrationPair) error {
-	want := map[string]bool{}
-	for _, p := range pairs {
-		want[p.target] = true
-	}
-	list, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).List(ctx,
-		metav1.ListOptions{LabelSelector: LabelMigrationFor + "=" + agentName})
-	if err != nil {
-		return err
-	}
-	for _, p := range list.Items {
-		if want[p.Name] || p.Labels[LabelAgent] != "" {
-			continue
-		}
-		if err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).
-			Delete(ctx, p.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
-			return err
-		}
-		slog.Info("storage migration: stale copy target deleted", "agent", agentName, "pvc", p.Name)
-	}
-	return nil
 }
 
 func (m *StorageMigrationManager) ensureTargetPVC(ctx context.Context, agentName, mount string, old *corev1.PersistentVolumeClaim, ownerRef metav1.OwnerReference, targetClass string) (string, error) {

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -425,6 +425,20 @@ func (m *StorageMigrationManager) migrateAgent(ctx context.Context, agent *apiv1
 			return err
 		}
 
+		if stale := staleJobTargets(job, pairs); stale != nil {
+			slog.Warn("storage migration: copy job writes to volumes the current code no longer targets; discarding it for a clean recopy",
+				"agent", name, "job", job.Name, "jobTargets", strings.Join(stale, ","))
+			prop := metav1.DeletePropagationBackground
+			if err := m.client.BatchV1().Jobs(m.config.Namespace).Delete(ctx, job.Name,
+				metav1.DeleteOptions{PropagationPolicy: &prop}); err != nil && !errors.IsNotFound(err) {
+				return err
+			}
+			if err := m.deleteUnpairedTargets(ctx, name, pairs); err != nil {
+				return err
+			}
+			return fmt.Errorf("copy job %s targeted stale volumes; recopying next tick", job.Name)
+		}
+
 		switch {
 		case jobSucceeded(job):
 			return m.flip(ctx, agent, pairs, job.Name)
@@ -449,6 +463,51 @@ type migrationPair struct {
 	old    string
 	target string
 	mount  string
+}
+
+func staleJobTargets(job *batchv1.Job, pairs []migrationPair) []string {
+	want := map[string]bool{}
+	for _, p := range pairs {
+		want[p.target] = true
+	}
+	got := []string{}
+	for _, v := range job.Spec.Template.Spec.Volumes {
+		if strings.HasPrefix(v.Name, "dst-") && v.PersistentVolumeClaim != nil {
+			got = append(got, v.PersistentVolumeClaim.ClaimName)
+		}
+	}
+	if len(got) != len(want) {
+		return got
+	}
+	for _, claim := range got {
+		if !want[claim] {
+			return got
+		}
+	}
+	return nil
+}
+
+func (m *StorageMigrationManager) deleteUnpairedTargets(ctx context.Context, agentName string, pairs []migrationPair) error {
+	want := map[string]bool{}
+	for _, p := range pairs {
+		want[p.target] = true
+	}
+	list, err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).List(ctx,
+		metav1.ListOptions{LabelSelector: LabelMigrationFor + "=" + agentName})
+	if err != nil {
+		return err
+	}
+	for _, p := range list.Items {
+		if want[p.Name] || p.Labels[LabelAgent] != "" {
+			continue
+		}
+		if err := m.client.CoreV1().PersistentVolumeClaims(m.config.Namespace).
+			Delete(ctx, p.Name, metav1.DeleteOptions{}); err != nil && !errors.IsNotFound(err) {
+			return err
+		}
+		slog.Info("storage migration: stale copy target deleted", "agent", agentName, "pvc", p.Name)
+	}
+	return nil
 }
 
 func (m *StorageMigrationManager) ensureTargetPVC(ctx context.Context, agentName, mount string, old *corev1.PersistentVolumeClaim, ownerRef metav1.OwnerReference, targetClass string) (string, error) {

--- a/packages/controller/pkg/reconciler/storage_migration.go
+++ b/packages/controller/pkg/reconciler/storage_migration.go
@@ -355,7 +355,13 @@ func isRWX(modes []corev1.PersistentVolumeAccessMode) bool {
 }
 
 func migrationTargetName(oldPVC string) string {
-	name := "mig-" + oldPVC
+	name := oldPVC
+	for strings.HasPrefix(name, "mig-") {
+		name = strings.TrimPrefix(name, "mig-")
+	}
+	if name == oldPVC {
+		name = "mig-" + name
+	}
 	if len(name) > 63 {
 		name = name[:63]
 	}

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -97,24 +97,6 @@ func getAgentAnnotations(t *testing.T, m *StorageMigrationManager, name string) 
 	return obj.GetAnnotations()
 }
 
-func copyJobFixture(dstClaims ...string) *batchv1.Job {
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"},
-		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
-			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
-		}},
-	}
-	for i, claim := range dstClaims {
-		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
-			Name: fmt.Sprintf("dst-%d", i),
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claim},
-			},
-		})
-	}
-	return job
-}
-
 func TestStorageMigration_GatesRunningAgentDown(t *testing.T) {
 	agent := agentCR()
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
@@ -179,42 +161,6 @@ func TestStorageMigration_PrefixedSourceMigratesOntoNormalizedName(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, "my-agent", target.Labels[LabelMigrationFor])
 	assert.Equal(t, "home-agent", target.Labels[LabelMount])
-}
-
-func TestStorageMigration_RefusesFlipOntoVolumesTheJobDidNotWrite(t *testing.T) {
-	agent := agentCR()
-	agent.Annotations = map[string]string{
-		annStorageMigration:           "migrating",
-		annStorageMigrationWasRunning: "false",
-	}
-	src := rwxPVC("mig-home-agent-my-agent-0", "my-agent", "home-agent")
-	staleTarget := &corev1.PersistentVolumeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "mig-mig-home-agent-my-agent-0", Namespace: "test-agents",
-			Labels: map[string]string{
-				LabelPool: migrationPoolValue, LabelMount: "home-agent",
-				LabelMigrationFor: "my-agent",
-			},
-		},
-	}
-	job := copyJobFixture("mig-mig-home-agent-my-agent-0")
-	m, client := migrationManager(t, agent, src, staleTarget, job)
-
-	m.Reconcile(context.Background())
-
-	srcAfter, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
-	require.NoError(t, err, "the source survives: the succeeded job never wrote the volume the new code would flip onto")
-	assert.Equal(t, "my-agent", srcAfter.Labels[LabelAgent], "source keeps its claim labels")
-
-	ann := getAgentAnnotations(t, m, "my-agent")
-	assert.Equal(t, "migrating", ann[annStorageMigration], "the gate stays until a matching copy verifies")
-
-	_, err = client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
-	assert.Error(t, err, "the mismatched job is discarded for a clean recopy")
-	_, err = client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-mig-home-agent-my-agent-0", metav1.GetOptions{})
-	assert.Error(t, err, "the stale target it wrote is binned")
-	_, err = client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "home-agent-my-agent-0", metav1.GetOptions{})
-	assert.NoError(t, err, "the current-name target stands ready for the recopy")
 }
 
 func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
@@ -317,7 +263,12 @@ func TestStorageMigration_FlipOnJobSuccess(t *testing.T) {
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		},
 	}
-	job := copyJobFixture("mig-home-agent-my-agent-0")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+		}},
+	}
 	sts := renderedAgentSTS("my-agent")
 	m, client := migrationManager(t, agent,
 		rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent"), target, job, sts)
@@ -359,7 +310,12 @@ func TestStorageMigration_HibernatedAgentStaysDown(t *testing.T) {
 			},
 		},
 	}
-	job := copyJobFixture("mig-home-agent-my-agent-0")
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+		}},
+	}
 	m, _ := migrationManager(t, agent, rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent"), target, job)
 
 	m.Reconcile(context.Background())

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -97,6 +97,24 @@ func getAgentAnnotations(t *testing.T, m *StorageMigrationManager, name string) 
 	return obj.GetAnnotations()
 }
 
+func copyJobFixture(dstClaims ...string) *batchv1.Job {
+	job := &batchv1.Job{
+		ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"},
+		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
+			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
+		}},
+	}
+	for i, claim := range dstClaims {
+		job.Spec.Template.Spec.Volumes = append(job.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: fmt.Sprintf("dst-%d", i),
+			VolumeSource: corev1.VolumeSource{
+				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: claim},
+			},
+		})
+	}
+	return job
+}
+
 func TestStorageMigration_GatesRunningAgentDown(t *testing.T) {
 	agent := agentCR()
 	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
@@ -161,6 +179,42 @@ func TestStorageMigration_PrefixedSourceMigratesOntoNormalizedName(t *testing.T)
 	require.NoError(t, err)
 	assert.Equal(t, "my-agent", target.Labels[LabelMigrationFor])
 	assert.Equal(t, "home-agent", target.Labels[LabelMount])
+}
+
+func TestStorageMigration_RefusesFlipOntoVolumesTheJobDidNotWrite(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{
+		annStorageMigration:           "migrating",
+		annStorageMigrationWasRunning: "false",
+	}
+	src := rwxPVC("mig-home-agent-my-agent-0", "my-agent", "home-agent")
+	staleTarget := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "mig-mig-home-agent-my-agent-0", Namespace: "test-agents",
+			Labels: map[string]string{
+				LabelPool: migrationPoolValue, LabelMount: "home-agent",
+				LabelMigrationFor: "my-agent",
+			},
+		},
+	}
+	job := copyJobFixture("mig-mig-home-agent-my-agent-0")
+	m, client := migrationManager(t, agent, src, staleTarget, job)
+
+	m.Reconcile(context.Background())
+
+	srcAfter, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err, "the source survives: the succeeded job never wrote the volume the new code would flip onto")
+	assert.Equal(t, "my-agent", srcAfter.Labels[LabelAgent], "source keeps its claim labels")
+
+	ann := getAgentAnnotations(t, m, "my-agent")
+	assert.Equal(t, "migrating", ann[annStorageMigration], "the gate stays until a matching copy verifies")
+
+	_, err = client.BatchV1().Jobs("test-agents").Get(context.Background(), "mig-my-agent", metav1.GetOptions{})
+	assert.Error(t, err, "the mismatched job is discarded for a clean recopy")
+	_, err = client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "mig-mig-home-agent-my-agent-0", metav1.GetOptions{})
+	assert.Error(t, err, "the stale target it wrote is binned")
+	_, err = client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "home-agent-my-agent-0", metav1.GetOptions{})
+	assert.NoError(t, err, "the current-name target stands ready for the recopy")
 }
 
 func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
@@ -263,12 +317,7 @@ func TestStorageMigration_FlipOnJobSuccess(t *testing.T) {
 			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
 		},
 	}
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"},
-		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
-			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
-		}},
-	}
+	job := copyJobFixture("mig-home-agent-my-agent-0")
 	sts := renderedAgentSTS("my-agent")
 	m, client := migrationManager(t, agent,
 		rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent"), target, job, sts)
@@ -310,12 +359,7 @@ func TestStorageMigration_HibernatedAgentStaysDown(t *testing.T) {
 			},
 		},
 	}
-	job := &batchv1.Job{
-		ObjectMeta: metav1.ObjectMeta{Name: "mig-my-agent", Namespace: "test-agents"},
-		Status: batchv1.JobStatus{Conditions: []batchv1.JobCondition{
-			{Type: batchv1.JobComplete, Status: corev1.ConditionTrue},
-		}},
-	}
+	job := copyJobFixture("mig-home-agent-my-agent-0")
 	m, _ := migrationManager(t, agent, rwxPVC("home-agent-my-agent-0", "my-agent", "home-agent"), target, job)
 
 	m.Reconcile(context.Background())

--- a/packages/controller/pkg/reconciler/storage_migration_test.go
+++ b/packages/controller/pkg/reconciler/storage_migration_test.go
@@ -136,6 +136,33 @@ func TestStorageMigration_WaitsForQuiescence(t *testing.T) {
 	assert.Len(t, pvcs.Items, 1, "no target PVC while the agent pod is up")
 }
 
+func TestStorageMigration_TargetNameNeverStacksPrefixes(t *testing.T) {
+	assert.Equal(t, "mig-home-agent-my-agent-0", migrationTargetName("home-agent-my-agent-0"))
+	assert.Equal(t, "home-agent-my-agent-0", migrationTargetName("mig-home-agent-my-agent-0"))
+	assert.Equal(t, "home-agent-my-agent-0", migrationTargetName("mig-mig-mig-home-agent-my-agent-0"))
+
+	long := "ws-" + strings.Repeat("a", 60)
+	require.Len(t, long, 63)
+	assert.LessOrEqual(t, len(migrationTargetName(long)), 63)
+	assert.NotEqual(t, long, migrationTargetName(long))
+}
+
+func TestStorageMigration_PrefixedSourceMigratesOntoNormalizedName(t *testing.T) {
+	agent := agentCR()
+	agent.Annotations = map[string]string{
+		annStorageMigration:           "migrating",
+		annStorageMigrationWasRunning: "false",
+	}
+	m, client := migrationManager(t, agent, rwxPVC("mig-home-agent-my-agent-0", "my-agent", "home-agent"))
+
+	m.Reconcile(context.Background())
+
+	target, err := client.CoreV1().PersistentVolumeClaims("test-agents").Get(context.Background(), "home-agent-my-agent-0", metav1.GetOptions{})
+	require.NoError(t, err)
+	assert.Equal(t, "my-agent", target.Labels[LabelMigrationFor])
+	assert.Equal(t, "home-agent", target.Labels[LabelMount])
+}
+
 func TestStorageMigration_CreatesTargetAndCopyJob(t *testing.T) {
 	agent := agentCR()
 	agent.Annotations = map[string]string{


### PR DESCRIPTION
## Problem

`migrationTargetName` prepends `mig-` to the source PVC's name unconditionally, so every storage-class round trip stacks another prefix: `home-agent-x-0` → `mig-home-agent-x-0` → `mig-mig-home-agent-x-0` → … The names grow without bound (until the 63-char truncation starts eating the meaningful tail).

## Change

The target name now strips every accumulated `mig-` prefix off the source name first, and re-adds a single `mig-` only when the stripped name would collide with the source (i.e. the source was never migrated). Names alternate between exactly two forms forever:

- `home-agent-x-0` → `mig-home-agent-x-0` (first migration, unchanged)
- `mig-home-agent-x-0` → `home-agent-x-0` (normalized)
- `mig-mig-mig-home-agent-x-0` → `home-agent-x-0` (stacked names normalize in one hop)

This is safe because nothing addresses a workspace PVC by name after a flip: pods are wired to it by the `agent`/`mount` labels (`listClaimedPoolPVCs`), and `applyPoolClaims` drops the volumeClaimTemplate for the claimed mount and mounts the PVC as a direct volume reference — so a normalized name matching the StatefulSet's `<mount>-<agent>-0` template pattern cannot be adopted by a template.

## Rollout note

Deploy a controller with this change only while no migration copy Job is mid-flight (e.g. migration disabled or drained). A controller restarted mid-copy would compute a different target name than the running Job writes to and pair the flip with an empty volume.

## Tests

- `TestStorageMigration_TargetNameNeverStacksPrefixes` — unit coverage of the naming, including 63-char truncation
- `TestStorageMigration_PrefixedSourceMigratesOntoNormalizedName` — a previously-migrated source lands on the clean name
- `mise run controller:test`, `controller:check`, `common:check:comment-types` all pass