### PR TITLE
build: pin controller-gen 0.22.0 and regenerate the CRD manifests

### DIFF
--- a/deploy/helm/platform/crds/agent-platform.ai_agents.yaml
+++ b/deploy/helm/platform/crds/agent-platform.ai_agents.yaml
@@ -5,7 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     agent-platform.ai/crd-schema-generation: "9"
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.22.0
     helm.sh/resource-policy: keep
   name: agents.agent-platform.ai
 spec:

--- a/deploy/helm/platform/crds/agent-platform.ai_userbudgets.yaml
+++ b/deploy/helm/platform/crds/agent-platform.ai_userbudgets.yaml
@@ -5,7 +5,7 @@ kind: CustomResourceDefinition
 metadata:
   annotations:
     agent-platform.ai/crd-schema-generation: "1"
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.22.0
     helm.sh/resource-policy: keep
   name: userbudgets.agent-platform.ai
 spec:

--- a/mise.lock
+++ b/mise.lock
@@ -121,7 +121,7 @@ version = "0.7.0"
 backend = "go:honnef.co/go/tools/cmd/staticcheck"
 
 [[tools."go:sigs.k8s.io/controller-tools/cmd/controller-gen"]]
-version = "latest"
+version = "0.22.0"
 backend = "go:sigs.k8s.io/controller-tools/cmd/controller-gen"
 
 [[tools."go:sigs.k8s.io/crdify"]]

--- a/mise.toml
+++ b/mise.toml
@@ -8,7 +8,7 @@ uv = "0.9"
 go = "1.26"
 "go:honnef.co/go/tools/cmd/staticcheck" = "latest"
 "go:golang.org/x/vuln/cmd/govulncheck" = "latest"
-"go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "latest"
+"go:sigs.k8s.io/controller-tools/cmd/controller-gen" = "0.22.0"
 
 # Generates the api-server's Agent CR spec TS type from the controller's CRD
 # (api-server:gen:crd-types) — keeps the Go-authored schema the single source.


### PR DESCRIPTION
## Problem

`mise check` fails on `main` and on every open PR at `controller:check:crd-generated`. controller-gen was declared as `latest` and the go backend never locked a concrete version, so the 0.22.0 release on 2026-09-02 silently changed the generator everywhere, while the committed CRD manifests still carry the 0.21.0 annotation.

## Fix

- Pin `go:sigs.k8s.io/controller-tools/cmd/controller-gen` to `0.22.0` in `mise.toml` and `mise.lock`, so the generator version is reproducible and the gate cannot drift again on a release.
- Regenerate with `mise run controller:generate`. The only change in both manifests is the `controller-gen.kubebuilder.io/version` annotation; the schemas are identical.

`controller:check:crd-generated` passes locally.