### PR TITLE
chore(ui): point compute request link at the Slack message, note default removal

### DIFF
--- a/deploy/helm/platform/values.yaml
+++ b/deploy/helm/platform/values.yaml
@@ -56,7 +56,7 @@ terms:
 links:
   # Where "Request more" next to the compute meter points — a chat channel,
   # form, or ticket queue. Complete URL. Empty string uses the UI's bundled
-  # default.
+  # default, which is install-specific and slated for removal — set this.
   computeRequest: ""
 
 # -- Base domain for the app. UI and API share this host; the ingress

--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -13,4 +13,4 @@ export const MCP_DOCS_URL =
   "https://pages.github.ibm.com/dam-agents/docs/core-concepts/connections/#mcp-servers";
 
 export const COMPUTE_REQUEST_URL =
-  "https://ibm.enterprise.slack.com/archives/C0B3F03NB24";
+  "https://ibm-research.slack.com/archives/C0B3F03NB24/p1788879773235759";


### PR DESCRIPTION
The bundled fallback for "Request more budget" now points at the Slack message describing how to ask. Installs should set `links.computeRequest` in Helm values instead; the default is install-specific and marked for removal once they do (dam-ops sets it in the companion PR).