### PR TITLE
fix(ui): label the file viewer toggle Source/Preview

### DIFF
--- a/packages/ui/src/modules/files/components/render-toggle.tsx
+++ b/packages/ui/src/modules/files/components/render-toggle.tsx
@@ -11,7 +11,7 @@ export function RenderToggle({ rendered, onToggle }: Props) {
   return (
     <Button variant="outline" size="xs" className="text-sm" onClick={onToggle}>
       {rendered ? <Code size={14} /> : <View size={14} />}
-      {rendered ? "Raw" : "Render"}
+      {rendered ? "Source" : "Preview"}
     </Button>
   );
 }


### PR DESCRIPTION
Closes #3543

The file viewer was the only surface labelling the rendered/raw toggle `Raw` / `Render`. The artifact panel, the artifact preview dialog and the skill viewer all use `Source` / `Preview`. Icons already matched.

One-line copy change in `packages/ui/src/modules/files/components/render-toggle.tsx`. The toggle drives SVG, Markdown and HTML previews in the file viewer.

Not run locally: `mise run ui:fix` and the UI tests — the toolchain fetch is blocked in this pod (dl.google.com, download.java.net). CI covers lint, format and tests.