### PR TITLE
fix(ui): stop and pause actions explained in agent actions menu

### DIFF
--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -76,6 +76,21 @@ function DropdownMenuCheckboxItem({
   );
 }
 
+function DropdownMenuLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Label>) {
+  return (
+    <DropdownMenuPrimitive.Label
+      className={cn(
+        "px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground",
+        className,
+      )}
+      {...props}
+    />
+  );
+}
+
 function DropdownMenuSeparator({
   className,
   ...props
@@ -93,6 +108,7 @@ export {
   DropdownMenuCheckboxItem,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 };

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -144,7 +144,6 @@ export function AgentRow({
               {display.state === "running" && (
                 <FreeUpComputeItems
                   agent={agent}
-                  configureLabel={configureLabel}
                   onPause={onPause}
                   onStop={onStop}
                 />

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -144,6 +144,7 @@ export function AgentRow({
               {display.state === "running" && (
                 <FreeUpComputeItems
                   agent={agent}
+                  configureLabel={configureLabel}
                   onPause={onPause}
                   onStop={onStop}
                 />

--- a/packages/ui/src/modules/agents/components/agent-row.tsx
+++ b/packages/ui/src/modules/agents/components/agent-row.tsx
@@ -21,6 +21,7 @@ import {
   type TemporaryDraw,
 } from "../utils/temporary-sandboxes.js";
 import { ContributionFailuresBadge } from "./contribution-failures-badge.js";
+import { FreeUpComputeItems } from "./power-menu-items.js";
 import { UpdateAvailableAction } from "./update-available-action.js";
 
 interface Props {
@@ -140,6 +141,13 @@ export function AgentRow({
                 </DropdownMenuItem>
               )}
               <DropdownMenuSeparator />
+              {display.state === "running" && (
+                <FreeUpComputeItems
+                  agent={agent}
+                  onPause={onPause}
+                  onStop={onStop}
+                />
+              )}
               {display.powerAction === "start" ? (
                 <DropdownMenuItem onSelect={onWake}>
                   {}
@@ -152,16 +160,6 @@ export function AgentRow({
                 >
                   Restart
                 </DropdownMenuItem>
-              )}
-              {display.state === "running" && (
-                <>
-                  <DropdownMenuItem onSelect={onPause}>
-                    Pause — wakes on next use
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={onStop}>
-                    Stop — until started again
-                  </DropdownMenuItem>
-                </>
               )}
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/packages/ui/src/modules/agents/components/power-menu-items.tsx
+++ b/packages/ui/src/modules/agents/components/power-menu-items.tsx
@@ -1,3 +1,4 @@
+import { Badge } from "@/components/ui/badge";
 import {
   DropdownMenuItem,
   DropdownMenuLabel,
@@ -8,10 +9,12 @@ import type { AgentView } from "../../../types.js";
 
 export function FreeUpComputeItems({
   agent,
+  configureLabel,
   onPause,
   onStop,
 }: {
   agent: AgentView;
+  configureLabel: string;
   onPause: () => void;
   onStop: () => void;
 }) {
@@ -30,18 +33,20 @@ export function FreeUpComputeItems({
         />
       </DropdownMenuItem>
       <DropdownMenuItem
-        className="h-auto py-2"
+        className="h-auto py-2 data-[disabled]:pointer-events-auto"
         disabled={neverHibernates}
         onSelect={onPause}
         data-testid="agent-pause"
+        title={
+          neverHibernates
+            ? `This agent is set to never hibernate, so pausing it would wake itself. Change its idle timeout in ${configureLabel}.`
+            : undefined
+        }
       >
         <MenuItemBody
           title="Pause"
-          description={
-            neverHibernates
-              ? "This agent is set to never hibernate, so pausing it would wake itself. Change its idle timeout in Configure agent."
-              : "Wakes on any action (a schedule firing, a message arriving, or you opening a chat)"
-          }
+          tag={neverHibernates ? "Unavailable" : undefined}
+          description="Wakes on any action (a schedule firing, a message arriving, or you opening a chat)"
         />
       </DropdownMenuItem>
       <DropdownMenuSeparator />
@@ -51,14 +56,23 @@ export function FreeUpComputeItems({
 
 function MenuItemBody({
   title,
+  tag,
   description,
 }: {
   title: string;
+  tag?: string;
   description: string;
 }) {
   return (
     <span className="flex max-w-72 flex-col gap-0.5">
-      <span>{title}</span>
+      <span className="flex items-center gap-2">
+        {title}
+        {tag && (
+          <Badge variant="muted" size="sm">
+            {tag}
+          </Badge>
+        )}
+      </span>
       <span className="whitespace-normal text-xs text-muted-foreground">
         {description}
       </span>

--- a/packages/ui/src/modules/agents/components/power-menu-items.tsx
+++ b/packages/ui/src/modules/agents/components/power-menu-items.tsx
@@ -1,0 +1,67 @@
+import {
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
+
+import type { AgentView } from "../../../types.js";
+
+export function FreeUpComputeItems({
+  agent,
+  onPause,
+  onStop,
+}: {
+  agent: AgentView;
+  onPause: () => void;
+  onStop: () => void;
+}) {
+  const neverHibernates = agent.hibernationTimeoutMin === 0;
+  return (
+    <>
+      <DropdownMenuLabel>Free up compute</DropdownMenuLabel>
+      <DropdownMenuItem
+        className="h-auto py-2"
+        onSelect={onStop}
+        data-testid="agent-stop"
+      >
+        <MenuItemBody
+          title="Stop"
+          description="Wakes only when a schedule fires or you start it"
+        />
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        className="h-auto py-2"
+        disabled={neverHibernates}
+        onSelect={onPause}
+        data-testid="agent-pause"
+      >
+        <MenuItemBody
+          title="Pause"
+          description={
+            neverHibernates
+              ? "This agent is set to never hibernate, so pausing it would wake itself. Change its idle timeout in Configure agent."
+              : "Wakes on any action (a schedule firing, a message arriving, or you opening a chat)"
+          }
+        />
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+    </>
+  );
+}
+
+function MenuItemBody({
+  title,
+  description,
+}: {
+  title: string;
+  description: string;
+}) {
+  return (
+    <span className="flex max-w-72 flex-col gap-0.5">
+      <span>{title}</span>
+      <span className="whitespace-normal text-xs text-muted-foreground">
+        {description}
+      </span>
+    </span>
+  );
+}

--- a/packages/ui/src/modules/agents/components/power-menu-items.tsx
+++ b/packages/ui/src/modules/agents/components/power-menu-items.tsx
@@ -9,16 +9,16 @@ import type { AgentView } from "../../../types.js";
 
 export function FreeUpComputeItems({
   agent,
-  configureLabel,
   onPause,
   onStop,
 }: {
   agent: AgentView;
-  configureLabel: string;
   onPause: () => void;
   onStop: () => void;
 }) {
   const neverHibernates = agent.hibernationTimeoutMin === 0;
+  const pauseUnavailableReason =
+    "This agent is set to never hibernate, so pausing it would wake itself. Change its idle timeout in Agent Setup.";
   return (
     <>
       <DropdownMenuLabel>Free up compute</DropdownMenuLabel>
@@ -37,17 +37,16 @@ export function FreeUpComputeItems({
         disabled={neverHibernates}
         onSelect={onPause}
         data-testid="agent-pause"
-        title={
-          neverHibernates
-            ? `This agent is set to never hibernate, so pausing it would wake itself. Change its idle timeout in ${configureLabel}.`
-            : undefined
-        }
+        title={neverHibernates ? pauseUnavailableReason : undefined}
       >
         <MenuItemBody
           title="Pause"
           tag={neverHibernates ? "Unavailable" : undefined}
           description="Wakes on any action (a schedule firing, a message arriving, or you opening a chat)"
         />
+        {neverHibernates && (
+          <span className="sr-only">{pauseUnavailableReason}</span>
+        )}
       </DropdownMenuItem>
       <DropdownMenuSeparator />
     </>

--- a/packages/ui/src/modules/budgets/components/compute-usage.tsx
+++ b/packages/ui/src/modules/budgets/components/compute-usage.tsx
@@ -63,7 +63,7 @@ export function ComputeUsage({ agents, workingAgentIds }: Props) {
         <span className="flex items-center gap-1.5 text-foreground">
           Compute resources
           <Tooltip
-            content="What your running agents reserve, not what they are using. Stop or pause an agent to free it."
+            content="What your running agents reserve, not what they are using. Stop or pause an agent to free up compute."
             side="bottom"
           >
             <Help size={14} className="cursor-help text-muted-foreground/60" />

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -15,6 +15,7 @@ import { StatusBadge } from "../../../components/status-indicator.js";
 import { useStore } from "../../../store.js";
 import type { AgentView } from "../../../types.js";
 import { useDeleteAgent } from "../../agents/api/mutations.js";
+import { FreeUpComputeItems } from "../../agents/components/power-menu-items.js";
 import { UpdateAvailableAction } from "../../agents/components/update-available-action.js";
 import { useRestartAgent } from "../../agents/hooks/use-restart-agent.js";
 import { useSuspendAgent } from "../../agents/hooks/use-suspend-agent.js";
@@ -116,6 +117,13 @@ export function SandboxHomeHeader({ agent, display }: Props) {
               </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent>
+              {display.state === "running" && (
+                <FreeUpComputeItems
+                  agent={agent}
+                  onPause={() => suspend.pause(agent.id)}
+                  onStop={() => void onStop()}
+                />
+              )}
               {display.powerAction === "start" ? (
                 <DropdownMenuItem onSelect={() => wakeAgent.wake(agent.id)}>
                   Wake
@@ -127,16 +135,6 @@ export function SandboxHomeHeader({ agent, display }: Props) {
                 >
                   Restart
                 </DropdownMenuItem>
-              )}
-              {display.state === "running" && (
-                <>
-                  <DropdownMenuItem onSelect={() => suspend.pause(agent.id)}>
-                    Pause — wakes on next use
-                  </DropdownMenuItem>
-                  <DropdownMenuItem onSelect={() => void onStop()}>
-                    Stop — until started again
-                  </DropdownMenuItem>
-                </>
               )}
               <DropdownMenuSeparator />
               <DropdownMenuItem

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -120,7 +120,6 @@ export function SandboxHomeHeader({ agent, display }: Props) {
               {display.state === "running" && (
                 <FreeUpComputeItems
                   agent={agent}
-                  configureLabel="the setup section below"
                   onPause={() => suspend.pause(agent.id)}
                   onStop={() => void onStop()}
                 />

--- a/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
+++ b/packages/ui/src/modules/sandboxes/components/sandbox-home-header.tsx
@@ -120,6 +120,7 @@ export function SandboxHomeHeader({ agent, display }: Props) {
               {display.state === "running" && (
                 <FreeUpComputeItems
                   agent={agent}
+                  configureLabel="the setup section below"
                   onPause={() => suspend.pause(agent.id)}
                   onStop={() => void onStop()}
                 />


### PR DESCRIPTION
The three-dot menus on the agent list and the agent page now group Stop and Pause under a "Free up compute" section, with a one-line description of when the agent wakes again. 

For agents set to never hibernate, Pause is disabled and the description explains why and where to change it.

The compute box tooltip on Home now ends with "Stop or pause an agent to free up compute."

Closes #3059