### PR TITLE
feat(ui): name the Knowledge bases destination "Knowledge base agents"

### DIFF
--- a/docs/ubiquitous-language.md
+++ b/docs/ubiquitous-language.md
@@ -21,6 +21,7 @@ Two rules govern the whole set:
 | temporary agent | A short-lived agent the platform starts for one piece of work and discards afterwards | Sweepable Agent ([Agents](#agents-bounded-context)), typically an [Invocation](#invocations-bounded-context--proposed-in-flight-pr-2816) target | Wherever spawned short-lived agents surface — the agents list groups them behind their driver. Never offered as something a user creates |
 | harness | The coding-agent program running inside the agent (Claude Code, Codex, Gemini CLI) | Harness Lease and Session ([Agents](#agents-bounded-context)) | Only where "agent" would be wrong: harness model selection, harness config. Subtext and advanced surfaces, never a top-level header |
 | sandbox | The isolated container an agent runs in | Sandbox ([Agents](#agents-bounded-context)) | Only when the copy is *about* the container — "runs in its own isolated sandbox", "inside the sandbox", "sandbox image", "VM sandboxes". Never as the name of the thing a user owns; that is an agent |
+| knowledge base agent | An agent that builds and maintains a wiki the user chats with | Knowledge Base ([Knowledge Bases](#knowledge-bases-bounded-context)) | The destination name, its page title and its create buttons, so the section reads as agents like the neighbouring ones (#3508). "Knowledge base" alone stays correct for the body of knowledge itself — what is shared, what is connected, what a share link points at |
 
 ### Retired words — say this, not that
 

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -20,6 +20,7 @@ import { useStore } from "../store.js";
 
 interface Destination {
   label: string;
+  shortLabel?: string;
   icon: CarbonIconType;
   active: boolean;
   badge: number;
@@ -61,7 +62,8 @@ export function IconRail({
     navigate: navigateToExperiments,
   };
   const knowledgeBases: Destination = {
-    label: "Knowledge bases",
+    label: "Knowledge base agents",
+    shortLabel: "Knowledge",
     icon: Book,
     active: view === "knowledge-bases" || view === "knowledge-base-chat",
     badge: 0,
@@ -209,6 +211,7 @@ function RailItem({
 
 function BottomBarItem({
   label,
+  shortLabel,
   icon: Icon,
   active,
   badge,
@@ -224,7 +227,7 @@ function BottomBarItem({
       )}
     >
       <IconWithBadge icon={Icon} badge={badge} />
-      <span className="text-[10px] font-semibold">{label}</span>
+      <span className="text-[10px] font-semibold">{shortLabel ?? label}</span>
     </button>
   );
 }

--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -221,13 +221,16 @@ function BottomBarItem({
     <button
       type="button"
       onClick={navigate}
+      aria-label={badge > 0 ? `${label}, ${badge} pending` : label}
       className={cn(
-        "flex-1 flex flex-col items-center justify-center gap-0.5 py-2 transition-colors",
+        "flex-1 min-w-0 flex flex-col items-center justify-center gap-0.5 py-2 transition-colors",
         active ? "text-primary" : "text-muted-foreground",
       )}
     >
       <IconWithBadge icon={Icon} badge={badge} />
-      <span className="text-[10px] font-semibold">{shortLabel ?? label}</span>
+      <span className="max-w-full truncate text-[10px] font-semibold">
+        {shortLabel ?? label}
+      </span>
     </button>
   );
 }

--- a/packages/ui/src/modules/agents/components/welcome-entry-points.tsx
+++ b/packages/ui/src/modules/agents/components/welcome-entry-points.tsx
@@ -47,7 +47,7 @@ const ENTRY_POINTS: EntryPoint[] = [
     choice: "knowledge-base",
     setupView: "knowledge-base-new",
     icon: Book,
-    title: "Start a knowledge base",
+    title: "Start a knowledge base agent",
     description:
       "Organize and converse with data sourced from repos, documents, and more (LLM wiki).",
   },
@@ -69,8 +69,8 @@ export function WelcomeEntryPoints() {
       </h2>
       <p className="mt-1.5 max-w-[560px] text-sm leading-relaxed text-muted-foreground">
         Run agents in isolated cloud environments with credentials and tools
-        securely injected. Create knowledge bases, run experiments to compare
-        agent variants, and trigger agents from Slack or on a schedule.
+        securely injected. Create knowledge base agents, run experiments to
+        compare agent variants, and trigger agents from Slack or on a schedule.
       </p>
 
       <div className="mt-6 grid grid-cols-1 gap-3 md:grid-cols-3">

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-base-setup-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-base-setup-view.tsx
@@ -61,13 +61,13 @@ export function KnowledgeBaseSetupView() {
 
   return (
     <SetupPageShell
-      title="Setup your knowledge base"
-      subtitle="Name your knowledge base, choose a template, and add connections."
+      title="Setup your knowledge base agent"
+      subtitle="Name your agent, choose a template, and add connections."
       footer={
         <Button onClick={() => void create()} disabled={!canCreate}>
           {createKnowledgeBase.isPending
             ? "Creating…"
-            : "Create knowledge base"}
+            : "Create knowledge base agent"}
         </Button>
       }
     >

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
@@ -50,15 +50,17 @@ export function KnowledgeBasesListView() {
   return (
     <div>
       <PageHeader
-        title="Knowledge bases"
+        title="Knowledge base agents"
         description={
           knowledgeBases.length > 0
-            ? "A knowledge base is an agent that builds and maintains a wiki in its workspace. Open one to work with it in chat — ask questions and add to it."
+            ? "A knowledge base agent builds and maintains a wiki in its workspace. Open one to work with it in chat — ask questions and add to it."
             : undefined
         }
         actions={
           knowledgeBases.length > 0 ? (
-            <Button onClick={createKnowledgeBase}>Create knowledge base</Button>
+            <Button onClick={createKnowledgeBase}>
+              Create knowledge base agent
+            </Button>
           ) : undefined
         }
       />
@@ -68,15 +70,15 @@ export function KnowledgeBasesListView() {
       {initialLoaded && (
         <OutdatedTemplatesBanner
           agents={knowledgeBases}
-          noun="knowledge bases"
+          noun="knowledge base agents"
         />
       )}
 
       {initialLoaded && knowledgeBases.length === 0 && (
         <PageEmptyState
-          title="No knowledge bases yet"
-          message="A knowledge base is an agent that builds and maintains a wiki you can chat with. Point it at a repo or docs, or add knowledge as you go. Create an agent with the knowledge base preset to get started."
-          actionLabel="Create knowledge base"
+          title="No knowledge base agents yet"
+          message="A knowledge base agent builds and maintains a wiki you can chat with. Point it at a repo or docs, or add knowledge as you go. Create an agent with the knowledge base preset to get started."
+          actionLabel="Create knowledge base agent"
           onAction={createKnowledgeBase}
         />
       )}

--- a/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
+++ b/packages/ui/src/modules/knowledge-bases/views/knowledge-bases-list-view.tsx
@@ -97,7 +97,7 @@ export function KnowledgeBasesListView() {
                 )}
                 onSelect={() => openKnowledgeBase(agent.id)}
                 onConfigure={() => navigateToSandboxHome(agent.id)}
-                configureLabel="Configure knowledge base"
+                configureLabel="Configure knowledge base agent"
                 onShare={() =>
                   navigateToSandboxHome(agent.id, "setup", "knowledge")
                 }


### PR DESCRIPTION
Closes #3508.

## What changed

| Surface | Before | After |
|---|---|---|
| Left rail + mobile bar | Knowledge bases | Knowledge base agents (bottom bar shows "Knowledge") |
| List page title | Knowledge bases | Knowledge base agents |
| List description | "A knowledge base is an agent that builds…" | "A knowledge base agent builds…" |
| Empty state | No knowledge bases yet | No knowledge base agents yet |
| Create buttons | Create knowledge base | Create knowledge base agent |
| Out-of-date banner noun | knowledge bases | knowledge base agents |
| Setup page | Setup your knowledge base | Setup your knowledge base agent |
| Welcome card | Start a knowledge base | Start a knowledge base agent |

## What did not change, deliberately

"Knowledge base" alone is still the right term for the body of knowledge — so sharing copy, the share dialog, connected-knowledge-base copy, the `Knowledge base` row badge and the chat-view menu items keep it. Renaming those would say "share this knowledge base agent", which points at the agent instead of the wiki it publishes.

The `knowledge-base` Agent Kind, view names and routes are untouched — copy only.

## Notes

The mobile bottom bar renders six tabs side by side, so the full label would wrap there. `Destination` gains an optional `shortLabel`, used by the bottom bar only; the rail, its tooltip and the accessible name all use the full label.

`mise run ui:fix` could not run here — the toolchain downloads are blocked by network policy (`tls handshake eof` on go, helm, kubectl), and the workspace has no installed `node_modules`. Changes are string literals plus one optional interface field; new/changed lines are hand-wrapped inside 80 columns to match Prettier's existing output in these files.