### PR TITLE
fix(api-server): a reconnecting Agent watch holds one connection and one retry timer

### DIFF
--- a/packages/api-server/src/__tests__/unit/k8s-agent-watch.test.ts
+++ b/packages/api-server/src/__tests__/unit/k8s-agent-watch.test.ts
@@ -1,4 +1,4 @@
-// TEST_OVERVIEW: the lease-elected K8s agent watch projects resource transitions into per-owner invalidation hints, including deletions that happened while the watch was disconnected.
+// TEST_OVERVIEW: the lease-elected K8s agent watch projects resource transitions into per-owner invalidation hints, including deletions that happened while the watch was disconnected. Its reconnect holds at most one live connection and one pending retry timer, and stop() releases whatever exists.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { startAgentWatch } from "../../modules/live-events/infrastructure/k8s-agent-watch.js";
 import type { LiveEventsBus } from "../../modules/live-events/services/live-events-service.js";
@@ -23,13 +23,20 @@ describe("k8s agent watch", () => {
       publish: (ownerSub: string, hint: { agentId?: string }) =>
         void hints.push({ ownerSub, agentId: hint.agentId }),
     } as unknown as LiveEventsBus;
-    const conns: { onEvent: OnEvent; onEnd: OnEnd }[] = [];
+    const conns: { onEvent: OnEvent; onEnd: OnEnd; stopCalls: number }[] = [];
     const watch = startAgentWatch(
       bus,
       {
         watchCustomObjects: (_plural, onEvent, onEnd) => {
-          conns.push({ onEvent: onEvent as OnEvent, onEnd: onEnd as OnEnd });
-          return () => {};
+          const conn = {
+            onEvent: onEvent as OnEvent,
+            onEnd: onEnd as OnEnd,
+            stopCalls: 0,
+          };
+          conns.push(conn);
+          return () => {
+            conn.stopCalls += 1;
+          };
         },
       },
       { plural: "agents", ownerLabel: "owner", log: () => {}, debounceMs: 1 },
@@ -68,5 +75,42 @@ describe("k8s agent watch", () => {
 
     expect(hints).toEqual([]);
     watch.stop();
+  });
+
+  // TEST_SCENARIO: one connection reports its end twice — only one reconnect may follow, the ended connection must be released, and the duplicate end must not schedule a second retry.
+  it("reconnects once per ended connection, even when the end is reported twice", async () => {
+    const { conns, watch } = harness();
+
+    conns[0]!.onEnd(new Error("gone"));
+    conns[0]!.onEnd(new Error("gone"));
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(conns).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(conns).toHaveLength(2);
+    expect(conns[0]!.stopCalls).toBe(1);
+    watch.stop();
+  });
+
+  // TEST_SCENARIO: after a reconnect, stop() must reach the connection that is live now, not the one that ended.
+  it("stop() closes the reconnected connection", async () => {
+    const { conns, watch } = harness();
+
+    conns[0]!.onEnd(new Error("gone"));
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(conns).toHaveLength(2);
+
+    watch.stop();
+    expect(conns[1]!.stopCalls).toBe(1);
+  });
+
+  // TEST_SCENARIO: stop() while a retry is pending must cancel it, so no connection opens after shutdown.
+  it("stop() cancels a pending reconnect", async () => {
+    const { conns, watch } = harness();
+
+    conns[0]!.onEnd(new Error("gone"));
+    watch.stop();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(conns).toHaveLength(1);
   });
 });

--- a/packages/api-server/src/modules/live-events/infrastructure/k8s-agent-watch.ts
+++ b/packages/api-server/src/modules/live-events/infrastructure/k8s-agent-watch.ts
@@ -20,7 +20,7 @@ export function startAgentWatch(
   const debounceMs = opts.debounceMs ?? 300;
 
   let stopped = false;
-  let stopWatch: (() => void) | null = null;
+  let connection: { stop(): void } | null = null;
   let retryTimer: NodeJS.Timeout | null = null;
   let sweepTimer: NodeJS.Timeout | null = null;
   let seenSinceConnect: Set<string> | null = null;
@@ -93,7 +93,12 @@ export function startAgentWatch(
       }
     }, REPLAY_SWEEP_MS);
     sweepTimer.unref();
-    stopWatch = k8s.watchCustomObjects(opts.plural, onEvent, (err) => {
+    const link = { stop: () => {} };
+    connection = link;
+    link.stop = k8s.watchCustomObjects(opts.plural, onEvent, (err) => {
+      if (connection !== link) return;
+      connection = null;
+      link.stop();
       if (stopped) return;
       if (err) opts.log(`agent watch ended: ${String(err)}`);
       retryTimer = setTimeout(connect, RECONNECT_MS);
@@ -105,7 +110,7 @@ export function startAgentWatch(
   return {
     stop() {
       stopped = true;
-      stopWatch?.();
+      connection?.stop();
       if (retryTimer) clearTimeout(retryTimer);
       if (sweepTimer) clearTimeout(sweepTimer);
       for (const timer of pending.values()) clearTimeout(timer);


### PR DESCRIPTION
The lease-elected Agent watch reconnects by calling its own `connect()` from the end callback of the connection that just died. That overwrote the stored stop function and retry timer without releasing the previous ones. If one connection reported its end twice, or a reconnect raced a still-live connection, two watches fed the same handler, the second one was unreferenced so shutdown could not close it, and an orphaned timer kept the process from settling in tests. Raised in review on #3493, tracked as #3494.

## What changed

- **Each end callback is tied to its own connection.** Every connect records a link as the current connection. The end callback returns early unless its link is still current, clears the slot, releases the ended connection, and only then schedules the retry. A duplicate end from the same connection, or a late end from a stale one, is a no-op.
- **One connection, one timer, by construction.** Only the retry timer opens a new connection, and only an end that is still current schedules that timer. So at most one connection and one pending retry timer exist, and `stop()` always reaches the live one.
- **Tests** join the existing watch spec: a doubled end produces exactly one reconnect and releases the ended connection (three connections opened before this change), `stop()` after a reconnect closes the reconnected connection, and `stop()` during a pending retry cancels it.

## Not touched

- The replay sweep and its timer already run at most once per connect and are cleared on `stop()`.
- The installed client library already guards its own done callback against firing twice, so nothing observed this in production. The adapter no longer depends on that guarantee.

No architecture page changes: the reconnect and replay-sweep behaviour on platform-topology is unchanged.

Closes #3494
