### PR TITLE
chore(meta): ZAP scan tooling for the dev deployment under meta/zap

### DIFF
--- a/meta/zap/.gitignore
+++ b/meta/zap/.gitignore
@@ -1,0 +1,6 @@
+browsers/
+zaphome/
+sessions/
+*.log
+procedures.json
+scan.pid

--- a/meta/zap/README.md
+++ b/meta/zap/README.md
@@ -5,7 +5,7 @@ Headless [ZAP](https://www.zaproxy.org/) 2.17 run against `dam-dev`, driven by t
 ```
 ./scan.sh            # crawl + API seed + active scan, ~2 h
 ./scan.sh api        # one plan only
-python3 cleanup.py   # delete what the scan created under the zap user
+python3 cleanup.py   # delete what the last run created under the zap user (--all wipes the account)
 ```
 
 Three plans, run in order:
@@ -14,4 +14,4 @@ Three plans, run in order:
 - `api.yaml` — the same login through Keycloak's password grant, then one request per tRPC procedure over the HTTP transport (`/api/trpc/*`). `enumerate.mts` walks `appRouter` and samples each input schema; `gen-requests.py` writes the list into the plan. `e2e.*` and `egressRules.applyPreset` are excluded.
 - `active.yaml` — the active scan over the seeded API context, throttled to 250 ms between requests (dev is shared).
 
-Reports go to `reports/` (gitignored, only the latest run is kept). Known ZAP quirks: never set `failOnError: true` against a daemon (a failing job exits ZAP); call the API via `127.0.0.1`, not `localhost`; keep the chromedriver under `browsers/` on the same major version as the Playwright Chrome it drives. Boolean-based "SQL Injection" alerts on this API have so far always been false positives (two Zod validation errors compared as different pages). Host-header probes produce router 503s ("Application is not available"), not capacity problems.
+Reports go to `reports/` (gitignored, only the latest run is kept). `cleanup.py` removes items that carry a sampler literal (`zap`, `zap-1`, `https://example.com/zap`, …) or a `createdAt` at or after `reports/started-at`; anything else under the zap account is listed and kept. The enumerator fails closed: an input pattern it has no sample for, or an empty router, aborts the run before `api.yaml` is rewritten. Known ZAP quirks: never set `failOnError: true` against a daemon (a failing job exits ZAP); call the API via `127.0.0.1`, not `localhost`; keep the chromedriver under `browsers/` on the same major version as the Playwright Chrome it drives. Boolean-based "SQL Injection" alerts on this API have so far always been false positives (two Zod validation errors compared as different pages). Host-header probes produce router 503s ("Application is not available"), not capacity problems.

--- a/meta/zap/README.md
+++ b/meta/zap/README.md
@@ -1,0 +1,17 @@
+# ZAP scan of the dev deployment
+
+Headless [ZAP](https://www.zaproxy.org/) 2.17 run against `dam-dev`, driven by the Automation Framework.
+
+```
+./scan.sh            # crawl + API seed + active scan, ~2 h
+./scan.sh api        # one plan only
+python3 cleanup.py   # delete what the scan created under the zap user
+```
+
+Three plans, run in order:
+
+- `crawl.yaml` — browser-based Keycloak login (`zap`/`zap`) and the AJAX spider over the UI; the UI talks tRPC over WebSocket only, so this is passive coverage.
+- `api.yaml` — the same login through Keycloak's password grant, then one request per tRPC procedure over the HTTP transport (`/api/trpc/*`). `enumerate.mts` walks `appRouter` and samples each input schema; `gen-requests.py` writes the list into the plan. `e2e.*` and `egressRules.applyPreset` are excluded.
+- `active.yaml` — the active scan over the seeded API context, throttled to 250 ms between requests (dev is shared).
+
+Reports go to `reports/` (gitignored, only the latest run is kept). Known ZAP quirks: never set `failOnError: true` against a daemon (a failing job exits ZAP); call the API via `127.0.0.1`, not `localhost`; keep the chromedriver under `browsers/` on the same major version as the Playwright Chrome it drives. Boolean-based "SQL Injection" alerts on this API have so far always been false positives (two Zod validation errors compared as different pages). Host-header probes produce router 503s ("Application is not available"), not capacity problems.

--- a/meta/zap/README.md
+++ b/meta/zap/README.md
@@ -5,7 +5,7 @@ Headless [ZAP](https://www.zaproxy.org/) 2.17 run against `dam-dev`, driven by t
 ```
 ./scan.sh            # crawl + API seed + active scan, ~2 h
 ./scan.sh api        # one plan only
-python3 cleanup.py   # delete what the last run created under the zap user (--all wipes the account)
+python3 cleanup.py   # delete the folders, skill sets and skill sources the last run created (--all empties those three)
 ```
 
 Three plans, run in order:
@@ -14,4 +14,4 @@ Three plans, run in order:
 - `api.yaml` — the same login through Keycloak's password grant, then one request per tRPC procedure over the HTTP transport (`/api/trpc/*`). `enumerate.mts` walks `appRouter` and samples each input schema; `gen-requests.py` writes the list into the plan. `e2e.*` and `egressRules.applyPreset` are excluded.
 - `active.yaml` — the active scan over the seeded API context, throttled to 250 ms between requests (dev is shared).
 
-Reports go to `reports/` (gitignored, only the latest run is kept). `cleanup.py` removes items that carry a sampler literal (`zap`, `zap-1`, `https://example.com/zap`, …) or a `createdAt` at or after `reports/started-at`; anything else under the zap account is listed and kept. The enumerator fails closed: an input pattern it has no sample for, or an empty router, aborts the run before `api.yaml` is rewritten. Known ZAP quirks: never set `failOnError: true` against a daemon (a failing job exits ZAP); call the API via `127.0.0.1`, not `localhost`; keep the chromedriver under `browsers/` on the same major version as the Playwright Chrome it drives. Boolean-based "SQL Injection" alerts on this API have so far always been false positives (two Zod validation errors compared as different pages). Host-header probes produce router 503s ("Application is not available"), not capacity problems.
+Reports go to `reports/` (gitignored, only the latest run is kept). `cleanup.py` walks the three collections a run fills (artifact folders, skill sets, skill sources) and removes items that carry a sampler literal (`zap`, `zap-1`, `https://example.com/zap`, …) or a `createdAt` at or after `reports/started-at`; anything else in them is listed and kept. The enumerator fails closed: a sample that does not pass its own Zod schema (unknown regex, cross-field refinement), or an empty router, aborts the run before `api.yaml` is rewritten. Known ZAP quirks: never set `failOnError: true` against a daemon (a failing job exits ZAP); call the API via `127.0.0.1`, not `localhost`; keep the chromedriver under `browsers/` on the same major version as the Playwright Chrome it drives. Boolean-based "SQL Injection" alerts on this API have so far always been false positives (two Zod validation errors compared as different pages). Host-header probes produce router 503s ("Application is not available"), not capacity problems.

--- a/meta/zap/active.yaml
+++ b/meta/zap/active.yaml
@@ -1,0 +1,63 @@
+env:
+  contexts:
+    - name: dam-api
+      urls:
+        - https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api
+      includePaths:
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/.*
+      excludePaths:
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/trpc/e2e\..*
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/trpc/egressRules\.applyPreset.*
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/trpc-ws.*
+      authentication:
+        method: form
+        parameters:
+          loginPageUrl: https://keycloak-dam-dev.apps.dam-cl.fmaas.res.ibm.com/realms/platform/protocol/openid-connect/token
+          loginRequestUrl: https://keycloak-dam-dev.apps.dam-cl.fmaas.res.ibm.com/realms/platform/protocol/openid-connect/token
+          loginRequestBody: "grant_type=password&client_id=platform-ui&scope=openid&username={%username%}&password={%password%}"
+        verification:
+          method: poll
+          pollFrequency: 20
+          pollUnits: requests
+          pollUrl: https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.list
+          loggedInRegex: "\\QHTTP/1.1 200\\E"
+          loggedOutRegex: "\\QHTTP/1.1 401\\E"
+      sessionManagement:
+        method: headers
+        parameters:
+          Authorization: "Bearer {%json:access_token%}"
+      users:
+        - name: zap
+          credentials:
+            username: zap
+            password: zap
+  parameters:
+    failOnError: false
+    failOnWarning: false
+    progressToStdout: true
+jobs:
+  - type: activeScan
+    parameters:
+      context: dam-api
+      user: zap
+      maxScanDurationInMins: 90
+      maxRuleDurationInMins: 10
+      threadPerHost: 4
+      delayInMs: 250
+  - type: passiveScan-wait
+  - type: report
+    parameters:
+      template: traditional-html-plus
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: active
+      reportTitle: DAM dev - active scan (HTTP API)
+  - type: report
+    parameters:
+      template: traditional-json
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: active
+  - type: report
+    parameters:
+      template: sarif-json
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: active.sarif

--- a/meta/zap/api.yaml
+++ b/meta/zap/api.yaml
@@ -65,12 +65,12 @@ jobs:
         method: POST
         name: agents.create
         headers: ["Content-Type: application/json"]
-        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"env\": [{\"name\": \"zap-1\", \"value\": \"zap\"}], \"secretRef\": \"zap\", \"registryCredential\": {\"server\": \"zap\", \"username\": \"zap\", \"password\": \"zap\"}, \"egressPreset\": \"none\", \"hibernationTimeoutMin\": 0, \"gitRepo\": {\"url\": \"https://example.com/zap\", \"ref\": \"zap\"}, \"connectionIds\": [\"zap\"], \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}, \"sweepable\": true, \"lifetimeMs\": 0}"
+        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"env\": [{\"name\": \"ZAP\", \"value\": \"zap\"}], \"secretRef\": \"zap\", \"registryCredential\": {\"server\": \"zap\", \"username\": \"zap\", \"password\": \"zap\"}, \"egressPreset\": \"none\", \"hibernationTimeoutMin\": 0, \"gitRepo\": {\"url\": \"https://example.com/zap\", \"ref\": \"zap\"}, \"connectionIds\": [\"zap\"], \"size\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"sweepable\": true, \"lifetimeMs\": 0}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.update"
         method: POST
         name: agents.update
         headers: ["Content-Type: application/json"]
-        data: "{\"id\": \"zap\", \"name\": \"zap\", \"description\": \"zap\", \"env\": [{\"name\": \"zap-1\", \"value\": \"zap\"}], \"secretRef\": \"zap\", \"hibernationTimeoutMin\": 0, \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}}"
+        data: "{\"id\": \"zap\", \"name\": \"zap\", \"description\": \"zap\", \"env\": [{\"name\": \"ZAP\", \"value\": \"zap\"}], \"secretRef\": \"zap\", \"hibernationTimeoutMin\": 0, \"size\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.delete"
         method: POST
         name: agents.delete
@@ -147,12 +147,12 @@ jobs:
         method: POST
         name: schedules.createRRule
         headers: ["Content-Type: application/json"]
-        data: "{\"name\": \"zap\", \"agentId\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"zap-1\", \"endTime\": \"zap-1\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+        data: "{\"name\": \"zap\", \"agentId\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"09:30\", \"endTime\": \"09:30\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.updateRRule"
         method: POST
         name: schedules.updateRRule
         headers: ["Content-Type: application/json"]
-        data: "{\"id\": \"zap\", \"name\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"zap-1\", \"endTime\": \"zap-1\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+        data: "{\"id\": \"zap\", \"name\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"09:30\", \"endTime\": \"09:30\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.delete"
         method: POST
         name: schedules.delete
@@ -192,7 +192,7 @@ jobs:
         method: POST
         name: connections.startOAuth
         headers: ["Content-Type: application/json"]
-        data: "{\"connectionId\": \"zap\", \"returnTo\": \"zap-1\", \"popup\": true}"
+        data: "{\"connectionId\": \"zap\", \"returnTo\": \"/zap\", \"popup\": true}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.discoverMcp"
         method: POST
         name: connections.discoverMcp
@@ -387,7 +387,7 @@ jobs:
         method: POST
         name: experiments.createSandbox
         headers: ["Content-Type: application/json"]
-        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"connectionIds\": [\"zap\"], \"egressPreset\": \"none\", \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}}"
+        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"connectionIds\": [\"zap\"], \"egressPreset\": \"none\", \"size\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.list"
         method: GET
         name: experiments.list
@@ -419,7 +419,7 @@ jobs:
         method: POST
         name: knowledgeBases.create
         headers: ["Content-Type: application/json"]
-        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"connectionIds\": [\"zap\"], \"egressPreset\": \"none\", \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}, \"kbTemplateId\": \"llm-wiki\"}"
+        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"connectionIds\": [\"zap\"], \"egressPreset\": \"none\", \"size\": {\"cpu\": \"500m\", \"memory\": \"512Mi\"}, \"kbTemplateId\": \"llm-wiki\"}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.status?input=%7B%22agentId%22%3A%20%22zap%22%7D"
         method: GET
         name: kbShares.status
@@ -433,7 +433,7 @@ jobs:
         method: POST
         name: kbShares.create
         headers: ["Content-Type: application/json"]
-        data: "{\"agentId\": \"zap\", \"roots\": [\"zap-1\"]}"
+        data: "{\"agentId\": \"zap\", \"roots\": [\"zap\"]}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.reveal"
         method: POST
         name: kbShares.reveal
@@ -453,7 +453,7 @@ jobs:
         method: POST
         name: kbShares.refresh
         headers: ["Content-Type: application/json"]
-        data: "{\"agentId\": \"zap\", \"roots\": [\"zap-1\"]}"
+        data: "{\"agentId\": \"zap\", \"roots\": [\"zap\"]}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.setName"
         method: POST
         name: kbShares.setName

--- a/meta/zap/api.yaml
+++ b/meta/zap/api.yaml
@@ -147,12 +147,12 @@ jobs:
         method: POST
         name: schedules.createRRule
         headers: ["Content-Type: application/json"]
-        data: "{\"name\": \"zap\", \"agentId\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"09:30\", \"endTime\": \"09:30\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+        data: "{\"name\": \"zap\", \"agentId\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"09:30\", \"endTime\": \"10:30\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.updateRRule"
         method: POST
         name: schedules.updateRRule
         headers: ["Content-Type: application/json"]
-        data: "{\"id\": \"zap\", \"name\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"09:30\", \"endTime\": \"09:30\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+        data: "{\"id\": \"zap\", \"name\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"09:30\", \"endTime\": \"10:30\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.delete"
         method: POST
         name: schedules.delete
@@ -486,12 +486,12 @@ jobs:
         method: POST
         name: artifactLibrary.create
         headers: ["Content-Type: application/json"]
-        data: "{\"title\": \"zap\", \"content\": \"zap\", \"uploadRef\": \"zap\", \"fileName\": \"zap\", \"kind\": \"html\", \"contentType\": \"zap\", \"folderId\": \"zap\", \"visibility\": \"private\", \"expiresInHours\": 1}"
+        data: "{\"title\": \"zap\", \"content\": \"zap\", \"fileName\": \"zap\", \"kind\": \"html\", \"contentType\": \"zap\", \"folderId\": \"zap\", \"visibility\": \"private\", \"expiresInHours\": 1}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.update"
         method: POST
         name: artifactLibrary.update
         headers: ["Content-Type: application/json"]
-        data: "{\"id\": \"zap\", \"title\": \"zap\", \"folderId\": \"zap\", \"content\": \"zap\", \"uploadRef\": \"zap\", \"fileName\": \"zap\", \"contentType\": \"zap\"}"
+        data: "{\"id\": \"zap\", \"title\": \"zap\", \"folderId\": \"zap\", \"content\": \"zap\", \"fileName\": \"zap\", \"contentType\": \"zap\"}"
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.setSharing"
         method: POST
         name: artifactLibrary.setSharing
@@ -558,7 +558,7 @@ jobs:
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/metrics.overview?input=%7B%22agentId%22%3A%20%22zap%22%2C%20%22sessionId%22%3A%20%22zap%22%2C%20%22sinceHours%22%3A%201%2C%20%22limit%22%3A%201%7D"
         method: GET
         name: metrics.overview
-      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/metrics.spendBreakdown?input=%7B%22from%22%3A%20%222026-01-01T00%3A00%3A00.000Z%22%2C%20%22to%22%3A%20%222026-01-01T00%3A00%3A00.000Z%22%2C%20%22agentId%22%3A%20%22zap%22%2C%20%22timeZone%22%3A%20%22zap%22%7D"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/metrics.spendBreakdown?input=%7B%22from%22%3A%20%222026-01-01T00%3A00%3A00.000Z%22%2C%20%22to%22%3A%20%222026-01-01T00%3A00%3A00.000Z%22%2C%20%22agentId%22%3A%20%22zap%22%2C%20%22timeZone%22%3A%20%22UTC%22%7D"
         method: GET
         name: metrics.spendBreakdown
       - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/terms.current"

--- a/meta/zap/api.yaml
+++ b/meta/zap/api.yaml
@@ -1,0 +1,615 @@
+env:
+  contexts:
+    - name: dam-api
+      urls:
+        - https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api
+      includePaths:
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/.*
+      excludePaths:
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/trpc/e2e\..*
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/trpc/egressRules\.applyPreset.*
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/api/trpc-ws.*
+      authentication:
+        method: form
+        parameters:
+          loginPageUrl: https://keycloak-dam-dev.apps.dam-cl.fmaas.res.ibm.com/realms/platform/protocol/openid-connect/token
+          loginRequestUrl: https://keycloak-dam-dev.apps.dam-cl.fmaas.res.ibm.com/realms/platform/protocol/openid-connect/token
+          loginRequestBody: "grant_type=password&client_id=platform-ui&scope=openid&username={%username%}&password={%password%}"
+        verification:
+          method: poll
+          pollFrequency: 20
+          pollUnits: requests
+          pollUrl: https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.list
+          loggedInRegex: "\\QHTTP/1.1 200\\E"
+          loggedOutRegex: "\\QHTTP/1.1 401\\E"
+      sessionManagement:
+        method: headers
+        parameters:
+          Authorization: "Bearer {%json:access_token%}"
+      users:
+        - name: zap
+          credentials:
+            username: zap
+            password: zap
+  parameters:
+    failOnError: false
+    failOnWarning: false
+    progressToStdout: true
+jobs:
+  - type: passiveScan-config
+    parameters:
+      maxAlertsPerRule: 10
+  - type: requestor
+    parameters:
+      user: zap
+    requests:
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/templates.list"
+        method: GET
+        name: templates.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/templates.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: templates.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/repos.list"
+        method: GET
+        name: repos.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.list"
+        method: GET
+        name: agents.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: agents.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.backgroundWork?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: agents.backgroundWork
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.create"
+        method: POST
+        name: agents.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"env\": [{\"name\": \"zap-1\", \"value\": \"zap\"}], \"secretRef\": \"zap\", \"registryCredential\": {\"server\": \"zap\", \"username\": \"zap\", \"password\": \"zap\"}, \"egressPreset\": \"none\", \"hibernationTimeoutMin\": 0, \"gitRepo\": {\"url\": \"https://example.com/zap\", \"ref\": \"zap\"}, \"connectionIds\": [\"zap\"], \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}, \"sweepable\": true, \"lifetimeMs\": 0}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.update"
+        method: POST
+        name: agents.update
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"name\": \"zap\", \"description\": \"zap\", \"env\": [{\"name\": \"zap-1\", \"value\": \"zap\"}], \"secretRef\": \"zap\", \"hibernationTimeoutMin\": 0, \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.delete"
+        method: POST
+        name: agents.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.restart"
+        method: POST
+        name: agents.restart
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.wake"
+        method: POST
+        name: agents.wake
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.stop"
+        method: POST
+        name: agents.stop
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.pause"
+        method: POST
+        name: agents.pause
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.upgrade"
+        method: POST
+        name: agents.upgrade
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"expectedToImage\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.connectSlack"
+        method: POST
+        name: agents.connectSlack
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"slackChannelId\": \"zap\", \"ambient\": true}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.disconnectSlack"
+        method: POST
+        name: agents.disconnectSlack
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"slackChannelId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.bindSlackChannel"
+        method: POST
+        name: agents.bindSlackChannel
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"flowId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.listTelegramChats?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: agents.listTelegramChats
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.unbindTelegramChat"
+        method: POST
+        name: agents.unbindTelegramChat
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"conversationId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/agents.bindTelegramChat"
+        method: POST
+        name: agents.bindTelegramChat
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"flowId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.list?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: schedules.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.listForOwner?input=%7B%22limit%22%3A%201%7D"
+        method: GET
+        name: schedules.listForOwner
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: schedules.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.createCron"
+        method: POST
+        name: schedules.createCron
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"agentId\": \"zap\", \"cron\": \"zap\", \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.createRRule"
+        method: POST
+        name: schedules.createRRule
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"agentId\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"zap-1\", \"endTime\": \"zap-1\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.updateRRule"
+        method: POST
+        name: schedules.updateRRule
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"name\": \"zap\", \"rrule\": \"zap\", \"timezone\": \"zap\", \"quietHours\": [{\"startTime\": \"zap-1\", \"endTime\": \"zap-1\", \"enabled\": true}], \"task\": \"zap\", \"sessionMode\": \"continuous\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.delete"
+        method: POST
+        name: schedules.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.toggle"
+        method: POST
+        name: schedules.toggle
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/schedules.resetSession"
+        method: POST
+        name: schedules.resetSession
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/channels.available"
+        method: GET
+        name: channels.available
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/channels.telegramBot"
+        method: GET
+        name: channels.telegramBot
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.listTemplates"
+        method: GET
+        name: connections.listTemplates
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.list"
+        method: GET
+        name: connections.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: connections.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.create"
+        method: POST
+        name: connections.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"templateId\": \"zap\", \"name\": \"zap-1\", \"authKind\": \"oauth\", \"url\": \"https://example.com/zap\", \"host\": \"zap\", \"clientId\": \"zap\", \"clientSecret\": \"zap\", \"appSlug\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.startOAuth"
+        method: POST
+        name: connections.startOAuth
+        headers: ["Content-Type: application/json"]
+        data: "{\"connectionId\": \"zap\", \"returnTo\": \"zap-1\", \"popup\": true}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.discoverMcp"
+        method: POST
+        name: connections.discoverMcp
+        headers: ["Content-Type: application/json"]
+        data: "{\"url\": \"https://example.com/zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.probeClusterCa"
+        method: POST
+        name: connections.probeClusterCa
+        headers: ["Content-Type: application/json"]
+        data: "{\"host\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.probeGitHubAppInstallation"
+        method: POST
+        name: connections.probeGitHubAppInstallation
+        headers: ["Content-Type: application/json"]
+        data: "{\"templateId\": \"zap\", \"appId\": \"zap\", \"installationId\": \"zap\", \"privateKey\": \"zap\", \"host\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.probeGitHubAppInstallationForConnection"
+        method: POST
+        name: connections.probeGitHubAppInstallationForConnection
+        headers: ["Content-Type: application/json"]
+        data: "{\"connectionId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.updateGitHubAppScope"
+        method: POST
+        name: connections.updateGitHubAppScope
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"repositories\": \"zap\", \"repositoryIds\": \"zap\", \"permissions\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.update"
+        method: POST
+        name: connections.update
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"value\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.delete"
+        method: POST
+        name: connections.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.testAnthropic"
+        method: POST
+        name: connections.testAnthropic
+        headers: ["Content-Type: application/json"]
+        data: "{\"value\": \"zap\", \"envName\": \"ANTHROPIC_API_KEY\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.getAgentConnections?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: connections.getAgentConnections
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/connections.setAgentConnections"
+        method: POST
+        name: connections.setAgentConnections
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"connectionIds\": [\"zap\"]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sources.list?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.sources.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sources.create"
+        method: POST
+        name: skills.sources.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"gitUrl\": \"https://example.com/zap\", \"path\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sources.delete"
+        method: POST
+        name: skills.sources.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sources.refresh"
+        method: POST
+        name: skills.sources.refresh
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.list?input=%7B%22sourceId%22%3A%20%22zap%22%2C%20%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.listWithScan?input=%7B%22sourceId%22%3A%20%22zap%22%2C%20%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.listWithScan
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.getSkillContent?input=%7B%22sourceId%22%3A%20%22zap%22%2C%20%22name%22%3A%20%22zap%22%2C%20%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.getSkillContent
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.install"
+        method: POST
+        name: skills.install
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"source\": \"https://example.com/zap\", \"name\": \"zap\", \"version\": \"zap\", \"contentHash\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.uninstall"
+        method: POST
+        name: skills.uninstall
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"source\": \"https://example.com/zap\", \"name\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.applyBatch"
+        method: POST
+        name: skills.applyBatch
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"install\": [{\"source\": \"https://example.com/zap\", \"name\": \"zap\", \"version\": \"zap\", \"contentHash\": \"zap\"}], \"uninstall\": [{\"source\": \"https://example.com/zap\", \"name\": \"zap\"}]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sets.list"
+        method: GET
+        name: skills.sets.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sets.create"
+        method: POST
+        name: skills.sets.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap-1\", \"skills\": [{\"source\": \"https://example.com/zap\", \"name\": \"zap\"}]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sets.delete"
+        method: POST
+        name: skills.sets.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.sets.applyToAgent"
+        method: POST
+        name: skills.sets.applyToAgent
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"setIds\": [\"zap\"]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.createLocal"
+        method: POST
+        name: skills.createLocal
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"skills\": [{\"name\": \"zap\", \"content\": \"zap\"}]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.deleteLocal"
+        method: POST
+        name: skills.deleteLocal
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"name\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.listLocal?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.listLocal
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.readLocal?input=%7B%22agentId%22%3A%20%22zap%22%2C%20%22name%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.readLocal
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.state?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: skills.state
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/skills.publish"
+        method: POST
+        name: skills.publish
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"sourceId\": \"zap\", \"name\": \"zap\", \"title\": \"zap\", \"body\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.listForOwner?input=%7B%22limit%22%3A%201%2C%20%22status%22%3A%20%22pending%22%7D"
+        method: GET
+        name: approvals.listForOwner
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.listForInstance?input=%7B%22limit%22%3A%201%2C%20%22status%22%3A%20%22pending%22%2C%20%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: approvals.listForInstance
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.approveOnce"
+        method: POST
+        name: approvals.approveOnce
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.approvePermanent"
+        method: POST
+        name: approvals.approvePermanent
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.approveHost"
+        method: POST
+        name: approvals.approveHost
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.denyForever"
+        method: POST
+        name: approvals.denyForever
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/approvals.dismiss"
+        method: POST
+        name: approvals.dismiss
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.listForAgent?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: egressRules.listForAgent
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: egressRules.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.currentPreset?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: egressRules.currentPreset
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.create"
+        method: POST
+        name: egressRules.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"host\": \"zap\", \"port\": 1, \"method\": \"zap\", \"pathPattern\": \"zap\", \"verdict\": \"allow\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.update"
+        method: POST
+        name: egressRules.update
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"method\": \"zap\", \"pathPattern\": \"zap\", \"verdict\": \"allow\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.revoke"
+        method: POST
+        name: egressRules.revoke
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/egressRules.trustedHosts"
+        method: GET
+        name: egressRules.trustedHosts
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.createSandbox"
+        method: POST
+        name: experiments.createSandbox
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"connectionIds\": [\"zap\"], \"egressPreset\": \"none\", \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.list"
+        method: GET
+        name: experiments.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.driverSummaries"
+        method: GET
+        name: experiments.driverSummaries
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: experiments.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.feed?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: experiments.feed
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.startRun"
+        method: POST
+        name: experiments.startRun
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.stop"
+        method: POST
+        name: experiments.stop
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/experiments.delete"
+        method: POST
+        name: experiments.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/knowledgeBases.create"
+        method: POST
+        name: knowledgeBases.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"templateId\": \"zap\", \"image\": \"zap\", \"description\": \"zap\", \"connectionIds\": [\"zap\"], \"egressPreset\": \"none\", \"size\": {\"cpu\": \"zap-1\", \"memory\": \"zap-1\"}, \"kbTemplateId\": \"llm-wiki\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.status?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: kbShares.status
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.list"
+        method: GET
+        name: kbShares.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.defaults?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: kbShares.defaults
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.create"
+        method: POST
+        name: kbShares.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"roots\": [\"zap-1\"]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.reveal"
+        method: POST
+        name: kbShares.reveal
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.rotate"
+        method: POST
+        name: kbShares.rotate
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.revoke"
+        method: POST
+        name: kbShares.revoke
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.refresh"
+        method: POST
+        name: kbShares.refresh
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"roots\": [\"zap-1\"]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.setName"
+        method: POST
+        name: kbShares.setName
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"name\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/kbShares.resolveLink"
+        method: POST
+        name: kbShares.resolveLink
+        headers: ["Content-Type: application/json"]
+        data: "{\"shareString\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.touches?input=%7B%22agentId%22%3A%20%22zap%22%2C%20%22sessionIds%22%3A%20%5B%22zap%22%5D%2C%20%22limit%22%3A%201%7D"
+        method: GET
+        name: artifactLibrary.touches
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.list?input=%7B%22folderId%22%3A%20%22zap%22%2C%20%22agentId%22%3A%20%22zap%22%2C%20%22search%22%3A%20%22zap%22%7D"
+        method: GET
+        name: artifactLibrary.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: artifactLibrary.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.getContent?input=%7B%22id%22%3A%20%22zap%22%2C%20%22version%22%3A%201%7D"
+        method: GET
+        name: artifactLibrary.getContent
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.preview?input=%7B%22id%22%3A%20%22zap%22%2C%20%22version%22%3A%201%7D"
+        method: GET
+        name: artifactLibrary.preview
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.listVersions?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: artifactLibrary.listVersions
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.create"
+        method: POST
+        name: artifactLibrary.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"title\": \"zap\", \"content\": \"zap\", \"uploadRef\": \"zap\", \"fileName\": \"zap\", \"kind\": \"html\", \"contentType\": \"zap\", \"folderId\": \"zap\", \"visibility\": \"private\", \"expiresInHours\": 1}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.update"
+        method: POST
+        name: artifactLibrary.update
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"title\": \"zap\", \"folderId\": \"zap\", \"content\": \"zap\", \"uploadRef\": \"zap\", \"fileName\": \"zap\", \"contentType\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.setSharing"
+        method: POST
+        name: artifactLibrary.setSharing
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"visibility\": \"private\", \"expiresInHours\": 1}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.delete"
+        method: POST
+        name: artifactLibrary.delete
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.createUploadUrl"
+        method: POST
+        name: artifactLibrary.createUploadUrl
+        headers: ["Content-Type: application/json"]
+        data: "{\"fileName\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.listFolders"
+        method: GET
+        name: artifactLibrary.listFolders
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.createFolder"
+        method: POST
+        name: artifactLibrary.createFolder
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.updateFolder"
+        method: POST
+        name: artifactLibrary.updateFolder
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\", \"name\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.deleteFolder"
+        method: POST
+        name: artifactLibrary.deleteFolder
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/artifactLibrary.folderShareUrl?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: artifactLibrary.folderShareUrl
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/caseStudies.list"
+        method: GET
+        name: caseStudies.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/caseStudies.get?input=%7B%22id%22%3A%20%22zap%22%7D"
+        method: GET
+        name: caseStudies.get
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/caseStudies.release"
+        method: POST
+        name: caseStudies.release
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/features.flags"
+        method: GET
+        name: features.flags
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/features.setFlag"
+        method: POST
+        name: features.setFlag
+        headers: ["Content-Type: application/json"]
+        data: "{\"feature\": \"advanced-connections\", \"enabled\": true}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/files.upload"
+        method: POST
+        name: files.upload
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"path\": \"zap\", \"contentBase64\": \"zap\", \"contentType\": \"zap\", \"overwrite\": true}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/links.all"
+        method: GET
+        name: links.all
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/metrics.overview?input=%7B%22agentId%22%3A%20%22zap%22%2C%20%22sessionId%22%3A%20%22zap%22%2C%20%22sinceHours%22%3A%201%2C%20%22limit%22%3A%201%7D"
+        method: GET
+        name: metrics.overview
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/metrics.spendBreakdown?input=%7B%22from%22%3A%20%222026-01-01T00%3A00%3A00.000Z%22%2C%20%22to%22%3A%20%222026-01-01T00%3A00%3A00.000Z%22%2C%20%22agentId%22%3A%20%22zap%22%2C%20%22timeZone%22%3A%20%22zap%22%7D"
+        method: GET
+        name: metrics.spendBreakdown
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/terms.current"
+        method: GET
+        name: terms.current
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/terms.latestAcceptance"
+        method: GET
+        name: terms.latestAcceptance
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/terms.accept"
+        method: POST
+        name: terms.accept
+        headers: ["Content-Type: application/json"]
+        data: "{\"version\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/usage.entryPointChosen"
+        method: POST
+        name: usage.entryPointChosen
+        headers: ["Content-Type: application/json"]
+        data: "{\"choice\": \"sandbox\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/apiKeys.list"
+        method: GET
+        name: apiKeys.list
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/apiKeys.create"
+        method: POST
+        name: apiKeys.create
+        headers: ["Content-Type: application/json"]
+        data: "{\"name\": \"zap\", \"scopes\": [\"agents:read\"], \"agentIds\": \"*\", \"expiresAt\": \"2026-01-01T00:00:00.000Z\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/apiKeys.revoke"
+        method: POST
+        name: apiKeys.revoke
+        headers: ["Content-Type: application/json"]
+        data: "{\"id\": \"zap\"}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/harnessConfig.status?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: harnessConfig.status
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/harnessConfig.settled?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: harnessConfig.settled
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/harnessConfig.snapshot?input=%7B%22agentId%22%3A%20%22zap%22%7D"
+        method: GET
+        name: harnessConfig.snapshot
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/harnessConfig.set"
+        method: POST
+        name: harnessConfig.set
+        headers: ["Content-Type: application/json"]
+        data: "{\"agentId\": \"zap\", \"model\": \"zap\", \"mode\": \"zap\", \"configOptions\": {}, \"unset\": [\"zap\"]}"
+      - url: "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/budgets.reserved"
+        method: GET
+        name: budgets.reserved
+  - type: passiveScan-wait
+  - type: report
+    parameters:
+      template: traditional-json
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: api-passive

--- a/meta/zap/cleanup.py
+++ b/meta/zap/cleanup.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Delete the folders, skill sets and skill sources the ZAP scan created under the zap user on dam-dev."""
+import json, ssl, urllib.parse, urllib.request
+
+ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
+BASE = "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/"
+TOKEN_URL = "https://keycloak-dam-dev.apps.dam-cl.fmaas.res.ibm.com/realms/platform/protocol/openid-connect/token"
+
+def token():
+    body = urllib.parse.urlencode({"grant_type": "password", "client_id": "platform-ui", "username": "zap", "password": "zap", "scope": "openid"}).encode()
+    return json.load(urllib.request.urlopen(urllib.request.Request(TOKEN_URL, body), context=ctx))["access_token"]
+
+tok = token()
+
+def call(proc, inp=None, post=False):
+    global tok
+    url = BASE + proc + ("" if inp is None or post else "?input=" + urllib.parse.quote(json.dumps(inp)))
+    req = urllib.request.Request(url, data=json.dumps(inp).encode() if post else None,
+                                 headers={"Authorization": "Bearer " + tok, "Content-Type": "application/json"})
+    try:
+        return json.load(urllib.request.urlopen(req, context=ctx))
+    except urllib.error.HTTPError as e:
+        if e.code == 401:
+            tok = token(); return call(proc, inp, post)
+        return {"error": e.code, "body": e.read()[:120].decode()}
+
+for lst, dele in (("artifactLibrary.listFolders", "artifactLibrary.deleteFolder"),
+                  ("skills.sets.list", "skills.sets.delete"),
+                  ("skills.sources.list", "skills.sources.delete")):
+    items = call(lst)["result"]["data"]
+    failed = [(it.get("name"), call(dele, {"id": it["id"]}, post=True)) for it in items]
+    failed = [f for f in failed if "error" in f[1]]
+    print(f"{lst}: {len(items) - len(failed)} deleted, {len(failed)} failed, {len(call(lst)['result']['data'])} remaining", failed[:2])

--- a/meta/zap/cleanup.py
+++ b/meta/zap/cleanup.py
@@ -1,12 +1,15 @@
 #!/usr/bin/env python3
-"""Delete what a scan run created under the zap user on dam-dev.
+"""Delete what a scan run created under the zap user on dam-dev, in the three
+collections a run is known to fill: artifact folders, skill sets, skill sources.
 
 An item is deleted when it carries a marker of the scan: a field equal to one
 of the enumerator's sample literals (the active scanner mutates one field per
 request, so every created item keeps at least one), or a createdAt at or after
 the run start (reports/started-at, written by scan.sh, or --since ISO-8601).
-Anything else under the account is listed and left alone. --all wipes the
-whole account instead.
+Anything else in those collections is listed and left alone. --all empties the
+three collections instead. Other kinds the seed list can create (agents,
+schedules, connections, API keys, ...) have so far always been rejected at
+validation or ownership checks; inspect them by hand if a run changes that.
 """
 import json, ssl, sys, urllib.parse, urllib.request
 from datetime import datetime, timezone

--- a/meta/zap/cleanup.py
+++ b/meta/zap/cleanup.py
@@ -1,14 +1,36 @@
 #!/usr/bin/env python3
-"""Delete the folders, skill sets and skill sources the ZAP scan created under the zap user on dam-dev."""
-import json, ssl, urllib.parse, urllib.request
+"""Delete what a scan run created under the zap user on dam-dev.
+
+An item is deleted when it carries a marker of the scan: a field equal to one
+of the enumerator's sample literals (the active scanner mutates one field per
+request, so every created item keeps at least one), or a createdAt at or after
+the run start (reports/started-at, written by scan.sh, or --since ISO-8601).
+Anything else under the account is listed and left alone. --all wipes the
+whole account instead.
+"""
+import json, ssl, sys, urllib.parse, urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
 
 ctx = ssl.create_default_context(); ctx.check_hostname = False; ctx.verify_mode = ssl.CERT_NONE
 BASE = "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/"
 TOKEN_URL = "https://keycloak-dam-dev.apps.dam-cl.fmaas.res.ibm.com/realms/platform/protocol/openid-connect/token"
+SAMPLE_LITERALS = {"zap", "zap-1", "ZAP", "https://example.com/zap", "/zap"}  # keep in step with enumerate.mts
+
+wipe_all = "--all" in sys.argv
+since = None
+if not wipe_all:
+    if "--since" in sys.argv:
+        since_text = sys.argv[sys.argv.index("--since") + 1]
+    else:
+        started = Path(__file__).with_name("reports") / "started-at"
+        since_text = started.read_text().strip() if started.exists() else sys.exit("no reports/started-at; pass --since ISO-8601 or --all")
+    since = datetime.fromisoformat(since_text.replace("Z", "+00:00")).astimezone(timezone.utc)
 
 def token():
     body = urllib.parse.urlencode({"grant_type": "password", "client_id": "platform-ui", "username": "zap", "password": "zap", "scope": "openid"}).encode()
-    return json.load(urllib.request.urlopen(urllib.request.Request(TOKEN_URL, body), context=ctx))["access_token"]
+    with urllib.request.urlopen(urllib.request.Request(TOKEN_URL, body), context=ctx) as r:
+        return json.load(r)["access_token"]
 
 tok = token()
 
@@ -18,16 +40,26 @@ def call(proc, inp=None, post=False):
     req = urllib.request.Request(url, data=json.dumps(inp).encode() if post else None,
                                  headers={"Authorization": "Bearer " + tok, "Content-Type": "application/json"})
     try:
-        return json.load(urllib.request.urlopen(req, context=ctx))
+        with urllib.request.urlopen(req, context=ctx) as r:
+            return json.load(r)
     except urllib.error.HTTPError as e:
         if e.code == 401:
             tok = token(); return call(proc, inp, post)
         return {"error": e.code, "body": e.read()[:120].decode()}
 
+def from_scan(item):
+    if wipe_all or any(v in SAMPLE_LITERALS for v in item.values() if isinstance(v, str)):
+        return True
+    created = item.get("createdAt")
+    return bool(created) and datetime.fromisoformat(created.replace("Z", "+00:00")).astimezone(timezone.utc) >= since
+
 for lst, dele in (("artifactLibrary.listFolders", "artifactLibrary.deleteFolder"),
                   ("skills.sets.list", "skills.sets.delete"),
                   ("skills.sources.list", "skills.sources.delete")):
     items = call(lst)["result"]["data"]
-    failed = [(it.get("name"), call(dele, {"id": it["id"]}, post=True)) for it in items]
-    failed = [f for f in failed if "error" in f[1]]
-    print(f"{lst}: {len(items) - len(failed)} deleted, {len(failed)} failed, {len(call(lst)['result']['data'])} remaining", failed[:2])
+    mine = [it for it in items if from_scan(it)]
+    kept = [it for it in items if it not in mine]
+    failed = [(it.get("name"), r) for it in mine if "error" in (r := call(dele, {"id": it["id"]}, post=True))]
+    print(f"{lst}: {len(mine) - len(failed)} deleted, {len(failed)} failed, {len(kept)} not from the scan and kept", failed[:2])
+    for it in kept:
+        print(f"  kept: {it.get('name')!r} ({it['id']})")

--- a/meta/zap/crawl.yaml
+++ b/meta/zap/crawl.yaml
@@ -1,0 +1,53 @@
+env:
+  contexts:
+    - name: dam-dev
+      urls:
+        - https://dam-dev.apps.dam-cl.fmaas.res.ibm.com
+      includePaths:
+        - https://dam-dev\.apps\.dam-cl\.fmaas\.res\.ibm\.com/.*
+      excludePaths:
+        - .*logout.*
+        - .*/assets/.*
+      authentication:
+        method: browser
+        parameters:
+          loginPageUrl: https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/
+          loginPageWait: 8
+          browserId: chrome-headless
+        verification:
+          method: autodetect
+      sessionManagement:
+        method: autodetect
+      users:
+        - name: zap
+          credentials:
+            username: zap
+            password: zap
+  parameters:
+    failOnError: false
+    failOnWarning: false
+    progressToStdout: true
+jobs:
+  - type: passiveScan-config
+    parameters:
+      maxAlertsPerRule: 10
+  - type: spiderAjax
+    parameters:
+      context: dam-dev
+      user: zap
+      browserId: chrome-headless
+      maxDuration: 15
+      maxCrawlDepth: 10
+      runOnlyIfModern: false
+  - type: passiveScan-wait
+  - type: report
+    parameters:
+      template: traditional-html-plus
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: crawl-passive
+      reportTitle: DAM dev - crawl + passive scan
+  - type: report
+    parameters:
+      template: traditional-json
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: crawl-passive

--- a/meta/zap/enumerate.mts
+++ b/meta/zap/enumerate.mts
@@ -1,0 +1,43 @@
+import { z } from "../../packages/api-server-api/node_modules/zod/index.js";
+import { appRouter } from "../../packages/api-server-api/src/router.ts";
+
+function sample(s: any, defs: any): any {
+  if (!s || typeof s !== "object") return "zap";
+  if (s.$ref) return sample(defs[s.$ref.replace("#/$defs/", "")], defs);
+  if (s.const !== undefined) return s.const;
+  if (s.enum) return s.enum[0];
+  if (s.anyOf) return sample(s.anyOf[0], defs);
+  if (s.oneOf) return sample(s.oneOf[0], defs);
+  if (s.allOf) return Object.assign({}, ...s.allOf.map((x: any) => sample(x, defs)));
+  if (s.prefixItems) return s.prefixItems.map((x: any) => sample(x, defs));
+  const t = Array.isArray(s.type) ? s.type[0] : s.type;
+  switch (t) {
+    case "string":
+      if (s.format === "uuid") return "00000000-0000-4000-8000-000000000000";
+      if (s.format === "date-time") return "2026-01-01T00:00:00.000Z";
+      if (s.format === "uri" || s.format === "url") return "https://example.com/zap";
+      if (s.format === "email") return "zap@example.com";
+      return s.pattern ? "zap-1" : "zap";
+    case "number": case "integer": return s.minimum ?? 1;
+    case "boolean": return true;
+    case "null": return null;
+    case "array": return [sample(s.items, defs)];
+    case "object": return Object.fromEntries(Object.entries(s.properties ?? {}).map(([k, v]) => [k, sample(v, defs)]));
+    default: return s.properties ? sample({ ...s, type: "object" }, defs) : "zap";
+  }
+}
+
+const out = [];
+for (const [path, proc] of Object.entries<any>(appRouter._def.procedures)) {
+  const type = proc._def.type;
+  const inputSchema = proc._def.inputs?.[0];
+  let input: any = undefined, schema: any = undefined, err: string | undefined;
+  if (inputSchema) {
+    try {
+      schema = z.toJSONSchema(inputSchema, { io: "input", unrepresentable: "any" });
+      input = sample(schema, schema.$defs ?? {});
+    } catch (e: any) { err = String(e.message ?? e); }
+  }
+  out.push({ path, type, input, err });
+}
+console.log(JSON.stringify(out, null, 1));

--- a/meta/zap/enumerate.mts
+++ b/meta/zap/enumerate.mts
@@ -19,6 +19,14 @@ const PATTERN_SAMPLES: Record<string, string> = {
   "^\\d{4}-\\d{2}-\\d{2}$": "2026-01-01",
 };
 
+const INPUT_FIXES: Record<string, (v: any) => any> = {
+  "artifactLibrary.create": ({ uploadRef: _uploadRef, ...v }) => v,
+  "artifactLibrary.update": ({ uploadRef: _uploadRef, ...v }) => v,
+  "metrics.spendBreakdown": (v) => ({ ...v, timeZone: "UTC" }),
+  "schedules.createRRule": (v) => ({ ...v, quietHours: [{ ...v.quietHours[0], endTime: "10:30" }] }),
+  "schedules.updateRRule": (v) => ({ ...v, quietHours: [{ ...v.quietHours[0], endTime: "10:30" }] }),
+};
+
 function sample(s: any, defs: any): any {
   if (!s || typeof s !== "object") return "zap";
   if (s.$ref) return sample(defs[s.$ref.replace("#/$defs/", "")], defs);
@@ -58,7 +66,9 @@ for (const [path, proc] of Object.entries<any>(appRouter._def.procedures)) {
   if (inputSchema) {
     try {
       const schema = z.toJSONSchema(inputSchema, { io: "input", unrepresentable: "any" });
-      input = sample(schema, schema.$defs ?? {});
+      input = (INPUT_FIXES[path] ?? ((v) => v))(sample(schema, schema.$defs ?? {}));
+      const parsed = inputSchema.safeParse(input);
+      if (!parsed.success) throw new Error(`sample fails the input schema: ${parsed.error.issues.map((i: any) => i.path.join(".") + " " + i.message).join("; ")}`);
     } catch (e) {
       failures.push(`${path}: ${e instanceof Error ? e.message : String(e)}`);
     }

--- a/meta/zap/enumerate.mts
+++ b/meta/zap/enumerate.mts
@@ -1,5 +1,23 @@
-import { z } from "../../packages/api-server-api/node_modules/zod/index.js";
+import { createRequire } from "node:module";
 import { appRouter } from "../../packages/api-server-api/src/router.ts";
+
+const { z } = createRequire(
+  new URL("../../packages/api-server-api/src/", import.meta.url),
+)("zod") as typeof import("zod");
+
+const PATTERN_SAMPLES: Record<string, string> = {
+  "^[a-z0-9]+(-[a-z0-9]+)*$": "zap-1",
+  "^[A-Z_][A-Z0-9_]*$": "ZAP",
+  "^[A-Za-z_][A-Za-z0-9_]*$": "ZAP",
+  "^(?!\\.)[A-Za-z0-9._-]+$": "zap",
+  "^\\/(?!\\/)": "/zap",
+  "^\\d+(Mi|Gi)$": "512Mi",
+  "^\\d+(\\.\\d+)?m?$": "500m",
+  "^[a-f0-9]{64}$": "0".repeat(64),
+  "^[0-9a-f]{64}$": "0".repeat(64),
+  "^([01]\\d|2[0-3]):[0-5]\\d$": "09:30",
+  "^\\d{4}-\\d{2}-\\d{2}$": "2026-01-01",
+};
 
 function sample(s: any, defs: any): any {
   if (!s || typeof s !== "object") return "zap";
@@ -17,7 +35,12 @@ function sample(s: any, defs: any): any {
       if (s.format === "date-time") return "2026-01-01T00:00:00.000Z";
       if (s.format === "uri" || s.format === "url") return "https://example.com/zap";
       if (s.format === "email") return "zap@example.com";
-      return s.pattern ? "zap-1" : "zap";
+      if (s.pattern) {
+        const v = PATTERN_SAMPLES[s.pattern];
+        if (v === undefined) throw new Error(`no sample for pattern ${s.pattern}`);
+        return v;
+      }
+      return "zap";
     case "number": case "integer": return s.minimum ?? 1;
     case "boolean": return true;
     case "null": return null;
@@ -28,16 +51,26 @@ function sample(s: any, defs: any): any {
 }
 
 const out = [];
+const failures: string[] = [];
 for (const [path, proc] of Object.entries<any>(appRouter._def.procedures)) {
-  const type = proc._def.type;
   const inputSchema = proc._def.inputs?.[0];
-  let input: any = undefined, schema: any = undefined, err: string | undefined;
+  let input: unknown = undefined;
   if (inputSchema) {
     try {
-      schema = z.toJSONSchema(inputSchema, { io: "input", unrepresentable: "any" });
+      const schema = z.toJSONSchema(inputSchema, { io: "input", unrepresentable: "any" });
       input = sample(schema, schema.$defs ?? {});
-    } catch (e: any) { err = String(e.message ?? e); }
+    } catch (e) {
+      failures.push(`${path}: ${e instanceof Error ? e.message : String(e)}`);
+    }
   }
-  out.push({ path, type, input, err });
+  out.push({ path, type: proc._def.type, input });
+}
+if (failures.length > 0) {
+  console.error(`could not sample ${failures.length} procedure(s):\n  ${failures.join("\n  ")}`);
+  process.exit(1);
+}
+if (out.length === 0) {
+  console.error("appRouter exposed no procedures; refusing to emit an empty seed list");
+  process.exit(1);
 }
 console.log(JSON.stringify(out, null, 1));

--- a/meta/zap/gen-requests.py
+++ b/meta/zap/gen-requests.py
@@ -1,13 +1,19 @@
-import json, urllib.parse
-p = json.load(open("procedures.json"))
+import json, sys, urllib.parse
+
+with open("procedures.json") as f:
+    procedures = json.load(f)
+if not procedures:
+    sys.exit("procedures.json is empty; refusing to rewrite api.yaml")
+
 base = "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/"
 # e2e.* are test hooks, applyPreset mutates cluster-wide egress config, subscriptions are WS-only.
 skip = lambda x: x["path"].startswith("e2e.") or x["path"] == "egressRules.applyPreset" or x["type"] == "subscription"
 lines = ["  - type: requestor", "    parameters:", "      user: zap", "    requests:"]
 n = 0
-for x in p:
-    if skip(x): continue
-    inp = json.dumps(x.get("input")) if "input" in x else None
+for x in procedures:
+    if skip(x):
+        continue
+    inp = json.dumps(x["input"]) if "input" in x else None
     if x["type"] == "query":
         url = base + x["path"] + (f"?input={urllib.parse.quote(inp, safe='')}" if inp else "")
         lines += [f"      - url: {json.dumps(url)}", "        method: GET", "        name: " + x["path"]]
@@ -15,8 +21,11 @@ for x in p:
         lines += [f"      - url: {json.dumps(base + x['path'])}", "        method: POST", "        name: " + x["path"],
                   '        headers: ["Content-Type: application/json"]', f"        data: {json.dumps(inp or '{}')}"]
     n += 1
-api = open("api.yaml").read()
+
+with open("api.yaml") as f:
+    api = f.read()
 head, _, tail = api.partition("  - type: requestor")
 tail = tail[tail.index("  - type: passiveScan-wait"):]
-open("api.yaml", "w").write(head + "\n".join(lines) + "\n" + tail)
+with open("api.yaml", "w") as f:
+    f.write(head + "\n".join(lines) + "\n" + tail)
 print("requests:", n)

--- a/meta/zap/gen-requests.py
+++ b/meta/zap/gen-requests.py
@@ -1,0 +1,22 @@
+import json, urllib.parse
+p = json.load(open("procedures.json"))
+base = "https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/api/trpc/"
+# e2e.* are test hooks, applyPreset mutates cluster-wide egress config, subscriptions are WS-only.
+skip = lambda x: x["path"].startswith("e2e.") or x["path"] == "egressRules.applyPreset" or x["type"] == "subscription"
+lines = ["  - type: requestor", "    parameters:", "      user: zap", "    requests:"]
+n = 0
+for x in p:
+    if skip(x): continue
+    inp = json.dumps(x.get("input")) if "input" in x else None
+    if x["type"] == "query":
+        url = base + x["path"] + (f"?input={urllib.parse.quote(inp, safe='')}" if inp else "")
+        lines += [f"      - url: {json.dumps(url)}", "        method: GET", "        name: " + x["path"]]
+    else:
+        lines += [f"      - url: {json.dumps(base + x['path'])}", "        method: POST", "        name: " + x["path"],
+                  '        headers: ["Content-Type: application/json"]', f"        data: {json.dumps(inp or '{}')}"]
+    n += 1
+api = open("api.yaml").read()
+head, _, tail = api.partition("  - type: requestor")
+tail = tail[tail.index("  - type: passiveScan-wait"):]
+open("api.yaml", "w").write(head + "\n".join(lines) + "\n" + tail)
+print("requests:", n)

--- a/meta/zap/reports/.gitignore
+++ b/meta/zap/reports/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/meta/zap/scan.sh
+++ b/meta/zap/scan.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 cd "$(dirname "$0")"
 REPO="$(cd ../.. && pwd)"
 export ZAP_REPORT_DIR="$PWD/reports"
+mkdir -p "$ZAP_REPORT_DIR"
+# cleanup.py deletes only what was created at or after this instant (plus sampler-literal matches).
+date -u +%Y-%m-%dT%H:%M:%SZ > "$ZAP_REPORT_DIR/started-at"
 Z=http://127.0.0.1:8090
 CHROME="$HOME/Library/Caches/ms-playwright/chromium-1223/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
 CHROMEDRIVER=$(find "$PWD/browsers" -type f -name chromedriver | head -1)

--- a/meta/zap/scan.sh
+++ b/meta/zap/scan.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Headless ZAP scan of DAM dev. Usage: ./scan.sh [crawl|api|active ...]  (default: all three, in order)
+# Requires: /Applications/ZAP.app, Playwright chromium (~/Library/Caches/ms-playwright), chromedriver matching its major version under ./browsers.
+# Reports land in ./reports (gitignored); the plans read the directory from ZAP_REPORT_DIR.
+set -euo pipefail
+cd "$(dirname "$0")"
+REPO="$(cd ../.. && pwd)"
+export ZAP_REPORT_DIR="$PWD/reports"
+Z=http://127.0.0.1:8090
+CHROME="$HOME/Library/Caches/ms-playwright/chromium-1223/chrome-mac-arm64/Google Chrome for Testing.app/Contents/MacOS/Google Chrome for Testing"
+CHROMEDRIVER=$(find "$PWD/browsers" -type f -name chromedriver | head -1)
+
+# Regenerate the tRPC request seed list from the router.
+mise exec -- pnpm --dir "$REPO" --filter api-server exec tsx "$REPO/meta/zap/enumerate.mts" > procedures.json
+python3 gen-requests.py
+
+if ! curl -s -m 2 "$Z/JSON/core/view/version/" >/dev/null; then
+  mkdir -p sessions
+  nohup /Applications/ZAP.app/Contents/Java/zap.sh -daemon -port 8090 -dir "$PWD/zaphome" \
+    -newsession "$PWD/sessions/dam-dev-$(date +%Y%m%d-%H%M)" \
+    -config api.disablekey=true -config api.addrs.addr.name=127.0.0.1 -config api.addrs.addr.regex=false \
+    -config "selenium.chromeBinary=$CHROME" -config "selenium.chromeDriver=$CHROMEDRIVER" > zap-daemon.log 2>&1 &
+  until curl -s -m 2 "$Z/JSON/core/view/version/" | grep -q version; do sleep 2; done
+fi
+
+plans=("$@"); [ ${#plans[@]} -eq 0 ] && plans=(crawl api active)
+for plan in "${plans[@]}"; do
+  # The API answers the version view before the automation add-on is ready; retry until a plan id comes back.
+  until id=$(curl -s "$Z/JSON/automation/action/runPlan/?filePath=$PWD/$plan.yaml" | python3 -c 'import json,sys; print(json.load(sys.stdin)["planId"])' 2>/dev/null); do sleep 3; done
+  echo "== $plan.yaml (plan $id)"
+  until curl -s -m 5 "$Z/JSON/automation/view/planProgress/?planId=$id" | grep -q '"finished": *"20'; do sleep 15; done
+  curl -s "$Z/JSON/automation/view/planProgress/?planId=$id" | python3 -c 'import json,sys; d=json.load(sys.stdin); print("\n".join(d["info"])); print("WARN",d["warn"]); print("ERR",d["error"])'
+done
+echo "reports: $PWD/reports"


### PR DESCRIPTION
The ZAP setup used for the three dam-dev scans on 2026-09-08 (which led to #3602, #3611, #3613), moved into the repo so it can be re-run.

## What is in `meta/zap`

- `scan.sh` — launches headless ZAP 2.17 from `/Applications/ZAP.app`, points it at the Playwright Chrome plus a matching chromedriver, records the run start in `reports/started-at`, and runs the three plans in order. Paths are repo-relative; the plans read the report directory from `ZAP_REPORT_DIR`.
- `crawl.yaml` — browser-based Keycloak login and AJAX spider over the UI (passive coverage; the UI uses tRPC over WebSocket only).
- `api.yaml` — Keycloak password grant plus one request per tRPC procedure over HTTP, generated by `enumerate.mts` (walks `appRouter`, samples each Zod input; regex-constrained strings come from a per-pattern table) and `gen-requests.py`. Both fail closed: an unsampled schema or an empty router aborts before `api.yaml` is rewritten.
- `active.yaml` — active scan over the seeded API context, throttled to 250 ms.
- `cleanup.py` — deletes the folders, skill sets and skill sources the last run created under the zap user: items carrying a sampler literal, or a `createdAt` at or after `reports/started-at`. Anything else under the account is listed and kept; `--all` wipes the whole account explicitly.
- `README.md` — usage and the ZAP quirks that cost time.

`reports/` is tracked as an empty directory and its contents are gitignored; only the latest (clean) run is kept locally. `browsers/`, `zaphome/`, `sessions/`, logs and the generated `procedures.json` are gitignored.

https://claude.ai/code/session_01BGaKuoKWJad1BVu4FpQeXW
