### PR TITLE
fix(ui): coding agents wear the code icon, matching the feed

### DIFF
--- a/packages/ui/src/components/icon-rail.tsx
+++ b/packages/ui/src/components/icon-rail.tsx
@@ -4,7 +4,7 @@ import {
   Chemistry,
   ChevronLeft,
   ChevronRight,
-  ContainerSoftware,
+  Code,
   Folders,
   Home,
   Settings,
@@ -48,7 +48,7 @@ export function IconRail({
   };
   const codingAgents: Destination = {
     label: "Coding agents",
-    icon: ContainerSoftware,
+    icon: Code,
     active: view === "coding-agents",
     badge: 0,
     navigate: () => setView("coding-agents"),

--- a/packages/ui/src/modules/agents/components/welcome-entry-points.tsx
+++ b/packages/ui/src/modules/agents/components/welcome-entry-points.tsx
@@ -3,7 +3,7 @@ import {
   Book,
   type CarbonIconType,
   Chemistry,
-  ContainerSoftware,
+  Code,
 } from "@carbon/icons-react";
 import type { EntryPointChoice } from "api-server-api";
 
@@ -30,7 +30,7 @@ const ENTRY_POINTS: EntryPoint[] = [
   {
     choice: "sandbox",
     setupView: "coding-agent-new",
-    icon: ContainerSoftware,
+    icon: Code,
     title: "Create a coding agent",
     description:
       "Work with your preferred coding agent, credentials, and tools in an isolated environment.",


### PR DESCRIPTION
The left navigation and the welcome screen still showed the sandbox cube for coding agents, while the Home feed already used the code icon design confirmed. Both now use the code icon, and the cube is gone from the UI.

Closes #3503
