### PR TITLE
fix(security): set CSP and cache-control response headers

### DIFF
--- a/helm/templates/ui/app.yaml
+++ b/helm/templates/ui/app.yaml
@@ -16,6 +16,13 @@ data:
         ''      '';
     }
 
+    # The shell (index.html) must always revalidate so a deploy is picked up on
+    # the next load; /assets/ files are content-hashed, so they never change.
+    map $uri $static_cache_control {
+        default     "no-cache, no-store, must-revalidate";
+        ~^/assets/  "public, max-age=31536000, immutable";
+    }
+
     # Structured JSON access log, one object per line on stdout.
     log_format json_access escape=json
         '{'
@@ -80,6 +87,11 @@ data:
             add_header X-Frame-Options "DENY" always;
             add_header Referrer-Policy "no-referrer" always;
             add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+            # Navigation-only CSP. Fetch directives (script-src, img-src, ...) are
+            # inherited by the srcdoc iframes that preview artifacts and files, and
+            # those render arbitrary HTML, so any fetch restriction here breaks them.
+            add_header Content-Security-Policy "frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+            add_header Cache-Control $static_cache_control always;
             try_files $uri $uri/ /index.html;
         }
     }

--- a/meta/zap/crawl.yaml
+++ b/meta/zap/crawl.yaml
@@ -14,6 +14,7 @@ env:
           loginPageUrl: https://dam-dev.apps.dam-cl.fmaas.res.ibm.com/
           loginPageWait: 8
           browserId: chrome-headless
+          diagnostics: true
         verification:
           method: autodetect
       sessionManagement:
@@ -39,7 +40,15 @@ jobs:
       maxDuration: 15
       maxCrawlDepth: 10
       runOnlyIfModern: false
+      # Keycloak is out of scope; Strict blocks the OIDC redirect in the spider's browser, so login never happens.
+      scopeCheck: Flexible
+      logoutAvoidance: true
   - type: passiveScan-wait
+  - type: report
+    parameters:
+      template: auth-report-json
+      reportDir: ${ZAP_REPORT_DIR}
+      reportFile: crawl-auth
   - type: report
     parameters:
       template: traditional-html-plus

--- a/packages/api-server/src/__tests__/unit/public-agent-routes.test.ts
+++ b/packages/api-server/src/__tests__/unit/public-agent-routes.test.ts
@@ -55,14 +55,4 @@ describe("public agent routes", () => {
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ agent: null });
   });
-
-  /**
-   * TEST_SCENARIO: An agent can be renamed or deleted at any moment, and the
-   * answer names a person. A cached copy in a shared proxy would outlive both.
-   */
-  it("tells caches not to store the answer", async () => {
-    const res = await ROUTES.request("/agents/agent-1");
-
-    expect(res.headers.get("Cache-Control")).toBe("no-store");
-  });
 });

--- a/packages/api-server/src/__tests__/unit/security-headers.test.ts
+++ b/packages/api-server/src/__tests__/unit/security-headers.test.ts
@@ -1,0 +1,50 @@
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+
+import { securityHeaders } from "../../apps/api-server/app.js";
+
+/*
+ * TEST_OVERVIEW: A response passing through this middleware leaves with the
+ * baseline security headers and a Cache-Control that forbids caching, unless
+ * the route chose its own caching (brand icons are public for five minutes) or
+ * the response is a 304 whose cached copy the client must keep.
+ */
+describe("securityHeaders", () => {
+  const app = new Hono();
+  app.use("*", securityHeaders);
+  app.get("/plain", (c) => c.json({ ok: true }));
+  app.get("/cached", (c) => {
+    c.header("Cache-Control", "public, max-age=300");
+    return c.body("icon");
+  });
+  app.get("/conditional", (c) => c.body(null, 304));
+
+  /*
+   * TEST_SCENARIO: A route that sets no Cache-Control gets the no-store
+   * default; ZAP's cache-control rule wants all three directives present.
+   */
+  it("defaults Cache-Control to no-store", async () => {
+    const res = await app.request("/plain");
+    expect(res.headers.get("Cache-Control")).toBe(
+      "no-cache, no-store, must-revalidate",
+    );
+    expect(res.headers.get("X-Frame-Options")).toBe("DENY");
+  });
+
+  /* TEST_SCENARIO: A route that sets its own Cache-Control keeps it. */
+  it("keeps a route's own Cache-Control", async () => {
+    const res = await app.request("/cached");
+    expect(res.headers.get("Cache-Control")).toBe("public, max-age=300");
+  });
+
+  /*
+   * TEST_SCENARIO: A 304 sets no Cache-Control on its conditional branch (the
+   * brand-icon routes do this). Stamping no-store would tell the client to drop
+   * the cached copy it just revalidated, so the middleware leaves 304 alone.
+   */
+  it("leaves a 304 without Cache-Control", async () => {
+    const res = await app.request("/conditional");
+    expect(res.status).toBe(304);
+    expect(res.headers.get("Cache-Control")).toBeNull();
+  });
+});

--- a/packages/api-server/src/apps/api-server/app.ts
+++ b/packages/api-server/src/apps/api-server/app.ts
@@ -31,8 +31,10 @@ import {
 
 export type { ApiServerDeps } from "./deps.js";
 
-const securityHeaders: MiddlewareHandler = async (c, next) => {
+export const securityHeaders: MiddlewareHandler = async (c, next) => {
   await next();
+  if (c.res.status !== 304 && !c.res.headers.has("Cache-Control"))
+    c.header("Cache-Control", "no-cache, no-store, must-revalidate");
   c.header("X-Content-Type-Options", "nosniff");
   c.header("X-Frame-Options", "DENY");
   c.header("Referrer-Policy", "no-referrer");

--- a/packages/api-server/src/apps/api-server/trpc/http.ts
+++ b/packages/api-server/src/apps/api-server/trpc/http.ts
@@ -18,7 +18,6 @@ export function createTrpcHttpHandler(deps: {
       req: c.req.raw,
       router: appRouter,
       onError: logInternalError,
-      responseMeta: () => ({ headers: { "Cache-Control": "no-store" } }),
       createContext: () => {
         const ctx = deps.composeApiContext(c.get("user"), c.get("surface"));
         markTermsProven(ctx);

--- a/packages/api-server/src/modules/agents/infrastructure/public-agent-routes.ts
+++ b/packages/api-server/src/modules/agents/infrastructure/public-agent-routes.ts
@@ -23,7 +23,6 @@ export function createPublicAgentRoutes(deps: PublicAgentRoutesDeps): Hono {
 
   routes.get("/agents/:agentId", async (c) => {
     const agent = await deps.service.get(c.req.param("agentId"));
-    c.header("Cache-Control", "no-store");
     return c.json({ agent } satisfies PublicAgentResponse);
   });
 

--- a/packages/ui/default.conf
+++ b/packages/ui/default.conf
@@ -12,6 +12,13 @@ log_format json_access escape=json
     '"user_agent":"$http_user_agent"'
     '}';
 
+# The shell (index.html) must always revalidate so a deploy is picked up on the
+# next load; /assets/ files are content-hashed, so they never change.
+map $uri $static_cache_control {
+    default     "no-cache, no-store, must-revalidate";
+    ~^/assets/  "public, max-age=31536000, immutable";
+}
+
 server {
     listen       8080;
     server_name  localhost;
@@ -20,14 +27,18 @@ server {
     access_log /dev/stdout json_access;
 
     # Static UI has no cookies/auth of its own (the api-server owns that), so
-    # these are safe platform-wide defaults. style-src needs 'unsafe-inline'
-    # for inline style attributes set by UI component libraries; font-src/
-    # style-src allow Google Fonts, the one external asset this app loads.
+    # these are safe platform-wide defaults.
     add_header X-Content-Type-Options "nosniff" always;
     add_header X-Frame-Options "DENY" always;
     add_header Referrer-Policy "no-referrer" always;
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'self'; base-uri 'self'; form-action 'self'" always;
+    # Navigation-only CSP. Fetch directives (script-src, connect-src, img-src,
+    # ...) are omitted on purpose: the srcdoc iframes that preview artifacts and
+    # files render arbitrary HTML and inherit this policy, and the SPA fetches
+    # Keycloak and Google Fonts cross-origin, so any fetch restriction here
+    # breaks one of them.
+    add_header Content-Security-Policy "frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'" always;
+    add_header Cache-Control $static_cache_control always;
 
     # The app ships as one 654KB entry chunk plus a 1.9MB lazily-loaded chunk.
     # Uncompressed that is the whole cost of a first visit, which the public


### PR DESCRIPTION
## What

Fix the two actionable findings from the authenticated ZAP scan of the dev deployment, and teach the scan's UI crawl to log in so those findings reflect the real app.

### Security headers (`fix(security)`)

- **CSP.** The app shell was served with no `Content-Security-Policy`. nginx now sends a navigation-only policy in both the Helm ConfigMap and the image `default.conf`:

  ```
  Content-Security-Policy: frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'
  ```

  Fetch directives (`script-src`, `connect-src`, `img-src`, ...) are left out on purpose. The `srcdoc` iframes that preview artifacts and files render arbitrary HTML and inherit the parent policy, and the SPA calls Keycloak and Google Fonts cross-origin, so any fetch restriction breaks one of them. This is the tradeoff `docs/architecture/artifact-library.md` already records. It also replaces `default.conf`'s stricter CSP, which would have blocked both the Keycloak token call and the previews had that config ever served.

- **Cache-Control.** api-server now defaults `Cache-Control: no-cache, no-store, must-revalidate` unless a route sets its own (brand icons keep their 5-minute cache); the redundant per-route `no-store` on the tRPC handler and the public-agent route is removed. nginx serves the shell `no-store` and content-hashed `/assets/` `immutable`.

### Scan auth (`chore(zap)`)

The AJAX spider was crawling the unauthenticated shell: under the default Strict scope check its browser blocked the out-of-scope Keycloak redirect, so login never happened. `scopeCheck: Flexible` lets the OIDC redirect through; `logoutAvoidance` and an auth-report job are added so a run proves it reaches the logged-in session.

## Why the CSP is safe here

- Rule 10038 (CSP header not set) is satisfied by the header being present.
- Rule 10055 does not alert on a missing `default-src`, and its "no fallback" alert only fires on a wildcard in `frame-ancestors`/`form-action`. This policy has no wildcards.

## Verification

- Replayed the live dev app through a proxy with the header injected, logged in as the scan user, browsed four routes: zero CSP violations, `srcdoc` inline scripts still run, and a positive control confirmed enforcement.
- `//packages/api-server:check` and the full api-server suite (1349 tests) pass, including a new `security-headers.test.ts`.
- `//helm:check:render` and `//helm:check:lint` pass.

Not verified by a live scan: that needs the Helm change deployed to the dev cluster, which this branch does not do.

## Notdone

An earlier draft filtered ZAP's "Suspicious Comments" false positive in the scan plan; removed at the reviewer's request, so that informational alert will still appear.
