### PR TITLE
fix(claude-code-vm): unbreak the VM build — repin skopeo, unpin the bootc base

### DIFF
--- a/packages/agents/claude-code-vm/Containerfile
+++ b/packages/agents/claude-code-vm/Containerfile
@@ -19,11 +19,15 @@
 ARG AGENT_IMAGE=platform-claude-code:latest
 FROM ${AGENT_IMAGE} AS agent
 
-# Pinned by digest, and k3s by version below: the same commit must build the
-# same guest. dnf packages stay unpinned on purpose — Fedora mirrors drop
-# superseded NVRs within weeks, so pinning them breaks the build instead of
-# fixing it. Bump the pins deliberately, together with a full VM test.
-FROM quay.io/fedora/fedora-bootc:44@sha256:1bc549cb2909ebd1bb69e05088797dd602eee691f7deaa40f5b9914c3ce84b36
+# Tag, not digest: fedora-bootc publishes no immutable tag — :44 and its
+# per-arch variants all move — and quay expires a manifest as soon as no tag
+# points at it, so a digest pinned here 404s within weeks. That is what broke
+# main CI. dnf packages stay unpinned for the same reason: Fedora mirrors drop
+# superseded NVRs, so pinning them breaks the build instead of fixing it —
+# which also means a base digest bought little reproducibility here. k3s below
+# stays pinned by version, a tag upstream keeps forever. Bump :44 to the next
+# Fedora deliberately, together with a full VM test.
+FROM quay.io/fedora/fedora-bootc:44
 
 # runc explicitly: install_weak_deps=False drops it, and dockerd then dies on
 # startup — "failed to find runc binary" while initialising buildkit — so the

--- a/packages/agents/claude-code-vm/build.sh
+++ b/packages/agents/claude-code-vm/build.sh
@@ -29,7 +29,10 @@ AGENT_IMAGE="${AGENT_IMAGE:-platform-claude-code:latest}"
 OUT_TAG="${OUT_TAG:-platform-claude-code-vm:latest}"
 STORAGE_VOL="platform-ccvm-storage"
 # Digest-pinned: bib decides the disk layout, so a silently moved :latest would
-# change the output for an unchanged bootc image.
+# change the output for an unchanged bootc image. Safe to pin off :latest here
+# only because cosign leaves a `sha256-<digest>` tag on every published bib
+# manifest, so quay never sees one untagged and never expires it — unlike
+# skopeo below, whose old digests do vanish.
 BIB_IMAGE="quay.io/centos-bootc/bootc-image-builder:latest@sha256:2b52843ea2bfda73b0a08d97e76b734393b1d3a804681b9fabb26723bd3a2f0b"
 # Pin to an -immutable version tag, not :latest: skopeo garbage-collects the
 # digests that :latest used to point at, and once the pinned digest is GC'd

--- a/packages/agents/claude-code-vm/build.sh
+++ b/packages/agents/claude-code-vm/build.sh
@@ -31,7 +31,11 @@ STORAGE_VOL="platform-ccvm-storage"
 # Digest-pinned: bib decides the disk layout, so a silently moved :latest would
 # change the output for an unchanged bootc image.
 BIB_IMAGE="quay.io/centos-bootc/bootc-image-builder:latest@sha256:2b52843ea2bfda73b0a08d97e76b734393b1d3a804681b9fabb26723bd3a2f0b"
-SKOPEO_IMAGE="quay.io/skopeo/stable:latest@sha256:b9ca6a549aa71990d50ab390a8bddf606a6689379026aa24e7f4f70b5a43fbcd"
+# Pin to an -immutable version tag, not :latest: skopeo garbage-collects the
+# digests that :latest used to point at, and once the pinned digest is GC'd
+# every pull fails MANIFEST_UNKNOWN — which the preflight below swallows and
+# mis-reports as a loop-device failure. The -immutable tags are retained.
+SKOPEO_IMAGE="quay.io/skopeo/stable:v1.22.2-immutable@sha256:4a16d57b37617a04b3d643079a477a2848efe892dffcdf0ce56df4262b65f810"
 
 # Preflight: osbuild assembles the disk on loop devices; containerized hosts
 # whose device cgroup blocks them (e.g. Locki sandboxes) can never build this
@@ -39,6 +43,13 @@ SKOPEO_IMAGE="quay.io/skopeo/stable:latest@sha256:b9ca6a549aa71990d50ab390a8bddf
 # Detach what the probe attaches: the loop device outlives the container, and
 # leaking one per build exhausts the kernel's 8-device default — after which
 # every later build fails this very check and blames the environment.
+# Pull first and separately: a failed pull (e.g. a GC'd digest) is not a
+# loop-device problem, and folding it into the probe below misdiagnoses it.
+if ! docker pull "$SKOPEO_IMAGE" >/dev/null 2>&1; then
+	echo "claude-code-vm: FATAL: cannot pull $SKOPEO_IMAGE" >&2
+	echo "(pull failed — check the pinned digest still exists in the registry)." >&2
+	exit 1
+fi
 if ! docker run --rm --privileged --entrypoint sh "$SKOPEO_IMAGE" -c \
 	'truncate -s 1M /tmp/probe && d=$(losetup -f --show /tmp/probe) && losetup -d "$d"' >/dev/null 2>&1; then
 	echo "claude-code-vm: FATAL: this environment cannot attach loop devices" >&2


### PR DESCRIPTION
Supersedes #3657 (same first commit, kept as-is with @pilartomas' authorship) and finishes the job: #3657's own CI still fails, because the *next* image along was garbage-collected the same way.

## What's broken

`build-claude-code-vm` on #3657 dies at the `docker build`:

```
#3 [internal] load metadata for quay.io/fedora/fedora-bootc:44@sha256:1bc549cb…
#3 ERROR: quay.io/fedora/fedora-bootc:44@sha256:1bc549cb…: not found
```

Same failure mode #3657 diagnosed for skopeo: quay expires a manifest once no tag points at it, `:44` moved off that digest, the pin 404s.

## Digest audit

Every digest pin in the repo, checked against the registry (cache-busted — the sandbox proxy will happily serve a stale 200 for a dead manifest):

| pin | tag | live? |
|---|---|---|
| `skopeo/stable:latest@b9ca6a54` | moving | ❌ 404 — #3657's fix |
| `fedora/fedora-bootc:44@1bc549cb` | moving | ❌ 404 — **fixed here** |
| `centos-bootc/bootc-image-builder:latest@2b52843e` | moving | ✅ |
| `keycloak/keycloak:26.7.2@9d1f1b2b` | version | ✅ |
| `ghcr.io/jdx/mise:2026.9@812f7860` (×3) | version, ghcr | ✅ |

## Fix

**fedora-bootc — drop the digest, keep `:44`.** There is nothing immutable to repin to: `:44`, `:latest` and every `44-<arch>` variant move, and no datestamped `44.*` tags are retained (unlike the `41.20250718.0`-style tags that still exist for older releases). Any digest we pin there is a 404 within weeks — and this job only builds when its source changes, so it would sit red most of the time rather than fail once.

The reproducibility we give up is smaller than it looks: the `dnf install` right below is already unpinned on purpose, for the same reason (Fedora mirrors drop superseded NVRs), so the same commit never did rebuild byte-identically. k3s stays pinned by version, a tag upstream keeps forever.

**bootc-image-builder — left on `:latest@sha256:…`, now with the reason written down.** It looks like the same hazard and isn't: cosign leaves a `sha256-<digest>` tag on every bib manifest it publishes, so quay never sees one untagged and never expires it. The repo also publishes no version tag to move to. Comment added so the asymmetry with skopeo two lines below reads as a decision.

**skopeo and the split preflight** — unchanged from #3657.

## Verification

`docker buildx imagetools inspect quay.io/fedora/fedora-bootc:44` — the exact resolution CI failed on — succeeds and returns the current index (`sha256:9409d49f…`, linux/amd64 + arm64 present). The new skopeo pin resolves too. The full qcow2 build needs loop devices, so CI is the real check.

Closes #3658