### PR TITLE
docs(postgres): grant usage_readers membership WITH INHERIT TRUE

### DIFF
--- a/docs/notes/postgres-role-operations.md
+++ b/docs/notes/postgres-role-operations.md
@@ -125,9 +125,18 @@ admin role:
   each owning its own database; `REVOKE CONNECT ON DATABASE … FROM PUBLIC` and
   grant it back only to the owner. This is portable SQL.
 - Create `usage_readers` as `NOLOGIN` (no password), and `GRANT CONNECT ON
-  DATABASE platform` to it. Then `GRANT usage_readers TO <read-only login>`
-  for whichever login should read the metrics — that membership is what
-  survives future view migrations. Order does not matter, but a restart does:
+  DATABASE platform` to it. Then `GRANT usage_readers TO <read-only login>
+  WITH INHERIT TRUE` for whichever login should read the metrics — that
+  membership is what survives future view migrations. The `WITH INHERIT TRUE`
+  matters: on PostgreSQL 16+ a membership confers the group's privileges only
+  when that option is on, and it defaults to the member's own `INHERIT`
+  attribute. A read-only login is often created `NOINHERIT` as hardening, and
+  then a bare `GRANT` records a membership that confers nothing — the
+  reconcile still reports every passthrough readable for the group, while the
+  login is denied on each of them. (On 15 and older the option does not
+  exist; the login itself must be `INHERIT`.) Verify with
+  `SELECT pg_has_role('<login>', 'usage_readers', 'USAGE')`, which must be
+  true. Order does not matter, but a restart does:
   the api-server reconciles the view grants at startup, so a role created
   after a release is picked up by the **next api-server start** — and nothing
   in a release forces one, so create the role before the release or restart

--- a/helm/templates/postgres.yaml
+++ b/helm/templates/postgres.yaml
@@ -46,8 +46,10 @@ data:
     -- views. NOLOGIN and password-less: the role is a group, it holds no
     -- credential and grants nobody anything by itself. An operator grants
     -- membership to whichever login should read the metrics (`GRANT
-    -- usage_readers TO <login>`), and membership is attached to the two
-    -- roles rather than to any view, so no view migration can revoke it. The
+    -- usage_readers TO <login> WITH INHERIT TRUE` — without the option a
+    -- NOINHERIT login is a member that reads nothing), and membership is
+    -- attached to the two roles rather than to any view, so no view migration
+    -- can revoke it. The
     -- api-server reconciles SELECT on the passthroughs for this role after
     -- running migrations on every start, which is why the name is fixed
     -- rather than configurable. Because it reconciles, this role may be


### PR DESCRIPTION
## Why

Setting up the analytics consumer on a managed PostgreSQL 18 instance today, the runbook was followed as written: `usage_readers` created, `CONNECT` granted, `GRANT usage_readers TO usage_reader`. The api-server's reconcile then reported every `usage_src_*` passthrough readable for the group, and the consumer was still `permission denied for view usage_src_*` on all of them.

The login had been created `NOINHERIT` as read-only hardening. On PostgreSQL 16+ a membership confers the group's privileges only when its `INHERIT` option is on, and a bare `GRANT` defaults that option to the member's own `INHERIT` attribute. So the login was a member (`pg_has_role(..., 'MEMBER')` true) that inherited nothing (`'USAGE'` false). Re-granting `WITH INHERIT TRUE` fixed it.

## What

Docs only. The api-server never grants membership, so nothing in code changes.

- `docs/notes/postgres-role-operations.md`: the managed-instance bullet now grants `WITH INHERIT TRUE`, explains the failure mode, notes the PG ≤15 equivalent, and gives the `pg_has_role(..., 'USAGE')` check that tells the two states apart.
- `helm/templates/postgres.yaml`: the same statement in the bootstrap SQL comment.

## Possible follow-up (not in this PR)

The reconcile could list members of `usage_readers` whose membership does not inherit and log them the way it logs `usage.grants.unreachable`. It would have surfaced this at api-server start instead of at the consumer.
