### PR TITLE
fix(agents): start each Codex terminal session on its own thread

### DIFF
--- a/packages/agents/codex/Dockerfile
+++ b/packages/agents/codex/Dockerfile
@@ -16,6 +16,7 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=65532 \
 COPY --chmod=0755 harness-chat.sh /usr/local/bin/harness-chat
 COPY --chmod=0755 harness-terminal.sh /usr/local/bin/harness-terminal
 COPY --chown=65532:0 system-config.toml /etc/codex/config.toml
+COPY --chown=65532:0 requirements.toml /etc/codex/requirements.toml
 COPY --chown=65532:0 workspace/ /app/working-dir/
 
 # placeholder satisfies the CLI startup check; real credential injected on the wire

--- a/packages/agents/codex/README.md
+++ b/packages/agents/codex/README.md
@@ -37,9 +37,11 @@ The harness scripts translate `OPENAI_BASE_URL` into Codex's `-c openai_base_url
 | Script | Runs | Purpose |
 |---|---|---|
 | `harness-chat.sh` | `codex-acp` | ACP subprocess for chat-mode sessions (UI) |
-| `harness-terminal.sh` | `codex` / `codex resume` | Interactive TUI for terminal-mode sessions |
+| `harness-terminal.sh` | `codex` / `codex resume <thread>` | Interactive TUI for terminal-mode sessions |
 
 Terminal sessions use `--dangerously-bypass-approvals-and-sandbox` since the pod itself is the sandbox (network isolation + Envoy credential injection).
+
+Codex mints its own thread id on the first turn, so the platform session id cannot be passed in. A managed `SessionStart` hook (`requirements.toml`, shipped as `/etc/codex/requirements.toml` and therefore pre-trusted) records the thread id under `~/.codex/platform-sessions/$HARNESS_SESSION_ID`; `harness-terminal.sh` resumes that thread when the file exists and starts a fresh conversation otherwise. A terminal closed before its first turn leaves no pin and simply starts fresh next time.
 
 ## Usage
 

--- a/packages/agents/codex/harness-terminal.sh
+++ b/packages/agents/codex/harness-terminal.sh
@@ -7,12 +7,10 @@ if [ -n "$OPENAI_MODEL" ]; then
   set -- "$@" -c "model=\"$OPENAI_MODEL\""
 fi
 
-SESSION_MARKER="$HOME/.codex/.session-started"
-mkdir -p "$HOME/.codex" >/dev/null 2>&1
-
-if [ -f "$SESSION_MARKER" ]; then
-  exec codex resume --last "$@"
+# pinned by the SessionStart hook in /etc/codex/requirements.toml
+THREAD_FILE="$HOME/.codex/platform-sessions/$HARNESS_SESSION_ID"
+if [ -s "$THREAD_FILE" ]; then
+  exec codex resume "$(cat "$THREAD_FILE")" "$@"
 else
-  touch "$SESSION_MARKER"
   exec codex "$@"
 fi

--- a/packages/agents/codex/requirements.toml
+++ b/packages/agents/codex/requirements.toml
@@ -1,0 +1,9 @@
+# Managed hooks are trusted by policy, so no per-user review prompt. Codex mints
+# its thread id on the first turn, so the terminal harness can't pass one in;
+# this hook records it under the platform session id for harness-terminal to resume.
+[[hooks.SessionStart]]
+matcher = "startup"
+
+[[hooks.SessionStart.hooks]]
+type = "command"
+command = '''if [ -n "$HARNESS_SESSION_ID" ]; then mkdir -p "$HOME/.codex/platform-sessions" && sed -n 's/.*"session_id":"\([^"]*\)".*/\1/p' > "$HOME/.codex/platform-sessions/$HARNESS_SESSION_ID"; fi'''


### PR DESCRIPTION
Closes #3633

## Problem

`harness-terminal.sh` kept a pod-wide `.session-started` marker. After the first terminal in a pod, every launch ran `codex resume --last`, so each "new" terminal session loaded the most recent thread instead of starting fresh.

## Why not `HARNESS_SESSION_ID` like the other harnesses

Codex mints its own thread id lazily on the first turn and has no flag or env var to pass one in (`CODEX_THREAD_ID` is output-only). So the mapping platform session → Codex thread has to be recorded from inside Codex.

## Fix

- **`requirements.toml`** (new, shipped as `/etc/codex/requirements.toml`): a managed `SessionStart` hook writes the Codex thread id to `~/.codex/platform-sessions/$HARNESS_SESSION_ID`. Managed hooks are trusted by policy, so no per-user review prompt. No-op for chat sessions (env var unset there).
- **`harness-terminal.sh`**: `codex resume <pinned thread>` when the pin exists, plain `codex` otherwise. Marker logic removed.
- Dockerfile copies the requirements file; README documents the mechanism.

## Verification

Driven the real harness script under a pseudo-terminal against the pinned Codex 0.133.0:

1. First session with id A starts fresh; after its first turn the pin file holds the thread UUID.
2. Reopening with id A resumes that thread (history visible, no new rollout file).
3. Opening with a new id B starts clean with no prior context.
4. A terminal closed before its first turn leaves no pin and starts fresh next time.

`check:comment-types` reports three pre-existing violations in `security-headers.test.ts`, unrelated to this change.