### PR TITLE
fix(ui): an old session no longer opens looking like it is still running

### DIFF
--- a/packages/ui/src/modules/sessions/components/thought-block.tsx
+++ b/packages/ui/src/modules/sessions/components/thought-block.tsx
@@ -16,7 +16,7 @@ export function ThoughtBlock({
   text: string;
   streaming: boolean;
 }) {
-  const [open, setOpen] = useState(true);
+  const [open, setOpen] = useState(streaming);
   const userToggled = useRef(false);
   const { copy, copied, state: copyState } = useCopy();
 

--- a/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
@@ -71,6 +71,8 @@ export interface UseAcpConnectionResult {
     sid: string,
     replayBefore?: string,
   ) => Promise<Message[]>;
+  runtimeIdle: (sid: string) => boolean;
+  clearRuntimeIdle: (sid: string) => void;
   connectionRef: React.MutableRefObject<LiveConnection | null>;
   reset: () => void;
 }
@@ -282,6 +284,7 @@ export function useAcpConnection(
   }, [selectedAgent, makeUpdateHandler, attachCloseHandler]);
 
   const loadChainRef = useRef<Promise<unknown>>(Promise.resolve());
+  const idleSessionsRef = useRef(new Set<string>());
 
   const runSessionLoad = useCallback(
     async (sid: string, replayBefore?: string): Promise<Message[]> => {
@@ -370,6 +373,8 @@ export function useAcpConnection(
           ? turn.data.interruptedAt
           : undefined,
       );
+      if (turn.success && !turn.data.inFlight) idleSessionsRef.current.add(sid);
+      else idleSessionsRef.current.delete(sid);
       if (replayBefore === undefined && generation === generationRef.current) {
         bindEngagement(sid);
         pendingReloadRef.current = false;
@@ -508,11 +513,22 @@ export function useAcpConnection(
     reset();
   }, [sessionId, sessionMode, reset]);
 
+  const runtimeIdle = useCallback(
+    (sid: string): boolean => idleSessionsRef.current.has(sid),
+    [],
+  );
+
+  const clearRuntimeIdle = useCallback((sid: string): void => {
+    idleSessionsRef.current.delete(sid);
+  }, []);
+
   return {
     state,
     ensureLive,
     beginSession,
     loadSessionHistory,
+    runtimeIdle,
+    clearRuntimeIdle,
     connectionRef,
     reset,
   };

--- a/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
@@ -375,10 +375,10 @@ export function useAcpConnection(
           ? turn.data.interruptedAt
           : undefined,
       );
-      if (turn.success && !turn.data.inFlight)
-        idleSessionsRef.current.set(sid, Date.now());
-      else idleSessionsRef.current.delete(sid);
       if (replayBefore === undefined && generation === generationRef.current) {
+        if (turn.success && !turn.data.inFlight)
+          idleSessionsRef.current.set(sid, Date.now());
+        else idleSessionsRef.current.delete(sid);
         bindEngagement(sid);
         pendingReloadRef.current = false;
         setState("live");

--- a/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-connection.ts
@@ -28,6 +28,8 @@ import { draftKey } from "../lib/draft-key.js";
 import { clearUndelivered, readUndelivered } from "../lib/undelivered-store.js";
 import type { PromptDelivery } from "./use-prompt-delivery.js";
 
+const REPLAY_IDLE_WINDOW_MS = 3000;
+
 export interface LiveConnection {
   connection: ClientSideConnection;
   ws: WebSocket;
@@ -284,7 +286,7 @@ export function useAcpConnection(
   }, [selectedAgent, makeUpdateHandler, attachCloseHandler]);
 
   const loadChainRef = useRef<Promise<unknown>>(Promise.resolve());
-  const idleSessionsRef = useRef(new Set<string>());
+  const idleSessionsRef = useRef(new Map<string, number>());
 
   const runSessionLoad = useCallback(
     async (sid: string, replayBefore?: string): Promise<Message[]> => {
@@ -373,7 +375,8 @@ export function useAcpConnection(
           ? turn.data.interruptedAt
           : undefined,
       );
-      if (turn.success && !turn.data.inFlight) idleSessionsRef.current.add(sid);
+      if (turn.success && !turn.data.inFlight)
+        idleSessionsRef.current.set(sid, Date.now());
       else idleSessionsRef.current.delete(sid);
       if (replayBefore === undefined && generation === generationRef.current) {
         bindEngagement(sid);
@@ -513,10 +516,13 @@ export function useAcpConnection(
     reset();
   }, [sessionId, sessionMode, reset]);
 
-  const runtimeIdle = useCallback(
-    (sid: string): boolean => idleSessionsRef.current.has(sid),
-    [],
-  );
+  const runtimeIdle = useCallback((sid: string): boolean => {
+    const answeredAt = idleSessionsRef.current.get(sid);
+    if (answeredAt === undefined) return false;
+    if (Date.now() - answeredAt <= REPLAY_IDLE_WINDOW_MS) return true;
+    idleSessionsRef.current.delete(sid);
+    return false;
+  }, []);
 
   const clearRuntimeIdle = useCallback((sid: string): void => {
     idleSessionsRef.current.delete(sid);

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -2,6 +2,7 @@ import { SessionMode } from "api-server-api";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { useStore } from "../../../store.js";
+import type { Attachment } from "../../../types.js";
 import {
   classifyResumeError,
   resumeFailureKind,
@@ -10,6 +11,7 @@ import {
 } from "../../acp/errors.js";
 import {
   appendUndelivered,
+  finalizeAllStreaming,
   hasStreamingAssistant,
 } from "../../acp/session-projection.js";
 import { useIsAgentOperable } from "../../agents/api/queries.js";
@@ -18,10 +20,12 @@ import { setSessionRunning } from "../api/queries.js";
 import { draftKey } from "../lib/draft-key.js";
 import { readUndelivered } from "../lib/undelivered-store.js";
 import { useAcpConnection } from "./use-acp-connection.js";
-import { useAcpPrompt } from "./use-acp-prompt.js";
+import { type SendPromptOptions, useAcpPrompt } from "./use-acp-prompt.js";
 import { useAcpSessionEngagement } from "./use-acp-session-engagement.js";
 import { useAcpUpdateHandler } from "./use-acp-update-handler.js";
 import { usePromptDelivery } from "./use-prompt-delivery.js";
+
+const REPLAY_SETTLE_MS = 150;
 
 async function classifyResumeFailure(
   agentId: string,
@@ -81,6 +85,8 @@ export function useAcpSession(
     ensureLive,
     beginSession,
     loadSessionHistory,
+    runtimeIdle,
+    clearRuntimeIdle,
     connectionRef,
     state: connectionState,
     reset: resetConnection,
@@ -97,6 +103,17 @@ export function useAcpSession(
     setMessages,
     delivery,
   });
+
+  useEffect(() => {
+    if (!sessionId || !runtimeIdle(sessionId)) return;
+    if (!hasStreamingAssistant(useStore.getState().messages)) return;
+    const settle = setTimeout(() => {
+      setMessages((p) => finalizeAllStreaming(p));
+    }, REPLAY_SETTLE_MS);
+    return () => {
+      clearTimeout(settle);
+    };
+  }, [sessionId, messages, runtimeIdle, setMessages]);
 
   useEffect(() => {
     if (!selectedAgent || sessionId !== null) return;
@@ -185,7 +202,7 @@ export function useAcpSession(
     [loadSessionHistory, setMessages],
   );
 
-  const { sendPrompt, stopAgent } = useAcpPrompt({
+  const { sendPrompt: promptAgent, stopAgent } = useAcpPrompt({
     selectedAgent,
     ensureConnection: ensureLive,
     beginSession,
@@ -194,6 +211,18 @@ export function useAcpSession(
     textareaRef,
     delivery,
   });
+
+  const sendPrompt = useCallback(
+    (
+      text: string,
+      attachments?: Attachment[],
+      opts?: SendPromptOptions,
+    ): Promise<void> => {
+      if (sessionId) clearRuntimeIdle(sessionId);
+      return promptAgent(text, attachments, opts);
+    },
+    [sessionId, clearRuntimeIdle, promptAgent],
+  );
 
   return {
     resetSession,

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -1,5 +1,11 @@
 import { SessionMode } from "api-server-api";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
 
 import { useStore } from "../../../store.js";
 import type { Attachment } from "../../../types.js";
@@ -24,8 +30,6 @@ import { type SendPromptOptions, useAcpPrompt } from "./use-acp-prompt.js";
 import { useAcpSessionEngagement } from "./use-acp-session-engagement.js";
 import { useAcpUpdateHandler } from "./use-acp-update-handler.js";
 import { usePromptDelivery } from "./use-prompt-delivery.js";
-
-const REPLAY_SETTLE_MS = 150;
 
 async function classifyResumeFailure(
   agentId: string,
@@ -104,17 +108,11 @@ export function useAcpSession(
     delivery,
   });
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!sessionId || !runtimeIdle(sessionId)) return;
     if (!hasStreamingAssistant(useStore.getState().messages)) return;
-    const settle = setTimeout(() => {
-      clearRuntimeIdle(sessionId);
-      setMessages((p) => finalizeAllStreaming(p));
-    }, REPLAY_SETTLE_MS);
-    return () => {
-      clearTimeout(settle);
-    };
-  }, [sessionId, messages, runtimeIdle, clearRuntimeIdle, setMessages]);
+    setMessages((p) => finalizeAllStreaming(p));
+  }, [sessionId, messages, runtimeIdle, setMessages]);
 
   useEffect(() => {
     if (!selectedAgent || sessionId !== null) return;

--- a/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
+++ b/packages/ui/src/modules/sessions/hooks/use-acp-session.ts
@@ -108,12 +108,13 @@ export function useAcpSession(
     if (!sessionId || !runtimeIdle(sessionId)) return;
     if (!hasStreamingAssistant(useStore.getState().messages)) return;
     const settle = setTimeout(() => {
+      clearRuntimeIdle(sessionId);
       setMessages((p) => finalizeAllStreaming(p));
     }, REPLAY_SETTLE_MS);
     return () => {
       clearTimeout(settle);
     };
-  }, [sessionId, messages, runtimeIdle, setMessages]);
+  }, [sessionId, messages, runtimeIdle, clearRuntimeIdle, setMessages]);
 
   useEffect(() => {
     if (!selectedAgent || sessionId !== null) return;


### PR DESCRIPTION
Opening a finished session from the list left an empty assistant bubble streaming at the end of the transcript, and the busy flag derived from it marked the row in the session list as running. Loading the very same session by URL rendered it correctly.

## Cause

The replay is collected only while the `session/load` call is awaited — the collector is detached in a `finally` as soon as the call resolves. The runtime answers before the harness has replayed the transcript, so those updates can arrive after the collector is gone and are applied as live ones. A replayed transcript carries no turn-end marker (only the live stream does), so the last reply stays streaming.

It is a race, which is why the symptom was asymmetric: on a full page load the updates won and the replay was collected; on an in-app click the response won.

## Fix

The load response already carries the answer: the runtime reports on `_meta.platform.turn.inFlight` whether a turn is in flight — an existing contract this change consumes, nothing on the runtime side changes. When it reports none, nothing in that session may render as running, no matter which path the updates took to reach the store.

Three things the naive form of this would get wrong, all handled here:

- A prompt sent into a session you just opened must still render as running, so sending clears the mark (delivery failure detection reads `bubble.streaming` and keeps working).
- The transcript settles once the replay goes quiet rather than immediately, so a late chunk arriving after a closed bubble cannot split one reply across several bubbles — `appendToActive` only appends to a streaming message.
- The mark is bounded, so it cannot act on a turn it was never read for. A turn started elsewhere for the same session — the trigger driver, or a second client — arrives here as plain chunks and cannot be told apart by update kind, because `promptStarted` is sent only to the channel that sent the prompt (`prompt-scheduler.ts:146`). So the mark is consumed by the settle that acts on it, and expires shortly after the load that recorded it.

Files changed: `use-acp-connection.ts`, `use-acp-session.ts`. Not harness-specific — nothing on this path branches per harness; it was simply reproduced on Bob.

## Verification

`mise run check` and `mise run //packages/ui:test` (43 files, 366 tests) pass. `check:comment-types` fails on a pre-existing config parse error (`unknown field deny_net` at `.mise/config.toml:98` under mise 2026.9.3, which is the declared `min_version`); comment types were verified with `mise run strip-comments -- --check` instead.

An earlier form of this fix was verified against the original reproduction on a live cluster — the two sessions that showed the indicator on an in-app switch showed none afterwards. **This revision has not been re-run on a cluster yet.**

## Tests

No unit test. The logic lives in a hook, not a pure function, and the suite has no React Testing Library setup — all 366 tests are pure-function tests. Extracting a named predicate to test would be a design change rather than added coverage; happy to do it if reviewers want it.
