### PR TITLE
fix(ui): a long MCP address can no longer widen its catalogue row

### DIFF
--- a/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
+++ b/packages/ui/src/modules/connections/components/catalog-connection-row.tsx
@@ -55,11 +55,11 @@ export function CatalogConnectionRow({
               className="shrink-0 text-foreground/80"
             />
           )}
-          <p className="truncate text-[15px] text-foreground">
+          <p className="max-w-[50%] shrink-0 truncate text-[15px] text-foreground">
             {connection.name}
           </p>
-          <Badge variant="muted" className="shrink-0 font-normal">
-            {tag}
+          <Badge variant="muted" className="min-w-0 font-normal" title={tag}>
+            <span className="truncate">{tag}</span>
           </Badge>
           {connection.status !== "active" && (
             <ConnectionStatusBadge status={connection.status} />

--- a/packages/ui/src/modules/connections/components/connection-catalog-modal.tsx
+++ b/packages/ui/src/modules/connections/components/connection-catalog-modal.tsx
@@ -116,7 +116,7 @@ export function ConnectionCatalogModal({
           orientation="vertical"
           className="w-[200px] shrink-0 border-r border-border p-3"
         />
-        <div className="flex min-h-0 flex-1 flex-col">
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col">
           {pane.kind === "browse" && (
             <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-5">
               {(byTab.get(activeTab) ?? []).map((group) => (


### PR DESCRIPTION
The connection catalogue row showed an MCP server's host in a badge that could not shrink, so a long address — and routed cluster addresses usually are — set the row's width and pushed "Add to agent", the actions menu and "New" out of the dialog with no way to scroll to them.

The badge now shrinks and truncates, with the full address on hover. The connection name keeps its reserved minimum width, and the buttons stay in place at any address length. The same row serves the credentials tab's header-auth entries, which showed their host the same way, so those are covered too.

Closes #3564
