### PR TITLE
fix(api-server): NUL byte inside a jsonb value answers 400

### DIFF
--- a/packages/api-server-api/src/trpc.ts
+++ b/packages/api-server-api/src/trpc.ts
@@ -23,6 +23,7 @@ function isTermsStaleCause(cause: unknown): boolean {
 
 const PG_INVALID_TEXT_REPRESENTATION = "22P02";
 const PG_CHARACTER_NOT_IN_REPERTOIRE = "22021";
+const PG_UNTRANSLATABLE_CHARACTER = "22P05";
 const PG_UNIQUE_VIOLATION = "23505";
 const PG_ERRORS: Record<string, { code: TRPCError["code"]; message: string }> =
   {
@@ -31,6 +32,10 @@ const PG_ERRORS: Record<string, { code: TRPCError["code"]; message: string }> =
       message: "malformed identifier",
     },
     [PG_CHARACTER_NOT_IN_REPERTOIRE]: {
+      code: "BAD_REQUEST",
+      message: "unsupported character in input",
+    },
+    [PG_UNTRANSLATABLE_CHARACTER]: {
       code: "BAD_REQUEST",
       message: "unsupported character in input",
     },

--- a/packages/api-server/src/__tests__/unit/trpc-errors.test.ts
+++ b/packages/api-server/src/__tests__/unit/trpc-errors.test.ts
@@ -41,6 +41,13 @@ describe("tRPC error mapping", () => {
     });
   });
 
+  /* TEST_SCENARIO: A NUL byte inside a jsonb value is rejected as an unsupported Unicode escape (SQLSTATE 22P05); the caller must see BAD_REQUEST. */
+  it("maps untranslatable-character to BAD_REQUEST", async () => {
+    await expect(caller().call.fail(pgError("22P05"))).rejects.toMatchObject({
+      code: "BAD_REQUEST",
+    });
+  });
+
   /* TEST_SCENARIO: A duplicate row violates a unique index (SQLSTATE 23505); the caller must see CONFLICT. */
   it("maps unique violation to CONFLICT", async () => {
     await expect(caller().call.fail(pgError("23505"))).rejects.toMatchObject({


### PR DESCRIPTION
Third ZAP pass against dam-dev after #3611 deployed. The run is otherwise clean: zero alerts above Informational, zero stack traces or SQL text across ~41k API responses, and exactly one 500 left.

## Finding

`skills.sets.create` with a NUL byte (U+0000) nested inside `skills[].name` still answered 500. The value lands in a jsonb column, and Postgres rejects NUL there as SQLSTATE `22P05` (`untranslatable_character`, "unsupported Unicode escape sequence") rather than the `22021` that plain text columns raise and that #3611 mapped.

## What

- `trpc.ts`: `22P05` -> `BAD_REQUEST` "unsupported character in input", beside the existing `22021` entry.
- one more scenario in `trpc-errors.test.ts`.

https://claude.ai/code/session_01BGaKuoKWJad1BVu4FpQeXW
