### PR TITLE
chore(ui): point the compute request link at the pinned #dam-community post

### DIFF
--- a/packages/ui/src/constants.ts
+++ b/packages/ui/src/constants.ts
@@ -13,4 +13,4 @@ export const MCP_DOCS_URL =
   "https://pages.github.ibm.com/dam-agents/docs/core-concepts/connections/#mcp-servers";
 
 export const COMPUTE_REQUEST_URL =
-  "https://ibm.enterprise.slack.com/archives/C0B3F03NB24";
+  "https://ibm-research.slack.com/archives/C0B3F03NB24/p1788879773235759";


### PR DESCRIPTION
## Context

"Request more budget" next to the compute meter opened the #dam-community channel root. People landed on whatever was posted last and had to find the request instructions themselves. It now opens the pinned post that explains how to ask for more compute.

## What changed

- `COMPUTE_REQUEST_URL` now points at the pinned post permalink instead of the channel root.

## Not touched

- The `links.computeRequest` Helm value still overrides the target per install. This changes only the bundled default.