### PR TITLE
fix(ui): point the LiteLLM key guide link at its real docs page

### DIFF
--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -4,7 +4,7 @@ export const CUSTOM_IMAGE_DOCS_URL =
   "https://pages.github.ibm.com/dam-agents/docs/guides/custom-image/";
 
 export const KEY_GUIDE_URL =
-  "https://pages.github.ibm.com/dam-agents/docs/guides/litellm-key/";
+  "https://pages.github.ibm.com/dam-agents/docs/reference/litellm-key/";
 
 export const CLI_REFERENCE_URL =
   "https://pages.github.ibm.com/dam-agents/docs/reference/cli/";


### PR DESCRIPTION
## Problem

In Settings → Providers → IBM LiteLLM ETE Proxy, the **Need an API key?** link returns 404.

It points at `docs/guides/litellm-key/`. The page is published at `docs/reference/litellm-key/`.

## Fix

One-line change to `KEY_GUIDE_URL` in `packages/ui/src/constants.ts`.

Verified against the docs repo tree: `docs/reference/litellm-key.md` exists, `docs/guides/litellm-key.md` does not. The other doc URLs in `constants.ts` (`guides/custom-image`, `reference/cli`, `core-concepts/connections`) all resolve to real pages and are unchanged.

Note: `mise run ui:fix` could not run in this environment — the toolchain downloads are blocked by network policy. The change is a string literal, so no formatting or import impact.