### PR TITLE
bump: v0.2.18

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: platform
 description: ADK — Secure Agent Execution Platform
 type: application
-version: 0.2.17
-appVersion: "0.2.17"
+version: 0.2.18
+appVersion: "0.2.18"
 dependencies:
   # Agent-telemetry backend; gated by clickstack.enabled (default off). Operators + CRDs
   # install out-of-band (the cluster:install task). See docs/architecture/observability.md.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dam-agents/cli",
   "author": "IBM Corp.",
-  "version": "0.2.17",
+  "version": "0.2.18",
   "type": "module",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dam-agents/dam/tree/main/packages/cli#readme",


### PR DESCRIPTION
Bump pending version on `main` to 0.2.18 after opening `release-v0.2.17`.