### PR TITLE
fix(ui): describe the IBM LiteLLM proxy as external

### DIFF
--- a/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
+++ b/packages/ui/src/modules/providers/components/ibm-litellm/form.tsx
@@ -8,6 +8,7 @@ import { Input } from "@/components/ui/input";
 import { KEY_GUIDE_URL } from "@/constants.js";
 import { externalLinkProps } from "@/lib/external-link";
 
+import { IBM_LITELLM_DESCRIPTION } from "../../lib/provider-rows.js";
 import { ProviderFormShell } from "../provider-form-shell.js";
 import { MODES, stripWhitespace } from "./modes.js";
 
@@ -55,7 +56,7 @@ export function IbmLitellmForm({
       description={
         isEdit
           ? "Paste a new token to replace the existing one."
-          : "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS."
+          : IBM_LITELLM_DESCRIPTION
       }
       onSubmit={onSubmit}
       onCancel={onCancel}

--- a/packages/ui/src/modules/providers/lib/provider-rows.ts
+++ b/packages/ui/src/modules/providers/lib/provider-rows.ts
@@ -5,10 +5,13 @@ export interface ProviderRowDef {
   description: string;
 }
 
+export const IBM_LITELLM_DESCRIPTION =
+  "IBM's external LiteLLM proxy — Claude on watsonx-routed AWS.";
+
 export const PROVIDER_ROWS: readonly ProviderRowDef[] = [
   {
     type: "ibm-litellm",
-    description: "IBM's internal LiteLLM proxy — Claude on watsonx-routed AWS.",
+    description: IBM_LITELLM_DESCRIPTION,
   },
   {
     type: "bob",


### PR DESCRIPTION
The provider description called the IBM LiteLLM proxy internal. It is external. The wrong word appeared in two places: the provider row in the provider list, and the connect form for that provider.

Both now say external, from one shared constant, so the two copies cannot drift again.

Copy change only. No behaviour change.

Closes #3665