### PR TITLE
fix(ci): keep dependency output out of scanner JSON

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -859,7 +859,7 @@ jobs:
       - name: Detect vulnerabilities
         run: |
           set -euo pipefail
-          results=$(mise x -- pnpm audit --prod --json) || true
+          results=$(mise x --no-deps -- pnpm audit --prod --json) || true
           out=$(printf '%s' "$results" | jq '
             [ (.advisories // {}) | to_entries[] | .value
               | { id: (((.cves // []) | first) // .github_advisory_id // (.id | tostring)),
@@ -993,7 +993,7 @@ jobs:
             echo "${QUAY_PASSWORD}" | docker login quay.io -u "${QUAY_USERNAME}" --password-stdin
           fi
           # trivy.yaml at the repo root sets ignore-unfixed.
-          report=$(mise x -- trivy image --quiet --format json "${IMAGE_PREFIX}/${COMPONENT}:${SHA}") || {
+          report=$(mise x --no-deps -- trivy image --quiet --format json "${IMAGE_PREFIX}/${COMPONENT}:${SHA}") || {
             echo "::notice::Trivy scan skipped for ${COMPONENT} (no ${SHA} image — reused unchanged, or its build failed); see log"
             exit 0
           }


### PR DESCRIPTION
The automatic pnpm dependency preparation enabled in #3612 runs inside the scanner commands' stdout capture. Its progress output precedes the JSON report, so pnpm audit and Trivy jobs fail with `jq: parse error: Invalid numeric literal at line 1, column 11`.

Add `--no-deps` to these two `mise x` invocations. pnpm audit reads the lockfile and Trivy scans a published image; neither needs a workspace install. This keeps dependency preparation output out of the captured reports without changing scanner options or findings processing.

Validation: workflow security analysis (`mise run --no-deps check:zizmor`), comment check (`mise run --no-deps check:comment-types`), and `git diff --check`. Full scanner runs remain for CI.

Failure: https://github.com/dam-agents/dam/actions/runs/34330620286/job/102399594250
